### PR TITLE
Prevent the overlay list from being doubled.

### DIFF
--- a/Source/Scene/Scene.js
+++ b/Source/Scene/Scene.js
@@ -983,6 +983,7 @@ define([
         if (near !== Number.MAX_VALUE && (numFrustums !== numberOfFrustums || (frustumCommandsList.length !== 0 &&
                 (near < frustumCommandsList[0].near || far > frustumCommandsList[numberOfFrustums - 1].far)))) {
             updateFrustums(near, far, farToNearRatio, numFrustums, frustumCommandsList);
+            overlayList.length = 0;
             createPotentiallyVisibleSet(scene);
         }
     }

--- a/Source/Scene/Scene.js
+++ b/Source/Scene/Scene.js
@@ -916,6 +916,7 @@ define([
                 frustumCommandsList[n].indices[p] = 0;
             }
         }
+        overlayList.length = 0;
 
         var near = Number.MAX_VALUE;
         var far = Number.MIN_VALUE;
@@ -983,7 +984,6 @@ define([
         if (near !== Number.MAX_VALUE && (numFrustums !== numberOfFrustums || (frustumCommandsList.length !== 0 &&
                 (near < frustumCommandsList[0].near || far > frustumCommandsList[numberOfFrustums - 1].far)))) {
             updateFrustums(near, far, farToNearRatio, numFrustums, frustumCommandsList);
-            overlayList.length = 0;
             createPotentiallyVisibleSet(scene);
         }
     }


### PR DESCRIPTION
The `Scene` class has a helper called `createPotentiallyVisibleSet` that calls itself if the view frustums have changed since the last frame.  However, this helper always adds all overlay draw commands, doubling up the number of overlay draw commands when this takes place.

This change zeros out the overlay command list prior to re-creating the potentiallyVisibleSet.  Not sure if this is the right or best way to fix this.

Fixes #2642.