### PR TITLE
Mention smallterrain replaced by STK World Terrain in Changes.MD

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,8 @@ Change Log
   * Removed `Camera.transform`, which was deprecated in Cesium 1.6. Use `Camera.lookAtTransform`.
   * Removed the `direction` and `up` options to `Camera.flyTo`, which were deprecated in Cesium 1.6. Use the `orientation` option.
   * Removed `Camera.flyToRectangle`, which was deprecated in Cesium 1.6. Use `Camera.flyTo`.
+* Deprecated
+  * The `smallterrain` tileset has been deprecated and will be removed in 1.11. Use the [STK World Terrain](http://cesiumjs.org/data-and-assets/terrain/stk-world-terrain.html) tileset instead.
 * Added `Entity.show` which is a boolean for easily hiding or showing an entity and its children.
 * Added `Entity.isShowing` which is a read-only property that indicates if an entity is currently being drawn.
 * Added support for the KML `visibility` element.

--- a/Source/Core/CesiumTerrainProvider.js
+++ b/Source/Core/CesiumTerrainProvider.js
@@ -66,7 +66,7 @@ define([
      * // Construct a terrain provider that uses per vertex normals for lighting
      * // to add shading detail to an imagery provider.
      * var terrainProvider = new Cesium.CesiumTerrainProvider({
-     *     url : '//cesiumjs.org/stk-terrain/tilesets/world/tiles',
+     *     url : '//assets.agi.com/stk-terrain/world',
      *     requestVertexNormals : true
      * });
      *

--- a/Source/Core/sampleTerrain.js
+++ b/Source/Core/sampleTerrain.js
@@ -31,7 +31,7 @@ define([
      * @example
      * // Query the terrain height of two Cartographic positions
      * var terrainProvider = new Cesium.CesiumTerrainProvider({
-     *     url : '//cesiumjs.org/stk-terrain/world'
+     *     url : '//assets.agi.com/stk-terrain/world'
      * });
      * var positions = [
      *     Cesium.Cartographic.fromDegrees(86.925145, 27.988257),

--- a/Source/Widgets/BaseLayerPicker/createDefaultTerrainProviderViewModels.js
+++ b/Source/Widgets/BaseLayerPicker/createDefaultTerrainProviderViewModels.js
@@ -32,7 +32,7 @@ define([
             tooltip : 'High-resolution, mesh-based terrain for the entire globe. Free for use on the Internet. Closed-network options are available.\nhttp://www.agi.com',
             creationFunction : function() {
                 return new CesiumTerrainProvider({
-                    url : '//cesiumjs.org/stk-terrain/world',
+                    url : '//assets.agi.com/stk-terrain/world',
                     requestWaterMask : true,
                     requestVertexNormals : true
                 });

--- a/Source/Widgets/CesiumWidget/CesiumWidget.js
+++ b/Source/Widgets/CesiumWidget/CesiumWidget.js
@@ -167,7 +167,7 @@ define([
      * var widget = new Cesium.CesiumWidget('cesiumContainer', {
      *     imageryProvider : new Cesium.OpenStreetMapImageryProvider(),
      *     terrainProvider : new Cesium.CesiumTerrainProvider({
-     *         url : '//cesiumjs.org/stk-terrain/world'
+     *         url : '//assets.agi.com/stk-terrain/world'
      *     }),
      *     // Use high-res stars downloaded from https://github.com/AnalyticalGraphicsInc/cesium-assets
      *     skyBox : new Cesium.SkyBox({

--- a/Source/Widgets/Viewer/Viewer.js
+++ b/Source/Widgets/Viewer/Viewer.js
@@ -251,7 +251,7 @@ define([
      *     sceneMode : Cesium.SceneMode.COLUMBUS_VIEW,
      *     //Use standard Cesium terrain
      *     terrainProvider : new Cesium.CesiumTerrainProvider({
-     *         url : '//cesiumjs.org/stk-terrain/world'
+     *         url : '//assets.agi.com/stk-terrain/world'
      *     }),
      *     //Hide the base layer picker
      *     baseLayerPicker : false,

--- a/Specs/Core/sampleTerrainSpec.js
+++ b/Specs/Core/sampleTerrainSpec.js
@@ -13,7 +13,7 @@ defineSuite([
     /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn*/
 
     var terrainProvider = new CesiumTerrainProvider({
-        url : '//cesiumjs.org/stk-terrain/world'
+        url : '//assets.agi.com/stk-terrain/world'
     });
 
     it('queries heights', function() {
@@ -98,11 +98,11 @@ defineSuite([
 
     it('works for a dodgy point right near the edge of a tile', function() {
         var stkWorldTerrain = new CesiumTerrainProvider({
-            url : 'http://cesiumjs.org/stk-terrain/tilesets/world/tiles'
+            url : '//assets.agi.com/stk-terrain/world'
         });
 
         var positions = [new Cartographic(0.33179290856829535, 0.7363107781851078)];
-        
+
         return sampleTerrain(stkWorldTerrain, 12, positions).then(function() {
             expect(positions[0].height).toBeDefined();
         });

--- a/Specs/Scene/GlobeSurfaceTileProviderSpec.js
+++ b/Specs/Scene/GlobeSurfaceTileProviderSpec.js
@@ -577,7 +577,7 @@ defineSuite([
 
         var terrainCredit = new Credit('terrain credit');
         globe.terrainProvider = new CesiumTerrainProvider({
-            url : 'http://cesiumjs.org/stk-terrain/tilesets/world/tiles',
+            url : '//assets.agi.com/stk-terrain/world',
             credit : terrainCredit
         });
 

--- a/Specs/Scene/GlobeSurfaceTileSpec.js
+++ b/Specs/Scene/GlobeSurfaceTileSpec.js
@@ -497,7 +497,7 @@ defineSuite([
 
         it('gets correct results even when the mesh includes normals', function() {
             var terrainProvider = new CesiumTerrainProvider({
-                url : '//cesiumjs.org/stk-terrain/tilesets/world/tiles',
+                url : '//assets.agi.com/stk-terrain/world',
                 requestVertexNormals : true
             });
 


### PR DESCRIPTION
Also a minor doc fix.  The previous tileset link was broken (unversioned).

This is for #2593