### PR TITLE
Add support for KML files with explicitly specified namespaces.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@ Change Log
 * Added optional drilling limit to `Scene.drillPick`.
 * Added optional `ellipsoid` parameter to construction options of imagery and terrain providers that were lacking it.  Note that terrain bounding spheres are precomputed on the server, so any supplied terrain ellipsoid must match the one used by the server.
 * Upgraded Autolinker from version 0.15.2 to 0.17.1.
+* `KmlDataSource` can now load a KML file that uses explicit XML namespacing, e.g. `kml:Document`.
 
 ### 1.9 - 2015-05-01
 
@@ -85,14 +86,14 @@ Change Log
   * Deprecated the `sourceUri` parameter to all `CzmlDataSource` load and process functions. Support will be removed in 1.10.  Instead pass an `options` object with `sourceUri` property.
 * Added initial support for [KML 2.2](https://developers.google.com/kml/) via `KmlDataSource`. Check out the new [Sandcastle Demo](http://cesiumjs.org/Cesium/Apps/Sandcastle/index.html?src=KML.html) and the [reference documentation](http://cesiumjs.org/Cesium/Build/Documentation/KmlDataSource.html) for more details.
 * `InfoBox` sanitization now relies on [iframe sandboxing](http://www.html5rocks.com/en/tutorials/security/sandboxed-iframes/). This allows for much more content to be displayed in the InfoBox (and still be secure).
-* Added `InfoBox.frame` which is the instance of the iframe that is used to host description content. Sanitization can be controlled via the frame's `sandbox` attribute.  See the above link for additional information. 
+* Added `InfoBox.frame` which is the instance of the iframe that is used to host description content. Sanitization can be controlled via the frame's `sandbox` attribute.  See the above link for additional information.
 * Worked around a bug in Safari that caused most of Cesium to be broken. Cesium should now work much better on Safari for both desktop and mobile.
 * Fixed incorrect ellipse texture coordinates. [#2363](https://github.com/AnalyticalGraphicsInc/cesium/issues/2363) and [#2465](https://github.com/AnalyticalGraphicsInc/cesium/issues/2465)
 * Fixed a bug that would cause incorrect geometry for long Corridors and Polyline Volumes. [#2513](https://github.com/AnalyticalGraphicsInc/cesium/issues/2513)
 * Fixed a bug in imagery loading that could cause some or all of the globe to be missing when using an imagery layer that does not cover the entire globe.
 * Fixed a bug that caused `ElipseOutlineGeometry` and `CircleOutlineGeometry` to be extruded to the ground when they should have instead been drawn at height. [#2499](https://github.com/AnalyticalGraphicsInc/cesium/issues/2499).
 * Fixed a bug that prevented per-vertex colors from working with `PolylineGeometry` and `SimplePolylineGeometry` when used asynchronously. [#2516](https://github.com/AnalyticalGraphicsInc/cesium/issues/2516)
-* Fixed a bug that would caused duplicate graphics if non-time-dynamic `Entity` objects were modified in quick succession. [#2514](https://github.com/AnalyticalGraphicsInc/cesium/issues/2514).  
+* Fixed a bug that would caused duplicate graphics if non-time-dynamic `Entity` objects were modified in quick succession. [#2514](https://github.com/AnalyticalGraphicsInc/cesium/issues/2514).
 * Fixed a bug where `camera.flyToBoundingSphere` would ignore range if the bounding sphere radius was 0. [#2519](https://github.com/AnalyticalGraphicsInc/cesium/issues/2519)
 * Fixed some styling issues with `InfoBox` and `BaseLayerPicker` caused by using Bootstrap with Cesium. [#2487](https://github.com/AnalyticalGraphicsInc/cesium/issues/2479)
 * Added support for rendering a water effect on Quantized-Mesh terrain tiles.
@@ -128,7 +129,7 @@ Change Log
   * `DataSourceDisplay` methods `getScene` and `getDataSources` have been deprecated and replaced with `scene` and `dataSources` properties. They will be removed in Cesium 1.9.
   * The `Entity` constructor taking a single string value for the id has been deprecated. The constructor now takes an options object which allows you to provide any and all `Entity` related properties at construction time. Support for the deprecated behavior will be removed in Cesium 1.9.
   * The `EntityCollection.entities` and `CompositeEntityCollect.entities` properties have both been renamed to `values`.  Support for the deprecated behavior will be removed in Cesium 1.9.
-* Fixed an issue which caused order independent translucency to be broken on many video cards. Disabling order independent translucency should no longer be necessary. 
+* Fixed an issue which caused order independent translucency to be broken on many video cards. Disabling order independent translucency should no longer be necessary.
 * `GeoJsonDataSource` now supports polygons with holes.
 * Many Sandcastle examples have been rewritten to make use of the newly improved Entity API.
 * Instead of throwing an exception when there are not enough unique positions to define a geometry, creating a `Primitive` will succeed, but not render. [#2375](https://github.com/AnalyticalGraphicsInc/cesium/issues/2375)

--- a/Source/DataSources/KmlDataSource.js
+++ b/Source/DataSources/KmlDataSource.js
@@ -1680,7 +1680,7 @@ define([
      * @param {String|Document|Blob} data A url, parsed KML document, or Blob containing binary KMZ data or a parsed KML document.
      * @param {Object} [options] An object with the following properties:
      * @param {DefaultProxy} [options.proxy] A proxy to be used for loading external data.
-     * @param {Number} [options.sourceUri] Overrides the url to use for resolving relative links and other KML network features.
+     * @param {String} [options.sourceUri] Overrides the url to use for resolving relative links and other KML network features.
      * @returns {Promise} A promise that will resolve to a new KmlDataSource instance once the KML is loaded.
      */
     KmlDataSource.load = function(data, options) {

--- a/Source/DataSources/KmlDataSource.js
+++ b/Source/DataSources/KmlDataSource.js
@@ -641,9 +641,9 @@ define([
         for (var i = 0, len = styleNode.childNodes.length; i < len; i++) {
             var node = styleNode.childNodes.item(i);
             var material;
-            if (node.nodeName === 'IconStyle') {
+            if (node.localName === 'IconStyle') {
                 processBillboardIcon(dataSource, node, targetEntity, sourceUri, uriResolver);
-            } else if (node.nodeName === 'LabelStyle') {
+            } else if (node.localName === 'LabelStyle') {
                 var label = targetEntity.label;
                 if (!defined(label)) {
                     label = createDefaultLabel();
@@ -652,7 +652,7 @@ define([
                 label.scale = defaultValue(queryNumericValue(node, 'scale', namespaces.kml), label.scale);
                 label.fillColor = defaultValue(queryColorValue(node, 'color', namespaces.kml), label.fillColor);
                 label.text = targetEntity.name;
-            } else if (node.nodeName === 'LineStyle') {
+            } else if (node.localName === 'LineStyle') {
                 var polyline = targetEntity.polyline;
                 if (!defined(polyline)) {
                     polyline = new PolylineGraphics();
@@ -660,7 +660,7 @@ define([
                 }
                 polyline.width = queryNumericValue(node, 'width', namespaces.kml);
                 polyline.material = queryColorValue(node, 'color', namespaces.kml);
-            } else if (node.nodeName === 'PolyStyle') {
+            } else if (node.localName === 'PolyStyle') {
                 var polygon = targetEntity.polygon;
                 if (!defined(polygon)) {
                     polygon = createDefaultPolygon();
@@ -669,7 +669,7 @@ define([
                 polygon.material = defaultValue(queryColorValue(node, 'color', namespaces.kml), polygon.material);
                 polygon.fill = defaultValue(queryBooleanValue(node, 'fill', namespaces.kml), polygon.fill);
                 polygon.outline = defaultValue(queryBooleanValue(node, 'outline', namespaces.kml), polygon.outline);
-            } else if (node.nodeName === 'BalloonStyle') {
+            } else if (node.localName === 'BalloonStyle') {
                 var bgColor = defaultValue(parseColorString(queryStringValue(node, 'bgColor', namespaces.kml)), Color.WHITE);
                 var textColor = defaultValue(parseColorString(queryStringValue(node, 'textColor', namespaces.kml)), Color.BLACK);
                 var text = queryStringValue(node, 'text', namespaces.kml);
@@ -1471,7 +1471,7 @@ define([
     }
 
     function processUnsupported(dataSource, parent, node, entityCollection, styleCollection, sourceUri, uriResolver) {
-        window.console.log('KML - Unsupported feature: ' + node.nodeName);
+        window.console.log('KML - Unsupported feature: ' + node.localName);
     }
 
     function processNetworkLink(dataSource, parent, node, entityCollection, styleCollection, sourceUri, uriResolver) {
@@ -1510,11 +1510,11 @@ define([
     };
 
     function processFeatureNode(dataSource, node, parent, entityCollection, styleCollection, sourceUri, uriResolver) {
-        var featureProocessor = featureTypes[node.nodeName];
+        var featureProocessor = featureTypes[node.localName];
         if (defined(featureProocessor)) {
             featureProocessor(dataSource, parent, node, entityCollection, styleCollection, sourceUri, uriResolver);
         } else {
-            window.console.log('KML - Unsupported feature node: ' + node.nodeName);
+            window.console.log('KML - Unsupported feature node: ' + node.localName);
         }
     }
 
@@ -1534,7 +1534,7 @@ define([
         var styleCollection = new EntityCollection();
         return when.all(processStyles(dataSource, kml, styleCollection, sourceUri, false, uriResolver), function() {
             var element = kml.documentElement;
-            if (element.nodeName === 'kml') {
+            if (element.localName === 'kml') {
                 element = element.firstElementChild;
             }
             processFeatureNode(dataSource, element, undefined, entityCollection, styleCollection, sourceUri, uriResolver);
@@ -1680,7 +1680,7 @@ define([
      * @param {String|Document|Blob} data A url, parsed KML document, or Blob containing binary KMZ data or a parsed KML document.
      * @param {Object} [options] An object with the following properties:
      * @param {DefaultProxy} [options.proxy] A proxy to be used for loading external data.
-     * @param {String} [options.sourceUri] Overrides the url to use for resolving relative links and other KML network features.
+     * @param {Number} [options.sourceUri] Overrides the url to use for resolving relative links and other KML network features.
      * @returns {Promise} A promise that will resolve to a new KmlDataSource instance once the KML is loaded.
      */
     KmlDataSource.load = function(data, options) {

--- a/Specs/Data/KML/namespaced.kml
+++ b/Specs/Data/KML/namespaced.kml
@@ -1,0 +1,31 @@
+<kml:kml xmlns:kml="http://www.opengis.net/kml/2.2">
+    <kml:Document id="docid">
+        <kml:name>Namespaced</kml:name>
+        <kml:description>Test that Cesium is able to load a KML document with explicit namespaces.</kml:description>
+        <kml:visibility>1</kml:visibility>
+        <kml:Placemark>
+            <kml:name>Foo</kml:name>
+            <kml:description>Bar</kml:description>
+            <kml:visibility>1</kml:visibility>
+            <kml:Polygon>
+                <kml:outerBoundaryIs>
+                    <kml:LinearRing>
+                        <kml:coordinates>129.129819,-25.311793 129.130142,-25.311992 129.129671,-25.312533 129.129341,-25.312338 129.129633,-25.312009 129.129555,-25.311964 129.129717,-25.311790 129.129789,-25.311830 129.129819,-25.311793</kml:coordinates>
+                    </kml:LinearRing>
+                </kml:outerBoundaryIs>
+            </kml:Polygon>
+        </kml:Placemark>
+        <kml:Placemark>
+            <kml:name>Another</kml:name>
+            <kml:description>Test</kml:description>
+            <kml:visibility>1</kml:visibility>
+            <kml:Polygon>
+                <kml:outerBoundaryIs>
+                    <kml:LinearRing>
+                        <kml:coordinates>129.129580,-25.311670 129.129205,-25.312091 129.128890,-25.311903 129.129043,-25.311721 129.128839,-25.311598 129.129053,-25.311358 129.129580,-25.311670</kml:coordinates>
+                    </kml:LinearRing>
+                </kml:outerBoundaryIs>
+            </kml:Polygon>
+        </kml:Placemark>
+    </kml:Document>
+</kml:kml>

--- a/Specs/DataSources/KmlDataSourceSpec.js
+++ b/Specs/DataSources/KmlDataSourceSpec.js
@@ -2797,4 +2797,10 @@ defineSuite([
             expect(entities[1].parent).toBe(entities[0]);
         });
     });
+
+    it('can load a KML file with explicit namespaces', function() {
+        return KmlDataSource.load('Data/KML/namespaced.kml').then(function(dataSource) {
+            expect(dataSource.entities.values.length).toBe(2);
+        });
+    });
 });


### PR DESCRIPTION
KML files with explicit namespace specifications didn't previously work, like this:

```
<kml:kml xmlns:kml="http://www.opengis.net/kml/2.2">
    <kml:Document id="docid">
        ...
    </kml:Document>
</kml:kml>
```

Now they do, just by checking `localName` instead of `nodeName` everywhere.  Strictly speaking, we should be checking the namespace, too, but checking localName only makes Cesium a bit more tolerant of crazy KML files, which is (mostly) good.
