### PR TITLE
Fix Material caching issue

### DIFF
--- a/Source/Scene/Material.js
+++ b/Source/Scene/Material.js
@@ -416,7 +416,7 @@ define([
                 texture = context.createTexture2D({
                     source : image
                 });
-                Material._textureCache.addTexture(this._texturePaths[uniformId], texture);
+                Material._textureCache.addTexture(this._texturePaths[uniformId], texture, image);
             }
 
             this._textures[uniformId] = texture;
@@ -451,7 +451,7 @@ define([
                         negativeZ : images[5]
                     }
                 });
-                Material._textureCache.addTexture(this._texturePaths[uniformId], cubeMap);
+                Material._textureCache.addTexture(this._texturePaths[uniformId], cubeMap, images);
             }
 
             this._textures[uniformId] = cubeMap;
@@ -702,6 +702,10 @@ define([
                 if (defined(newTexture)) {
                     Material._textureCache.releaseTexture(material._texturePaths[uniformId]);
                     material._textures[uniformId] = newTexture;
+                    material._loadedImages.push({
+                        id : uniformId,
+                        image : Material._textureCache.getTextureSource(uniformValue)
+                    });
                 } else {
                     when(loadImage(uniformValue), function(image) {
                         material._loadedImages.push({
@@ -746,6 +750,10 @@ define([
                 if (defined(newTexture)) {
                     Material._textureCache.releaseTexture(material._texturePaths[uniformId]);
                     material._textures[uniformId] = newTexture;
+                    material._loadedCubeMaps.push({
+                        id : uniformId,
+                        images : Material._textureCache.getTextureSource(path)
+                    });
                 } else {
                     var promises = [
                         loadImage(uniformValue.positiveX),
@@ -943,10 +951,11 @@ define([
     Material._textureCache = {
         _textures : {},
 
-        addTexture : function(path, texture) {
+        addTexture : function(path, texture, source) {
             this._textures[path] = {
                 texture : texture,
-                count : 1
+                count : 1,
+                source : source
             };
         },
 
@@ -956,6 +965,16 @@ define([
             if (defined(entry)) {
                 entry.count++;
                 return entry.texture;
+            }
+
+            return undefined;
+        },
+
+        getTextureSource : function(path) {
+            var entry = this._textures[path];
+
+            if (defined(entry)) {
+                return entry.source;
             }
 
             return undefined;


### PR DESCRIPTION
Run the below code in Sandcastle, hit the first button, wait for it to load, then his the second button.  In master the second polygon will be gray, in this branch both polygons will have the proper texture.  The problem is that in master, neither the `_loadedImages` or `_loadedCubeMaps` arrays are being properly populated when the image was already in the texture cache.  In order to fix this I had to keep the source images around in the cache as well and add them to the proper collection when a cache hit occurs.

There also appears to be a race condition in Material, which I'll write up a second issue for.  Basically if you hit the buttons below quickly (or just add them both in the same function instead of having 2 buttons) everything works.  This is because Material actually loads the same image twice, rather than keeping a promise to the image from the first request.  Looking at the Material code, there are most likely additional bugs as well, we should really look into refactoring the entire object.

```javascript
Cesium.Material._materialCache.addMaterial('Wallpaper', {
    fabric : {
        type : 'Wallpaper',
        uniforms : {
            image : Cesium.Material.DefaultImageId,
            anchor : new Cesium.Cartesian2(0, 0)
        },
        components : {
            diffuse : 'texture2D(image, fract((gl_FragCoord.xy - anchor.xy) / vec2(imageDimensions.xy))).rgb',
            alpha : 'texture2D(image, fract((gl_FragCoord.xy - anchor.xy) / vec2(imageDimensions.xy))).a'
        }
    },
    translucent : false
});

var WallPaperMaterialProperty = function(scene, image, anchor) {
    this._scene = scene;
    this._image = image;
    this._anchor = anchor;
    this.definitionChanged = new Cesium.Event();
    this.isConstant = true;
};

WallPaperMaterialProperty.prototype.getType = function(time) {
    return 'Wallpaper';
};

WallPaperMaterialProperty.prototype.getValue = function(time, result) {
    if (!Cesium.defined(result)) {
        result = {
            image : undefined,
            anchor : undefined
        };
    }
    result.image = this._image;
    result.anchor = Cesium.SceneTransforms.wgs84ToDrawingBufferCoordinates(this._scene, this._anchor, result.anchor);
    if (Cesium.defined(result.anchor)) {
        result.anchor.x = Math.floor(result.anchor.x);
        result.anchor.y = Math.floor(result.anchor.y);
    } else {
        result.anchor = new Cesium.Cartesian2(0, 0);
    }
    return result;
};

WallPaperMaterialProperty.prototype.equals = function(other) {
    return this === other || //
    (other instanceof WallPaperMaterialProperty && //
    this._image === other._image);
};

var viewer = new Cesium.Viewer('cesiumContainer');

Sandcastle.addToolbarButton('Test1', function() {
    var customDataSource1 = new Cesium.CustomDataSource("testing");
    viewer.dataSources.add(customDataSource1);
    var customRectangle = customDataSource1.entities.add({
        id : "rect1",
        rectangle : {
            coordinates : Cesium.Rectangle.fromDegrees(-119, 44, -112, 47),
            material : new WallPaperMaterialProperty(viewer.scene, "../images/checkerboard.png", Cesium.Cartesian3.fromDegrees(-119, 44))
        }
    });

});

Sandcastle.addToolbarButton('Test2', function() {
    var customRectangle2 = viewer.entities.add({
        id : "rect2",
        rectangle : {
            coordinates : Cesium.Rectangle.fromDegrees(-110.0, 20.0, -80.0, 25.0),
            material : new WallPaperMaterialProperty(viewer.scene, "../images/checkerboard.png", Cesium.Cartesian3.fromDegrees(-110, 20))
        }
    });
});
```