### PR TITLE
Changes to make Cesium behave better in a Browserify-like environment

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,7 +13,7 @@ Change Log
 * Upgraded Autolinker from version 0.15.2 to 0.17.1.
 * Added `Camera.moveStart` and `Camera.moveEnd` events.
 * Added `buildModuleUrl.setBaseUrl` function to allow the Cesium base URL to be set without the use of the global CESIUM_BASE_URL variable.
-* Changed `ThirdParty/zip` to defer its called to `buildModuleUrl` until it is needed, rather than executing during module loading.
+* Changed `ThirdParty/zip` to defer its call to `buildModuleUrl` until it is needed, rather than executing during module loading.
 * Changed `createGeometry` to load individual-geometry workers using a CommonJS-style `require` when run in a CommonJS-like environment.
 
 ### 1.9 - 2015-05-01

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,9 @@ Change Log
 * Added optional `ellipsoid` parameter to construction options of imagery and terrain providers that were lacking it.  Note that terrain bounding spheres are precomputed on the server, so any supplied terrain ellipsoid must match the one used by the server.
 * Upgraded Autolinker from version 0.15.2 to 0.17.1.
 * Added `Camera.moveStart` and `Camera.moveEnd` events.
+* Added `buildModuleUrl.setBaseUrl` function to allow the Cesium base URL to be set without the use of the global CESIUM_BASE_URL variable.
+* Changed `ThirdParty/zip` to defer its called to `buildModuleUrl` until it is needed, rather than executing during module loading.
+* Changed `createGeometry` to load individual-geometry workers using a CommonJS-style `require` when run in a CommonJS-like environment.
 
 ### 1.9 - 2015-05-01
 
@@ -88,14 +91,14 @@ Change Log
   * Deprecated the `sourceUri` parameter to all `CzmlDataSource` load and process functions. Support will be removed in 1.10.  Instead pass an `options` object with `sourceUri` property.
 * Added initial support for [KML 2.2](https://developers.google.com/kml/) via `KmlDataSource`. Check out the new [Sandcastle Demo](http://cesiumjs.org/Cesium/Apps/Sandcastle/index.html?src=KML.html) and the [reference documentation](http://cesiumjs.org/Cesium/Build/Documentation/KmlDataSource.html) for more details.
 * `InfoBox` sanitization now relies on [iframe sandboxing](http://www.html5rocks.com/en/tutorials/security/sandboxed-iframes/). This allows for much more content to be displayed in the InfoBox (and still be secure).
-* Added `InfoBox.frame` which is the instance of the iframe that is used to host description content. Sanitization can be controlled via the frame's `sandbox` attribute.  See the above link for additional information. 
+* Added `InfoBox.frame` which is the instance of the iframe that is used to host description content. Sanitization can be controlled via the frame's `sandbox` attribute.  See the above link for additional information.
 * Worked around a bug in Safari that caused most of Cesium to be broken. Cesium should now work much better on Safari for both desktop and mobile.
 * Fixed incorrect ellipse texture coordinates. [#2363](https://github.com/AnalyticalGraphicsInc/cesium/issues/2363) and [#2465](https://github.com/AnalyticalGraphicsInc/cesium/issues/2465)
 * Fixed a bug that would cause incorrect geometry for long Corridors and Polyline Volumes. [#2513](https://github.com/AnalyticalGraphicsInc/cesium/issues/2513)
 * Fixed a bug in imagery loading that could cause some or all of the globe to be missing when using an imagery layer that does not cover the entire globe.
 * Fixed a bug that caused `ElipseOutlineGeometry` and `CircleOutlineGeometry` to be extruded to the ground when they should have instead been drawn at height. [#2499](https://github.com/AnalyticalGraphicsInc/cesium/issues/2499).
 * Fixed a bug that prevented per-vertex colors from working with `PolylineGeometry` and `SimplePolylineGeometry` when used asynchronously. [#2516](https://github.com/AnalyticalGraphicsInc/cesium/issues/2516)
-* Fixed a bug that would caused duplicate graphics if non-time-dynamic `Entity` objects were modified in quick succession. [#2514](https://github.com/AnalyticalGraphicsInc/cesium/issues/2514).  
+* Fixed a bug that would caused duplicate graphics if non-time-dynamic `Entity` objects were modified in quick succession. [#2514](https://github.com/AnalyticalGraphicsInc/cesium/issues/2514).
 * Fixed a bug where `camera.flyToBoundingSphere` would ignore range if the bounding sphere radius was 0. [#2519](https://github.com/AnalyticalGraphicsInc/cesium/issues/2519)
 * Fixed some styling issues with `InfoBox` and `BaseLayerPicker` caused by using Bootstrap with Cesium. [#2487](https://github.com/AnalyticalGraphicsInc/cesium/issues/2479)
 * Added support for rendering a water effect on Quantized-Mesh terrain tiles.
@@ -131,7 +134,7 @@ Change Log
   * `DataSourceDisplay` methods `getScene` and `getDataSources` have been deprecated and replaced with `scene` and `dataSources` properties. They will be removed in Cesium 1.9.
   * The `Entity` constructor taking a single string value for the id has been deprecated. The constructor now takes an options object which allows you to provide any and all `Entity` related properties at construction time. Support for the deprecated behavior will be removed in Cesium 1.9.
   * The `EntityCollection.entities` and `CompositeEntityCollect.entities` properties have both been renamed to `values`.  Support for the deprecated behavior will be removed in Cesium 1.9.
-* Fixed an issue which caused order independent translucency to be broken on many video cards. Disabling order independent translucency should no longer be necessary. 
+* Fixed an issue which caused order independent translucency to be broken on many video cards. Disabling order independent translucency should no longer be necessary.
 * `GeoJsonDataSource` now supports polygons with holes.
 * Many Sandcastle examples have been rewritten to make use of the newly improved Entity API.
 * Instead of throwing an exception when there are not enough unique positions to define a geometry, creating a `Primitive` will succeed, but not render. [#2375](https://github.com/AnalyticalGraphicsInc/cesium/issues/2375)

--- a/Source/Core/buildModuleUrl.js
+++ b/Source/Core/buildModuleUrl.js
@@ -91,5 +91,13 @@ define([
     // exposed for testing
     buildModuleUrl._cesiumScriptRegex = cesiumScriptRegex;
 
+    /**
+     * Sets the base URL for resolving modules.
+     * @param {String} value The new base URL.
+     */
+    buildModuleUrl.setBaseUrl = function(value) {
+        baseUrl = new Uri(value).resolve(new Uri(document.location.href));
+    };
+
     return buildModuleUrl;
 });

--- a/Source/ThirdParty/zip.js
+++ b/Source/ThirdParty/zip.js
@@ -397,7 +397,7 @@ define(['../Core/buildModuleUrl'], function(buildModuleUrl) {
 		}
 
 		if (obj.zip.useWebWorkers) {
-			worker = new Worker(getWorkerScriptsPath(obj.zip) + INFLATE_JS);
+			worker = new Worker(obj.zip.workerScriptsPath + INFLATE_JS);
 			launchWorkerProcess(worker, reader, writer, offset, size, oninflateappend, onprogress, oninflateend, onreaderror, onwriteerror);
 		} else
 			launchProcess(new obj.zip.Inflater(), reader, writer, offset, size, oninflateappend, onprogress, oninflateend, onreaderror, onwriteerror);
@@ -422,7 +422,7 @@ define(['../Core/buildModuleUrl'], function(buildModuleUrl) {
 		}
 
 		if (obj.zip.useWebWorkers) {
-			worker = new Worker(getWorkerScriptsPath(obj.zip) + DEFLATE_JS);
+			worker = new Worker(obj.zip.workerScriptsPath + DEFLATE_JS);
 			worker.addEventListener(MESSAGE_EVENT, onmessage, false);
 			worker.postMessage({
 				init : true,
@@ -779,13 +779,6 @@ define(['../Core/buildModuleUrl'], function(buildModuleUrl) {
 		};
 	}
 
-	function getWorkerScriptsPath(zip) {
-		if (typeof zip.workerScriptsPath === 'undefined') {
-			zip.workerScriptsPath = buildModuleUrl('ThirdParty/Workers/');
-		}
-		return zip.workerScriptsPath;
-	}
-
 	obj.zip = {
 		Reader : Reader,
 		Writer : Writer,
@@ -805,9 +798,19 @@ define(['../Core/buildModuleUrl'], function(buildModuleUrl) {
 				callback(createZipWriter(writer, onerror, dontDeflate));
 			}, onerror);
 		},
-		workerScriptsPath : undefined,
 		useWebWorkers : true
 	};
+
+	var workerScriptsPath;
+
+	Object.defineProperty(obj.zip, 'workerScriptsPath', {
+		get : function() {
+			if (typeof workerScriptsPath === 'undefined') {
+				workerScriptsPath = buildModuleUrl('ThirdParty/Workers/');
+			}
+			return workerScriptsPath;
+		}
+	});
 
 })(tmp);
 

--- a/Source/ThirdParty/zip.js
+++ b/Source/ThirdParty/zip.js
@@ -397,7 +397,7 @@ define(['../Core/buildModuleUrl'], function(buildModuleUrl) {
 		}
 
 		if (obj.zip.useWebWorkers) {
-			worker = new Worker(obj.zip.workerScriptsPath + INFLATE_JS);
+			worker = new Worker(getWorkerScriptsPath(obj.zip) + INFLATE_JS);
 			launchWorkerProcess(worker, reader, writer, offset, size, oninflateappend, onprogress, oninflateend, onreaderror, onwriteerror);
 		} else
 			launchProcess(new obj.zip.Inflater(), reader, writer, offset, size, oninflateappend, onprogress, oninflateend, onreaderror, onwriteerror);
@@ -422,7 +422,7 @@ define(['../Core/buildModuleUrl'], function(buildModuleUrl) {
 		}
 
 		if (obj.zip.useWebWorkers) {
-			worker = new Worker(obj.zip.workerScriptsPath + DEFLATE_JS);
+			worker = new Worker(getWorkerScriptsPath(obj.zip) + DEFLATE_JS);
 			worker.addEventListener(MESSAGE_EVENT, onmessage, false);
 			worker.postMessage({
 				init : true,
@@ -779,6 +779,13 @@ define(['../Core/buildModuleUrl'], function(buildModuleUrl) {
 		};
 	}
 
+	function getWorkerScriptsPath(zip) {
+		if (typeof zip.workerScriptsPath === 'undefined') {
+			zip.workerScriptsPath = buildModuleUrl('ThirdParty/Workers/');
+		}
+		return zip.workerScriptsPath;
+	}
+
 	obj.zip = {
 		Reader : Reader,
 		Writer : Writer,
@@ -798,7 +805,7 @@ define(['../Core/buildModuleUrl'], function(buildModuleUrl) {
 				callback(createZipWriter(writer, onerror, dontDeflate));
 			}, onerror);
 		},
-		workerScriptsPath : buildModuleUrl('ThirdParty/Workers/'),
+		workerScriptsPath : undefined,
 		useWebWorkers : true
 	};
 

--- a/Source/Workers/createGeometry.js
+++ b/Source/Workers/createGeometry.js
@@ -18,11 +18,17 @@ define([
     function getModule(moduleName) {
         var module = moduleCache[moduleName];
         if (!defined(module)) {
-            // in web workers, require is synchronous
-            require(['./' + moduleName], function(f) {
-                module = f;
-                moduleCache[module] = f;
-            });
+            if (typeof exports === 'object') {
+                // Use CommonJS-style require.
+                moduleCache[module] = module = require('Workers/' + moduleName);
+            } else {
+                // Use AMD-style require.
+                // in web workers, require is synchronous
+                require(['./' + moduleName], function(f) {
+                    module = f;
+                    moduleCache[module] = f;
+                });
+            }
         }
         return module;
     }


### PR DESCRIPTION
This isn't everything that is need to use Cesium with Browserify+deamdify, but these are the low-impact changes that may have some benefit outside that environment as well.

In addition to what you see here, [terriajs-cesium](https://www.npmjs.com/package/terriajs-cesium) has a completely-new version of `cesiumWorkerBootstrapper.js` that looks like this:

```javascript
/*global require,importScripts,self*/
"use strict";

importScripts('Cesium-WebWorkers.js');

self.onmessage = function(event) {
    var data = event.data;
    var worker = require(data.workerModule);
    self.onmessage = worker;
};
```

(we build all of Cesium's workers into `Cesium-WebWorkers.js`, though there are of course other ways it could be done).

I don't think it makes sense to try to incorporate that version of `cesiumWorkerBootstrapper.js` somehow, but the changes in this pull request are low impact.