### PR TITLE
Don't throw on calls to remove with undefined.

### DIFF
--- a/Source/Core/AssociativeArray.js
+++ b/Source/Core/AssociativeArray.js
@@ -107,7 +107,7 @@ define([
      */
     AssociativeArray.prototype.remove = function(key) {
         //>>includeStart('debug', pragmas.debug);
-        if (typeof key !== 'string' && typeof key !== 'number') {
+        if (defined(key) && typeof key !== 'string' && typeof key !== 'number') {
             throw new DeveloperError('key is required to be a string or number.');
         }
         //>>includeEnd('debug');

--- a/Source/DataSources/EntityCollection.js
+++ b/Source/DataSources/EntityCollection.js
@@ -211,12 +211,9 @@ define([
      * @returns {Boolean} true if the item was removed, false if it did not exist in the collection.
      */
     EntityCollection.prototype.remove = function(entity) {
-        //>>includeStart('debug', pragmas.debug);
         if (!defined(entity)) {
-            throw new DeveloperError('entity is required');
+            return false;
         }
-        //>>includeEnd('debug');
-
         return this.removeById(entity.id);
     };
 
@@ -227,11 +224,9 @@ define([
      * @returns {Boolean} true if the item was removed, false if no item with the provided id existed in the collection.
      */
     EntityCollection.prototype.removeById = function(id) {
-        //>>includeStart('debug', pragmas.debug);
         if (!defined(id)) {
-            throw new DeveloperError('id is required.');
+            return false;
         }
-        //>>includeEnd('debug');
 
         var entities = this._entities;
         var entity = entities.get(id);

--- a/Specs/Core/AssociativeArraySpec.js
+++ b/Specs/Core/AssociativeArraySpec.js
@@ -73,10 +73,8 @@ defineSuite([
         }).toThrowDeveloperError();
     });
 
-    it('remove throws with undefined key', function() {
+    it('remove returns false with undefined key', function() {
         var associativeArray = new AssociativeArray();
-        expect(function() {
-            associativeArray.remove(undefined);
-        }).toThrowDeveloperError();
+        expect(associativeArray.remove(undefined)).toBe(false);
     });
 });

--- a/Specs/DataSources/EntityCollectionSpec.js
+++ b/Specs/DataSources/EntityCollectionSpec.js
@@ -341,18 +341,14 @@ defineSuite([
         }).toThrowRuntimeError();
     });
 
-    it('remove throws with undefined Entity', function() {
+    it('remove returns false with undefined Entity', function() {
         var entityCollection = new EntityCollection();
-        expect(function() {
-            entityCollection.remove(undefined);
-        }).toThrowDeveloperError();
+        expect(entityCollection.remove(undefined)).toBe(false);
     });
 
-    it('removeById throws for undefined id', function() {
+    it('removeById returns false with undefined id', function() {
         var entityCollection = new EntityCollection();
-        expect(function() {
-            entityCollection.removeById(undefined);
-        }).toThrowDeveloperError();
+        expect(entityCollection.removeById(undefined)).toBe(false);
     });
 
     it('getById throws if no id specified', function() {


### PR DESCRIPTION
AssociativeArray and EntityCollection both throw if their `remove` function is passed `undefined`. In keeping with other collections in Cesium, they now succeed and return false.