### PR TITLE
2D Picking

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -59,6 +59,7 @@ Change Log
 * All Entity and related class can now be assigned using anonymous objects as well as be passed template objects. The correct underlying instance is created for you automatically.
 * Many Sandcastle examples have been rewritten to make use of the newly improved Entity API.
 * For a more detailed overview of changes to the Entity API, read [this forum thread](https://groups.google.com/d/msg/cesium-dev/ol7edT6EtZw/a2-gvI4H0IwJ) for details.
+* Fixed picking in 2D. [#2447](https://github.com/AnalyticalGraphicsInc/cesium/issues/2447)
 
 ### 1.5 - 2015-01-05
 

--- a/Source/Scene/Globe.js
+++ b/Source/Scene/Globe.js
@@ -801,11 +801,6 @@ define([
                         enabled : true
                     }
                 });
-                this._depthCommand.renderState = context.createRenderState({
-                    cull : {
-                        enabled : true
-                    }
-                });
             }
         }
 
@@ -935,7 +930,7 @@ define([
             }
         }
 
-        if (pass.pick) {
+        if (pass.pick && mode === SceneMode.SCENE3D) {
             // Not actually pickable, but render depth-only so primitives on the backface
             // of the globe are not picked.
             commandList.push(this._depthCommand);

--- a/Source/Scene/Scene.js
+++ b/Source/Scene/Scene.js
@@ -1457,6 +1457,8 @@ define([
 
         camera._setTransform(transform);
 
+        Cartesian3.fromElements(origin.z, origin.x, origin.y, origin);
+
         scratchBufferDimensions.x = drawingBufferWidth;
         scratchBufferDimensions.y = drawingBufferHeight;
 

--- a/Source/Scene/Scene.js
+++ b/Source/Scene/Scene.js
@@ -1432,6 +1432,7 @@ define([
     var scratchDirection = new Cartesian3();
     var scratchBufferDimensions = new Cartesian2();
     var scratchPixelSize = new Cartesian2();
+    var scratchPickVolumeMatrix4 = new Matrix4();
 
     function getPickOrthographicCullingVolume(scene, drawingBufferPosition, width, height) {
         var camera = scene._camera;
@@ -1445,11 +1446,16 @@ define([
         var y = (2.0 / drawingBufferHeight) * (drawingBufferHeight - drawingBufferPosition.y) - 1.0;
         y *= (frustum.top - frustum.bottom) * 0.5;
 
+        var transform = Matrix4.clone(camera.transform, scratchPickVolumeMatrix4);
+        camera._setTransform(Matrix4.IDENTITY);
+
         var origin = Cartesian3.clone(camera.position, scratchOrigin);
         Cartesian3.multiplyByScalar(camera.right, x, scratchDirection);
         Cartesian3.add(scratchDirection, origin, origin);
         Cartesian3.multiplyByScalar(camera.up, y, scratchDirection);
         Cartesian3.add(scratchDirection, origin, origin);
+
+        camera._setTransform(transform);
 
         Cartesian3.fromElements(origin.z, origin.x, origin.y, origin);
 

--- a/Source/Scene/Scene.js
+++ b/Source/Scene/Scene.js
@@ -1457,8 +1457,6 @@ define([
 
         camera._setTransform(transform);
 
-        Cartesian3.fromElements(origin.z, origin.x, origin.y, origin);
-
         scratchBufferDimensions.x = drawingBufferWidth;
         scratchBufferDimensions.y = drawingBufferHeight;
 

--- a/Specs/Scene/PickSpec.js
+++ b/Specs/Scene/PickSpec.js
@@ -165,14 +165,11 @@ defineSuite([
         var ellipsoid = scene.mapProjection.ellipsoid;
         var maxRadii = ellipsoid.maximumRadius;
 
-        camera.lookAtTransform(new Matrix4(0.0, 0.0, 1.0, 0.0,
-                                           1.0, 0.0, 0.0, 0.0,
-                                           0.0, 1.0, 0.0, 0.0,
-                                           0.0, 0.0, 0.0, 1.0));
-
         camera.position = new Cartesian3(0.0, 0.0, 2.0 * maxRadii);
-        camera.direction = Cartesian3.normalize(Cartesian3.negate(camera.position, new Cartesian3()), new Cartesian3());
-        camera.up = Cartesian3.clone(Cartesian3.UNIT_Y);
+        Cartesian3.clone(Cartesian3.UNIT_Z, camera.direction);
+        Cartesian3.negate(camera.direction, camera.direction);
+        Cartesian3.negate(Cartesian3.UNIT_X, camera.up);
+        Cartesian3.clone(Cartesian3.UNIT_Y, camera.right);
 
         var frustum = new OrthographicFrustum();
         frustum.right = maxRadii * Math.PI;
@@ -187,6 +184,7 @@ defineSuite([
         scene.morphTime = SceneMode.getMorphTime(scene.mode);
 
         var rectangle = createRectangle();
+        scene.initializeFrame();
         var pickedObject = scene.pick(new Cartesian2(0, 0));
         expect(pickedObject.primitive).toEqual(rectangle);
     });
@@ -195,14 +193,11 @@ defineSuite([
         var ellipsoid = scene.mapProjection.ellipsoid;
         var maxRadii = ellipsoid.maximumRadius;
 
-        camera.lookAtTransform(new Matrix4(0.0, 0.0, 1.0, 0.0,
-                                           1.0, 0.0, 0.0, 0.0,
-                                           0.0, 1.0, 0.0, 0.0,
-                                           0.0, 0.0, 0.0, 1.0));
-
         camera.position = new Cartesian3(0.0, 0.0, 2.0 * maxRadii);
-        camera.direction = Cartesian3.normalize(Cartesian3.negate(camera.position, new Cartesian3()), new Cartesian3());
-        camera.up = Cartesian3.negate(Cartesian3.UNIT_X, new Cartesian3());
+        Cartesian3.clone(Cartesian3.UNIT_Z, camera.direction);
+        Cartesian3.negate(camera.direction, camera.direction);
+        Cartesian3.negate(Cartesian3.UNIT_X, camera.up);
+        Cartesian3.clone(Cartesian3.UNIT_Y, camera.right);
 
         var frustum = new OrthographicFrustum();
         frustum.right = maxRadii * Math.PI;
@@ -217,7 +212,8 @@ defineSuite([
         scene.morphTime = SceneMode.getMorphTime(scene.mode);
 
         var rectangle = createRectangle();
-        var pickedObject = scene.pick(new Cartesian2(0, 0));
+        scene.initializeFrame();
+        var pickedObject = scene.pick(new Cartesian2(0.0, 0.0));
         expect(pickedObject.primitive).toEqual(rectangle);
     });
 }, 'WebGL');


### PR DESCRIPTION
Fixes #2447. Remove globe depth rendering and fix pick culling volume in 2D.

