### PR TITLE
Cartesian3.prototype.equalsEpsilon

### DIFF
--- a/Source/Core/Cartesian2.js
+++ b/Source/Core/Cartesian2.js
@@ -726,15 +726,16 @@ define([
 
     /**
      * Compares this Cartesian against the provided Cartesian componentwise and returns
-     * <code>true</code> if they are within the provided epsilon,
+     * <code>true</code> if they pass an absolute or relative tolerance test,
      * <code>false</code> otherwise.
      *
      * @param {Cartesian2} [right] The right hand side Cartesian.
-     * @param {Number} epsilon The epsilon to use for equality testing.
+     * @param {Number} relativeEpsilon The relative epsilon tolerance to use for equality testing.
+     * @param {Number} [absoluteEpsilon=relativeEpsilon] The absolute epsilon tolerance to use for equality testing.
      * @returns {Boolean} <code>true</code> if they are within the provided epsilon, <code>false</code> otherwise.
      */
-    Cartesian2.prototype.equalsEpsilon = function(right, epsilon) {
-        return Cartesian2.equalsEpsilon(this, right, epsilon);
+    Cartesian2.prototype.equalsEpsilon = function(right, relativeEpsilon, absoluteEpsilon) {
+        return Cartesian2.equalsEpsilon(this, right, relativeEpsilon, absoluteEpsilon);
     };
 
     /**

--- a/Source/Core/Cartesian3.js
+++ b/Source/Core/Cartesian3.js
@@ -1041,15 +1041,16 @@ define([
 
     /**
      * Compares this Cartesian against the provided Cartesian componentwise and returns
-     * <code>true</code> if they are within the provided epsilon,
+     * <code>true</code> if they pass an absolute or relative tolerance test,
      * <code>false</code> otherwise.
      *
      * @param {Cartesian3} [right] The right hand side Cartesian.
-     * @param {Number} epsilon The epsilon to use for equality testing.
+     * @param {Number} relativeEpsilon The relative epsilon tolerance to use for equality testing.
+     * @param {Number} [absoluteEpsilon=relativeEpsilon] The absolute epsilon tolerance to use for equality testing.
      * @returns {Boolean} <code>true</code> if they are within the provided epsilon, <code>false</code> otherwise.
      */
-    Cartesian3.prototype.equalsEpsilon = function(right, epsilon) {
-        return Cartesian3.equalsEpsilon(this, right, epsilon);
+    Cartesian3.prototype.equalsEpsilon = function(right, relativeEpsilon, absoluteEpsilon) {
+        return Cartesian3.equalsEpsilon(this, right, relativeEpsilon, absoluteEpsilon);
     };
 
     /**

--- a/Source/Core/Cartesian4.js
+++ b/Source/Core/Cartesian4.js
@@ -798,15 +798,16 @@ define([
 
     /**
      * Compares this Cartesian against the provided Cartesian componentwise and returns
-     * <code>true</code> if they are within the provided epsilon,
+     * <code>true</code> if they pass an absolute or relative tolerance test,
      * <code>false</code> otherwise.
      *
      * @param {Cartesian4} [right] The right hand side Cartesian.
-     * @param {Number} epsilon The epsilon to use for equality testing.
+     * @param {Number} relativeEpsilon The relative epsilon tolerance to use for equality testing.
+     * @param {Number} [absoluteEpsilon=relativeEpsilon] The absolute epsilon tolerance to use for equality testing.
      * @returns {Boolean} <code>true</code> if they are within the provided epsilon, <code>false</code> otherwise.
      */
-    Cartesian4.prototype.equalsEpsilon = function(right, epsilon) {
-        return Cartesian4.equalsEpsilon(this, right, epsilon);
+    Cartesian4.prototype.equalsEpsilon = function(right, relativeEpsilon, absoluteEpsilon) {
+        return Cartesian4.equalsEpsilon(this, right, relativeEpsilon, absoluteEpsilon);
     };
 
     /**

--- a/Specs/Core/Cartesian2Spec.js
+++ b/Specs/Core/Cartesian2Spec.js
@@ -524,21 +524,22 @@ defineSuite([
 
     it('equalsEpsilon', function() {
         var cartesian = new Cartesian2(1.0, 2.0);
-        expect(Cartesian2.equalsEpsilon(cartesian, new Cartesian2(1.0, 2.0), 0.0)).toEqual(true);
-        expect(Cartesian2.equalsEpsilon(cartesian, new Cartesian2(1.0, 2.0), 1.0)).toEqual(true);
-        expect(Cartesian2.equalsEpsilon(cartesian, new Cartesian2(2.0, 2.0), 1.0)).toEqual(true);
-        expect(Cartesian2.equalsEpsilon(cartesian, new Cartesian2(1.0, 3.0), 1.0)).toEqual(true);
-        expect(Cartesian2.equalsEpsilon(cartesian, new Cartesian2(1.0, 3.0), CesiumMath.EPSILON6)).toEqual(false);
-        expect(Cartesian2.equalsEpsilon(cartesian, undefined, 1)).toEqual(false);
+        expect(cartesian.equalsEpsilon(new Cartesian2(1.0, 2.0), 0.0)).toEqual(true);
+        expect(cartesian.equalsEpsilon(new Cartesian2(1.0, 2.0), 1.0)).toEqual(true);
+        expect(cartesian.equalsEpsilon(new Cartesian2(2.0, 2.0), 1.0)).toEqual(true);
+        expect(cartesian.equalsEpsilon(new Cartesian2(1.0, 3.0), 1.0)).toEqual(true);
+        expect(cartesian.equalsEpsilon(new Cartesian2(1.0, 3.0), CesiumMath.EPSILON6)).toEqual(false);
+        expect(cartesian.equalsEpsilon(undefined, 1)).toEqual(false);
 
         cartesian = new Cartesian2(3000000.0, 4000000.0);
-        expect(Cartesian2.equalsEpsilon(cartesian, new Cartesian2(3000000.0, 4000000.0), 0.0)).toEqual(true);
-        expect(Cartesian2.equalsEpsilon(cartesian, new Cartesian2(3000000.0, 4000000.2), CesiumMath.EPSILON7)).toEqual(true);
-        expect(Cartesian2.equalsEpsilon(cartesian, new Cartesian2(3000000.2, 4000000.0), CesiumMath.EPSILON7)).toEqual(true);
-        expect(Cartesian2.equalsEpsilon(cartesian, new Cartesian2(3000000.2, 4000000.2), CesiumMath.EPSILON7)).toEqual(true);
-        expect(Cartesian2.equalsEpsilon(cartesian, new Cartesian2(3000000.2, 4000000.2), CesiumMath.EPSILON9)).toEqual(false);
+        expect(cartesian.equalsEpsilon(new Cartesian2(3000000.0, 4000000.0), 0.0)).toEqual(true);
+        expect(cartesian.equalsEpsilon(new Cartesian2(3000000.0, 4000000.2), CesiumMath.EPSILON7)).toEqual(true);
+        expect(cartesian.equalsEpsilon(new Cartesian2(3000000.2, 4000000.0), CesiumMath.EPSILON7)).toEqual(true);
+        expect(cartesian.equalsEpsilon(new Cartesian2(3000000.2, 4000000.2), CesiumMath.EPSILON7)).toEqual(true);
+        expect(cartesian.equalsEpsilon(new Cartesian2(3000000.2, 4000000.2), CesiumMath.EPSILON9)).toEqual(false);
+        expect(cartesian.equalsEpsilon(undefined, 1)).toEqual(false);
+
         expect(Cartesian2.equalsEpsilon(undefined, cartesian, 1)).toEqual(false);
-        expect(Cartesian2.equalsEpsilon(cartesian, undefined, 1)).toEqual(false);
     });
 
     it('toString', function() {

--- a/Specs/Core/Cartesian3Spec.js
+++ b/Specs/Core/Cartesian3Spec.js
@@ -590,25 +590,26 @@ defineSuite([
 
     it('equalsEpsilon', function() {
         var cartesian = new Cartesian3(1.0, 2.0, 3.0);
-        expect(Cartesian3.equalsEpsilon(cartesian, new Cartesian3(1.0, 2.0, 3.0), 0.0)).toEqual(true);
-        expect(Cartesian3.equalsEpsilon(cartesian, new Cartesian3(1.0, 2.0, 3.0), 1.0)).toEqual(true);
-        expect(Cartesian3.equalsEpsilon(cartesian, new Cartesian3(2.0, 2.0, 3.0), 1.0)).toEqual(true);
-        expect(Cartesian3.equalsEpsilon(cartesian, new Cartesian3(1.0, 3.0, 3.0), 1.0)).toEqual(true);
-        expect(Cartesian3.equalsEpsilon(cartesian, new Cartesian3(1.0, 2.0, 4.0), 1.0)).toEqual(true);
-        expect(Cartesian3.equalsEpsilon(cartesian, new Cartesian3(2.0, 2.0, 3.0), CesiumMath.EPSILON6)).toEqual(false);
-        expect(Cartesian3.equalsEpsilon(cartesian, new Cartesian3(1.0, 3.0, 3.0), CesiumMath.EPSILON6)).toEqual(false);
-        expect(Cartesian3.equalsEpsilon(cartesian, new Cartesian3(1.0, 2.0, 4.0), CesiumMath.EPSILON6)).toEqual(false);
-        expect(Cartesian3.equalsEpsilon(cartesian, undefined, 1)).toEqual(false);
+        expect(cartesian.equalsEpsilon(new Cartesian3(1.0, 2.0, 3.0), 0.0)).toEqual(true);
+        expect(cartesian.equalsEpsilon(new Cartesian3(1.0, 2.0, 3.0), 1.0)).toEqual(true);
+        expect(cartesian.equalsEpsilon(new Cartesian3(2.0, 2.0, 3.0), 1.0)).toEqual(true);
+        expect(cartesian.equalsEpsilon(new Cartesian3(1.0, 3.0, 3.0), 1.0)).toEqual(true);
+        expect(cartesian.equalsEpsilon(new Cartesian3(1.0, 2.0, 4.0), 1.0)).toEqual(true);
+        expect(cartesian.equalsEpsilon(new Cartesian3(2.0, 2.0, 3.0), CesiumMath.EPSILON6)).toEqual(false);
+        expect(cartesian.equalsEpsilon(new Cartesian3(1.0, 3.0, 3.0), CesiumMath.EPSILON6)).toEqual(false);
+        expect(cartesian.equalsEpsilon(new Cartesian3(1.0, 2.0, 4.0), CesiumMath.EPSILON6)).toEqual(false);
+        expect(cartesian.equalsEpsilon(undefined, 1)).toEqual(false);
 
         cartesian = new Cartesian3(3000000.0, 4000000.0, 5000000.0);
-        expect(Cartesian3.equalsEpsilon(cartesian, new Cartesian3(3000000.0, 4000000.0, 5000000.0), 0.0)).toEqual(true);
-        expect(Cartesian3.equalsEpsilon(cartesian, new Cartesian3(3000000.2, 4000000.0, 5000000.0), CesiumMath.EPSILON7)).toEqual(true);
-        expect(Cartesian3.equalsEpsilon(cartesian, new Cartesian3(3000000.0, 4000000.2, 5000000.0), CesiumMath.EPSILON7)).toEqual(true);
-        expect(Cartesian3.equalsEpsilon(cartesian, new Cartesian3(3000000.0, 4000000.0, 5000000.2), CesiumMath.EPSILON7)).toEqual(true);
-        expect(Cartesian3.equalsEpsilon(cartesian, new Cartesian3(3000000.2, 4000000.2, 5000000.2), CesiumMath.EPSILON7)).toEqual(true);
-        expect(Cartesian3.equalsEpsilon(cartesian, new Cartesian3(3000000.2, 4000000.2, 5000000.2), CesiumMath.EPSILON9)).toEqual(false);
+        expect(cartesian.equalsEpsilon(new Cartesian3(3000000.0, 4000000.0, 5000000.0), 0.0)).toEqual(true);
+        expect(cartesian.equalsEpsilon(new Cartesian3(3000000.2, 4000000.0, 5000000.0), CesiumMath.EPSILON7)).toEqual(true);
+        expect(cartesian.equalsEpsilon(new Cartesian3(3000000.0, 4000000.2, 5000000.0), CesiumMath.EPSILON7)).toEqual(true);
+        expect(cartesian.equalsEpsilon(new Cartesian3(3000000.0, 4000000.0, 5000000.2), CesiumMath.EPSILON7)).toEqual(true);
+        expect(cartesian.equalsEpsilon(new Cartesian3(3000000.2, 4000000.2, 5000000.2), CesiumMath.EPSILON7)).toEqual(true);
+        expect(cartesian.equalsEpsilon(new Cartesian3(3000000.2, 4000000.2, 5000000.2), CesiumMath.EPSILON9)).toEqual(false);
+        expect(cartesian.equalsEpsilon(undefined, 1)).toEqual(false);
+
         expect(Cartesian3.equalsEpsilon(undefined, cartesian, 1)).toEqual(false);
-        expect(Cartesian3.equalsEpsilon(cartesian, undefined, 1)).toEqual(false);
     });
 
     it('toString', function() {

--- a/Specs/Core/Cartesian4Spec.js
+++ b/Specs/Core/Cartesian4Spec.js
@@ -649,28 +649,29 @@ defineSuite([
 
     it('equalsEpsilon', function() {
         var cartesian = new Cartesian4(1.0, 2.0, 3.0, 4.0);
-        expect(Cartesian4.equalsEpsilon(cartesian, new Cartesian4(1.0, 2.0, 3.0, 4.0), 0.0)).toEqual(true);
-        expect(Cartesian4.equalsEpsilon(cartesian, new Cartesian4(1.0, 2.0, 3.0, 4.0), 1.0)).toEqual(true);
-        expect(Cartesian4.equalsEpsilon(cartesian, new Cartesian4(2.0, 2.0, 3.0, 4.0), 1.0)).toEqual(true);
-        expect(Cartesian4.equalsEpsilon(cartesian, new Cartesian4(1.0, 3.0, 3.0, 4.0), 1.0)).toEqual(true);
-        expect(Cartesian4.equalsEpsilon(cartesian, new Cartesian4(1.0, 2.0, 4.0, 4.0), 1.0)).toEqual(true);
-        expect(Cartesian4.equalsEpsilon(cartesian, new Cartesian4(1.0, 2.0, 3.0, 5.0), 1.0)).toEqual(true);
-        expect(Cartesian4.equalsEpsilon(cartesian, new Cartesian4(2.0, 2.0, 3.0, 4.0), CesiumMath.EPSILON6)).toEqual(false);
-        expect(Cartesian4.equalsEpsilon(cartesian, new Cartesian4(1.0, 3.0, 3.0, 4.0), CesiumMath.EPSILON6)).toEqual(false);
-        expect(Cartesian4.equalsEpsilon(cartesian, new Cartesian4(1.0, 2.0, 4.0, 4.0), CesiumMath.EPSILON6)).toEqual(false);
-        expect(Cartesian4.equalsEpsilon(cartesian, new Cartesian4(1.0, 2.0, 3.0, 5.0), CesiumMath.EPSILON6)).toEqual(false);
-        expect(Cartesian4.equalsEpsilon(cartesian, undefined, 1)).toEqual(false);
+        expect(cartesian.equalsEpsilon(new Cartesian4(1.0, 2.0, 3.0, 4.0), 0.0)).toEqual(true);
+        expect(cartesian.equalsEpsilon(new Cartesian4(1.0, 2.0, 3.0, 4.0), 1.0)).toEqual(true);
+        expect(cartesian.equalsEpsilon(new Cartesian4(2.0, 2.0, 3.0, 4.0), 1.0)).toEqual(true);
+        expect(cartesian.equalsEpsilon(new Cartesian4(1.0, 3.0, 3.0, 4.0), 1.0)).toEqual(true);
+        expect(cartesian.equalsEpsilon(new Cartesian4(1.0, 2.0, 4.0, 4.0), 1.0)).toEqual(true);
+        expect(cartesian.equalsEpsilon(new Cartesian4(1.0, 2.0, 3.0, 5.0), 1.0)).toEqual(true);
+        expect(cartesian.equalsEpsilon(new Cartesian4(2.0, 2.0, 3.0, 4.0), CesiumMath.EPSILON6)).toEqual(false);
+        expect(cartesian.equalsEpsilon(new Cartesian4(1.0, 3.0, 3.0, 4.0), CesiumMath.EPSILON6)).toEqual(false);
+        expect(cartesian.equalsEpsilon(new Cartesian4(1.0, 2.0, 4.0, 4.0), CesiumMath.EPSILON6)).toEqual(false);
+        expect(cartesian.equalsEpsilon(new Cartesian4(1.0, 2.0, 3.0, 5.0), CesiumMath.EPSILON6)).toEqual(false);
+        expect(cartesian.equalsEpsilon(undefined, 1)).toEqual(false);
 
         cartesian = new Cartesian4(3000000.0, 4000000.0, 5000000.0, 6000000.0);
-        expect(Cartesian4.equalsEpsilon(cartesian, new Cartesian4(3000000.0, 4000000.0, 5000000.0, 6000000.0), 0.0)).toEqual(true);
-        expect(Cartesian4.equalsEpsilon(cartesian, new Cartesian4(3000000.2, 4000000.0, 5000000.0, 6000000.0), CesiumMath.EPSILON7)).toEqual(true);
-        expect(Cartesian4.equalsEpsilon(cartesian, new Cartesian4(3000000.0, 4000000.2, 5000000.0, 6000000.0), CesiumMath.EPSILON7)).toEqual(true);
-        expect(Cartesian4.equalsEpsilon(cartesian, new Cartesian4(3000000.0, 4000000.0, 5000000.2, 6000000.0), CesiumMath.EPSILON7)).toEqual(true);
-        expect(Cartesian4.equalsEpsilon(cartesian, new Cartesian4(3000000.0, 4000000.0, 5000000.0, 6000000.2), CesiumMath.EPSILON7)).toEqual(true);
-        expect(Cartesian4.equalsEpsilon(cartesian, new Cartesian4(3000000.2, 4000000.2, 5000000.2, 6000000.2), CesiumMath.EPSILON7)).toEqual(true);
-        expect(Cartesian4.equalsEpsilon(cartesian, new Cartesian4(3000000.2, 4000000.2, 5000000.2, 6000000.2), CesiumMath.EPSILON9)).toEqual(false);
+        expect(cartesian.equalsEpsilon(new Cartesian4(3000000.0, 4000000.0, 5000000.0, 6000000.0), 0.0)).toEqual(true);
+        expect(cartesian.equalsEpsilon(new Cartesian4(3000000.2, 4000000.0, 5000000.0, 6000000.0), CesiumMath.EPSILON7)).toEqual(true);
+        expect(cartesian.equalsEpsilon(new Cartesian4(3000000.0, 4000000.2, 5000000.0, 6000000.0), CesiumMath.EPSILON7)).toEqual(true);
+        expect(cartesian.equalsEpsilon(new Cartesian4(3000000.0, 4000000.0, 5000000.2, 6000000.0), CesiumMath.EPSILON7)).toEqual(true);
+        expect(cartesian.equalsEpsilon(new Cartesian4(3000000.0, 4000000.0, 5000000.0, 6000000.2), CesiumMath.EPSILON7)).toEqual(true);
+        expect(cartesian.equalsEpsilon(new Cartesian4(3000000.2, 4000000.2, 5000000.2, 6000000.2), CesiumMath.EPSILON7)).toEqual(true);
+        expect(cartesian.equalsEpsilon(new Cartesian4(3000000.2, 4000000.2, 5000000.2, 6000000.2), CesiumMath.EPSILON9)).toEqual(false);
+        expect(cartesian.equalsEpsilon(undefined, 1)).toEqual(false);
+
         expect(Cartesian4.equalsEpsilon(undefined, cartesian, 1)).toEqual(false);
-        expect(Cartesian4.equalsEpsilon(cartesian, undefined, 1)).toEqual(false);
     });
 
     it('toString', function() {


### PR DESCRIPTION
The prototype version of `Cartesian3.equalsEpsilon` was never updated to take both relative and absolute epsilon values.

Fixes #2532