### PR TITLE
Deprecate Camera.setTransform

### DIFF
--- a/Apps/Sandcastle/gallery/3D Models.html
+++ b/Apps/Sandcastle/gallery/3D Models.html
@@ -53,13 +53,15 @@ function createModel(url, height, heading, pitch, roll) {
             loop : Cesium.ModelAnimationLoop.REPEAT
         });
         
+        var camera = viewer.camera;
+        
         // Zoom to model
         var controller = scene.screenSpaceCameraController;
         var r = 2.0 * Math.max(model.boundingSphere.radius, camera.frustum.near);
         controller.minimumZoomDistance = r * 0.5;
         
         var center = Cesium.Matrix4.multiplyByPoint(model.modelMatrix, model.boundingSphere.center, new Cesium.Cartesian3());
-        viewer.camera.lookAt(center, new Cesium.Cartesian3(r, r, r));
+        camera.lookAt(center, new Cesium.Cartesian3(r, r, r));
     }).otherwise(function(error){
         window.alert(error);
     });

--- a/Apps/Sandcastle/gallery/Camera.html
+++ b/Apps/Sandcastle/gallery/Camera.html
@@ -204,7 +204,7 @@ Sandcastle.reset = function() {
     scene.primitives.removeAll();
     scene.tweens.removeAll();
 
-    viewer.camera.setTransform(Cesium.Matrix4.IDENTITY);
+    viewer.camera.lookAtTransform(Cesium.Matrix4.IDENTITY);
 
     clock.multiplier = 1.0;
     scene.preRender.removeEventListener(icrf);

--- a/Apps/Sandcastle/gallery/GeoJSON and TopoJSON.html
+++ b/Apps/Sandcastle/gallery/GeoJSON and TopoJSON.html
@@ -91,7 +91,7 @@ Sandcastle.reset = function() {
   
   //Set the camera to a US centered tilted view and switch back to moving in world coordinates.
   viewer.camera.lookAt(Cesium.Cartesian3.fromDegrees(-98.0, 40.0), new Cesium.Cartesian3(0.0, -4790000.0, 3930000.0));
-  viewer.camera.lookAtTransform(Matrix4.IDENTITY);
+  viewer.camera.lookAtTransform(Cesium.Matrix4.IDENTITY);
 };
 //Sandcastle_End
     Sandcastle.finishedLoading();

--- a/Apps/Sandcastle/gallery/GeoJSON and TopoJSON.html
+++ b/Apps/Sandcastle/gallery/GeoJSON and TopoJSON.html
@@ -91,7 +91,7 @@ Sandcastle.reset = function() {
   
   //Set the camera to a US centered tilted view and switch back to moving in world coordinates.
   viewer.camera.lookAt(Cesium.Cartesian3.fromDegrees(-98.0, 40.0), new Cesium.Cartesian3(0.0, -4790000.0, 3930000.0));
-  viewer.camera.setTransform(Matrix4.IDENTITY);
+  viewer.camera.lookAtTransform(Matrix4.IDENTITY);
 };
 //Sandcastle_End
     Sandcastle.finishedLoading();

--- a/Apps/Sandcastle/gallery/Terrain.html
+++ b/Apps/Sandcastle/gallery/Terrain.html
@@ -78,39 +78,33 @@ Sandcastle.addToolbarMenu([{
 }], 'terrainMenu');
 
 Sandcastle.addToolbarButton('Mount Everest', function() {
-    var eye, target, up;
-
     if (scene.mode === Cesium.SceneMode.SCENE3D || scene.mode === Cesium.SceneMode.COLUMBUS_VIEW) {
         var target = new Cesium.Cartesian3(300770.50872389384, 5634912.131394585, 2978152.2865545116);
         var offset = new Cesium.Cartesian3(6344.974098678562, -793.3419798081741, 2499.9508860763162);
         viewer.camera.lookAt(target, offset);
-        viewer.camera.setTransform(Cesium.Matrix4.IDENTITY);
+        viewer.camera.lookAtTransform(Cesium.Matrix4.IDENTITY);
     } else {
         viewer.camera.viewRectangle(new Cesium.Rectangle(1.516102969, 0.48744464, 1.518102969, 0.48944464));
     }
 }, 'zoomButtons');
 
 Sandcastle.addToolbarButton('Half Dome', function() {
-    var eye, target, up;
-
     if (scene.mode === Cesium.SceneMode.SCENE3D || scene.mode === Cesium.SceneMode.COLUMBUS_VIEW) {
         var target = new Cesium.Cartesian3(-2489625.0836225147, -4393941.44443024, 3882535.9454173897);
         var offset = new Cesium.Cartesian3(-6857.40902037546, 412.3284835694358, 2147.5545426812023);
         viewer.camera.lookAt(target, offset);
-        viewer.camera.setTransform(Cesium.Matrix4.IDENTITY);
+        viewer.camera.lookAtTransform(Cesium.Matrix4.IDENTITY);
     } else {
         viewer.camera.viewRectangle(new Cesium.Rectangle(-2.08724538, 0.6577939, -2.08524538, 0.6597939));
     }
 }, 'zoomButtons');
 
 Sandcastle.addToolbarButton('San Francisco Bay', function() {
-    var eye, target, up;
-
     if (scene.mode === Cesium.SceneMode.SCENE3D || scene.mode === Cesium.SceneMode.COLUMBUS_VIEW) {
         var target = new Cesium.Cartesian3(-2708814.85583248, -4254159.450845907, 3891403.9457429945);
         var offset = new Cesium.Cartesian3(70642.66030209465, -31661.517948317807, 35505.179997143336);
         viewer.camera.lookAt(target, offset);
-        viewer.camera.setTransform(Cesium.Matrix4.IDENTITY);
+        viewer.camera.lookAtTransform(Cesium.Matrix4.IDENTITY);
     } else {
         viewer.camera.viewRectangle(new Cesium.Rectangle(-2.147621889, 0.64829691, -2.125621889, 0.67029691));
     }

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@ Change Log
   * `Camera.tilt` was deprecated in Cesium 1.6. It will be removed in Cesium 1.7. Use `Camera.pitch`.
   * `Camera.heading` and `Camera.tilt` were deprecated in Cesium 1.6. They will become read-only in Cesium 1.7. Use `Camera.setView`.
   * `Camera.setPositionCartographic` was deprecated in Cesium 1.6. It will be removed in Cesium 1.7. Use `Camera.setView`.
+  * `Camera.setTransform` was deprecated in Cesium 1.6. It will be removed in Cesium 1.8. Use `Camera.lookAtTransform`.
    * The `eye`, `target`, and `up` parameters to `Camera.lookAt` were deprecated in Cesium 1.6. It will be removed in Cesium 1.8. Use the `target` and `offset`.
   * `PolygonGraphics.positions` was deprecated and replaced with `PolygonGraphics.hierarchy`, whose value is a `PolygonHierarchy` instead of an array of positions.  `PolygonGraphics.positions` will be removed in Cesium 1.8.
   * The `Model.readyToRender` event was deprecated and will be removed in Cesium 1.9.  Use the new `Model.readyPromise` instead.

--- a/Source/Scene/Camera.js
+++ b/Source/Scene/Camera.js
@@ -646,7 +646,7 @@ define([
 
                     var oldTransform = Matrix4.clone(this.transform, scratchHPRMatrix1);
                     var transform = Transforms.eastNorthUpToFixedFrame(this.positionWC, ellipsoid, scratchHPRMatrix2);
-                    this.setTransform(transform);
+                    this._setTransform(transform);
 
                     var right = this.right;
                     var direction = this.direction;
@@ -658,7 +658,7 @@ define([
                         heading = Math.atan2(right.y, right.x);
                     }
 
-                    this.setTransform(oldTransform);
+                    this._setTransform(oldTransform);
 
                     return CesiumMath.TWO_PI - CesiumMath.zeroToTwoPi(heading);
                 }
@@ -694,11 +694,11 @@ define([
 
                     var oldTransform = Matrix4.clone(this.transform, scratchHPRMatrix1);
                     var transform = Transforms.eastNorthUpToFixedFrame(this.positionWC, ellipsoid, scratchHPRMatrix2);
-                    this.setTransform(transform);
+                    this._setTransform(transform);
 
                     var pitch = CesiumMath.PI_OVER_TWO - CesiumMath.acosClamped(this.direction.z);
 
-                    this.setTransform(oldTransform);
+                    this._setTransform(oldTransform);
 
                     return pitch;
                 }
@@ -749,7 +749,7 @@ define([
 
                     var oldTransform = Matrix4.clone(this.transform, scratchHPRMatrix1);
                     var transform = Transforms.eastNorthUpToFixedFrame(this.positionWC, ellipsoid, scratchHPRMatrix2);
-                    this.setTransform(transform);
+                    this._setTransform(transform);
 
                     var up = this.up;
                     var right = this.right;
@@ -759,7 +759,7 @@ define([
                         roll = CesiumMath.PI - roll;
                     }
 
-                    this.setTransform(oldTransform);
+                    this._setTransform(oldTransform);
 
                     return CesiumMath.TWO_PI - CesiumMath.zeroToTwoPi(roll);
                 }
@@ -805,16 +805,23 @@ define([
         }
     };
 
-    var setTransformPosition = new Cartesian3();
-    var setTransformUp = new Cartesian3();
-    var setTransformDirection = new Cartesian3();
-
     /**
      * Sets the camera's transform without changing the current view.
+     *
+     * @deprecated
      *
      * @param {Matrix4} transform The camera transform.
      */
     Camera.prototype.setTransform = function(transform) {
+        deprecationWarning('Camera.setTransform', 'Camera.setTransform was deprecated in Cesium 1.6. It will be removed in Cesium 1.8. Use Camera.lookAtTransform.');
+        this._setTransform(transform);
+    };
+
+    var setTransformPosition = new Cartesian3();
+    var setTransformUp = new Cartesian3();
+    var setTransformDirection = new Cartesian3();
+
+    Camera.prototype._setTransform = function(transform) {
         var position = Cartesian3.clone(this.positionWC, setTransformPosition);
         var up = Cartesian3.clone(this.upWC, setTransformUp);
         var direction = Cartesian3.clone(this.directionWC, setTransformDirection);
@@ -904,7 +911,7 @@ define([
 
         var currentTransform = Matrix4.clone(this.transform, scratchSetViewTransform1);
         var localTransform = Transforms.eastNorthUpToFixedFrame(cartesian, ellipsoid, scratchSetViewTransform2);
-        this.setTransform(localTransform);
+        this._setTransform(localTransform);
 
         if (scene2D) {
             Cartesian2.clone(Cartesian3.ZERO, this.position);
@@ -932,7 +939,7 @@ define([
         Matrix3.getColumn(rotMat, 2, this.up);
         Cartesian3.cross(this.direction, this.up, this.right);
 
-        this.setTransform(currentTransform);
+        this._setTransform(currentTransform);
     };
 
     /**
@@ -1612,6 +1619,9 @@ define([
         if (!defined(target)) {
             throw new DeveloperError('target is required');
         }
+        if (!defined(offset)) {
+            throw new DeveloperError('offset is required');
+        }
         //>>includeEnd('debug');
 
         var transform = Transforms.eastNorthUpToFixedFrame(target, Ellipsoid.WGS84, scratchLookAtMatrix4);
@@ -1642,15 +1652,15 @@ define([
         if (!defined(transform)) {
             throw new DeveloperError('transform is required');
         }
-        if (!defined(offset)) {
-            throw new DeveloperError('offset is required');
-        }
         if (this._mode === SceneMode.MORPHING) {
             throw new DeveloperError('lookAtTransform is not supported while morphing.');
         }
         //>>includeEnd('debug');
 
-        this.setTransform(transform);
+        this._setTransform(transform);
+        if (!defined(offset)) {
+            return;
+        }
 
         if (this._mode === SceneMode.SCENE2D) {
             Cartesian2.clone(Cartesian2.ZERO, this.position);
@@ -1659,7 +1669,7 @@ define([
             Cartesian3.normalize(this.up, this.up);
             this.up.z = 0.0;
 
-            this.setTransform(Matrix4.IDENTITY);
+            this._setTransform(Matrix4.IDENTITY);
 
             if (Cartesian3.magnitudeSquared(this.up) < CesiumMath.EPSILON10) {
                 Cartesian3.clone(Cartesian3.UNIT_Y, this.up);
@@ -1676,7 +1686,7 @@ define([
             frustum.top = ratio * frustum.right;
             frustum.bottom = -frustum.top;
 
-            this.setTransform(transform);
+            this._setTransform(transform);
 
             return;
         }

--- a/Source/Scene/CameraFlightPath.js
+++ b/Source/Scene/CameraFlightPath.js
@@ -228,7 +228,7 @@ define([
             camera.up = Matrix3.getRow(rotMatrix, 1, camera.up);
             camera.direction = Cartesian3.negate(Matrix3.getRow(rotMatrix, 2, camera.direction), camera.direction);
 
-            camera.setTransform(currentFrame);
+            camera._setTransform(currentFrame);
         };
 
         return update;
@@ -347,7 +347,7 @@ define([
             camera.up = Matrix3.getRow(rotMatrix, 1, camera.up);
             camera.direction = Cartesian3.negate(Matrix3.getRow(rotMatrix, 2, camera.direction), camera.direction);
 
-            camera.setTransform(currentFrame);
+            camera._setTransform(currentFrame);
         };
 
         return update;
@@ -452,7 +452,7 @@ define([
         var camera = scene.camera;
         var transform = options.endTransform;
         if (defined(transform)) {
-            camera.setTransform(transform);
+            camera._setTransform(transform);
         }
 
         var frustum = camera.frustum;

--- a/Source/Scene/SceneTransitioner.js
+++ b/Source/Scene/SceneTransitioner.js
@@ -271,7 +271,7 @@ define([
         var scene = transitioner._scene;
 
         var camera = scene.camera;
-        camera.setTransform(Matrix4.IDENTITY);
+        camera._setTransform(Matrix4.IDENTITY);
 
         var startPos = camera.position;
         var startDir = camera.direction;
@@ -309,7 +309,7 @@ define([
         duration *= 0.5;
 
         var camera = transitioner._scene.camera;
-        camera.setTransform(Matrix4.IDENTITY);
+        camera._setTransform(Matrix4.IDENTITY);
 
         morphOrthographicToPerspective(transitioner, duration, ellipsoid, function() {
             camera.frustum = transitioner._cameraCV.frustum.clone();
@@ -361,7 +361,7 @@ define([
     function morphFromColumbusViewTo2D(transitioner, duration, ellipsoid, complete) {
         var scene = transitioner._scene;
         var camera = scene.camera;
-        camera.setTransform(Matrix4.IDENTITY);
+        camera._setTransform(Matrix4.IDENTITY);
         var maxRadii = ellipsoid.maximumRadius;
 
         var startPos = Cartesian3.clone(camera.position);
@@ -496,7 +496,7 @@ define([
     function morphFrom2DToColumbusView(transitioner, duration, ellipsoid, complete) {
         var scene = transitioner._scene;
         var camera = scene.camera;
-        camera.setTransform(Matrix4.IDENTITY);
+        camera._setTransform(Matrix4.IDENTITY);
 
         duration *= 0.5;
 
@@ -541,7 +541,7 @@ define([
     function morphFrom3DToColumbusView(transitioner, duration, endCamera, complete) {
         var scene = transitioner._scene;
         var camera = scene.camera;
-        camera.setTransform(Matrix4.IDENTITY);
+        camera._setTransform(Matrix4.IDENTITY);
 
         var startPos = Cartesian3.clone(camera.position);
         var startDir = Cartesian3.clone(camera.direction);

--- a/Source/Scene/ScreenSpaceCameraController.js
+++ b/Source/Scene/ScreenSpaceCameraController.js
@@ -717,11 +717,11 @@ define([
         controller._rotateRateRangeAdjustment = 1.0;
 
         var oldTransform = Matrix4.clone(camera.transform, rotateCVOldTransform);
-        camera.setTransform(transform);
+        camera._setTransform(transform);
 
         rotate3D(controller, startPosition, movement, Cartesian3.UNIT_Z);
 
-        camera.setTransform(oldTransform);
+        camera._setTransform(oldTransform);
         controller._globe = oldGlobe;
         controller._ellipsoid = oldEllipsoid;
 
@@ -815,14 +815,14 @@ define([
         var constrainedAxis = Cartesian3.UNIT_Z;
 
         var oldTransform = Matrix4.clone(camera.transform, rotateCVOldTransform);
-        camera.setTransform(transform);
+        camera._setTransform(transform);
 
         var tangent = Cartesian3.cross(Cartesian3.UNIT_Z, Cartesian3.normalize(camera.position, rotateCVCartesian3), rotateCVCartesian3);
         var dot = Cartesian3.dot(camera.right, tangent);
 
         rotate3D(controller, startPosition, movement, constrainedAxis, false, true);
 
-        camera.setTransform(verticalTransform);
+        camera._setTransform(verticalTransform);
         if (dot < 0.0) {
             if (movement.startPosition.y > movement.endPosition.y) {
                 constrainedAxis = undefined;
@@ -853,7 +853,7 @@ define([
             }
         }
 
-        camera.setTransform(oldTransform);
+        camera._setTransform(oldTransform);
         controller._globe = oldGlobe;
         controller._ellipsoid = oldEllipsoid;
 
@@ -865,7 +865,7 @@ define([
         adjustHeightForTerrain(controller);
 
         if (!Cartesian3.equals(camera.positionWC, originalPosition)) {
-            camera.setTransform(verticalTransform);
+            camera._setTransform(verticalTransform);
             camera.worldToCameraCoordinatesPoint(originalPosition, originalPosition);
 
             var magSqrd = Cartesian3.magnitudeSquared(originalPosition);
@@ -885,7 +885,7 @@ define([
             Cartesian3.cross(camera.direction, camera.up, camera.right);
             Cartesian3.cross(camera.right, camera.direction, camera.up);
 
-            camera.setTransform(oldTransform);
+            camera._setTransform(oldTransform);
         }
     }
 
@@ -1314,11 +1314,11 @@ define([
         controller._rotateRateRangeAdjustment = 1.0;
 
         var oldTransform = Matrix4.clone(camera.transform, tilt3DOldTransform);
-        camera.setTransform(transform);
+        camera._setTransform(transform);
 
         rotate3D(controller, startPosition, movement, Cartesian3.UNIT_Z);
 
-        camera.setTransform(oldTransform);
+        camera._setTransform(oldTransform);
         controller._globe = oldGlobe;
         controller._ellipsoid = oldEllipsoid;
 
@@ -1395,14 +1395,14 @@ define([
         var constrainedAxis = Cartesian3.UNIT_Z;
 
         var oldTransform = Matrix4.clone(camera.transform, tilt3DOldTransform);
-        camera.setTransform(transform);
+        camera._setTransform(transform);
 
         var tangent = Cartesian3.cross(verticalCenter, camera.positionWC, tilt3DCartesian3);
         var dot = Cartesian3.dot(camera.rightWC, tangent);
 
         rotate3D(controller, startPosition, movement, constrainedAxis, false, true);
 
-        camera.setTransform(verticalTransform);
+        camera._setTransform(verticalTransform);
 
         if (dot < 0.0) {
             if (movement.startPosition.y > movement.endPosition.y) {
@@ -1434,7 +1434,7 @@ define([
             }
         }
 
-        camera.setTransform(oldTransform);
+        camera._setTransform(oldTransform);
         controller._globe = oldGlobe;
         controller._ellipsoid = oldEllipsoid;
 
@@ -1446,7 +1446,7 @@ define([
         adjustHeightForTerrain(controller);
 
         if (!Cartesian3.equals(camera.positionWC, originalPosition)) {
-            camera.setTransform(verticalTransform);
+            camera._setTransform(verticalTransform);
             camera.worldToCameraCoordinatesPoint(originalPosition, originalPosition);
 
             var magSqrd = Cartesian3.magnitudeSquared(originalPosition);
@@ -1466,7 +1466,7 @@ define([
             Cartesian3.cross(camera.direction, camera.up, camera.right);
             Cartesian3.cross(camera.right, camera.direction, camera.up);
 
-            camera.setTransform(oldTransform);
+            camera._setTransform(oldTransform);
         }
     }
 

--- a/Source/Widgets/Viewer/Viewer.js
+++ b/Source/Widgets/Viewer/Viewer.js
@@ -951,7 +951,7 @@ Either specify options.terrainProvider instead or set options.baseLayerPicker to
                         this._entityView = new EntityView(value, scene, this.scene.globe.ellipsoid);
                     } else {
                         this._entityView = undefined;
-                        this.camera.setTransform(Matrix4.IDENTITY);
+                        this.camera.lookAtTransform(Matrix4.IDENTITY, this.camera.positionWC);
                     }
                 }
             }

--- a/Specs/Scene/CameraSpec.js
+++ b/Specs/Scene/CameraSpec.js
@@ -341,28 +341,6 @@ defineSuite([
         }).toThrowDeveloperError();
     });
 
-    it('setTransform', function() {
-        var ellipsoid = Ellipsoid.WGS84;
-        var cartOrigin = Cartographic.fromDegrees(-75.59777, 40.03883);
-        var origin = ellipsoid.cartographicToCartesian(cartOrigin);
-        var transform = Transforms.eastNorthUpToFixedFrame(origin);
-
-        var height = 1000.0;
-        cartOrigin.height = height;
-
-        camera.position = ellipsoid.cartographicToCartesian(cartOrigin);
-        camera.direction = Cartesian3.negate(Cartesian3.fromCartesian4(Matrix4.getColumn(transform, 2, new Cartesian4())), new Cartesian3());
-        camera.up = Cartesian3.fromCartesian4(Matrix4.getColumn(transform, 1, new Cartesian4(), new Matrix4()));
-        camera.right = Cartesian3.fromCartesian4(Matrix4.getColumn(transform, 0, new Cartesian4()));
-
-        camera.setTransform(transform);
-
-        expect(camera.position).toEqualEpsilon(new Cartesian3(0.0, 0.0, height), CesiumMath.EPSILON9);
-        expect(camera.direction).toEqualEpsilon(Cartesian3.negate(Cartesian3.UNIT_Z, new Cartesian3()), CesiumMath.EPSILON9);
-        expect(camera.up).toEqualEpsilon(Cartesian3.UNIT_Y, CesiumMath.EPSILON9);
-        expect(camera.right).toEqualEpsilon(Cartesian3.UNIT_X, CesiumMath.EPSILON9);
-    });
-
     it('setView with cartographic in 2D', function() {
         var ellipsoid = Ellipsoid.WGS84;
         var projection = new GeographicProjection(ellipsoid);
@@ -985,15 +963,31 @@ defineSuite([
         expect(1.0 - Cartesian3.magnitude(tempCamera.right)).toBeLessThan(CesiumMath.EPSILON14);
     });
 
+    it('lookAtTransform with no offset parameter', function() {
+        var ellipsoid = Ellipsoid.WGS84;
+        var cartOrigin = Cartographic.fromDegrees(-75.59777, 40.03883);
+        var origin = ellipsoid.cartographicToCartesian(cartOrigin);
+        var transform = Transforms.eastNorthUpToFixedFrame(origin);
+
+        var height = 1000.0;
+        cartOrigin.height = height;
+
+        camera.position = ellipsoid.cartographicToCartesian(cartOrigin);
+        camera.direction = Cartesian3.negate(Cartesian3.fromCartesian4(Matrix4.getColumn(transform, 2, new Cartesian4())), new Cartesian3());
+        camera.up = Cartesian3.fromCartesian4(Matrix4.getColumn(transform, 1, new Cartesian4(), new Matrix4()));
+        camera.right = Cartesian3.fromCartesian4(Matrix4.getColumn(transform, 0, new Cartesian4()));
+
+        camera.lookAtTransform(transform);
+
+        expect(camera.position).toEqualEpsilon(new Cartesian3(0.0, 0.0, height), CesiumMath.EPSILON9);
+        expect(camera.direction).toEqualEpsilon(Cartesian3.negate(Cartesian3.UNIT_Z, new Cartesian3()), CesiumMath.EPSILON9);
+        expect(camera.up).toEqualEpsilon(Cartesian3.UNIT_Y, CesiumMath.EPSILON9);
+        expect(camera.right).toEqualEpsilon(Cartesian3.UNIT_X, CesiumMath.EPSILON9);
+    });
+
     it('lookAtTransform throws with no transform parameter', function() {
         expect(function() {
             camera.lookAtTransform(undefined, Cartesian3.ZERO);
-        }).toThrowDeveloperError();
-    });
-
-    it('lookAtTransform throws with no offset parameter', function() {
-        expect(function() {
-            camera.lookAtTransform(Matrix4.IDENTITY, undefined);
         }).toThrowDeveloperError();
     });
 

--- a/Specs/Scene/GeometryRenderingSpec.js
+++ b/Specs/Scene/GeometryRenderingSpec.js
@@ -569,7 +569,7 @@ defineSuite([
                 var transform = Matrix4.multiplyByTranslation(
                         Transforms.eastNorthUpToFixedFrame(primitive._boundingSphereWC[0].center),
                         new Cartesian3(0.0, 0.0, height), new Matrix4());
-                frameState.camera.setTransform(transform);
+                frameState.camera.lookAtTransform(transform, new Cartesian3(0.0, 0.0, primitive._boundingSphereWC[0].radius));
                 frameState.camera.rotateDown(CesiumMath.PI);
             };
             render3D(instance, afterView);
@@ -578,7 +578,7 @@ defineSuite([
         it('renders wall', function() {
             var afterView = function(frameState, primitive) {
                 var transform = Transforms.eastNorthUpToFixedFrame(primitive._boundingSphereWC[0].center);
-                frameState.camera.setTransform(transform);
+                frameState.camera.lookAtTransform(transform, new Cartesian3(0.0, 0.0, primitive._boundingSphereWC[0].radius));
                 frameState.camera.rotateDown(CesiumMath.PI_OVER_TWO);
             };
             render3D(instance, afterView);
@@ -792,7 +792,7 @@ defineSuite([
         it('renders bottom', function() {
             var afterView = function(frameState, primitive) {
                 var transform = Transforms.eastNorthUpToFixedFrame(primitive._boundingSphereWC[0].center);
-                frameState.camera.setTransform(transform);
+                frameState.camera.lookAtTransform(transform, new Cartesian3(0.0, 0.0, primitive._boundingSphereWC[0].radius));
                 frameState.camera.rotateDown(CesiumMath.PI);
             };
             render3D(instance, afterView);
@@ -801,7 +801,7 @@ defineSuite([
         it('renders north wall', function() {
             var afterView = function(frameState, primitive) {
                 var transform = Transforms.eastNorthUpToFixedFrame(primitive._boundingSphereWC[0].center);
-                frameState.camera.setTransform(transform);
+                frameState.camera.lookAtTransform(transform, new Cartesian3(0.0, 0.0, primitive._boundingSphereWC[0].radius));
                 frameState.camera.rotateDown(-CesiumMath.PI_OVER_TWO);
             };
             render3D(instance, afterView);
@@ -810,7 +810,7 @@ defineSuite([
         it('renders south wall', function() {
             var afterView = function(frameState, primitive) {
                 var transform = Transforms.eastNorthUpToFixedFrame(primitive._boundingSphereWC[0].center);
-                frameState.camera.setTransform(transform);
+                frameState.camera.lookAtTransform(transform, new Cartesian3(0.0, 0.0, primitive._boundingSphereWC[0].radius));
                 frameState.camera.rotateDown(CesiumMath.PI_OVER_TWO);
             };
             render3D(instance, afterView);
@@ -819,7 +819,7 @@ defineSuite([
         it('renders west wall', function() {
             var afterView = function(frameState, primitive) {
                 var transform = Transforms.eastNorthUpToFixedFrame(primitive._boundingSphereWC[0].center);
-                frameState.camera.setTransform(transform);
+                frameState.camera.lookAtTransform(transform, new Cartesian3(0.0, 0.0, primitive._boundingSphereWC[0].radius));
                 frameState.camera.rotateRight(-CesiumMath.PI_OVER_TWO);
             };
             render3D(instance, afterView);
@@ -828,7 +828,7 @@ defineSuite([
         it('renders east wall', function() {
             var afterView = function(frameState, primitive) {
                 var transform = Transforms.eastNorthUpToFixedFrame(primitive._boundingSphereWC[0].center);
-                frameState.camera.setTransform(transform);
+                frameState.camera.lookAtTransform(transform, new Cartesian3(0.0, 0.0, primitive._boundingSphereWC[0].radius));
                 frameState.camera.rotateRight(CesiumMath.PI_OVER_TWO);
             };
             render3D(instance, afterView);
@@ -991,7 +991,7 @@ defineSuite([
                 var transform = Matrix4.multiplyByTranslation(
                         Transforms.eastNorthUpToFixedFrame(primitive._boundingSphereWC[0].center),
                         new Cartesian3(0.0, 0.0, height), new Matrix4());
-                frameState.camera.setTransform(transform);
+                frameState.camera.lookAtTransform(transform, new Cartesian3(0.0, 0.0, primitive._boundingSphereWC[0].radius));
                 frameState.camera.rotateDown(CesiumMath.PI);
             };
             render3D(instance, afterView);
@@ -1000,7 +1000,7 @@ defineSuite([
         it('renders wall 1', function() {
             var afterView = function(frameState, primitive) {
                 var transform = Transforms.eastNorthUpToFixedFrame(primitive._boundingSphereWC[0].center);
-                frameState.camera.setTransform(transform);
+                frameState.camera.lookAtTransform(transform, new Cartesian3(0.0, 0.0, primitive._boundingSphereWC[0].radius));
                 frameState.camera.rotateUp(CesiumMath.PI_OVER_TWO);
             };
             render3D(instance, afterView);
@@ -1009,7 +1009,7 @@ defineSuite([
         it('renders wall 2', function() {
             var afterView = function(frameState, primitive) {
                 var transform = Transforms.eastNorthUpToFixedFrame(primitive._boundingSphereWC[0].center);
-                frameState.camera.setTransform(transform);
+                frameState.camera.lookAtTransform(transform, new Cartesian3(0.0, 0.0, primitive._boundingSphereWC[0].radius));
                 frameState.camera.rotateDown(-CesiumMath.PI_OVER_TWO);
             };
             render3D(instance, afterView);
@@ -1018,7 +1018,7 @@ defineSuite([
         it('renders wall 3', function() {
             var afterView = function(frameState, primitive) {
                 var transform = Transforms.eastNorthUpToFixedFrame(primitive._boundingSphereWC[0].center);
-                frameState.camera.setTransform(transform);
+                frameState.camera.lookAtTransform(transform, new Cartesian3(0.0, 0.0, primitive._boundingSphereWC[0].radius));
                 frameState.camera.rotateRight(-CesiumMath.PI_OVER_TWO);
             };
             render3D(instance, afterView);
@@ -1027,7 +1027,7 @@ defineSuite([
         it('renders wall 4', function() {
             var afterView = function(frameState, primitive) {
                 var transform = Transforms.eastNorthUpToFixedFrame(primitive._boundingSphereWC[0].center);
-                frameState.camera.setTransform(transform);
+                frameState.camera.lookAtTransform(transform, new Cartesian3(0.0, 0.0, primitive._boundingSphereWC[0].radius));
                 frameState.camera.rotateRight(CesiumMath.PI_OVER_TWO);
             };
             render3D(instance, afterView);
@@ -1065,7 +1065,7 @@ defineSuite([
             viewSphere3D(frameState.camera, primitive._boundingSphereWC[0], primitive.modelMatrix);
 
             var transform = Transforms.eastNorthUpToFixedFrame(primitive._boundingSphereWC[0].center);
-            frameState.camera.setTransform(transform);
+            frameState.camera.lookAtTransform(transform, new Cartesian3(0.0, 0.0, primitive._boundingSphereWC[0].radius));
             frameState.camera.rotateDown(-CesiumMath.PI_OVER_TWO);
             frameState.camera.moveForward(primitive._boundingSphereWC[0].radius * 0.75);
 
@@ -1106,9 +1106,8 @@ defineSuite([
 
             afterView3D = function(frameState, primitive) {
                 var transform = Transforms.eastNorthUpToFixedFrame(primitive._boundingSphereWC[0].center);
-                frameState.camera.setTransform(transform);
+                frameState.camera.lookAtTransform(transform, new Cartesian3(0.0, 0.0, primitive._boundingSphereWC[0].radius));
                 frameState.camera.rotateDown(-CesiumMath.PI_OVER_TWO);
-                frameState.camera.zoomIn(primitive._boundingSphereWC[0].radius * 0.99);
             };
 
             afterViewCV = function(frameState, primitive) {
@@ -1258,7 +1257,7 @@ defineSuite([
                 var transform = Matrix4.multiplyByTranslation(
                         Transforms.eastNorthUpToFixedFrame(primitive._boundingSphereWC[0].center),
                         new Cartesian3(0.0, 0.0, height), new Matrix4());
-                frameState.camera.setTransform(transform);
+                frameState.camera.lookAtTransform(transform, new Cartesian3(0.0, 0.0, primitive._boundingSphereWC[0].radius));
                 frameState.camera.rotateDown(CesiumMath.PI);
             };
             render3D(instance, afterView);
@@ -1267,7 +1266,7 @@ defineSuite([
         it('renders north wall', function() {
             var afterView = function(frameState, primitive) {
                 var transform = Transforms.eastNorthUpToFixedFrame(primitive._boundingSphereWC[0].center);
-                frameState.camera.setTransform(transform);
+                frameState.camera.lookAtTransform(transform, new Cartesian3(0.0, 0.0, primitive._boundingSphereWC[0].radius));
                 frameState.camera.rotateDown(-CesiumMath.PI_OVER_TWO);
             };
             render3D(instance, afterView);
@@ -1276,7 +1275,7 @@ defineSuite([
         it('renders south wall', function() {
             var afterView = function(frameState, primitive) {
                 var transform = Transforms.eastNorthUpToFixedFrame(primitive._boundingSphereWC[0].center);
-                frameState.camera.setTransform(transform);
+                frameState.camera.lookAtTransform(transform, new Cartesian3(0.0, 0.0, primitive._boundingSphereWC[0].radius));
                 frameState.camera.rotateDown(CesiumMath.PI_OVER_TWO);
             };
             render3D(instance, afterView);
@@ -1285,7 +1284,7 @@ defineSuite([
         it('renders west wall', function() {
             var afterView = function(frameState, primitive) {
                 var transform = Transforms.eastNorthUpToFixedFrame(primitive._boundingSphereWC[0].center);
-                frameState.camera.setTransform(transform);
+                frameState.camera.lookAtTransform(transform, new Cartesian3(0.0, 0.0, primitive._boundingSphereWC[0].radius));
                 frameState.camera.rotateRight(-CesiumMath.PI_OVER_TWO);
             };
             render3D(instance, afterView);
@@ -1294,7 +1293,7 @@ defineSuite([
         it('renders east wall', function() {
             var afterView = function(frameState, primitive) {
                 var transform = Transforms.eastNorthUpToFixedFrame(primitive._boundingSphereWC[0].center);
-                frameState.camera.setTransform(transform);
+                frameState.camera.lookAtTransform(transform, new Cartesian3(0.0, 0.0, primitive._boundingSphereWC[0].radius));
                 frameState.camera.rotateRight(CesiumMath.PI_OVER_TWO);
             };
             render3D(instance, afterView);
@@ -1355,7 +1354,7 @@ defineSuite([
                 var transform = Matrix4.multiplyByTranslation(
                         Transforms.eastNorthUpToFixedFrame(primitive._boundingSphereWC[0].center),
                         new Cartesian3(0.0, 0.0, height), new Matrix4());
-                frameState.camera.setTransform(transform);
+                frameState.camera.lookAtTransform(transform, new Cartesian3(0.0, 0.0, primitive._boundingSphereWC[0].radius));
                 frameState.camera.rotateDown(CesiumMath.PI);
             };
             render3D(instance, afterView);
@@ -1364,7 +1363,7 @@ defineSuite([
         it('renders north wall', function() {
             var afterView = function(frameState, primitive) {
                 var transform = Transforms.eastNorthUpToFixedFrame(primitive._boundingSphereWC[0].center);
-                frameState.camera.setTransform(transform);
+                frameState.camera.lookAtTransform(transform, new Cartesian3(0.0, 0.0, primitive._boundingSphereWC[0].radius));
                 frameState.camera.rotateDown(-CesiumMath.PI_OVER_TWO);
             };
             render3D(instance, afterView);
@@ -1373,7 +1372,7 @@ defineSuite([
         it('renders south wall', function() {
             var afterView = function(frameState, primitive) {
                 var transform = Transforms.eastNorthUpToFixedFrame(primitive._boundingSphereWC[0].center);
-                frameState.camera.setTransform(transform);
+                frameState.camera.lookAtTransform(transform, new Cartesian3(0.0, 0.0, primitive._boundingSphereWC[0].radius));
                 frameState.camera.rotateDown(CesiumMath.PI_OVER_TWO);
             };
             render3D(instance, afterView);
@@ -1382,7 +1381,7 @@ defineSuite([
         it('renders west wall', function() {
             var afterView = function(frameState, primitive) {
                 var transform = Transforms.eastNorthUpToFixedFrame(primitive._boundingSphereWC[0].center);
-                frameState.camera.setTransform(transform);
+                frameState.camera.lookAtTransform(transform, new Cartesian3(0.0, 0.0, primitive._boundingSphereWC[0].radius));
                 frameState.camera.rotateRight(-CesiumMath.PI_OVER_TWO);
             };
             render3D(instance, afterView);
@@ -1391,7 +1390,7 @@ defineSuite([
         it('renders east wall', function() {
             var afterView = function(frameState, primitive) {
                 var transform = Transforms.eastNorthUpToFixedFrame(primitive._boundingSphereWC[0].center);
-                frameState.camera.setTransform(transform);
+                frameState.camera.lookAtTransform(transform, new Cartesian3(0.0, 0.0, primitive._boundingSphereWC[0].radius));
                 frameState.camera.rotateRight(CesiumMath.PI_OVER_TWO);
             };
             render3D(instance, afterView);

--- a/Specs/Scene/ImageryLayerCollectionSpec.js
+++ b/Specs/Scene/ImageryLayerCollectionSpec.js
@@ -431,7 +431,7 @@ defineSuite([
             runs(function() {
                 var ellipsoid = Ellipsoid.WGS84;
                 camera.lookAt(new Cartesian3(ellipsoid.maximumRadius, 0.0, 0.0), new Cartesian3(0.0, 0.0, 100.0));
-                camera.setTransform(Matrix4.IDENTITY);
+                camera.lookAtTransform(Matrix4.IDENTITY);
 
                 var ray = new Ray(camera.position, camera.direction);
                 var featuresPromise = scene.imageryLayers.pickImageryLayerFeatures(ray, scene);
@@ -512,7 +512,7 @@ defineSuite([
             runs(function() {
                 var ellipsoid = Ellipsoid.WGS84;
                 camera.lookAt(new Cartesian3(ellipsoid.maximumRadius, 0.0, 0.0), new Cartesian3(0.0, 0.0, 100.0));
-                camera.setTransform(Matrix4.IDENTITY);
+                camera.lookAtTransform(Matrix4.IDENTITY);
 
                 var ray = new Ray(camera.position, camera.direction);
                 var featuresPromise = scene.imageryLayers.pickImageryLayerFeatures(ray, scene);


### PR DESCRIPTION
NOTE: This is a PR into the `look-at` branch.

Deprecates `Camera.setTransform`. Use `Camera.lookAtTransform` instead.