### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 /.metadata
-/Build
 /Instrumented
 /Cesium-*.zip
 .DS_Store
@@ -10,11 +9,6 @@ Thumbs.db
 /Apps/Sandcastle/jsHintOptions.js
 /Apps/Sandcastle/gallery/gallery-index.js
 
-/Source/Cesium.js
-
-/Source/Shaders/*.js
-/Source/Shaders/*/*.js
-/Source/Shaders/*/*/*.js
 !/Source/Shaders/Shaders.profile.js
 
 /Specs/SpecList.js


### PR DESCRIPTION
In order to use the project with a package management solution such as composer or bower, the final product of the build process is needed. As of now, to use Cesium, this has to be done manually.