### PR TITLE
Improve GeoJSON tolerance for null values.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@ Change Log
   * Removed the `direction` and `up` options to `Camera.flyTo`, which were deprecated in Cesium 1.6. Use the `orientation` option.
   * Removed `Camera.flyToRectangle`, which was deprecated in Cesium 1.6. Use `Camera.flyTo`.
 * Fixed an issue with transparency. [#2572](https://github.com/AnalyticalGraphicsInc/cesium/issues/2572)
+* Fixed improper handling of null values when loading `GeoJSON` data.
 
 ### 1.7.1 - 2015-03-06
 

--- a/Source/Core/definedNotNull.js
+++ b/Source/Core/definedNotNull.js
@@ -1,0 +1,22 @@
+/*global define*/
+define(function() {
+    "use strict";
+
+    /**
+     * Returns true if the object is defined and not null, returns false otherwise.
+     *
+     * @exports definedNotNull
+     *
+     * @example
+     * if (Cesium.definedNotNull(positions)) {
+     *      doSomething();
+     * } else {
+     *      doSomethingElse();
+     * }
+     */
+    var definedNotNull = function(value) {
+        return value !== undefined && value !== null;
+    };
+
+    return definedNotNull;
+});

--- a/Source/DataSources/GeoJsonDataSource.js
+++ b/Source/DataSources/GeoJsonDataSource.js
@@ -5,6 +5,7 @@ define([
         '../Core/createGuid',
         '../Core/defaultValue',
         '../Core/defined',
+        '../Core/definedNotNull',
         '../Core/defineProperties',
         '../Core/deprecationWarning',
         '../Core/DeveloperError',
@@ -32,6 +33,7 @@ define([
         createGuid,
         defaultValue,
         defined,
+        definedNotNull,
         defineProperties,
         deprecationWarning,
         DeveloperError,
@@ -97,7 +99,7 @@ define([
                     continue;
                 }
                 var value = properties[key];
-                if (defined(value)) {
+                if (definedNotNull(value)) {
                     if (typeof value === 'object') {
                         html += '<tr><th>' + key + '</th><td>' + describe(value) + '</td></tr>';
                     } else {
@@ -129,7 +131,7 @@ define([
     //we can't use it for them either.
     function createObject(geoJson, entityCollection) {
         var id = geoJson.id;
-        if (!defined(id) || geoJson.type !== 'Feature') {
+        if (!definedNotNull(id) || geoJson.type !== 'Feature') {
             id = createGuid();
         } else {
             var i = 2;
@@ -143,7 +145,7 @@ define([
 
         var entity = entityCollection.getOrCreateEntity(id);
         var properties = geoJson.properties;
-        if (defined(properties)) {
+        if (definedNotNull(properties)) {
             entity.addProperty('properties');
             entity.properties = properties;
 
@@ -151,7 +153,7 @@ define([
 
             //Check for the simplestyle specified name first.
             var name = properties.title;
-            if (defined(name)) {
+            if (definedNotNull(name)) {
                 entity.name = name;
                 nameProperty = 'title';
             } else {
@@ -182,7 +184,7 @@ define([
                         }
                     }
                 }
-                if (defined(nameProperty)) {
+                if (definedNotNull(nameProperty)) {
                     entity.name = properties[nameProperty];
                 }
             }
@@ -190,7 +192,7 @@ define([
             var description = properties.description;
             if (!defined(description)) {
                 entity.description = new CallbackProperty(createDescriptionCallback(properties, nameProperty), true);
-            } else {
+            } else if (description !== null) {
                 entity.description = new ConstantProperty(description);
             }
         }
@@ -217,7 +219,7 @@ define([
         } else {
             var geometryType = feature.geometry.type;
             var geometryHandler = geometryTypes[geometryType];
-            if (!defined(geometryHandler)) {
+            if (!definedNotNull(geometryHandler)) {
                 throw new RuntimeError('Unknown geometry type: ' + geometryType);
             }
             geometryHandler(dataSource, feature, feature.geometry, crsFunction, options);
@@ -237,7 +239,7 @@ define([
             var geometry = geometries[i];
             var geometryType = geometry.type;
             var geometryHandler = geometryTypes[geometryType];
-            if (!defined(geometryHandler)) {
+            if (!definedNotNull(geometryHandler)) {
                 throw new RuntimeError('Unknown geometry type: ' + geometryType);
             }
             geometryHandler(dataSource, geoJson, geometry, crsFunction, options);
@@ -250,14 +252,17 @@ define([
         var size = options.markerSize;
 
         var properties = geoJson.properties;
-        if (defined(properties)) {
+        if (definedNotNull(properties)) {
             var cssColor = properties['marker-color'];
-            if (defined(cssColor)) {
+            if (definedNotNull(cssColor)) {
                 color = Color.fromCssColorString(cssColor);
             }
 
             size = defaultValue(sizes[properties['marker-size']], size);
-            symbol = defaultValue(properties['marker-symbol'], symbol);
+            var markerSymbol = properties['marker-symbol'];
+            if (definedNotNull(markerSymbol)) {
+                symbol = markerSymbol;
+            }
         }
 
         stringifyScratch[0] = symbol;
@@ -303,19 +308,19 @@ define([
         var widthProperty = options.strokeWidthProperty;
 
         var properties = geoJson.properties;
-        if (defined(properties)) {
+        if (definedNotNull(properties)) {
             var width = properties['stroke-width'];
-            if (defined(width)) {
+            if (definedNotNull(width)) {
                 widthProperty = new ConstantProperty(width);
             }
 
             var color;
             var stroke = properties.stroke;
-            if (defined(stroke)) {
+            if (definedNotNull(stroke)) {
                 color = Color.fromCssColorString(stroke);
             }
             var opacity = properties['stroke-opacity'];
-            if (defined(opacity) && opacity !== 1.0) {
+            if (definedNotNull(opacity) && opacity !== 1.0) {
                 if (!defined(color)) {
                     color = material.color.clone();
                 }
@@ -356,19 +361,19 @@ define([
         var widthProperty = options.strokeWidthProperty;
 
         var properties = geoJson.properties;
-        if (defined(properties)) {
+        if (definedNotNull(properties)) {
             var width = properties['stroke-width'];
-            if (defined(width)) {
+            if (definedNotNull(width)) {
                 widthProperty = new ConstantProperty(width);
             }
 
             var color;
             var stroke = properties.stroke;
-            if (defined(stroke)) {
+            if (definedNotNull(stroke)) {
                 color = Color.fromCssColorString(stroke);
             }
             var opacity = properties['stroke-opacity'];
-            if (defined(opacity) && opacity !== 1.0) {
+            if (definedNotNull(opacity) && opacity !== 1.0) {
                 if (!defined(color)) {
                     color = options.strokeMaterialProperty.color.clone();
                 }
@@ -381,12 +386,12 @@ define([
 
             var fillColor;
             var fill = properties.fill;
-            if (defined(fill)) {
+            if (definedNotNull(fill)) {
                 fillColor = Color.fromCssColorString(fill);
                 fillColor.alpha = material.color.alpha;
             }
             opacity = properties['fill-opacity'];
-            if (defined(opacity) && opacity !== material.color.alpha) {
+            if (definedNotNull(opacity) && opacity !== material.color.alpha) {
                 if (!defined(fillColor)) {
                     fillColor = material.color.clone();
                 }

--- a/Specs/Core/definedNotNullSpec.js
+++ b/Specs/Core/definedNotNullSpec.js
@@ -1,0 +1,14 @@
+/*global defineSuite*/
+defineSuite([
+        'Core/definedNotNull'
+    ], function(
+        definedNotNull) {
+    "use strict";
+    /*global jasmine,it,expect*/
+
+    it('works', function() {
+        expect(definedNotNull(0)).toEqual(true);
+        expect(definedNotNull(undefined)).toEqual(false);
+        expect(definedNotNull(null)).toEqual(false);
+    });
+});


### PR DESCRIPTION
It's legal to include `null` values in many places with GeoJSON but we weren't always handling these cases in Cesium.  This change introduces a new helper, `definedNotNull`, which as the name implies checks for both
`undefined` and `null`.  We now use this in GeoJsonDataSource when reading parsed JSON. We treat `null` in JSON the same as `undefined`, unless the specification explicitly says otherwsie.