### PR TITLE
Fix drillPick without geometry id

### DIFF
--- a/Source/Scene/Scene.js
+++ b/Source/Scene/Scene.js
@@ -1642,11 +1642,13 @@ define([
 
             //If the picked object has a show attribute, use it.
             if (typeof primitive.getGeometryInstanceAttributes === 'function') {
-                attributes = primitive.getGeometryInstanceAttributes(pickedResult.id);
-                if (defined(attributes) && defined(attributes.show)) {
-                    hasShowAttribute = true;
-                    attributes.show = ShowGeometryInstanceAttribute.toValue(false, attributes.show);
-                    pickedAttributes.push(attributes);
+                if (defined(pickedResult.id)) {
+                    attributes = primitive.getGeometryInstanceAttributes(pickedResult.id);
+                    if (defined(attributes) && defined(attributes.show)) {
+                        hasShowAttribute = true;
+                        attributes.show = ShowGeometryInstanceAttribute.toValue(false, attributes.show);
+                        pickedAttributes.push(attributes);
+                    }
                 }
             }
 

--- a/Specs/Scene/PickSpec.js
+++ b/Specs/Scene/PickSpec.js
@@ -223,6 +223,39 @@ defineSuite([
         expect(pickedObjects[1].id).toEqual(1);
     });
 
+    it('can drill pick without ID', function() {
+        var geometry = new RectangleGeometry({
+            rectangle : Rectangle.fromDegrees(-50.0, -50.0, 50.0, 50.0),
+            ellipsoid : Ellipsoid.UNIT_SPHERE,
+            granularity : CesiumMath.toRadians(20.0),
+            vertexFormat : EllipsoidSurfaceAppearance.VERTEX_FORMAT
+        });
+
+        var instance1 = new GeometryInstance({
+            geometry : geometry,
+            attributes : {
+                show : new ShowGeometryInstanceAttribute(true)
+            }
+        });
+
+        var instance2 = new GeometryInstance({
+            geometry : geometry,
+            attributes : {
+                show : new ShowGeometryInstanceAttribute(true)
+            }
+        });
+
+        var primitive = primitives.add(new Primitive({
+            geometryInstances : [instance1, instance2],
+            asynchronous : false,
+            appearance : new EllipsoidSurfaceAppearance()
+        }));
+
+        var pickedObjects = scene.drillPick(new Cartesian2(0, 0));
+        expect(pickedObjects.length).toEqual(1);
+        expect(pickedObjects[0].primitive).toEqual(primitive);
+    });
+
     it('drill pick batched Primitives without show attribute', function() {
         var geometry = new RectangleGeometry({
             rectangle : Rectangle.fromDegrees(-50.0, -50.0, 50.0, 50.0),


### PR DESCRIPTION
As reported [on the forum](https://groups.google.com/d/msg/cesium-dev/pdafC4wZEOk/Y_YaOagFxRoJ).

Also add test, which crashes in master without this fix.