### PR TITLE
Add Model.readyPromise and Primitive.readyPromise

### DIFF
--- a/Apps/Sandcastle/gallery/3D Models.html
+++ b/Apps/Sandcastle/gallery/3D Models.html
@@ -42,7 +42,7 @@ function createModel(url, height) {
         minimumPixelSize : 128
     }));
 
-    model.readyToRender.addEventListener(function(model) {
+    model.readyPromise.then(function(model) {
         // Play and loop all animations at half-speed
         model.activeAnimations.addAll({
             speedup : 0.5,
@@ -58,6 +58,8 @@ function createModel(url, height) {
         var r = 2.0 * Math.max(model.boundingSphere.radius, camera.frustum.near);
         controller.minimumZoomDistance = r * 0.5;
         camera.lookAt(new Cesium.Cartesian3(r, r, r), Cesium.Cartesian3.ZERO, Cesium.Cartesian3.UNIT_Z);
+    }).otherwise(function(error){
+        window.alert(error);
     });
 }
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,7 @@ Change Log
 * Added `PolygonHierarchy` to make defining polygons with holes clearer.
 * Added `PolygonGraphics.hierarchy` for supporting polygons with holes via data sources.
 * Added 'BoundingSphere.fromBoundingSpheres', which creates a BoundingSphere that encloses the specified array of BoundingSpheres.
+* Added 'Model.readyPromise' and 'Primitive.readyPromise' which are promises that resolve when the primitives are ready.
 * `GeoJsonDataSource` now supports polygons with holes.
 * `ConstantProperty` can now hold any value; previously it was limited to values that implemented `equals` and `clones` functions, as well as a few special cases.
 * Fixed a bug in `EllipsoidGeodesic` that caused it to modify the `height` of the positions passed to the constructor or to to `setEndPoints`.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@ Change Log
   * `PolygonGraphics.positions` created by `GeoJSONDataSource` now evaluate to a `PolygonHierarchy` object instead of an array of positions.
 * Deprecated
   * `PolygonGraphics.positions` was deprecated and replaced with `PolygonGraphics.hierarchy`, whose value is a `PolygonHierarchy` instead of an array of positions.  `PolygonGraphics.positions` will be removed in Cesium 1.8.
+  * The `Model.readyToRender` event was deprecated and will be removed in Cesium 1.9.  Use the new 'Model.readyPromise' instead.
 * Improved performance of asynchronous geometry creation (as much as 20% faster in some use cases). [#2342](https://github.com/AnalyticalGraphicsInc/cesium/issues/2342)
 * Added `PolylineVolumeGraphics` and `Entity.polylineVolume`
 * Added `BillboardGraphics.imageSubRegion`, to enable custom texture atlas use for `Entity` instances.

--- a/Source/Core/TaskProcessor.js
+++ b/Source/Core/TaskProcessor.js
@@ -6,7 +6,9 @@ define([
         './defaultValue',
         './defined',
         './destroyObject',
+        './DeveloperError',
         './isCrossOriginUrl',
+        './RuntimeError',
         'require'
     ], function(
         Uri,
@@ -15,7 +17,9 @@ define([
         defaultValue,
         defined,
         destroyObject,
+        DeveloperError,
         isCrossOriginUrl,
+        RuntimeError,
         require) {
     "use strict";
 
@@ -73,7 +77,15 @@ define([
         var deferred = deferreds[id];
 
         if (defined(data.error)) {
-            deferred.reject(data.error);
+            var error = data.error;
+            if (error.name === 'RuntimeError') {
+                error = new RuntimeError(data.error.message);
+                error.stack = data.error.stack;
+            } else if (error.name === 'DeveloperError') {
+                error = new DeveloperError(data.error.message);
+                error.stack = data.error.stack;
+            }
+            deferred.reject(error);
         } else {
             deferred.resolve(data.result);
         }

--- a/Source/DataSources/ModelVisualizer.js
+++ b/Source/DataSources/ModelVisualizer.js
@@ -20,6 +20,7 @@ define([
         ModelAnimationLoop,
         Property) {
     "use strict";
+    /*global console*/
 
     var defaultScale = 1.0;
     var defaultMinimumPixelSize = 0.0;
@@ -105,7 +106,7 @@ define([
                     url : uri
                 });
 
-                model.readyToRender.addEventListener(readyToRender, this);
+                model.readyPromise.then(onModelReady).otherwise(onModelError);
 
                 model.id = entity;
                 primitives.add(model);
@@ -185,17 +186,20 @@ define([
     function removeModel(visualizer, entity, modelHash, primitives) {
         var modelData = modelHash[entity.id];
         if (defined(modelData)) {
-            var model = modelData.modelPrimitive;
-            model.readyToRender.removeEventListener(readyToRender, visualizer);
-            primitives.removeAndDestroy(model);
+            primitives.removeAndDestroy(modelData.modelPrimitive);
             delete modelHash[entity.id];
         }
     }
 
-    function readyToRender(model) {
+    function onModelReady(model) {
         model.activeAnimations.addAll({
             loop : ModelAnimationLoop.REPEAT
         });
     }
+
+    function onModelError(error) {
+        console.error(error);
+    }
+
     return ModelVisualizer;
 });

--- a/Source/Scene/Model.js
+++ b/Source/Scene/Model.js
@@ -509,7 +509,7 @@ define([
          *
          * @default undefined
          *
-         * @exception {DeveloperError} The model is not loaded.  Use the Model.readyPromise or wait for Model.ready to be true.
+         * @exception {DeveloperError} The model is not loaded.  Use Model.readyPromise or wait for Model.ready to be true.
          *
          * @example
          * // Center in WGS84 coordinates
@@ -519,7 +519,7 @@ define([
             get : function() {
                 //>>includeStart('debug', pragmas.debug);
                 if (this._state !== ModelState.LOADED) {
-                    throw new DeveloperError('The model is not loaded.  Use the Model.readyPromise or wait for Model.ready to be true.');
+                    throw new DeveloperError('The model is not loaded.  Use Model.readyPromise or wait for Model.ready to be true.');
                 }
                 //>>includeEnd('debug');
 
@@ -759,7 +759,7 @@ define([
     function getRuntime(model, runtimeName, name) {
         //>>includeStart('debug', pragmas.debug);
         if (model._state !== ModelState.LOADED) {
-            throw new DeveloperError('The model is not loaded.  Use the Model.readyPromise or wait for Model.ready to be true.');
+            throw new DeveloperError('The model is not loaded.  Use Model.readyPromise or wait for Model.ready to be true.');
         }
 
         if (!defined(name)) {
@@ -777,7 +777,7 @@ define([
      * @param {String} name The glTF name of the node.
      * @returns {ModelNode} The node or <code>undefined</code> if no node with <code>name</code> exists.
      *
-     * @exception {DeveloperError} The model is not loaded.  Use the Model.readyPromise or wait for Model.ready to be true.
+     * @exception {DeveloperError} The model is not loaded.  Use Model.readyPromise or wait for Model.ready to be true.
      *
      * @example
      * // Apply non-uniform scale to node LOD3sp
@@ -796,7 +796,7 @@ define([
      *
      * @returns {ModelMesh} The mesh or <code>undefined</code> if no mesh with <code>name</code> exists.
      *
-     * @exception {DeveloperError} The model is not loaded.  Use the Model.readyPromise or wait for Model.ready to be true.
+     * @exception {DeveloperError} The model is not loaded.  Use Model.readyPromise or wait for Model.ready to be true.
      */
     Model.prototype.getMesh = function(name) {
         return getRuntime(this, 'meshesByName', name);
@@ -808,7 +808,7 @@ define([
      * @param {String} name The glTF name of the material.
      * @returns {ModelMaterial} The material or <code>undefined</code> if no material with <code>name</code> exists.
      *
-     * @exception {DeveloperError} The model is not loaded.  Use the Model.readyPromise or wait for Model.ready to be true.
+     * @exception {DeveloperError} The model is not loaded.  Use Model.readyPromise or wait for Model.ready to be true.
      */
     Model.prototype.getMaterial = function(name) {
         return getRuntime(this, 'materialsByName', name);

--- a/Source/Scene/Model.js
+++ b/Source/Scene/Model.js
@@ -31,6 +31,7 @@ define([
         '../Renderer/TextureWrap',
         '../ThirdParty/gltfDefaults',
         '../ThirdParty/Uri',
+        '../ThirdParty/when',
         './getModelAccessor',
         './ModelAnimationCache',
         './ModelAnimationCollection',
@@ -71,6 +72,7 @@ define([
         TextureWrap,
         gltfDefaults,
         Uri,
+        when,
         getModelAccessor,
         ModelAnimationCache,
         ModelAnimationCollection,
@@ -348,6 +350,7 @@ define([
          */
         this.readyToRender = new Event();
         this._ready = false;
+        this._readyPromise = when.defer();
 
         /**
          * The currently playing glTF animations.
@@ -560,6 +563,18 @@ define([
         ready : {
             get : function() {
                 return this._ready;
+            }
+        },
+
+        /**
+         * Gets a promise that resolves when the model is ready to render.
+         * @memberof Model.prototype
+         * @type {Promise}
+         * @readonly
+         */
+        readyPromise : {
+            get : function() {
+                return this._readyPromise;
             }
         },
 
@@ -2605,6 +2620,7 @@ define([
             frameState.afterRender.push(function() {
                 model._ready = true;
                 model.readyToRender.raiseEvent(model);
+                model.readyPromise.resolve(model);
             });
             return;
         }

--- a/Source/Scene/Scene.js
+++ b/Source/Scene/Scene.js
@@ -812,7 +812,6 @@ define([
         frameState.camera = camera;
         frameState.cullingVolume = camera.frustum.computeCullingVolume(camera.positionWC, camera.directionWC, camera.upWC);
         frameState.occluder = getOccluder(scene);
-        frameState.afterRender.length = 0;
 
         clearPasses(frameState.passes);
     }

--- a/Specs/BadGeometry.js
+++ b/Specs/BadGeometry.js
@@ -1,0 +1,25 @@
+/*global define*/
+define(['Core/RuntimeError'], function(RuntimeError) {
+    "use strict";
+
+    var BadGeometry = function() {
+        this._workerName = '../../Specs/TestWorkers/createBadGeometry';
+    };
+
+    BadGeometry.createGeometry = function() {
+        //This function is only called when synchronous, see Specs/TestWorks/createBadGeometry for asynchronous.
+        throw new RuntimeError('BadGeometry.createGeometry');
+    };
+
+    BadGeometry.packedLength = 0;
+
+    BadGeometry.pack = function() {
+
+    };
+
+    BadGeometry.unpack = function() {
+        return new BadGeometry();
+    };
+
+    return BadGeometry;
+});

--- a/Specs/Scene/ModelSpec.js
+++ b/Specs/Scene/ModelSpec.js
@@ -105,6 +105,7 @@ defineSuite([
     }
 
     function verifyRender(model) {
+        expect(model.ready).toBe(true);
         expect(scene.renderForSpecs()).toEqual([0, 0, 0, 255]);
         model.show = true;
         model.zoomTo();

--- a/Specs/Scene/ModelSpec.js
+++ b/Specs/Scene/ModelSpec.js
@@ -13,7 +13,8 @@ defineSuite([
         'Core/Transforms',
         'Scene/ModelAnimationLoop',
         'Specs/createScene',
-        'Specs/destroyScene'
+        'Specs/destroyScene',
+        'Specs/waitsForPromise'
     ], function(
         Model,
         Cartesian2,
@@ -28,7 +29,8 @@ defineSuite([
         Transforms,
         ModelAnimationLoop,
         createScene,
-        destroyScene) {
+        destroyScene,
+        waitsForPromise) {
     "use strict";
     /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor,WebGLRenderingContext*/
 
@@ -148,6 +150,12 @@ defineSuite([
 
     it('renders', function() {
         verifyRender(duckModel);
+    });
+
+    it('resolves readyPromise', function() {
+        waitsForPromise(duckModel.readyPromise, function(model) {
+            verifyRender(model);
+        });
     });
 
     it('renders from glTF', function() {

--- a/Specs/Scene/PrimitiveSpec.js
+++ b/Specs/Scene/PrimitiveSpec.js
@@ -27,7 +27,8 @@ defineSuite([
         'Specs/destroyContext',
         'Specs/destroyScene',
         'Specs/pick',
-        'Specs/render'
+        'Specs/render',
+        'Specs/waitsForPromise'
     ], function(
         Primitive,
         BoxGeometry,
@@ -56,7 +57,8 @@ defineSuite([
         destroyContext,
         destroyScene,
         pick,
-        render) {
+        render,
+        waitsForPromise) {
     "use strict";
     /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
@@ -199,6 +201,21 @@ defineSuite([
         expect(primitive.geometryInstances).toBeDefined();
 
         primitive = primitive && primitive.destroy();
+    });
+
+    it('does not release geometry instances when releaseGeometryInstances is false', function() {
+        var primitive = new Primitive({
+            geometryInstances : [rectangleInstance1, rectangleInstance2],
+            appearance : new PerInstanceColorAppearance(),
+            releaseGeometryInstances : false,
+            asynchronous : false
+        });
+
+        waitsForPromise(primitive.readyPromise, function(param) {
+            expect(param.ready).toBe(true);
+            primitive = primitive && primitive.destroy();
+        });
+        primitive.update(context, frameState, []);
     });
 
     it('does not render when geometryInstances is an empty array', function() {

--- a/Specs/TestWorkers/createBadGeometry.js
+++ b/Specs/TestWorkers/createBadGeometry.js
@@ -1,0 +1,8 @@
+/*global define*/
+define(['Core/RuntimeError'], function(RuntimeError) {
+    "use strict";
+
+    return function() {
+        throw new RuntimeError('BadGeometry.createGeometry');
+    };
+});


### PR DESCRIPTION
We should also deprecate `Model.readyToRender`, but I wanted to make sure @pjcozzi was okay with it first.  Having an event that only fires once are just the sort of problem promises are meant to solve.