### PR TITLE
Render Passes

### DIFF
--- a/Source/Scene/FrustumCommands.js
+++ b/Source/Scene/FrustumCommands.js
@@ -1,8 +1,10 @@
 /*global define*/
 define([
-        '../Core/defaultValue'
+        '../Core/defaultValue',
+        './Pass'
     ], function(
-        defaultValue) {
+        defaultValue,
+        Pass) {
     "use strict";
 
     /**
@@ -19,15 +21,17 @@ define([
         this.near = defaultValue(near, 0.0);
         this.far = defaultValue(far, 0.0);
 
-        this.globeCommands = [];
-        this.groundCommands = [];
-        this.opaqueCommands = [];
-        this.translucentCommands = [];
+        var numPasses = Pass.NUMBER_OF_PASSES;
+        var commands = new Array(numPasses);
+        var indices = new Array(numPasses);
 
-        this.globeIndex = 0;
-        this.groundIndex = 0;
-        this.opaqueIndex = 0;
-        this.translucentIndex = 0;
+        for (var i = 0; i < numPasses; ++i) {
+            commands[i] = [];
+            indices[i] = 0;
+        }
+
+        this.commands = commands;
+        this.indices = indices;
     };
 
     return FrustumCommands;

--- a/Source/Scene/FrustumCommands.js
+++ b/Source/Scene/FrustumCommands.js
@@ -18,8 +18,16 @@ define([
     var FrustumCommands = function(near, far) {
         this.near = defaultValue(near, 0.0);
         this.far = defaultValue(far, 0.0);
+
+        this.globeCommands = [];
+        this.groundCommands = [];
         this.opaqueCommands = [];
         this.translucentCommands = [];
+
+        this.globeIndex = 0;
+        this.groundIndex = 0;
+        this.opaqueIndex = 0;
+        this.translucentIndex = 0;
     };
 
     return FrustumCommands;

--- a/Source/Scene/GlobeSurfaceTileProvider.js
+++ b/Source/Scene/GlobeSurfaceTileProvider.js
@@ -997,7 +997,7 @@ define([
             command.primitiveType = PrimitiveType.TRIANGLES;
             command.vertexArray = surfaceTile.vertexArray;
             command.uniformMap = uniformMap;
-            command.pass = Pass.OPAQUE;
+            command.pass = Pass.GLOBE;
 
             if (tileProvider._debug.wireframe) {
                 createWireframeVertexArrayIfNecessary(context, tileProvider, tile);

--- a/Source/Scene/Pass.js
+++ b/Source/Scene/Pass.js
@@ -13,6 +13,9 @@ define([
     var Pass = {
         GLOBE : 0,
         OPAQUE : 1,
+        // Commands are executed in order by pass up to the translucent pass.
+        // Translucent geometry needs special handling (sorting/OIT). Overlays
+        // are also special (they're executed last, they're not sorted by frustum).
         TRANSLUCENT : 2,
         OVERLAY : 3,
         NUMBER_OF_PASSES : 4

--- a/Source/Scene/Pass.js
+++ b/Source/Scene/Pass.js
@@ -11,9 +11,11 @@ define([
      * @private
      */
     var Pass = {
-        OPAQUE : 0,
-        TRANSLUCENT : 1,
-        OVERLAY : 2
+        GLOBE : 0,
+        GROUND : 1,
+        OPAQUE : 2,
+        TRANSLUCENT : 3,
+        OVERLAY : 4
     };
 
     return freezeObject(Pass);

--- a/Source/Scene/Pass.js
+++ b/Source/Scene/Pass.js
@@ -12,10 +12,10 @@ define([
      */
     var Pass = {
         GLOBE : 0,
-        GROUND : 1,
-        OPAQUE : 2,
-        TRANSLUCENT : 3,
-        OVERLAY : 4
+        OPAQUE : 1,
+        TRANSLUCENT : 2,
+        OVERLAY : 3,
+        NUMBER_OF_PASSES : 4
     };
 
     return freezeObject(Pass);

--- a/Specs/Scene/FrustumCommandsSpec.js
+++ b/Specs/Scene/FrustumCommandsSpec.js
@@ -1,8 +1,10 @@
 /*global defineSuite*/
 defineSuite([
-        'Scene/FrustumCommands'
+        'Scene/FrustumCommands',
+        'Scene/Pass'
     ], function(
-        FrustumCommands) {
+        FrustumCommands,
+        Pass) {
     "use strict";
     /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
@@ -10,10 +12,10 @@ defineSuite([
         var frustum = new FrustumCommands();
         expect(frustum.near).toEqual(0.0);
         expect(frustum.far).toEqual(0.0);
-        expect(frustum.opaqueCommands).toBeDefined();
-        expect(frustum.opaqueCommands.length).toEqual(0);
-        expect(frustum.translucentCommands).toBeDefined();
-        expect(frustum.translucentCommands.length).toEqual(0);
+        expect(frustum.commands).toBeDefined();
+        expect(frustum.commands.length).toEqual(Pass.NUMBER_OF_PASSES);
+        expect(frustum.indices).toBeDefined();
+        expect(frustum.indices.length).toEqual(Pass.NUMBER_OF_PASSES);
     });
 
     it('constructs with arguments', function() {
@@ -22,9 +24,9 @@ defineSuite([
         var frustum = new FrustumCommands(near, far);
         expect(frustum.near).toEqual(near);
         expect(frustum.far).toEqual(far);
-        expect(frustum.opaqueCommands).toBeDefined();
-        expect(frustum.opaqueCommands.length).toEqual(0);
-        expect(frustum.translucentCommands).toBeDefined();
-        expect(frustum.translucentCommands.length).toEqual(0);
+        expect(frustum.commands).toBeDefined();
+        expect(frustum.commands.length).toEqual(Pass.NUMBER_OF_PASSES);
+        expect(frustum.indices).toBeDefined();
+        expect(frustum.indices.length).toEqual(Pass.NUMBER_OF_PASSES);
     });
 });

--- a/Specs/pick.js
+++ b/Specs/pick.js
@@ -2,6 +2,7 @@
 define([
         'Core/BoundingRectangle',
         'Core/Color',
+        'Core/defined',
         'Renderer/ClearCommand',
         'Scene/CreditDisplay',
         'Scene/FrameState',
@@ -9,6 +10,7 @@ define([
     ], function(
         BoundingRectangle,
         Color,
+        defined,
         ClearCommand,
         CreditDisplay,
         FrameState,
@@ -41,21 +43,22 @@ define([
         });
         clear.execute(context, passState);
 
-        var opaqueCommands = [];
-        var translucentCommands = [];
-
-        var length = commands.length;
-        for (var i = 0; i < length; i++) {
-            var command = commands[i];
-            if (command.pass === Pass.OPAQUE) {
-                opaqueCommands.push(command);
-            } else if (command.pass === Pass.TRANSLUCENT) {
-                translucentCommands.push(command);
-            }
+        var i;
+        var renderCommands = new Array(Pass.NUMBER_OF_PASSES);
+        for (i = 0; i < Pass.NUMBER_OF_PASSES; ++i) {
+            renderCommands[i] = [];
         }
 
-        executeCommands(context, passState, opaqueCommands);
-        executeCommands(context, passState, translucentCommands);
+        var length = commands.length;
+        for (i = 0; i < length; i++) {
+            var command = commands[i];
+            var pass = defined(command.pass) ? command.pass : Pass.OPAQUE;
+            renderCommands[pass].push(command);
+        }
+
+        for (i = 0; i < Pass.NUMBER_OF_PASSES; ++i) {
+            executeCommands(context, passState, renderCommands[i]);
+        }
 
         frameState.passes = oldPasses;
 

--- a/Specs/render.js
+++ b/Specs/render.js
@@ -43,25 +43,23 @@ define([
         commands = defaultValue(commands, []);
         primitive.update(context, frameState, commands);
 
-        var opaqueCommands = [];
-        var translucentCommands = [];
-        var overlayCommands = [];
-
-        var length = commands.length;
-        for (var i = 0; i < length; i++) {
-            var command = commands[i];
-            if (command.pass === Pass.OPAQUE) {
-                opaqueCommands.push(command);
-            } else if (command.pass === Pass.TRANSLUCENT) {
-                translucentCommands.push(command);
-            } else if (command.pass === Pass.OVERLAY) {
-                overlayCommands.push(command);
-            }
+        var i;
+        var renderCommands = new Array(Pass.NUMBER_OF_PASSES);
+        for (i = 0; i < Pass.NUMBER_OF_PASSES; ++i) {
+            renderCommands[i] = [];
         }
 
-        var commandsExecuted = executeCommands(context, frameState, opaqueCommands);
-        commandsExecuted += executeCommands(context, frameState, translucentCommands);
-        commandsExecuted += executeCommands(context, frameState, overlayCommands);
+        var length = commands.length;
+        for (i = 0; i < length; i++) {
+            var command = commands[i];
+            var pass = defined(command.pass) ? command.pass : Pass.OPAQUE;
+            renderCommands[pass].push(command);
+        }
+
+        var commandsExecuted = 0;
+        for (i = 0; i < Pass.NUMBER_OF_PASSES; ++i) {
+            commandsExecuted += executeCommands(context, frameState, renderCommands[i]);
+        }
 
         return commandsExecuted;
     }


### PR DESCRIPTION
* Adds a `GLOBE` pass that executes before the opaque and translucent passes.
* Makes it easier to add a new pass. Only the `Pass` enum needs to be updated unless special care is needed like for translucent commands.
* Passes are executed in order up to the translucent pass. Translucent and overlay passes are special cases.