### PR TITLE
Workaround issue in Firefox 35

### DIFF
--- a/Source/Core/FeatureDetection.js
+++ b/Source/Core/FeatureDetection.js
@@ -124,6 +124,15 @@ define([
         return isFirefoxResult;
     }
 
+    var isWindowsResult;
+    function isWindows() {
+        if (!defined(isWindowsResult)) {
+            isWindowsResult = /Windows/i.test(navigator.appVersion);
+        }
+        return isWindowsResult;
+    }
+
+
     function firefoxVersion() {
         return isFirefox() && firefoxVersionResult;
     }
@@ -146,6 +155,7 @@ define([
         internetExplorerVersion : internetExplorerVersion,
         isFirefox : isFirefox,
         firefoxVersion : firefoxVersion,
+        isWindows : isWindows,
         hardwareConcurrency : defaultValue(navigator.hardwareConcurrency, 3)
     };
 

--- a/Source/Renderer/Context.js
+++ b/Source/Renderer/Context.js
@@ -212,9 +212,10 @@ define([
         webglOptions.alpha = defaultValue(webglOptions.alpha, false); // WebGL default is true
         webglOptions.failIfMajorPerformanceCaveat = defaultValue(webglOptions.failIfMajorPerformanceCaveat, true); // WebGL default is false
 
-        // Firefox 35 has a regression that causes alpha : false to affect all framebuffers
+        // Firefox 35 with ANGLE has a regression that causes alpha : false to affect all framebuffers
+        // Since we can't detect for ANGLE without a context, we just detect for Windows.
         // https://github.com/AnalyticalGraphicsInc/cesium/issues/2431
-        if (FeatureDetection.isFirefox()) {
+        if (FeatureDetection.isFirefox() && FeatureDetection.isWindows()) {
             var firefoxVersion = FeatureDetection.firefoxVersion();
             if (firefoxVersion[0] === 35) {
                 webglOptions.alpha = true;

--- a/Source/Renderer/Context.js
+++ b/Source/Renderer/Context.js
@@ -9,6 +9,7 @@ define([
         '../Core/defineProperties',
         '../Core/destroyObject',
         '../Core/DeveloperError',
+        '../Core/FeatureDetection',
         '../Core/Geometry',
         '../Core/GeometryAttribute',
         '../Core/IndexDatatype',
@@ -47,6 +48,7 @@ define([
         defineProperties,
         destroyObject,
         DeveloperError,
+        FeatureDetection,
         Geometry,
         GeometryAttribute,
         IndexDatatype,
@@ -208,9 +210,16 @@ define([
 
         // Override select WebGL defaults
         webglOptions.alpha = defaultValue(webglOptions.alpha, false); // WebGL default is true
-        // TODO: WebGL default is false. This works around a bug in Canary and can be removed when fixed: https://code.google.com/p/chromium/issues/detail?id=335273
-        webglOptions.stencil = defaultValue(webglOptions.stencil, false);
         webglOptions.failIfMajorPerformanceCaveat = defaultValue(webglOptions.failIfMajorPerformanceCaveat, true); // WebGL default is false
+
+        // Firefox 35 has a regression that causes alpha : false to affect all framebuffers
+        // https://github.com/AnalyticalGraphicsInc/cesium/issues/2431
+        if (FeatureDetection.isFirefox()) {
+            var firefoxVersion = FeatureDetection.firefoxVersion();
+            if (firefoxVersion[0] === 35) {
+                webglOptions.alpha = true;
+            }
+        }
 
         this._originalGLContext = canvas.getContext('webgl', webglOptions) || canvas.getContext('experimental-webgl', webglOptions) || undefined;
 

--- a/Source/Shaders/Builtin/Functions/cosineAndSine.glsl
+++ b/Source/Shaders/Builtin/Functions/cosineAndSine.glsl
@@ -1,6 +1,3 @@
-// Firefox 33-34 has a regression that prevents the CORDIC implementation from compiling
-#ifndef DISABLE_CORDIC
-
 /**
  * @private
  */
@@ -212,5 +209,3 @@ vec2 czm_cosineAndSine(float angle)
         return cordic(angle);
     }
 }
-
-#endif


### PR DESCRIPTION
In Firefox 35 we need to force the context alpha to true because setting it to false affects all framebuffers. Fixes #2431

Also removed old workaround for a Chrome issue that was fixed in Feb 2014 as well as an unused glsl #ifdef that was left over from an older workaround for Firefox.

On a side note, we should look for all of the places in the code that we have workaround and determine if they are still relevant.  We should probably also start writing up issues for new workarounds that we add, similar to how we handle deprecation.  This way we revisit them from time to time until they are no longer an issue.