### PR TITLE
Added `Color.fromAlpha` and `Color.addAlpha`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,7 @@ Change Log
   * The `Model.readyToRender` event was deprecated and will be removed in Cesium 1.9.  Use the new `Model.readyPromise` instead.
   * The `mouseMoveOnDocument` parameter to the `ScreenSpaceEventHandler` constructor was deprecated in Cesium 1.6. It will be removed in Cesium 1.7. `ScreenSpaceEventHandler` will be constructed as if `mouseMoveOnDocument` is `false`.
 * Improved performance of asynchronous geometry creation (as much as 20% faster in some use cases). [#2342](https://github.com/AnalyticalGraphicsInc/cesium/issues/2342)
+* Added `Color.fromAlpha` and `Color.addAlpha` to make it easy to create translucent colors from constants, i.e. `var translucentRed = Color.RED.addAlpha(0.95)`.
 * Added `PolylineVolumeGraphics` and `Entity.polylineVolume`
 * Added `Camera.lookAtTransform` which sets the camera position and orientation given a transformation matrix defining a reference frame and either a cartesian offset or heading/pitch/range from the center of that frame.
 * Added `Camera.setView` (which use heading, pitch, and roll) and `Camera.roll`.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,7 +21,7 @@ Change Log
   * The `Model.readyToRender` event was deprecated and will be removed in Cesium 1.9.  Use the new `Model.readyPromise` instead.
   * The `mouseMoveOnDocument` parameter to the `ScreenSpaceEventHandler` constructor was deprecated in Cesium 1.6. It will be removed in Cesium 1.7. `ScreenSpaceEventHandler` will be constructed as if `mouseMoveOnDocument` is `false`.
 * Improved performance of asynchronous geometry creation (as much as 20% faster in some use cases). [#2342](https://github.com/AnalyticalGraphicsInc/cesium/issues/2342)
-* Added `Color.fromAlpha` and `Color.addAlpha` to make it easy to create translucent colors from constants, i.e. `var translucentRed = Color.RED.addAlpha(0.95)`.
+* Added `Color.fromAlpha` and `Color.withAlpha` to make it easy to create translucent colors from constants, i.e. `var translucentRed = Color.RED.withAlpha(0.95)`.
 * Added `PolylineVolumeGraphics` and `Entity.polylineVolume`
 * Added `Camera.lookAtTransform` which sets the camera position and orientation given a transformation matrix defining a reference frame and either a cartesian offset or heading/pitch/range from the center of that frame.
 * Added `Camera.setView` (which use heading, pitch, and roll) and `Camera.roll`.

--- a/Source/Core/Color.js
+++ b/Source/Core/Color.js
@@ -695,9 +695,9 @@ define([
      * @param {Color} [result] The object onto which to store the result.
      * @returns {Color} The modified result parameter or a new Color instance if one was not provided.
      *
-     * @example var translucentRed = Cesium.Color.RED.addAlpha(0.9);
+     * @example var translucentRed = Cesium.Color.RED.withAlpha(0.9);
      */
-    Color.prototype.addAlpha = function(alpha, result) {
+    Color.prototype.withAlpha = function(alpha, result) {
         return Color.fromAlpha(this, alpha, result);
     };
 

--- a/Source/Core/Color.js
+++ b/Source/Core/Color.js
@@ -108,14 +108,56 @@ define([
      * @param {Number} [green=255] The green component.
      * @param {Number} [blue=255] The blue component.
      * @param {Number} [alpha=255] The alpha component.
-     * @returns {Color} A new color instance.
+     * @param {Color} [result] The object onto which to store the result.
+     * @returns {Color} The modified result parameter or a new Color instance if one was not provided.
      */
-    Color.fromBytes = function(red, green, blue, alpha) {
+    Color.fromBytes = function(red, green, blue, alpha, result) {
         red = Color.byteToFloat(defaultValue(red, 255.0));
         green = Color.byteToFloat(defaultValue(green, 255.0));
         blue = Color.byteToFloat(defaultValue(blue, 255.0));
         alpha = Color.byteToFloat(defaultValue(alpha, 255.0));
-        return new Color(red, green, blue, alpha);
+
+        if (!defined(result)) {
+            return new Color(red, green, blue, alpha);
+        }
+
+        result.red = red;
+        result.green = green;
+        result.blue = blue;
+        result.alpha = alpha;
+        return result;
+    };
+
+    /**
+     * Creates a new Color that has the same red, green, and blue components
+     * of the specified color, but with the specified alpha value.
+     *
+     * @param {Color} color The base color
+     * @param {Number} alpha The new alpha component.
+     * @param {Color} [result] The object onto which to store the result.
+     * @returns {Color} The modified result parameter or a new Color instance if one was not provided.
+     *
+     * @example var translucentRed = Cesium.Color.fromColor(Cesium.Color.RED, 0.9);
+     */
+    Color.fromAlpha = function(color, alpha, result) {
+        //>>includeStart('debug', pragmas.debug);
+        if (!defined(color)) {
+            throw new DeveloperError('color is required');
+        }
+        if (!defined(alpha)) {
+            throw new DeveloperError('alpha is required');
+        }
+        //>>includeEnd('debug');
+
+        if (!defined(result)) {
+            return new Color(color.red, color.green, color.blue, alpha);
+        }
+
+        result.red = color.red;
+        result.green = color.green;
+        result.blue = color.blue;
+        result.alpha = alpha;
+        return result;
     };
 
     var scratchArrayBuffer;
@@ -643,6 +685,20 @@ define([
         result.blue = this.blue * magnitude;
         result.alpha = this.alpha;
         return result;
+    };
+
+    /**
+     * Creates a new Color that has the same red, green, and blue components
+     * as this Color, but with the specified alpha value.
+     *
+     * @param {Number} alpha The new alpha component.
+     * @param {Color} [result] The object onto which to store the result.
+     * @returns {Color} The modified result parameter or a new Color instance if one was not provided.
+     *
+     * @example var translucentRed = Cesium.Color.RED.addAlpha(0.9);
+     */
+    Color.prototype.addAlpha = function(alpha, result) {
+        return Color.fromAlpha(this, alpha, result);
     };
 
     /**

--- a/Specs/Core/ColorSpec.js
+++ b/Specs/Core/ColorSpec.js
@@ -391,9 +391,9 @@ defineSuite([
         }).toThrowDeveloperError();
     });
 
-    it('addAlpha works', function() {
+    it('withAlpha works', function() {
         var resultParam = new Color();
-        var result = Color.RED.addAlpha(0.5, resultParam);
+        var result = Color.RED.withAlpha(0.5, resultParam);
         expect(resultParam).toBe(result);
         expect(result).toEqual(new Color(1, 0, 0, 0.5));
     });

--- a/Specs/Core/ColorSpec.js
+++ b/Specs/Core/ColorSpec.js
@@ -44,6 +44,16 @@ defineSuite([
         expect(v.alpha).toEqual(0.4);
     });
 
+    it('fromBytes works with result parameter', function() {
+        var result = new Color();
+        var v = Color.fromBytes(0, 255, 51, 102, result);
+        expect(v).toBe(result);
+        expect(v.red).toEqual(0.0);
+        expect(v.green).toEqual(1.0);
+        expect(v.blue).toEqual(0.2);
+        expect(v.alpha).toEqual(0.4);
+    });
+
     it('toBytes returns the same values that fromBytes took', function() {
         var r = 5;
         var g = 87;
@@ -345,6 +355,47 @@ defineSuite([
                 maximumAlpha : 0
             });
         }).toThrowDeveloperError();
+    });
+
+    it('fromAlpha works', function() {
+        var result = Color.fromAlpha(Color.RED, 0.5);
+        expect(result).toEqual(new Color(1, 0, 0, 0.5));
+    });
+
+    it('fromAlpha works with result parameter', function() {
+        var resultParam = new Color();
+        var result = Color.fromAlpha(Color.RED, 0.5, resultParam);
+        expect(resultParam).toBe(result);
+        expect(result).toEqual(new Color(1, 0, 0, 0.5));
+    });
+
+    it('fromAlpha throws with undefined color', function() {
+        var result = new Color();
+        expect(function() {
+            Color.fromAlpha(undefined, 0.5, result);
+        }).toThrowDeveloperError();
+    });
+
+    it('fromAlpha throws with undefined color', function() {
+        var result = new Color();
+        expect(function() {
+            Color.fromAlpha(undefined, 0.5, result);
+        }).toThrowDeveloperError();
+    });
+
+    it('fromAlpha throws with undefined alpha', function() {
+        var result = new Color();
+        var color = new Color();
+        expect(function() {
+            Color.fromAlpha(color, undefined, result);
+        }).toThrowDeveloperError();
+    });
+
+    it('addAlpha works', function() {
+        var resultParam = new Color();
+        var result = Color.RED.addAlpha(0.5, resultParam);
+        expect(resultParam).toBe(result);
+        expect(result).toEqual(new Color(1, 0, 0, 0.5));
     });
 
     it('toString produces correct results', function() {


### PR DESCRIPTION
While overhauling Sandcastle as part of the Entity API work, I noticed that many of our examples create a new Color instance rather than use a constant color because we need it to be translucent. Other libraries, such as .NET, have a way to create a new color from an existing color with alpha value so I thought it would be a good idea to add one to Cesium.

Consider:
```
var color = new Cesium.Color(1, 0, 0, 0.95);
```
versus
```
var color = Cesium.Color.RED.addAlpha(0.95);
```

It gets even more useful when using non-primary colors. I also added a result parameter to `Color.fromBytes`, since I noticed it didn't have one. I haven't updated any examples because they have been changed a lot in the entity-sandcastle branch.  I'll update them there if/when this goes into master.