### PR TITLE
Fix polygon geometry packing.

### DIFF
--- a/Source/Core/PolygonGeometry.js
+++ b/Source/Core/PolygonGeometry.js
@@ -604,8 +604,13 @@ define([
      * var geometry = Cesium.PolygonGeometry.createGeometry(extrudedPolygon);
      */
     var PolygonGeometry = function(options) {
-        options = defaultValue(options, defaultValue.EMPTY_OBJECT);
+        //>>includeStart('debug', pragmas.debug);
+        if (!defined(options) || !defined(options.polygonHierarchy)) {
+            throw new DeveloperError('options.polygonHierarchy is required.');
+        }
+        //>>includeEnd('debug');
 
+        var polygonHierarchy = options.polygonHierarchy;
         var vertexFormat = defaultValue(options.vertexFormat, VertexFormat.DEFAULT);
         var ellipsoid = defaultValue(options.ellipsoid, Ellipsoid.WGS84);
         var granularity = defaultValue(options.granularity, CesiumMath.RADIANS_PER_DEGREE);
@@ -620,13 +625,6 @@ define([
             extrudedHeight = Math.min(h, height);
             height = Math.max(h, height);
         }
-        var polygonHierarchy = options.polygonHierarchy;
-
-        //>>includeStart('debug', pragmas.debug);
-        if (!defined(polygonHierarchy)) {
-            throw new DeveloperError('options.polygonHierarchy is required.');
-        }
-        //>>includeEnd('debug');
 
         this._vertexFormat = VertexFormat.clone(vertexFormat);
         this._ellipsoid = Ellipsoid.clone(ellipsoid);
@@ -643,7 +641,7 @@ define([
          * The number of elements used to pack the object into an array.
          * @type {Number}
          */
-        this.packedLength = PolygonGeometryLibrary.computeHierarchyPackedLength(polygonHierarchy) + Ellipsoid.packedLength + VertexFormat.packedLength + 6;
+        this.packedLength = PolygonGeometryLibrary.computeHierarchyPackedLength(polygonHierarchy) + Ellipsoid.packedLength + VertexFormat.packedLength + 7;
     };
 
     /**
@@ -730,20 +728,16 @@ define([
         array[startingIndex++] = value._granularity;
         array[startingIndex++] = value._stRotation;
         array[startingIndex++] = value._extrude ? 1.0 : 0.0;
-        array[startingIndex] = value._perPositionHeight ? 1.0 : 0.0;
+        array[startingIndex++] = value._perPositionHeight ? 1.0 : 0.0;
+        array[startingIndex] = value.packedLength;
     };
 
     var scratchEllipsoid = Ellipsoid.clone(Ellipsoid.UNIT_SPHERE);
     var scratchVertexFormat = new VertexFormat();
-    var scratchOptions = {
-        polygonHierarchy : undefined,
-        ellipsoid : scratchEllipsoid,
-        vertexFormat : scratchVertexFormat,
-        height : undefined,
-        extrudedHeight : undefined,
-        granularity : undefined,
-        stRotation : undefined,
-        perPositionHeight : undefined
+
+    //Only used to avoid inaability to default construct.
+    var dummyOptions = {
+        polygonHierarchy : {}
     };
 
     /**
@@ -777,16 +771,11 @@ define([
         var granularity = array[startingIndex++];
         var stRotation = array[startingIndex++];
         var extrude = array[startingIndex++] === 1.0;
-        var perPositionHeight = array[startingIndex] === 1.0;
+        var perPositionHeight = array[startingIndex++] === 1.0;
+        var packedLength = array[startingIndex];
 
         if (!defined(result)) {
-            scratchOptions.polygonHierarchy = polygonHierarchy;
-            scratchOptions.height = height;
-            scratchOptions.extrudedHeight = extrudedHeight;
-            scratchOptions.granularity = granularity;
-            scratchOptions.stRotation = stRotation;
-            scratchOptions.perPositionHeight = perPositionHeight;
-            return new PolygonGeometry(scratchOptions);
+            result = new PolygonGeometry(dummyOptions);
         }
 
         result._polygonHierarchy = polygonHierarchy;
@@ -798,7 +787,7 @@ define([
         result._stRotation = stRotation;
         result._extrude = extrude;
         result._perPositionHeight = perPositionHeight;
-
+        result.packedLength = packedLength;
         return result;
     };
 

--- a/Specs/Core/PolygonGeometrySpec.js
+++ b/Specs/Core/PolygonGeometrySpec.js
@@ -418,7 +418,8 @@ defineSuite([
     var polygon = new PolygonGeometry({
         vertexFormat : VertexFormat.POSITION_ONLY,
         polygonHierarchy : hierarchy,
-        granularity : CesiumMath.PI_OVER_THREE
+        granularity : CesiumMath.PI_OVER_THREE,
+        perPositionHeight : true
     });
 
     function addPositions(array, positions) {
@@ -433,6 +434,6 @@ defineSuite([
     packedInstance.push(3.0, 0.0);
     addPositions(packedInstance, holePositions1);
     packedInstance.push(Ellipsoid.WGS84.radii.x, Ellipsoid.WGS84.radii.y, Ellipsoid.WGS84.radii.z);
-    packedInstance.push(1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, CesiumMath.PI_OVER_THREE, 0.0, 0.0, 0.0);
+    packedInstance.push(1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, CesiumMath.PI_OVER_THREE, 0.0, 0.0, 1.0, 49);
     createPackableSpecs(PolygonGeometry, polygon, packedInstance);
 });

--- a/Specs/Core/PolygonOutlineGeometrySpec.js
+++ b/Specs/Core/PolygonOutlineGeometrySpec.js
@@ -307,7 +307,8 @@ defineSuite([
     };
     var polygon = new PolygonOutlineGeometry({
         polygonHierarchy : hierarchy,
-        granularity : CesiumMath.PI_OVER_THREE
+        granularity : CesiumMath.PI_OVER_THREE,
+        perPositionHeight : true
     });
      function addPositions(array, positions) {
         for (var i = 0; i < positions.length; ++i) {
@@ -321,7 +322,7 @@ defineSuite([
     packedInstance.push(3.0, 0.0);
     addPositions(packedInstance, holePositions1);
     packedInstance.push(Ellipsoid.WGS84.radii.x, Ellipsoid.WGS84.radii.y, Ellipsoid.WGS84.radii.z);
-    packedInstance.push(0.0, 0.0, CesiumMath.PI_OVER_THREE, 0.0, 0.0);
+    packedInstance.push(0.0, 0.0, CesiumMath.PI_OVER_THREE, 0.0, 1.0, 42);
     createPackableSpecs(PolygonOutlineGeometry, polygon, packedInstance);
 
 });

--- a/Specs/createPackableSpecs.js
+++ b/Specs/createPackableSpecs.js
@@ -15,6 +15,13 @@ define(['Core/defined'], function(defined) {
             expect(packedArray).toEqual(packedInstance);
         });
 
+        it('can roundtrip', function() {
+            var packedArray = [];
+            packable.pack(instance, packedArray);
+            var result = packable.unpack(packedArray);
+            expect(instance).toEqual(result);
+        });
+
         it('can unpack', function() {
             var result = packable.unpack(packedInstance);
             expect(result).toEqual(instance);


### PR DESCRIPTION
Even when `options.height` is undefined, we set it to 0.  We then compute a separate `_extrude` boolean property based on `perPositionHeight`.  When we started packing/unpacking geometry, the `_extrude` property would be incorrectly computed because the `unpack` process would see `options.height` as 0 instead of undefined.

I did a quick review of the other geometry and it looked like polygons were the only ones affected by this issue.  It wasn't caught by the packing tests because the packing tests always caused `_extrude` to be false because neither `height`, `extrudedHeight`, or `perPositionHeight` were set in the test data.

While looking over the code, I found some other potential areas for cleanup as well; but I'll write a separate issue for those so I can look at them in the future.

Fixes #2398