### PR TITLE
Apparently some services don't have a default SVG MIME type.

### DIFF
--- a/web.config
+++ b/web.config
@@ -16,6 +16,8 @@
             <mimeMap fileExtension=".topojson" mimeType="application/json" />
             <remove fileExtension=".woff" />
             <mimeMap fileExtension=".woff" mimeType="application/font-woff" />
+            <remove fileExtension=".svg" />
+            <mimeMap fileExtension=".svg" mimeType="image/svg+xml" />
         </staticContent>
     </system.webServer>
 </configuration>


### PR DESCRIPTION
Ted ran into this on an Azure virtual site.  Not sure if he had a bad config someplace, but it doesn't hurt to explicitly specify the mapping instead of assuming a default.