### PR TITLE
Fix InfoBox on Mac

### DIFF
--- a/Source/Widgets/InfoBox/InfoBox.js
+++ b/Source/Widgets/InfoBox/InfoBox.js
@@ -119,8 +119,9 @@ click: function () { closeClicked.raiseEvent(this); }');
                 //color for the body of the InfoBox. This makes the padding match
                 //the content and produces much nicer results.
                 var background = null;
-                if (frameContent.childNodes.length === 1) {
-                    var style = window.getComputedStyle(frameContent.firstChild);
+                var firstElementChild = frameContent.firstElementChild;
+                if (firstElementChild !== null && frameContent.childNodes.length === 1) {
+                    var style = window.getComputedStyle(firstElementChild);
                     if (style !== null) {
                         var color = Color.fromCssColorString(style['background-color']);
                         if (color.alpha !== 0) {


### PR DESCRIPTION
On Chrome and Firefox in Windows, `window.getComputedStyle` works on any node and returns null for non-element nodes.  Under the same browsers on OS X, `getComputedStyle` throws for non-element ndoes, leading to test failures and a crash in the Cesium WMS picking demo.

This change simply verifies that the first child is indeed an element before calling `getComputedStyle`.

Fixes #2545 and #2553, both OS X only