### PR TITLE
PolygonPipeline.removeDuplicates shouldn't throw with less than 3 positions

### DIFF
--- a/Source/Core/PolygonPipeline.js
+++ b/Source/Core/PolygonPipeline.js
@@ -716,15 +716,10 @@ define([
         if (!defined(positions)) {
             throw new DeveloperError('positions is required.');
         }
-        if (positions.length < 3) {
-            throw new DeveloperError('At least three positions are required.');
-        }
         //>>includeEnd('debug');
 
         var length = positions.length;
-
         var cleanedPositions = [];
-
         for ( var i0 = length - 1, i1 = 0; i1 < length; i0 = i1++) {
             var v0 = positions[i0];
             var v1 = positions[i1];

--- a/Source/DataSources/PolylineGeometryUpdater.js
+++ b/Source/DataSources/PolylineGeometryUpdater.js
@@ -467,7 +467,7 @@ define([
 
         var positionsProperty = polyline.positions;
         var positions = Property.getValueOrUndefined(positionsProperty, time, this._positions);
-        if (!defined(positions)) {
+        if (!defined(positions) || positions.length < 2) {
             line.show = false;
             return;
         }

--- a/Specs/Core/PolygonGeometrySpec.js
+++ b/Specs/Core/PolygonGeometrySpec.js
@@ -31,20 +31,18 @@ defineSuite([
         }).toThrowDeveloperError();
     });
 
-    it('throws with less than three positions', function() {
-        expect(function() {
-            return PolygonGeometry.createGeometry(PolygonGeometry.fromPositions({ positions : [new Cartesian3()] }));
-        }).toThrowDeveloperError();
+    it('returns undefined with less than three positions', function() {
+        expect(PolygonGeometry.createGeometry(PolygonGeometry.fromPositions({
+            positions : [new Cartesian3()]
+        }))).toBeUndefined();
     });
 
-    it('throws with polygon hierarchy with less than three positions', function() {
-        var hierarchy = {
-            positions : [Cartesian3.fromDegrees(0,0)]
-        };
-
-        expect(function() {
-            return PolygonGeometry.createGeometry(new PolygonGeometry({ polygonHierarchy : hierarchy }));
-        }).toThrowDeveloperError();
+    it('returns undefined with polygon hierarchy with less than three positions', function() {
+        expect(PolygonGeometry.createGeometry(new PolygonGeometry({
+            polygonHierarchy : {
+                positions : [Cartesian3.fromDegrees(0, 0)]
+            }
+        }))).toBeUndefined();
     });
 
     it('createGeometry returns undefined due to duplicate positions', function() {

--- a/Specs/Core/PolygonOutlineGeometrySpec.js
+++ b/Specs/Core/PolygonOutlineGeometrySpec.js
@@ -28,20 +28,18 @@ defineSuite([
         }).toThrowDeveloperError();
     });
 
-    it('throws with less than three positions', function() {
-        expect(function() {
-            return PolygonOutlineGeometry.createGeometry(PolygonOutlineGeometry.fromPositions({ positions : [new Cartesian3()] }));
-        }).toThrowDeveloperError();
+    it('returns undefined with less than three positions', function() {
+        expect(PolygonOutlineGeometry.createGeometry(PolygonOutlineGeometry.fromPositions({
+            positions : [new Cartesian3()]
+        }))).toBeUndefined();
     });
 
-    it('throws with polygon hierarchy with less than three positions', function() {
-        var hierarchy = {
-            positions : [Cartesian3.fromDegrees(0,0)]
-        };
-
-        expect(function() {
-            return PolygonOutlineGeometry.createGeometry(new PolygonOutlineGeometry({ polygonHierarchy : hierarchy }));
-        }).toThrowDeveloperError();
+    it('returns undefined with polygon hierarchy with less than three positions', function() {
+        expect(PolygonOutlineGeometry.createGeometry(new PolygonOutlineGeometry({
+            polygonHierarchy : {
+                positions : [Cartesian3.fromDegrees(0, 0)]
+            }
+        }))).toBeUndefined();
     });
 
     it('createGeometry returns undefined due to duplicate positions', function() {

--- a/Specs/Core/PolygonPipelineSpec.js
+++ b/Specs/Core/PolygonPipelineSpec.js
@@ -56,12 +56,6 @@ defineSuite([
         }).toThrowDeveloperError();
     });
 
-    it('removeDuplicates throws without three positions', function() {
-        expect(function() {
-            PolygonPipeline.removeDuplicates([Cartesian3.ZERO, Cartesian3.ZERO]);
-        }).toThrowDeveloperError();
-    });
-
     it('computeArea2D computes a positive area', function() {
         var area = PolygonPipeline.computeArea2D([
                                                   new Cartesian2(0.0, 0.0),

--- a/Specs/Scene/PolygonSpec.js
+++ b/Specs/Scene/PolygonSpec.js
@@ -235,17 +235,6 @@ defineSuite([
         expect(polygon.positions).not.toBeDefined();
     });
 
-    it('configureFromPolygonHierarchy throws with less than three positions', function() {
-        var hierarchy = {
-                positions : [Cartesian3.fromDegrees(0,0)]
-        };
-        polygon = createPolygon();
-        polygon.configureFromPolygonHierarchy(hierarchy);
-        expect(function() {
-            render(context, frameState, polygon);
-        }).toThrowDeveloperError();
-    });
-
     it('gets the default color', function() {
         polygon = new Polygon();
         expect(polygon.material.uniforms.color).toEqual({


### PR DESCRIPTION
I'm not sure why this check was ever in this area of the code to begin with, but this was preventing out new behavior of simply not rendering from working in many cases.

I also found a spot in PolylineGeometryUpdater that has a simialr problem with dynamic polylines.