### PR TITLE
Explicitly set box-sizing to avoid visual bugs when using bootstrap.

### DIFF
--- a/Apps/Sandcastle/CesiumSandcastle.css
+++ b/Apps/Sandcastle/CesiumSandcastle.css
@@ -30,13 +30,17 @@ html, body {
 }
 
 #toolbar, #galleryContainer {
+    -ms-user-select: none;
     -moz-user-select: -moz-none;  /* allows for re-enabling on sub-elements like the search box */
     -webkit-user-select: none;
+    user-select: none;
 }
 
 #search {
+    -ms-user-select: text;
     -moz-user-select: text;
     -webkit-user-select: text;
+    user-select: text;
  }
 
 .cesiumTitle {

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,7 @@ Change Log
 * Added `pack` and `unpack` functions to `Matrix2` and `Matrix3`.
 * Added camera-terrain collision detection/response when the camera reference frame is set.
 * Added `ScreenSpaceCameraController.enableCollisionDetection` to enable/disable camera collision detection with terrain.
+* Fixed some styling issues with `InfoBox` and `BaseLayerPicker` caused by using Bootstrap with Cesium. [#2487](https://github.com/AnalyticalGraphicsInc/cesium/issues/2479)
 
 ### 1.6 - 2015-02-02
 

--- a/Source/Widgets/Animation/Animation.css
+++ b/Source/Widgets/Animation/Animation.css
@@ -54,6 +54,7 @@
     cursor: pointer;
     -moz-user-select: none;
     -webkit-user-select: none;
+    -ms-user-select: none;
     user-select: none;
 }
 
@@ -90,6 +91,7 @@
 .cesium-animation-buttonDisabled {
     -moz-user-select: none;
     -webkit-user-select: none;
+    -ms-user-select: none;
     user-select: none;
 }
 

--- a/Source/Widgets/BaseLayerPicker/BaseLayerPicker.css
+++ b/Source/Widgets/BaseLayerPicker/BaseLayerPicker.css
@@ -29,7 +29,6 @@
     user-select: none;
     -webkit-transform: translate(0, -20%);
     -moz-transform: translate(0, -20%);
-    -ms-transform: translate(0, -20%);
     transform: translate(0, -20%);
     visibility: hidden;
     opacity: 0;
@@ -41,7 +40,6 @@
 .cesium-baseLayerPicker-dropDown-visible {
     -webkit-transform: translate(0, 0);
     -moz-transform: translate(0, 0);
-    -ms-transform: translate(0, 0);
     transform: translate(0, 0);
     visibility: visible;
     opacity: 1;
@@ -84,7 +82,6 @@
     vertical-align: middle;
     color: #edffff;
     cursor: pointer;
-    -ms-word-wrap: break-word;
     word-wrap: break-word;
 }
 

--- a/Source/Widgets/BaseLayerPicker/BaseLayerPicker.css
+++ b/Source/Widgets/BaseLayerPicker/BaseLayerPicker.css
@@ -10,10 +10,12 @@
 .cesium-baseLayerPicker-dropDown {
     display: block;
     position: absolute;
+    -moz-box-sizing: content-box;
+    -webkit-box-sizing: content-box;
     box-sizing: content-box;
     top: auto;
     right: 0;
-    width: 320px;  /* Includes space needed for scrollbar */
+    width: 320px; /* Includes space needed for scrollbar */
     max-height: 500px;
     margin-top: 5px;
     background-color: rgba(38, 38, 38, 0.75);
@@ -23,25 +25,32 @@
     border-radius: 10px;
     -moz-user-select: none;
     -webkit-user-select: none;
+    -ms-user-select: none;
     user-select: none;
     -webkit-transform: translate(0, -20%);
     -moz-transform: translate(0, -20%);
+    -ms-transform: translate(0, -20%);
+    -o-transform: translate(0, -20%);
     transform: translate(0, -20%);
     visibility: hidden;
     opacity: 0;
     -webkit-transition: visibility 0s 0.2s, opacity 0.2s ease-in, -webkit-transform 0.2s ease-in;
     -moz-transition: visibility 0s 0.2s, opacity 0.2s ease-in, -moz-transform 0.2s ease-in;
+    -o-transition: visibility 0s 0.2s, opacity 0.2s ease-in, transform 0.2s ease-in;
     transition: visibility 0s 0.2s, opacity 0.2s ease-in, transform 0.2s ease-in;
 }
 
 .cesium-baseLayerPicker-dropDown-visible {
     -webkit-transform: translate(0, 0);
     -moz-transform: translate(0, 0);
+    -ms-transform: translate(0, 0);
+    -o-transform: translate(0, 0);
     transform: translate(0, 0);
     visibility: visible;
     opacity: 1;
     -webkit-transition: opacity 0.2s ease-out, -webkit-transform 0.2s ease-out;
     -moz-transition: opacity 0.2s ease-out, -moz-transform 0.2s ease-out;
+    -o-transition: opacity 0.2s ease-out, transform 0.2s ease-out;
     transition: opacity 0.2s ease-out, transform 0.2s ease-out;
 }
 
@@ -79,6 +88,7 @@
     vertical-align: middle;
     color: #edffff;
     cursor: pointer;
+    -ms-word-wrap: break-word;
     word-wrap: break-word;
 }
 
@@ -99,6 +109,7 @@
     padding: 0;
     cursor: pointer;
     -moz-box-sizing: border-box;
+    -webkit-box-sizing: border-box;
     box-sizing: border-box;
 }
 

--- a/Source/Widgets/BaseLayerPicker/BaseLayerPicker.css
+++ b/Source/Widgets/BaseLayerPicker/BaseLayerPicker.css
@@ -10,6 +10,7 @@
 .cesium-baseLayerPicker-dropDown {
     display: block;
     position: absolute;
+    box-sizing: content-box;
     top: auto;
     right: 0;
     width: 320px;  /* Includes space needed for scrollbar */

--- a/Source/Widgets/BaseLayerPicker/BaseLayerPicker.css
+++ b/Source/Widgets/BaseLayerPicker/BaseLayerPicker.css
@@ -30,13 +30,11 @@
     -webkit-transform: translate(0, -20%);
     -moz-transform: translate(0, -20%);
     -ms-transform: translate(0, -20%);
-    -o-transform: translate(0, -20%);
     transform: translate(0, -20%);
     visibility: hidden;
     opacity: 0;
     -webkit-transition: visibility 0s 0.2s, opacity 0.2s ease-in, -webkit-transform 0.2s ease-in;
     -moz-transition: visibility 0s 0.2s, opacity 0.2s ease-in, -moz-transform 0.2s ease-in;
-    -o-transition: visibility 0s 0.2s, opacity 0.2s ease-in, transform 0.2s ease-in;
     transition: visibility 0s 0.2s, opacity 0.2s ease-in, transform 0.2s ease-in;
 }
 
@@ -44,13 +42,11 @@
     -webkit-transform: translate(0, 0);
     -moz-transform: translate(0, 0);
     -ms-transform: translate(0, 0);
-    -o-transform: translate(0, 0);
     transform: translate(0, 0);
     visibility: visible;
     opacity: 1;
     -webkit-transition: opacity 0.2s ease-out, -webkit-transform 0.2s ease-out;
     -moz-transition: opacity 0.2s ease-out, -moz-transform 0.2s ease-out;
-    -o-transition: opacity 0.2s ease-out, transform 0.2s ease-out;
     transition: opacity 0.2s ease-out, transform 0.2s ease-out;
 }
 

--- a/Source/Widgets/CesiumInspector/CesiumInspector.css
+++ b/Source/Widgets/CesiumInspector/CesiumInspector.css
@@ -2,7 +2,6 @@
     border-radius: 5px;
     -webkit-transition: width ease-in-out 0.25s;
     -moz-transition: width ease-in-out 0.25s;
-    -o-transition: width ease-in-out 0.25s;
     transition: width ease-in-out 0.25s;
     background: rgba(48, 51, 54, 0.8);
     border: 1px solid #444;
@@ -108,7 +107,6 @@
     margin-bottom: 10px;
     -webkit-transition: max-height 0.25s;
     -moz-transition: max-height 0.25s;
-    -o-transition: max-height 0.25s;
     transition: max-height 0.25s;
 }
 

--- a/Source/Widgets/CesiumInspector/CesiumInspector.css
+++ b/Source/Widgets/CesiumInspector/CesiumInspector.css
@@ -2,6 +2,7 @@
     border-radius: 5px;
     -webkit-transition: width ease-in-out 0.25s;
     -moz-transition: width ease-in-out 0.25s;
+    -o-transition: width ease-in-out 0.25s;
     transition: width ease-in-out 0.25s;
     background: rgba(48, 51, 54, 0.8);
     border: 1px solid #444;
@@ -11,6 +12,7 @@
     padding: 4px 12px;
     -moz-user-select: none;
     -webkit-user-select: none;
+    -ms-user-select: none;
     user-select: none;
     overflow: hidden;
 }
@@ -25,7 +27,7 @@
     padding-bottom: 3px;
 }
 
-.cesium-cesiumInspector input:enabled, .cesium-cesiumInspector-button{
+.cesium-cesiumInspector input:enabled, .cesium-cesiumInspector-button {
     cursor: pointer;
 }
 
@@ -71,16 +73,17 @@
     cursor: pointer;
     -moz-user-select: none;
     -webkit-user-select: none;
+    -ms-user-select: none;
     user-select: none;
     margin: 0 auto;
 }
 
 .cesium-cesiumInspector-pickButton:focus {
-     outline: none;
+    outline: none;
 }
 
 .cesium-cesiumInspector-pickButton:active, .cesium-cesiumInspector-pickButtonHighlight {
-    color: #000;  /* For text buttons */
+    color: #000; /* For text buttons */
     background: #adf;
     border-color: #fff;
     box-shadow: 0 0 8px #fff;
@@ -105,6 +108,7 @@
     margin-bottom: 10px;
     -webkit-transition: max-height 0.25s;
     -moz-transition: max-height 0.25s;
+    -o-transition: max-height 0.25s;
     transition: max-height 0.25s;
 }
 

--- a/Source/Widgets/CesiumWidget/CesiumWidget.css
+++ b/Source/Widgets/CesiumWidget/CesiumWidget.css
@@ -2,9 +2,10 @@
     position: relative;
 }
 
-.cesium-widget,.cesium-widget canvas {
+.cesium-widget, .cesium-widget canvas {
     width: 100%;
     height: 100%;
+    -ms-touch-action: none;
     touch-action: none;
 }
 

--- a/Source/Widgets/CesiumWidget/CesiumWidget.css
+++ b/Source/Widgets/CesiumWidget/CesiumWidget.css
@@ -5,7 +5,6 @@
 .cesium-widget, .cesium-widget canvas {
     width: 100%;
     height: 100%;
-    -ms-touch-action: none;
     touch-action: none;
 }
 

--- a/Source/Widgets/Geocoder/Geocoder.css
+++ b/Source/Widgets/Geocoder/Geocoder.css
@@ -14,7 +14,6 @@
     box-sizing: border-box;
     -webkit-transition: width ease-in-out 0.25s, background-color 0.2s ease-in-out;
     -moz-transition: width ease-in-out 0.25s, background-color 0.2s ease-in-out;
-    -o-transition: width ease-in-out 0.25s, background-color 0.2s ease-in-out;
     transition: width ease-in-out 0.25s, background-color 0.2s ease-in-out;
 }
 

--- a/Source/Widgets/Geocoder/Geocoder.css
+++ b/Source/Widgets/Geocoder/Geocoder.css
@@ -10,9 +10,11 @@
     padding: 0 32px 0 0;
     border-radius: 0;
     -moz-box-sizing: border-box;
+    -webkit-box-sizing: border-box;
     box-sizing: border-box;
     -webkit-transition: width ease-in-out 0.25s, background-color 0.2s ease-in-out;
     -moz-transition: width ease-in-out 0.25s, background-color 0.2s ease-in-out;
+    -o-transition: width ease-in-out 0.25s, background-color 0.2s ease-in-out;
     transition: width ease-in-out 0.25s, background-color 0.2s ease-in-out;
 }
 

--- a/Source/Widgets/InfoBox/InfoBox.css
+++ b/Source/Widgets/InfoBox/InfoBox.css
@@ -15,13 +15,11 @@
     -webkit-transform: translate(100%, 0);
     -moz-transform: translate(100%, 0);
     -ms-transform: translate(100%, 0);
-    -o-transform: translate(100%, 0);
     transform: translate(100%, 0);
     visibility: hidden;
     opacity: 0;
     -webkit-transition: visibility 0s 0.2s, opacity 0.2s ease-in, -webkit-transform 0.2s ease-in;
     -moz-transition: visibility 0s 0.2s, opacity 0.2s ease-in, -moz-transform 0.2s ease-in;
-    -o-transition: visibility 0s 0.2s, opacity 0.2s ease-in, transform 0.2s ease-in;
     transition: visibility 0s 0.2s, opacity 0.2s ease-in, transform 0.2s ease-in;
 }
 
@@ -29,13 +27,11 @@
     -webkit-transform: translate(0, 0);
     -moz-transform: translate(0, 0);
     -ms-transform: translate(0, 0);
-    -o-transform: translate(0, 0);
     transform: translate(0, 0);
     visibility: visible;
     opacity: 1;
     -webkit-transition: opacity 0.2s ease-out, -webkit-transform 0.2s ease-out;
     -moz-transition: opacity 0.2s ease-out, -moz-transform 0.2s ease-out;
-    -o-transition: opacity 0.2s ease-out, transform 0.2s ease-out;
     transition: opacity 0.2s ease-out, transform 0.2s ease-out;
 }
 
@@ -47,7 +43,6 @@
     border-top-left-radius: 7px;
     text-align: center;
     -ms-text-overflow: ellipsis;
-    -o-text-overflow: ellipsis;
     text-overflow: ellipsis;
     white-space: nowrap;
     overflow: hidden;

--- a/Source/Widgets/InfoBox/InfoBox.css
+++ b/Source/Widgets/InfoBox/InfoBox.css
@@ -43,6 +43,7 @@
     text-overflow: ellipsis;
     white-space: nowrap;
     overflow: hidden;
+    box-sizing: content-box;
 }
 
 .cesium-infoBox-bodyless .cesium-infoBox-title {

--- a/Source/Widgets/InfoBox/InfoBox.css
+++ b/Source/Widgets/InfoBox/InfoBox.css
@@ -14,7 +14,6 @@
     box-shadow: 0 0 10px 1px #000;
     -webkit-transform: translate(100%, 0);
     -moz-transform: translate(100%, 0);
-    -ms-transform: translate(100%, 0);
     transform: translate(100%, 0);
     visibility: hidden;
     opacity: 0;
@@ -26,7 +25,6 @@
 .cesium-infoBox-visible {
     -webkit-transform: translate(0, 0);
     -moz-transform: translate(0, 0);
-    -ms-transform: translate(0, 0);
     transform: translate(0, 0);
     visibility: visible;
     opacity: 1;
@@ -42,7 +40,6 @@
     background: rgba(84, 84, 84, 0.8);
     border-top-left-radius: 7px;
     text-align: center;
-    -ms-text-overflow: ellipsis;
     text-overflow: ellipsis;
     white-space: nowrap;
     overflow: hidden;

--- a/Source/Widgets/InfoBox/InfoBox.css
+++ b/Source/Widgets/InfoBox/InfoBox.css
@@ -14,22 +14,28 @@
     box-shadow: 0 0 10px 1px #000;
     -webkit-transform: translate(100%, 0);
     -moz-transform: translate(100%, 0);
+    -ms-transform: translate(100%, 0);
+    -o-transform: translate(100%, 0);
     transform: translate(100%, 0);
     visibility: hidden;
     opacity: 0;
     -webkit-transition: visibility 0s 0.2s, opacity 0.2s ease-in, -webkit-transform 0.2s ease-in;
     -moz-transition: visibility 0s 0.2s, opacity 0.2s ease-in, -moz-transform 0.2s ease-in;
+    -o-transition: visibility 0s 0.2s, opacity 0.2s ease-in, transform 0.2s ease-in;
     transition: visibility 0s 0.2s, opacity 0.2s ease-in, transform 0.2s ease-in;
 }
 
 .cesium-infoBox-visible {
     -webkit-transform: translate(0, 0);
     -moz-transform: translate(0, 0);
+    -ms-transform: translate(0, 0);
+    -o-transform: translate(0, 0);
     transform: translate(0, 0);
     visibility: visible;
     opacity: 1;
     -webkit-transition: opacity 0.2s ease-out, -webkit-transform 0.2s ease-out;
     -moz-transition: opacity 0.2s ease-out, -moz-transform 0.2s ease-out;
+    -o-transition: opacity 0.2s ease-out, transform 0.2s ease-out;
     transition: opacity 0.2s ease-out, transform 0.2s ease-out;
 }
 
@@ -40,9 +46,13 @@
     background: rgba(84, 84, 84, 0.8);
     border-top-left-radius: 7px;
     text-align: center;
+    -ms-text-overflow: ellipsis;
+    -o-text-overflow: ellipsis;
     text-overflow: ellipsis;
     white-space: nowrap;
     overflow: hidden;
+    -moz-box-sizing: content-box;
+    -webkit-box-sizing: content-box;
     box-sizing: content-box;
 }
 
@@ -74,7 +84,7 @@ button.cesium-infoBox-close {
     border: none;
     border-radius: 2px;
     font-weight: bold;
-    font-size:16px;
+    font-size: 16px;
     padding: 0 5px;
     margin: 0;
     color: #edffff;

--- a/Source/Widgets/NavigationHelpButton/NavigationHelpButton.css
+++ b/Source/Widgets/NavigationHelpButton/NavigationHelpButton.css
@@ -12,11 +12,9 @@
     border-radius: 10px;
     -webkit-transform: scale(0.01);
     -moz-transform: scale(0.01);
-    -ms-transform: scale(0.01);
     transform: scale(0.01);
     -webkit-transform-origin: 234px -10px;
     -moz-transform-origin: 234px -10px;
-    -ms-transform-origin: 234px -10px;
     transform-origin: 234px -10px;
     -webkit-transition: visibility 0s 0.25s, -webkit-transform 0.25s ease-in;
     -moz-transition: visibility 0s 0.25s, -moz-transform 0.25s ease-in;
@@ -27,7 +25,6 @@
     visibility: visible;
     -webkit-transform: scale(1);
     -moz-transform: scale(1);
-    -ms-transform: scale(1);
     transform: scale(1);
     -webkit-transition: -webkit-transform 0.25s ease-out;
     -moz-transition: -moz-transform 0.25s ease-out;

--- a/Source/Widgets/NavigationHelpButton/NavigationHelpButton.css
+++ b/Source/Widgets/NavigationHelpButton/NavigationHelpButton.css
@@ -13,16 +13,13 @@
     -webkit-transform: scale(0.01);
     -moz-transform: scale(0.01);
     -ms-transform: scale(0.01);
-    -o-transform: scale(0.01);
     transform: scale(0.01);
     -webkit-transform-origin: 234px -10px;
     -moz-transform-origin: 234px -10px;
     -ms-transform-origin: 234px -10px;
-    -o-transform-origin: 234px -10px;
     transform-origin: 234px -10px;
     -webkit-transition: visibility 0s 0.25s, -webkit-transform 0.25s ease-in;
     -moz-transition: visibility 0s 0.25s, -moz-transform 0.25s ease-in;
-    -o-transition: visibility 0s 0.25s, -o-transform 0.25s ease-in;
     transition: visibility 0s 0.25s, transform 0.25s ease-in;
 }
 
@@ -31,11 +28,9 @@
     -webkit-transform: scale(1);
     -moz-transform: scale(1);
     -ms-transform: scale(1);
-    -o-transform: scale(1);
     transform: scale(1);
     -webkit-transition: -webkit-transform 0.25s ease-out;
     -moz-transition: -moz-transform 0.25s ease-out;
-    -o-transition: -o-transform 0.25s ease-out;
     transition: transform 0.25s ease-out;
 }
 

--- a/Source/Widgets/NavigationHelpButton/NavigationHelpButton.css
+++ b/Source/Widgets/NavigationHelpButton/NavigationHelpButton.css
@@ -22,7 +22,6 @@
     transform-origin: 234px -10px;
     -webkit-transition: visibility 0s 0.25s, -webkit-transform 0.25s ease-in;
     -moz-transition: visibility 0s 0.25s, -moz-transform 0.25s ease-in;
-    -ms-transition: visibility 0s 0.25s, -ms-transform 0.25s ease-in;
     -o-transition: visibility 0s 0.25s, -o-transform 0.25s ease-in;
     transition: visibility 0s 0.25s, transform 0.25s ease-in;
 }
@@ -34,11 +33,10 @@
     -ms-transform: scale(1);
     -o-transform: scale(1);
     transform: scale(1);
-    transition: transform 0.25s ease-out;
     -webkit-transition: -webkit-transform 0.25s ease-out;
     -moz-transition: -moz-transform 0.25s ease-out;
-    -ms-transition: -ms-transform 0.25s ease-out;
     -o-transition: -o-transform 0.25s ease-out;
+    transition: transform 0.25s ease-out;
 }
 
 .cesium-navigation-help-instructions {

--- a/Source/Widgets/SceneModePicker/SceneModePicker.css
+++ b/Source/Widgets/SceneModePicker/SceneModePicker.css
@@ -7,6 +7,7 @@ span.cesium-sceneModePicker-wrapper {
 .cesium-sceneModePicker-visible {
     visibility: visible;
     opacity: 1;
+    -o-transition: opacity 0.25s linear;
     transition: opacity 0.25s linear;
     -webkit-transition: opacity 0.25s linear;
     -moz-transition: opacity 0.25s linear;
@@ -15,6 +16,7 @@ span.cesium-sceneModePicker-wrapper {
 .cesium-sceneModePicker-hidden {
     visibility: hidden;
     opacity: 0;
+    -o-transition: visibility 0s 0.25s, opacity 0.25s linear;
     transition: visibility 0s 0.25s, opacity 0.25s linear;
     -webkit-transition: visibility 0s 0.25s, opacity 0.25s linear;
     -moz-transition: visibility 0s 0.25s, opacity 0.25s linear;
@@ -27,6 +29,7 @@ span.cesium-sceneModePicker-wrapper {
 .cesium-sceneModePicker-slide-svg {
     -webkit-transition: left 2s;
     -moz-transition: left 2s;
+    -o-transition: left 2s;
     transition: left 2s;
     top: 0;
     left: 0;
@@ -34,6 +37,7 @@ span.cesium-sceneModePicker-wrapper {
 
 .cesium-sceneModePicker-wrapper .cesium-sceneModePicker-dropDown-icon {
     -moz-box-sizing: border-box;
+    -webkit-box-sizing: border-box;
     box-sizing: border-box;
     padding: 0;
     margin: 3px 0;

--- a/Source/Widgets/SceneModePicker/SceneModePicker.css
+++ b/Source/Widgets/SceneModePicker/SceneModePicker.css
@@ -7,7 +7,6 @@ span.cesium-sceneModePicker-wrapper {
 .cesium-sceneModePicker-visible {
     visibility: visible;
     opacity: 1;
-    -o-transition: opacity 0.25s linear;
     transition: opacity 0.25s linear;
     -webkit-transition: opacity 0.25s linear;
     -moz-transition: opacity 0.25s linear;
@@ -16,7 +15,6 @@ span.cesium-sceneModePicker-wrapper {
 .cesium-sceneModePicker-hidden {
     visibility: hidden;
     opacity: 0;
-    -o-transition: visibility 0s 0.25s, opacity 0.25s linear;
     transition: visibility 0s 0.25s, opacity 0.25s linear;
     -webkit-transition: visibility 0s 0.25s, opacity 0.25s linear;
     -moz-transition: visibility 0s 0.25s, opacity 0.25s linear;
@@ -29,7 +27,6 @@ span.cesium-sceneModePicker-wrapper {
 .cesium-sceneModePicker-slide-svg {
     -webkit-transition: left 2s;
     -moz-transition: left 2s;
-    -o-transition: left 2s;
     transition: left 2s;
     top: 0;
     left: 0;

--- a/Source/Widgets/SelectionIndicator/SelectionIndicator.css
+++ b/Source/Widgets/SelectionIndicator/SelectionIndicator.css
@@ -7,6 +7,7 @@
     opacity: 0;
     -webkit-transition: visibility 0s 0.2s, opacity 0.2s ease-in;
     -moz-transition: visibility 0s 0.2s, opacity 0.2s ease-in;
+    -o-transition: visibility 0s 0.2s, opacity 0.2s ease-in;
     transition: visibility 0s 0.2s, opacity 0.2s ease-in;
 }
 
@@ -15,6 +16,7 @@
     opacity: 1;
     -webkit-transition: opacity 0.2s ease-out;
     -moz-transition: opacity 0.2s ease-out;
+    -o-transition: opacity 0.2s ease-out;
     transition: opacity 0.2s ease-out;
 }
 

--- a/Source/Widgets/SelectionIndicator/SelectionIndicator.css
+++ b/Source/Widgets/SelectionIndicator/SelectionIndicator.css
@@ -7,7 +7,6 @@
     opacity: 0;
     -webkit-transition: visibility 0s 0.2s, opacity 0.2s ease-in;
     -moz-transition: visibility 0s 0.2s, opacity 0.2s ease-in;
-    -o-transition: visibility 0s 0.2s, opacity 0.2s ease-in;
     transition: visibility 0s 0.2s, opacity 0.2s ease-in;
 }
 
@@ -16,7 +15,6 @@
     opacity: 1;
     -webkit-transition: opacity 0.2s ease-out;
     -moz-transition: opacity 0.2s ease-out;
-    -o-transition: opacity 0.2s ease-out;
     transition: opacity 0.2s ease-out;
 }
 

--- a/Source/Widgets/Timeline/Timeline.css
+++ b/Source/Widgets/Timeline/Timeline.css
@@ -43,7 +43,6 @@
     background: rgba(32, 32, 32, 0.8);
     background: -moz-linear-gradient(top, rgba(116,117,119,0.8) 0%, rgba(58,68,82,0.8) 11%, rgba(46,50,56,0.8) 46%, rgba(53,53,53,0.8) 81%, rgba(53,53,53,0.8) 100%); /* FF3.6+ */
     background: -webkit-linear-gradient(top, rgba(116,117,119,0.8) 0%,rgba(58,68,82,0.8) 11%,rgba(46,50,56,0.8) 46%,rgba(53,53,53,0.8) 81%,rgba(53,53,53,0.8) 100%); /* Chrome10+,Safari5.1+ */
-    background: -ms-linear-gradient(top, rgba(116,117,119,0.8) 0%,rgba(58,68,82,0.8) 11%,rgba(46,50,56,0.8) 46%,rgba(53,53,53,0.8) 81%,rgba(53,53,53,0.8) 100%); /* IE10+ */
     background: linear-gradient(to bottom, rgba(116,117,119,0.8) 0%,rgba(58,68,82,0.8) 11%,rgba(46,50,56,0.8) 46%,rgba(53,53,53,0.8) 81%,rgba(53,53,53,0.8) 100%); /* W3C */
 }
 

--- a/Source/Widgets/Timeline/Timeline.css
+++ b/Source/Widgets/Timeline/Timeline.css
@@ -43,7 +43,6 @@
     background: rgba(32, 32, 32, 0.8);
     background: -moz-linear-gradient(top, rgba(116,117,119,0.8) 0%, rgba(58,68,82,0.8) 11%, rgba(46,50,56,0.8) 46%, rgba(53,53,53,0.8) 81%, rgba(53,53,53,0.8) 100%); /* FF3.6+ */
     background: -webkit-linear-gradient(top, rgba(116,117,119,0.8) 0%,rgba(58,68,82,0.8) 11%,rgba(46,50,56,0.8) 46%,rgba(53,53,53,0.8) 81%,rgba(53,53,53,0.8) 100%); /* Chrome10+,Safari5.1+ */
-    background: -o-linear-gradient(top, rgba(116,117,119,0.8) 0%,rgba(58,68,82,0.8) 11%,rgba(46,50,56,0.8) 46%,rgba(53,53,53,0.8) 81%,rgba(53,53,53,0.8) 100%); /* Opera 11.10+ */
     background: -ms-linear-gradient(top, rgba(116,117,119,0.8) 0%,rgba(58,68,82,0.8) 11%,rgba(46,50,56,0.8) 46%,rgba(53,53,53,0.8) 81%,rgba(53,53,53,0.8) 100%); /* IE10+ */
     background: linear-gradient(to bottom, rgba(116,117,119,0.8) 0%,rgba(58,68,82,0.8) 11%,rgba(46,50,56,0.8) 46%,rgba(53,53,53,0.8) 81%,rgba(53,53,53,0.8) 100%); /* W3C */
 }

--- a/Source/Widgets/Timeline/lighter.css
+++ b/Source/Widgets/Timeline/lighter.css
@@ -1,7 +1,6 @@
 .cesium-lighter .cesium-timeline-bar {
     background: -moz-linear-gradient(top, #eeeeee 0%, #ffffff 50%, #fafafa 100%); /* FF3.6+ */
     background: -webkit-linear-gradient(top, #eeeeee 0%,#ffffff 50%,#fafafa 100%); /* Chrome10+,Safari5.1+ */
-    background: -ms-linear-gradient(top, #eeeeee 0%,#ffffff 50%,#fafafa 100%); /* IE10+ */
     background: linear-gradient(to bottom, #eeeeee 0%,#ffffff 50%,#fafafa 100%); /* W3C */
 }
 

--- a/Source/Widgets/Timeline/lighter.css
+++ b/Source/Widgets/Timeline/lighter.css
@@ -1,7 +1,6 @@
 .cesium-lighter .cesium-timeline-bar {
     background: -moz-linear-gradient(top, #eeeeee 0%, #ffffff 50%, #fafafa 100%); /* FF3.6+ */
     background: -webkit-linear-gradient(top, #eeeeee 0%,#ffffff 50%,#fafafa 100%); /* Chrome10+,Safari5.1+ */
-    background: -o-linear-gradient(top, #eeeeee 0%,#ffffff 50%,#fafafa 100%); /* Opera 11.10+ */
     background: -ms-linear-gradient(top, #eeeeee 0%,#ffffff 50%,#fafafa 100%); /* IE10+ */
     background: linear-gradient(to bottom, #eeeeee 0%,#ffffff 50%,#fafafa 100%); /* W3C */
 }

--- a/Source/Widgets/Viewer/Viewer.css
+++ b/Source/Widgets/Viewer/Viewer.css
@@ -32,7 +32,7 @@
     padding-right: 0;
     color: #ffffff;
     font-size: 10px;
-    text-shadow: 0px 0px 2px #000000;
+    text-shadow: 0 0 2px #000000;
 }
 
 .cesium-viewer-timelineContainer {

--- a/Source/Widgets/lighterShared.css
+++ b/Source/Widgets/lighterShared.css
@@ -1,27 +1,27 @@
 .cesium-lighter .cesium-button {
-    color: #111;  /* For text buttons */
-    fill: #111;   /* For SVG buttons */
+    color: #111; /* For text buttons */
+    fill: #111; /* For SVG buttons */
     background: #e2f0ff;
     border: 1px solid #759dc0;
 }
 
 .cesium-lighter .cesium-button:focus {
-    color: #000;  /* For text buttons */
-    fill: #000;   /* For SVG buttons */
+    color: #000; /* For text buttons */
+    fill: #000; /* For SVG buttons */
     border-color: #ea4;
 }
 
 .cesium-lighter .cesium-button:hover {
-    color: #000;  /* For text buttons */
-    fill: #000;   /* For SVG buttons */
+    color: #000; /* For text buttons */
+    fill: #000; /* For SVG buttons */
     background: #a6d2ff;
     border-color: #aef;
     box-shadow: 0 0 8px #777;
 }
 
 .cesium-lighter .cesium-button:active {
-    color: #fff;  /* For text buttons */
-    fill: #fff;   /* For SVG buttons */
+    color: #fff; /* For text buttons */
+    fill: #fff; /* For SVG buttons */
     background: #48b;
     border-color: #ea0;
 }
@@ -33,7 +33,7 @@
 .cesium-lighter .cesium-button-disabled:active {
     background: #ccc;
     border-color: #999;
-    color: #999;  /* For text buttons */
-    fill: #999;   /* For SVG buttons */
+    color: #999; /* For text buttons */
+    fill: #999; /* For SVG buttons */
     box-shadow: none;
 }

--- a/Source/Widgets/shared.css
+++ b/Source/Widgets/shared.css
@@ -12,8 +12,8 @@
     position: relative;
     background: #303336;
     border: 1px solid #444;
-    color: #edffff;  /* For text buttons */
-    fill: #edffff;   /* For SVG buttons */
+    color: #edffff; /* For text buttons */
+    fill: #edffff; /* For SVG buttons */
     border-radius: 4px;
     padding: 5px 12px;
     margin: 2px 3px;
@@ -21,27 +21,28 @@
     overflow: hidden;
     -moz-user-select: none;
     -webkit-user-select: none;
+    -ms-user-select: none;
     user-select: none;
 }
 
 .cesium-button:focus {
-    color: #fff;  /* For text buttons */
-    fill: #fff;   /* For SVG buttons */
+    color: #fff; /* For text buttons */
+    fill: #fff; /* For SVG buttons */
     border-color: #ea4;
     outline: none;
 }
 
 .cesium-button:hover {
-    color: #fff;  /* For text buttons */
-    fill: #fff;   /* For SVG buttons */
+    color: #fff; /* For text buttons */
+    fill: #fff; /* For SVG buttons */
     background: #48b;
     border-color: #aef;
     box-shadow: 0 0 8px #fff;
 }
 
 .cesium-button:active {
-    color: #000;  /* For text buttons */
-    fill: #000;   /* For SVG buttons */
+    color: #000; /* For text buttons */
+    fill: #000; /* For SVG buttons */
     background: #adf;
     border-color: #fff;
     box-shadow: 0 0 8px #fff;
@@ -54,8 +55,8 @@
 .cesium-button-disabled:active {
     background: #303336;
     border-color: #444;
-    color: #646464;  /* For text buttons */
-    fill: #646464;   /* For SVG buttons */
+    color: #646464; /* For text buttons */
+    fill: #646464; /* For SVG buttons */
     box-shadow: none;
     cursor: default;
 }
@@ -71,11 +72,12 @@
 
 .cesium-toolbar-button {
     -moz-box-sizing: border-box;
+    -webkit-box-sizing: border-box;
     box-sizing: border-box;
     width: 32px;
     height: 32px;
     border-radius: 14%;
     padding: 0;
     vertical-align: middle;
-    z-index: 0;  /* Workaround for rounded raster image corners in Chrome */
+    z-index: 0; /* Workaround for rounded raster image corners in Chrome */
 }


### PR DESCRIPTION
As discussed in #2479 when using Bootstrap and Cesium together, the default box-sizing model gets changed on us, which created some visual bugs.  After this change, there are still visual differences in our widgets when using bootstrap, but the content sizing issues have been fixed.