### PR TITLE
Add quantized-mesh MIME type

### DIFF
--- a/web.config
+++ b/web.config
@@ -24,6 +24,8 @@
             <mimeMap fileExtension=".kmz" mimeType="application/vnd.google-earth.kmz" />
             <remove fileExtension=".svg" />
             <mimeMap fileExtension=".svg" mimeType="image/svg+xml" />
+            <remove fileExtension=".terrain" />
+            <mimeMap fileExtension=".terrain" mimeType="application/vnd.quantized-mesh" />
         </staticContent>
     </system.webServer>
 </configuration>


### PR DESCRIPTION
Running our unit tests under IIS would fail because the test terrain tiles could not be served. Fixes #2651