### PR TITLE
Asynchronous Primitive not setting ready on Failure

### DIFF
--- a/Source/Scene/Primitive.js
+++ b/Source/Scene/Primitive.js
@@ -867,7 +867,11 @@ define([
 
                         that._instanceIds = reorderedInstanceIds;
 
-                        that._state = defined(that._geometries) ? PrimitiveState.COMBINED : PrimitiveState.FAILED;
+                        if (defined(that._geometries)) {
+                            that._state = PrimitiveState.COMBINED;
+                        } else {
+                            setReady(that, frameState, PrimitiveState.FAILED, undefined);
+                        }
                     }).otherwise(function(error) {
                         setReady(that, frameState, PrimitiveState.FAILED, error);
                     });

--- a/Specs/Scene/PrimitiveSpec.js
+++ b/Specs/Scene/PrimitiveSpec.js
@@ -11,6 +11,7 @@ defineSuite([
         'Core/GeometryInstance',
         'Core/GeometryInstanceAttribute',
         'Core/Matrix4',
+        'Core/PolygonGeometry',
         'Core/PrimitiveType',
         'Core/Rectangle',
         'Core/RectangleGeometry',
@@ -41,6 +42,7 @@ defineSuite([
         GeometryInstance,
         GeometryInstanceAttribute,
         Matrix4,
+        PolygonGeometry,
         PrimitiveType,
         Rectangle,
         RectangleGeometry,
@@ -922,7 +924,56 @@ defineSuite([
                 }).toThrowRuntimeError();
             });
         });
+    });
 
+    it('internally invalid asynchronous geometry resolves promise and sets ready', function() {
+        var primitive = new Primitive({
+            geometryInstances : [new GeometryInstance({
+                geometry : PolygonGeometry.fromPositions({
+                    positions : []
+                })
+            })],
+            appearance : new MaterialAppearance({
+                materialSupport : MaterialAppearance.MaterialSupport.ALL
+            }),
+            compressVertices : false
+        });
+
+        return pollToPromise(function() {
+            if (frameState.afterRender.length > 0) {
+                frameState.afterRender[0]();
+                return true;
+            }
+            primitive.update(context, frameState, []);
+            return false;
+        }).then(function() {
+            return primitive.readyPromise.then(function(arg) {
+                expect(arg).toBe(primitive);
+                expect(primitive.ready).toBe(true);
+            });
+        });
+    });
+
+    it('internally invalid synchronous geometry resolves promise and sets ready', function() {
+        var primitive = new Primitive({
+            geometryInstances : [new GeometryInstance({
+                geometry : PolygonGeometry.fromPositions({
+                    positions : []
+                })
+            })],
+            appearance : new MaterialAppearance({
+                materialSupport : MaterialAppearance.MaterialSupport.ALL
+            }),
+            asynchronous : false,
+            compressVertices : false
+        });
+        primitive.update(context, frameState, []);
+
+        return primitive.readyPromise.then(function(arg) {
+                expect(arg).toBe(primitive);
+                expect(primitive.ready).toBe(true);
+            });
+        });
     });
 
     it('shader validation', function() {

--- a/Specs/Scene/PrimitiveSpec.js
+++ b/Specs/Scene/PrimitiveSpec.js
@@ -967,9 +967,16 @@ defineSuite([
             asynchronous : false,
             compressVertices : false
         });
-        primitive.update(context, frameState, []);
 
-        return primitive.readyPromise.then(function(arg) {
+        return pollToPromise(function() {
+            if (frameState.afterRender.length > 0) {
+                frameState.afterRender[0]();
+                return true;
+            }
+            primitive.update(context, frameState, []);
+            return false;
+        }).then(function() {
+            return primitive.readyPromise.then(function(arg) {
                 expect(arg).toBe(primitive);
                 expect(primitive.ready).toBe(true);
             });


### PR DESCRIPTION
For usability, we allow users to create "invalid" geometries, such as a polygon with two points, and simply don't render anything as a result. Unfortunately, this case was not being handled for unbatched asynchronous geometries, which resulted in the Primitive never being ready.

This change fixes that issue and also adds tests for both synchronous and asynchronous cases (the sychronous case was already being handled correctly but was untested).

Fixes #2591