### PR TITLE
Fixes 2D/CV lighting issue

### DIFF
--- a/Source/Shaders/Appearances/AllMaterialAppearanceFS.glsl
+++ b/Source/Shaders/Appearances/AllMaterialAppearanceFS.glsl
@@ -9,11 +9,9 @@ void main()
     vec3 positionToEyeEC = -v_positionEC; 
     mat3 tangentToEyeMatrix = czm_tangentToEyeSpaceMatrix(v_normalEC, v_tangentEC, v_binormalEC);
 
-	vec3 normalEC;
+	vec3 normalEC = normalize(v_normalEC);
 #ifdef FACE_FORWARD
-    normalEC = normalize(faceforward(v_normalEC, vec3(0.0, 0.0, 1.0), -v_normalEC));
-#else
-    normalEC = normalize(v_normalEC);
+    normalEC = faceforward(normalEC, vec3(0.0, 0.0, 1.0), -normalEC);
 #endif
 
     czm_materialInput materialInput;

--- a/Source/Shaders/Appearances/BasicMaterialAppearanceFS.glsl
+++ b/Source/Shaders/Appearances/BasicMaterialAppearanceFS.glsl
@@ -5,11 +5,9 @@ void main()
 {
     vec3 positionToEyeEC = -v_positionEC; 
 
-	vec3 normalEC;
+	vec3 normalEC = normalize(v_normalEC);
 #ifdef FACE_FORWARD
-    normalEC = normalize(faceforward(v_normalEC, vec3(0.0, 0.0, 1.0), -v_normalEC));
-#else
-    normalEC = normalize(v_normalEC);
+    normalEC = faceforward(normalEC, vec3(0.0, 0.0, 1.0), -normalEC);
 #endif
 
     czm_materialInput materialInput;

--- a/Source/Shaders/Appearances/EllipsoidSurfaceAppearanceFS.glsl
+++ b/Source/Shaders/Appearances/EllipsoidSurfaceAppearanceFS.glsl
@@ -6,11 +6,9 @@ void main()
 {
     czm_materialInput materialInput;
     
-	vec3 normalEC = czm_normal3D * czm_geodeticSurfaceNormal(v_positionMC, vec3(0.0), vec3(1.0));
+	vec3 normalEC = normalize(czm_normal3D * czm_geodeticSurfaceNormal(v_positionMC, vec3(0.0), vec3(1.0)));
 #ifdef FACE_FORWARD
-    normalEC = normalize(faceforward(normalEC, vec3(0.0, 0.0, 1.0), -normalEC));
-#else
-    normalEC = normalize(normalEC);
+    normalEC = faceforward(normalEC, vec3(0.0, 0.0, 1.0), -normalEC);
 #endif
     
     materialInput.s = v_st.s;

--- a/Source/Shaders/Appearances/PerInstanceColorAppearanceFS.glsl
+++ b/Source/Shaders/Appearances/PerInstanceColorAppearanceFS.glsl
@@ -6,11 +6,9 @@ void main()
 {
     vec3 positionToEyeEC = -v_positionEC;
     
-	vec3 normalEC;
+	vec3 normalEC = normalize(v_normalEC);
 #ifdef FACE_FORWARD
-    normalEC = normalize(faceforward(v_normalEC, vec3(0.0, 0.0, 1.0), -v_normalEC));
-#else
-    normalEC = normalize(v_normalEC);
+    normalEC = faceforward(normalEC, vec3(0.0, 0.0, 1.0), -normalEC);
 #endif
     
     czm_materialInput materialInput;

--- a/Source/Shaders/Appearances/TexturedMaterialAppearanceFS.glsl
+++ b/Source/Shaders/Appearances/TexturedMaterialAppearanceFS.glsl
@@ -6,11 +6,9 @@ void main()
 {
     vec3 positionToEyeEC = -v_positionEC; 
 
-	vec3 normalEC;
+	vec3 normalEC = normalize(v_normalEC);;
 #ifdef FACE_FORWARD
-    normalEC = normalize(faceforward(v_normalEC, vec3(0.0, 0.0, 1.0), -v_normalEC));
-#else
-    normalEC = normalize(v_normalEC);
+    normalEC = faceforward(normalEC, vec3(0.0, 0.0, 1.0), -normalEC);
 #endif
 
     czm_materialInput materialInput;

--- a/Source/Shaders/Builtin/Functions/phong.glsl
+++ b/Source/Shaders/Builtin/Functions/phong.glsl
@@ -28,8 +28,12 @@ float czm_private_getSpecularOfMaterial(vec3 lightDirectionEC, vec3 toEyeEC, czm
  */
 vec4 czm_phong(vec3 toEye, czm_material material)
 {
-    // Diffuse from directional light sources at eye (for top-down and horizon views)
-    float diffuse = czm_private_getLambertDiffuseOfMaterial(vec3(0.0, 0.0, 1.0), material) + czm_private_getLambertDiffuseOfMaterial(vec3(0.0, 1.0, 0.0), material);
+    // Diffuse from directional light sources at eye (for top-down)
+    float diffuse = czm_private_getLambertDiffuseOfMaterial(vec3(0.0, 0.0, 1.0), material);
+    if (czm_sceneMode == czm_sceneMode3D) {
+        // (and horizon views in 3D)
+        diffuse += czm_private_getLambertDiffuseOfMaterial(vec3(0.0, 1.0, 0.0), material);
+    }
 
     // Specular from sun and pseudo-moon
     float specular = czm_private_getSpecularOfMaterial(czm_sunDirectionEC, toEye, material) + czm_private_getSpecularOfMaterial(czm_moonDirectionEC, toEye, material);


### PR DESCRIPTION
Partially fixes #1825, at least what was discussed on the forum. You can test with the GeoJSON Sandcastle example in 2D/CV. The code example in #1825 definitely has other issues. The fix is in `phong.glsl`. The rest is clean up (varying normals need to be renormalized before use).