### PR TITLE
Tile provider improvements

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,12 @@ Change Log
 * Added optional drilling limit to `Scene.drillPick`.
 * Added optional `ellipsoid` parameter to construction options of imagery and terrain providers that were lacking it.  Note that terrain bounding spheres are precomputed on the server, so any supplied terrain ellipsoid must match the one used by the server.
 * Upgraded Autolinker from version 0.15.2 to 0.17.1.
+* `TileProviderError` now optionally takes an `error` parameter with more details of the error or exception that occurred.  `ImageryLayer` passes that information through when tiles fail to load.  This allows tile provider error handling to take a different action when a tile returns a 404 versus a 500, for example.
+* `ArcGisMapServerImageryProvider` now has a `maximumLevel` constructor parameter.
+* `ArcGisMapServerImageryProvider` picking now works correctly when the `layers` parameter is specified.  Previously, it would pick from all layers even if only displaying a subset.
+* Fixed a crash caused by `ImageryLayer` attempting to generate mipmaps for textures that are not a power-of-two size.
+* Fixed a bug where `ImageryLayerCollection.pickImageryLayerFeatures` would return incorrect results when picking from a terrain tile that was partially covered by correct-level imagery and partially covered by imagery from an ancestor level.
+* Fixed incorrect counting of `debug.tilesWaitingForChildren` in `QuadtreePrimitive`.
 
 ### 1.9 - 2015-05-01
 
@@ -85,14 +91,14 @@ Change Log
   * Deprecated the `sourceUri` parameter to all `CzmlDataSource` load and process functions. Support will be removed in 1.10.  Instead pass an `options` object with `sourceUri` property.
 * Added initial support for [KML 2.2](https://developers.google.com/kml/) via `KmlDataSource`. Check out the new [Sandcastle Demo](http://cesiumjs.org/Cesium/Apps/Sandcastle/index.html?src=KML.html) and the [reference documentation](http://cesiumjs.org/Cesium/Build/Documentation/KmlDataSource.html) for more details.
 * `InfoBox` sanitization now relies on [iframe sandboxing](http://www.html5rocks.com/en/tutorials/security/sandboxed-iframes/). This allows for much more content to be displayed in the InfoBox (and still be secure).
-* Added `InfoBox.frame` which is the instance of the iframe that is used to host description content. Sanitization can be controlled via the frame's `sandbox` attribute.  See the above link for additional information. 
+* Added `InfoBox.frame` which is the instance of the iframe that is used to host description content. Sanitization can be controlled via the frame's `sandbox` attribute.  See the above link for additional information.
 * Worked around a bug in Safari that caused most of Cesium to be broken. Cesium should now work much better on Safari for both desktop and mobile.
 * Fixed incorrect ellipse texture coordinates. [#2363](https://github.com/AnalyticalGraphicsInc/cesium/issues/2363) and [#2465](https://github.com/AnalyticalGraphicsInc/cesium/issues/2465)
 * Fixed a bug that would cause incorrect geometry for long Corridors and Polyline Volumes. [#2513](https://github.com/AnalyticalGraphicsInc/cesium/issues/2513)
 * Fixed a bug in imagery loading that could cause some or all of the globe to be missing when using an imagery layer that does not cover the entire globe.
 * Fixed a bug that caused `ElipseOutlineGeometry` and `CircleOutlineGeometry` to be extruded to the ground when they should have instead been drawn at height. [#2499](https://github.com/AnalyticalGraphicsInc/cesium/issues/2499).
 * Fixed a bug that prevented per-vertex colors from working with `PolylineGeometry` and `SimplePolylineGeometry` when used asynchronously. [#2516](https://github.com/AnalyticalGraphicsInc/cesium/issues/2516)
-* Fixed a bug that would caused duplicate graphics if non-time-dynamic `Entity` objects were modified in quick succession. [#2514](https://github.com/AnalyticalGraphicsInc/cesium/issues/2514).  
+* Fixed a bug that would caused duplicate graphics if non-time-dynamic `Entity` objects were modified in quick succession. [#2514](https://github.com/AnalyticalGraphicsInc/cesium/issues/2514).
 * Fixed a bug where `camera.flyToBoundingSphere` would ignore range if the bounding sphere radius was 0. [#2519](https://github.com/AnalyticalGraphicsInc/cesium/issues/2519)
 * Fixed some styling issues with `InfoBox` and `BaseLayerPicker` caused by using Bootstrap with Cesium. [#2487](https://github.com/AnalyticalGraphicsInc/cesium/issues/2479)
 * Added support for rendering a water effect on Quantized-Mesh terrain tiles.
@@ -128,7 +134,7 @@ Change Log
   * `DataSourceDisplay` methods `getScene` and `getDataSources` have been deprecated and replaced with `scene` and `dataSources` properties. They will be removed in Cesium 1.9.
   * The `Entity` constructor taking a single string value for the id has been deprecated. The constructor now takes an options object which allows you to provide any and all `Entity` related properties at construction time. Support for the deprecated behavior will be removed in Cesium 1.9.
   * The `EntityCollection.entities` and `CompositeEntityCollect.entities` properties have both been renamed to `values`.  Support for the deprecated behavior will be removed in Cesium 1.9.
-* Fixed an issue which caused order independent translucency to be broken on many video cards. Disabling order independent translucency should no longer be necessary. 
+* Fixed an issue which caused order independent translucency to be broken on many video cards. Disabling order independent translucency should no longer be necessary.
 * `GeoJsonDataSource` now supports polygons with holes.
 * Many Sandcastle examples have been rewritten to make use of the newly improved Entity API.
 * Instead of throwing an exception when there are not enough unique positions to define a geometry, creating a `Primitive` will succeed, but not render. [#2375](https://github.com/AnalyticalGraphicsInc/cesium/issues/2375)

--- a/Source/Core/TileProviderError.js
+++ b/Source/Core/TileProviderError.js
@@ -24,8 +24,9 @@ define([
      * @param {Number} [level] The level of the tile that experienced the error, or undefined if the error
      *        is not specific to a particular tile.
      * @param {Number} [timesRetried=0] The number of times this operation has been retried.
+     * @param {Error} [error] The error or exception that occurred, if any.
      */
-    var TileProviderError = function TileProviderError(provider, message, x, y, level, timesRetried) {
+    var TileProviderError = function TileProviderError(provider, message, x, y, level, timesRetried, error) {
         /**
          * The {@link ImageryProvider} or {@link TerrainProvider} that experienced the error.
          * @type {ImageryProvider|TerainProvider}
@@ -74,6 +75,12 @@ define([
          * @default false
          */
         this.retry = false;
+
+        /**
+         * The error or exception that occurred, if any.
+         * @type {Error}
+         */
+        this.error = error;
     };
 
     /**
@@ -96,14 +103,15 @@ define([
      *        error is not specific to a particular tile.
      * @param {TileProviderError~RetryFunction} retryFunction The function to call to retry the operation.  If undefined, the
      *        operation will not be retried.
+     * @param {Error} [errorDetails] The error or exception that occurred, if any.
      * @returns {TileProviderError} The error instance that was passed to the event listeners and that
      *          should be passed to this function the next time it is called for the same error in order
      *          to track retry counts.
      */
-    TileProviderError.handleError = function(previousError, provider, event, message, x, y, level, retryFunction) {
+    TileProviderError.handleError = function(previousError, provider, event, message, x, y, level, retryFunction, errorDetails) {
         var error = previousError;
         if (!defined(previousError)) {
-            error = new TileProviderError(provider, message, x, y, level, 0);
+            error = new TileProviderError(provider, message, x, y, level, 0, errorDetails);
         } else {
             error.provider = provider;
             error.message = message;
@@ -111,6 +119,7 @@ define([
             error.y = y;
             error.level = level;
             error.retry = false;
+            error.error = errorDetails;
             ++error.timesRetried;
         }
 

--- a/Source/Scene/ArcGisMapServerImageryProvider.js
+++ b/Source/Scene/ArcGisMapServerImageryProvider.js
@@ -82,6 +82,9 @@ define([
      *                    a tiled layer.
      * @param {TilingScheme} [options.tilingScheme=new GeographicTilingScheme()] The tiling scheme to use to divide the world into tiles.
      *                       This parameter is ignored when accessing a tiled server.
+     * @param {Ellipsoid} [options.ellipsoid] The ellipsoid.  If the tilingScheme is specified and used,
+     *                    this parameter is ignored and the tiling scheme's ellipsoid is used instead. If neither
+     *                    parameter is specified, the WGS84 ellipsoid is used.
      * @param {Number} [options.tileWidth=256] The width of each tile in pixels.  This parameter is ignored when accessing a tiled server.
      * @param {Number} [options.tileHeight=256] The height of each tile in pixels.  This parameter is ignored when accessing a tiled server.
      * @param {Number} [options.maximumLevel] The maximum tile level to request, or undefined if there is no maximum.  This parameter is ignored when accessing
@@ -118,7 +121,7 @@ define([
         this._tileWidth = defaultValue(options.tileWidth, 256);
         this._tileHeight = defaultValue(options.tileHeight, 256);
         this._maximumLevel = options.maximumLevel;
-        this._tilingScheme = defaultValue(options.tilingScheme, new GeographicTilingScheme());
+        this._tilingScheme = defaultValue(options.tilingScheme, new GeographicTilingScheme({ ellipsoid : options.ellipsoid }));
         this._credit = undefined;
         this._useTiles = defaultValue(options.usePreCachedTilesIfAvailable, true);
         this._rectangle = defaultValue(options.rectangle, this._tilingScheme.rectangle);
@@ -143,9 +146,9 @@ define([
 
                 if (tileInfo.spatialReference.wkid === 102100 ||
                     tileInfo.spatialReference.wkid === 102113) {
-                    that._tilingScheme = new WebMercatorTilingScheme();
+                    that._tilingScheme = new WebMercatorTilingScheme({ ellipsoid : options.ellipsoid });
                 } else if (data.tileInfo.spatialReference.wkid === 4326) {
-                    that._tilingScheme = new GeographicTilingScheme();
+                    that._tilingScheme = new GeographicTilingScheme({ ellipsoid : options.ellipsoid });
                 } else {
                     var message = 'Tile spatial reference WKID ' + data.tileInfo.spatialReference.wkid + ' is not supported.';
                     metadataError = TileProviderError.handleError(metadataError, that, that._errorEvent, message, undefined, undefined, undefined, requestMetadata);

--- a/Source/Scene/ImageryLayer.js
+++ b/Source/Scene/ImageryLayer.js
@@ -592,7 +592,8 @@ define([
                     imageryProvider.errorEvent,
                     message,
                     imagery.x, imagery.y, imagery.level,
-                    doRequest);
+                    doRequest,
+                    e);
         }
 
         function doRequest() {
@@ -879,7 +880,9 @@ define([
         // to the texture via the FBO, and calling generateMipmap later,
         // will result in the texture appearing blank.  I can't pretend to
         // understand exactly why this is.
-        outputTexture.generateMipmap(MipmapHint.NICEST);
+        if (CesiumMath.isPowerOfTwo(width) && CesiumMath.isPowerOfTwo(height)) {
+            outputTexture.generateMipmap(MipmapHint.NICEST);
+        }
 
         if (defined(reproject.framebuffer)) {
             reproject.framebuffer.destroy();

--- a/Source/Scene/ImageryLayerCollection.js
+++ b/Source/Scene/ImageryLayerCollection.js
@@ -413,7 +413,7 @@ define([
             // Check the textureCoordinateRectangle.
             var applicableRectangle = applicableRectangleScratch;
 
-            var epsilon = 1 / 1024; // 1/4 of a pixel.
+            var epsilon = 1 / 1024; // 1/4 of a pixel in a typical 256x256 tile.
             applicableRectangle.west = CesiumMath.lerp(pickedTile.rectangle.west, pickedTile.rectangle.east, terrainImagery.textureCoordinateRectangle.x - epsilon);
             applicableRectangle.east = CesiumMath.lerp(pickedTile.rectangle.west, pickedTile.rectangle.east, terrainImagery.textureCoordinateRectangle.z + epsilon);
             applicableRectangle.south = CesiumMath.lerp(pickedTile.rectangle.south, pickedTile.rectangle.north, terrainImagery.textureCoordinateRectangle.y - epsilon);

--- a/Source/Scene/ImageryLayerCollection.js
+++ b/Source/Scene/ImageryLayerCollection.js
@@ -333,6 +333,8 @@ define([
         this.layerMoved.raiseEvent(layer, 0, index);
     };
 
+    var applicableRectangleScratch = new Rectangle();
+
     /**
      * Asynchronously determines the imagery layer features that are intersected by a pick ray.  The intersected imagery
      * layer features are found by invoking {@link ImageryProvider#pickFeatures} for each imagery layer tile intersected
@@ -404,6 +406,19 @@ define([
             }
 
             if (!Rectangle.contains(imagery.rectangle, pickedLocation)) {
+                continue;
+            }
+
+            // If this imagery came from a parent, it may not be applicable to its entire rectangle.
+            // Check the textureCoordinateRectangle.
+            var applicableRectangle = applicableRectangleScratch;
+
+            var epsilon = 1 / 1024; // 1/4 of a pixel.
+            applicableRectangle.west = CesiumMath.lerp(pickedTile.rectangle.west, pickedTile.rectangle.east, terrainImagery.textureCoordinateRectangle.x - epsilon);
+            applicableRectangle.east = CesiumMath.lerp(pickedTile.rectangle.west, pickedTile.rectangle.east, terrainImagery.textureCoordinateRectangle.z + epsilon);
+            applicableRectangle.south = CesiumMath.lerp(pickedTile.rectangle.south, pickedTile.rectangle.north, terrainImagery.textureCoordinateRectangle.y - epsilon);
+            applicableRectangle.north = CesiumMath.lerp(pickedTile.rectangle.south, pickedTile.rectangle.north, terrainImagery.textureCoordinateRectangle.w + epsilon);
+            if (!Rectangle.contains(applicableRectangle, pickedLocation)) {
                 continue;
             }
 

--- a/Source/Scene/QuadtreePrimitive.js
+++ b/Source/Scene/QuadtreePrimitive.js
@@ -333,7 +333,6 @@ define([
                     }
                 }
             } else {
-                ++debug.tilesWaitingForChildren;
                 // SSE is not good enough but not all children are loaded, so render this tile anyway.
                 addTileToRenderList(primitive, tile);
             }

--- a/Source/Scene/SingleTileImageryProvider.js
+++ b/Source/Scene/SingleTileImageryProvider.js
@@ -109,7 +109,8 @@ define([
                     that._errorEvent,
                     message,
                     0, 0, 0,
-                    doRequest);
+                    doRequest,
+                    e);
         }
 
         function doRequest() {

--- a/Specs/Scene/ArcGisMapServerImageryProviderSpec.js
+++ b/Specs/Scene/ArcGisMapServerImageryProviderSpec.js
@@ -791,5 +791,26 @@ defineSuite([
                 expect(provider.pickFeatures(0, 0, 0, 0.5, 0.5)).toBeUndefined();
             });
         });
+
+        it('picks from individual layers', function() {
+            var provider = new ArcGisMapServerImageryProvider({
+                url : 'made/up/map/server',
+                usePreCachedTilesIfAvailable : false,
+                layers : 'someLayer,anotherLayerYay'
+            });
+
+            loadWithXhr.load = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
+                expect(url).toContain('layers=visible:someLayer,anotherLayerYay');
+                loadWithXhr.defaultLoad('Data/ArcGIS/identify-WebMercator.json', responseType, method, data, headers, deferred, overrideMimeType);
+            };
+
+            return pollToPromise(function() {
+                return provider.ready;
+            }).then(function() {
+                return provider.pickFeatures(0, 0, 0, 0.5, 0.5).then(function(pickResult) {
+                    expect(pickResult.length).toBe(1);
+                });
+            });
+        });
     });
 });


### PR DESCRIPTION
This is a bit of a grab bag, but it's all good stuff and (hopefully) nothing too controversial.  

* `TileProviderError` now optionally takes an `error` parameter with more details of the error or exception that occurred.  `ImageryLayer` passes that information through when tiles fail to load.  This allows tile provider error handling to take a different action when a tile returns a 404 versus a 500, for example.
* `ArcGisMapServerImageryProvider` now has a `maximumLevel` constructor parameter.
* `ArcGisMapServerImageryProvider` picking now works correctly when the `layers` parameter is specified.  Previously, it would pick from all layers even if only displaying a subset.
* Fixed a crash caused by `ImageryLayer` attempting to generate mipmaps for textures that are not a power-of-two size.
* Fixed a bug where `ImageryLayerCollection.pickImageryLayerFeatures` would return incorrect results when picking from a terrain tile that was partially covered by correct-level imagery and partially covered by imagery from an ancestor level.
* Fixed incorrect counting of `debug.tilesWaitingForChildren` in `QuadtreePrimitive`.