### PR TITLE
Fix caching issue with entity geometry

### DIFF
--- a/Source/DataSources/DataSourceDisplay.js
+++ b/Source/DataSources/DataSourceDisplay.js
@@ -96,8 +96,6 @@ define([
         }
 
         var defaultDataSource = new CustomDataSource();
-        var visualizers = this._visualizersCallback(this._scene, defaultDataSource);
-        defaultDataSource._visualizers = visualizers;
         this._onDataSourceAdded(undefined, defaultDataSource);
         this._defaultDataSource = defaultDataSource;
     };

--- a/Source/DataSources/GeometryVisualizer.js
+++ b/Source/DataSources/GeometryVisualizer.js
@@ -178,6 +178,25 @@ define([
         var id;
         var updater;
 
+        for (i = changed.length - 1; i > -1; i--) {
+            entity = changed[i];
+            id = entity.id;
+            updater = this._updaters.get(id);
+
+            //If in a single update, an entity gets removed and a new instance
+            //re-added with the same id, the updater no longer tracks the
+            //correct entity, we need to both remove the old one and
+            //add the new one, which is done by pushing the entity
+            //onto the removed/added lists.
+            if (updater.entity === entity) {
+                removeUpdater(this, updater);
+                insertUpdaterIntoBatch(this, time, updater);
+            } else {
+                removed.push(entity);
+                added.push(entity);
+            }
+        }
+
         for (i = removed.length - 1; i > -1; i--) {
             entity = removed[i];
             id = entity.id;
@@ -196,14 +215,6 @@ define([
             this._updaters.set(id, updater);
             insertUpdaterIntoBatch(this, time, updater);
             this._subscriptions.set(id, updater.geometryChanged.addEventListener(GeometryVisualizer._onGeometryChanged, this));
-        }
-
-        for (i = changed.length - 1; i > -1; i--) {
-            entity = changed[i];
-            id = entity.id;
-            updater = this._updaters.get(id);
-            removeUpdater(this, updater);
-            insertUpdaterIntoBatch(this, time, updater);
         }
 
         addedObjects.removeAll();


### PR DESCRIPTION
If you removed an entity with geometry and then immediately added a new entity with the old entity's id, none of the geometry graphics would ever update because the visualizers had a handle to the old, removed entity.

In addition to the unit test I added, you can use paste the below into Sandcastle, it fails in master (or on the website) but passes in this branch.

```javascript
var viewer = new Cesium.Viewer('cesiumContainer');

var entity = viewer.entities.add({
    id : '1',
    position: Cesium.Cartesian3.fromDegrees(-114.0, 40.0, 300000.0),
    box : {
        dimensions : new Cesium.Cartesian3(400000.0, 300000.0, 500000.0),
        material : Cesium.Color.BLUE
    }
});

Sandcastle.addToolbarButton('Trigger Bug', function(){
    viewer.entities.remove(entity);
    
    entity = viewer.entities.add({
        id : '1',
        position: Cesium.Cartesian3.fromDegrees(-114.0, 40.0, 300000.0),
        box : {
            dimensions : new Cesium.Cartesian3(400000.0, 300000.0, 500000.0),
            material : Cesium.Color.YELLOW
        }
    });
    viewer.zoomTo(entity);
});
```

Also realized we were creating 2 sets of visualizers for the `viewer.entities` object, and then immediately throwing one of them away, the small change to `DataSourceDisplay.js` fixes this.