### PR TITLE
Fix `Entity.viewFrom`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@ Change Log
 * Deprecated
   *
 * An exception is now thrown if `Primitive.modelMatrix` is not the identity matrix when in in 2D or Columbus View.
+* Fix a bug which caused `Entity.viewFrom` to be ignored when flying to, zooming to, or tracking an Entity.
 
 ### 1.8 - 2015-04-01
 

--- a/Source/DataSources/EntityView.js
+++ b/Source/DataSources/EntityView.js
@@ -220,8 +220,9 @@ define([
         this._lastEntity = undefined;
         this._mode = undefined;
 
-        //Re-usable objects to be used for retrieving position.
         this._lastCartesian = new Cartesian3();
+        this._defaultOffset3D = undefined;
+        this._defaultOffset2D = undefined;
 
         this._offset3D = new Cartesian3();
         this._offset2D = new HeadingPitchRange();
@@ -294,15 +295,17 @@ define([
         var updateLookAt = objectChanged || sceneModeChanged;
         if (objectChanged) {
             var viewFromProperty = entity.viewFrom;
+            var hasViewFrom = defined(viewFromProperty);
             var sphere = this.boundingSphere;
             this._boundingSphereOffset = undefined;
-            if (defined(sphere)) {
+
+            if (!hasViewFrom && defined(sphere)) {
                 var controller = scene.screenSpaceCameraController;
                 controller.minimumZoomDistance = Math.min(controller.minimumZoomDistance, sphere.radius * 0.5);
                 camera.viewBoundingSphere(sphere);
                 this._boundingSphereOffset = Cartesian3.subtract(sphere.center, entity.position.getValue(time), new Cartesian3());
                 updateLookAt = false;
-            } else if (!defined(viewFromProperty) || !defined(viewFromProperty.getValue(time, offset3D))) {
+            } else if (!hasViewFrom || !defined(viewFromProperty.getValue(time, offset3D))) {
                 HeadingPitchRange.clone(EntityView._defaultOffset2D, offset2D);
                 Cartesian3.clone(EntityView._defaultOffset3D, offset3D);
             } else {

--- a/Specs/DataSources/EntityViewSpec.js
+++ b/Specs/DataSources/EntityViewSpec.js
@@ -1,6 +1,7 @@
 /*global defineSuite*/
 defineSuite([
         'DataSources/EntityView',
+        'Core/BoundingSphere',
         'Core/Cartesian3',
         'Core/Ellipsoid',
         'Core/JulianDate',
@@ -9,6 +10,7 @@ defineSuite([
         'Specs/createScene'
     ], function(
         EntityView,
+        BoundingSphere,
         Cartesian3,
         Ellipsoid,
         JulianDate,
@@ -19,9 +21,14 @@ defineSuite([
     /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn*/
 
     var scene;
+    var defaultOffset = EntityView.defaultOffset3D;
 
     beforeAll(function() {
         scene = createScene();
+    });
+
+    beforeEach(function() {
+        EntityView.defaultOffset3D = defaultOffset.clone();
     });
 
     afterAll(function() {
@@ -51,8 +58,37 @@ defineSuite([
         entity.position = new ConstantPositionProperty(Cartesian3.fromDegrees(0.0, 0.0));
         var view = new EntityView(entity, scene);
         view.update(JulianDate.now());
-        expect(Cartesian3.equalsEpsilon(EntityView.defaultOffset3D, sampleOffset, 1e-10)).toBe(true);
-        expect(Cartesian3.equalsEpsilon(view.scene.camera.position, sampleOffset, 1e-10)).toBe(true);
+        expect(EntityView.defaultOffset3D).toEqualEpsilon(sampleOffset, 1e-10);
+        expect(view.scene.camera.position).toEqualEpsilon(sampleOffset, 1e-10);
+    });
+
+    it('uses entity viewFrom', function() {
+        var sampleOffset = new Cartesian3(1, 2, 3);
+        var entity = new Entity();
+        entity.position = new ConstantPositionProperty(Cartesian3.fromDegrees(0.0, 0.0));
+        entity.viewFrom = sampleOffset;
+        var view = new EntityView(entity, scene);
+        view.update(JulianDate.now());
+        expect(view.scene.camera.position).toEqualEpsilon(sampleOffset, 1e-10);
+    });
+
+    it('uses entity bounding sphere', function() {
+        var sampleOffset = new Cartesian3(-1.3322676295501878e-15, -7.348469228349534, 7.3484692283495345);
+        var entity = new Entity();
+        entity.position = new ConstantPositionProperty(Cartesian3.fromDegrees(0.0, 0.0));
+        var view = new EntityView(entity, scene, undefined, new BoundingSphere(new Cartesian3(3, 4, 5), 6));
+        view.update(JulianDate.now());
+        expect(view.scene.camera.position).toEqualEpsilon(sampleOffset, 1e-10);
+    });
+
+    it('uses entity viewFrom if available and boundingsphere is supplied', function() {
+        var sampleOffset = new Cartesian3(1, 2, 3);
+        var entity = new Entity();
+        entity.position = new ConstantPositionProperty(Cartesian3.fromDegrees(0.0, 0.0));
+        entity.viewFrom = sampleOffset;
+        var view = new EntityView(entity, scene, undefined, new BoundingSphere(new Cartesian3(3, 4, 5), 6));
+        view.update(JulianDate.now());
+        expect(view.scene.camera.position).toEqualEpsilon(sampleOffset, 1e-10);
     });
 
     it('update throws without time parameter', function() {


### PR DESCRIPTION
`Entity.viewFrom` has been broken since 1.6.  This fixes the logic so that it gets used again.  I also added tests for better coverage. 2 out of the 3 should fail in master without these changes.