### PR TITLE
Tweak 2569

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,13 @@ Change Log
 ==========
 
 ### 1.8 -2015-04-01
+* Breaking changes
+  *
+* Deprecated
+  *
+* An exception is now thrown if `Primitive.modelMatrix` is not the identity matrix when in in 2D or Columbus View.
+
+### 1.8 -2015-04-01
 
 * Breaking changes
   * Removed the `eye`, `target`, and `up` parameters to `Camera.lookAt` which were deprecated in Cesium 1.6. Use the `target` and `offset`.
@@ -28,7 +35,6 @@ Change Log
 * Added new construction options to `CesiumWidget` and `Viewer`, for `skyBox`, `skyAtmosphere`, and `globe`.
 * Fixed a bug that prevented Cesium from working in browser configurations that explicitly disabled localStorage, such as Safari's private browsing mode.
 * Cesium is now tested using Jasmine 2.2.0.
-* Exception will be thrown on updating Primitive.modelMatrix in 2D or Columbus View or if it has more than one instance.
 
 ### 1.7.1 - 2015-03-06
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,14 +1,14 @@
 Change Log
 ==========
 
-### 1.8 -2015-04-01
+### 1.9 - 2015-05-01
 * Breaking changes
   *
 * Deprecated
   *
 * An exception is now thrown if `Primitive.modelMatrix` is not the identity matrix when in in 2D or Columbus View.
 
-### 1.8 -2015-04-01
+### 1.8 - 2015-04-01
 
 * Breaking changes
   * Removed the `eye`, `target`, and `up` parameters to `Camera.lookAt` which were deprecated in Cesium 1.6. Use the `target` and `offset`.

--- a/Source/Scene/Primitive.js
+++ b/Source/Scene/Primitive.js
@@ -204,7 +204,7 @@ define([
          * by {@link Transforms.eastNorthUpToFixedFrame}.
          *
          * <p>
-         * If the model matrix is changed after creation, it only affects primitives with one instance and only in 3D mode.
+         * This property is only supported in 3D mode.
          * </p>
          *
          * @type Matrix4
@@ -706,7 +706,7 @@ define([
      *
      * @exception {DeveloperError} All instance geometries must have the same primitiveType.
      * @exception {DeveloperError} Appearance and material have a uniform with the same name.
-     * @exception {DeveloperError} Primitive.modelMatrix is only supported in 3D mode and only for single geometry instances.
+     * @exception {DeveloperError} Primitive.modelMatrix is only supported in 3D mode.
      */
     Primitive.prototype.update = function(context, frameState, commandList) {
         if (((!defined(this.geometryInstances)) && (this._va.length === 0)) ||
@@ -1215,19 +1215,12 @@ define([
             attributes.length = 0;
         }
 
-        var modelMatrix;
-        if ((this._numberOfInstances > 1 && !this._validModelMatrix) || frameState.mode !== SceneMode.SCENE3D) {
-            modelMatrix = Matrix4.IDENTITY;
-
-            //>>includeStart('debug', pragmas.debug);
-            if (!Matrix4.equals(this.modelMatrix, Matrix4.IDENTITY)) {
-                throw new DeveloperError('Primitive.modelMatrix is only supported in 3D mode and only for single geometry instances.');
-            }
-            //>>includeEnd('debug');
-            
-        } else {
-            modelMatrix = this.modelMatrix;
+        var modelMatrix = this.modelMatrix;
+        //>>includeStart('debug', pragmas.debug);
+        if (frameState.mode !== SceneMode.SCENE3D && !Matrix4.equals(modelMatrix, Matrix4.IDENTITY)) {
+            throw new DeveloperError('Primitive.modelMatrix is only supported in 3D mode.');
         }
+        //>>includeEnd('debug');
 
         if (!Matrix4.equals(modelMatrix, this._modelMatrix)) {
             Matrix4.clone(modelMatrix, this._modelMatrix);

--- a/Specs/Scene/PrimitiveSpec.js
+++ b/Specs/Scene/PrimitiveSpec.js
@@ -514,29 +514,6 @@ defineSuite([
         frameState.scene3DOnly = false;
     });
 
-    it('update model matrix throws for more than one instance in 3D with different model matrices', function() {
-        var primitive = new Primitive({
-            geometryInstances : [rectangleInstance1, rectangleInstance2],
-            appearance : new PerInstanceColorAppearance(),
-            asynchronous : false
-        });
-
-        var commands = [];
-        primitive.update(context, frameState, commands);
-        expect(commands.length).toEqual(1);
-        expect(commands[0].modelMatrix).toEqual(Matrix4.IDENTITY);
-
-        var modelMatrix = Matrix4.fromUniformScale(10.0);
-        primitive.modelMatrix = modelMatrix;
-
-        commands.length = 0;
-        expect(function() {
-            primitive.update(context, frameState, commands);
-        }).toThrowDeveloperError();
-
-        primitive = primitive && primitive.destroy();
-    });
-
     it('update model matrix throws in Columbus view', function() {
         var primitive = new Primitive({
             geometryInstances : [rectangleInstance1, rectangleInstance2],


### PR DESCRIPTION
After merging #2569 I realized that our doc has actually been wrong for Primitive for quite some time.  We actually support modifying the `modelMatrix` property even when there is more than one geometry instances, what we don't support is doing anything with `modelMatrix` in 2D/CV modes.  For example, paste this sandcastle example into the website and it works (even though there are two instances in a single batched primitive).  So this change cleans up #2569 but also updates the doc to match the actual behavior.

```javascript
// Create the viewer.
var viewer = new Cesium.Viewer('cesiumContainer');
var scene = viewer.scene;

// Draw a red box and position it on the globe surface.

var dimensions = new Cesium.Cartesian3(400000.0, 300000.0, 500000.0);
// Box geometries are initially centered on the origin.
// We can use a model matrix to position the box on the
// globe surface.
var positionOnEllipsoid = Cesium.Cartesian3.fromDegrees(-105.0, 45.0);
var boxModelMatrix = Cesium.Matrix4.multiplyByTranslation(
    Cesium.Transforms.eastNorthUpToFixedFrame(positionOnEllipsoid),
    new Cesium.Cartesian3(0.0, 0.0, dimensions.z * 0.5), new Cesium.Matrix4());
// Create a box geometry.
var boxGeometry = Cesium.BoxGeometry.fromDimensions({
    vertexFormat : Cesium.PerInstanceColorAppearance.VERTEX_FORMAT,
    dimensions : dimensions
});
// Create a geometry instance using the geometry
// and model matrix created above.
var boxGeometryInstance = new Cesium.GeometryInstance({
    geometry : boxGeometry,
    attributes : {
        color : Cesium.ColorGeometryInstanceAttribute.fromColor(new Cesium.Color(1.0, 0.0, 0.0, 0.5))
    }
});

var boxGeometryInstance2 = new Cesium.GeometryInstance({
    geometry : Cesium.BoxGeometry.fromDimensions({
    vertexFormat : Cesium.PerInstanceColorAppearance.VERTEX_FORMAT,
    dimensions : new Cesium.Cartesian3(400000.0, 150000.0, 250000.0)
}),
    attributes : {
        color : Cesium.ColorGeometryInstanceAttribute.fromColor(new Cesium.Color(0.0, 1.0, 0.0, 0.5))
    }
});
// Add the geometry instance to primitives.
var p = scene.primitives.add(new Cesium.Primitive({
    geometryInstances : [boxGeometryInstance,boxGeometryInstance2],
    modelMatrix : boxModelMatrix,
    appearance : new Cesium.PerInstanceColorAppearance({
        closed: true
    })
}));

var i = 0;
Sandcastle.addToolbarButton('Change', function(){
    i+= 10000;
p.modelMatrix = Cesium.Matrix4.multiplyByTranslation(
    Cesium.Transforms.eastNorthUpToFixedFrame(positionOnEllipsoid),
    new Cesium.Cartesian3(i, 0.0, dimensions.z * 0.5), new Cesium.Matrix4());
});
```