### PR TITLE
camera.flyToBoundingSphere should always use range when it's supplied

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,6 +23,7 @@ Change Log
 * Fixed a bug that would cause incorrect geometry for long Corridors and Polyline Volumes. [#2513](https://github.com/AnalyticalGraphicsInc/cesium/issues/2513)
 * Fixed a bug in imagery loading that could cause some or all of the globe to be missing when using an imagery layer that does not cover the entire globe.
 * Fixed a bug that caused `ElipseOutlineGeometry` and `CircleOutlineGeometry` to be extruded to the ground when they should have instead been drawn at height. [#2499](https://github.com/AnalyticalGraphicsInc/cesium/issues/2499).
+* Fixed a bug where `camera.flyToBoundingSphere` would ignore range if the bounding sphere radius was 0. [#2519](https://github.com/AnalyticalGraphicsInc/cesium/issues/2519)
 * Fixed some styling issues with `InfoBox` and `BaseLayerPicker` caused by using Bootstrap with Cesium. [#2487](https://github.com/AnalyticalGraphicsInc/cesium/issues/2479)
 * Added support for rendering a water effect on Quantized-Mesh terrain tiles.
 * Added `pack` and `unpack` functions to `Matrix2` and `Matrix3`.

--- a/Source/Scene/Camera.js
+++ b/Source/Scene/Camera.js
@@ -2410,7 +2410,7 @@ define([
             right = heightRatio;
         }
 
-        return Math.max(right, top) * 1.25;
+        return Math.max(right, top) * 1.50;
     }
 
     var scratchDefaultOffset = new HeadingPitchRange(0.0, -CesiumMath.PI_OVER_FOUR, 0.0);
@@ -2418,15 +2418,17 @@ define([
 
     function adjustBoundingSphereOffset(camera, boundingSphere, offset) {
         if (!defined(offset)) {
-            offset = scratchDefaultOffset;
-            offset.range = 0.0;
+            offset = HeadingPitchRange.clone(scratchDefaultOffset);
         }
 
-        if (boundingSphere.radius === 0.0) {
-            offset.range = MINIMUM_ZOOM;
-        } else if (defined(offset.range) && offset.range === 0.0) {
+        var range = offset.range;
+        if (!defined(range) || range === 0.0) {
             var radius = boundingSphere.radius;
-            offset.range = camera._mode === SceneMode.SCENE2D ? distanceToBoundingSphere2D(camera, radius) : distanceToBoundingSphere3D(camera, radius);
+            if (radius === 0.0) {
+                offset.range = MINIMUM_ZOOM;
+            } else {
+                offset.range = camera._mode === SceneMode.SCENE2D ? distanceToBoundingSphere2D(camera, radius) : distanceToBoundingSphere3D(camera, radius);
+            }
         }
 
         return offset;


### PR DESCRIPTION
Fixes #2519 

I also tweaked `distanceToBoundingSphere2D` because it was giving incorrect results on my machine.

@bagnell you'll probably want to double check the logic here, but I think the updated code does what was originally intended (always use a user-supplied range if it is given and non-zero).

We should try and get this into 1.7.

