### PR TITLE
Fix Cesium Viewer css

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -587,6 +587,9 @@
 				<include name="Widgets/**" />
 				<exclude name="Widgets/**/*.css" />
 			</fileset>
+			<fileset dir="${buildOutputDirectory}">
+				<include name="Widgets/InfoBox/InfoBoxDescription.css" />
+			</fileset>
 		</copy>
 
 		<!-- Copy web.config -->


### PR DESCRIPTION
`Widgets/InfoBox/InfoBoxDescription.css` needs to be copied to the output directory.

@shunter am I write that this needs to be different fileset because `<exclude name="Widgets/**/*.css" />` beats any includes?

Fixes #2551 