### PR TITLE
Fix localStorage access

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -26,6 +26,7 @@ Change Log
 * Added the ability to specify the desired tiling scheme, rectangle, and width and height of tiles to the `ArcGisMapServerImagerProvider` constructor.
 * Added the ability to access dynamic ArcGIS MapServer layers by specifying the `layers` parameter to the `ArcGisMapServerImagerProvider` constructor.
 * Fixed a bug that could cause incorrect rendering of an `ArcGisMapServerImageProvider` with a "singleFusedMapCache" in the geographic projection (EPSG:4326).
+* Fixed a bug that prevented Cesium from working in browser configurations that explicitly disabled localStorage, such as Safari's private browsing mode.
 
 ### 1.7.1 - 2015-03-06
 

--- a/Source/Widgets/Viewer/Viewer.js
+++ b/Source/Widgets/Viewer/Viewer.js
@@ -4,6 +4,7 @@ define([
         '../../Core/Cartesian3',
         '../../Core/defaultValue',
         '../../Core/defined',
+        '../../Core/definedNotNull',
         '../../Core/defineProperties',
         '../../Core/destroyObject',
         '../../Core/DeveloperError',
@@ -42,6 +43,7 @@ define([
         Cartesian3,
         defaultValue,
         defined,
+        definedNotNull,
         defineProperties,
         destroyObject,
         DeveloperError,
@@ -467,13 +469,19 @@ Either specify options.terrainProvider instead or set options.baseLayerPicker to
         var navigationHelpButton;
         if (!defined(options.navigationHelpButton) || options.navigationHelpButton !== false) {
             var showNavHelp = true;
-            if (defined(window.localStorage)) {
-                var hasSeenNavHelp = window.localStorage.getItem('cesium-hasSeenNavHelp');
-                if (defined(hasSeenNavHelp) && Boolean(hasSeenNavHelp)) {
-                    showNavHelp = false;
-                } else {
-                    window.localStorage.setItem('cesium-hasSeenNavHelp', 'true');
+            try {
+                //window.localStorage is null if disabled in Firefox or undefined in browsers with implementation
+                if (definedNotNull(window.localStorage)) {
+                    var hasSeenNavHelp = window.localStorage.getItem('cesium-hasSeenNavHelp');
+                    if (defined(hasSeenNavHelp) && Boolean(hasSeenNavHelp)) {
+                        showNavHelp = false;
+                    } else {
+                        window.localStorage.setItem('cesium-hasSeenNavHelp', 'true');
+                    }
                 }
+            } catch (e) {
+                //Accessing window.localStorage throws if disabled in Chrome
+                //window.localStorage.setItem throws if in Safari private browsing mode or in any browser if we are over quota.
             }
             navigationHelpButton = new NavigationHelpButton({
                 container : toolbar,


### PR DESCRIPTION
As initially reported on [the forum](https://groups.google.com/d/msg/cesium-dev/GkW0LrCrhBE/QSkZ4RDVoW0J)

What I found was:
1. If local storage is disabled in Firefox, the value is null, not undefined.
2. If local storage is disabled in Chrome, even checking for existence throws.
3. If we are above our localstorage quota in any browser, setItem will throw.
4. Safari's private browsing mode sets a quota of 0.
5. IE is the only browser that behaved sanely, i.e. `window.localStorage` is simply undefined if the feature isn't available.

In master, doing any of the following will break the Viewer widget (or anything using the help button).  In this branch everything works fine.
__Firefox 1__ Disable localStorage in about:config
__Firefox 2__ Enable localStorage in about:config but set the quota to 0.
__Safari__ Browse inPrivate mode
__Chrome__ In Settings->Advanced->Content Settings Choose "Block sites from setting any data"
__IE__ InternetOptions->Advance uncheck Enable DOM storage

We should probably get this into 1.8.