### PR TITLE
Fix an imagery loading bug.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@ Change Log
   * Removed `Camera.heading` and `Camera.tilt`. They were deprecated in Cesium 1.6. Use `Camera.setView`.
   * Removed `Camera.setPositionCartographic`, which was was deprecated in Cesium 1.6. Use `Camera.setView`.
 * Fixed incorrect ellipse texture coordinates. [#2363](https://github.com/AnalyticalGraphicsInc/cesium/issues/2363) and [#2465](https://github.com/AnalyticalGraphicsInc/cesium/issues/2465)
+* Fixed a bug in imagery loading that could cause some or all of the globe to be missing when using an imagery layer that does not cover the entire globe.
 
 ### 1.6 - 2015-02-02
 

--- a/Source/Scene/Imagery.js
+++ b/Source/Scene/Imagery.js
@@ -80,5 +80,22 @@ define([
         return this.referenceCount;
     };
 
+    Imagery.prototype.processStateMachine = function(context) {
+        if (this.state === ImageryState.UNLOADED) {
+            this.state = ImageryState.TRANSITIONING;
+            this.imageryLayer._requestImagery(this);
+        }
+
+        if (this.state === ImageryState.RECEIVED) {
+            this.state = ImageryState.TRANSITIONING;
+            this.imageryLayer._createTexture(context, this);
+        }
+
+        if (this.state === ImageryState.TEXTURE_LOADED) {
+            this.state = ImageryState.TRANSITIONING;
+            this.imageryLayer._reprojectTexture(context, this);
+        }
+    };
+
     return Imagery;
 });

--- a/Specs/Scene/GlobeSurfaceTileSpec.js
+++ b/Specs/Scene/GlobeSurfaceTileSpec.js
@@ -2,32 +2,44 @@
 defineSuite([
         'Scene/GlobeSurfaceTile',
         'Core/Cartesian3',
+        'Core/Cartesian4',
         'Core/CesiumTerrainProvider',
         'Core/defined',
         'Core/Ellipsoid',
         'Core/GeographicTilingScheme',
         'Core/Ray',
+        'Core/Rectangle',
         'Core/WebMercatorTilingScheme',
+        'Scene/Imagery',
+        'Scene/ImageryLayer',
         'Scene/ImageryLayerCollection',
+        'Scene/ImageryState',
         'Scene/QuadtreeTile',
         'Scene/QuadtreeTileLoadState',
         'Scene/TerrainState',
+        'Scene/TileImagery',
         'Specs/createContext',
         'Specs/destroyContext',
         'ThirdParty/when'
     ], function(
         GlobeSurfaceTile,
         Cartesian3,
+        Cartesian4,
         CesiumTerrainProvider,
         defined,
         Ellipsoid,
         GeographicTilingScheme,
         Ray,
+        Rectangle,
         WebMercatorTilingScheme,
+        Imagery,
+        ImageryLayer,
         ImageryLayerCollection,
+        ImageryState,
         QuadtreeTile,
         QuadtreeTileLoadState,
         TerrainState,
+        TileImagery,
         createContext,
         destroyContext,
         when) {
@@ -490,6 +502,34 @@ defineSuite([
 
             runs(function() {
                 expect(childTile.data.waterMaskTexture).toBeUndefined();
+            });
+        });
+
+        it('loads parent imagery tile even for root terrain tiles', function() {
+            var tile = new QuadtreeTile({
+                tilingScheme : new GeographicTilingScheme(),
+                level : 0,
+                x : 1,
+                y : 0
+            });
+
+            var imageryLayerCollection = new ImageryLayerCollection();
+
+            GlobeSurfaceTile.processStateMachine(tile, context, alwaysDeferTerrainProvider, imageryLayerCollection);
+
+            var layer = new ImageryLayer({
+                requestImage : function() {
+                    return when.reject();
+                }
+            });
+            var imagery = new Imagery(layer, 0, 0, 1, Rectangle.MAX_VALUE);
+            tile.data.imagery.push(new TileImagery(imagery, new Cartesian4()));
+
+            expect(imagery.parent.state).toBe(ImageryState.UNLOADED);
+
+            waitsFor(function() {
+                GlobeSurfaceTile.processStateMachine(tile, context, alwaysDeferTerrainProvider, imageryLayerCollection);
+                return imagery.parent.state !== ImageryState.UNLOADED;
             });
         });
     }, 'WebGL');


### PR DESCRIPTION
When a terrain tile maps to a non-level-zero tile, and that non-level-zero imagery fails to load, the terrain tile will never be considered done loading.  If the imagery tile must be renderable before the terrain tile is renderable, the terrain tile will never be renderable and part of the globe will be missing.

The fix is for TileImagerys to process the statemachine of not just the imagery tile they'd like to use, but also the ancestor imagery tile they're stuck with.  Previously we relied on other terrain tiles to move the imagery tile through the load process, but this fails in the case described above.