### PR TITLE
Turning off globe turns off defaults for baseLayerPicker & imageryProvider

### DIFF
--- a/Source/Widgets/CesiumWidget/CesiumWidget.js
+++ b/Source/Widgets/CesiumWidget/CesiumWidget.js
@@ -303,7 +303,7 @@ define([
             }
 
             //Set the terrain provider if one is provided.
-            if (defined(options.terrainProvider)) {
+            if (defined(options.terrainProvider) && options.globe !== false) {
                 scene.terrainProvider = options.terrainProvider;
             }
 

--- a/Source/Widgets/CesiumWidget/CesiumWidget.js
+++ b/Source/Widgets/CesiumWidget/CesiumWidget.js
@@ -146,7 +146,7 @@ define([
      * @param {Boolean} [options.scene3DOnly=false] When <code>true</code>, each geometry instance will only be rendered in 3D to save GPU memory.
      * @param {Boolean} [options.orderIndependentTranslucency=true] If true and the configuration supports it, use order independent translucency.
      * @param {MapProjection} [options.mapProjection=new GeographicProjection()] The map projection to use in 2D and Columbus View modes.
-     * @param {Globe} [options.globe=new Globe(mapProjection.ellipsoid)] The globe to use in the scene.  If set to <code>false</code>, no globe will be added, and <code>imageryProvider</code> must also be set <code>false</code>.
+     * @param {Globe} [options.globe=new Globe(mapProjection.ellipsoid)] The globe to use in the scene.  If set to <code>false</code>, no globe will be added.
      * @param {Boolean} [options.useDefaultRenderLoop=true] True if this widget should control the render loop, false otherwise.
      * @param {Number} [options.targetFrameRate] The target frame rate when using the default render loop.
      * @param {Boolean} [options.showRenderLoopErrors=true] If true, this widget will automatically display an HTML panel to the user containing the error, if a render loop error occurs.
@@ -192,8 +192,9 @@ define([
         if (!defined(container)) {
             throw new DeveloperError('container is required.');
         }
-        if (defined(options) && defined(options.globe) && options.globe === false && options.imageryProvider !== false) {
-            throw new DeveloperError('To turn off the globe, options.imageryProvider must be set to false.');
+        if (defined(options) && defined(options.globe) && options.globe === false &&
+                defined(options.imageryProvider) && options.imageryProvider !== false) {
+            throw new DeveloperError('Specifying options.imageryProvider is not useful without a globe.');
         }
         //>>includeEnd('debug');
 
@@ -294,7 +295,7 @@ define([
             }
 
             //Set the base imagery layer
-            var imageryProvider = options.imageryProvider;
+            var imageryProvider = (options.globe === false) ? false : options.imageryProvider;
             if (!defined(imageryProvider)) {
                 imageryProvider = new BingMapsImageryProvider({
                     url : '//dev.virtualearth.net'

--- a/Source/Widgets/CesiumWidget/CesiumWidget.js
+++ b/Source/Widgets/CesiumWidget/CesiumWidget.js
@@ -192,10 +192,6 @@ define([
         if (!defined(container)) {
             throw new DeveloperError('container is required.');
         }
-        if (defined(options) && defined(options.globe) && options.globe === false &&
-                defined(options.imageryProvider) && options.imageryProvider !== false) {
-            throw new DeveloperError('Specifying options.imageryProvider is not useful without a globe.');
-        }
         //>>includeEnd('debug');
 
         container = getElement(container);

--- a/Source/Widgets/Viewer/Viewer.js
+++ b/Source/Widgets/Viewer/Viewer.js
@@ -227,7 +227,7 @@ define([
      * @param {Object} [options.contextOptions] Context and WebGL creation properties corresponding to <code>options</code> passed to {@link Scene}.
      * @param {SceneMode} [options.sceneMode=SceneMode.SCENE3D] The initial scene mode.
      * @param {MapProjection} [options.mapProjection=new GeographicProjection()] The map projection to use in 2D and Columbus View modes.
-     * @param {Globe} [options.globe=new Globe(mapProjection.ellipsoid)] The globe to use in the scene.  If set to <code>false</code>, no globe will be added, and <code>imageryProvider</code> and <code>baseLayerPicker</code> must also be set <code>false</code>.
+     * @param {Globe} [options.globe=new Globe(mapProjection.ellipsoid)] The globe to use in the scene.  If set to <code>false</code>, no globe will be added.
      * @param {Boolean} [options.orderIndependentTranslucency=true] If true and the configuration supports it, use order independent translucency.
      * @param {Element|String} [options.creditContainer] The DOM element or ID that will contain the {@link CreditDisplay}.  If not specified, the credits are added to the bottom of the widget itself.
      * @param {DataSourceCollection} [options.dataSources=new DataSourceCollection()] The collection of data sources visualized by the widget.  If this parameter is provided,
@@ -299,13 +299,13 @@ define([
         container = getElement(container);
         options = defaultValue(options, defaultValue.EMPTY_OBJECT);
 
-        var createBaseLayerPicker = !defined(options.baseLayerPicker) || options.baseLayerPicker !== false;
+        var createBaseLayerPicker = (!defined(options.globe) || options.globe !== false) &&
+            (!defined(options.baseLayerPicker) || options.baseLayerPicker !== false);
 
         //>>includeStart('debug', pragmas.debug);
         // If using BaseLayerPicker, globe must be present.
-        if (createBaseLayerPicker && defined(options.globe) && options.globe === false) {
-            throw new DeveloperError('A globe must be available to use the BaseLayerPicker widget. \
-Either ensure options.globe != false, or set options.baseLayerPicker to false.');
+        if (defined(options.globe) && options.globe === false && defined(options.baseLayerPicker) && options.baseLayerPicker === true) {
+            throw new DeveloperError('A globe must be available to use the BaseLayerPicker widget.');
         }
 
         // If using BaseLayerPicker, imageryProvider is an invalid option

--- a/Source/Widgets/Viewer/Viewer.js
+++ b/Source/Widgets/Viewer/Viewer.js
@@ -303,11 +303,6 @@ define([
             (!defined(options.baseLayerPicker) || options.baseLayerPicker !== false);
 
         //>>includeStart('debug', pragmas.debug);
-        // If using BaseLayerPicker, globe must be present.
-        if (defined(options.globe) && options.globe === false && defined(options.baseLayerPicker) && options.baseLayerPicker === true) {
-            throw new DeveloperError('A globe must be available to use the BaseLayerPicker widget.');
-        }
-
         // If using BaseLayerPicker, imageryProvider is an invalid option
         if (createBaseLayerPicker && defined(options.imageryProvider)) {
             throw new DeveloperError('options.imageryProvider is not available when using the BaseLayerPicker widget. \

--- a/Specs/Widgets/CesiumWidget/CesiumWidgetSpec.js
+++ b/Specs/Widgets/CesiumWidget/CesiumWidgetSpec.js
@@ -149,7 +149,6 @@ defineSuite([
 
     it('does not create a globe if option is false', function() {
         widget = new CesiumWidget(container, {
-            imageryProvider : false,
             globe : false
         });
         expect(widget.scene.globe).not.toBeDefined();

--- a/Specs/Widgets/Viewer/ViewerSpec.js
+++ b/Specs/Widgets/Viewer/ViewerSpec.js
@@ -445,8 +445,6 @@ defineSuite([
 
     it('does not create a globe if option is false', function() {
         viewer = new Viewer(container, {
-            imageryProvider : false,
-            baseLayerPicker : false,
             globe : false
         });
         expect(viewer.scene.globe).not.toBeDefined();


### PR DESCRIPTION
This is to address an idea @mramato had in #2535.