### PR TITLE
Make it easier to stop tracking an entity

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,8 @@ Change Log
 * `ConstantProperty` can now hold any value; previously it was limited to values that implemented `equals` and `clones` functions, as well as a few special cases.
 * Fixed a bug in `EllipsoidGeodesic` that caused it to modify the `height` of the positions passed to the constructor or to to `setEndPoints`.
 * Instead of throwing an exception when there are not enough unique positions to define a geometry, creating a `Primitive` will succeed, but not render. [#2375](https://github.com/AnalyticalGraphicsInc/cesium/issues/2375)
+* When you track an entity by clicking on the track button in the InfoBox, you can now stop tracking by clicking the button a second time.
+* Setting `viewer.trackedEntity` to `undefined` will now restore the camera controls to their default states.
 
 ### 1.5 - 2015-01-05
 

--- a/Source/Widgets/InfoBox/InfoBox.js
+++ b/Source/Widgets/InfoBox/InfoBox.js
@@ -55,7 +55,7 @@ css: { "cesium-infoBox-visible" : showInfo, "cesium-infoBox-bodyless" : _bodyles
         cameraElement.className = 'cesium-button cesium-infoBox-camera';
         cameraElement.setAttribute('data-bind', '\
 attr: { title: "Focus camera on object" },\
-click: function () { cameraClicked.raiseEvent(); },\
+click: function () { cameraClicked.raiseEvent(this); },\
 enable: enableCamera,\
 cesiumSvgPath: { path: cameraIconPath, width: 32, height: 32 }');
         infoElement.appendChild(cameraElement);
@@ -64,7 +64,7 @@ cesiumSvgPath: { path: cameraIconPath, width: 32, height: 32 }');
         closeElement.type = 'button';
         closeElement.className = 'cesium-infoBox-close';
         closeElement.setAttribute('data-bind', '\
-click: function () { closeClicked.raiseEvent(); }');
+click: function () { closeClicked.raiseEvent(this); }');
         closeElement.innerHTML = '&times;';
         infoElement.appendChild(closeElement);
 

--- a/Source/Widgets/InfoBox/InfoBoxViewModel.js
+++ b/Source/Widgets/InfoBox/InfoBoxViewModel.js
@@ -118,7 +118,7 @@ define([
         this.cameraIconPath = undefined;
         knockout.defineProperty(this, 'cameraIconPath', {
             get : function() {
-                return (this.enableCamera || this.isCameraTracking) ? cameraEnabledPath : cameraDisabledPath;
+                return (!this.enableCamera || this.isCameraTracking) ? cameraDisabledPath : cameraEnabledPath;
             }
         });
 

--- a/Source/Widgets/Viewer/Viewer.js
+++ b/Source/Widgets/Viewer/Viewer.js
@@ -1226,7 +1226,7 @@ Either specify options.terrainProvider instead or set options.baseLayerPicker to
 
         if (defined(this.trackedEntity)) {
             if (entityCollection.getById(this.trackedEntity.id) === this.trackedEntity) {
-                this.homeButton.viewModel.command();
+                this.trackedEntity = undefined;
             }
         }
 
@@ -1305,7 +1305,7 @@ Either specify options.terrainProvider instead or set options.baseLayerPicker to
         for (var i = 0; i < length; i++) {
             var removedObject = removed[i];
             if (this.trackedEntity === removedObject) {
-                this.homeButton.viewModel.command();
+                this.trackedEntity = undefined;
             }
             if (this.selectedEntity === removedObject) {
                 this.selectedEntity = undefined;

--- a/Source/Widgets/Viewer/Viewer.js
+++ b/Source/Widgets/Viewer/Viewer.js
@@ -7,6 +7,7 @@ define([
         '../../Core/destroyObject',
         '../../Core/DeveloperError',
         '../../Core/EventHelper',
+        '../../Core/Matrix4',
         '../../Core/ScreenSpaceEventType',
         '../../DataSources/ConstantPositionProperty',
         '../../DataSources/DataSourceCollection',
@@ -41,6 +42,7 @@ define([
         destroyObject,
         DeveloperError,
         EventHelper,
+        Matrix4,
         ScreenSpaceEventType,
         ConstantPositionProperty,
         DataSourceCollection,
@@ -382,8 +384,8 @@ Either specify options.terrainProvider instead or set options.baseLayerPicker to
             infoBox = new InfoBox(infoBoxContainer);
 
             var infoBoxViewModel = infoBox.viewModel;
-            eventHelper.add(infoBoxViewModel.cameraClicked, Viewer.prototype._trackSelectedEntity, this);
-            eventHelper.add(infoBoxViewModel.closeClicked, Viewer.prototype._clearSelectedEntity, this);
+            eventHelper.add(infoBoxViewModel.cameraClicked, Viewer.prototype._onInfoBoxCameraClicked, this);
+            eventHelper.add(infoBoxViewModel.closeClicked, Viewer.prototype._onInfoBoxClockClicked, this);
         }
 
         // Main Toolbar
@@ -949,6 +951,7 @@ Either specify options.terrainProvider instead or set options.baseLayerPicker to
                         this._entityView = new EntityView(value, scene, this.scene.globe.ellipsoid);
                     } else {
                         this._entityView = undefined;
+                        this.camera.setTransform(Matrix4.IDENTITY);
                     }
                 }
             }
@@ -1262,7 +1265,7 @@ Either specify options.terrainProvider instead or set options.baseLayerPicker to
             if (selectedEntity.isAvailable(time)) {
                 if (defined(selectedEntity.position)) {
                     position = selectedEntity.position.getValue(time, oldPosition);
-                    enableCamera = defined(position) && (this.trackedEntity !== this.selectedEntity);
+                    enableCamera = defined(position);
                 }
                 // else "position" is undefined and "enableCamera" is false.
             }
@@ -1313,8 +1316,12 @@ Either specify options.terrainProvider instead or set options.baseLayerPicker to
     /**
      * @private
      */
-    Viewer.prototype._trackSelectedEntity = function() {
-        this.trackedEntity = this.selectedEntity;
+    Viewer.prototype._onInfoBoxCameraClicked = function(infoBoxViewModel) {
+        if (infoBoxViewModel.isCameraTracking && (this.trackedEntity === this.selectedEntity)) {
+            this.trackedEntity = undefined;
+        } else {
+            this.trackedEntity = this.selectedEntity;
+        }
     };
 
     /**
@@ -1327,7 +1334,7 @@ Either specify options.terrainProvider instead or set options.baseLayerPicker to
     /**
      * @private
      */
-    Viewer.prototype._clearSelectedEntity = function() {
+    Viewer.prototype._onInfoBoxClockClicked = function(infoBoxViewModel) {
         this.selectedEntity = undefined;
     };
 

--- a/Specs/Widgets/InfoBox/InfoBoxViewModelSpec.js
+++ b/Specs/Widgets/InfoBox/InfoBoxViewModelSpec.js
@@ -84,10 +84,21 @@ defineSuite([
     it('camera icon changes when tracking is not available, unless due to active tracking', function() {
         var viewModel = new InfoBoxViewModel();
         viewModel.enableCamera = true;
-        var enabledCameraPath = viewModel.cameraIconPath;
+        viewModel.isCameraTracking = false;
+        var enabledTrackingPath = viewModel.cameraIconPath;
+
         viewModel.enableCamera = false;
-        expect(viewModel.cameraIconPath).not.toBe(enabledCameraPath);
+        viewModel.isCameraTracking = false;
+        expect(viewModel.cameraIconPath).not.toBe(enabledTrackingPath);
+
+        var disableTrackingPath = viewModel.cameraIconPath;
+
+        viewModel.enableCamera = true;
         viewModel.isCameraTracking = true;
-        expect(viewModel.cameraIconPath).toBe(enabledCameraPath);
+        expect(viewModel.cameraIconPath).toBe(disableTrackingPath);
+
+        viewModel.enableCamera = false;
+        viewModel.isCameraTracking = true;
+        expect(viewModel.cameraIconPath).toBe(disableTrackingPath);
     });
 });


### PR DESCRIPTION
1. When you track an entity by clicking on the track button in the InfoBox, you can now stop tracking by clicking the button a second time.
2. Setting `viewer.trackedEntity` to `undefined` will now restore the camera controls to their default states.
3. Don't fly home if an entity is removed from its DataSource or the DataSource itself is removed.  Instead we just stop tracking as if `viewer.trackedEntity` was set to `undefined`.  The previous behavior created problems because it unexpectedly generated a camera flight and was inconsistent than what happens when the `trackedEntity` becomes `undefined`.  Now the behavior is consistent all around.

[forum discussion](https://groups.google.com/d/msg/cesium-dev/16dwOVGrWdA/Q9GENTrb2UcJ)