### PR TITLE
EntityView 2D rotation

### DIFF
--- a/Source/Scene/HeadingPitchRange.js
+++ b/Source/Scene/HeadingPitchRange.js
@@ -1,5 +1,9 @@
 /*global define*/
-define(['../Core/defaultValue'], function(defaultValue) {
+define(['../Core/defaultValue',
+        '../Core/defined'],
+        function(
+            defaultValue,
+            defined) {
     "use strict";
 
     /**
@@ -33,6 +37,27 @@ define(['../Core/defaultValue'], function(defaultValue) {
          * @type {Number}
          */
         this.range = defaultValue(range, 0.0);
+    };
+
+    /**
+     * Duplicates a HeadingPitchRange instance.
+     *
+     * @param {HeadingPitchRange} hpr The HeadingPitchRange to duplicate.
+     * @param {HeadingPitchRange} [result] The object onto which to store the result.
+     * @returns {HeadingPitchRange} The modified result parameter or a new HeadingPitchRange instance if one was not provided. (Returns undefined if hpr is undefined)
+     */
+    HeadingPitchRange.clone = function(hpr, result) {
+        if (!defined(hpr)) {
+            return undefined;
+        }
+        if (!defined(result)) {
+            result = new HeadingPitchRange();
+        }
+
+        result.heading = hpr.heading;
+        result.pitch = hpr.pitch;
+        result.range = hpr.range;
+        return result;
     };
 
     return HeadingPitchRange;

--- a/Specs/Scene/HeadingPitchRangeSpec.js
+++ b/Specs/Scene/HeadingPitchRangeSpec.js
@@ -1,0 +1,35 @@
+/*global defineSuite*/
+defineSuite(['Scene/HeadingPitchRange'], function(HeadingPitchRange) {
+    "use strict";
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
+
+    it('construct with default values', function() {
+        var hpr = new HeadingPitchRange();
+        expect(hpr.heading).toEqual(0.0);
+        expect(hpr.pitch).toEqual(0.0);
+        expect(hpr.range).toEqual(0.0);
+    });
+
+    it('construct with all values', function() {
+        var hpr = new HeadingPitchRange(1.0, 2.0, 3.0);
+        expect(hpr.heading).toEqual(1.0);
+        expect(hpr.pitch).toEqual(2.0);
+        expect(hpr.range).toEqual(3.0);
+    });
+
+    it('clone with a result parameter', function() {
+        var hpr = new HeadingPitchRange(1.0, 2.0, 3.0);
+        var result = new HeadingPitchRange();
+        var returnedResult = HeadingPitchRange.clone(hpr, result);
+        expect(hpr).toNotBe(result);
+        expect(result).toBe(returnedResult);
+        expect(hpr).toEqual(result);
+    });
+
+    it('clone works with a result parameter that is an input parameter', function() {
+        var hpr = new HeadingPitchRange(1.0, 2.0, 3.0);
+        var returnedResult = HeadingPitchRange.clone(hpr, hpr);
+        expect(hpr).toBe(returnedResult);
+    });
+
+});


### PR DESCRIPTION
NOTE: This is a PR into entity-sandcastle

Fixes rotating in 2D when tracking an entity with EntityView. See the GeoJSON simplestyle Sandcastle example: http://localhost:8080/Apps/Sandcastle/index.html?src=GeoJSON%20simplestyle.html&label=Showcases