### PR TITLE
Fix InfoBox crash

### DIFF
--- a/Source/DataSources/KmlDataSource.js
+++ b/Source/DataSources/KmlDataSource.js
@@ -557,7 +557,7 @@ define([
         label.translucencyByDistance = new NearFarScalar(3000000, 1.0, 5000000, 0.0);
         label.pixelOffset = new Cartesian2(17, 0);
         label.horizontalOrigin = HorizontalOrigin.LEFT;
-        label.font = '16px san-serif';
+        label.font = '16px sans-serif';
         label.style = LabelStyle.FILL_AND_OUTLINE;
         return label;
     }

--- a/Source/Widgets/InfoBox/InfoBox.js
+++ b/Source/Widgets/InfoBox/InfoBox.js
@@ -118,15 +118,17 @@ click: function () { closeClicked.raiseEvent(this); }');
                 //If the snippet is a single element, then use its background
                 //color for the body of the InfoBox. This makes the padding match
                 //the content and produces much nicer results.
+                var background = null;
                 if (frameContent.childNodes.length === 1) {
                     var style = window.getComputedStyle(frameContent.firstChild);
-                    var color = Color.fromCssColorString(style['background-color']);
-                    if (color.alpha !== 0) {
-                        infoElement.style['background-color'] = style['background-color'];
+                    if (style !== null) {
+                        var color = Color.fromCssColorString(style['background-color']);
+                        if (color.alpha !== 0) {
+                            background = style['background-color'];
+                        }
                     }
-                } else {
-                    infoElement.style['background-color'] = null;
                 }
+                infoElement.style['background-color'] = background;
 
                 // Measure and set the new custom height, based on text wrapped above.
                 var height = frameContent.getBoundingClientRect().height;

--- a/Specs/DataSources/KmlDataSourceSpec.js
+++ b/Specs/DataSources/KmlDataSourceSpec.js
@@ -1728,7 +1728,7 @@ defineSuite([
         expect(label.eyeOffset).toBeUndefined();
         expect(label.pixelOffsetScaleByDistance).toBeUndefined();
 
-        expect(label.font.getValue()).toEqual('16px san-serif');
+        expect(label.font.getValue()).toEqual('16px sans-serif');
         expect(label.style.getValue()).toEqual(LabelStyle.FILL_AND_OUTLINE);
         expect(label.horizontalOrigin.getValue()).toEqual(HorizontalOrigin.LEFT);
         expect(label.pixelOffset.getValue()).toEqual(new Cartesian2(17, 0));

--- a/Specs/Widgets/InfoBox/InfoBoxSpec.js
+++ b/Specs/Widgets/InfoBox/InfoBoxSpec.js
@@ -1,31 +1,74 @@
 /*global defineSuite*/
 defineSuite([
-        'Widgets/InfoBox/InfoBox'
+        'Widgets/InfoBox/InfoBox',
+        'Core/defined'
     ], function(
-        InfoBox) {
+        InfoBox,
+        defined) {
     "use strict";
     /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
+    var testContainer;
+    var infoBox;
+    beforeEach(function() {
+        testContainer = document.createElement('span');
+        testContainer.id = 'testContainer';
+        document.body.appendChild(testContainer);
+    });
+
+    afterEach(function() {
+        if (defined(infoBox) && !infoBox.isDestroyed()) {
+            infoBox = infoBox.destroy();
+        }
+        document.body.removeChild(testContainer);
+    });
+
     it('constructor sets expected values', function() {
-        var testElement = document.createElement('span');
-        document.body.appendChild(testElement);
-        var infoBox = new InfoBox(testElement);
-        expect(infoBox.container).toBe(testElement);
+        infoBox = new InfoBox(testContainer);
+        expect(infoBox.container).toBe(testContainer);
         expect(infoBox.viewModel).toBeDefined();
         expect(infoBox.isDestroyed()).toEqual(false);
         infoBox.destroy();
-        document.body.removeChild(testElement);
         expect(infoBox.isDestroyed()).toEqual(true);
     });
 
+    it('can set description body', function() {
+        var infoBox = new InfoBox(testContainer);
+        var node;
+
+        var infoElement = testContainer.firstChild;
+
+        infoBox.viewModel.description = 'Please do not crash';
+        waitsFor(function() {
+            node = infoBox.frame.contentDocument.body.firstChild;
+            return node !== null;
+        });
+
+        runs(function() {
+            expect(infoElement.style['background-color']).toEqual('');
+        });
+
+        waitsFor(function() {
+            return node.innerHTML === infoBox.viewModel.description;
+        });
+
+        runs(function() {
+            infoBox.viewModel.description = '<div style="background-color: rgb(255, 255, 255)">Please do not crash</div>';
+            expect(infoElement.style['background-color']).toEqual('rgb(255, 255, 255)');
+        });
+
+        waitsFor(function() {
+            return node.innerHTML === infoBox.viewModel.description;
+        });
+
+        runs(function() {
+            expect(infoElement['background-color']).toBeUndefined();
+        });
+    });
+
     it('constructor works with string id container', function() {
-        var testElement = document.createElement('span');
-        testElement.id = 'testElement';
-        document.body.appendChild(testElement);
-        var infoBox = new InfoBox('testElement');
-        expect(infoBox.container).toBe(testElement);
-        document.body.removeChild(testElement);
-        infoBox.destroy();
+        infoBox = new InfoBox('testContainer');
+        expect(infoBox.container).toBe(testContainer);
     });
 
     it('throws if container is undefined', function() {
@@ -36,7 +79,7 @@ defineSuite([
 
     it('throws if container string is undefined', function() {
         expect(function() {
-            return new InfoBox('testElement');
+            return new InfoBox('foo');
         }).toThrowDeveloperError();
     });
 });


### PR DESCRIPTION
`window.getComputedStyle` can return `null`, which I didn't realize, leading to a crash when assigning unstyled text. I also improved the specs for this (which were non-existent).  The new specs fail in master but succeed in this branch.

This fixes  #2545 and may warrant a 1.7.1 release.

I also fixed a stupid KML typo that was specifying `san-serif` instead of `sans-serif`.