### PR TITLE
Don't set billboard.image values if they are the same.

### DIFF
--- a/Source/DataSources/BillboardVisualizer.js
+++ b/Source/DataSources/BillboardVisualizer.js
@@ -221,6 +221,7 @@ define([
         if (defined(item)) {
             var billboard = item.billboard;
             if (defined(billboard)) {
+                item.textureValue = undefined;
                 item.billboard = undefined;
                 billboard.show = false;
                 billboard.image = undefined;

--- a/Source/DataSources/BillboardVisualizer.js
+++ b/Source/DataSources/BillboardVisualizer.js
@@ -50,6 +50,7 @@ define([
     var EntityData = function(entity) {
         this.entity = entity;
         this.billboard = undefined;
+        this.textureValue = undefined;
     };
 
     /**
@@ -137,7 +138,10 @@ define([
             }
 
             billboard.show = show;
-            billboard.image = textureValue;
+            if (item.textureValue !== textureValue) {
+                billboard.image = textureValue;
+                item.textureValue = textureValue;
+            }
             billboard.position = position;
             billboard.color = Property.getValueOrDefault(billboardGraphics._color, time, defaultColor, color);
             billboard.eyeOffset = Property.getValueOrDefault(billboardGraphics._eyeOffset, time, defaultEyeOffset, eyeOffset);

--- a/Source/DataSources/GeoJsonDataSource.js
+++ b/Source/DataSources/GeoJsonDataSource.js
@@ -259,25 +259,18 @@ define([
         stringifyScratch[2] = size;
         var id = JSON.stringify(stringifyScratch);
 
-        var dataURLPromise = dataSource._pinCache[id];
-        if (!defined(dataURLPromise)) {
-            var canvasOrPromise;
-            if (defined(symbol)) {
-                if (symbol.length === 1) {
-                    canvasOrPromise = dataSource._pinBuilder.fromText(symbol.toUpperCase(), color, size);
-                } else {
-                    canvasOrPromise = dataSource._pinBuilder.fromMakiIconId(symbol, color, size);
-                }
+        var canvasOrPromise;
+        if (defined(symbol)) {
+            if (symbol.length === 1) {
+                canvasOrPromise = dataSource._pinBuilder.fromText(symbol.toUpperCase(), color, size);
             } else {
-                canvasOrPromise = dataSource._pinBuilder.fromColor(color, size);
+                canvasOrPromise = dataSource._pinBuilder.fromMakiIconId(symbol, color, size);
             }
-            dataURLPromise = when(canvasOrPromise, function(canvas) {
-                return canvas.toDataURL();
-            });
-            dataSource._pinCache[id] = dataURLPromise;
+        } else {
+            canvasOrPromise = dataSource._pinBuilder.fromColor(color, size);
         }
 
-        dataSource._promises.push(when(dataURLPromise, function(dataUrl) {
+        dataSource._promises.push(when(canvasOrPromise, function(dataUrl) {
             var billboard = new BillboardGraphics();
             billboard.verticalOrigin = new ConstantProperty(VerticalOrigin.BOTTOM);
             billboard.image = new ConstantProperty(dataUrl);
@@ -496,7 +489,6 @@ define([
         this._loading = new Event();
         this._entityCollection = new EntityCollection();
         this._promises = [];
-        this._pinCache = {};
         this._pinBuilder = new PinBuilder();
     };
 
@@ -864,7 +856,6 @@ define([
 
             return when.all(that._promises, function() {
                 that._promises.length = 0;
-                that._pinCache = {};
                 DataSource.setLoading(that, false);
             });
         }).otherwise(function(error) {

--- a/Specs/DataSources/GeoJsonDataSourceSpec.js
+++ b/Specs/DataSources/GeoJsonDataSourceSpec.js
@@ -491,7 +491,7 @@ defineSuite([
             expect(entity.polygon.outlineWidth.getValue()).toEqual(options.strokeWidth);
 
             entity = entities[2];
-            var expectedImage = dataSource._pinBuilder.fromMakiIconId(options.markerSymbol, options.markerColor, options.markerSize).toDataURL();
+            var expectedImage = dataSource._pinBuilder.fromMakiIconId(options.markerSymbol, options.markerColor, options.markerSize);
             expect(entity.billboard.image.getValue()).toEqual(expectedImage);
         });
     });
@@ -519,7 +519,7 @@ defineSuite([
             expect(entity.polygon.outlineWidth.getValue()).toEqual(GeoJsonDataSource.strokeWidth);
 
             entity = entities[2];
-            var expectedImage = dataSource._pinBuilder.fromMakiIconId(GeoJsonDataSource.markerSymbol, GeoJsonDataSource.markerColor, GeoJsonDataSource.markerSize).toDataURL();
+            var expectedImage = dataSource._pinBuilder.fromMakiIconId(GeoJsonDataSource.markerSymbol, GeoJsonDataSource.markerColor, GeoJsonDataSource.markerSize);
             expect(entity.billboard.image.getValue()).toEqual(expectedImage);
         });
     });


### PR DESCRIPTION
Every time we assign a canvas to billboard.image it creates a new texture, even if it's the same canvas instance. This is by design because canvases can be drawn to multiple times. (like people trying to do billboard animation). Since using a canvas causes this to happen every frame in the BillboardVisualizer, we are constantly creating textures and adding them to the atlas.

To fix this in the short term, I simply treat canvas elements in the Entity API as if it's always the same image. This prevents the problem and the only "feature" we lose is to keep drawing to a canvas and have it automatically update in the billboard (which is probably the wrong way to do billboard animation anyway since it's incredibly inneficient).

When I have some free time, I'll look into adding a proper billboard animation demo to Sandcastle using the Entity API. We may even be able to handle animated GIFs this way.

This also allowed me to remove some code from GeoJSONDataSource.