### PR TITLE
PolylineGlowMaterialProperty doc fix

### DIFF
--- a/Source/DataSources/PolylineGlowMaterialProperty.js
+++ b/Source/DataSources/PolylineGlowMaterialProperty.js
@@ -22,14 +22,14 @@ define([
 
     /**
      * A {@link MaterialProperty} that maps to polyline glow {@link Material} uniforms.
-     * @alias PolylineGlowProperty
+     * @alias PolylineGlowMaterialProperty
      * @constructor
      *
      * @param {Object} [options] Object with the following properties:
      * @param {Property} [options.color=Color.WHITE] A Property specifying the {@link Color} of the line.
      * @param {Property} [options.glowPower=0.25] A numeric Property specifying the strength of the glow, as a percentage of the total line width.
      */
-    var PolylineGlowProperty = function(options) {
+    var PolylineGlowMaterialProperty = function(options) {
         options = defaultValue(options, defaultValue.EMPTY_OBJECT);
 
         this._definitionChanged = new Event();
@@ -42,11 +42,11 @@ define([
         this.glowPower = options.glowPower;
     };
 
-    defineProperties(PolylineGlowProperty.prototype, {
+    defineProperties(PolylineGlowMaterialProperty.prototype, {
         /**
          * Gets a value indicating if this property is constant.  A property is considered
          * constant if getValue always returns the same result for the current definition.
-         * @memberof PolylineGlowProperty.prototype
+         * @memberof PolylineGlowMaterialProperty.prototype
          * @type {Boolean}
          * @readonly
          */
@@ -59,7 +59,7 @@ define([
          * Gets the event that is raised whenever the definition of this property changes.
          * The definition is considered to have changed if a call to getValue would return
          * a different result for the same time.
-         * @memberof PolylineGlowProperty.prototype
+         * @memberof PolylineGlowMaterialProperty.prototype
          * @type {Event}
          * @readonly
          */
@@ -70,13 +70,13 @@ define([
         },
         /**
          * Gets or sets the Property specifying the {@link Color} of the line.
-         * @memberof PolylineGlowProperty.prototype
+         * @memberof PolylineGlowMaterialProperty.prototype
          * @type {Property}
          */
         color : createPropertyDescriptor('color'),
         /**
          * Gets or sets the numeric Property specifying the strength of the glow, as a percentage of the total line width (less than 1.0).
-         * @memberof PolylineGlowProperty.prototype
+         * @memberof PolylineGlowMaterialProperty.prototype
          * @type {Property}
          */
         glowPower : createPropertyDescriptor('glowPower')
@@ -88,7 +88,7 @@ define([
      * @param {JulianDate} time The time for which to retrieve the type.
      * @returns {String} The type of material.
      */
-    PolylineGlowProperty.prototype.getType = function(time) {
+    PolylineGlowMaterialProperty.prototype.getType = function(time) {
         return 'PolylineGlow';
     };
 
@@ -99,7 +99,7 @@ define([
      * @param {Object} [result] The object to store the value into, if omitted, a new instance is created and returned.
      * @returns {Object} The modified result parameter or a new instance if the result parameter was not supplied.
      */
-    PolylineGlowProperty.prototype.getValue = function(time, result) {
+    PolylineGlowMaterialProperty.prototype.getValue = function(time, result) {
         if (!defined(result)) {
             result = {};
         }
@@ -115,12 +115,12 @@ define([
      * @param {Property} [other] The other property.
      * @returns {Boolean} <code>true</code> if left and right are equal, <code>false</code> otherwise.
      */
-    PolylineGlowProperty.prototype.equals = function(other) {
+    PolylineGlowMaterialProperty.prototype.equals = function(other) {
         return this === other || //
-               (other instanceof PolylineGlowProperty && //
+               (other instanceof PolylineGlowMaterialProperty && //
                 Property.equals(this._color, other._color) &&
                 Property.equals(this._glowPower, other._glowPower));
     };
 
-    return PolylineGlowProperty;
+    return PolylineGlowMaterialProperty;
 });


### PR DESCRIPTION
PolylineGlowMaterialProperty was being referred to as `PolylineGlowProperty` in both the doc and module declaration. This is a non-breaking change, it was always `Cesium.PolylineGlowMaterialProperty` in the actual API.

Fixes #2482 We should take this for 1.7.