### PR TITLE
Fix perVertex colors for PolylineGeometry and SimplePolylineGeometry

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,6 +23,7 @@ Change Log
 * Fixed a bug that would cause incorrect geometry for long Corridors and Polyline Volumes. [#2513](https://github.com/AnalyticalGraphicsInc/cesium/issues/2513)
 * Fixed a bug in imagery loading that could cause some or all of the globe to be missing when using an imagery layer that does not cover the entire globe.
 * Fixed a bug that caused `ElipseOutlineGeometry` and `CircleOutlineGeometry` to be extruded to the ground when they should have instead been drawn at height. [#2499](https://github.com/AnalyticalGraphicsInc/cesium/issues/2499).
+* Fixed a bug that prevented per-vertex colors from working with `PolylineGeometry` and `SimplePolylineGeometry` when used asynchronously. [#2516](https://github.com/AnalyticalGraphicsInc/cesium/issues/2516)
 * Fixed some styling issues with `InfoBox` and `BaseLayerPicker` caused by using Bootstrap with Cesium. [#2487](https://github.com/AnalyticalGraphicsInc/cesium/issues/2479)
 * Added support for rendering a water effect on Quantized-Mesh terrain tiles.
 * Added `pack` and `unpack` functions to `Matrix2` and `Matrix3`.

--- a/Source/Core/PolylineGeometry.js
+++ b/Source/Core/PolylineGeometry.js
@@ -115,7 +115,7 @@ define([
         var positions = options.positions;
         var colors = options.colors;
         var width = defaultValue(options.width, 1.0);
-        var perVertex = defaultValue(options.colorsPerVertex, false);
+        var colorsPerVertex = defaultValue(options.colorsPerVertex, false);
 
         //>>includeStart('debug', pragmas.debug);
         if ((!defined(positions)) || (positions.length < 2)) {
@@ -124,7 +124,7 @@ define([
         if (width < 1.0) {
             throw new DeveloperError('width must be greater than or equal to one.');
         }
-        if (defined(colors) && ((perVertex && colors.length < positions.length) || (!perVertex && colors.length < positions.length - 1))) {
+        if (defined(colors) && ((colorsPerVertex && colors.length < positions.length) || (!colorsPerVertex && colors.length < positions.length - 1))) {
             throw new DeveloperError('colors has an invalid length.');
         }
         //>>includeEnd('debug');
@@ -132,7 +132,7 @@ define([
         this._positions = positions;
         this._colors = colors;
         this._width = width;
-        this._perVertex = perVertex;
+        this._colorsPerVertex = colorsPerVertex;
         this._vertexFormat = VertexFormat.clone(defaultValue(options.vertexFormat, VertexFormat.DEFAULT));
         this._followSurface = defaultValue(options.followSurface, true);
         this._granularity = defaultValue(options.granularity, CesiumMath.RADIANS_PER_DEGREE);
@@ -194,7 +194,7 @@ define([
         startingIndex += VertexFormat.packedLength;
 
         array[startingIndex++] = value._width;
-        array[startingIndex++] = value._perVertex ? 1.0 : 0.0;
+        array[startingIndex++] = value._colorsPerVertex ? 1.0 : 0.0;
         array[startingIndex++] = value._followSurface ? 1.0 : 0.0;
         array[startingIndex]   = value._granularity;
     };
@@ -207,7 +207,7 @@ define([
         ellipsoid : scratchEllipsoid,
         vertexFormat : scratchVertexFormat,
         width : undefined,
-        perVertex : undefined,
+        colorsPerVertex : undefined,
         followSurface : undefined,
         granularity : undefined
     };
@@ -251,7 +251,7 @@ define([
         startingIndex += VertexFormat.packedLength;
 
         var width = array[startingIndex++];
-        var perVertex = array[startingIndex++] === 1.0;
+        var colorsPerVertex = array[startingIndex++] === 1.0;
         var followSurface = array[startingIndex++] === 1.0;
         var granularity = array[startingIndex];
 
@@ -259,7 +259,7 @@ define([
             scratchOptions.positions = positions;
             scratchOptions.colors = colors;
             scratchOptions.width = width;
-            scratchOptions.perVertex = perVertex;
+            scratchOptions.colorsPerVertex = colorsPerVertex;
             scratchOptions.followSurface = followSurface;
             scratchOptions.granularity = granularity;
             return new PolylineGeometry(scratchOptions);
@@ -270,7 +270,7 @@ define([
         result._ellipsoid = Ellipsoid.clone(ellipsoid, result._ellipsoid);
         result._vertexFormat = VertexFormat.clone(vertexFormat, result._vertexFormat);
         result._width = width;
-        result._perVertex = perVertex;
+        result._colorsPerVertex = colorsPerVertex;
         result._followSurface = followSurface;
         result._granularity = granularity;
 
@@ -292,7 +292,7 @@ define([
         var width = polylineGeometry._width;
         var vertexFormat = polylineGeometry._vertexFormat;
         var colors = polylineGeometry._colors;
-        var perVertex = polylineGeometry._perVertex;
+        var colorsPerVertex = polylineGeometry._colorsPerVertex;
         var followSurface = polylineGeometry._followSurface;
         var granularity = polylineGeometry._granularity;
         var ellipsoid = polylineGeometry._ellipsoid;
@@ -331,7 +331,7 @@ define([
                     var c0 = colors[i];
 
                     var numColors = PolylinePipeline.numberOfPoints(p0, p1, minDistance);
-                    if (perVertex && i < colorLength) {
+                    if (colorsPerVertex && i < colorLength) {
                         var c1 = colors[i+1];
                         var interpolatedColors = interpolateColors(p0, p1, c0, c1, numColors);
                         var interpolatedColorsLength = interpolatedColors.length;
@@ -403,7 +403,7 @@ define([
 
             var color0, color1;
             if (defined(finalColors)) {
-                if (j !== 0 && !perVertex) {
+                if (j !== 0 && !colorsPerVertex) {
                     color0 = colors[j - 1];
                 } else {
                     color0 = colors[j];

--- a/Source/Core/SimplePolylineGeometry.js
+++ b/Source/Core/SimplePolylineGeometry.js
@@ -110,20 +110,20 @@ define([
         options = defaultValue(options, defaultValue.EMPTY_OBJECT);
         var positions = options.positions;
         var colors = options.colors;
-        var perVertex = defaultValue(options.colorsPerVertex, false);
+        var colorsPerVertex = defaultValue(options.colorsPerVertex, false);
 
         //>>includeStart('debug', pragmas.debug);
         if ((!defined(positions)) || (positions.length < 2)) {
             throw new DeveloperError('At least two positions are required.');
         }
-        if (defined(colors) && ((perVertex && colors.length < positions.length) || (!perVertex && colors.length < positions.length - 1))) {
+        if (defined(colors) && ((colorsPerVertex && colors.length < positions.length) || (!colorsPerVertex && colors.length < positions.length - 1))) {
             throw new DeveloperError('colors has an invalid length.');
         }
         //>>includeEnd('debug');
 
         this._positions = positions;
         this._colors = colors;
-        this._perVertex = perVertex;
+        this._colorsPerVertex = colorsPerVertex;
         this._followSurface = defaultValue(options.followSurface, true);
         this._granularity = defaultValue(options.granularity, CesiumMath.RADIANS_PER_DEGREE);
         this._ellipsoid = defaultValue(options.ellipsoid, Ellipsoid.WGS84);
@@ -180,7 +180,7 @@ define([
         Ellipsoid.pack(value._ellipsoid, array, startingIndex);
         startingIndex += Ellipsoid.packedLength;
 
-        array[startingIndex++] = value._perVertex ? 1.0 : 0.0;
+        array[startingIndex++] = value._colorsPerVertex ? 1.0 : 0.0;
         array[startingIndex++] = value._followSurface ? 1.0 : 0.0;
         array[startingIndex]   = value._granularity;
     };
@@ -220,7 +220,7 @@ define([
         var ellipsoid = Ellipsoid.unpack(array, startingIndex);
         startingIndex += Ellipsoid.packedLength;
 
-        var perVertex = array[startingIndex++] === 1.0;
+        var colorsPerVertex = array[startingIndex++] === 1.0;
         var followSurface = array[startingIndex++] === 1.0;
         var granularity = array[startingIndex];
 
@@ -229,7 +229,7 @@ define([
                 positions : positions,
                 colors : colors,
                 ellipsoid : ellipsoid,
-                perVertex : perVertex,
+                colorsPerVertex : colorsPerVertex,
                 followSurface : followSurface,
                 granularity : granularity
             });
@@ -238,7 +238,7 @@ define([
         result._positions = positions;
         result._colors = colors;
         result._ellipsoid = ellipsoid;
-        result._perVertex = perVertex;
+        result._colorsPerVertex = colorsPerVertex;
         result._followSurface = followSurface;
         result._granularity = granularity;
 
@@ -263,13 +263,13 @@ define([
     SimplePolylineGeometry.createGeometry = function(simplePolylineGeometry) {
         var positions = simplePolylineGeometry._positions;
         var colors = simplePolylineGeometry._colors;
-        var perVertex = simplePolylineGeometry._perVertex;
+        var colorsPerVertex = simplePolylineGeometry._colorsPerVertex;
         var followSurface = simplePolylineGeometry._followSurface;
         var granularity = simplePolylineGeometry._granularity;
         var ellipsoid = simplePolylineGeometry._ellipsoid;
 
         var minDistance = CesiumMath.chordLength(granularity, ellipsoid.maximumRadius);
-        var perSegmentColors = defined(colors) && !perVertex;
+        var perSegmentColors = defined(colors) && !colorsPerVertex;
 
         var i;
         var length = positions.length;

--- a/Specs/Core/PolylineGeometrySpec.js
+++ b/Specs/Core/PolylineGeometrySpec.js
@@ -161,14 +161,29 @@ defineSuite([
         expect(geometry).not.toBeDefined();
     });
 
-    var positions = [new Cartesian3(1.0, 0.0, 0.0), new Cartesian3(0.0, 1.0, 0.0), new Cartesian3(0.0, 0.0, 1.0)];
+    var positions = [new Cartesian3(1, 2, 3), new Cartesian3(4, 5, 6), new Cartesian3(7, 8, 9)];
     var line = new PolylineGeometry({
         positions : positions,
         width : 10.0,
+        colors : [Color.RED, Color.LIME, Color.BLUE],
+        colorsPerVertex : true,
+        followSurface : false,
+        granularity : 11,
         vertexFormat : VertexFormat.POSITION_ONLY,
-        granularity : Math.PI,
-        ellipsoid: Ellipsoid.UNIT_SPHERE
+        ellipsoid : new Ellipsoid(12, 13, 14)
     });
-    var packedInstance = [3.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 1.0, 1.0, 1.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 10.0, 0.0, 1.0, Math.PI];
+    var packedInstance = [3, 1, 2, 3, 4, 5, 6, 7, 8, 9, 3, 1, 0, 0, 1, 0, 1, 0, 1, 0, 0, 1, 1, 12, 13, 14, 1, 0, 0, 0, 0, 0, 10, 1, 0, 11];
+    createPackableSpecs(PolylineGeometry, line, packedInstance, "per vertex colors");
+
+    line = new PolylineGeometry({
+        positions : positions,
+        width : 10.0,
+        colorsPerVertex : false,
+        followSurface : false,
+        granularity : 11,
+        vertexFormat : VertexFormat.POSITION_ONLY,
+        ellipsoid : new Ellipsoid(12, 13, 14)
+    });
+    packedInstance = [3, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 12, 13, 14, 1, 0, 0, 0, 0, 0, 10, 0, 0, 11];
     createPackableSpecs(PolylineGeometry, line, packedInstance);
 });

--- a/Specs/Core/SimplePolylineGeometrySpec.js
+++ b/Specs/Core/SimplePolylineGeometrySpec.js
@@ -135,13 +135,25 @@ defineSuite([
         expect(line.attributes.color.values.length).toEqual(numVertices * 4);
     });
 
-    var positions = [new Cartesian3(1.0, 0.0, 0.0), new Cartesian3(0.0, 1.0, 0.0), new Cartesian3(0.0, 0.0, 1.0)];
+    var positions = [new Cartesian3(1, 2, 3), new Cartesian3(4, 5, 6), new Cartesian3(7, 8, 9)];
     var line = new SimplePolylineGeometry({
         positions : positions,
-        ellipsoid : Ellipsoid.UNIT_SPHERE,
-        granularity : 0.1,
-        followSurface: false
+        colors : [Color.RED, Color.LIME, Color.BLUE],
+        colorsPerVertex : true,
+        followSurface : false,
+        granularity : 11,
+        ellipsoid : new Ellipsoid(12, 13, 14)
     });
-    var packedInstance = [3.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 1.0, 1.0, 1.0, 0.0, 0.0, 0.1];
+    var packedInstance = [3, 1, 2, 3, 4, 5, 6, 7, 8, 9, 3, 1, 0, 0, 1, 0, 1, 0, 1, 0, 0, 1, 1, 12, 13, 14, 1, 0, 11];
+    createPackableSpecs(SimplePolylineGeometry, line, packedInstance, "per vertex colors");
+
+    line = new SimplePolylineGeometry({
+        positions : positions,
+        colorsPerVertex : false,
+        followSurface : false,
+        granularity : 11,
+        ellipsoid : new Ellipsoid(12, 13, 14)
+    });
+    packedInstance = [3, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 12, 13, 14, 0, 0, 11];
     createPackableSpecs(SimplePolylineGeometry, line, packedInstance);
 });


### PR DESCRIPTION
Was broken due to a typo in the code (and no matching unit test for it). We were using `perVertex` internally and `colorsPerVertex` for the API. In addition to fixing the typo, I changed it to `colorsPerVertex` to avoid confusion in the future.  I also updated tests to make sure everything was what it should be.

This was a regression in 1.6, so we should merge this for 1.7.