### PR TITLE
Fix Geocoder styling issue in Safari.

### DIFF
--- a/Source/Widgets/Geocoder/Geocoder.css
+++ b/Source/Widgets/Geocoder/Geocoder.css
@@ -15,6 +15,7 @@
     -webkit-transition: width ease-in-out 0.25s, background-color 0.2s ease-in-out;
     -moz-transition: width ease-in-out 0.25s, background-color 0.2s ease-in-out;
     transition: width ease-in-out 0.25s, background-color 0.2s ease-in-out;
+    -webkit-appearance: none;
 }
 
 .cesium-viewer-geocoderContainer:hover .cesium-geocoder-input {


### PR DESCRIPTION
In order to properly style text input fields in Safari, you need to specify the `-webkit-appearance: none;` style.

Fixes #2658