### PR TITLE
Add BoundingSpheres.fromBoundingSpheres

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,7 @@ Change Log
 * Added `CheckerboardMaterialProperty` to enable use of the checkerboard material with the entity API.
 * Added `PolygonHierarchy` to make defining polygons with holes clearer.
 * Added `PolygonGraphics.hierarchy` for supporting polygons with holes via data sources.
+* Added 'BoundingSphere.fromBoundingSpheres', which creates a BoundingSphere that encloses the specified array of BoundingSpheres.
 * `GeoJsonDataSource` now supports polygons with holes.
 * `ConstantProperty` can now hold any value; previously it was limited to values that implemented `equals` and `clones` functions, as well as a few special cases.
 * Fixed a bug in `EllipsoidGeodesic` that caused it to modify the `height` of the positions passed to the constructor or to to `setEndPoints`.

--- a/Source/Core/BoundingSphere.js
+++ b/Source/Core/BoundingSphere.js
@@ -539,6 +539,55 @@ define([
         return result;
     };
 
+    var fromBoundingSpheresScratch = new Cartesian3();
+
+    /**
+     * Computes a tight-fitting bounding sphere enclosing the provided array of bounding spheres.
+     *
+     * @param {BoundingSphere} boundingSpheres The array of bounding spheres.
+     * @param {BoundingSphere} [result] The object onto which to store the result.
+     * @returns {BoundingSphere} The modified result parameter or a new BoundingSphere instance if none was provided.
+     *
+     * @exception
+     */
+    BoundingSphere.fromBoundingSpheres = function(boundingSpheres, result) {
+        if (!defined(result)) {
+            result = new BoundingSphere();
+        }
+
+        if (!defined(boundingSpheres) || boundingSpheres.length === 0) {
+            result.center = Cartesian3.clone(Cartesian3.ZERO, result.center);
+            result.radius = 0.0;
+            return result;
+        }
+
+        var length = boundingSpheres.length;
+        if (length === 1) {
+            return BoundingSphere.clone(boundingSpheres[0], result);
+        }
+
+        if (length === 2) {
+            return BoundingSphere.union(boundingSpheres[0], boundingSpheres[1], result);
+        }
+
+        var positions = [];
+        for (var i = 0; i < length; i++) {
+            positions.push(boundingSpheres[i].center);
+        }
+
+        result = BoundingSphere.fromPoints(positions, result);
+
+        var center = result.center;
+        var radius = result.radius;
+        for (i = 0; i < length; i++) {
+            var tmp = boundingSpheres[i];
+            radius = Math.max(radius, Cartesian3.distance(center, tmp.center, fromBoundingSpheresScratch) + tmp.radius);
+        }
+        result.radius = radius;
+
+        return result;
+    };
+
     /**
      * Duplicates a BoundingSphere instance.
      *

--- a/Source/Core/BoundingSphere.js
+++ b/Source/Core/BoundingSphere.js
@@ -544,7 +544,7 @@ define([
     /**
      * Computes a tight-fitting bounding sphere enclosing the provided array of bounding spheres.
      *
-     * @param {BoundingSphere} boundingSpheres The array of bounding spheres.
+     * @param {BoundingSphere[]} boundingSpheres The array of bounding spheres.
      * @param {BoundingSphere} [result] The object onto which to store the result.
      * @returns {BoundingSphere} The modified result parameter or a new BoundingSphere instance if none was provided.
      */

--- a/Source/Core/BoundingSphere.js
+++ b/Source/Core/BoundingSphere.js
@@ -547,8 +547,6 @@ define([
      * @param {BoundingSphere} boundingSpheres The array of bounding spheres.
      * @param {BoundingSphere} [result] The object onto which to store the result.
      * @returns {BoundingSphere} The modified result parameter or a new BoundingSphere instance if none was provided.
-     *
-     * @exception
      */
     BoundingSphere.fromBoundingSpheres = function(boundingSpheres, result) {
         if (!defined(result)) {

--- a/Specs/Core/BoundingSphereSpec.js
+++ b/Specs/Core/BoundingSphereSpec.js
@@ -347,6 +347,43 @@ defineSuite([
         }).toThrowDeveloperError();
     });
 
+    it('fromBoundingSpheres with undefined returns an empty sphere', function() {
+        var sphere = BoundingSphere.fromBoundingSpheres();
+        expect(sphere.center).toEqual(Cartesian3.ZERO);
+        expect(sphere.radius).toEqual(0.0);
+    });
+
+    it('fromBoundingSpheres with empty array returns an empty sphere', function() {
+        var sphere = BoundingSphere.fromBoundingSpheres([]);
+        expect(sphere.center).toEqual(Cartesian3.ZERO);
+        expect(sphere.radius).toEqual(0.0);
+    });
+
+    it('fromBoundingSpheres works with 1 sphere', function() {
+        var one = new BoundingSphere(new Cartesian3(1, 2, 3), 4);
+
+        var sphere = BoundingSphere.fromBoundingSpheres([one]);
+        expect(sphere).toEqual(one);
+    });
+
+    it('fromBoundingSpheres works with 2 spheres', function() {
+        var one = new BoundingSphere(new Cartesian3(1, 2, 3), 4);
+        var two = new BoundingSphere(new Cartesian3(5, 6, 7), 8);
+
+        var sphere = BoundingSphere.fromBoundingSpheres([one, two]);
+        expect(sphere).toEqual(BoundingSphere.union(one, two, new BoundingSphere()));
+    });
+
+    it('fromBoundingSpheres works with 3 spheres', function() {
+        var one = new BoundingSphere(new Cartesian3(0, 0, 0), 1);
+        var two = new BoundingSphere(new Cartesian3(0, 3, 0), 1);
+        var three = new BoundingSphere(new Cartesian3(0, 0, 4), 1);
+
+        var expected = new BoundingSphere(new Cartesian3(0.0, 1.5, 2.0), 3.5);
+        var sphere = BoundingSphere.fromBoundingSpheres([one, two, three]);
+        expect(sphere).toEqual(expected);
+    });
+
     it('sphere on the positive side of a plane', function() {
         var sphere = new BoundingSphere(Cartesian3.ZERO, 0.5);
         var normal = Cartesian3.negate(Cartesian3.UNIT_X, new Cartesian3());


### PR DESCRIPTION
Creates a BoundingSphere that encloses the specified array of BoundingSpheres.

In addition to tests, I wrote the following Sandcastle example to inspect things visually

```
var numberOfSpheres = 10;
var geometry = [];
var spheres = [];
var viewer = new Cesium.Viewer('cesiumContainer');

for (var i = 0; i < numberOfSpheres; i++) {
    var radius = 1000000 + Math.random() * 3000000;
    var center = new Cesium.Cartesian3(8000000 + Math.random() * 8000000, Math.random() * 8000000, Math.random() * 8000000);
    spheres.push(new Cesium.BoundingSphere(center, radius));

    geometry.push(new Cesium.GeometryInstance({
        geometry : new Cesium.SphereOutlineGeometry({
            radius : radius
        }),
        modelMatrix : Cesium.Matrix4.fromTranslation(center),
        attributes : {
            color : Cesium.ColorGeometryInstanceAttribute.fromColor(Cesium.Color.fromRandom({
                alpha : 1
            }))
        }
    }));

}

var sphere = Cesium.BoundingSphere.fromBoundingSpheres(spheres);

geometry.push(new Cesium.GeometryInstance({
    geometry : new Cesium.SphereOutlineGeometry({
        radius : sphere.radius
    }),
    modelMatrix : Cesium.Matrix4.fromTranslation(sphere.center),
    attributes : {
        color : Cesium.ColorGeometryInstanceAttribute.fromColor(Cesium.Color.WHITE)
    }
}));

viewer.scene.primitives.add(new Cesium.Primitive({
    geometryInstances : geometry,
    appearance : new Cesium.PerInstanceColorAppearance({
        flat : true,
        renderState : {
            lineWidth : Math.min(2.0, viewer.scene.maximumAliasedLineWidth)
        }
    })
}));
```