### PR TITLE
Fix undefined reference

### DIFF
--- a/Source/Scene/CameraEventAggregator.js
+++ b/Source/Scene/CameraEventAggregator.js
@@ -71,7 +71,6 @@ define([
             aggregator._buttonsDown++;
             isDown[key] = true;
             pressTime[key] = new Date();
-            Cartesian2.clone(event.position, eventStartPosition[key]);
         }, ScreenSpaceEventType.PINCH_START, modifier);
 
         aggregator._eventHandler.setInputAction(function() {
@@ -418,7 +417,7 @@ define([
         }
         //>>includeEnd('debug');
 
-        if (type === CameraEventType.WHEEL) {
+        if (type === CameraEventType.WHEEL || type === CameraEventType.PINCH) {
             return this._currentMousePosition;
         }
 

--- a/Source/Scene/ScreenSpaceCameraController.js
+++ b/Source/Scene/ScreenSpaceCameraController.js
@@ -1687,13 +1687,7 @@ define([
      */
     ScreenSpaceCameraController.prototype.destroy = function() {
         this._tweens.removeAll();
-        this._spinHandler = this._spinHandler && this._spinHandler.destroy();
-        this._translateHandler = this._translateHandler && this._translateHandler.destroy();
-        this._lookHandler = this._lookHandler && this._lookHandler.destroy();
-        this._rotateHandler = this._rotateHandler && this._rotateHandler.destroy();
-        this._zoomHandler = this._zoomHandler && this._zoomHandler.destroy();
-        this._zoomWheelHandler = this._zoomWheelHandler && this._zoomWheelHandler.destroy();
-        this._pinchHandler = this._pinchHandler && this._pinchHandler.destroy();
+        this._aggregator = this._aggregator && this._aggregator.destroy();
         return destroyObject(this);
     };
 


### PR DESCRIPTION
Good catch by @jbo023.  The `eventStartPosition` is meaningless for PINCH like it is for WHEEL, so I've applied the WHEEL behavior here.  I don't see any difference on our old ASUS tablet, but it's pretty outdated now.

Along the way I also found and fixed some obsolete code in `ScreenSpaceCameraController.destroy`.

Fixes #2664.