### PR TITLE
Don't call initializeFrame when the canvas size is 0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,7 @@ Change Log
 * Fixed crash when modifying a translucent entity geometry outline. [#2630](https://github.com/AnalyticalGraphicsInc/cesium/pull/2630)
 * Fixed crash when loading KML GroundOverlays that spanned 360 degrees. [#2639](https://github.com/AnalyticalGraphicsInc/cesium/pull/2639)
 * Fixed `Geocoder` styling issue in Safari. [#2658](https://github.com/AnalyticalGraphicsInc/cesium/pull/2658).
+* Fixed a crash that would occur when the `Viewer` or `CesiumWidget` was resized to 0 while the camera was in motion.
 * Added number of cached shaders to the `CesiumInspector` debugging widget.
 
 ### 1.8 - 2015-04-01

--- a/Source/Widgets/CesiumWidget/CesiumWidget.js
+++ b/Source/Widgets/CesiumWidget/CesiumWidget.js
@@ -644,10 +644,12 @@ define([
      * unless <code>useDefaultRenderLoop</code> is set to false;
      */
     CesiumWidget.prototype.render = function() {
-        this._scene.initializeFrame();
-        var currentTime = this._clock.tick();
         if (this._canRender) {
+            this._scene.initializeFrame();
+            var currentTime = this._clock.tick();
             this._scene.render(currentTime);
+        } else {
+            this._clock.tick();
         }
     };
 


### PR DESCRIPTION
Having the default render loop call `scene.initializeFrame` when the canvas height or width is 0 causes issues in camera code which expects these values to be non-zero.  As far as I can tell, similar to `render`, there's no reason we should be calling `initializeFrame` in this case anyway.

Fixes #2662 (some additional discussion there as well)