### PR TITLE
Added `BillboardGraphics.imageSubRegion`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@ Change Log
 * Deprecated
   *
 * Added `PolylineVolumeGraphics` and `Entity.polylineVolume`
+* Added `BillboardGraphics.imageSubRegion`, to enable custom texture atlas use for `Entity` instances.
 
 ### 1.5 - 2015-01-05
 

--- a/Source/DataSources/BillboardGraphics.js
+++ b/Source/DataSources/BillboardGraphics.js
@@ -24,6 +24,8 @@ define([
     var BillboardGraphics = function() {
         this._image = undefined;
         this._imageSubscription = undefined;
+        this._imageSubRegion = undefined;
+        this._imageSubRegionSubscription = undefined;
         this._width = undefined;
         this._widthSubscription = undefined;
         this._height = undefined;
@@ -75,6 +77,14 @@ define([
          * @type {Property}
          */
         image : createPropertyDescriptor('image'),
+
+        /**
+         * Gets or sets the {@link BoundingRectangle} that defines a sub-region of the
+         * specified image to use for the billboard, rather than the entire image.
+         * @memberof BillboardGraphics.prototype
+         * @type {Property}
+         */
+        imageSubRegion : createPropertyDescriptor('imageSubRegion'),
 
         /**
          * Gets or sets the numeric {@link Property} specifying the billboard's scale.
@@ -194,6 +204,7 @@ define([
         result.eyeOffset = this._eyeOffset;
         result.horizontalOrigin = this._horizontalOrigin;
         result.image = this._image;
+        result.imageSubRegion = this._imageSubRegion;
         result.pixelOffset = this._pixelOffset;
         result.scale = this._scale;
         result.rotation = this._rotation;
@@ -221,21 +232,22 @@ define([
         }
         //>>includeEnd('debug');
 
-        this.color = defaultValue(this._color, source._color);
-        this.eyeOffset = defaultValue(this._eyeOffset, source._eyeOffset);
-        this.horizontalOrigin = defaultValue(this._horizontalOrigin, source._horizontalOrigin);
-        this.image = defaultValue(this._image, source._image);
-        this.pixelOffset = defaultValue(this._pixelOffset, source._pixelOffset);
-        this.scale = defaultValue(this._scale, source._scale);
-        this.rotation = defaultValue(this._rotation, source._rotation);
-        this.alignedAxis = defaultValue(this._alignedAxis, source._alignedAxis);
-        this.show = defaultValue(this._show, source._show);
-        this.verticalOrigin = defaultValue(this._verticalOrigin, source._verticalOrigin);
-        this.width = defaultValue(this._width, source._width);
-        this.height = defaultValue(this._height, source._height);
-        this.scaleByDistance = defaultValue(this._scaleByDistance, source._scaleByDistance);
-        this.translucencyByDistance = defaultValue(this._translucencyByDistance, source._translucencyByDistance);
-        this.pixelOffsetScaleByDistance = defaultValue(this._pixelOffsetScaleByDistance, source._pixelOffsetScaleByDistance);
+        this.color = defaultValue(this._color, source.color);
+        this.eyeOffset = defaultValue(this._eyeOffset, source.eyeOffset);
+        this.horizontalOrigin = defaultValue(this._horizontalOrigin, source.horizontalOrigin);
+        this.image = defaultValue(this._image, source.image);
+        this.imageSubRegion = defaultValue(this._imageSubRegion, source.imageSubRegion);
+        this.pixelOffset = defaultValue(this._pixelOffset, source.pixelOffset);
+        this.scale = defaultValue(this._scale, source.scale);
+        this.rotation = defaultValue(this._rotation, source.rotation);
+        this.alignedAxis = defaultValue(this._alignedAxis, source.alignedAxis);
+        this.show = defaultValue(this._show, source.show);
+        this.verticalOrigin = defaultValue(this._verticalOrigin, source.verticalOrigin);
+        this.width = defaultValue(this._width, source.width);
+        this.height = defaultValue(this._height, source.height);
+        this.scaleByDistance = defaultValue(this._scaleByDistance, source.scaleByDistance);
+        this.translucencyByDistance = defaultValue(this._translucencyByDistance, source.translucencyByDistance);
+        this.pixelOffsetScaleByDistance = defaultValue(this._pixelOffsetScaleByDistance, source.pixelOffsetScaleByDistance);
     };
 
     return BillboardGraphics;

--- a/Source/DataSources/BillboardVisualizer.js
+++ b/Source/DataSources/BillboardVisualizer.js
@@ -1,6 +1,7 @@
 /*global define*/
 define([
         '../Core/AssociativeArray',
+        '../Core/BoundingRectangle',
         '../Core/Cartesian2',
         '../Core/Cartesian3',
         '../Core/Color',
@@ -14,6 +15,7 @@ define([
         './Property'
     ], function(
         AssociativeArray,
+        BoundingRectangle,
         Cartesian2,
         Cartesian3,
         Color,
@@ -43,6 +45,7 @@ define([
     var scaleByDistance = new NearFarScalar();
     var translucencyByDistance = new NearFarScalar();
     var pixelOffsetScaleByDistance = new NearFarScalar();
+    var boundingRectangle = new BoundingRectangle();
 
     var EntityData = function(entity) {
         this.entity = entity;
@@ -149,6 +152,11 @@ define([
             billboard.scaleByDistance = Property.getValueOrUndefined(billboardGraphics._scaleByDistance, time, scaleByDistance);
             billboard.translucencyByDistance = Property.getValueOrUndefined(billboardGraphics._translucencyByDistance, time, translucencyByDistance);
             billboard.pixelOffsetScaleByDistance = Property.getValueOrUndefined(billboardGraphics._pixelOffsetScaleByDistance, time, pixelOffsetScaleByDistance);
+
+            var subRegion = Property.getValueOrUndefined(billboardGraphics._imageSubRegion, time, boundingRectangle);
+            if (defined(subRegion)) {
+                billboard.setImageSubRegion(billboard._imageId, subRegion);
+            }
         }
         return true;
     };

--- a/Source/Scene/Billboard.js
+++ b/Source/Scene/Billboard.js
@@ -889,7 +889,7 @@ define([
 
         this._imageIndex = -1;
         this._imageId = id;
-        this._imageSubRegion = subRegion;
+        this._imageSubRegion = BoundingRectangle.clone(subRegion);
 
         if (defined(this._billboardCollection._textureAtlas)) {
             this._loadImage();

--- a/Specs/DataSources/BillboardGraphicsSpec.js
+++ b/Specs/DataSources/BillboardGraphicsSpec.js
@@ -23,6 +23,7 @@ defineSuite([
     it('merge assigns unassigned properties', function() {
         var source = new BillboardGraphics();
         source.image = new ConstantProperty('');
+        source.imageSubRegion = new ConstantProperty();
         source.rotation = new ConstantProperty(5);
         source.alignedAxis = new ConstantProperty(new Cartesian3());
         source.color = new ConstantProperty(Color.BLACK);
@@ -42,6 +43,7 @@ defineSuite([
         target.merge(source);
 
         expect(target.image).toBe(source.image);
+        expect(target.imageSubRegion).toBe(source.imageSubRegion);
         expect(target.rotation).toBe(source.rotation);
         expect(target.alignedAxis).toBe(source.alignedAxis);
         expect(target.color).toBe(source.color);
@@ -61,6 +63,7 @@ defineSuite([
     it('merge does not assign assigned properties', function() {
         var source = new BillboardGraphics();
         source.image = new ConstantProperty('');
+        source.imageSubRegion = new ConstantProperty();
         source.rotation = new ConstantProperty(5);
         source.alignedAxis = new ConstantProperty(new Cartesian3());
         source.color = new ConstantProperty(Color.BLACK);
@@ -77,6 +80,7 @@ defineSuite([
         source.pixelOffsetScaleByDistance = new ConstantProperty(new NearFarScalar(1.0, 0.0, 3.0e9, 0.0));
 
         var image = new ConstantProperty('');
+        var imageSubRegion = new ConstantProperty();
         var rotation = new ConstantProperty(5);
         var alignedAxis = new ConstantProperty(new Cartesian3());
         var color = new ConstantProperty(Color.BLACK);
@@ -94,6 +98,7 @@ defineSuite([
 
         var target = new BillboardGraphics();
         target.image = image;
+        target.imageSubRegion = imageSubRegion;
         target.rotation = rotation;
         target.alignedAxis = alignedAxis;
         target.color = color;
@@ -112,6 +117,7 @@ defineSuite([
         target.merge(source);
 
         expect(target.image).toBe(image);
+        expect(target.imageSubRegion).toBe(imageSubRegion);
         expect(target.rotation).toBe(rotation);
         expect(target.alignedAxis).toBe(alignedAxis);
         expect(target.color).toBe(color);
@@ -131,6 +137,7 @@ defineSuite([
     it('clone works', function() {
         var source = new BillboardGraphics();
         source.image = new ConstantProperty('');
+        source.imageSubRegion = new ConstantProperty();
         source.rotation = new ConstantProperty(5);
         source.alignedAxis = new ConstantProperty(new Cartesian3());
         source.color = new ConstantProperty(Color.BLACK);
@@ -148,6 +155,7 @@ defineSuite([
 
         var result = source.clone();
         expect(result.image).toBe(source.image);
+        expect(result.imageSubRegion).toBe(source.imageSubRegion);
         expect(result.rotation).toBe(source.rotation);
         expect(result.alignedAxis).toBe(source.alignedAxis);
         expect(result.color).toBe(source.color);

--- a/Specs/DataSources/BillboardVisualizerSpec.js
+++ b/Specs/DataSources/BillboardVisualizerSpec.js
@@ -1,6 +1,7 @@
 /*global defineSuite*/
 defineSuite([
         'DataSources/BillboardVisualizer',
+        'Core/BoundingRectangle',
         'Core/Cartesian2',
         'Core/Cartesian3',
         'Core/Color',
@@ -16,6 +17,7 @@ defineSuite([
         'Specs/destroyScene'
     ], function(
         BillboardVisualizer,
+        BoundingRectangle,
         Cartesian2,
         Cartesian3,
         Color,
@@ -129,6 +131,7 @@ defineSuite([
             billboard.show = new ConstantProperty(true);
             billboard.color = new ConstantProperty(new Color(0.5, 0.5, 0.5, 0.5));
             billboard.image = new ConstantProperty('Data/Images/Blue.png');
+            billboard.imageSubRegion = new ConstantProperty(new BoundingRectangle(0, 0, 1, 1));
             billboard.eyeOffset = new ConstantProperty(new Cartesian3(1.0, 2.0, 3.0));
             billboard.scale = new ConstantProperty(12.5);
             billboard.rotation = new ConstantProperty(1.5);
@@ -165,6 +168,7 @@ defineSuite([
                     expect(bb.scaleByDistance).toEqual(testObject.billboard.scaleByDistance.getValue(time));
                     expect(bb.translucencyByDistance).toEqual(testObject.billboard.translucencyByDistance.getValue(time));
                     expect(bb.pixelOffsetScaleByDistance).toEqual(testObject.billboard.pixelOffsetScaleByDistance.getValue(time));
+                    expect(bb._imageSubRegion).toEqual(testObject.billboard.imageSubRegion.getValue(time));
                 }
                 return bb.show; //true once the image is loaded.
             });


### PR DESCRIPTION
Added `BillboardGraphics.imageSubRegion` to enable custom texture atlas capabilities for `Entity` instances.

This brings parity to the existing lower-level `Billboard.setImageSubRegion` method and is needed as part of the work being done in #2382.