### PR TITLE
Camera look-at with heading/pitch/range

### DIFF
--- a/Apps/Sandcastle/gallery/3D Models.html
+++ b/Apps/Sandcastle/gallery/3D Models.html
@@ -53,13 +53,17 @@ function createModel(url, height, heading, pitch, roll) {
             loop : Cesium.ModelAnimationLoop.REPEAT
         });
         
+        var camera = viewer.camera;
+        
         // Zoom to model
         var controller = scene.screenSpaceCameraController;
         var r = 2.0 * Math.max(model.boundingSphere.radius, camera.frustum.near);
         controller.minimumZoomDistance = r * 0.5;
         
         var center = Cesium.Matrix4.multiplyByPoint(model.modelMatrix, model.boundingSphere.center, new Cesium.Cartesian3());
-        viewer.camera.lookAt(center, new Cesium.Cartesian3(r, r, r));
+        var heading = Cesium.Math.toRadians(50.0);
+        var pitch = Cesium.Math.toRadians(-20.0);
+        camera.lookAtHeadingPitchRange(center, heading, pitch, r * 2.0);
     }).otherwise(function(error){
         window.alert(error);
     });

--- a/Apps/Sandcastle/gallery/3D Models.html
+++ b/Apps/Sandcastle/gallery/3D Models.html
@@ -61,7 +61,7 @@ function createModel(url, height, heading, pitch, roll) {
         controller.minimumZoomDistance = r * 0.5;
         
         var center = Cesium.Matrix4.multiplyByPoint(model.modelMatrix, model.boundingSphere.center, new Cesium.Cartesian3());
-        var heading = Cesium.Math.toRadians(50.0);
+        var heading = Cesium.Math.toRadians(230.0);
         var pitch = Cesium.Math.toRadians(-20.0);
         camera.lookAtHeadingPitchRange(center, heading, pitch, r * 2.0);
     }).otherwise(function(error){

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,8 @@ Change Log
 * Improved performance of asynchronous geometry creation (as much as 20% faster in some use cases). [#2342](https://github.com/AnalyticalGraphicsInc/cesium/issues/2342)
 * Added `PolylineVolumeGraphics` and `Entity.polylineVolume`
 * Added `Camera.lookAtTransform` which sets the camera position and orientation given a transformation matrix defining a reference frame and an offset from the center of that frame.
+* Added `Camera.lookAtHeadingPitchRange` which sets the camera position and orientation given a target in world coordinates, heading/pitch angles, and a range from the target.
+* Added `Camera.lookAtTransformHeadingPitchRange` which sets the camera position and orientation given a transformation matrix defining a reference frame, heading/pitch angles, and a range from the center of the reference frame.
 * Added `Camera.setView` (which use heading, pitch, and roll) and `Camera.roll`.
 * Added `Quaternion.fromHeadingPitchRoll` to create a rotation from heading, pitch, and roll angles.
 * Added `Transforms.headingPitchRollToFixedFrame` to create a local frame from a position and heading/pitch/roll angles.

--- a/Source/Scene/Camera.js
+++ b/Source/Scene/Camera.js
@@ -1618,6 +1618,72 @@ define([
         this.lookAtTransform(transform, offset);
     };
 
+    var scratchLookAtHeadingPitchRangeOffset = new Cartesian3();
+    var scratchLookAtHeadingPitchRangeQuaternion1 = new Quaternion();
+    var scratchLookAtHeadingPitchRangeQuaternion2 = new Quaternion();
+    var scratchHeadingPitchRangeMatrix3 = new Matrix3();
+
+    function offsetFromHeadingPitchRange(heading, pitch, range) {
+        pitch = CesiumMath.clamp(pitch, -CesiumMath.PI_OVER_TWO, CesiumMath.PI_OVER_TWO);
+        heading = CesiumMath.zeroToTwoPi(heading + CesiumMath.PI_OVER_TWO);
+
+        var pitchQuat = Quaternion.fromAxisAngle(Cartesian3.UNIT_Y, -pitch, scratchLookAtHeadingPitchRangeQuaternion1);
+        var headingQuat = Quaternion.fromAxisAngle(Cartesian3.UNIT_Z, -heading, scratchLookAtHeadingPitchRangeQuaternion2);
+        var rotQuat = Quaternion.multiply(headingQuat, pitchQuat, headingQuat);
+        var rotMatrix = Matrix3.fromQuaternion(rotQuat, scratchHeadingPitchRangeMatrix3);
+
+        var offset = Cartesian3.clone(Cartesian3.UNIT_X, scratchLookAtHeadingPitchRangeOffset);
+        Matrix3.multiplyByVector(rotMatrix, offset, offset);
+        Cartesian3.negate(offset, offset);
+        Cartesian3.multiplyByScalar(offset, range, offset);
+        return offset;
+    }
+
+    /**
+     * Sets the camera position and orientation using a target, heading, pitch and range. The target must be given in
+     * world coordinates. Both the heading and the pitch angles are defined in the local east-north-up reference
+     * frame centered at the target. The heading is the angle from north and increasing in the east direction. Pitch is the rotation
+     * from the local east-north plane. Positive pitch angles are above the plane. Negative pitch angles are below the plane. The range
+     * is the distance from the target.
+     *
+     * In 2D, there must be a top down view. The camera will be placed above the target looking down. The height above the
+     * target will be the range.
+     *
+     * @param {Cartesian3} target The target position in world coordinates.
+     * @param {Number} heading The heading angle in radians.
+     * @param {Number} pitch The pitch angle in radians.
+     * @param {Number} range The distance from the target in meters.
+     *
+     * @example
+     * var center = Cartesian3.fromDegrees(-72.0, 40.0);
+     * var heading = Cesium.Math.toRadians(50.0);
+     * var pitch = Cesium.Math.toRadians(-20.0);
+     * var range = 5000.0;
+     * camera.lookAtHeadingPitchRange(center, heading, pitch, range);
+     */
+    Camera.prototype.lookAtHeadingPitchRange = function(target, heading, pitch, range) {
+      //>>includeStart('debug', pragmas.debug);
+        if (!defined(target)) {
+            throw new DeveloperError('target is required');
+        }
+        if (!defined(heading)) {
+            throw new DeveloperError('heading is required');
+        }
+        if (!defined(pitch)) {
+            throw new DeveloperError('pitch is required');
+        }
+        if (!defined(range)) {
+            throw new DeveloperError('range is required');
+        }
+        if (this._mode === SceneMode.MORPHING) {
+            throw new DeveloperError('lookAtTransform is not supported while morphing.');
+        }
+        //>>includeEnd('debug');
+
+
+        this.lookAt(target, offsetFromHeadingPitchRange(heading, pitch, range));
+    };
+
     /**
      * Sets the camera position and orientation using a target and transformation matrix. The offset is a cartesian
      * offset from the center of the reference frame defined by the transformation matrix.
@@ -1693,6 +1759,49 @@ define([
         Cartesian3.normalize(this.right, this.right);
         Cartesian3.cross(this.right, this.direction, this.up);
         Cartesian3.normalize(this.up, this.up);
+    };
+
+    /**
+     * Sets the camera position and orientation using a transformation matrix, heading, pitch and range. Both the heading and the pitch angles are
+     * defined in the reference frame defined by the transformation matrix. The heading is the angle from y axis and increasing towards
+     * the x axis. Pitch is the rotation from the xy-plane. Positive pitch angles are above the plane. Negative pitch angles are below the plane. The range
+     * is the distance from the center.
+     *
+     * In 2D, there must be a top down view. The camera will be placed above the center of the reference frame looking down. The height above the
+     * center will be the range.
+     *
+     * @param {Matrix4} transform The transformation matrix defining the reference frame.
+     * @param {Number} heading The heading angle in radians.
+     * @param {Number} pitch The pitch angle in radians.
+     * @param {Number} range The distance from the target in meters.
+     *
+     * @example
+     * var transform = Cesium.Transforms.eastNorthUpToFixedFrame(Cartesian3.fromDegrees(-72.0, 40.0));
+     * var heading = Cesium.Math.toRadians(50.0);
+     * var pitch = Cesium.Math.toRadians(-20.0);
+     * var range = 5000.0;
+     * camera.lookAtTransformHeadingPitchRange(transform, heading, pitch, range);
+     */
+    Camera.prototype.lookAtTransformHeadingPitchRange = function(transform, heading, pitch, range) {
+      //>>includeStart('debug', pragmas.debug);
+        if (!defined(transform)) {
+            throw new DeveloperError('transform is required');
+        }
+        if (!defined(heading)) {
+            throw new DeveloperError('heading is required');
+        }
+        if (!defined(pitch)) {
+            throw new DeveloperError('pitch is required');
+        }
+        if (!defined(range)) {
+            throw new DeveloperError('range is required');
+        }
+        if (this._mode === SceneMode.MORPHING) {
+            throw new DeveloperError('lookAtTransform is not supported while morphing.');
+        }
+        //>>includeEnd('debug');
+
+        this.lookAtTransform(transform, offsetFromHeadingPitchRange(heading, pitch, range));
     };
 
     var viewRectangle3DCartographic = new Cartographic();

--- a/Source/Scene/Camera.js
+++ b/Source/Scene/Camera.js
@@ -1625,7 +1625,7 @@ define([
 
     function offsetFromHeadingPitchRange(heading, pitch, range) {
         pitch = CesiumMath.clamp(pitch, -CesiumMath.PI_OVER_TWO, CesiumMath.PI_OVER_TWO);
-        heading = CesiumMath.zeroToTwoPi(heading + CesiumMath.PI_OVER_TWO);
+        heading = CesiumMath.zeroToTwoPi(heading) - CesiumMath.PI_OVER_TWO;
 
         var pitchQuat = Quaternion.fromAxisAngle(Cartesian3.UNIT_Y, -pitch, scratchLookAtHeadingPitchRangeQuaternion1);
         var headingQuat = Quaternion.fromAxisAngle(Cartesian3.UNIT_Z, -heading, scratchLookAtHeadingPitchRangeQuaternion2);
@@ -1679,7 +1679,6 @@ define([
             throw new DeveloperError('lookAtTransform is not supported while morphing.');
         }
         //>>includeEnd('debug');
-
 
         this.lookAt(target, offsetFromHeadingPitchRange(heading, pitch, range));
     };

--- a/Specs/Scene/CameraSpec.js
+++ b/Specs/Scene/CameraSpec.js
@@ -954,7 +954,7 @@ defineSuite([
         var tempCamera = camera.clone();
         tempCamera.lookAtHeadingPitchRange(target, heading, pitch, range);
 
-        tempCamera.setTransform(Matrix4.IDENTITY);
+        tempCamera.lookAtTransform(Matrix4.IDENTITY);
 
         expect(Cartesian3.distance(tempCamera.position, target)).toEqualEpsilon(range, CesiumMath.EPSILON6);
         expect(tempCamera.heading).toEqualEpsilon(heading, CesiumMath.EPSILON6);
@@ -1011,7 +1011,7 @@ defineSuite([
 
         expect(Cartesian2.clone(tempCamera.position)).toEqual(Cartesian2.ZERO);
 
-        tempCamera.setTransform(Matrix4.IDENTITY);
+        tempCamera.lookAtTransform(Matrix4.IDENTITY);
         expect(tempCamera.direction).toEqual(Cartesian3.negate(Cartesian3.UNIT_Z, new Cartesian3()));
         expect(tempCamera.heading).toEqualEpsilon(heading, CesiumMath.EPSILON6);
         expect(tempCamera.frustum.right).toEqual(range);
@@ -1107,7 +1107,7 @@ defineSuite([
         var tempCamera = camera.clone();
         tempCamera.lookAtTransformHeadingPitchRange(transform, heading, pitch, range);
 
-        tempCamera.setTransform(Matrix4.IDENTITY);
+        tempCamera.lookAtTransform(Matrix4.IDENTITY);
 
         expect(Cartesian3.distance(tempCamera.position, target)).toEqualEpsilon(range, CesiumMath.EPSILON6);
         expect(tempCamera.heading).toEqualEpsilon(heading, CesiumMath.EPSILON6);
@@ -1165,7 +1165,7 @@ defineSuite([
 
         expect(Cartesian2.clone(tempCamera.position)).toEqual(Cartesian2.ZERO);
 
-        tempCamera.setTransform(Matrix4.IDENTITY);
+        tempCamera.lookAtTransform(Matrix4.IDENTITY);
         expect(tempCamera.direction).toEqual(Cartesian3.negate(Cartesian3.UNIT_Z, new Cartesian3()));
         expect(tempCamera.heading).toEqualEpsilon(heading, CesiumMath.EPSILON6);
         expect(tempCamera.frustum.right).toEqual(range);

--- a/Specs/Scene/CameraSpec.js
+++ b/Specs/Scene/CameraSpec.js
@@ -967,6 +967,79 @@ defineSuite([
         }).toThrowDeveloperError();
     });
 
+    it('lookAtHeadingPitchRange', function() {
+        var target = Cartesian3.fromDegrees(0.0, 0.0);
+        var heading = CesiumMath.toRadians(45.0);
+        var pitch = CesiumMath.toRadians(-45.0);
+        var range = 2.0;
+
+        var tempCamera = camera.clone();
+        tempCamera.lookAtHeadingPitchRange(target, heading, pitch, range);
+
+        tempCamera.setTransform(Matrix4.IDENTITY);
+
+        expect(Cartesian3.distance(tempCamera.position, target)).toEqualEpsilon(range, CesiumMath.EPSILON6);
+        expect(tempCamera.heading).toEqualEpsilon(heading, CesiumMath.EPSILON6);
+        expect(tempCamera.pitch).toEqualEpsilon(pitch, CesiumMath.EPSILON6);
+
+        expect(1.0 - Cartesian3.magnitude(tempCamera.direction)).toBeLessThan(CesiumMath.EPSILON14);
+        expect(1.0 - Cartesian3.magnitude(tempCamera.up)).toBeLessThan(CesiumMath.EPSILON14);
+        expect(1.0 - Cartesian3.magnitude(tempCamera.right)).toBeLessThan(CesiumMath.EPSILON14);
+    });
+
+    it('lookAtHeadingPitchRange throws with no target parameter', function() {
+        expect(function() {
+            camera.lookAtHeadingPitchRange(undefined, 1.0, 2.0, 3.0);
+        }).toThrowDeveloperError();
+    });
+
+    it('lookAtHeadingPitchRange throws with no heading parameter', function() {
+        expect(function() {
+            camera.lookAtHeadingPitchRange(Cartesian3.ZERO, undefined, 2.0, 3.0);
+        }).toThrowDeveloperError();
+    });
+
+    it('lookAtHeadingPitchRange throws with no pitch parameter', function() {
+        expect(function() {
+            camera.lookAtHeadingPitchRange(Cartesian3.ZERO, 1.0, undefined, 3.0);
+        }).toThrowDeveloperError();
+    });
+
+    it('lookAtHeadingPitchRange throws with no range parameter', function() {
+        expect(function() {
+            camera.lookAtHeadingPitchRange(Cartesian3.ZERO, 1.0, 2.0, undefined);
+        }).toThrowDeveloperError();
+    });
+
+    it('lookAtHeadingPitchRange in 2D mode', function() {
+        var frustum = new OrthographicFrustum();
+        frustum.near = 1.0;
+        frustum.far = 2.0;
+        frustum.left = -2.0;
+        frustum.right = 2.0;
+        frustum.top = 1.0;
+        frustum.bottom = -1.0;
+
+        var tempCamera = camera.clone();
+        tempCamera.frustum = frustum;
+        tempCamera.update(SceneMode.SCENE2D);
+
+        var target = Cartesian3.fromDegrees(0.0, 0.0);
+        var heading = CesiumMath.toRadians(90.0);
+        var pitch = CesiumMath.toRadians(-45.0);
+        var range = 2.0;
+
+        tempCamera.lookAtHeadingPitchRange(target, heading, pitch, range);
+
+        expect(Cartesian2.clone(tempCamera.position)).toEqual(Cartesian2.ZERO);
+
+        tempCamera.setTransform(Matrix4.IDENTITY);
+        expect(tempCamera.direction).toEqual(Cartesian3.negate(Cartesian3.UNIT_Z, new Cartesian3()));
+        expect(tempCamera.heading).toEqualEpsilon(heading, CesiumMath.EPSILON6);
+        expect(tempCamera.frustum.right).toEqual(range);
+        expect(tempCamera.frustum.left).toEqual(-range);
+    });
+
     it('lookAtTransform', function() {
         var target = new Cartesian3(-1.0, -1.0, 0.0);
         var offset = new Cartesian3(1.0, 1.0, 0.0);
@@ -1027,6 +1100,89 @@ defineSuite([
 
         expect(function() {
             camera.lookAtTransform(Matrix4.IDENTITY, Cartesian3.UNIT_X);
+        }).toThrowDeveloperError();
+    });
+
+    it('lookAtTransformHeadingPitchRange', function() {
+        var target = Cartesian3.fromDegrees(0.0, 0.0);
+        var heading = CesiumMath.toRadians(45.0);
+        var pitch = CesiumMath.toRadians(-45.0);
+        var range = 2.0;
+        var transform = Transforms.eastNorthUpToFixedFrame(target);
+
+        var tempCamera = camera.clone();
+        tempCamera.lookAtTransformHeadingPitchRange(transform, heading, pitch, range);
+
+        tempCamera.setTransform(Matrix4.IDENTITY);
+
+        expect(Cartesian3.distance(tempCamera.position, target)).toEqualEpsilon(range, CesiumMath.EPSILON6);
+        expect(tempCamera.heading).toEqualEpsilon(heading, CesiumMath.EPSILON6);
+        expect(tempCamera.pitch).toEqualEpsilon(pitch, CesiumMath.EPSILON6);
+
+        expect(1.0 - Cartesian3.magnitude(tempCamera.direction)).toBeLessThan(CesiumMath.EPSILON14);
+        expect(1.0 - Cartesian3.magnitude(tempCamera.up)).toBeLessThan(CesiumMath.EPSILON14);
+        expect(1.0 - Cartesian3.magnitude(tempCamera.right)).toBeLessThan(CesiumMath.EPSILON14);
+    });
+
+    it('lookAtTransformHeadingPitchRange throws with no transform parameter', function() {
+        expect(function() {
+            camera.lookAtTransformHeadingPitchRange(undefined, 1.0, 2.0, 3.0);
+        }).toThrowDeveloperError();
+    });
+
+    it('lookAtTransformHeadingPitchRange throws with no heading parameter', function() {
+        expect(function() {
+            camera.lookAtTransformHeadingPitchRange(Matrix4.IDENTITY, undefined, 2.0, 3.0);
+        }).toThrowDeveloperError();
+    });
+
+    it('lookAtTransformHeadingPitchRange throws with no pitch parameter', function() {
+        expect(function() {
+            camera.lookAtTransformHeadingPitchRange(Matrix4.IDENTITY, 1.0, undefined, 3.0);
+        }).toThrowDeveloperError();
+    });
+
+    it('lookAtTransformHeadingPitchRange throws with no range parameter', function() {
+        expect(function() {
+            camera.lookAtTransformHeadingPitchRange(Matrix4.IDENTITY, 1.0, 2.0, undefined);
+        }).toThrowDeveloperError();
+    });
+
+    it('lookAtTransformHeadinPitchRange in 2D mode', function() {
+        var frustum = new OrthographicFrustum();
+        frustum.near = 1.0;
+        frustum.far = 2.0;
+        frustum.left = -2.0;
+        frustum.right = 2.0;
+        frustum.top = 1.0;
+        frustum.bottom = -1.0;
+
+        var tempCamera = camera.clone();
+        tempCamera.frustum = frustum;
+        tempCamera.update(SceneMode.SCENE2D);
+
+        var target = Cartesian3.fromDegrees(0.0, 0.0);
+        var heading = CesiumMath.toRadians(90.0);
+        var pitch = CesiumMath.toRadians(-45.0);
+        var range = 2.0;
+        var transform = Transforms.eastNorthUpToFixedFrame(target);
+
+        tempCamera.lookAtTransformHeadingPitchRange(transform, heading, pitch, range);
+
+        expect(Cartesian2.clone(tempCamera.position)).toEqual(Cartesian2.ZERO);
+
+        tempCamera.setTransform(Matrix4.IDENTITY);
+        expect(tempCamera.direction).toEqual(Cartesian3.negate(Cartesian3.UNIT_Z, new Cartesian3()));
+        expect(tempCamera.heading).toEqualEpsilon(heading, CesiumMath.EPSILON6);
+        expect(tempCamera.frustum.right).toEqual(range);
+        expect(tempCamera.frustum.left).toEqual(-range);
+    });
+
+    it('lookAtTransformHeadinPitchRange throws when morphing', function() {
+        camera.update(SceneMode.MORPHING);
+
+        expect(function() {
+            camera.lookAtTransformHeadingPitchRange(Matrix4.IDENTITY, 1.0, 2.0, 3.0);
         }).toThrowDeveloperError();
     });
 


### PR DESCRIPTION
NOTE: This is a PR into the look-at branch.

Adds look-at functions that set the orientation using heading/pitch angles and a range from the target.

CC @mramato This is exactly what the KML <LookAt> tag does, but they use `tilt` instead of `pitch` and the clamp the angle to [0, 90] degrees.