### PR TITLE
Fix a bad test

### DIFF
--- a/Specs/Scene/RectanglePrimitiveSpec.js
+++ b/Specs/Scene/RectanglePrimitiveSpec.js
@@ -147,33 +147,9 @@ defineSuite([
             debugShowBoundingVolume : true
         });
 
-        var commandList = [];
-        rectangle.update(context, frameState, commandList);
-
-        var sphere = commandList[0].boundingVolume;
-        var center = Cartesian3.clone(sphere.center);
-        var radius = sphere.radius;
-
-        var camera = frameState.camera;
-        var direction = Ellipsoid.WGS84.geodeticSurfaceNormal(center, camera.direction);
-        Cartesian3.negate(direction, direction);
-        Cartesian3.normalize(direction, direction);
-        var right = Cartesian3.cross(direction, Cartesian3.UNIT_Z, camera.right);
-        Cartesian3.normalize(right, right);
-        Cartesian3.cross(right, direction, camera.up);
-
-        var scalar = Cartesian3.magnitude(center) + radius;
-        Cartesian3.normalize(center, center);
-        Cartesian3.multiplyByScalar(center, scalar, camera.position);
-
-        frameState.cullingVolume = camera.frustum.computeCullingVolume(camera.position, camera.direction, camera.up);
-        context.uniformState.update(context, frameState);
-
         var commands = [];
-        render(context, frameState, rectangle, commands);
+        rectangle.update(context, frameState, commands);
 
-        // Our spec render function doesn't honor the debugShowBoundingVolume flag.  So just verify that it
-        // was set.
         expect(commands.length).toBeGreaterThan(0);
         for (var i = 0; i < commands.length; ++i) {
             expect(commands[i].debugShowBoundingVolume).toBe(true);

--- a/Specs/Scene/RectanglePrimitiveSpec.js
+++ b/Specs/Scene/RectanglePrimitiveSpec.js
@@ -166,8 +166,18 @@ defineSuite([
         Cartesian3.normalize(center, center);
         Cartesian3.multiplyByScalar(center, scalar, camera.position);
 
-        render(context, frameState, rectangle);
-        expect(context.readPixels()).not.toEqual([0, 0, 0, 0]);
+        frameState.cullingVolume = camera.frustum.computeCullingVolume(camera.position, camera.direction, camera.up);
+        context.uniformState.update(context, frameState);
+
+        var commands = [];
+        render(context, frameState, rectangle, commands);
+
+        // Our spec render function doesn't honor the debugShowBoundingVolume flag.  So just verify that it
+        // was set.
+        expect(commands.length).toBeGreaterThan(0);
+        for (var i = 0; i < commands.length; ++i) {
+            expect(commands[i].debugShowBoundingVolume).toBe(true);
+        }
     });
 
     it('is picked', function() {


### PR DESCRIPTION
RectanglePrimitive's 'renders bounding volume with debugShowBoundingVolume' was attempting to assert that the bounding volume was rendered.  But the `render` function used in our specs doesn't know how to render bounding volumes.  The only reason this passed is because previous tests were drawing something and the buffer wasn't being cleared.  If this test was run by itself or if the tests were run in a different order, this test would fail.

This changes the test to just check for the presence of the flag on the command, rather than rendering anything.