### PR TITLE
Fix KML loading crash due to an empty <ExtendedData> node.

### DIFF
--- a/Source/DataSources/KmlDataSource.js
+++ b/Source/DataSources/KmlDataSource.js
@@ -1171,10 +1171,6 @@ define([
             text = defaultValue(balloonStyle.text, description);
         }
 
-        if (!defined(text) && !defined(extendedData)) {
-            return;
-        }
-
         var value;
         if (defined(text)) {
             text = text.replace('$[name]', defaultValue(entity.name, ''));
@@ -1207,7 +1203,7 @@ define([
                     }
                 }
             }
-        } else {
+        } else if (defined(extendedData)) {
             //If no description exists, build a table out of the extended data
             keys = Object.keys(extendedData);
             if (keys.length > 0) {
@@ -1219,6 +1215,11 @@ define([
                 }
                 text += '</tbody></table>';
             }
+        }
+
+        if (!defined(text)) {
+            //No description
+            return;
         }
 
         //Turns non-explicit links into clickable links.

--- a/Specs/DataSources/KmlDataSourceSpec.js
+++ b/Specs/DataSources/KmlDataSourceSpec.js
@@ -1541,6 +1541,19 @@ defineSuite([
         expect(table.rows[2].cells[1].textContent).toEqual('');
     });
 
+    it('BalloonStyle: does not create a description for empty ExtendedData', function() {
+        var kml = '<?xml version="1.0" encoding="UTF-8"?>\
+            <Placemark>\
+                <ExtendedData>\
+                </ExtendedData>\
+            </Placemark>';
+
+        waitsForPromise(KmlDataSource.load(parser.parseFromString(kml, "text/xml")).then(function(dataSource) {
+            var entity = dataSource.entities.values[0];
+            expect(entity.description).toBeUndefined();
+        }));
+    });
+
     it('BalloonStyle: description creates links from text', function() {
         var kml = '<?xml version="1.0" encoding="UTF-8"?>\
         <Placemark>\


### PR DESCRIPTION
Thanks to @GatorScott for some sample KML files that triggered this.