### PR TITLE
Fix changing static point colors

### DIFF
--- a/Source/DataSources/PointVisualizer.js
+++ b/Source/DataSources/PointVisualizer.js
@@ -132,8 +132,8 @@ define([
             var colorProperty = pointGraphics._color;
             var outlineColorProperty = pointGraphics._outlineColor;
 
-            var newColor = init || !Property.isConstant(colorProperty) ? Property.getValueOrDefault(colorProperty, time, defaultColor, color) : item.color;
-            var newOutlineColor = init || !Property.isConstant(outlineColorProperty) ? Property.getValueOrDefault(outlineColorProperty, time, defaultOutlineColor, outlineColor) : item.outlineColor;
+            var newColor = Property.getValueOrDefault(colorProperty, time, defaultColor, color);
+            var newOutlineColor = Property.getValueOrDefault(outlineColorProperty, time, defaultOutlineColor, outlineColor);
             var newOutlineWidth = Math.round(Property.getValueOrDefault(pointGraphics._outlineWidth, time, defaultOutlineWidth));
             var newPixelSize = Math.max(1, Math.round(Property.getValueOrDefault(pointGraphics._pixelSize, time, defaultPixelSize)));
 

--- a/Specs/DataSources/PointVisualizerSpec.js
+++ b/Specs/DataSources/PointVisualizerSpec.js
@@ -109,45 +109,46 @@ defineSuite([
         var entityCollection = new EntityCollection();
         visualizer = new PointVisualizer(scene, entityCollection);
 
-        var testObject = entityCollection.getOrCreateEntity('test');
-        testObject.position = new ConstantProperty(new Cartesian3(1234, 5678, 9101112));
-
-        var point = testObject.point = new PointGraphics();
-        point.show = new ConstantProperty(true);
-        point.color = new ConstantProperty(new Color(0.8, 0.7, 0.6, 0.5));
-        point.pixelSize = new ConstantProperty(12.5);
-        point.outlineColor = new ConstantProperty(new Color(0.1, 0.2, 0.3, 0.4));
-        point.outlineWidth = new ConstantProperty(2.5);
-        point.scaleByDistance = new ConstantProperty(new NearFarScalar());
+        var entity = entityCollection.add({
+            position : new Cartesian3(1234, 5678, 9101112),
+            point : {
+                show : true,
+                color : new Color(0.1, 0.2, 0.3, 0.4),
+                outlineColor : new Color(0.5, 0.6, 0.7, 0.8),
+                outlineWidth : 9,
+                pixelSize : 10,
+                scaleByDistance : new NearFarScalar(11, 12, 13, 14)
+            }
+        });
+        var point = entity.point;
 
         visualizer.update(time);
 
         var billboardCollection = scene.primitives.get(0);
         expect(billboardCollection.length).toEqual(1);
-        var bb = billboardCollection.get(0);
+        var billboard = billboardCollection.get(0);
+
+        expect(billboard.show).toEqual(point.show.getValue(time));
+        expect(billboard.position).toEqual(entity.position.getValue(time));
+        expect(billboard.scaleByDistance).toEqual(point.scaleByDistance.getValue(time));
+        expect(billboard.image).toEqual('["rgba(25,51,76,0.4)",10,"rgba(128,153,179,0.8)",9]');
+
+        point.color = new Color(0.15, 0.16, 0.17, 0.18);
+        point.outlineColor = new Color(0.19, 0.20, 0.21, 0.22);
+        point.pixelSize = 23;
+        point.outlineWidth = 24;
+        point.scaleByDistance = new NearFarScalar(25, 26, 27, 28);
 
         visualizer.update(time);
-        expect(bb.show).toEqual(testObject.point.show.getValue(time));
-        expect(bb.position).toEqual(testObject.position.getValue(time));
-        expect(bb.scaleByDistance).toEqual(testObject.point.scaleByDistance.getValue(time));
 
-        //There used to be a caching but with point visualizers.
-        //In order to verify it actually detect changes properly, we modify existing values
-        //here rather than creating new ones.
-        new Cartesian3(5678, 1234, 1293434).clone(testObject.position.value);
-        new Color(0.1, 0.2, 0.3, 0.4).clone(point.color.value);
-        point.pixelSize.value = 2.5;
-        new Color(0.5, 0.6, 0.7, 0.8).clone(point.outlineColor.value);
-        point.outlineWidth.value = 12.5;
+        expect(billboard.show).toEqual(point.show.getValue(time));
+        expect(billboard.position).toEqual(entity.position.getValue(time));
+        expect(billboard.scaleByDistance).toEqual(point.scaleByDistance.getValue(time));
+        expect(billboard.image).toEqual('["rgba(38,40,43,0.18)",23,"rgba(48,51,53,0.22)",24]');
 
+        point.show = false;
         visualizer.update(time);
-        expect(bb.show).toEqual(testObject.point.show.getValue(time));
-        expect(bb.position).toEqual(testObject.position.getValue(time));
-        expect(bb.scaleByDistance).toEqual(testObject.point.scaleByDistance.getValue(time));
-
-        point.show = new ConstantProperty(false);
-        visualizer.update(time);
-        expect(bb.show).toEqual(testObject.point.show.getValue(time));
+        expect(billboard.show).toEqual(point.show.getValue(time));
     });
 
     it('Reuses primitives when hiding one and showing another', function() {


### PR DESCRIPTION
As [reported on the forum](https://groups.google.com/d/msg/cesium-dev/plbxGWaPxr8/twTdRAzbC8UJ), there was a false optimization that would cause changing a point's color from one constnat value to another to have no affect.

I fixed the issue and update an existing test (which was old and partially incorrect anyway).  The test fails in master bu passes in this branch.