### PR TITLE
Fix 2D and CV path visualization for inertial data

### DIFF
--- a/Source/DataSources/PathVisualizer.js
+++ b/Source/DataSources/PathVisualizer.js
@@ -441,7 +441,7 @@ define([
             var entity = item.entity;
             var positionProperty = entity._position;
 
-            var lastUpdater = entity._pathUpdater;
+            var lastUpdater = item.updater;
 
             var frameToVisualize = ReferenceFrame.FIXED;
             if (this._scene.mode === SceneMode.SCENE3D) {

--- a/Specs/DataSources/PathVisualizerSpec.js
+++ b/Specs/DataSources/PathVisualizerSpec.js
@@ -3,6 +3,7 @@ defineSuite([
         'DataSources/PathVisualizer',
         'Core/Cartesian3',
         'Core/Color',
+        'Core/Matrix4',
         'Core/JulianDate',
         'Core/ReferenceFrame',
         'Core/TimeInterval',
@@ -17,11 +18,13 @@ defineSuite([
         'DataSources/SampledPositionProperty',
         'DataSources/ScaledPositionProperty',
         'DataSources/TimeIntervalCollectionPositionProperty',
+        'Scene/SceneMode',
         'Specs/createScene'
     ], function(
         PathVisualizer,
         Cartesian3,
         Color,
+        Matrix4,
         JulianDate,
         ReferenceFrame,
         TimeInterval,
@@ -36,6 +39,7 @@ defineSuite([
         SampledPositionProperty,
         ScaledPositionProperty,
         TimeIntervalCollectionPositionProperty,
+        SceneMode,
         createScene) {
     "use strict";
     /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn*/
@@ -263,6 +267,51 @@ defineSuite([
 
         visualizer.update(time);
         expect(polylineCollection.length).toEqual(1);
+    });
+
+    it('Switches from inertial to fixed paths in 2D', function() {
+        var times = [new JulianDate(0, 0), new JulianDate(1, 0)];
+        var time = new JulianDate(0.5, 0);
+        var positions = [new Cartesian3(1234, 5678, 9101112), new Cartesian3(5678, 1234, 1101112)];
+
+        var position = new SampledPositionProperty(ReferenceFrame.INERTIAL);
+        position.addSamples(times, positions);
+
+        var entityCollection = new EntityCollection();
+        visualizer = new PathVisualizer(scene, entityCollection);
+        var testObject = entityCollection.getOrCreateEntity('test');
+        testObject.position = position;
+        testObject.path = new PathGraphics();
+        testObject.path.leadTime = new ConstantProperty(25);
+        testObject.path.trailTime = new ConstantProperty(10);
+
+        visualizer.update(time);
+
+        expect(scene.primitives.length).toEqual(1);
+
+        //They'll be one inertial polyline collection
+        var inertialPolylineCollection = scene.primitives.get(0);
+        expect(inertialPolylineCollection.length).toEqual(1);
+        expect(inertialPolylineCollection.modelMatrix).not.toEqual(Matrix4.IDENTITY);
+
+        var inertialLine = inertialPolylineCollection.get(0);
+        expect(inertialLine.show).toEqual(true);
+
+        scene.mode = SceneMode.Scene2D;
+        visualizer.update(time);
+
+        //They'll be one inertial polyline collection (with no visible lines)
+        //and a new fixed polyline collection.
+        expect(scene.primitives.length).toEqual(2);
+
+        var fixedPolylineCollection = scene.primitives.get(1);
+
+        expect(inertialLine.show).toEqual(false);
+        expect(fixedPolylineCollection.length).toEqual(1);
+        expect(fixedPolylineCollection.modelMatrix).toEqual(Matrix4.IDENTITY);
+
+        var fixedLine = fixedPolylineCollection.get(0);
+        expect(fixedLine.show).toEqual(true);
     });
 
     it('clear hides primitives.', function() {


### PR DESCRIPTION
Apparently broken since 1.3, 421f666236083a0afc8ae9cd970291d04ea84340, inertial paths like simple.czml were drawn incorrectly in 2D and CV modes, obvious when you see it because nothing lines up. I added a test case that fails in master and passes with this fix.

My kingdom for static typing.