### PR TITLE
Fix createTangentSpaceDebugPrimitive

### DIFF
--- a/Source/Scene/createTangentSpaceDebugPrimitive.js
+++ b/Source/Scene/createTangentSpaceDebugPrimitive.js
@@ -42,7 +42,7 @@ define([
      *    modelMatrix : instance.modelMatrix
      * }));
      */
-    function createTangentSpaceDebugPrimitive(options) {
+    var createTangentSpaceDebugPrimitive = function(options) {
         options = defaultValue(options, defaultValue.EMPTY_OBJECT);
         var instances = [];
         var geometry = options.geometry;
@@ -95,6 +95,7 @@ define([
 
         if (instances.length > 0) {
             return new Primitive({
+                asynchronous : false,
                 geometryInstances : instances,
                 appearance : new PerInstanceColorAppearance({
                     flat : true,
@@ -104,7 +105,7 @@ define([
         }
 
         return undefined;
-    }
+    };
 
     return createTangentSpaceDebugPrimitive;
 });

--- a/Specs/Scene/createTangentSpaceDebugPrimitiveSpec.js
+++ b/Specs/Scene/createTangentSpaceDebugPrimitiveSpec.js
@@ -32,6 +32,7 @@ defineSuite([
 
         expect(primitive.geometryInstances).toBeDefined();
         expect(primitive.appearance).toBeDefined();
+        expect(primitive.asynchronous).toBe(false);
 
         var instances = primitive.geometryInstances;
         expect(instances.length).toEqual(3);


### PR DESCRIPTION
`createTangentSpaceDebugPrimitive` needs to use `asynchronous : false`, since we currently don't support pre-created async geometry.

Also fix problem where createTangentSpaceDebugPrimitive was not showing up in documentation due to use of named function over variable.

Fixes #2614