### PR TITLE
Fix crash when modifying a translucent entity outline.

### DIFF
--- a/Source/DataSources/StaticOutlineGeometryBatch.js
+++ b/Source/DataSources/StaticOutlineGeometryBatch.js
@@ -253,7 +253,7 @@ define([
         var translucentBatches = this._translucentBatches.values;
         var translucentBatchesLength = translucentBatches.length;
         for (i = 0; i < translucentBatchesLength; i++) {
-            if (translucentBatches.remove(updater)) {
+            if (translucentBatches[i].remove(updater)) {
                 return;
             }
         }

--- a/Specs/DataSources/GeometryVisualizerSpec.js
+++ b/Specs/DataSources/GeometryVisualizerSpec.js
@@ -327,6 +327,53 @@ defineSuite([
         });
     });
 
+    it('Correctly handles modifying translucent outline color', function() {
+        var entities = new EntityCollection();
+        var visualizer = new GeometryVisualizer(EllipseGeometryUpdater, scene, entities);
+
+        var color = Color.BLUE.withAlpha(0.5);
+        var entity = entities.add({
+            position : new Cartesian3(1234, 5678, 9101112),
+            ellipse : {
+                semiMajorAxis : 2,
+                semiMinorAxis : 1,
+                fill : false,
+                outline : true,
+                outlineColor : color
+            }
+        });
+
+        return pollToPromise(function() {
+            scene.initializeFrame();
+            var isUpdated = visualizer.update(time);
+            scene.render(time);
+            return isUpdated;
+        }).then(function() {
+            var primitive = scene.primitives.get(0);
+            var attributes = primitive.getGeometryInstanceAttributes(entity);
+            expect(attributes).toBeDefined();
+            expect(attributes.color).toEqual(ColorGeometryInstanceAttribute.toValue(color));
+
+            color = Color.RED.withAlpha(0.5);
+            entity.ellipse.outlineColor.setValue(color);
+
+            return pollToPromise(function() {
+                scene.initializeFrame();
+                var isUpdated = visualizer.update(time);
+                scene.render(time);
+                return isUpdated;
+            });
+        }).then(function() {
+            var primitive = scene.primitives.get(0);
+            var attributes = primitive.getGeometryInstanceAttributes(entity);
+            expect(attributes).toBeDefined();
+            expect(attributes.color).toEqual(ColorGeometryInstanceAttribute.toValue(color));
+
+            entities.remove(entity);
+            visualizer.destroy();
+        });
+    });
+
     it('Creates and removes dynamic geometry', function() {
         var objects = new EntityCollection();
         var visualizer = new GeometryVisualizer(EllipseGeometryUpdater, scene, objects);


### PR DESCRIPTION
The code for removing items wasn't covered in the unit tests and we were missing an array indexer. New test crashes in master, passes in this branch.