### PR TITLE
DataSource API cleanup

### DIFF
--- a/Apps/CesiumViewer/CesiumViewer.js
+++ b/Apps/CesiumViewer/CesiumViewer.js
@@ -94,7 +94,7 @@ define([
             loadPromise = dataSource.loadUrl(source);
         } else if (/\.geojson$/i.test(source) || /\.json$/i.test(source) || /\.topojson$/i.test(source)) {
             dataSource = new GeoJsonDataSource(getFilenameFromUri(source));
-            loadPromise = dataSource.loadUrl(source);
+            loadPromise = dataSource.load(source);
         } else {
             showLoadError(source, 'Unknown format.');
         }

--- a/Apps/Sandcastle/gallery/CZML.html
+++ b/Apps/Sandcastle/gallery/CZML.html
@@ -28,20 +28,14 @@
 function startup(Cesium) {
     "use strict";
 //Sandcastle_Begin
-var gallery = '../../SampleData/';
-
 var viewer = new Cesium.Viewer('cesiumContainer');
 
 Sandcastle.addDefaultToolbarButton('Satellites', function() {
-    var czmlDataSource = new Cesium.CzmlDataSource();
-    czmlDataSource.loadUrl(gallery + 'simple.czml');
-    viewer.dataSources.add(czmlDataSource);
+    viewer.dataSources.add(Cesium.CzmlDataSource.load('../../SampleData/simple.czml'));
 });
 
 Sandcastle.addToolbarButton('Vehicle', function() {
-    var czmlDataSource = new Cesium.CzmlDataSource();
-    czmlDataSource.loadUrl(gallery + 'Vehicle.czml');
-    viewer.dataSources.add(czmlDataSource);
+    viewer.dataSources.add(Cesium.CzmlDataSource.load('../../SampleData/Vehicle.czml'));
 });
 
 Sandcastle.reset = function() {

--- a/Apps/Sandcastle/gallery/GeoJSON and TopoJSON.html
+++ b/Apps/Sandcastle/gallery/GeoJSON and TopoJSON.html
@@ -31,12 +31,12 @@ var viewer = new Cesium.Viewer('cesiumContainer');
 
 //Example 1: Load with default styling.
 Sandcastle.addDefaultToolbarButton('Default styling', function() {
-    viewer.dataSources.add(Cesium.GeoJsonDataSource.fromUrl('../../SampleData/ne_10m_us_states.topojson'));
+    viewer.dataSources.add(Cesium.GeoJsonDataSource.load('../../SampleData/ne_10m_us_states.topojson'));
 });
 
 //Example 2: Load with basic styling options.
 Sandcastle.addToolbarButton('Basic styling', function() {
-    viewer.dataSources.add(Cesium.GeoJsonDataSource.fromUrl('../../SampleData/ne_10m_us_states.topojson', {
+    viewer.dataSources.add(Cesium.GeoJsonDataSource.load('../../SampleData/ne_10m_us_states.topojson', {
         stroke: Cesium.Color.HOTPINK,
         fill: Cesium.Color.PINK,
         strokeWidth: 3
@@ -48,12 +48,10 @@ Sandcastle.addToolbarButton('Custom styling', function() {
     //Seed the random number generator for repeatable results.
     Cesium.Math.setRandomNumberSeed(0);
 
-    //Create a new GeoJSON data source and add it to the list.
-    var dataSource = new Cesium.GeoJsonDataSource();
-    viewer.dataSources.add(dataSource);
-    
-    //Load the document into the data source and then set custom graphics
-    dataSource.loadUrl('../../SampleData/ne_10m_us_states.topojson').then(function() {
+    var promise = Cesium.GeoJsonDataSource.load('../../SampleData/ne_10m_us_states.topojson');
+    promise.then(function(dataSource) {
+        viewer.dataSources.add(dataSource);
+
         //Get the array of entities
         var entities = dataSource.entities.values;
         
@@ -82,6 +80,9 @@ Sandcastle.addToolbarButton('Custom styling', function() {
             //Since the population is a huge number, we divide by 50.
             entity.polygon.extrudedHeight = entity.properties.Population / 50.0;
         }
+    }).otherwise(function(error){
+        //Display any errrors encountered while loading.
+        window.alert(error);
     });
 });
 

--- a/Apps/Sandcastle/gallery/GeoJSON simplestyle.html
+++ b/Apps/Sandcastle/gallery/GeoJSON simplestyle.html
@@ -39,10 +39,9 @@ var viewer = new Cesium.Viewer('cesiumContainer', {
     animation : false
 });
 
-Cesium.GeoJsonDataSource.load('../../SampleData/simplestyles.geojson').then(function(dataSource) {
-    viewer.dataSources.add(dataSource);
-    viewer.zoomTo(dataSource);
-});
+var dataSource = Cesium.GeoJsonDataSource.fromUrl('../../SampleData/simplestyles.geojson');
+viewer.dataSources.add(dataSource);
+viewer.zoomTo(dataSource);
 //Sandcastle_End
     Sandcastle.finishedLoading();
 }

--- a/Apps/Sandcastle/gallery/GeoJSON simplestyle.html
+++ b/Apps/Sandcastle/gallery/GeoJSON simplestyle.html
@@ -39,9 +39,10 @@ var viewer = new Cesium.Viewer('cesiumContainer', {
     animation : false
 });
 
-var dataSource = Cesium.GeoJsonDataSource.fromUrl('../../SampleData/simplestyles.geojson');
-viewer.dataSources.add(dataSource);
-viewer.zoomTo(dataSource);
+Cesium.GeoJsonDataSource.load('../../SampleData/simplestyles.geojson').then(function(dataSource) {
+    viewer.dataSources.add(dataSource);
+    viewer.zoomTo(dataSource);
+});
 //Sandcastle_End
     Sandcastle.finishedLoading();
 }

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,13 +8,24 @@ Change Log
   * Removed `Camera.tilt`, which was deprecated in Cesium 1.6. Use `Camera.pitch`.
   * Removed `Camera.heading` and `Camera.tilt`. They were deprecated in Cesium 1.6. Use `Camera.setView`.
   * Removed `Camera.setPositionCartographic`, which was was deprecated in Cesium 1.6. Use `Camera.setView`.
+* Deprecated
+  * Deprecated `GeoJsonDataSource.fromUrl`, it will be removed in 1.10. Use `GeoJsonDataSource.load` instead. Unlike fromUrl, load can take either a url or parsed JSON object and returns a promise to a new instance, rather than a new instance.
+  * Deprecated `GeoJsonDataSource.prototype.loadUrl`, it will be removed in 1.10.  Instead, pass a url as the first parameter to `GeoJsonDataSource.prototype.load`.
+  * Deprecated `CzmlDataSource.prototype.loadUrl`, it will be removed in 1.10.  Instead, pass a url as the first parameter to `CzmlDataSource.prototype.load`.
+  * Deprecated `CzmlDataSource.prototype.processUrl`, it will be removed in 1.10.  Instead, pass a url as the first parameter to `CzmlDataSource.prototype.process`.
+  * Deprecated the `sourceUri` parameter to all `CzmlDataSource` load and process functions. Support will be removed in 1.10.  Instead pass an `options` object with `sourceUri` property.
 * Fixed incorrect ellipse texture coordinates. [#2363](https://github.com/AnalyticalGraphicsInc/cesium/issues/2363) and [#2465](https://github.com/AnalyticalGraphicsInc/cesium/issues/2465)
 * Fixed a bug in imagery loading that could cause some or all of the globe to be missing when using an imagery layer that does not cover the entire globe.
+* Fixed some styling issues with `InfoBox` and `BaseLayerPicker` caused by using Bootstrap with Cesium. [#2487](https://github.com/AnalyticalGraphicsInc/cesium/issues/2479)
 * Added support for rendering a water effect on Quantized-Mesh terrain tiles.
 * Added `pack` and `unpack` functions to `Matrix2` and `Matrix3`.
 * Added camera-terrain collision detection/response when the camera reference frame is set.
 * Added `ScreenSpaceCameraController.enableCollisionDetection` to enable/disable camera collision detection with terrain.
-* Fixed some styling issues with `InfoBox` and `BaseLayerPicker` caused by using Bootstrap with Cesium. [#2487](https://github.com/AnalyticalGraphicsInc/cesium/issues/2479)
+* Added `CzmlDataSource.load` and `GeoJsonDataSource.load` to make it easy to create and load data in a single line.
+* Added the ability to pass a `Promise` to a `DataSource` to `DataSourceCollection.add`.  The `DataSource` will not actually be added until the promise resolves.
+* Added the ability to pass a `Promise` to a target to `viewer.zoomTo` and `viewer.flyTo`.
+* All `CzmlDataSource` and `GeoJsonDataSource` loading functions now return `Promise` instances that resolve to the instances after data is loaded.
+* Error handling in all `CzmlDataSource` and `GeoJsonDataSource` loading functions is now more consistent.  Rather than a mix of exceptions and `Promise` rejections, all errors are raised via `Promise` rejections.
 
 ### 1.6 - 2015-02-02
 

--- a/Source/DataSources/CzmlDataSource.js
+++ b/Source/DataSources/CzmlDataSource.js
@@ -10,6 +10,7 @@ define([
         '../Core/defaultValue',
         '../Core/defined',
         '../Core/defineProperties',
+        '../Core/deprecationWarning',
         '../Core/DeveloperError',
         '../Core/Ellipsoid',
         '../Core/Event',
@@ -78,6 +79,7 @@ define([
         defaultValue,
         defined,
         defineProperties,
+        deprecationWarning,
         DeveloperError,
         Ellipsoid,
         Event,
@@ -1413,6 +1415,33 @@ define([
         return false;
     }
 
+    function load(dataSource, czml, options, clear) {
+        //>>includeStart('debug', pragmas.debug);
+        if (!defined(czml)) {
+            throw new DeveloperError('czml is required.');
+        }
+        //>>includeEnd('debug');
+
+        options = defaultValue(options, defaultValue.EMPTY_OBJECT);
+
+        var promise = czml;
+        var sourceUri = options.sourceUri;
+        if (typeof czml === 'string') {
+            promise = loadJson(czml);
+            sourceUri = defaultValue(sourceUri, czml);
+        }
+
+        DataSource.setLoading(dataSource, true);
+
+        return when(promise, function(czml) {
+            return loadCzml(dataSource, czml, sourceUri, clear);
+        }).otherwise(function(error) {
+            DataSource.setLoading(dataSource, false);
+            dataSource._error.raiseEvent(dataSource, error);
+            return when.reject(error);
+        });
+    }
+
     function loadCzml(dataSource, czml, sourceUri, clear) {
         DataSource.setLoading(dataSource, true);
         var entityCollection = dataSource._entityCollection;
@@ -1440,6 +1469,8 @@ define([
         if (raiseChangedEvent) {
             dataSource._changed.raiseEvent(dataSource);
         }
+
+        return dataSource;
     }
 
     var DocumentPacket = function() {
@@ -1448,7 +1479,7 @@ define([
     };
 
     /**
-     * A {@link DataSource} which processes CZML.
+     * A {@link DataSource} which processes {@link https://github.com/AnalyticalGraphicsInc/cesium/wiki/CZML-Guide|CZML}.
      * @alias CzmlDataSource
      * @constructor
      *
@@ -1466,6 +1497,18 @@ define([
         this._documentPacket = new DocumentPacket();
         this._version = undefined;
         this._entityCollection = new EntityCollection();
+    };
+
+    /**
+     * Creates a Promise to a new instance loaded with the provided CZML data.
+     *
+     * @param {String|Object} data A url or CZML object to be processed.
+     * @param {Object} [options] An object with the following properties:
+     * @param {String} [options.sourceUri] Overrides the url to use for resolving relative links.
+     * @returns {Promise} A promise that resolves to the new instance once the data is processed.
+     */
+    CzmlDataSource.load = function(czml, options) {
+        return new CzmlDataSource().load(czml, options);
     };
 
     defineProperties(CzmlDataSource.prototype, {
@@ -1568,85 +1611,49 @@ define([
     processAvailability];
 
     /**
-     * Processes the provided CZML without clearing any existing data.
+     * Processes the provided url or CZML object without clearing any existing data.
      *
-     * @param {Object} czml The CZML to be processed.
-     * @param {String} sourceUri The source URI of the CZML.
+     * @param {String|Object} data A url or CZML object to be processed.
+     * @param {Object} [options] An object with the following properties:
+     * @param {String} [options.sourceUri] Overrides the url to use for resolving relative links.
+     * @returns {Promise} A promise that resolves to this instances once the data is processed.
      */
-    CzmlDataSource.prototype.process = function(czml, sourceUri) {
-        //>>includeStart('debug', pragmas.debug);
-        if (!defined(czml)) {
-            throw new DeveloperError('czml is required.');
+    CzmlDataSource.prototype.process = function(czml, options) {
+        if (typeof options === 'string') {
+            options = {
+                sourceUri : options
+            };
+            deprecationWarning('CzmlDataSource.process.options', 'Passing a sourceUri string as the second paraameter to CzmlDataSource.process has been deprecated. Pass an options object instead.');
         }
-        //>>includeEnd('debug');
-
-        loadCzml(this, czml, sourceUri, false);
+        return load(this, czml, options, false);
     };
 
     /**
-     * Replaces any existing data with the provided CZML.
+     * Loads the provided url or CZML object, replacing any existing data.
      *
-     * @param {Object} czml The CZML to be processed.
-     * @param {String} source The source URI of the CZML.
+     * @param {String|Object} data A url or CZML object to be processed.
+     * @param {Object} [options] An object with the following properties:
+     * @param {String} [options.sourceUri] Overrides the url to use for resolving relative links.
+     * @returns {Promise} A promise that resolves to this instances once the data is processed.
      */
-    CzmlDataSource.prototype.load = function(czml, sourceUri) {
-        //>>includeStart('debug', pragmas.debug);
-        if (!defined(czml)) {
-            throw new DeveloperError('czml is required.');
+    CzmlDataSource.prototype.load = function(czml, options) {
+        if (typeof options === 'string') {
+            options = {
+                sourceUri : options
+            };
+            deprecationWarning('CzmlDataSource.process.load', 'Passing a sourceUri string as the second paraameter to CzmlDataSource.load has been deprecated. Pass an options object instead.');
         }
-        //>>includeEnd('debug');
-
-        loadCzml(this, czml, sourceUri, true);
+        return load(this, czml, options, true);
     };
 
-    /**
-     * Asynchronously processes the CZML at the provided url without clearing any existing data.
-     *
-     * @param {Object} url The url to be processed.
-     * @returns {Promise} a promise that will resolve when the CZML is processed.
-     */
     CzmlDataSource.prototype.processUrl = function(url) {
-        //>>includeStart('debug', pragmas.debug);
-        if (!defined(url)) {
-            throw new DeveloperError('url is required.');
-        }
-        //>>includeEnd('debug');
-
-        DataSource.setLoading(this, true);
-
-        var dataSource = this;
-        return when(loadJson(url), function(czml) {
-            loadCzml(dataSource, czml, url, false);
-        }).otherwise(function(error) {
-            DataSource.setLoading(dataSource, false);
-            dataSource._error.raiseEvent(dataSource, error);
-            return when.reject(error);
-        });
+        deprecationWarning('CzmlDataSource.prototype.processUrl', 'CzmlDataSource.processUrl has been deprecated.  Use CzmlDataSource.process instead.');
+        return this.process(url);
     };
 
-    /**
-     * Asynchronously loads the CZML at the provided url, replacing any existing data.
-     *
-     * @param {Object} url The url to be processed.
-     * @returns {Promise} a promise that will resolve when the CZML is processed.
-     */
     CzmlDataSource.prototype.loadUrl = function(url) {
-        //>>includeStart('debug', pragmas.debug);
-        if (!defined(url)) {
-            throw new DeveloperError('url is required.');
-        }
-        //>>includeEnd('debug');
-
-        DataSource.setLoading(this, true);
-
-        var dataSource = this;
-        return when(loadJson(url), function(czml) {
-            loadCzml(dataSource, czml, url, true);
-        }).otherwise(function(error) {
-            DataSource.setLoading(dataSource, false);
-            dataSource._error.raiseEvent(dataSource, error);
-            return when.reject(error);
-        });
+        deprecationWarning('CzmlDataSource.prototype.loadUrl', 'CzmlDataSource.loadUrl has been deprecated.  Use CzmlDataSource.load instead.');
+        return this.load(url);
     };
 
     /**

--- a/Source/DataSources/CzmlDataSource.js
+++ b/Source/DataSources/CzmlDataSource.js
@@ -347,7 +347,7 @@ define([
         case VerticalOrigin:
             return VerticalOrigin[defaultValue(czmlInterval.verticalOrigin, czmlInterval)];
         default:
-            throw new DeveloperError(type);
+            throw new RuntimeError(type);
         }
     }
 

--- a/Source/DataSources/DataSourceCollection.js
+++ b/Source/DataSources/DataSourceCollection.js
@@ -74,7 +74,7 @@ define([
      * @param {DataSource|Promise} dataSource A data source or a promise to a data source to add to the collection.
      *                                        When passing a promise, the data source will not actually be added
      *                                        to the collection until the promise resolves successfully.
-     * @returns {DataSource|Promise} The input argument for promise chaining.
+     * @returns {Promise} A Promise that resolves once the data source has been added to the collection.
      */
     DataSourceCollection.prototype.add = function(dataSource) {
         //>>includeStart('debug', pragmas.debug);

--- a/Source/DataSources/DataSourceCollection.js
+++ b/Source/DataSources/DataSourceCollection.js
@@ -5,14 +5,16 @@ define([
         '../Core/defineProperties',
         '../Core/destroyObject',
         '../Core/DeveloperError',
-        '../Core/Event'
+        '../Core/Event',
+        '../ThirdParty/when'
     ], function(
         defaultValue,
         defined,
         defineProperties,
         destroyObject,
         DeveloperError,
-        Event) {
+        Event,
+        when) {
     "use strict";
 
     /**
@@ -69,7 +71,10 @@ define([
     /**
      * Adds a data source to the collection.
      *
-     * @param {DataSource} dataSource The data source to add.
+     * @param {DataSource|Promise} dataSource A data source or a promise to a data source to add to the collection.
+     *                                        When passing a promise, the data source will not actually be added
+     *                                        to the collection until the promise resolves successfully.
+     * @returns {DataSource|Promise} The input argument for promise chaining.
      */
     DataSourceCollection.prototype.add = function(dataSource) {
         //>>includeStart('debug', pragmas.debug);
@@ -78,8 +83,17 @@ define([
         }
         //>>includeEnd('debug');
 
-        this._dataSources.push(dataSource);
-        this._dataSourceAdded.raiseEvent(this, dataSource);
+        var that = this;
+        var dataSources = this._dataSources;
+        return when(dataSource, function(value) {
+            //Only add the data source if removeAll has not been called
+            //Since it was added.
+            if (dataSources === that._dataSources) {
+                that._dataSources.push(value);
+                that._dataSourceAdded.raiseEvent(that, value);
+            }
+            return value;
+        });
     };
 
     /**
@@ -125,7 +139,7 @@ define([
                 dataSource.destroy();
             }
         }
-        dataSources.length = 0;
+        this._dataSources = [];
     };
 
     /**

--- a/Source/DataSources/GeoJsonDataSource.js
+++ b/Source/DataSources/GeoJsonDataSource.js
@@ -462,7 +462,7 @@ define([
     /**
      * A {@link DataSource} which processes both
      * {@link http://www.geojson.org/|GeoJSON} and {@link https://github.com/mbostock/topojson|TopoJSON} data.
-     * {@link https://github.com/mapbox/simplestyle-spec|Simplestyle} properties will also be used if they
+     * {@link https://github.com/mapbox/simplestyle-spec|simplestyle-spec} properties will also be used if they
      * are present.
      *
      * @alias GeoJsonDataSource
@@ -476,7 +476,7 @@ define([
      *
      * @example
      * var viewer = new Cesium.Viewer('cesiumContainer');
-     * viewer.dataSources.add(Cesium.GeoJsonDataSource.fromUrl('../../SampleData/ne_10m_us_states.topojson', {
+     * viewer.dataSources.add(Cesium.GeoJsonDataSource.load('../../SampleData/ne_10m_us_states.topojson', {
      *   stroke: Cesium.Color.HOTPINK,
      *   fill: Cesium.Color.PINK,
      *   strokeWidth: 3,
@@ -494,21 +494,6 @@ define([
         this._pinBuilder = new PinBuilder();
     };
 
-    /**
-     * Creates a new instance and asynchronously loads the provided url.
-     *
-     * @param {Object} url The url to be processed.
-     * @param {Object} [options] An object with the following properties:
-     * @param {Number} [options.markerSize=GeoJsonDataSource.markerSize] The default size of the map pin created for each point, in pixels.
-     * @param {String} [options.markerSymbol=GeoJsonDataSource.markerSymbol] The default symbol of the map pin created for each point.
-     * @param {Color} [options.markerColor=GeoJsonDataSource.markerColor] The default color of the map pin created for each point.
-     * @param {Color} [options.stroke=GeoJsonDataSource.stroke] The default color of polylines and polygon outlines.
-     * @param {Number} [options.strokeWidth=GeoJsonDataSource.strokeWidth] The default width of polylines and polygon outlines.
-     * @param {Color} [options.fill=GeoJsonDataSource.fill] The default color for polygon interiors.
-     *
-     * @returns {GeoJsonDataSource} A new instance set to load the specified url.
-     * @deprecated
-     */
     GeoJsonDataSource.fromUrl = function(url, options) {
         deprecationWarning('GeoJsonDataSource.fromUrl', 'GeoJsonDataSource.fromUrl has been deprecated.  Use GeoJsonDataSource.load instead.');
         var result = new GeoJsonDataSource();
@@ -516,8 +501,23 @@ define([
         return result;
     };
 
-    GeoJsonDataSource.load = function(geoJson, options) {
-        return new GeoJsonDataSource().load(geoJson, options);
+    /**
+     * Creates a Promise to a new instance loaded with the provided GeoJSON or TopoJSON data.
+     *
+     * @param {String|Object} data A url, GeoJSON object, or TopoJSON object to be loaded.
+     * @param {Object} [options] An object with the following properties:
+     * @param {String} [options.sourceUri] Overrides the url to use for resolving relative links.
+     * @param {Number} [options.markerSize=GeoJsonDataSource.markerSize] The default size of the map pin created for each point, in pixels.
+     * @param {String} [options.markerSymbol=GeoJsonDataSource.markerSymbol] The default symbol of the map pin created for each point.
+     * @param {Color} [options.markerColor=GeoJsonDataSource.markerColor] The default color of the map pin created for each point.
+     * @param {Color} [options.stroke=GeoJsonDataSource.stroke] The default color of polylines and polygon outlines.
+     * @param {Number} [options.strokeWidth=GeoJsonDataSource.strokeWidth] The default width of polylines and polygon outlines.
+     * @param {Color} [options.fill=GeoJsonDataSource.fill] The default color for polygon interiors.
+     *
+     * @returns {Promise} A promise that will resolve when the data is loaded.
+     */
+    GeoJsonDataSource.load = function(data, options) {
+        return new GeoJsonDataSource().load(data, options);
     };
 
     defineProperties(GeoJsonDataSource, {
@@ -726,147 +726,127 @@ define([
         }
     });
 
-    /**
-     * Asynchronously loads the GeoJSON at the provided url, replacing any existing data.
-     *
-     * @param {Object} url The url to be processed.
-     * @param {Object} [options] An object with the following properties:
-     * @param {Number} [options.markerSize=GeoJsonDataSource.markerSize] The default size of the map pin created for each point, in pixels.
-     * @param {String} [options.markerSymbol=GeoJsonDataSource.markerSymbol] The default symbol of the map pin created for each point.
-     * @param {Color} [options.markerColor=GeoJsonDataSource.markerColor] The default color of the map pin created for each point.
-     * @param {Color} [options.stroke=GeoJsonDataSource.stroke] The default color of polylines and polygon outlines.
-     * @param {Number} [options.strokeWidth=GeoJsonDataSource.strokeWidth] The default width of polylines and polygon outlines.
-     * @param {Color} [options.fill=GeoJsonDataSource.fill] The default color for polygon interiors.
-     *
-     * @returns {Promise} a promise that will resolve when the GeoJSON is loaded.
-     * @deprecated
-     */
     GeoJsonDataSource.prototype.loadUrl = function(url, options) {
         deprecationWarning('GeoJsonDataSource.prototype.loadUrl', 'GeoJsonDataSource.loadUrl has been deprecated.  You can now pass a url to GeoJsonDataSource.load.');
         return this.load(url, options);
     };
 
     /**
-     * Asynchronously loads the provided GeoJSON object, replacing any existing data.
+     * Asynchronously loads the provided GeoJSON or TopoJSON data, replacing any existing data.
      *
-     * @param {Object} geoJson The object to be processed.
+     * @param {String|Object} data A url, GeoJSON object, or TopoJSON object to be loaded.
      * @param {Object} [options] An object with the following properties:
-     * @param {String} [options.sourceUri] The base URI of any relative links in the geoJson object.
+     * @param {String} [options.sourceUri] Overrides the url to use for resolving relative links.
      * @param {Number} [options.markerSize=GeoJsonDataSource.markerSize] The default size of the map pin created for each point, in pixels.
      * @param {String} [options.markerSymbol=GeoJsonDataSource.markerSymbol] The default symbol of the map pin created for each point.
      * @param {Color} [options.markerColor=GeoJsonDataSource.markerColor] The default color of the map pin created for each point.
      * @param {Color} [options.stroke=GeoJsonDataSource.stroke] The default color of polylines and polygon outlines.
      * @param {Number} [options.strokeWidth=GeoJsonDataSource.strokeWidth] The default width of polylines and polygon outlines.
      * @param {Color} [options.fill=GeoJsonDataSource.fill] The default color for polygon interiors.
-     * @returns {Promise} a promise that will resolve when the GeoJSON is loaded.
      *
-     * @exception {DeveloperError} Unsupported GeoJSON object type.
-     * @exception {RuntimeError} crs is null.
-     * @exception {RuntimeError} crs.properties is undefined.
-     * @exception {RuntimeError} Unknown crs name.
-     * @exception {RuntimeError} Unable to resolve crs link.
-     * @exception {RuntimeError} Unknown crs type.
+     * @returns {Promise} a promise that will resolve when the GeoJSON is loaded.
      */
-    GeoJsonDataSource.prototype.load = function(geoJson, options) {
+    GeoJsonDataSource.prototype.load = function(data, options) {
         //>>includeStart('debug', pragmas.debug);
-        if (!defined(geoJson)) {
-            throw new DeveloperError('geoJson is required.');
+        if (!defined(data)) {
+            throw new DeveloperError('data is required.');
         }
         //>>includeEnd('debug');
 
-        return load(this, geoJson, options);
-    };
+        DataSource.setLoading(this, true);
 
-    function load(that, urlOrData, options) {
-        var promise = urlOrData;
+        var promise = data;
         options = defaultValue(options, defaultValue.EMPTY_OBJECT);
         var sourceUri = options.sourceUri;
-
-        DataSource.setLoading(that, true);
-        if (typeof urlOrData === 'string') {
+        if (typeof data === 'string') {
             if (!defined(sourceUri)) {
-                sourceUri = urlOrData;
+                sourceUri = data;
             }
-            promise = loadJson(urlOrData);
+            promise = loadJson(data);
         }
 
+        options = {
+            markerSize : defaultValue(options.markerSize, defaultMarkerSize),
+            markerSymbol : defaultValue(options.markerSymbol, defaultMarkerSymbol),
+            markerColor : defaultValue(options.markerColor, defaultMarkerColor),
+            strokeWidthProperty : new ConstantProperty(defaultValue(options.strokeWidth, defaultStrokeWidth)),
+            strokeMaterialProperty : new ColorMaterialProperty(defaultValue(options.stroke, defaultStroke)),
+            fillMaterialProperty : new ColorMaterialProperty(defaultValue(options.fill, defaultFill))
+        };
+
+        var that = this;
         return when(promise, function(geoJson) {
-            options = {
-                markerSize : defaultValue(options.markerSize, defaultMarkerSize),
-                markerSymbol : defaultValue(options.markerSymbol, defaultMarkerSymbol),
-                markerColor : defaultValue(options.markerColor, defaultMarkerColor),
-                strokeWidthProperty : new ConstantProperty(defaultValue(options.strokeWidth, defaultStrokeWidth)),
-                strokeMaterialProperty : new ColorMaterialProperty(defaultValue(options.stroke, defaultStroke)),
-                fillMaterialProperty : new ColorMaterialProperty(defaultValue(options.fill, defaultFill))
-            };
-
-            var name;
-            if (defined(sourceUri)) {
-                name = getFilenameFromUri(sourceUri);
-            }
-
-            if (defined(name) && that._name !== name) {
-                that._name = name;
-                that._changed.raiseEvent(that);
-            }
-
-            var typeHandler = geoJsonObjectTypes[geoJson.type];
-            if (!defined(typeHandler)) {
-                throw new RuntimeError('Unsupported GeoJSON object type: ' + geoJson.type);
-            }
-
-            //Check for a Coordinate Reference System.
-            var crsFunction = defaultCrsFunction;
-            var crs = geoJson.crs;
-            if (defined(crs)) {
-                if (crs === null) {
-                    throw new RuntimeError('crs is null.');
-                }
-                if (!defined(crs.properties)) {
-                    throw new RuntimeError('crs.properties is undefined.');
-                }
-
-                var properties = crs.properties;
-                if (crs.type === 'name') {
-                    crsFunction = crsNames[properties.name];
-                    if (!defined(crsFunction)) {
-                        throw new RuntimeError('Unknown crs name: ' + properties.name);
-                    }
-                } else if (crs.type === 'link') {
-                    var handler = crsLinkHrefs[properties.href];
-                    if (!defined(handler)) {
-                        handler = crsLinkTypes[properties.type];
-                    }
-
-                    if (!defined(handler)) {
-                        throw new RuntimeError('Unable to resolve crs link: ' + JSON.stringify(properties));
-                    }
-
-                    crsFunction = handler(properties);
-                } else if (crs.type === 'EPSG') {
-                    crsFunction = crsNames['EPSG:' + properties.code];
-                    if (!defined(crsFunction)) {
-                        throw new RuntimeError('Unknown crs EPSG code: ' + properties.code);
-                    }
-                } else {
-                    throw new RuntimeError('Unknown crs type: ' + crs.type);
-                }
-            }
-
-            return when(crsFunction, function(crsFunction) {
-                that._entityCollection.removeAll();
-                typeHandler(that, geoJson, geoJson, crsFunction, options);
-
-                return when.all(that._promises, function() {
-                    that._promises.length = 0;
-                    DataSource.setLoading(that, false);
-                    return that;
-                });
-            });
+            return load(that, geoJson, options, sourceUri);
         }).otherwise(function(error) {
             DataSource.setLoading(that, false);
             that._error.raiseEvent(that, error);
             return when.reject(error);
+        });
+    };
+
+    function load(that, geoJson, options, sourceUri) {
+        var name;
+        if (defined(sourceUri)) {
+            name = getFilenameFromUri(sourceUri);
+        }
+
+        if (defined(name) && that._name !== name) {
+            that._name = name;
+            that._changed.raiseEvent(that);
+        }
+
+        var typeHandler = geoJsonObjectTypes[geoJson.type];
+        if (!defined(typeHandler)) {
+            throw new RuntimeError('Unsupported GeoJSON object type: ' + geoJson.type);
+        }
+
+        //Check for a Coordinate Reference System.
+        var crsFunction = defaultCrsFunction;
+        var crs = geoJson.crs;
+        if (defined(crs)) {
+            if (crs === null) {
+                throw new RuntimeError('crs is null.');
+            }
+            if (!defined(crs.properties)) {
+                throw new RuntimeError('crs.properties is undefined.');
+            }
+
+            var properties = crs.properties;
+            if (crs.type === 'name') {
+                crsFunction = crsNames[properties.name];
+                if (!defined(crsFunction)) {
+                    throw new RuntimeError('Unknown crs name: ' + properties.name);
+                }
+            } else if (crs.type === 'link') {
+                var handler = crsLinkHrefs[properties.href];
+                if (!defined(handler)) {
+                    handler = crsLinkTypes[properties.type];
+                }
+
+                if (!defined(handler)) {
+                    throw new RuntimeError('Unable to resolve crs link: ' + JSON.stringify(properties));
+                }
+
+                crsFunction = handler(properties);
+            } else if (crs.type === 'EPSG') {
+                crsFunction = crsNames['EPSG:' + properties.code];
+                if (!defined(crsFunction)) {
+                    throw new RuntimeError('Unknown crs EPSG code: ' + properties.code);
+                }
+            } else {
+                throw new RuntimeError('Unknown crs type: ' + crs.type);
+            }
+        }
+
+        return when(crsFunction, function(crsFunction) {
+            that._entityCollection.removeAll();
+            typeHandler(that, geoJson, geoJson, crsFunction, options);
+
+            return when.all(that._promises, function() {
+                that._promises.length = 0;
+                DataSource.setLoading(that, false);
+                return that;
+            });
         });
     }
 

--- a/Source/Widgets/Viewer/Viewer.js
+++ b/Source/Widgets/Viewer/Viewer.js
@@ -1438,7 +1438,7 @@ Either specify options.terrainProvider instead or set options.baseLayerPicker to
      * target will be the range. The heading will be determined from the offset. If the heading cannot be
      * determined from the offset, the heading will be north.</p>
      *
-     * @param {Entity|Entity[]|EntityCollection|DataSource} target The entity, array of entities, entity collection or data source to view.
+     * @param {Entity|Entity[]|EntityCollection|DataSource|Promise} target The entity, array of entities, entity collection or data source to view. You can also pass a promise that resolves to one of the previously mentioned types.
      * @param {HeadingPitchRange} [offset] The offset from the center of the entity in the local east-north-up reference frame.
      * @returns {Promise} A Promise that resolves to true if the zoom was successful or false if the entity is not currently visualized in the scene or the zoom was cancelled.
      */
@@ -1461,7 +1461,7 @@ Either specify options.terrainProvider instead or set options.baseLayerPicker to
      * target will be the range. The heading will be determined from the offset. If the heading cannot be
      * determined from the offset, the heading will be north.</p>
      *
-     * @param {Entity|Entity[]|EntityCollection|DataSource} target The entity, array of entities, entity collection or data source to view.
+     * @param {Entity|Entity[]|EntityCollection|DataSource|Promise} target The entity, array of entities, entity collection or data source to view. You can also pass a promise that resolves to one of the previously mentioned types.
      * @param {Object} [options] Object with the following properties:
      * @param {Number} [options.duration=3.0] The duration of the flight in seconds.
      * @param {HeadingPitchRange} [options.offset] The offset from the target in the local east-north-up reference frame centered at the target.
@@ -1489,32 +1489,39 @@ Either specify options.terrainProvider instead or set options.baseLayerPicker to
         that._zoomIsFlight = isFlight;
         that._zoomOptions = options;
 
-        //If the zoom target is a data source, and it's in the middle of loading, wait for it to finish loading.
-        if (zoomTarget.isLoading && defined(zoomTarget.loadingEvent)) {
-            var removeEvent = zoomTarget.loadingEvent.addEventListener(function() {
-                removeEvent();
-
-                //Only perform the zoom if it wasn't cancelled before the data source finished.
-                if (that._zoomPromise === zoomPromise) {
-                    that._zoomTarget = zoomTarget.entities.values.slice(0);
-                }
-            });
-        } else {
-            //zoomTarget is now an EntityCollection, this will retrieve the array
-            zoomTarget = defaultValue(zoomTarget.values, zoomTarget);
-
-            //If zoomTarget is a DataSource, this will retrieve the EntityCollection.
-            if (defined(zoomTarget.entities)) {
-                zoomTarget = zoomTarget.entities.values;
+        when(zoomTarget, function(zoomTarget) {
+            //Only perform the zoom if it wasn't cancelled before the promise resolved.
+            if (that._zoomPromise !== zoomPromise) {
+                return;
             }
 
-            if (isArray(zoomTarget)) {
-                that._zoomTarget = zoomTarget.slice(0);
+            //If the zoom target is a data source, and it's in the middle of loading, wait for it to finish loading.
+            if (zoomTarget.isLoading && defined(zoomTarget.loadingEvent)) {
+                var removeEvent = zoomTarget.loadingEvent.addEventListener(function() {
+                    removeEvent();
+
+                    //Only perform the zoom if it wasn't cancelled before the data source finished.
+                    if (that._zoomPromise === zoomPromise) {
+                        that._zoomTarget = zoomTarget.entities.values.slice(0);
+                    }
+                });
             } else {
-                //Single entity
-                that._zoomTarget = [zoomTarget];
+                //zoomTarget is now an EntityCollection, this will retrieve the array
+                zoomTarget = defaultValue(zoomTarget.values, zoomTarget);
+
+                //If zoomTarget is a DataSource, this will retrieve the EntityCollection.
+                if (defined(zoomTarget.entities)) {
+                    zoomTarget = zoomTarget.entities.values;
+                }
+
+                if (isArray(zoomTarget)) {
+                    that._zoomTarget = zoomTarget.slice(0);
+                } else {
+                    //Single entity
+                    that._zoomTarget = [zoomTarget];
+                }
             }
-        }
+        });
 
         return zoomPromise;
     }

--- a/Specs/DataSources/CzmlDataSourceSpec.js
+++ b/Specs/DataSources/CzmlDataSourceSpec.js
@@ -23,6 +23,7 @@ defineSuite([
         'Scene/HorizontalOrigin',
         'Scene/LabelStyle',
         'Scene/VerticalOrigin',
+        'Specs/waitsForPromise',
         'ThirdParty/when'
     ], function(
         CzmlDataSource,
@@ -48,6 +49,7 @@ defineSuite([
         HorizontalOrigin,
         LabelStyle,
         VerticalOrigin,
+        waitsForPromise,
         when) {
     "use strict";
     /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
@@ -313,20 +315,6 @@ defineSuite([
         }).toThrowDeveloperError();
     });
 
-    it('processUrl throws with undefined Url', function() {
-        var dataSource = new CzmlDataSource();
-        expect(function() {
-            dataSource.processUrl(undefined);
-        }).toThrowDeveloperError();
-    });
-
-    it('loadUrl throws with undefined Url', function() {
-        var dataSource = new CzmlDataSource();
-        expect(function() {
-            dataSource.loadUrl(undefined);
-        }).toThrowDeveloperError();
-    });
-
     it('raises changed event when loading CZML', function() {
         var dataSource = new CzmlDataSource();
 
@@ -421,13 +409,13 @@ defineSuite([
         expect(spy).not.toHaveBeenCalled();
     });
 
-    it('raises error when an error occurs in loadUrl', function() {
+    it('raises error when an error occurs in load', function() {
         var dataSource = new CzmlDataSource();
 
         var spy = jasmine.createSpy('errorEvent');
         dataSource.errorEvent.addEventListener(spy);
 
-        var promise = dataSource.loadUrl('Data/Images/Blue.png'); //not JSON
+        var promise = dataSource.load('Data/Images/Blue.png'); //not JSON
 
         var resolveSpy = jasmine.createSpy('resolve');
         var rejectSpy = jasmine.createSpy('reject');
@@ -444,13 +432,13 @@ defineSuite([
         });
     });
 
-    it('raises error when an error occurs in processUrl', function() {
+    it('raises error when an error occurs in process', function() {
         var dataSource = new CzmlDataSource();
 
         var spy = jasmine.createSpy('errorEvent');
         dataSource.errorEvent.addEventListener(spy);
 
-        var promise = dataSource.processUrl('Data/Images/Blue.png'); //not JSON
+        var promise = dataSource.process('Data/Images/Blue.png'); //not JSON
 
         var resolveSpy = jasmine.createSpy('resolve');
         var rejectSpy = jasmine.createSpy('reject');
@@ -2081,37 +2069,22 @@ defineSuite([
         expect(position.backwardExtrapolationDuration).toEqual(1.0);
     });
 
-    it('throws if first document packet lacks version information', function() {
-        var packet = {
+    it('rejects if first document packet lacks version information', function() {
+        waitsForPromise.toReject(CzmlDataSource.load({
             id : 'document'
-        };
-
-        var dataSource = new CzmlDataSource();
-        expect(function() {
-            dataSource.load(packet);
-        }).toThrowRuntimeError();
+        }));
     });
 
-    it('throws if first packet is not document', function() {
-        var packet = {
+    it('rejects if first packet is not document', function() {
+        waitsForPromise.toReject(CzmlDataSource.load({
             id : 'someId'
-        };
-
-        var dataSource = new CzmlDataSource();
-        expect(function() {
-            dataSource.load(packet);
-        }).toThrowRuntimeError();
+        }));
     });
 
-    it('throws if document packet contains bad version', function() {
-        var packet = {
+    it('rejects if document packet contains bad version', function() {
+        waitsForPromise.toReject(CzmlDataSource.load({
             id : 'document',
             version : 12
-        };
-
-        var dataSource = new CzmlDataSource();
-        expect(function() {
-            dataSource.load(packet);
-        }).toThrowRuntimeError();
+        }));
     });
 });

--- a/Specs/DataSources/DataSourceCollectionSpec.js
+++ b/Specs/DataSources/DataSourceCollectionSpec.js
@@ -1,9 +1,11 @@
 /*global defineSuite*/
 defineSuite([
         'DataSources/DataSourceCollection',
+        'ThirdParty/when',
         'Specs/MockDataSource'
     ], function(
         DataSourceCollection,
+        when,
         MockDataSource) {
     "use strict";
     /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
@@ -35,27 +37,57 @@ defineSuite([
         var source = new MockDataSource();
         var collection = new DataSourceCollection();
 
-        var addCalled = 0;
-        collection.dataSourceAdded.addEventListener(function(sender, dataSource) {
-            addCalled++;
-            expect(sender).toBe(collection);
-            expect(dataSource).toBe(source);
-        });
+        var addSpy = jasmine.createSpy('dataSourceAdded');
+        collection.dataSourceAdded.addEventListener(addSpy);
 
-        var removeCalled = 0;
-        collection.dataSourceRemoved.addEventListener(function(sender, dataSource) {
-            removeCalled++;
-            expect(sender).toBe(collection);
-            expect(dataSource).toBe(source);
-        });
+        var removeSpy = jasmine.createSpy('dataSourceRemoved');
+        collection.dataSourceRemoved.addEventListener(removeSpy);
 
         collection.add(source);
-        expect(addCalled).toEqual(1);
-        expect(removeCalled).toEqual(0);
+        expect(addSpy).toHaveBeenCalledWith(collection, source);
+        expect(removeSpy).not.toHaveBeenCalled();
+
+        addSpy.reset();
+        removeSpy.reset();
 
         expect(collection.remove(source)).toEqual(true);
-        expect(addCalled).toEqual(1);
-        expect(removeCalled).toEqual(1);
+        expect(addSpy).not.toHaveBeenCalled();
+        expect(removeSpy).toHaveBeenCalledWith(collection, source);
+    });
+
+    it('add works with promise', function() {
+        var promise = when.defer();
+        var source = new MockDataSource();
+        var collection = new DataSourceCollection();
+
+        var addSpy = jasmine.createSpy('dataSourceAdded');
+        collection.dataSourceAdded.addEventListener(addSpy);
+        collection.add(promise);
+
+        expect(collection.length).toEqual(0);
+        expect(addSpy).not.toHaveBeenCalled();
+
+        promise.resolve(source);
+        expect(addSpy).toHaveBeenCalledWith(collection, source);
+        expect(collection.length).toEqual(1);
+    });
+
+    it('promise does not get added if not resolved before removeAll', function() {
+        var promise = when.defer();
+        var source = new MockDataSource();
+        var collection = new DataSourceCollection();
+
+        var addSpy = jasmine.createSpy('dataSourceAdded');
+        collection.dataSourceAdded.addEventListener(addSpy);
+        collection.add(promise);
+        expect(collection.length).toEqual(0);
+
+        expect(addSpy).not.toHaveBeenCalled();
+        collection.removeAll();
+
+        promise.resolve(source);
+        expect(addSpy).not.toHaveBeenCalled();
+        expect(collection.length).toEqual(0);
     });
 
     it('removeAll triggers events', function() {
@@ -65,7 +97,7 @@ defineSuite([
         var removeCalled = 0;
         collection.dataSourceRemoved.addEventListener(function(sender, dataSource) {
             expect(sender).toBe(collection);
-            expect(sources.indexOf(dataSource)).toNotEqual(-1);
+            expect(sources.indexOf(dataSource)).not.toEqual(-1);
             removeCalled++;
         });
 


### PR DESCRIPTION
While working on KML, I realized that we could do a much better job making the various data sources consistent and easier to use:

__Things I noticed and changed__
1. Error reporting was inconsistent, sometimes loading data led to thrown exceptions and other times it lead to rejected promises.  Now all non-DeveloperError errors in all data sources end up in rejected promises.
2. Having separate `load` and `loadUrl` functions didn't make sense because we can figure it out based on input.  This got even worse when I was working with KML because of the many different input formats.  Each data source should have a single `load` function. `load` always clears out any existing data.
3. If a DataSource supports incremental additions, it should have a single `process` function as well (just CZML for now).
4. The static `GeoJsonDataSource.fromUrl` made it impossible to handle some errors due to the loss of access to the load promise.  `CzmlDataSource` didn't even have a static helper function.  All data sources should have a static `load` function which behaves exactly like it's prototype version but creates a new instance for you.  Rather than return the instance, it now returns a Promise to the instance that is resolved after the data is loaded.
5. The `load` function signature should likewise be similar.  I updated `CzmlDataSource` to match `GeoJsonDatasource`.  The `load` function now takes the data to load as the first parameter and an optional `options` object with any additional options.

The above changes make things much cleaner and should be a big benefit for new users going forward, as well as helping code readability. It also lays some ground work that we'll need to add additional CZML features layer on (such as background processing to avoid locking up the browser for big data sets).

__Low level code change details__
1. Deprecated `GeoJsonDataSource.fromUrl`, replace it with `GeoJsonDataSource.load`.  Unlike `fromUrl`, load can take either a url or parsed JSON and it returns a promise to a new instance, rather than a new instance.
2. Add `CzmlDataSource.load`, which works just like `GeoJsonDataSource.load`, but for CZML.
2. Deprecate `GeoJsonDataSource.prototype.loadUrl`, you can now pass a url directly to `GeoJsonDataSource.prototype.load`.
5. Deprecate `CzmlDataSource.prototype.loadUrl` and `CzmlDataSource.prototype.processUrl`. You can now pass a url directly to `CzmlDataSource.prototype.load` and `CzmlDataSource.prototype.process`.
6. All `DataSource` loading and processing functions now return Promises, regardless of whether the processing ended up being async or not.
7. All non-DeveloperErrors now cause rejected promise rather than a mix of thrown exceptions and rejected promises; making it much easier to add error handling.
8. To make the new promises easier to use, you can now add a promise to a DataSource to DataSourceCollection (the actual data source isn't added until promise resolves).
9. `viewer.zoomTo` and `viewer.flyTo` can also now take a promise as well.