### PR TITLE
Correct interpolation of headings/angles 

### DIFF
--- a/Source/DataSources/Angle.js
+++ b/Source/DataSources/Angle.js
@@ -1,0 +1,97 @@
+/*global define*/
+define([
+        '../Core/defaultValue',
+        '../Core/defined',
+        '../Core/defineProperties',
+        '../Core/DeveloperError',
+        '../Core/Event'
+    ], function(
+        defaultValue,
+        defined,
+        defineProperties,
+        DeveloperError,
+        Event) {
+    "use strict";
+
+    /**
+     * A property type whose value is always interpolated by taking the the shortest distances between 2 angles.
+
+     *
+     * @alias ConstantProperty
+     * @constructor
+     *
+     * @param {Object} [value] The property value.
+     *
+     * @see ConstantPositionProperty
+     *
+     * @exception {DeveloperError} value.clone is a required function.
+     * @exception {DeveloperError} value.equals is a required function.
+     */
+
+    //A value that always interpolates the shortest distances between 2 angles.
+    var Angle = {
+        packedLength : 1,
+        packedInterpolationLength : 1,
+        pack : function(value, array, startingIndex) {
+            startingIndex = defaultValue(startingIndex, 0);
+            array[startingIndex] = value;
+        },
+        unpack : function(array, startingIndex, result) {
+            startingIndex = defaultValue(startingIndex, 0);
+
+            if (!array.length) {
+                result = array;
+            } else {
+                result = array[startingIndex];
+            }
+
+            return result;
+        },
+        convertPackedArrayForInterpolation : function(packedArray, startingIndex, lastIndex, result) {
+            for (var i = 0, len = lastIndex - startingIndex + 1; i < len; i++) {
+                result[i] = packedArray[startingIndex + i];
+            }
+        },
+
+        unpackInterpolationResult : function(value, sourceArray, firstIndex, lastIndex, result) {
+
+        //shortest_angle=((((end - start) % 360) + 540) % 360) - 180;
+        //return shortest_angle * amount;
+
+            var start = sourceArray[firstIndex];
+            var end = sourceArray[lastIndex];
+            var difference = Math.abs(end - start);
+            var angle180 = Math.PI / 2;
+            
+            var delta = value / difference;
+
+            if(difference > angle180) {
+
+               if (start<angle180) {
+                   end = end - (360.0 * Math.PI / 180);
+               } else
+               if (start>=angle180) {
+                   delta = 1.0 - delta;
+                   start = start - (360.0 * Math.PI / 180);
+               }
+
+               result = (start * (1.0-delta) + end * delta);
+
+               if (result<0) {
+                result = result + (360.0 * Math.PI / 180);
+               }
+
+            } else {
+                result = (start * (1.0-delta) + end * delta);
+            }
+            
+            return result;
+        },
+
+        defaultValue: function(czmlInterval){
+            return defaultValue(czmlInterval.number, czmlInterval);
+        }
+    };
+
+    return Angle;
+});

--- a/Source/DataSources/CzmlDataSource.js
+++ b/Source/DataSources/CzmlDataSource.js
@@ -375,9 +375,9 @@ define([
         case VerticalOrigin:
             return VerticalOrigin[defaultValue(czmlInterval.verticalOrigin, czmlInterval)];
         default:
-        	if (type && type.defaultValue) {
-        		return type.defaultValue(czmlInterval);
-        		}
+            if (type && type.defaultValue)  {
+                return type.defaultValue(czmlInterval);
+            }
             throw new RuntimeError(type);
         }
     }

--- a/Source/DataSources/CzmlDataSource.js
+++ b/Source/DataSources/CzmlDataSource.js
@@ -375,6 +375,9 @@ define([
         case VerticalOrigin:
             return VerticalOrigin[defaultValue(czmlInterval.verticalOrigin, czmlInterval)];
         default:
+        	if (type && type.defaultValue) {
+        		return type.defaultValue(czmlInterval);
+        		}
             throw new RuntimeError(type);
         }
     }

--- a/Source/DataSources/CzmlDataSource.js
+++ b/Source/DataSources/CzmlDataSource.js
@@ -36,7 +36,7 @@ define([
         '../Scene/VerticalOrigin',
         '../ThirdParty/Uri',
         '../ThirdParty/when',
-        './Angle',
+        './Rotation',
         './BillboardGraphics',
         './ColorMaterialProperty',
         './CompositeMaterialProperty',
@@ -106,7 +106,7 @@ define([
         VerticalOrigin,
         Uri,
         when,
-        Angle,
+        Rotation,
         BillboardGraphics,
         ColorMaterialProperty,
         CompositeMaterialProperty,
@@ -362,6 +362,8 @@ define([
             return JulianDate.fromIso8601(defaultValue(czmlInterval.date, czmlInterval));
         case LabelStyle:
             return LabelStyle[defaultValue(czmlInterval.labelStyle, czmlInterval)];
+        case Rotation:
+            return defaultValue(czmlInterval.number, czmlInterval);
         case Number:
             return defaultValue(czmlInterval.number, czmlInterval);
         case String:
@@ -377,9 +379,6 @@ define([
         case VerticalOrigin:
             return VerticalOrigin[defaultValue(czmlInterval.verticalOrigin, czmlInterval)];
         default:
-            if (type && type.defaultValue)  {
-                return type.defaultValue(czmlInterval);
-            }
             throw new RuntimeError(type);
         }
     }

--- a/Source/DataSources/CzmlDataSource.js
+++ b/Source/DataSources/CzmlDataSource.js
@@ -1010,7 +1010,7 @@ define([
         processPacketData(Image, billboard, 'image', billboardData.image, interval, sourceUri, entityCollection);
         processPacketData(Cartesian2, billboard, 'pixelOffset', billboardData.pixelOffset, interval, sourceUri, entityCollection);
         processPacketData(Number, billboard, 'scale', billboardData.scale, interval, sourceUri, entityCollection);
-        processPacketData(Angle, billboard, 'rotation', billboardData.rotation, interval, sourceUri, entityCollection);
+        processPacketData(Rotation, billboard, 'rotation', billboardData.rotation, interval, sourceUri, entityCollection);
         processPacketData(Cartesian3, billboard, 'alignedAxis', billboardData.alignedAxis, interval, sourceUri, entityCollection);
         processPacketData(Boolean, billboard, 'show', billboardData.show, interval, sourceUri, entityCollection);
         processPacketData(VerticalOrigin, billboard, 'verticalOrigin', billboardData.verticalOrigin, interval, sourceUri, entityCollection);

--- a/Source/DataSources/CzmlDataSource.js
+++ b/Source/DataSources/CzmlDataSource.js
@@ -36,6 +36,7 @@ define([
         '../Scene/VerticalOrigin',
         '../ThirdParty/Uri',
         '../ThirdParty/when',
+        './Angle',
         './BillboardGraphics',
         './ColorMaterialProperty',
         './CompositeMaterialProperty',
@@ -105,6 +106,7 @@ define([
         VerticalOrigin,
         Uri,
         when,
+        Angle,
         BillboardGraphics,
         ColorMaterialProperty,
         CompositeMaterialProperty,
@@ -1009,7 +1011,7 @@ define([
         processPacketData(Image, billboard, 'image', billboardData.image, interval, sourceUri, entityCollection);
         processPacketData(Cartesian2, billboard, 'pixelOffset', billboardData.pixelOffset, interval, sourceUri, entityCollection);
         processPacketData(Number, billboard, 'scale', billboardData.scale, interval, sourceUri, entityCollection);
-        processPacketData(Number, billboard, 'rotation', billboardData.rotation, interval, sourceUri, entityCollection);
+        processPacketData(Angle, billboard, 'rotation', billboardData.rotation, interval, sourceUri, entityCollection);
         processPacketData(Cartesian3, billboard, 'alignedAxis', billboardData.alignedAxis, interval, sourceUri, entityCollection);
         processPacketData(Boolean, billboard, 'show', billboardData.show, interval, sourceUri, entityCollection);
         processPacketData(VerticalOrigin, billboard, 'verticalOrigin', billboardData.verticalOrigin, interval, sourceUri, entityCollection);

--- a/Source/DataSources/Rotation.js
+++ b/Source/DataSources/Rotation.js
@@ -1,41 +1,28 @@
 /*global define*/
 define([
-        '../Core/defaultValue',
-        '../Core/defined',
-        '../Core/defineProperties',
-        '../Core/DeveloperError',
-        '../Core/Event'
+        '../Core/defaultValue'
     ], function(
-        defaultValue,
-        defined,
-        defineProperties,
-        DeveloperError,
-        Event) {
+        defaultValue) {
     "use strict";
 
     /**
-     * A property type whose value is always interpolated by taking the the shortest distances between 2 angles.
-
+     * Static interface for {@link Packable} properties which require interpolation between two shortest values (eg: angles)
      *
-     * @alias ConstantProperty
-     * @constructor
+     * @namespace
+     * @alias Rotation
      *
-     * @param {Object} [value] The property value.
-     *
-     * @see ConstantPositionProperty
-     *
-     * @exception {DeveloperError} value.clone is a required function.
-     * @exception {DeveloperError} value.equals is a required function.
+     * @see PackableForInterpolation
      */
 
-    //A value that always interpolates the shortest distances between 2 angles.
-    var Angle = {
+    var Rotation = {
         packedLength : 1,
         packedInterpolationLength : 1,
+
         pack : function(value, array, startingIndex) {
             startingIndex = defaultValue(startingIndex, 0);
             array[startingIndex] = value;
         },
+
         unpack : function(array, startingIndex, result) {
             startingIndex = defaultValue(startingIndex, 0);
 
@@ -47,6 +34,7 @@ define([
 
             return result;
         },
+        
         convertPackedArrayForInterpolation : function(packedArray, startingIndex, lastIndex, result) {
             for (var i = 0, len = lastIndex - startingIndex + 1; i < len; i++) {
                 result[i] = packedArray[startingIndex + i];
@@ -54,10 +42,6 @@ define([
         },
 
         unpackInterpolationResult : function(value, sourceArray, firstIndex, lastIndex, result) {
-
-        //shortest_angle=((((end - start) % 360) + 540) % 360) - 180;
-        //return shortest_angle * amount;
-
             var start = sourceArray[firstIndex];
             var end = sourceArray[lastIndex];
             var difference = Math.abs(end - start);
@@ -86,12 +70,8 @@ define([
             }
             
             return result;
-        },
-
-        defaultValue: function(czmlInterval){
-            return defaultValue(czmlInterval.number, czmlInterval);
         }
     };
 
-    return Angle;
+    return Rotation;
 });


### PR DESCRIPTION
This very small patch does two things:
- Allows adding custom types to CZML properties via Cesium.CzmlDataSource.processPacketData()
- Implements a Angle type which is now used for Billboards rotations

The previous version of Cesium has a list of hardcoded types in function unwrapInterval() which is called by processPacketData(). If an unknown type is passed in, it simply throws an exception.

This patch simply allows any custom type to be passed in, as long as the type provides a method to calculate a defaultValue (which is exactly what unwrapInterval did for the builtin-types).

The main motivation for this was to add suport for proper interpolation of angles/headings, which is implemented via the Angle type, which can now be passed to the processPacketData() method as the 'type' argument.

The discussion that led to this patch can be found here:
https://groups.google.com/forum/#!topic/cesium-dev/2ZrxVg9PLbg

