### PR TITLE
Fix entity.show handling for static geometry with dynamic attributes

### DIFF
--- a/Source/DataSources/StaticGeometryColorBatch.js
+++ b/Source/DataSources/StaticGeometryColorBatch.js
@@ -124,12 +124,10 @@ define([
                     }
                 }
 
-                if (!updater.hasConstantFill) {
-                    var show = updater.entity.isShowing && updater.isFilled(time);
-                    var currentShow = attributes.show[0] === 1;
-                    if (show !== currentShow) {
-                        attributes.show = ShowGeometryInstanceAttribute.toValue(show, attributes.show);
-                    }
+                var show = updater.entity.isShowing && (updater.hasConstantFill || updater.isFilled(time));
+                var currentShow = attributes.show[0] === 1;
+                if (show !== currentShow) {
+                    attributes.show = ShowGeometryInstanceAttribute.toValue(show, attributes.show);
                 }
             }
 

--- a/Source/DataSources/StaticGeometryPerMaterialBatch.js
+++ b/Source/DataSources/StaticGeometryPerMaterialBatch.js
@@ -136,12 +136,10 @@ define([
                     this.attributes.set(instance.id.id, attributes);
                 }
 
-                if (!updater.hasConstantFill) {
-                    var show = entity.isShowing && updater.isFilled(time);
-                    var currentShow = attributes.show[0] === 1;
-                    if (show !== currentShow) {
-                        attributes.show = ShowGeometryInstanceAttribute.toValue(show, attributes.show);
-                    }
+                var show = entity.isShowing && (updater.hasConstantFill || updater.isFilled(time));
+                var currentShow = attributes.show[0] === 1;
+                if (show !== currentShow) {
+                    attributes.show = ShowGeometryInstanceAttribute.toValue(show, attributes.show);
                 }
             }
 

--- a/Source/DataSources/StaticOutlineGeometryBatch.js
+++ b/Source/DataSources/StaticOutlineGeometryBatch.js
@@ -129,12 +129,10 @@ define([
                     }
                 }
 
-                if (!updater.hasConstantOutline) {
-                    var show = updater.entity.isShowing && updater.isOutlineVisible(time);
-                    var currentShow = attributes.show[0] === 1;
-                    if (show !== currentShow) {
-                        attributes.show = ShowGeometryInstanceAttribute.toValue(show, attributes.show);
-                    }
+                var show = updater.entity.isShowing && (updater.hasConstantOutline || updater.isOutlineVisible(time));
+                var currentShow = attributes.show[0] === 1;
+                if (show !== currentShow) {
+                    attributes.show = ShowGeometryInstanceAttribute.toValue(show, attributes.show);
                 }
             }
 

--- a/Specs/DataSources/GeometryVisualizerSpec.js
+++ b/Specs/DataSources/GeometryVisualizerSpec.js
@@ -18,6 +18,7 @@ defineSuite([
         'DataSources/GridMaterialProperty',
         'DataSources/SampledProperty',
         'DataSources/StaticGeometryPerMaterialBatch',
+        'Specs/createDynamicProperty',
         'Specs/createScene',
         'Specs/pollToPromise'
     ], function(
@@ -39,6 +40,7 @@ defineSuite([
         GridMaterialProperty,
         SampledProperty,
         StaticGeometryPerMaterialBatch,
+        createDynamicProperty,
         createScene,
         pollToPromise) {
     "use strict";
@@ -595,4 +597,136 @@ defineSuite([
         });
     });
 
+    it('Sets static geometry  primitive show attribute when using dynamic fill color', function() {
+        var entities = new EntityCollection();
+        var visualizer = new GeometryVisualizer(EllipseGeometryUpdater, scene, entities);
+
+        var entity = entities.add({
+            position : new Cartesian3(1234, 5678, 9101112),
+            ellipse : {
+                semiMajorAxis : 2,
+                semiMinorAxis : 1,
+                material : new ColorMaterialProperty(createDynamicProperty(Color.BLUE))
+            }
+        });
+
+        return pollToPromise(function() {
+            scene.initializeFrame();
+            var isUpdated = visualizer.update(time);
+            scene.render(time);
+            return isUpdated;
+        }).then(function() {
+            var primitive = scene.primitives.get(0);
+            var attributes = primitive.getGeometryInstanceAttributes(entity);
+            expect(attributes).toBeDefined();
+            expect(attributes.show).toEqual(ShowGeometryInstanceAttribute.toValue(true));
+
+            entity.show = false;
+
+            return pollToPromise(function() {
+                scene.initializeFrame();
+                var isUpdated = visualizer.update(time);
+                scene.render(time);
+                return isUpdated;
+            });
+        }).then(function() {
+            var primitive = scene.primitives.get(0);
+            var attributes = primitive.getGeometryInstanceAttributes(entity);
+            expect(attributes).toBeDefined();
+            expect(attributes.show).toEqual(ShowGeometryInstanceAttribute.toValue(false));
+
+            entities.remove(entity);
+            visualizer.destroy();
+        });
+    });
+
+    it('Sets static geometry  primitive show attribute when using dynamic outline color', function() {
+        var entities = new EntityCollection();
+        var visualizer = new GeometryVisualizer(EllipseGeometryUpdater, scene, entities);
+
+        var entity = entities.add({
+            position : new Cartesian3(1234, 5678, 9101112),
+            ellipse : {
+                semiMajorAxis : 2,
+                semiMinorAxis : 1,
+                fill : false,
+                outline : true,
+                outlineColor : createDynamicProperty(Color.BLUE)
+            }
+        });
+
+        return pollToPromise(function() {
+            scene.initializeFrame();
+            var isUpdated = visualizer.update(time);
+            scene.render(time);
+            return isUpdated;
+        }).then(function() {
+            var primitive = scene.primitives.get(0);
+            var attributes = primitive.getGeometryInstanceAttributes(entity);
+            expect(attributes).toBeDefined();
+            expect(attributes.show).toEqual(ShowGeometryInstanceAttribute.toValue(true));
+
+            entity.show = false;
+
+            return pollToPromise(function() {
+                scene.initializeFrame();
+                var isUpdated = visualizer.update(time);
+                scene.render(time);
+                return isUpdated;
+            });
+        }).then(function() {
+            var primitive = scene.primitives.get(0);
+            var attributes = primitive.getGeometryInstanceAttributes(entity);
+            expect(attributes).toBeDefined();
+            expect(attributes.show).toEqual(ShowGeometryInstanceAttribute.toValue(false));
+
+            entities.remove(entity);
+            visualizer.destroy();
+        });
+    });
+
+    it('Sets static geometry primitive show attribute when using dynamic fill material', function() {
+        var entities = new EntityCollection();
+        var visualizer = new GeometryVisualizer(EllipseGeometryUpdater, scene, entities);
+
+        var entity = entities.add({
+            position : new Cartesian3(1234, 5678, 9101112),
+            ellipse : {
+                semiMajorAxis : 2,
+                semiMinorAxis : 1,
+                material : new GridMaterialProperty({
+                    color : createDynamicProperty(Color.BLUE)
+                })
+            }
+        });
+
+        return pollToPromise(function() {
+            scene.initializeFrame();
+            var isUpdated = visualizer.update(time);
+            scene.render(time);
+            return isUpdated;
+        }).then(function() {
+            var primitive = scene.primitives.get(0);
+            var attributes = primitive.getGeometryInstanceAttributes(entity);
+            expect(attributes).toBeDefined();
+            expect(attributes.show).toEqual(ShowGeometryInstanceAttribute.toValue(true));
+
+            entity.show = false;
+
+            return pollToPromise(function() {
+                scene.initializeFrame();
+                var isUpdated = visualizer.update(time);
+                scene.render(time);
+                return isUpdated;
+            });
+        }).then(function() {
+            var primitive = scene.primitives.get(0);
+            var attributes = primitive.getGeometryInstanceAttributes(entity);
+            expect(attributes).toBeDefined();
+            expect(attributes.show).toEqual(ShowGeometryInstanceAttribute.toValue(false));
+
+            entities.remove(entity);
+            visualizer.destroy();
+        });
+    });
 }, 'WebGL');


### PR DESCRIPTION
Setting entity.show would have no affect for static geometry if the outlineColor or material was dynamic.  This was an bad optimization on my part. Fixed the code and added unit tests to cover it.