### PR TITLE
Add Per-Instance bounding sphere

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,7 @@ Change Log
 * Fixed a bug in `EllipsoidGeodesic` that caused it to modify the `height` of the positions passed to the constructor or to to `setEndPoints`.
 * Instead of throwing an exception when there are not enough unique positions to define a geometry, creating a `Primitive` will succeed, but not render. [#2375](https://github.com/AnalyticalGraphicsInc/cesium/issues/2375)
 * `WebMapTileServiceImageryProvider` now supports RESTful requests (by accepting a tile-URL template).
+* The object returned by `Primitive.getGeometryInstanceAttributes` now contains the instance's bounding sphere.
 
 ### 1.5 - 2015-01-05
 

--- a/Source/Scene/Primitive.js
+++ b/Source/Scene/Primitive.js
@@ -1247,8 +1247,12 @@ define([
     };
 
     function createGetFunction(name, perInstanceAttributes) {
+        var attribute = perInstanceAttributes[name];
         return function() {
-            return perInstanceAttributes[name].value;
+            if (defined(attribute) && defined(attribute.value)) {
+                return perInstanceAttributes[name].value;
+            }
+            return attribute;
         };
     }
 
@@ -1317,9 +1321,12 @@ define([
             if (perInstanceAttributes.hasOwnProperty(name)) {
                 hasProperties = true;
                 properties[name] = {
-                    get : createGetFunction(name, perInstanceAttributes),
-                    set : createSetFunction(name, perInstanceAttributes, this._dirtyAttributes)
+                    get : createGetFunction(name, perInstanceAttributes)
                 };
+
+                if (name !== 'boundingSphere' && name !== 'boundingSphereCV') {
+                    properties[name].set = createSetFunction(name, perInstanceAttributes, this._dirtyAttributes);
+                }
             }
         }
 

--- a/Source/Scene/PrimitivePipeline.js
+++ b/Source/Scene/PrimitivePipeline.js
@@ -329,6 +329,13 @@ define([
     function computePerInstanceAttributeLocationsForGeometry(instanceIndex, geometry, instanceAttributes, names, attributeLocations, vertexArrays, indices, offsets, vaIndices) {
         var numberOfVertices = Geometry.computeNumberOfVertices(geometry);
 
+        if (!defined(indices[instanceIndex])) {
+            indices[instanceIndex] = {
+                boundingSphere : geometry.boundingSphere,
+                boundingSphereCV : geometry.boundingSphereCV
+            };
+        }
+
         var namesLength = names.length;
         for (var j = 0; j < namesLength; ++j) {
             var name = names[j];
@@ -346,10 +353,6 @@ define([
                     if (attribute.index === index) {
                         break;
                     }
-                }
-
-                if (!defined(indices[instanceIndex])) {
-                    indices[instanceIndex] = {};
                 }
 
                 if (!defined(indices[instanceIndex][name])) {
@@ -856,8 +859,14 @@ define([
         var count = 1 + length;
         for (var i = 0; i < length; i++) {
             var instance = attributeLocations[i];
+
+            count += 2;
+            count += defined(instance.boundingSphere) ? BoundingSphere.packedLength : 0.0;
+            count += defined(instance.boundingSphereCV) ? BoundingSphere.packedLength : 0.0;
+
             for ( var propertyName in instance) {
-                if (instance.hasOwnProperty(propertyName) && defined(instance[propertyName])) {
+                if (instance.hasOwnProperty(propertyName) && defined(instance[propertyName]) &&
+                        propertyName !== 'boundingSphere' && propertyName !== 'boundingSphereCV') {
                     var property = instance[propertyName];
                     count += 4 + (property.indices.length * 3) + property.value.length;
                 }
@@ -878,9 +887,26 @@ define([
         for (var i = 0; i < length; i++) {
             var instance = attributeLocations[i];
 
+            var boundingSphere = instance.boundingSphere;
+            var hasBoundingSphere = defined(boundingSphere);
+            packedData[count++] = hasBoundingSphere ? 1.0 : 0.0;
+            if (hasBoundingSphere) {
+                BoundingSphere.pack(boundingSphere, packedData, count);
+                count += BoundingSphere.packedLength;
+            }
+
+            boundingSphere = instance.boundingSphereCV;
+            hasBoundingSphere = defined(boundingSphere);
+            packedData[count++] = hasBoundingSphere ? 1.0 : 0.0;
+            if (hasBoundingSphere) {
+                BoundingSphere.pack(boundingSphere, packedData, count);
+                count += BoundingSphere.packedLength;
+            }
+
             var propertiesToWrite = [];
             for ( var propertyName in instance) {
-                if (instance.hasOwnProperty(propertyName) && defined(instance[propertyName])) {
+                if (instance.hasOwnProperty(propertyName) && defined(instance[propertyName]) &&
+                        propertyName !== 'boundingSphere' && propertyName !== 'boundingSphereCV') {
                     propertiesToWrite.push(propertyName);
                     if (!defined(stringHash[propertyName])) {
                         stringHash[propertyName] = stringTable.length;
@@ -937,6 +963,19 @@ define([
         var packedDataLength = packedData.length;
         while (i < packedDataLength) {
             var instance = {};
+
+            var hasBoundingSphere = packedData[i++] === 1.0;
+            if (hasBoundingSphere) {
+                instance.boundingSphere = BoundingSphere.unpack(packedData, i);
+                i += BoundingSphere.packedLength;
+            }
+
+            hasBoundingSphere = packedData[i++] === 1.0;
+            if (hasBoundingSphere) {
+                instance.boundingSphereCV = BoundingSphere.unpack(packedData, i);
+                i += BoundingSphere.packedLength;
+            }
+
             var numAttributes = packedData[i++];
             for (var x = 0; x < numAttributes; x++) {
                 var name = stringTable[packedData[i++]];

--- a/Specs/Scene/PrimitiveSpec.js
+++ b/Specs/Scene/PrimitiveSpec.js
@@ -731,6 +731,32 @@ defineSuite([
         primitive = primitive && primitive.destroy();
     });
 
+    it('get bounding sphere from per instance attribute', function() {
+        var primitive = new Primitive({
+            geometryInstances : rectangleInstance1,
+            appearance : new PerInstanceColorAppearance(),
+            asynchronous : false
+        });
+
+        frameState.camera.viewRectangle(rectangle1);
+        us.update(context, frameState);
+
+        ClearCommand.ALL.execute(context);
+        expect(context.readPixels()).toEqual([0, 0, 0, 0]);
+
+        render(context, frameState, primitive);
+        expect(context.readPixels()).not.toEqual([0, 0, 0, 0]);
+
+        var attributes = primitive.getGeometryInstanceAttributes('rectangle1');
+        expect(attributes.boundingSphere).toBeDefined();
+
+        var rectangleGeometry = RectangleGeometry.createGeometry(rectangleInstance1.geometry);
+        var expected = rectangleGeometry.boundingSphere;
+        expect(attributes.boundingSphere).toEqual(expected);
+
+        primitive = primitive && primitive.destroy();
+    });
+
     it('picking', function() {
         var primitive = new Primitive({
             geometryInstances : [rectangleInstance1, rectangleInstance2],


### PR DESCRIPTION
The object returned by `Primitive.getGeometryInstanceAttributes` now contains the instance's bounding sphere.