### PR TITLE
When cleaning polyline points, check if epsilons add up.

### DIFF
--- a/Source/Core/PolylinePipeline.js
+++ b/Source/Core/PolylinePipeline.js
@@ -245,10 +245,11 @@ define([
 
         var cleanedPositions = positions.slice(0, i);
         for (; i < length; ++i) {
-            v0 = positions[i - 1];
+            // v0 is set by either the previous loop, or the previous clean point.
             v1 = positions[i];
             if (!Cartesian3.equalsEpsilon(v0, v1, removeDuplicatesEpsilon)) {
                 cleanedPositions.push(Cartesian3.clone(v1));
+                v0 = v1;
             }
         }
 

--- a/Source/Core/WallGeometryLibrary.js
+++ b/Source/Core/WallGeometryLibrary.js
@@ -76,12 +76,11 @@ define([
                     cleanedBottomHeights[index] = 0.0;
                 }
 
+                Cartographic.clone(c1, c0);
                 ++index;
             } else if (c0.height < c1.height) {
                 cleanedTopHeights[index - 1] = c1.height;
             }
-
-            Cartographic.clone(c1, c0);
         }
 
         cleanedPositions.length = index;

--- a/Specs/Core/PolylinePipelineSpec.js
+++ b/Specs/Core/PolylinePipelineSpec.js
@@ -94,6 +94,20 @@ defineSuite([
         expect(noDuplicates).toEqual(expectedPositions);
     });
 
+    it('removeDuplicates keeps positions that add up past relative epsilon 7', function() {
+        var eightyPercentOfEpsilon7 = 0.8 * CesiumMath.EPSILON7;
+        var positions = [
+            new Cartesian3(0.0, 0.0, 1.0),
+            new Cartesian3(0.0, 0.0, 1.0 + eightyPercentOfEpsilon7),
+            new Cartesian3(0.0, 0.0, 1.0 + (2 * eightyPercentOfEpsilon7)),
+            new Cartesian3(0.0, 0.0, 1.0 + (3 * eightyPercentOfEpsilon7))];
+        var expectedPositions = [
+            new Cartesian3(0.0, 0.0, 1.0),
+            new Cartesian3(0.0, 0.0, 1.0 + (2 * eightyPercentOfEpsilon7))];
+        var noDuplicates = PolylinePipeline.removeDuplicates(positions);
+        expect(noDuplicates).toEqual(expectedPositions);
+    });
+
     it('removeDuplicates throws without positions', function() {
         expect(function() {
             PolylinePipeline.removeDuplicates();

--- a/Specs/Core/WallGeometrySpec.js
+++ b/Specs/Core/WallGeometrySpec.js
@@ -145,6 +145,32 @@ defineSuite([
         expect(cartographic.height).toEqualEpsilon(2000.0, CesiumMath.EPSILON8);
     });
 
+    it('does not clean positions that add up past EPSILON14', function() {
+        var eightyPercentOfEpsilon14 = 0.8 * CesiumMath.EPSILON14;
+        var inputPositions = Cartesian3.fromRadiansArrayHeights([
+            1.0, 1.0, 1000.0,
+            1.0, 1.0 + eightyPercentOfEpsilon14, 1000.0,
+            1.0, 1.0 + (2 * eightyPercentOfEpsilon14), 1000.0,
+            1.0, 1.0 + (3 * eightyPercentOfEpsilon14), 1000.0
+        ]);
+        var w = WallGeometry.createGeometry(new WallGeometry({
+            vertexFormat : VertexFormat.POSITION_ONLY,
+            positions    : inputPositions
+        }));
+        expect(w).toBeDefined();
+
+        var expectedPositions = Cartesian3.fromRadiansArrayHeights([
+            1.0, 1.0, 1000.0,
+            1.0, 1.0 + (2 * eightyPercentOfEpsilon14), 1000.0
+        ]);
+        var expectedW = WallGeometry.createGeometry(new WallGeometry({
+            vertexFormat : VertexFormat.POSITION_ONLY,
+            positions    : expectedPositions
+        }));
+        var positions = w.attributes.position.values;
+        expect(positions.length).toEqual(expectedW.attributes.position.values.length);
+    });
+
     it('cleans selects maximum height from duplicates', function() {
         var w = WallGeometry.createGeometry(new WallGeometry({
             vertexFormat : VertexFormat.POSITION_ONLY,


### PR DESCRIPTION
When removing polyline points, don't just check if adjacent points are below epsilon, instead, check against the previous non-removed point.

Added new test for this, that fails in master and passes here.