### PR TITLE
Camera fly to with heading, pitch, roll

### DIFF
--- a/Apps/Sandcastle/gallery/Camera.html
+++ b/Apps/Sandcastle/gallery/Camera.html
@@ -38,6 +38,16 @@ function flyToSanDiego() {
     });
 }
 
+function flyToHeadingPitchRoll() {
+    Sandcastle.declare(flyToHeadingPitchRoll);
+    viewer.camera.flyToHeadingPitchRoll({
+        destination : Cesium.Cartesian3.fromDegrees(-122.19, 46.25, 5000.0),
+        heading : Cesium.Math.toRadians(175.0),
+        pitch : Cesium.Math.toRadians(-35.0),
+        roll : 0.0
+    });
+}
+
 function flyToLocation() {
     Sandcastle.declare(flyToLocation);
 
@@ -167,6 +177,12 @@ Sandcastle.addToolbarMenu([{
     onselect : function() {
         flyToSanDiego();
         Sandcastle.highlight(flyToSanDiego);
+    }
+}, {
+    text : 'Fly to Location with heading, pitch and roll',
+    onselect : function() {
+        flyToHeadingPitchRoll();
+        Sandcastle.highlight(flyToHeadingPitchRoll);
     }
 }, {
     text : 'Fly to My Location',

--- a/Apps/Sandcastle/gallery/Camera.html
+++ b/Apps/Sandcastle/gallery/Camera.html
@@ -40,11 +40,13 @@ function flyToSanDiego() {
 
 function flyToHeadingPitchRoll() {
     Sandcastle.declare(flyToHeadingPitchRoll);
-    viewer.camera.flyToHeadingPitchRoll({
+    viewer.camera.flyTo({
         destination : Cesium.Cartesian3.fromDegrees(-122.19, 46.25, 5000.0),
-        heading : Cesium.Math.toRadians(175.0),
-        pitch : Cesium.Math.toRadians(-35.0),
-        roll : 0.0
+        orientation : {
+            heading : Cesium.Math.toRadians(175.0),
+            pitch : Cesium.Math.toRadians(-35.0),
+            roll : 0.0
+        }
     });
 }
 
@@ -93,7 +95,7 @@ function flyToRectangle() {
     var east = -87.0;
     var north = 40.0;
 
-    viewer.camera.flyToRectangle({
+    viewer.camera.flyTo({
         destination : Cesium.Rectangle.fromDegrees(west, south, east, north)
     });
 

--- a/Apps/Sandcastle/gallery/Camera.html
+++ b/Apps/Sandcastle/gallery/Camera.html
@@ -41,9 +41,9 @@ function flyToSanDiego() {
 function flyToHeadingPitchRoll() {
     Sandcastle.declare(flyToHeadingPitchRoll);
     viewer.camera.flyTo({
-        destination : Cesium.Cartesian3.fromDegrees(-122.19, 46.25, 5000.0),
+        destination : Cesium.Cartesian3.fromDegrees(-122.22, 46.12, 5000.0),
         orientation : {
-            heading : Cesium.Math.toRadians(175.0),
+            heading : Cesium.Math.toRadians(20.0),
             pitch : Cesium.Math.toRadians(-35.0),
             roll : 0.0
         }

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,13 +12,15 @@ Change Log
   * `Camera.tilt` was deprecated in Cesium 1.6. It will be removed in Cesium 1.7. Use `Camera.pitch`.
   * `Camera.heading` and `Camera.tilt` were deprecated in Cesium 1.6. They will become read-only in Cesium 1.7. Use `Camera.setView`.
   * `Camera.setPositionCartographic` was deprecated in Cesium 1.6. It will be removed in Cesium 1.7. Use `Camera.setView`.
+  * The `direction` and `up` options to `Camera.flyTo` have been deprecated in Cesium 1.6. They will be removed in Cesium 1.8. Use the `orientation` option.
+  * `Camera.flyToRectangle` has been deprecated in Cesium 1.6. They will be removed in Cesium 1.8. Use `Camera.flyTo`.
   * `PolygonGraphics.positions` was deprecated and replaced with `PolygonGraphics.hierarchy`, whose value is a `PolygonHierarchy` instead of an array of positions.  `PolygonGraphics.positions` will be removed in Cesium 1.8.
   * The `Model.readyToRender` event was deprecated and will be removed in Cesium 1.9.  Use the new `Model.readyPromise` instead.
   * The `mouseMoveOnDocument` parameter to the `ScreenSpaceEventHandler` constructor was deprecated in Cesium 1.6. It will be removed in Cesium 1.7. `ScreenSpaceEventHandler` will be constructed as if `mouseMoveOnDocument` is `false`.
 * Improved performance of asynchronous geometry creation (as much as 20% faster in some use cases). [#2342](https://github.com/AnalyticalGraphicsInc/cesium/issues/2342)
 * Added `PolylineVolumeGraphics` and `Entity.polylineVolume`
 * Added `Camera.setView` (which use heading, pitch, and roll) and `Camera.roll`.
-* Added `Camera.flyToHeadingPitchRoll` to fly to a position and orientation created from heading, pitch and roll angles.
+* Added an orientation option to `Camera.flyTo` that can be either direction and up unit vectors or heading, pitch and roll angles.
 * Added `Quaternion.fromHeadingPitchRoll` to create a rotation from heading, pitch, and roll angles.
 * Added `Transforms.headingPitchRollToFixedFrame` to create a local frame from a position and heading/pitch/roll angles.
 * Added `Transforms.headingPitchRollQuaternion` which is the quaternion rotation from `Transforms.headingPitchRollToFixedFrame`.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,7 @@ Change Log
 * Improved performance of asynchronous geometry creation (as much as 20% faster in some use cases). [#2342](https://github.com/AnalyticalGraphicsInc/cesium/issues/2342)
 * Added `PolylineVolumeGraphics` and `Entity.polylineVolume`
 * Added `Camera.setView` (which use heading, pitch, and roll) and `Camera.roll`.
+* Added `Camera.flyToHeadingPitchRoll` to fly to a position and orientation created from heading, pitch and roll angles.
 * Added `Quaternion.fromHeadingPitchRoll` to create a rotation from heading, pitch, and roll angles.
 * Added `Transforms.headingPitchRollToFixedFrame` to create a local frame from a position and heading/pitch/roll angles.
 * Added `Transforms.headingPitchRollQuaternion` which is the quaternion rotation from `Transforms.headingPitchRollToFixedFrame`.

--- a/Source/Core/Quaternion.js
+++ b/Source/Core/Quaternion.js
@@ -201,12 +201,11 @@ define([
         }
         //>>includeEnd('debug');
 
-        var headingQuaternion = Quaternion.fromAxisAngle(Cartesian3.UNIT_Z, -heading, result);
-        var pitchQuaternion = Quaternion.fromAxisAngle(Cartesian3.UNIT_Y, -pitch, scratchHPRQuaternion);
-        result = Quaternion.multiply(headingQuaternion, pitchQuaternion, headingQuaternion);
-
         var rollQuaternion = Quaternion.fromAxisAngle(Cartesian3.UNIT_X, roll, scratchHPRQuaternion);
-        return Quaternion.multiply(rollQuaternion, result, result);
+        var pitchQuaternion = Quaternion.fromAxisAngle(Cartesian3.UNIT_Y, -pitch, result);
+        result = Quaternion.multiply(pitchQuaternion, rollQuaternion, pitchQuaternion);
+        var headingQuaternion = Quaternion.fromAxisAngle(Cartesian3.UNIT_Z, -heading, scratchHPRQuaternion);
+        return Quaternion.multiply(headingQuaternion, result, result);
     };
 
     var sampledQuaternionAxis = new Cartesian3();

--- a/Source/Scene/Camera.js
+++ b/Source/Scene/Camera.js
@@ -878,7 +878,6 @@ define([
         options = defaultValue(options, defaultValue.EMPTY_OBJECT);
 
         var scene2D = this._mode === SceneMode.SCENE2D;
-        var sceneCV = this._mode === SceneMode.COLUMBUS_VIEW;
 
         var heading = defaultValue(options.heading, this.heading);
         var pitch = scene2D ? -CesiumMath.PI_OVER_TWO : defaultValue(options.pitch, this.pitch);
@@ -2167,6 +2166,19 @@ define([
     var scratchFlyToUp = new Cartesian3();
     var scratchFlyToMatrix4 = new Matrix4();
 
+    /**
+     * Flies the camera from its current position to a new position and orientation set with heading, pitch, and roll angles.
+     *
+     * @param {Object} Object with the following properties:@param {Object} options Object with the following properties:
+     * @param {Cartesian3} options.destination The final position of the camera in WGS84 (world) coordinates.
+     * @param {Number} [options.heading=0.0] The heading angle in radians.
+     * @param {Number} [options.pitch=Cesium.Math.PI_OVER_TWO] The pitch angle in radians.
+     * @param {Number} [options.roll=0.0] The roll angle in radians.
+     * @param {Number} [options.duration=3.0] The duration of the flight in seconds.
+     * @param {Camera~FlightCompleteCallback} [options.complete] The function to execute when the flight is complete.
+     * @param {Camera~FlightCancelledCallback} [options.cancel] The function to execute if the flight is cancelled.
+     * @param {Matrix4} [options.endTransform] Transform matrix representing the reference frame the camera will be in when the flight is completed.
+     */
     Camera.prototype.flyToHeadingPitchRoll = function(options) {
         options = defaultValue(options, defaultValue.EMPTY_OBJECT);
 

--- a/Source/Scene/Camera.js
+++ b/Source/Scene/Camera.js
@@ -2124,13 +2124,31 @@ define([
         return undefined;
     };
 
+
+    var scratchFlyToDestination = new Cartesian3();
+    var scratchFlyToQuaternion = new Quaternion();
+    var scratchFlyToMatrix3 = new Matrix3();
+    var scratchFlyToDirection = new Cartesian3();
+    var scratchFlyToUp = new Cartesian3();
+    var scratchFlyToMatrix4 = new Matrix4();
+    var newOptions = {
+        destination : undefined,
+        direction : undefined,
+        up : undefined,
+        duration : undefined,
+        complete : undefined,
+        cancel : undefined,
+        endTransform : undefined
+    };
+
     /**
      * Flies the camera from its current position to a new position.
      *
      * @param {Object} options Object with the following properties:
-     * @param {Cartesian3} options.destination The final position of the camera in WGS84 (world) coordinates.
-     * @param {Cartesian3} [options.direction] The final direction of the camera in WGS84 (world) coordinates. By default, the direction will point towards the center of the frame in 3D and in the negative z direction in Columbus view or 2D.
-     * @param {Cartesian3} [options.up] The final up direction in WGS84 (world) coordinates. By default, the up direction will point towards local north in 3D and in the positive y direction in Columbus view or 2D.
+     * @param {Cartesian3|Rectangle} options.destination The final position of the camera in WGS84 (world) coordinates or a rectangle that would be visible from a top-down view.
+     * @param {Object} [options.orientation] An object that contains either direction and up properties or heading, pith and roll properties. By default, the direction will point
+     * towards the center of the frame in 3D and in the negative z direction in Columbus view or 2D. The up direction will point towards local north in 3D and in the positive
+     * y direction in Columbus view or 2D.
      * @param {Number} [options.duration=3.0] The duration of the flight in seconds.
      * @param {Camera~FlightCompleteCallback} [options.complete] The function to execute when the flight is complete.
      * @param {Camera~FlightCancelledCallback} [options.cancel] The function to execute if the flight is cancelled.
@@ -2139,14 +2157,99 @@ define([
      *                  to be in the correct coordinate system.
      *
      * @exception {DeveloperError} If either direction or up is given, then both are required.
+     *
+     * @example
+     * // 1. Fly to a position with a top-down view
+     * viewer.camera.flyTo({
+     *     destination : Cesium.Cartesian3.fromDegrees(-117.16, 32.71, 15000.0)
+     * });
+     *
+     * // 2. Fly to a Rectangle with a top-down view
+     * viewer.camera.flyTo({
+     *     destination : Cesium.Rectangle.fromDegrees(west, south, east, north)
+     * });
+     *
+     * // 3. Fly to a position with an orientation using unit vectors.
+     * viewer.camera.flyTo({
+     *     destination : Cesium.Cartesian3.fromDegrees(-122.19, 46.25, 5000.0),
+     *     orientation : {
+     *         direction : new Cesium.Cartesian3(-0.04231243104240401, -0.20123236049443421, -0.97862924300734),
+     *         up : new Cesium.Cartesian3(-0.47934589305293746, -0.8553216253114552, 0.1966022179118339)
+     *     }
+     * });
+     *
+     * // 4. Fly to a position with an orientation using heading, pitch and roll.
+     * viewer.camera.flyTo({
+     *     destination : Cesium.Cartesian3.fromDegrees(-122.19, 46.25, 5000.0),
+     *     orientation : {
+     *         heading : Cesium.Math.toRadians(175.0),
+     *         pitch : Cesium.Math.toRadians(-35.0),
+     *         roll : 0.0
+     *     }
+     * });
      */
     Camera.prototype.flyTo = function(options) {
+        options = defaultValue(options, defaultValue.EMPTY_OBJECT);
+
+        var destination = options.destination;
+        //>>includeStart('debug', pragmas.debug);
+        if (!defined(destination)) {
+            throw new DeveloperError('destination is required.');
+        }
+        //>>includeEnd('debug');
+
         var scene = this._scene;
-        scene.tweens.add(CameraFlightPath.createTween(scene, options));
+
+        var isRectangle = defined(destination.west);
+        if (isRectangle) {
+            destination = scene.camera.getRectangleCameraCoordinates(destination, scratchFlyToDestination);
+        }
+
+        var direction;
+        var up;
+
+        var orientation = defaultValue(options.orientation, defaultValue.EMPTY_OBJECT);
+        if (defined(orientation.heading)) {
+            var heading = defaultValue(orientation.heading, 0.0);
+            var pitch = defaultValue(orientation.pitch, -CesiumMath.PI_OVER_TWO);
+            var roll = defaultValue(orientation.roll, 0.0);
+
+            var rotQuat = Quaternion.fromHeadingPitchRoll(heading - CesiumMath.PI_OVER_TWO, pitch, roll, scratchFlyToQuaternion);
+            var rotMat = Matrix3.fromQuaternion(rotQuat, scratchFlyToMatrix3);
+
+            direction = Matrix3.getColumn(rotMat, 0, scratchFlyToDirection);
+            up = Matrix3.getColumn(rotMat, 2, scratchFlyToUp);
+
+            var ellipsoid = this._projection.ellipsoid;
+            var transform = Transforms.eastNorthUpToFixedFrame(destination, ellipsoid, scratchFlyToMatrix4);
+
+            Matrix4.multiplyByPointAsVector(transform, direction, direction);
+            Matrix4.multiplyByPointAsVector(transform, up, up);
+        } else if (defined(orientation.direction)) {
+            direction = orientation.direction;
+            up = orientation.up;
+        } else if (defined(options.direction) || defined(options.up)) {
+            deprecationWarning('Camera.flyTo', 'The direction and up options to Camera.flyTo have been deprecated in Cesium 1.6. They will be removed in Cesium 1.8. Use the orientation option.');
+            direction = options.direction;
+            up = options.up;
+        }
+
+        newOptions.destination = destination;
+        newOptions.direction = direction;
+        newOptions.up = up;
+        newOptions.duration = options.duration;
+        newOptions.complete = options.complete;
+        newOptions.cancel = options.cancel;
+        newOptions.endTransform = options.endTransform;
+        newOptions.convert = isRectangle ? false : options.convert;
+
+        scene.tweens.add(CameraFlightPath.createTween(scene, newOptions));
     };
 
     /**
      * Flies the camera from its current position to a position where the entire rectangle is visible.
+     *
+     * @deprecated
      *
      * @param {Object} options Object with the following properties:
      * @param {Rectangle} options.destination The rectangle to view, in WGS84 (world) coordinates, which determines the final position of the camera.
@@ -2156,62 +2259,9 @@ define([
      * @param {Matrix4} [endTransform] Transform matrix representing the reference frame the camera will be in when the flight is completed.
      */
     Camera.prototype.flyToRectangle = function(options) {
+        deprecationWarning('Camera.flyToRectangle', 'Camera.flyToRectangle has been deprecated in Cesium 1.6. They will be removed in Cesium 1.8. Use Camera.flyTo.');
         var scene = this._scene;
         scene.tweens.add(CameraFlightPath.createTweenRectangle(scene, options));
-    };
-
-    var scratchFlyToQuaternion = new Quaternion();
-    var scratchFlyToMatrix3 = new Matrix3();
-    var scratchFlyToDirection = new Cartesian3();
-    var scratchFlyToUp = new Cartesian3();
-    var scratchFlyToMatrix4 = new Matrix4();
-
-    /**
-     * Flies the camera from its current position to a new position and orientation set with heading, pitch, and roll angles.
-     *
-     * @param {Object} Object with the following properties:@param {Object} options Object with the following properties:
-     * @param {Cartesian3} options.destination The final position of the camera in WGS84 (world) coordinates.
-     * @param {Number} [options.heading=0.0] The heading angle in radians.
-     * @param {Number} [options.pitch=Cesium.Math.PI_OVER_TWO] The pitch angle in radians.
-     * @param {Number} [options.roll=0.0] The roll angle in radians.
-     * @param {Number} [options.duration=3.0] The duration of the flight in seconds.
-     * @param {Camera~FlightCompleteCallback} [options.complete] The function to execute when the flight is complete.
-     * @param {Camera~FlightCancelledCallback} [options.cancel] The function to execute if the flight is cancelled.
-     * @param {Matrix4} [options.endTransform] Transform matrix representing the reference frame the camera will be in when the flight is completed.
-     */
-    Camera.prototype.flyToHeadingPitchRoll = function(options) {
-        options = defaultValue(options, defaultValue.EMPTY_OBJECT);
-
-        var heading = defaultValue(options.heading, 0.0);
-        var pitch = defaultValue(options.pitch, -CesiumMath.PI_OVER_TWO);
-        var roll = defaultValue(options.roll, 0.0);
-
-        var destination = options.destination;
-
-        var rotQuat = Quaternion.fromHeadingPitchRoll(heading - CesiumMath.PI_OVER_TWO, pitch, roll, scratchFlyToQuaternion);
-        var rotMat = Matrix3.fromQuaternion(rotQuat, scratchFlyToMatrix3);
-
-        var direction = Matrix3.getColumn(rotMat, 0, scratchFlyToDirection);
-        var up = Matrix3.getColumn(rotMat, 2, scratchFlyToUp);
-
-        var ellipsoid = this._projection.ellipsoid;
-        var transform = Transforms.eastNorthUpToFixedFrame(destination, ellipsoid, scratchFlyToMatrix4);
-
-        Matrix4.multiplyByPointAsVector(transform, direction, direction);
-        Matrix4.multiplyByPointAsVector(transform, up, up);
-
-        var newOptions = {
-            destination : destination,
-            direction : direction,
-            up : up,
-            duration : options.duration,
-            complete : options.complete,
-            cancel : options.cancel,
-            endTransform : options.endTransform
-        };
-
-        var scene = this._scene;
-        scene.tweens.add(CameraFlightPath.createTween(scene, newOptions));
     };
 
     /**

--- a/Source/Scene/Camera.js
+++ b/Source/Scene/Camera.js
@@ -884,10 +884,6 @@ define([
         var pitch = scene2D ? -CesiumMath.PI_OVER_TWO : defaultValue(options.pitch, this.pitch);
         var roll = scene2D ? 0.0 : defaultValue(options.roll, this.roll);
 
-        if (sceneCV) {
-            roll = -roll;
-        }
-
         var cartesian = options.position;
         var cartographic = options.positionCartographic;
 

--- a/Source/Widgets/HomeButton/HomeButtonViewModel.js
+++ b/Source/Widgets/HomeButton/HomeButtonViewModel.js
@@ -37,7 +37,7 @@ define([
         var up;
 
         if (mode === SceneMode.SCENE2D) {
-            scene.camera.flyToRectangle({
+            scene.camera.flyTo({
                 destination : Rectangle.MAX_VALUE,
                 duration : duration,
                 endTransform : Matrix4.IDENTITY

--- a/Specs/Core/QuaternionSpec.js
+++ b/Specs/Core/QuaternionSpec.js
@@ -122,12 +122,23 @@ defineSuite([
         expect(Matrix3.fromQuaternion(quaternion)).toEqualEpsilon(Matrix3.fromRotationX(angle), CesiumMath.EPSILON11);
     });
 
-    it('fromHeadingPitchRoll with all angles', function() {
+    it('fromHeadingPitchRoll with all angles (1)', function() {
         var angle = CesiumMath.toRadians(20.0);
         var quaternion = Quaternion.fromHeadingPitchRoll(angle, angle, angle);
-        var expected = Matrix3.fromRotationY(-angle);
+        var expected = Matrix3.fromRotationX(angle);
+        Matrix3.multiply(Matrix3.fromRotationY(-angle), expected, expected);
         Matrix3.multiply(Matrix3.fromRotationZ(-angle), expected, expected);
-        Matrix3.multiply(Matrix3.fromRotationX(angle), expected, expected);
+        expect(Matrix3.fromQuaternion(quaternion)).toEqualEpsilon(expected, CesiumMath.EPSILON11);
+    });
+
+    it('fromHeadingPitchRoll with all angles (2)', function() {
+        var heading =  CesiumMath.toRadians(180.0);
+        var pitch = CesiumMath.toRadians(-45.0);
+        var roll = CesiumMath.toRadians(45.0);
+        var quaternion = Quaternion.fromHeadingPitchRoll(heading, pitch, roll);
+        var expected = Matrix3.fromRotationX(roll);
+        Matrix3.multiply(Matrix3.fromRotationY(-pitch), expected, expected);
+        Matrix3.multiply(Matrix3.fromRotationZ(-heading), expected, expected);
         expect(Matrix3.fromQuaternion(quaternion)).toEqualEpsilon(expected, CesiumMath.EPSILON11);
     });
 

--- a/Specs/Scene/CameraSpec.js
+++ b/Specs/Scene/CameraSpec.js
@@ -1833,22 +1833,7 @@ defineSuite([
         expect(CameraFlightPath.createTween).toHaveBeenCalledWith(scene, options);
     });
 
-    it('flyToHeadingPitchRoll uses CameraFlightPath', function() {
-        spyOn(CameraFlightPath, 'createTween').andReturn({
-            startObject : {},
-            stopObject: {},
-            duration : 0.0
-        });
-
-        var options = {
-            destination : Cartesian3.fromDegrees(-117.16, 32.71, 15000.0)
-        };
-        camera.flyToHeadingPitchRoll(options);
-
-        expect(CameraFlightPath.createTween).toHaveBeenCalled();
-    });
-
-    it('flyToHeadingPitchRoll sets heading, pitch and roll', function() {
+    it('flyTo with heading, pitch and roll', function() {
         scene.mode = SceneMode.SCENE3D;
 
         var heading = CesiumMath.toRadians(180.0);
@@ -1857,12 +1842,14 @@ defineSuite([
 
         var options = {
             destination : Cartesian3.fromDegrees(-117.16, 32.71, 0.0),
-            heading : heading,
-            pitch : pitch,
-            roll : roll,
+            orientation : {
+                heading : heading,
+                pitch : pitch,
+                roll : roll
+            },
             duration : 0.0
         };
-        camera.flyToHeadingPitchRoll(options);
+        camera.flyTo(options);
 
         expect(camera.heading).toEqualEpsilon(heading, CesiumMath.EPSILON6);
         expect(camera.pitch).toEqualEpsilon(pitch, CesiumMath.EPSILON6);

--- a/Specs/Scene/CameraSpec.js
+++ b/Specs/Scene/CameraSpec.js
@@ -308,7 +308,7 @@ defineSuite([
         camera._mode = SceneMode.COLUMBUS_VIEW;
 
         camera.position = Cartesian3.fromDegrees(0.0, 0.0, 100000.0);
-        camera.direction = Cartesian3.negate(Cartesian3.normalize(camera.position, new Cartesian3()), new Cartesian3());
+        camera.direction = Cartesian3.clone(Cartesian3.UNIT_Y);
         camera.up = Cartesian3.clone(Cartesian3.UNIT_Z);
         camera.right = Cartesian3.cross(camera.direction, camera.up, new Cartesian3());
 
@@ -324,6 +324,11 @@ defineSuite([
 
     it('set roll in 3D', function() {
         camera._mode = SceneMode.SCENE3D;
+
+        camera.position = Cartesian3.fromDegrees(0.0, 0.0, 100000.0);
+        camera.direction = Cartesian3.clone(Cartesian3.UNIT_Z);
+        camera.up = Cartesian3.clone(Cartesian3.UNIT_X);
+        camera.right = Cartesian3.cross(camera.direction, camera.up, new Cartesian3());
 
         var roll = camera.roll;
         var newRoll = CesiumMath.PI_OVER_FOUR;
@@ -418,7 +423,7 @@ defineSuite([
         expect(camera.right).toEqualEpsilon(Cartesian3.UNIT_X, CesiumMath.EPSILON6);
     });
 
-    it('setView with  cartographic in 3D', function() {
+    it('setView with cartographic in 3D', function() {
         var ellipsoid = Ellipsoid.WGS84;
         var projection = new GeographicProjection(ellipsoid);
 
@@ -437,6 +442,25 @@ defineSuite([
         expect(camera.direction).toEqualEpsilon(Cartesian3.normalize(Cartesian3.negate(camera.position, new Cartesian3()), new Cartesian3()), CesiumMath.EPSILON6);
         expect(camera.up).toEqualEpsilon(Cartesian3.UNIT_Z, CesiumMath.EPSILON6);
         expect(camera.right).toEqualEpsilon(Cartesian3.cross(camera.direction, camera.up, new Cartesian3()), CesiumMath.EPSILON6);
+    });
+
+    it('setView right rotation order', function() {
+        var position = Cartesian3.fromDegrees(-117.16, 32.71, 0.0);
+        var heading =  CesiumMath.toRadians(180.0);
+        var pitch = CesiumMath.toRadians(0.0);
+        var roll = CesiumMath.toRadians(45.0);
+
+        camera.setView({
+            position : position,
+            heading : heading,
+            pitch : pitch,
+            roll : roll
+        });
+
+        expect(camera.position).toEqualEpsilon(position, CesiumMath.EPSILON6);
+        expect(camera.heading).toEqualEpsilon(heading, CesiumMath.EPSILON6);
+        expect(camera.pitch).toEqualEpsilon(pitch, CesiumMath.EPSILON6);
+        expect(camera.roll).toEqualEpsilon(roll, CesiumMath.EPSILON6);
     });
 
     it('worldToCameraCoordinates throws without cartesian', function() {

--- a/Specs/Scene/CameraSpec.js
+++ b/Specs/Scene/CameraSpec.js
@@ -64,6 +64,8 @@ defineSuite([
         this.drawingBufferHeight = 768;
         this.mapProjection = defaultValue(projection, new GeographicProjection());
         this.tweens = new TweenCollection();
+        this.screenSpaceCameraController = {};
+        this.camera = undefined;
     };
 
     beforeEach(function() {
@@ -81,6 +83,8 @@ defineSuite([
         camera.right = Cartesian3.clone(right);
 
         camera.minimumZoomDistance = 0.0;
+
+        scene.camera = camera;
     });
 
     it('constructor throws an exception when there is no canvas', function() {
@@ -1698,6 +1702,42 @@ defineSuite([
         camera.flyToRectangle(options);
 
         expect(CameraFlightPath.createTweenRectangle).toHaveBeenCalledWith(scene, options);
+    });
+
+    it('flyToHeadingPitchRoll uses CameraFlightPath', function() {
+        spyOn(CameraFlightPath, 'createTween').andReturn({
+            startObject : {},
+            stopObject: {},
+            duration : 0.0
+        });
+
+        var options = {
+            destination : Cartesian3.fromDegrees(-117.16, 32.71, 15000.0)
+        };
+        camera.flyToHeadingPitchRoll(options);
+
+        expect(CameraFlightPath.createTween).toHaveBeenCalled();
+    });
+
+    it('flyToHeadingPitchRoll sets heading, pitch and roll', function() {
+        scene.mode = SceneMode.SCENE3D;
+
+        var heading = CesiumMath.toRadians(180.0);
+        var pitch = 0.0;
+        var roll = CesiumMath.toRadians(45.0);
+
+        var options = {
+            destination : Cartesian3.fromDegrees(-117.16, 32.71, 0.0),
+            heading : heading,
+            pitch : pitch,
+            roll : roll,
+            duration : 0.0
+        };
+        camera.flyToHeadingPitchRoll(options);
+
+        expect(camera.heading).toEqualEpsilon(heading, CesiumMath.EPSILON6);
+        expect(camera.pitch).toEqualEpsilon(pitch, CesiumMath.EPSILON6);
+        expect(camera.roll).toEqualEpsilon(roll, CesiumMath.EPSILON6);
     });
 
 });

--- a/Specs/Scene/CameraSpec.js
+++ b/Specs/Scene/CameraSpec.js
@@ -1689,21 +1689,6 @@ defineSuite([
         expect(CameraFlightPath.createTween).toHaveBeenCalledWith(scene, options);
     });
 
-    it('flyToRectangle uses createTweenRectangle', function() {
-        spyOn(CameraFlightPath, 'createTweenRectangle').andReturn({
-            startObject : {},
-            stopObject: {},
-            duration : 0.0
-        });
-
-        var options = {
-            destination : Rectangle.fromDegrees(0.0, 20.0, 10.0, 30.0)
-        };
-        camera.flyToRectangle(options);
-
-        expect(CameraFlightPath.createTweenRectangle).toHaveBeenCalledWith(scene, options);
-    });
-
     it('flyToHeadingPitchRoll uses CameraFlightPath', function() {
         spyOn(CameraFlightPath, 'createTween').andReturn({
             startObject : {},


### PR DESCRIPTION
* Added `Camera.flyToHeadingPitchRoll`.
* Fixed the order of applying the heading, pitch and roll rotations. The roll and pitch angles would rotate around the same axis if heading is set to 0.0 or 180.0 degrees. Here is an example that you can paste into Sandcastle that works in this branch but not in master:
```javascript
var position = Cesium.Cartesian3.fromDegrees(-117.16, 32.71, 5000.0);
var heading =  Cesium.Math.toRadians(180.0);
var pitch = Cesium.Math.toRadians(-45.0);
var roll = Cesium.Math.toRadians(45.0);

viewer.camera.setView({
    position : position,
    heading : heading,
    pitch : pitch,
    roll : roll
});
```