### PR TITLE
Add Ellipsoid options from some missing places.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@ Change Log
 * Added new `PointPrimitive` and `PointPrimitiveCollection`, which are faster and use less memory than billboards with circles.
 * Changed `Entity.point` back-end graphics to use the new `PointPrimitive` instead of billboards.  No change to the `Entity.point` API.
 * Added optional drilling limit to `Scene.drillPick`.
+* Added optional `ellipsoid` parameter to construction options of imagery and terrain providers that were lacking it.  Note that terrain bounding spheres are precomputed on the server, so any supplied terrain ellipsoid must match the one used by the server.
 * Upgraded Autolinker from version 0.15.2 to 0.17.1.
 
 ### 1.9 - 2015-05-01

--- a/Source/Core/CesiumTerrainProvider.js
+++ b/Source/Core/CesiumTerrainProvider.js
@@ -58,6 +58,7 @@ define([
      * @param {Proxy} [options.proxy] A proxy to use for requests. This object is expected to have a getURL function which returns the proxied URL, if needed.
      * @param {Boolean} [options.requestVertexNormals=false] Flag that indicates if the client should request additional lighting information from the server, in the form of per vertex normals if available.
      * @param {Boolean} [options.requestWaterMask=false] Flag that indicates if the client should request per tile water masks from the server,  if available.
+     * @param {Ellipsoid} [options.ellipsoid] The ellipsoid.  If not specified, the WGS84 ellipsoid is used.
      * @param {Credit|String} [options.credit] A credit for the data source, which is displayed on the canvas.
      *
      * @see TerrainProvider
@@ -98,7 +99,8 @@ define([
 
         this._tilingScheme = new GeographicTilingScheme({
             numberOfLevelZeroTilesX : 2,
-            numberOfLevelZeroTilesY : 1
+            numberOfLevelZeroTilesY : 1,
+            ellipsoid : options.ellipsoid
         });
 
         this._heightmapWidth = 65;

--- a/Source/Scene/ArcGisMapServerImageryProvider.js
+++ b/Source/Scene/ArcGisMapServerImageryProvider.js
@@ -82,6 +82,9 @@ define([
      *                    a tiled layer.
      * @param {TilingScheme} [options.tilingScheme=new GeographicTilingScheme()] The tiling scheme to use to divide the world into tiles.
      *                       This parameter is ignored when accessing a tiled server.
+     * @param {Ellipsoid} [options.ellipsoid] The ellipsoid.  If the tilingScheme is specified and used,
+     *                    this parameter is ignored and the tiling scheme's ellipsoid is used instead. If neither
+     *                    parameter is specified, the WGS84 ellipsoid is used.
      * @param {Number} [options.tileWidth=256] The width of each tile in pixels.  This parameter is ignored when accessing a tiled server.
      * @param {Number} [options.tileHeight=256] The height of each tile in pixels.  This parameter is ignored when accessing a tiled server.
      *
@@ -116,7 +119,7 @@ define([
         this._tileWidth = defaultValue(options.tileWidth, 256);
         this._tileHeight = defaultValue(options.tileHeight, 256);
         this._maximumLevel = undefined;
-        this._tilingScheme = defaultValue(options.tilingScheme, new GeographicTilingScheme());
+        this._tilingScheme = defaultValue(options.tilingScheme, new GeographicTilingScheme({ ellipsoid : options.ellipsoid }));
         this._credit = undefined;
         this._useTiles = defaultValue(options.usePreCachedTilesIfAvailable, true);
         this._rectangle = defaultValue(options.rectangle, this._tilingScheme.rectangle);
@@ -141,9 +144,9 @@ define([
 
                 if (tileInfo.spatialReference.wkid === 102100 ||
                     tileInfo.spatialReference.wkid === 102113) {
-                    that._tilingScheme = new WebMercatorTilingScheme();
+                    that._tilingScheme = new WebMercatorTilingScheme({ ellipsoid : options.ellipsoid });
                 } else if (data.tileInfo.spatialReference.wkid === 4326) {
-                    that._tilingScheme = new GeographicTilingScheme();
+                    that._tilingScheme = new GeographicTilingScheme({ ellipsoid : options.ellipsoid });
                 } else {
                     var message = 'Tile spatial reference WKID ' + data.tileInfo.spatialReference.wkid + ' is not supported.';
                     metadataError = TileProviderError.handleError(metadataError, that, that._errorEvent, message, undefined, undefined, undefined, requestMetadata);

--- a/Source/Scene/BingMapsImageryProvider.js
+++ b/Source/Scene/BingMapsImageryProvider.js
@@ -59,6 +59,7 @@ define([
      * @param {String} [options.culture=''] The culture to use when requesting Bing Maps imagery. Not
      *        all cultures are supported. See {@link http://msdn.microsoft.com/en-us/library/hh441729.aspx}
      *        for information on the supported cultures.
+     * @param {Ellipsoid} [options.ellipsoid] The ellipsoid.  If not specified, the WGS84 ellipsoid is used.
      * @param {TileDiscardPolicy} [options.tileDiscardPolicy] The policy that determines if a tile
      *        is invalid and should be discarded.  If this value is not specified, a default
      *        {@link DiscardMissingTileImagePolicy} is used which requests
@@ -124,7 +125,8 @@ define([
 
         this._tilingScheme = new WebMercatorTilingScheme({
             numberOfLevelZeroTilesX : 2,
-            numberOfLevelZeroTilesY : 2
+            numberOfLevelZeroTilesY : 2,
+            ellipsoid : options.ellipsoid
         });
 
         this._tileWidth = undefined;

--- a/Source/Scene/Camera.js
+++ b/Source/Scene/Camera.js
@@ -201,7 +201,7 @@ define([
         this._max2Dfrustum = undefined;
 
         // set default view
-        this.viewRectangle(Camera.DEFAULT_VIEW_RECTANGLE);
+        this.viewRectangle(Camera.DEFAULT_VIEW_RECTANGLE, scene.mapProjection.ellipsoid);
 
         var mag = Cartesian3.magnitude(this.position);
         mag += mag * Camera.DEFAULT_VIEW_FACTOR;

--- a/Source/Scene/GoogleEarthImageryProvider.js
+++ b/Source/Scene/GoogleEarthImageryProvider.js
@@ -72,6 +72,7 @@ define([
      * @param {TileDiscardPolicy} [options.tileDiscardPolicy] The policy that determines if a tile
      *        is invalid and should be discarded. To ensure that no tiles are discarded, construct and pass
      *        a {@link NeverTileDiscardPolicy} for this parameter.
+     * @param {Ellipsoid} [options.ellipsoid] The ellipsoid.  If not specified, the WGS84 ellipsoid is used.
      * @param {Proxy} [options.proxy] A proxy to use for requests. This object is
      *        expected to have a getURL function which returns the proxied URL, if needed.
      *
@@ -181,13 +182,15 @@ define([
               that._tilingScheme = new GeographicTilingScheme({
                   numberOfLevelZeroTilesX : 2,
                   numberOfLevelZeroTilesY : 2,
-                  rectangle: new Rectangle(-Math.PI, -Math.PI, Math.PI, Math.PI)
+                  rectangle: new Rectangle(-Math.PI, -Math.PI, Math.PI, Math.PI),
+                  ellipsoid : options.ellipsoid
               });
             // Default to mercator projection when projection is undefined
             } else if(!defined(data.projection) || data.projection === 'mercator') {
               that._tilingScheme = new WebMercatorTilingScheme({
                   numberOfLevelZeroTilesX : 2,
-                  numberOfLevelZeroTilesY : 2
+                  numberOfLevelZeroTilesY : 2,
+                  ellipsoid : options.ellipsoid
               });
             } else {
               message = 'Unsupported projection ' + data.projection + '.';

--- a/Source/Scene/GridImageryProvider.js
+++ b/Source/Scene/GridImageryProvider.js
@@ -28,6 +28,9 @@ define([
      *
      * @param {Object} [options] Object with the following properties:
      * @param {TilingScheme} [options.tilingScheme=new GeographicTilingScheme()] The tiling scheme for which to draw tiles.
+     * @param {Ellipsoid} [options.ellipsoid] The ellipsoid.  If the tilingScheme is specified,
+     *                    this parameter is ignored and the tiling scheme's ellipsoid is used instead. If neither
+     *                    parameter is specified, the WGS84 ellipsoid is used.
      * @param {Number} [options.cells=8] The number of grids cells.
      * @param {Color} [options.color=Color(1.0, 1.0, 1.0, 0.4)] The color to draw grid lines.
      * @param {Color} [options.glowColor=Color(0.0, 1.0, 0.0, 0.05)] The color to draw glow for grid lines.
@@ -40,7 +43,7 @@ define([
     var GridImageryProvider = function GridImageryProvider(options) {
         options = defaultValue(options, defaultValue.EMPTY_OBJECT);
 
-        this._tilingScheme = defined(options.tilingScheme) ? options.tilingScheme : new GeographicTilingScheme();
+        this._tilingScheme = defined(options.tilingScheme) ? options.tilingScheme : new GeographicTilingScheme({ ellipsoid : options.ellipsoid });
         this._cells = defaultValue(options.cells, 8);
         this._color = defaultValue(options.color, defaultColor);
         this._glowColor = defaultValue(options.glowColor, defaultGlowColor);

--- a/Source/Scene/OpenStreetMapImageryProvider.js
+++ b/Source/Scene/OpenStreetMapImageryProvider.js
@@ -40,6 +40,7 @@ define([
      * @param {Rectangle} [options.rectangle=Rectangle.MAX_VALUE] The rectangle of the layer.
      * @param {Number} [options.minimumLevel=0] The minimum level-of-detail supported by the imagery provider.
      * @param {Number} [options.maximumLevel=18] The maximum level-of-detail supported by the imagery provider.
+     * @param {Ellipsoid} [options.ellipsoid] The ellipsoid.  If not specified, the WGS84 ellipsoid is used.
      * @param {Credit|String} [options.credit='MapQuest, Open Street Map and contributors, CC-BY-SA'] A credit for the data source, which is displayed on the canvas.
      *
      * @see ArcGisMapServerImageryProvider
@@ -71,7 +72,7 @@ define([
         this._proxy = options.proxy;
         this._tileDiscardPolicy = options.tileDiscardPolicy;
 
-        this._tilingScheme = new WebMercatorTilingScheme();
+        this._tilingScheme = new WebMercatorTilingScheme({ ellipsoid : options.ellipsoid });
 
         this._tileWidth = 256;
         this._tileHeight = 256;

--- a/Source/Scene/Scene.js
+++ b/Source/Scene/Scene.js
@@ -229,8 +229,6 @@ define([
             owner : this
         });
 
-        this._transitioner = new SceneTransitioner(this);
-
         this._renderError = new Event();
         this._preRender = new Event();
         this._postRender = new Event();
@@ -325,6 +323,8 @@ define([
         this._mode = SceneMode.SCENE3D;
 
         this._mapProjection = defined(options.mapProjection) ? options.mapProjection : new GeographicProjection();
+
+        this._transitioner = new SceneTransitioner(this, this._mapProjection.ellipsoid);
 
         /**
          * The current morph transition time between 2D/Columbus View and 3D,

--- a/Source/Scene/SingleTileImageryProvider.js
+++ b/Source/Scene/SingleTileImageryProvider.js
@@ -36,6 +36,7 @@ define([
      * @param {String} options.url The url for the tile.
      * @param {Rectangle} [options.rectangle=Rectangle.MAX_VALUE] The rectangle, in radians, covered by the image.
      * @param {Credit|String} [options.credit] A credit for the data source, which is displayed on the canvas.
+     * @param {Ellipsoid} [options.ellipsoid] The ellipsoid.  If not specified, the WGS84 ellipsoid is used.
      * @param {Object} [options.proxy] A proxy to use for requests. This object is expected to have a getURL function which returns the proxied URL, if needed.
      *
      * @see ArcGisMapServerImageryProvider
@@ -64,7 +65,8 @@ define([
         var tilingScheme = new GeographicTilingScheme({
             rectangle : rectangle,
             numberOfLevelZeroTilesX : 1,
-            numberOfLevelZeroTilesY : 1
+            numberOfLevelZeroTilesY : 1,
+            ellipsoid : options.ellipsoid
         });
         this._tilingScheme = tilingScheme;
 

--- a/Source/Scene/TileCoordinatesImageryProvider.js
+++ b/Source/Scene/TileCoordinatesImageryProvider.js
@@ -25,6 +25,9 @@ define([
      *
      * @param {Object} [options] Object with the following properties:
      * @param {TilingScheme} [options.tilingScheme=new GeographicTilingScheme()] The tiling scheme for which to draw tiles.
+     * @param {Ellipsoid} [options.ellipsoid] The ellipsoid.  If the tilingScheme is specified,
+     *                    this parameter is ignored and the tiling scheme's ellipsoid is used instead. If neither
+     *                    parameter is specified, the WGS84 ellipsoid is used.
      * @param {Color} [options.color=Color.YELLOW] The color to draw the tile box and label.
      * @param {Number} [options.tileWidth=256] The width of the tile for level-of-detail selection purposes.
      * @param {Number} [options.tileHeight=256] The height of the tile for level-of-detail selection purposes.
@@ -32,7 +35,7 @@ define([
     var TileCoordinatesImageryProvider = function TileCoordinatesImageryProvider(options) {
         options = defaultValue(options, defaultValue.EMPTY_OBJECT);
 
-        this._tilingScheme = defined(options.tilingScheme) ? options.tilingScheme : new GeographicTilingScheme();
+        this._tilingScheme = defined(options.tilingScheme) ? options.tilingScheme : new GeographicTilingScheme({ ellipsoid : options.ellipsoid });
         this._color = defaultValue(options.color, Color.YELLOW);
         this._errorEvent = new Event();
         this._tileWidth = defaultValue(options.tileWidth, 256);

--- a/Source/Scene/TileMapServiceImageryProvider.js
+++ b/Source/Scene/TileMapServiceImageryProvider.js
@@ -54,6 +54,9 @@ define([
      * @param {TilingScheme} [options.tilingScheme] The tiling scheme specifying how the ellipsoidal
      * surface is broken into tiles.  If this parameter is not provided, a {@link WebMercatorTilingScheme}
      * is used.
+     * @param {Ellipsoid} [options.ellipsoid] The ellipsoid.  If the tilingScheme is specified,
+     *                    this parameter is ignored and the tiling scheme's ellipsoid is used instead. If neither
+     *                    parameter is specified, the WGS84 ellipsoid is used.
      * @param {Number} [options.tileWidth=256] Pixel width of image tiles.
      * @param {Number} [options.tileHeight=256] Pixel height of image tiles.
      *
@@ -167,9 +170,9 @@ define([
 
             if (!defined(that._tilingScheme)) {
                 if (tilingSchemeName === 'geodetic' || tilingSchemeName === 'global-geodetic') {
-                    that._tilingScheme = new GeographicTilingScheme();
+                    that._tilingScheme = new GeographicTilingScheme({ ellipsoid : options.ellipsoid });
                 } else if (tilingSchemeName === 'mercator' || tilingSchemeName === 'global-mercator') {
-                    that._tilingScheme = new WebMercatorTilingScheme();
+                    that._tilingScheme = new WebMercatorTilingScheme({ ellipsoid : options.ellipsoid });
                 } else {
                     var message = url + 'tilemapresource.xml specifies an unsupported profile attribute, ' + tilingSchemeName + '.';
                     metadataError = TileProviderError.handleError(metadataError, that, that._errorEvent, message, undefined, undefined, undefined, requestMetadata);
@@ -246,7 +249,7 @@ define([
             that._tileHeight = defaultValue(options.tileHeight, 256);
             that._minimumLevel = defaultValue(options.minimumLevel, 0);
             that._maximumLevel = defaultValue(options.maximumLevel, 18);
-            that._tilingScheme = defined(options.tilingScheme) ? options.tilingScheme : new WebMercatorTilingScheme();
+            that._tilingScheme = defined(options.tilingScheme) ? options.tilingScheme : new WebMercatorTilingScheme({ ellipsoid : options.ellipsoid });
             that._rectangle = defaultValue(options.rectangle, that._tilingScheme.rectangle);
             that._ready = true;
         }

--- a/Source/Scene/WebMapServiceImageryProvider.js
+++ b/Source/Scene/WebMapServiceImageryProvider.js
@@ -85,6 +85,9 @@ define([
      *        will not support feature picking at all.
      * @param {Rectangle} [options.rectangle=Rectangle.MAX_VALUE] The rectangle of the layer.
      * @param {TilingScheme} [options.tilingScheme=new GeographicTilingScheme()] The tiling scheme to use to divide the world into tiles.
+     * @param {Ellipsoid} [options.ellipsoid] The ellipsoid.  If the tilingScheme is specified,
+     *        this parameter is ignored and the tiling scheme's ellipsoid is used instead. If neither
+     *        parameter is specified, the WGS84 ellipsoid is used.
      * @param {Number} [options.tileWidth=256] The width of each tile in pixels.
      * @param {Number} [options.tileHeight=256] The height of each tile in pixels.
      * @param {Number} [options.minimumLevel=0] The minimum level-of-detail supported by the imagery provider.  Take care when
@@ -145,7 +148,7 @@ define([
         this._maximumLevel = options.maximumLevel; // undefined means no limit
 
         this._rectangle = defaultValue(options.rectangle, Rectangle.MAX_VALUE);
-        this._tilingScheme = defined(options.tilingScheme) ? options.tilingScheme : new GeographicTilingScheme();
+        this._tilingScheme = defined(options.tilingScheme) ? options.tilingScheme : new GeographicTilingScheme({ ellipsoid : options.ellipsoid });
 
         this._rectangle = Rectangle.intersection(this._rectangle, this._tilingScheme.rectangle);
 

--- a/Source/Scene/WebMapTileServiceImageryProvider.js
+++ b/Source/Scene/WebMapTileServiceImageryProvider.js
@@ -52,6 +52,7 @@ define([
      * @param {Rectangle} [options.rectangle=Rectangle.MAX_VALUE] The rectangle covered by the layer.
      * @param {Number} [options.minimumLevel=0] The minimum level-of-detail supported by the imagery provider.
      * @param {Number} [options.maximumLevel=18] The maximum level-of-detail supported by the imagery provider.
+     * @param {Ellipsoid} [options.ellipsoid] The ellipsoid.  If not specified, the WGS84 ellipsoid is used.
      * @param {Credit|String} [options.credit] A credit for the data source, which is displayed on the canvas.
      *
      * @see ArcGisMapServerImageryProvider
@@ -112,7 +113,7 @@ define([
         this._proxy = options.proxy;
         this._tileDiscardPolicy = options.tileDiscardPolicy;
 
-        this._tilingScheme = defined(options.tilingScheme) ? options.tilingScheme : new WebMercatorTilingScheme();
+        this._tilingScheme = defined(options.tilingScheme) ? options.tilingScheme : new WebMercatorTilingScheme({ ellipsoid : options.ellipsoid });
         this._tileWidth = defaultValue(options.tileWidth, 256);
         this._tileHeight = defaultValue(options.tileHeight, 256);
 

--- a/Specs/Core/CesiumTerrainProviderSpec.js
+++ b/Specs/Core/CesiumTerrainProviderSpec.js
@@ -3,6 +3,7 @@ defineSuite([
         'Core/CesiumTerrainProvider',
         'Core/DefaultProxy',
         'Core/defined',
+        'Core/Ellipsoid',
         'Core/GeographicTilingScheme',
         'Core/HeightmapTerrainData',
         'Core/loadWithXhr',
@@ -15,6 +16,7 @@ defineSuite([
         CesiumTerrainProvider,
         DefaultProxy,
         defined,
+        Ellipsoid,
         GeographicTilingScheme,
         HeightmapTerrainData,
         loadWithXhr,
@@ -118,6 +120,22 @@ defineSuite([
         }).then(function() {
             var tilingScheme = provider.tilingScheme;
             expect(tilingScheme instanceof GeographicTilingScheme).toBe(true);
+        });
+    });
+
+    it('can use a custom ellipsoid', function() {
+        returnHeightmapTileJson();
+
+        var ellipsoid = new Ellipsoid(1, 2, 3);
+        var provider = new CesiumTerrainProvider({
+            url : 'made/up/url',
+            ellipsoid : ellipsoid
+        });
+
+        return pollToPromise(function() {
+            return provider.ready;
+        }).then(function() {
+            expect(provider.tilingScheme.ellipsoid).toEqual(ellipsoid);
         });
     });
 

--- a/Specs/Scene/GridImageryProviderSpec.js
+++ b/Specs/Scene/GridImageryProviderSpec.js
@@ -1,6 +1,7 @@
 /*global defineSuite*/
 defineSuite([
         'Scene/GridImageryProvider',
+        'Core/Ellipsoid',
         'Core/GeographicTilingScheme',
         'Core/WebMercatorTilingScheme',
         'Scene/ImageryProvider',
@@ -8,6 +9,7 @@ defineSuite([
         'ThirdParty/when'
     ], function(
         GridImageryProvider,
+        Ellipsoid,
         GeographicTilingScheme,
         WebMercatorTilingScheme,
         ImageryProvider,
@@ -27,6 +29,19 @@ defineSuite([
             return provider.ready;
         }).then(function() {
             expect(typeof provider.hasAlphaChannel).toBe('boolean');
+        });
+    });
+
+    it('can use a custom ellipsoid', function() {
+        var ellipsoid = new Ellipsoid(1, 2, 3);
+        var provider = new GridImageryProvider({
+            ellipsoid : ellipsoid
+        });
+
+        return pollToPromise(function() {
+            return provider.ready;
+        }).then(function() {
+            expect(provider.tilingScheme.ellipsoid).toEqual(ellipsoid);
         });
     });
 

--- a/Specs/Scene/SingleTileImageryProviderSpec.js
+++ b/Specs/Scene/SingleTileImageryProviderSpec.js
@@ -2,6 +2,7 @@
 defineSuite([
         'Scene/SingleTileImageryProvider',
         'Core/DefaultProxy',
+        'Core/Ellipsoid',
         'Core/GeographicTilingScheme',
         'Core/loadImage',
         'Core/Rectangle',
@@ -14,6 +15,7 @@ defineSuite([
     ], function(
         SingleTileImageryProvider,
         DefaultProxy,
+        Ellipsoid,
         GeographicTilingScheme,
         loadImage,
         Rectangle,
@@ -77,6 +79,20 @@ defineSuite([
             return new SingleTileImageryProvider({});
         }
         expect(constructWithoutUrl).toThrowDeveloperError();
+    });
+
+    it('can use a custom ellipsoid', function() {
+        var ellipsoid = new Ellipsoid(1, 2, 3);
+        var provider = new SingleTileImageryProvider({
+            url : 'Data/Images/Red16x16.png',
+            ellipsoid : ellipsoid
+        });
+
+        return pollToPromise(function() {
+            return provider.ready;
+        }).then(function() {
+            expect(provider.tilingScheme.ellipsoid).toEqual(ellipsoid);
+        });
     });
 
     it('requests the single image immediately upon construction', function() {

--- a/Specs/Scene/TileCoordinatesImageryProviderSpec.js
+++ b/Specs/Scene/TileCoordinatesImageryProviderSpec.js
@@ -2,6 +2,7 @@
 defineSuite([
         'Scene/TileCoordinatesImageryProvider',
         'Core/defined',
+        'Core/Ellipsoid',
         'Core/GeographicTilingScheme',
         'Core/WebMercatorTilingScheme',
         'Scene/ImageryProvider',
@@ -10,6 +11,7 @@ defineSuite([
     ], function(
         TileCoordinatesImageryProvider,
         defined,
+        Ellipsoid,
         GeographicTilingScheme,
         WebMercatorTilingScheme,
         ImageryProvider,
@@ -29,6 +31,19 @@ defineSuite([
             return provider.ready;
         }).then(function() {
             expect(typeof provider.hasAlphaChannel).toBe('boolean');
+        });
+    });
+
+    it('can use a custom ellipsoid', function() {
+        var ellipsoid = new Ellipsoid(1, 2, 3);
+        var provider = new TileCoordinatesImageryProvider({
+            ellipsoid : ellipsoid
+        });
+
+        return pollToPromise(function() {
+            return provider.ready;
+        }).then(function() {
+            expect(provider.tilingScheme.ellipsoid).toEqual(ellipsoid);
         });
     });
 

--- a/Specs/Scene/WebMapServiceImageryProviderSpec.js
+++ b/Specs/Scene/WebMapServiceImageryProviderSpec.js
@@ -4,6 +4,7 @@ defineSuite([
         'Core/Cartographic',
         'Core/DefaultProxy',
         'Core/defined',
+        'Core/Ellipsoid',
         'Core/GeographicTilingScheme',
         'Core/loadImage',
         'Core/loadWithXhr',
@@ -24,6 +25,7 @@ defineSuite([
         Cartographic,
         DefaultProxy,
         defined,
+        Ellipsoid,
         GeographicTilingScheme,
         loadImage,
         loadWithXhr,
@@ -79,6 +81,21 @@ defineSuite([
             return provider.ready;
         }).then(function() {
             expect(typeof provider.hasAlphaChannel).toBe('boolean');
+        });
+    });
+
+    it('can use a custom ellipsoid', function() {
+        var ellipsoid = new Ellipsoid(1, 2, 3);
+        var provider = new WebMapServiceImageryProvider({
+            url : 'made/up/wms/server',
+            layers : 'someLayer',
+            ellipsoid : ellipsoid
+        });
+
+        return pollToPromise(function() {
+            return provider.ready;
+        }).then(function() {
+            expect(provider.tilingScheme.ellipsoid).toEqual(ellipsoid);
         });
     });
 


### PR DESCRIPTION
There are still several places where the `ellipsoid` parameter is not getting passed through certain layers of the API, and the default ellipsoid is used instead.  In particular the terrain & imagery providers, I know several of them are specifically for Earth but I can imagine a case where one wanted to select a different Earth-based ellipsoid than WGS84.  @kring if you have time I'd appreciate some feedback here, as my changes to terrain/imagery are mostly copy-and-paste from providers that did pass the ellipsoid option through.

This will be useful for non-Earth visualization, for example the [recent Mars discussion](https://groups.google.com/forum/#!msg/cesium-dev/WOQEeH5VsUE/ITzuMFY6IBoJ) and the upcoming Pluto encounter, etc.

**Questions**
- [x] Enabling Earth terrain on non-Earth ellipsoids causes bounding spheres to run wild, and visibility calculations are wrong.  See example below, un-comment one line.  Is this expected? (Answer: Yes, these bounding spheres come from the server, not Cesium, so cannot be customized).
- [x] Core/RectangleGeometryLibrary constructs a scratch default `GeographicProjection` on [line 72](https://github.com/AnalyticalGraphicsInc/cesium/blob/1.9/Source/Core/RectangleGeometryLibrary.js#L72) and then uses it without any option to override it, guaranteeing use of WGS84, although this doesn't appear to be called by a typical empty CesiumViewer.  Is there a performant way to add and use an ellipsoid option or projection option here?  (Answer: not a priority at this time.)

**TODO**
- [x] Tests
- [x] CHANGES.md

Here's an example of a crazily distorted custom ellipsoid:

```
var ellipsoid = new Cesium.Ellipsoid(200000, 200000, 100000);

var imagery = new Cesium.TileMapServiceImageryProvider({
    url : Cesium.buildModuleUrl('Assets/Textures/NaturalEarthII'),
    ellipsoid : ellipsoid
});

var terrain = new Cesium.CesiumTerrainProvider({
    url : '//assets.agi.com/stk-terrain/world',
    requestWaterMask : true,
    requestVertexNormals : true,
    ellipsoid : ellipsoid
});

var viewer = new Cesium.Viewer('cesiumContainer', {
    mapProjection : new Cesium.GeographicProjection(ellipsoid),
    imageryProvider : imagery,
    //terrainProvider : terrain,
    baseLayerPicker : false
});

viewer.scene.globe.enableLighting = true;
```
