### PR TITLE
Add a drill pick limit

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ Change Log
   *
 * Added new `PointPrimitive` and `PointPrimitiveCollection`, which are faster and use less memory than billboards with circles.
 * Changed `Entity.point` back-end graphics to use the new `PointPrimitive` instead of billboards.  No change to the `Entity.point` API.
+* Added optional drilling limit to `Scene.drillPick`.
 * Upgraded Autolinker from version 0.15.2 to 0.17.1.
 
 ### 1.9 - 2015-05-01

--- a/Source/Scene/Scene.js
+++ b/Source/Scene/Scene.js
@@ -1610,6 +1610,7 @@ define([
      * scene (front to back).
      *
      * @param {Cartesian2} windowPosition Window coordinates to perform picking on.
+     * @param {Number} [limit] If supplied, stop drilling after collecting this many picks.
      * @returns {Object[]} Array of objects, each containing 1 picked primitives.
      *
      * @exception {DeveloperError} windowPosition is undefined.
@@ -1617,7 +1618,7 @@ define([
      * @example
      * var pickedObjects = Cesium.Scene.drillPick(new Cesium.Cartesian2(100.0, 200.0));
      */
-    Scene.prototype.drillPick = function(windowPosition) {
+    Scene.prototype.drillPick = function(windowPosition, limit) {
         // PERFORMANCE_IDEA: This function calls each primitive's update for each pass. Instead
         // we could update the primitive once, and then just execute their commands for each pass,
         // and cull commands for picked primitives.  e.g., base on the command's owner.
@@ -1633,10 +1634,16 @@ define([
         var result = [];
         var pickedPrimitives = [];
         var pickedAttributes = [];
+        if (!defined(limit)) {
+            limit = Number.MAX_VALUE;
+        }
 
         var pickedResult = this.pick(windowPosition);
         while (defined(pickedResult) && defined(pickedResult.primitive)) {
             result.push(pickedResult);
+            if (0 >= --limit) {
+                break;
+            }
 
             var primitive = pickedResult.primitive;
             var hasShowAttribute = false;

--- a/Specs/Scene/PickSpec.js
+++ b/Specs/Scene/PickSpec.js
@@ -88,13 +88,13 @@ defineSuite([
         return e;
     }
 
-    it('pick (undefined window position)', function() {
+    it('does not pick undefined window positions', function() {
         expect(function() {
             scene.pick(undefined);
         }).toThrowDeveloperError();
     });
 
-    it('is picked', function() {
+    it('picks a primitive', function() {
         if (FeatureDetection.isInternetExplorer()) {
             // Workaround IE 11.0.9.  This test fails when all tests are ran without a breakpoint here.
             return;
@@ -105,7 +105,7 @@ defineSuite([
         expect(pickedObject.primitive).toEqual(rectangle);
     });
 
-    it('is not picked (show === false)', function() {
+    it('does not pick primitives when show is false', function() {
         var rectangle = createRectangle();
         rectangle.show = false;
 
@@ -113,7 +113,7 @@ defineSuite([
         expect(pickedObject).not.toBeDefined();
     });
 
-    it('is not picked (alpha === 0.0)', function() {
+    it('does not pick primitives when alpha is zero', function() {
         var rectangle = createRectangle();
         rectangle.material.uniforms.color.alpha = 0.0;
 
@@ -121,7 +121,7 @@ defineSuite([
         expect(pickedObject).not.toBeDefined();
     });
 
-    it('is picked (top primitive only)', function() {
+    it('picks the top primitive', function() {
         createRectangle();
         var rectangle2 = createRectangle();
         rectangle2.height = 0.01;
@@ -130,13 +130,13 @@ defineSuite([
         expect(pickedObject.primitive).toEqual(rectangle2);
     });
 
-    it('drill pick (undefined window position)', function() {
+    it('does not drill pick undefined window positions', function() {
         expect(function() {
             scene.pick(undefined);
         }).toThrowDeveloperError();
     });
 
-    it('drill pick (all picked)', function() {
+    it('drill picks multiple objects', function() {
         var rectangle1 = createRectangle();
         var rectangle2 = createRectangle();
         rectangle2.height = 0.01;
@@ -147,7 +147,7 @@ defineSuite([
         expect(pickedObjects[1].primitive).toEqual(rectangle1);
     });
 
-    it('drill pick (show === false)', function() {
+    it('does not drill pick when show is false', function() {
         var rectangle1 = createRectangle();
         var rectangle2 = createRectangle();
         rectangle2.height = 0.01;
@@ -158,7 +158,7 @@ defineSuite([
         expect(pickedObjects[0].primitive).toEqual(rectangle1);
     });
 
-    it('drill pick (alpha === 0.0)', function() {
+    it('does not drill pick when alpha is zero', function() {
         var rectangle1 = createRectangle();
         var rectangle2 = createRectangle();
         rectangle2.height = 0.01;
@@ -169,7 +169,7 @@ defineSuite([
         expect(pickedObjects[0].primitive).toEqual(rectangle1);
     });
 
-    it('drill pick batched Primitives with show attribute', function() {
+    it('can drill pick batched Primitives with show attribute', function() {
         var geometry = new RectangleGeometry({
             rectangle : Rectangle.fromDegrees(-50.0, -50.0, 50.0, 50.0),
             ellipsoid : Ellipsoid.UNIT_SPHERE,
@@ -256,7 +256,7 @@ defineSuite([
         expect(pickedObjects[0].primitive).toEqual(primitive);
     });
 
-    it('drill pick batched Primitives without show attribute', function() {
+    it('can drill pick batched Primitives without show attribute', function() {
         var geometry = new RectangleGeometry({
             rectangle : Rectangle.fromDegrees(-50.0, -50.0, 50.0, 50.0),
             ellipsoid : Ellipsoid.UNIT_SPHERE,
@@ -299,7 +299,23 @@ defineSuite([
         expect(pickedObjects[0].id).toEqual(3);
     });
 
-    it('pick in 2D', function() {
+    it('stops drill picking when the limit is reached.', function() {
+        var rectangle1 = createRectangle();
+        var rectangle2 = createRectangle();
+        var rectangle3 = createRectangle();
+        var rectangle4 = createRectangle();
+        rectangle2.height = 0.01;
+        rectangle3.height = 0.02;
+        rectangle4.height = 0.03;
+
+        var pickedObjects = scene.drillPick(new Cartesian2(0, 0), 3);
+        expect(pickedObjects.length).toEqual(3);
+        expect(pickedObjects[0].primitive).toEqual(rectangle4);
+        expect(pickedObjects[1].primitive).toEqual(rectangle3);
+        expect(pickedObjects[2].primitive).toEqual(rectangle2);
+    });
+
+    it('picks in 2D', function() {
         var ellipsoid = scene.mapProjection.ellipsoid;
         var maxRadii = ellipsoid.maximumRadius;
 
@@ -327,7 +343,7 @@ defineSuite([
         expect(pickedObject.primitive).toEqual(rectangle);
     });
 
-    it('pick in 2D when rotated', function() {
+    it('picks in 2D when rotated', function() {
         var ellipsoid = scene.mapProjection.ellipsoid;
         var maxRadii = ellipsoid.maximumRadius;
 


### PR DESCRIPTION
This is useful when drill-picking scenes with hundreds of thousands of pointPrimitives in them.