### PR TITLE
Work around Safari bug

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,7 @@ Change Log
 * Added initial support for [KML 2.2](https://developers.google.com/kml/) via `KmlDataSource`. Check out the new [Sandcastle Demo](http://cesiumjs.org/Cesium/Apps/Sandcastle/index.html?src=KML.html) and the [reference documentation](http://cesiumjs.org/Cesium/Build/Documentation/KmlDataSource.html) for more details.
 * `InfoBox` sanitization now relies on [iframe sandboxing](http://www.html5rocks.com/en/tutorials/security/sandboxed-iframes/). This allows for much more content to be displayed in the InfoBox (and still be secure).
 * Added `InfoBox.frame` which is the instance of the iframe that is used to host description content. Sanitization can be controlled via the frame's `sandbox` attribute.  See the above link for additional information. 
+* Worked around a bug in Safari that caused most of Cesium to be broken. Cesium should now work much better on Safari for both desktop and mobile.
 * Fixed incorrect ellipse texture coordinates. [#2363](https://github.com/AnalyticalGraphicsInc/cesium/issues/2363) and [#2465](https://github.com/AnalyticalGraphicsInc/cesium/issues/2465)
 * Fixed a bug that would cause incorrect geometry for long Corridors and Polyline Volumes. [#2513](https://github.com/AnalyticalGraphicsInc/cesium/issues/2513)
 * Fixed a bug in imagery loading that could cause some or all of the globe to be missing when using an imagery layer that does not cover the entire globe.

--- a/Source/DataSources/createPropertyDescriptor.js
+++ b/Source/DataSources/createPropertyDescriptor.js
@@ -53,7 +53,9 @@ define([
      * @private
      */
     function createPropertyDescriptor(name, configurable, createPropertyCallback) {
-        return createProperty(name, '_' + name, '_' + name + 'Subscription', defaultValue(configurable, false), defaultValue(createPropertyCallback, createConstantProperty));
+        //Safari 8.0.3 has a JavaScript bug that causes it to confuse two variables and treat them as the same.
+        //The two extra toString calls work around the issue.
+        return createProperty(name, '_' + name.toString(), '_' + name.toString() + 'Subscription', defaultValue(configurable, false), defaultValue(createPropertyCallback, createConstantProperty));
     }
 
     return createPropertyDescriptor;


### PR DESCRIPTION
`createPropertyDescriptor`, which is one of the core functions for the entire Entity API, triggers a bug in Safari's JavaScript engine and causes lots of breakage in Cesium.  This one line change works around the
issue and makes all Sandcastle examples work. Doing a full test run still fails, but only because it gives up on creating additional WebGL contexts.  I'm pretty sure this will make Safari happy in most real-world usage of Cesium.

This is a slightly tweaked version of #2525, while we've known about this problem for a while, the suggestion from @speigg is the simplest fix for the problem so I'm happy to get it in.