### PR TITLE
Fix KML wrapping GroundOverlays

### DIFF
--- a/Source/DataSources/KmlDataSource.js
+++ b/Source/DataSources/KmlDataSource.js
@@ -1413,13 +1413,13 @@ define([
                 var north = queryNumericValue(latLonBox, 'north', namespaces.kml);
 
                 if (defined(west)) {
-                    west = CesiumMath.convertLongitudeRange(CesiumMath.toRadians(west));
+                    west = CesiumMath.negativePiToPi(CesiumMath.toRadians(west));
                 }
                 if (defined(south)) {
                     south = CesiumMath.negativePiToPi(CesiumMath.toRadians(south));
                 }
                 if (defined(east)) {
-                    east = CesiumMath.convertLongitudeRange(CesiumMath.toRadians(east));
+                    east = CesiumMath.negativePiToPi(CesiumMath.toRadians(east));
                 }
                 if (defined(north)) {
                     north = CesiumMath.negativePiToPi(CesiumMath.toRadians(north));

--- a/Specs/DataSources/KmlDataSourceSpec.js
+++ b/Specs/DataSources/KmlDataSourceSpec.js
@@ -668,6 +668,24 @@ defineSuite([
         });
     });
 
+    it('GroundOverlay: Handles wrapping longitude.', function() {
+        var kml = '<?xml version="1.0" encoding="UTF-8"?>\
+        <GroundOverlay>\
+            <LatLonBox>\
+                <west>-180</west>\
+                <south>-90</south>\
+                <east>180</east>\
+                <north>90</north>\
+            </LatLonBox>\
+        </GroundOverlay>';
+
+        return KmlDataSource.load(parser.parseFromString(kml, "text/xml")).then(function(dataSource) {
+            var entity = dataSource.entities.values[0];
+            expect(entity.polygon).toBeUndefined();
+            expect(entity.rectangle.coordinates.getValue()).toEqual(Rectangle.fromDegrees(-180, -90, 180, 90));
+        });
+    });
+
     it('GroundOverlay: Sets polygon coordinates for gx:LatLonQuad', function() {
         var kml = '<?xml version="1.0" encoding="UTF-8"?>\
         <GroundOverlay xmlns="http://www.opengis.net/kml/2.2"\


### PR DESCRIPTION
Replace `convertLongitudeRange` with `negativePiToPi` as discussed in #2624.

Fixes #2624