### PR TITLE
Better PointerEvent detection.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@ Change Log
   * Removed `Camera.transform`, which was deprecated in Cesium 1.6. Use `Camera.lookAtTransform`.
   * Removed the `direction` and `up` options to `Camera.flyTo`, which were deprecated in Cesium 1.6. Use the `orientation` option.
   * Removed `Camera.flyToRectangle`, which was deprecated in Cesium 1.6. Use `Camera.flyTo`.
+* Fixed `PointerEvent` detection so that it works with older implementations of the specification. This also fixes lack of mouse handling when detection failed, such as when using Cesium in the Windows `WebBrowser` control.
 * Fixed an issue with transparency. [#2572](https://github.com/AnalyticalGraphicsInc/cesium/issues/2572)
 * Fixed improper handling of null values when loading `GeoJSON` data.
 * Cesium is now tested using Jasmine 2.2.0.

--- a/Source/Core/FeatureDetection.js
+++ b/Source/Core/FeatureDetection.js
@@ -137,6 +137,18 @@ define([
         return isFirefox() && firefoxVersionResult;
     }
 
+    var hasPointerEvents;
+    function supportsPointerEvents() {
+        if (!defined(hasPointerEvents)) {
+            //While window.navigator.pointerEnabled is deprecated in the W3C specification
+            //we still need to use it if it exists in order to support browsers
+            //that rely on it, such as the Windows WebBrowser control which defines
+            //window.PointerEvent but sets window.navigator.pointerEnabled to false.
+            hasPointerEvents = defined(window.PointerEvent) && (!defined(window.navigator.pointerEnabled) || window.navigator.pointerEnabled);
+        }
+        return hasPointerEvents;
+    }
+
     /**
      * A set of functions to detect whether the current browser supports
      * various features.
@@ -156,7 +168,8 @@ define([
         isFirefox : isFirefox,
         firefoxVersion : firefoxVersion,
         isWindows : isWindows,
-        hardwareConcurrency : defaultValue(navigator.hardwareConcurrency, 3)
+        hardwareConcurrency : defaultValue(navigator.hardwareConcurrency, 3),
+        supportsPointerEvents : supportsPointerEvents
     };
 
     /**

--- a/Source/Core/ScreenSpaceEventHandler.js
+++ b/Source/Core/ScreenSpaceEventHandler.js
@@ -6,6 +6,7 @@ define([
         './defined',
         './destroyObject',
         './DeveloperError',
+        './FeatureDetection',
         './KeyboardEventModifier',
         './ScreenSpaceEventType'
     ], function(
@@ -15,6 +16,7 @@ define([
         defined,
         destroyObject,
         DeveloperError,
+        FeatureDetection,
         KeyboardEventModifier,
         ScreenSpaceEventType) {
     "use strict";
@@ -79,7 +81,7 @@ define([
         // this is affected by the existence of an undocumented disableRootEvents property on element.
         var alternateElement = !defined(element.disableRootEvents) ? document : element;
 
-        if (defined(window.PointerEvent)) {
+        if (FeatureDetection.supportsPointerEvents()) {
             registerListener(screenSpaceEventHandler, 'pointerdown', element, handlePointerDown);
             registerListener(screenSpaceEventHandler, 'pointerup', element, handlePointerUp);
             registerListener(screenSpaceEventHandler, 'pointermove', element, handlePointerMove);

--- a/Specs/Core/ScreenSpaceEventHandlerSpec.js
+++ b/Specs/Core/ScreenSpaceEventHandlerSpec.js
@@ -5,6 +5,7 @@ defineSuite([
         'Core/clone',
         'Core/combine',
         'Core/defined',
+        'Core/FeatureDetection',
         'Core/KeyboardEventModifier',
         'Core/ScreenSpaceEventType',
         'Specs/DomEventSimulator'
@@ -14,13 +15,14 @@ defineSuite([
         clone,
         combine,
         defined,
+        FeatureDetection,
         KeyboardEventModifier,
         ScreenSpaceEventType,
         DomEventSimulator) {
     "use strict";
     /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn*/
 
-    var usePointerEvents = defined(window.PointerEvent);
+    var usePointerEvents = FeatureDetection.supportsPointerEvents();
     var element;
     var handler;
 

--- a/Specs/Scene/CameraEventAggregatorSpec.js
+++ b/Specs/Scene/CameraEventAggregatorSpec.js
@@ -4,6 +4,7 @@ defineSuite([
         'Core/Cartesian2',
         'Core/combine',
         'Core/defined',
+        'Core/FeatureDetection',
         'Core/KeyboardEventModifier',
         'Scene/CameraEventType',
         'Specs/createCanvas',
@@ -14,6 +15,7 @@ defineSuite([
         Cartesian2,
         combine,
         defined,
+        FeatureDetection,
         KeyboardEventModifier,
         CameraEventType,
         createCanvas,
@@ -22,7 +24,7 @@ defineSuite([
     "use strict";
     /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn*/
 
-    var usePointerEvents = defined(window.PointerEvent);
+    var usePointerEvents = FeatureDetection.supportsPointerEvents();
     var canvas;
     var handler;
     var handler2;

--- a/Specs/Scene/ScreenSpaceCameraControllerSpec.js
+++ b/Specs/Scene/ScreenSpaceCameraControllerSpec.js
@@ -6,6 +6,7 @@ defineSuite([
         'Core/combine',
         'Core/defined',
         'Core/Ellipsoid',
+        'Core/FeatureDetection',
         'Core/GeographicProjection',
         'Core/IntersectionTests',
         'Core/KeyboardEventModifier',
@@ -26,6 +27,7 @@ defineSuite([
         combine,
         defined,
         Ellipsoid,
+        FeatureDetection,
         GeographicProjection,
         IntersectionTests,
         KeyboardEventModifier,
@@ -42,7 +44,7 @@ defineSuite([
     "use strict";
     /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn*/
 
-    var usePointerEvents = defined(window.PointerEvent);
+    var usePointerEvents = FeatureDetection.supportsPointerEvents();
     var scene;
     var canvas;
     var camera;


### PR DESCRIPTION
While window.navigator.pointerEnabled is deprecated in the W3C specification we still need to use it if it exists in order to support browsers that rely on it, such as the Windows WebBrowser control which defines window.PointerEvent but sets window.navigator.pointerEnabled to false.