### PR TITLE
Material Image loading error

### DIFF
--- a/Source/Scene/Material.js
+++ b/Source/Scene/Material.js
@@ -703,11 +703,13 @@ define([
                     Material._textureCache.releaseTexture(material._texturePaths[uniformId]);
                     material._textures[uniformId] = newTexture;
                 } else {
-                    when(loadImage(uniformValue), function(image) {
+                    loadImage(uniformValue).then(function(image) {
                         material._loadedImages.push({
                             id : uniformId,
                             image : image
                         });
+                    }).otherwise(function(error) {
+                        window.console.error('Unable to load image: ' + uniformValue);
                     });
                 }
 


### PR DESCRIPTION
For #2561. Print error to the console when a material image fails to load. This message will get sent to the Sandcastle console. The downside is that both a 404 and this message is printed to the dev console.