### PR TITLE
Fix crash when adding and removing a billboard before next update.

### DIFF
--- a/Source/Scene/BillboardCollection.js
+++ b/Source/Scene/BillboardCollection.js
@@ -1015,6 +1015,8 @@ define([
      * @exception {RuntimeError} image with id must be in the atlas.
      */
     BillboardCollection.prototype.update = function(context, frameState, commandList) {
+        removeBillboards(this);
+
         var billboards = this._billboards;
         var billboardsLength = billboards.length;
 
@@ -1036,7 +1038,6 @@ define([
             return;
         }
 
-        removeBillboards(this);
         updateMode(this, frameState);
 
         billboards = this._billboards;

--- a/Specs/Scene/BillboardCollectionSpec.js
+++ b/Specs/Scene/BillboardCollectionSpec.js
@@ -122,6 +122,12 @@ defineSuite([
         expect(b.id).not.toBeDefined();
     });
 
+    it('can add and remove before first update.', function() {
+        var b = billboards.add();
+        billboards.remove(b);
+        billboards.update(context, frameState, []);
+    });
+
     it('explicitly constructs a billboard', function() {
         var b = billboards.add({
             show : false,


### PR DESCRIPTION
As [reported on the forum](https://groups.google.com/d/msg/cesium-dev/Ti4jLsugBq4/13Qo5_daa68J), adding and then removing a billboard before the collection is updated causes a crash because we don't remove the billboards before trying to recreate the atlas (and then we call `loadImage` on the destroyed billboard).  The new test I added fails in master but  passes in this branch.