### PR TITLE
Cache attributes returned by getGeometryInstanceAttributes.

### DIFF
--- a/Source/Scene/Primitive.js
+++ b/Source/Scene/Primitive.js
@@ -273,6 +273,7 @@ define([
         this._boundingSphere2D = [];
         this._boundingSphereMorph = [];
         this._perInstanceAttributeLocations = undefined;
+        this._perInstanceAttributeCache = [];
         this._instanceIds = [];
         this._lastPerInstanceAttributeIndex = 0;
         this._dirtyAttributes = [];
@@ -1334,9 +1335,13 @@ define([
         if (index === -1) {
             return undefined;
         }
+        var attributes = this._perInstanceAttributeCache[index];
+        if (defined(attributes)) {
+            return attributes;
+        }
 
         var perInstanceAttributes = this._perInstanceAttributeLocations[index];
-        var attributes = {};
+        attributes = {};
         var properties = {};
         var hasProperties = false;
 
@@ -1358,7 +1363,7 @@ define([
         }
 
         this._lastPerInstanceAttributeIndex = index;
-
+        this._perInstanceAttributeCache[index] = attributes;
         return attributes;
     };
 

--- a/Specs/Scene/PrimitiveSpec.js
+++ b/Specs/Scene/PrimitiveSpec.js
@@ -783,6 +783,29 @@ defineSuite([
         primitive = primitive && primitive.destroy();
     });
 
+    it('getGeometryInstanceAttributes returns same object each time', function() {
+        var primitive = new Primitive({
+            geometryInstances : rectangleInstance1,
+            appearance : new PerInstanceColorAppearance(),
+            asynchronous : false
+        });
+
+        frameState.camera.viewRectangle(rectangle1);
+        us.update(context, frameState);
+
+        ClearCommand.ALL.execute(context);
+        expect(context.readPixels()).toEqual([0, 0, 0, 0]);
+
+        render(context, frameState, primitive);
+        expect(context.readPixels()).not.toEqual([0, 0, 0, 0]);
+
+        var attributes = primitive.getGeometryInstanceAttributes('rectangle1');
+        var attributes2 = primitive.getGeometryInstanceAttributes('rectangle1');
+        expect(attributes).toBe(attributes2);
+
+        primitive = primitive && primitive.destroy();
+    });
+
     it('picking', function() {
         var primitive = new Primitive({
             geometryInstances : [rectangleInstance1, rectangleInstance2],


### PR DESCRIPTION
I found this while working on entity bounding sphere support.  It seems like a straightforward optimization to me, but let me know if I'm missing something. Currently `getGeometryInstanceAttributes` generates a new object every time it's called.  This generates unecessary garbage and forces the caller to cache things himself in order to avoid it. This change simply makes it so that the attributes object is cached after creation and returns the same object the next time the function is called. This both reduces GC pressure and is faster (since we aren't constantly rebuilding objects).  The cache is per-primitive so the memory goes away as soon as the primitive does.