### PR TITLE
Added prompt to Sandcastle navigation.

### DIFF
--- a/Apps/Sandcastle/CesiumSandcastle.js
+++ b/Apps/Sandcastle/CesiumSandcastle.js
@@ -152,6 +152,8 @@ require({
     var searchRegExp;
     var hintTimer;
     var currentTab = '';
+    var demoHtml = '';
+    var demoJs = '';
 
     var galleryErrorMsg = document.createElement('span');
     galleryErrorMsg.className = 'galleryError';
@@ -479,6 +481,16 @@ require({
         }
     });
 
+    window.onbeforeunload = function (e) {
+        var htmlText = (htmlEditor.getValue()).replace(/\s/g, '');
+        var jsText = (jsEditor.getValue()).replace(/\s/g, '');
+        if (demoHtml === htmlText && demoJs === jsText) {
+            return ;
+        }
+
+        return 'Changes made by you are not saved.';
+    }
+
     registry.byId('codeContainer').watch('selectedChildWidget', function(name, oldPane, newPane) {
         if (newPane.id === 'jsContainer') {
             jsEditor.focus();
@@ -669,6 +681,7 @@ require({
         }
 
         var scriptCode = scriptMatch[1];
+        demoJs = scriptCode.replace(/\s/g, '');
         jsEditor.setValue(scriptCode);
         jsEditor.clearHistory();
 
@@ -680,7 +693,7 @@ require({
             childNode = doc.body.childNodes[++childIndex];
         }
         htmlText = htmlText.replace(/^\s+/, '');
-
+        demoHtml = htmlText.replace(/\s/g, '');
         htmlEditor.setValue(htmlText);
         htmlEditor.clearHistory();
 

--- a/Apps/Sandcastle/CesiumSandcastle.js
+++ b/Apps/Sandcastle/CesiumSandcastle.js
@@ -484,12 +484,10 @@ require({
     window.onbeforeunload = function (e) {
         var htmlText = (htmlEditor.getValue()).replace(/\s/g, '');
         var jsText = (jsEditor.getValue()).replace(/\s/g, '');
-        if (demoHtml === htmlText && demoJs === jsText) {
-            return ;
+        if (demoHtml !== htmlText || demoJs !== jsText) {
+            return 'Be sure to save a copy of any important edits before leaving this page.';
         }
-
-        return 'Changes made by you are not saved.';
-    }
+    };
 
     registry.byId('codeContainer').watch('selectedChildWidget', function(name, oldPane, newPane) {
         if (newPane.id === 'jsContainer') {
@@ -1021,13 +1019,21 @@ require({
             if (mouse.isMiddle(e)) {
                 window.open('gallery/' + demo.name + '.html');
             } else {
-                loadFromGallery(demo);
-                var demoSrc = demo.name + '.html';
-                if (demoSrc !== window.location.search.substring(1)) {
-                    window.history.pushState(demo, demo.name, '?src=' + demoSrc + '&label=' + currentTab);
-                }
-                document.title = demo.name + ' - Cesium Sandcastle';
-            }
+				var htmlText = (htmlEditor.getValue()).replace(/\s/g, '');
+				var jsText = (jsEditor.getValue()).replace(/\s/g, '');
+				var confirmChange = true;
+				if (demoHtml !== htmlText || demoJs !== jsText) {
+					confirmChange = window.confirm('You have unsaved changes. Are you sure you want to navigate away from this demo?');
+				}
+				if (confirmChange) {
+					loadFromGallery(demo);
+					var demoSrc = demo.name + '.html';
+					if (demoSrc !== window.location.search.substring(1)) {
+						window.history.pushState(demo, demo.name, '?src=' + demoSrc + '&label=' + currentTab);
+					}
+					document.title = demo.name + ' - Cesium Sandcastle';
+				}
+			}
             e.preventDefault();
         };
 


### PR DESCRIPTION
Resolves issue #2178 . Storing html and js in variables whenever any demo loads. If the user tries to navigate:
- If the codes are edited, a prompt shows up.
- If the codes are unedited, navigation successful.