### PR TITLE
Fix IE-only test failure

### DIFF
--- a/Source/Core/Color.js
+++ b/Source/Core/Color.js
@@ -2024,5 +2024,14 @@ define([
      */
     Color.YELLOWGREEN = freezeObject(Color.fromCssColorString('#9ACD32'));
 
+    /**
+     * An immutable Color instance initialized to CSS transparent.
+     * <span class="colorSwath" style="background: transparent;"></span>
+     *
+     * @constant
+     * @type {Color}
+     */
+    Color.TRANSPARENT = freezeObject(new Color(0, 0, 0, 0));
+
     return Color;
 });

--- a/Source/Widgets/InfoBox/InfoBox.js
+++ b/Source/Widgets/InfoBox/InfoBox.js
@@ -123,8 +123,9 @@ click: function () { closeClicked.raiseEvent(this); }');
                 if (firstElementChild !== null && frameContent.childNodes.length === 1) {
                     var style = window.getComputedStyle(firstElementChild);
                     if (style !== null) {
-                        var color = Color.fromCssColorString(style['background-color']);
-                        if (color.alpha !== 0) {
+                        var backgroundColor = style['background-color'];
+                        var color = Color.fromCssColorString(backgroundColor);
+                        if (defined(color) && color.alpha !== 0) {
                             background = style['background-color'];
                         }
                     }

--- a/Specs/Core/ColorSpec.js
+++ b/Specs/Core/ColorSpec.js
@@ -161,6 +161,10 @@ defineSuite([
         expect(new Color(0.1, 0.2, 0.3, 0.4).toCssColorString()).toEqual('rgba(25,51,76,0.4)');
     });
 
+    it('fromCssColorString supports transparent', function() {
+        expect(Color.fromCssColorString('transparent')).toEqual(new Color(0.0, 0.0, 0.0, 0.0));
+    });
+
     it('fromCssColorString supports the #rgb format', function() {
         expect(Color.fromCssColorString('#369')).toEqual(new Color(0.2, 0.4, 0.6, 1.0));
     });

--- a/Specs/Widgets/InfoBox/InfoBoxSpec.js
+++ b/Specs/Widgets/InfoBox/InfoBoxSpec.js
@@ -53,7 +53,7 @@ defineSuite([
         });
 
         runs(function() {
-            infoBox.viewModel.description = '<div style="background-color: rgb(255, 255, 255)">Please do not crash</div>';
+            infoBox.viewModel.description = '<div style="background-color: rgb(255, 255, 255);">Please do not crash</div>';
             expect(infoElement.style['background-color']).toEqual('rgb(255, 255, 255)');
         });
 


### PR DESCRIPTION
I'm pretty sure whitespace is the only way to get a PR smaller than this.

One of the InfoBox tests was missing a semi-color in an HTML string. Other browsers return the exact text set in innerHTML, but IE returns the corrected text (with semicolor).  Adding a semicolor fixes the test on all browsers.