### PR TITLE
Fix Corridor Geometry for sharp corners

### DIFF
--- a/Source/Core/CorridorGeometryLibrary.js
+++ b/Source/Core/CorridorGeometryLibrary.js
@@ -219,7 +219,7 @@ define([
             Cartesian3.subtract(backward, backwardProjection, backwardProjection);
             Cartesian3.normalize(backwardProjection, backwardProjection);
 
-            var doCorner = !CesiumMath.equalsEpsilon(Math.abs(Cartesian3.dot(forwardProjection, backwardProjection)), 1.0, CesiumMath.EPSILON1);
+            var doCorner = !CesiumMath.equalsEpsilon(Math.abs(Cartesian3.dot(forwardProjection, backwardProjection)), 1.0, CesiumMath.EPSILON7);
 
             if (doCorner) {
                 cornerDirection = Cartesian3.cross(cornerDirection, normal, cornerDirection);

--- a/Source/Core/PolylineVolumeGeometryLibrary.js
+++ b/Source/Core/PolylineVolumeGeometryLibrary.js
@@ -350,7 +350,7 @@ define([
             Cartesian3.subtract(backward, backwardProjection, backwardProjection);
             Cartesian3.normalize(backwardProjection, backwardProjection);
 
-            var doCorner = !CesiumMath.equalsEpsilon(Math.abs(Cartesian3.dot(forwardProjection, backwardProjection)), 1.0, CesiumMath.EPSILON1);
+            var doCorner = !CesiumMath.equalsEpsilon(Math.abs(Cartesian3.dot(forwardProjection, backwardProjection)), 1.0, CesiumMath.EPSILON7);
 
             if (doCorner) {
                 cornerDirection = Cartesian3.cross(cornerDirection, surfaceNormal, cornerDirection);

--- a/Specs/Core/CorridorGeometrySpec.js
+++ b/Specs/Core/CorridorGeometrySpec.js
@@ -180,6 +180,24 @@ defineSuite([
         expect(m.indices.length).toEqual(3 * 8);
     });
 
+    it('computes sharp turns', function() {
+        var m = CorridorGeometry.createGeometry(new CorridorGeometry({
+            vertexFormat : VertexFormat.POSITION_ONLY,
+            positions : Cartesian3.fromDegreesArray([
+                 2.00571672577652,52.7781459942399,
+                 1.99188457974115,52.7764958852886,
+                 2.01325961458495,52.7674170680511,
+                 1.98708058340534,52.7733979856253,
+                 2.00634853946644,52.7650460748473
+            ]),
+            cornerType: CornerType.BEVELED,
+            width : 100
+        }));
+
+        expect(m.attributes.position.values.length).toEqual(3 * 13);
+        expect(m.indices.length).toEqual(3 * 11);
+    });
+
     it('computes straight corridors', function() {
         var m = CorridorGeometry.createGeometry(new CorridorGeometry({
             vertexFormat : VertexFormat.POSITION_ONLY,

--- a/Specs/Core/PolylineVolumeGeometrySpec.js
+++ b/Specs/Core/PolylineVolumeGeometrySpec.js
@@ -169,6 +169,24 @@ defineSuite([
         expect(m.indices.length).toEqual(3 * (8 * 2 + 4 * 7 * 2 + 4));
     });
 
+    it('computes sharp turns', function() {
+        var m = PolylineVolumeGeometry.createGeometry(new PolylineVolumeGeometry({
+            vertexFormat : VertexFormat.POSITION_ONLY,
+            polylinePositions : Cartesian3.fromDegreesArrayHeights([
+                 2.00571672577652, 52.7781459942399, 500,
+                 1.99188457974115, 52.7764958852886, 500,
+                 2.01325961458495, 52.7674170680511, 500,
+                 1.98708058340534, 52.7733979856253, 500,
+                 2.00634853946644, 52.7650460748473, 500
+            ]),
+            cornerType: CornerType.BEVELED,
+            shapePositions: shape
+        }));
+
+        expect(m.attributes.position.values.length).toEqual(360);
+        expect(m.indices.length).toEqual(324);
+    });
+
     it('computes straight volume', function() {
         var m = PolylineVolumeGeometry.createGeometry(new PolylineVolumeGeometry({
             vertexFormat : VertexFormat.POSITION_ONLY,


### PR DESCRIPTION
As reported on [the forum](https://groups.google.com/d/msg/cesium-dev/conwnTxfDkk/9Z3I8pdTv2cJ). The below code was generating an incorrect shape.  I traced the problem down to a bad epsilon value in `CorridorGeometryLibrary`.  I'm not at all confident in this area of the code, so @bagnell please double check my work.  I also wasn't sure how to test it, so I just mimicked the other tests.

Should we have a single constant defined somewhere for all geometry epsilon checking?

```javascript
var viewer = new Cesium.Viewer('cesiumContainer');

var blueCorridor = viewer.entities.add({
    name : 'Blue corridor',
    corridor : {
        positions : Cesium.Cartesian3.fromDegreesArray([
            2.00571672577652,52.7781459942399,
            1.99188457974115,52.7764958852886,
            2.01325961458495,52.7674170680511,
            1.98708058340534,52.7733979856253,
            2.00634853946644,52.7650460748473
        ]),
        height : 1000.0,
        extrudedHeight : 50.0,
        width : 100.0,
        cornerType: Cesium.CornerType.MITERED,
        material : Cesium.Color.BLUE.withAlpha(0.5),
        outline : true,
        outlineColor : Cesium.Color.BLUE
    }
});


var polyline = viewer.entities.add({
    name : 'Polyline',
    polyline : {
        positions : Cesium.Cartesian3.fromDegreesArray([
            2.00571672577652,52.7781459942399,
            1.99188457974115,52.7764958852886,
            2.01325961458495,52.7674170680511,
            1.98708058340534,52.7733979856253,
            2.00634853946644,52.7650460748473
        ]),
        height : 1000.0,
        width : 10.0,
        material : Cesium.Color.RED.withAlpha(0.5)
    }
});

viewer.zoomTo(viewer.entities);
```