### PR TITLE
TileMapServiceImageryProvider minimum/maximum visible level

### DIFF
--- a/Source/Scene/ImageryLayer.js
+++ b/Source/Scene/ImageryLayer.js
@@ -132,6 +132,8 @@ define([
      * @param {Number} [options.maximumTerrainLevel] The maximum terrain level-of-detail at which to show this imagery layer,
      *                 or undefined to show it at all levels.  Level zero is the least-detailed level.
      */
+
+
     var ImageryLayer = function ImageryLayer(imageryProvider, options) {
         this._imageryProvider = imageryProvider;
 
@@ -199,6 +201,7 @@ define([
 
         this._minimumTerrainLevel = options.minimumTerrainLevel;
         this._maximumTerrainLevel = options.maximumTerrainLevel;
+
 
         this._rectangle = defaultValue(options.rectangle, Rectangle.MAX_VALUE);
         this._maximumAnisotropy = options.maximumAnisotropy;
@@ -358,6 +361,13 @@ define([
         }
 
         var imageryProvider = this._imageryProvider;
+
+        if (defined(imageryProvider.minimumLevelToShow) && tile.level < imageryProvider.minimumLevelToShow) {
+            return false;
+        }
+        if (defined(imageryProvider.maximumLevelToShow) && tile.level > imageryProvider.maximumLevelToShow) {
+            return false;
+        }
 
         if (!defined(insertionPoint)) {
             insertionPoint = surfaceTile.imagery.length;

--- a/Source/Scene/TileMapServiceImageryProvider.js
+++ b/Source/Scene/TileMapServiceImageryProvider.js
@@ -50,6 +50,10 @@ define([
      *                 this that the number of tiles at the minimum level is small, such as four or less.  A larger number is likely
      *                 to result in rendering problems.
      * @param {Number} [options.maximumLevel=18] The maximum level-of-detail supported by the imagery provider.
+     * @param {Number} [options.minimumLevelToShow] The minimum terrain level-of-detail at which to show this imagery layer,
+     *                 or undefined to show it at all levels.  Level zero is the least-detailed level.
+     * @param {Number} [options.maximumLevelToShow] The maximum terrain level-of-detail at which to show this imagery layer,
+     *                 or undefined to show it at all levels.  Level zero is the least-detailed level.
      * @param {Rectangle} [options.rectangle=Rectangle.MAX_VALUE] The rectangle, in radians, covered by the image.
      * @param {TilingScheme} [options.tilingScheme] The tiling scheme specifying how the ellipsoidal
      * surface is broken into tiles.  If this parameter is not provided, a {@link WebMercatorTilingScheme}
@@ -104,6 +108,8 @@ define([
         this._tileHeight = options.tileHeight;
         this._minimumLevel = options.minimumLevel;
         this._maximumLevel = options.maximumLevel;
+        this._minimumLevelToShow = options.minimumLevelToShow;
+        this._maximumLevelToShow = options.maximumLevelToShow;
         this._rectangle = Rectangle.clone(options.rectangle);
         this._tilingScheme = options.tilingScheme;
 
@@ -375,6 +381,30 @@ define([
                 //>>includeEnd('debug');
 
                 return this._minimumLevel;
+            }
+        },
+
+        /**
+         * Gets the maximum level-of-detail that can be viewed.
+         * @memberof TileMapServiceImageryProvider.prototype
+         * @type {Number}
+         * @readonly
+         */
+        maximumLevelToShow : {
+            get : function() {
+                return this._maximumLevelToShow;
+            }
+        },
+
+        /**
+         * Gets the minimum level-of-detail that can be viewed.
+         * @memberof TileMapServiceImageryProvider.prototype
+         * @type {Number}
+         * @readonly
+         */
+        minimumLevelToShow : {
+            get : function() {
+                return this._minimumLevelToShow;
             }
         },
 


### PR DESCRIPTION
This patch allows to define a minimum and maximum visible level for a tile provider. The motivation behind this is to allow more control of the tile providers used for a Cesium app, without requiring doing changes server-side.

Patch based on this discussion:
https://groups.google.com/forum/#!topic/cesium-dev/jv5NA-Ry6Yo