### PR TITLE
Model.boundingSphere was not properly scaling its center.

### DIFF
--- a/Source/Scene/Model.js
+++ b/Source/Scene/Model.js
@@ -87,6 +87,7 @@ define([
     /*global WebGLRenderingContext*/
 
     var yUpToZUp = Matrix4.fromRotationTranslation(Matrix3.fromRotationX(CesiumMath.PI_OVER_TWO));
+    var boundingSphereCartesian3Scratch = new Cartesian3();
 
     var ModelState = {
         NEEDS_LOAD : 0,
@@ -524,10 +525,12 @@ define([
                 }
                 //>>includeEnd('debug');
 
-                var scale = (this.scale * Matrix4.getMaximumScale(this.modelMatrix));
+                var nonUniformScale = Matrix4.getScale(this.modelMatrix, boundingSphereCartesian3Scratch);
+                Cartesian3.multiplyByScalar(nonUniformScale, this.scale, nonUniformScale);
+
                 var scaledBoundingSphere = this._scaledBoundingSphere;
-                scaledBoundingSphere.center = Cartesian3.multiplyByScalar(this._boundingSphere.center, scale, scaledBoundingSphere.center);
-                scaledBoundingSphere.radius = scale * this._initialRadius;
+                scaledBoundingSphere.center = Cartesian3.multiplyComponents(this._boundingSphere.center, nonUniformScale, scaledBoundingSphere.center);
+                scaledBoundingSphere.radius = Cartesian3.maximumComponent(nonUniformScale) * this._initialRadius;
                 return scaledBoundingSphere;
             }
         },

--- a/Source/Scene/Model.js
+++ b/Source/Scene/Model.js
@@ -373,6 +373,7 @@ define([
         this._computedModelMatrix = new Matrix4(); // Derived from modelMatrix and scale
         this._initialRadius = undefined;           // Radius without model's scale property, model-matrix scale, animations, or skins
         this._boundingSphere = undefined;
+        this._scaledBoundingSphere = new BoundingSphere();
         this._state = ModelState.NEEDS_LOAD;
         this._loadError = undefined;
         this._loadResources = undefined;
@@ -523,8 +524,11 @@ define([
                 }
                 //>>includeEnd('debug');
 
-                this._boundingSphere.radius = (this.scale * Matrix4.getMaximumScale(this.modelMatrix)) * this._initialRadius;
-                return this._boundingSphere;
+                var scale = (this.scale * Matrix4.getMaximumScale(this.modelMatrix));
+                var scaledBoundingSphere = this._scaledBoundingSphere;
+                scaledBoundingSphere.center = Cartesian3.multiplyByScalar(this._boundingSphere.center, scale, scaledBoundingSphere.center);
+                scaledBoundingSphere.radius = scale * this._initialRadius;
+                return scaledBoundingSphere;
             }
         },
 

--- a/Specs/Scene/ModelSpec.js
+++ b/Specs/Scene/ModelSpec.js
@@ -447,12 +447,26 @@ defineSuite([
         expect(boundingSphere.radius).toEqualEpsilon(1.268, CesiumMath.EPSILON3);
     });
 
-    it('boundingSphere returns the bounding sphere when scaled', function() {
+    it('boundingSphere returns the bounding sphere when scale property is set', function() {
+        var originalScale = duckModel.scale;
         duckModel.scale = 10;
+
         var boundingSphere = duckModel.boundingSphere;
-        expect(boundingSphere.center).toEqualEpsilon(new Cartesian3(1.343, 0.370, 08.694), CesiumMath.EPSILON3);
+        expect(boundingSphere.center).toEqualEpsilon(new Cartesian3(1.343, 0.370, 8.694), CesiumMath.EPSILON3);
         expect(boundingSphere.radius).toEqualEpsilon(12.688, CesiumMath.EPSILON3);
-        duckModel.scale = 1;
+
+        duckModel.scale = originalScale;
+    });
+
+    it('boundingSphere returns the bounding sphere when modelMatrix has non-uniform scale', function() {
+        var originalMatrix = Matrix4.clone(duckModel.modelMatrix);
+        Matrix4.multiplyByScale(duckModel.modelMatrix, new Cartesian3(2, 5, 10), duckModel.modelMatrix);
+
+        var boundingSphere = duckModel.boundingSphere;
+        expect(boundingSphere.center).toEqualEpsilon(new Cartesian3(0.268, 0.185, 8.694), CesiumMath.EPSILON3);
+        expect(boundingSphere.radius).toEqualEpsilon(12.688, CesiumMath.EPSILON3);
+
+        duckModel.modelMatrix = originalMatrix;
     });
 
     it('destroys', function() {

--- a/Specs/Scene/ModelSpec.js
+++ b/Specs/Scene/ModelSpec.js
@@ -447,6 +447,14 @@ defineSuite([
         expect(boundingSphere.radius).toEqualEpsilon(1.268, CesiumMath.EPSILON3);
     });
 
+    it('boundingSphere returns the bounding sphere when scaled', function() {
+        duckModel.scale = 10;
+        var boundingSphere = duckModel.boundingSphere;
+        expect(boundingSphere.center).toEqualEpsilon(new Cartesian3(1.343, 0.370, 08.694), CesiumMath.EPSILON3);
+        expect(boundingSphere.radius).toEqualEpsilon(12.688, CesiumMath.EPSILON3);
+        duckModel.scale = 1;
+    });
+
     it('destroys', function() {
         var m = loadModel(duckUrl);
 


### PR DESCRIPTION
When a scale is applied to a Model primitive, it scales the radius of `Model.boundingSphere` but not the center to match.  This is easy to see by using the Sandcastle 3D Models example and setting a `scale : 10` on the models and then switching to Cesium Man (the only model with a non-zero center). Instead of viewing the center of the model, as you get with scale of 1, you end up looking at his feet.

Also added a test to check for this, since we didn't have one.  The test passed in this branch but fails in master.