### PR TITLE
Add the cesium-button class to the infoBox.

### DIFF
--- a/Source/Widgets/InfoBox/InfoBoxDescription.css
+++ b/Source/Widgets/InfoBox/InfoBoxDescription.css
@@ -1,3 +1,4 @@
+@import url(../shared.css);
 body {
     margin: 0;
     padding: 0;


### PR DESCRIPTION
This makes the `cesium-button` and other shared classes available to descriptions in the `infoBox`.

I did a clean release build with this, with no changes to `build.xml`, and found:
* The built `Cesium` (minified) and `CesiumViewer` (built) folders both replace this `@import` with the minified contents of `shared.css`, so they work.
* The `CesiumUnminified` build folder does not replace the `@import` but already includes all of the un-minified CSS files, so it works too.
* The require.js version works of course, and Sandcastle works.

I think this is good to go as a one-line change.
