### PR TITLE
Improvements to WMS GetFeatureInfo

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,12 +6,15 @@ Change Log
   *
 * Deprecated
   * Deprecated `Camera.clone`. It will be removed in 1.11.
+  * `WebMapServiceImageryProvider` constructor parameters `options.getFeatureInfoAsGeoJson` and `options.getFeatureInfoAsXml` have been deprecated and will be removed in Cesium 1.13.  Use `options.getFeatureInfoFormats` instead.
 * Added new `PointPrimitive` and `PointPrimitiveCollection`, which are faster and use less memory than billboards with circles.
 * Changed `Entity.point` back-end graphics to use the new `PointPrimitive` instead of billboards.  No change to the `Entity.point` API.
 * Added optional drilling limit to `Scene.drillPick`.
 * Added optional `ellipsoid` parameter to construction options of imagery and terrain providers that were lacking it.  Note that terrain bounding spheres are precomputed on the server, so any supplied terrain ellipsoid must match the one used by the server.
 * Upgraded Autolinker from version 0.15.2 to 0.17.1.
 * Added `Camera.moveStart` and `Camera.moveEnd` events.
+* `WebMapServiceImageryProvider.pickFeatures` now works with WMS servers, such as Google Maps Engine, that can only return feature information in HTML format.
+* `WebMapServiceImageryProvider` now accepts an array of `GetFeatureInfoFormat` instances that it will use to obtain information about the features at a given position on the globe.  This enables an arbitrary `info_format` to be passed to the WMS server, and an arbitrary JavaScript function to be used to interpret the response.
 
 ### 1.9 - 2015-05-01
 
@@ -88,14 +91,14 @@ Change Log
   * Deprecated the `sourceUri` parameter to all `CzmlDataSource` load and process functions. Support will be removed in 1.10.  Instead pass an `options` object with `sourceUri` property.
 * Added initial support for [KML 2.2](https://developers.google.com/kml/) via `KmlDataSource`. Check out the new [Sandcastle Demo](http://cesiumjs.org/Cesium/Apps/Sandcastle/index.html?src=KML.html) and the [reference documentation](http://cesiumjs.org/Cesium/Build/Documentation/KmlDataSource.html) for more details.
 * `InfoBox` sanitization now relies on [iframe sandboxing](http://www.html5rocks.com/en/tutorials/security/sandboxed-iframes/). This allows for much more content to be displayed in the InfoBox (and still be secure).
-* Added `InfoBox.frame` which is the instance of the iframe that is used to host description content. Sanitization can be controlled via the frame's `sandbox` attribute.  See the above link for additional information. 
+* Added `InfoBox.frame` which is the instance of the iframe that is used to host description content. Sanitization can be controlled via the frame's `sandbox` attribute.  See the above link for additional information.
 * Worked around a bug in Safari that caused most of Cesium to be broken. Cesium should now work much better on Safari for both desktop and mobile.
 * Fixed incorrect ellipse texture coordinates. [#2363](https://github.com/AnalyticalGraphicsInc/cesium/issues/2363) and [#2465](https://github.com/AnalyticalGraphicsInc/cesium/issues/2465)
 * Fixed a bug that would cause incorrect geometry for long Corridors and Polyline Volumes. [#2513](https://github.com/AnalyticalGraphicsInc/cesium/issues/2513)
 * Fixed a bug in imagery loading that could cause some or all of the globe to be missing when using an imagery layer that does not cover the entire globe.
 * Fixed a bug that caused `ElipseOutlineGeometry` and `CircleOutlineGeometry` to be extruded to the ground when they should have instead been drawn at height. [#2499](https://github.com/AnalyticalGraphicsInc/cesium/issues/2499).
 * Fixed a bug that prevented per-vertex colors from working with `PolylineGeometry` and `SimplePolylineGeometry` when used asynchronously. [#2516](https://github.com/AnalyticalGraphicsInc/cesium/issues/2516)
-* Fixed a bug that would caused duplicate graphics if non-time-dynamic `Entity` objects were modified in quick succession. [#2514](https://github.com/AnalyticalGraphicsInc/cesium/issues/2514).  
+* Fixed a bug that would caused duplicate graphics if non-time-dynamic `Entity` objects were modified in quick succession. [#2514](https://github.com/AnalyticalGraphicsInc/cesium/issues/2514).
 * Fixed a bug where `camera.flyToBoundingSphere` would ignore range if the bounding sphere radius was 0. [#2519](https://github.com/AnalyticalGraphicsInc/cesium/issues/2519)
 * Fixed some styling issues with `InfoBox` and `BaseLayerPicker` caused by using Bootstrap with Cesium. [#2487](https://github.com/AnalyticalGraphicsInc/cesium/issues/2479)
 * Added support for rendering a water effect on Quantized-Mesh terrain tiles.
@@ -131,7 +134,7 @@ Change Log
   * `DataSourceDisplay` methods `getScene` and `getDataSources` have been deprecated and replaced with `scene` and `dataSources` properties. They will be removed in Cesium 1.9.
   * The `Entity` constructor taking a single string value for the id has been deprecated. The constructor now takes an options object which allows you to provide any and all `Entity` related properties at construction time. Support for the deprecated behavior will be removed in Cesium 1.9.
   * The `EntityCollection.entities` and `CompositeEntityCollect.entities` properties have both been renamed to `values`.  Support for the deprecated behavior will be removed in Cesium 1.9.
-* Fixed an issue which caused order independent translucency to be broken on many video cards. Disabling order independent translucency should no longer be necessary. 
+* Fixed an issue which caused order independent translucency to be broken on many video cards. Disabling order independent translucency should no longer be necessary.
 * `GeoJsonDataSource` now supports polygons with holes.
 * Many Sandcastle examples have been rewritten to make use of the newly improved Entity API.
 * Instead of throwing an exception when there are not enough unique positions to define a geometry, creating a `Primitive` will succeed, but not render. [#2375](https://github.com/AnalyticalGraphicsInc/cesium/issues/2375)

--- a/Source/Scene/GetFeatureInfoFormat.js
+++ b/Source/Scene/GetFeatureInfoFormat.js
@@ -250,11 +250,18 @@ define([
     }
 
     var emptyBodyRegex= /<body>\s*<\/body>/im;
+    var wmsServiceExceptionREportRegex = /<ServiceExceptionReport([^]*)<\/ServiceExceptionReport>/im;
     var titleRegex = /<title>([^]*)<\/title>/im;
 
     function textToFeatureInfo(text) {
         // If the text is HTML and it has an empty body tag, assume it means no features were found.
         if (emptyBodyRegex.test(text)) {
+            return undefined;
+        }
+
+        // If this is a WMS exception report, treat it as "no features found" rather than showing
+        // bogus feature info.
+        if (wmsServiceExceptionREportRegex.test(text)) {
             return undefined;
         }
 

--- a/Source/Scene/GetFeatureInfoFormat.js
+++ b/Source/Scene/GetFeatureInfoFormat.js
@@ -1,0 +1,276 @@
+/*global define*/
+define([
+        '../Core/Cartographic',
+        '../Core/defaultValue',
+        '../Core/defined',
+        '../Core/DeveloperError',
+        '../Core/RuntimeError',
+        './ImageryLayerFeatureInfo'
+    ], function(
+        Cartographic,
+        defaultValue,
+        defined,
+        DeveloperError,
+        RuntimeError,
+        ImageryLayerFeatureInfo) {
+    "use strict";
+
+    /**
+     * Describes the format in which to request GetFeatureInfo from a Web Map Service (WMS) server.
+     *
+     * @alias GetFeatureInfoFormat
+     * @constructor
+     *
+     * @param {String} type The type of response to expect from a GetFeatureInfo request.  Valid
+     *        values are 'json', 'xml', or 'text'.
+     * @param {String} [format] The info format to request from the WMS server.  This is usually a
+     *        MIME type such as 'application/json' or text/xml'.  If this parameter is not specified, the provider will request 'json'
+     *        using 'application/json', 'xml' using 'text/xml', 'html' using 'text/html', and 'text' using 'text/plain'.
+     * @param {Function} [options.callback] A function to invoke with the GetFeatureInfo response from the WMS server
+     *        in order to produce an array of picked {@link ImageryLayerFeatureInfo} instances.  If this parameter is not specified,
+     *        a default function for the type of response is used.
+     */
+    var GetFeatureInfoFormat = function(type, format, callback) {
+        //>>includeStart('debug', pragmas.debug);
+        if (!defined(type)) {
+            throw new DeveloperError('type is required.');
+        }
+        //>>includeEnd('debug');
+
+        this.type = type;
+
+        if (!defined(format)) {
+            if (type === 'json') {
+                format = 'application/json';
+            } else if (type === 'xml') {
+                format = 'text/xml';
+            } else if (type === 'html') {
+                format = 'text/html';
+            } else if (type === 'text') {
+                format = 'text/plain';
+            }
+            //>>includeStart('debug', pragmas.debug);
+            else {
+                throw new DeveloperError('format is required when type is not "json", "xml", "html", or "text".');
+            }
+            //>>includeEnd('debug');
+        }
+
+        this.format = format;
+
+        if (!defined(callback)) {
+            if (type === 'json') {
+                callback = geoJsonToFeatureInfo;
+            } else if (type === 'xml') {
+                callback = xmlToFeatureInfo;
+            } else if (type === 'html') {
+                callback = textToFeatureInfo;
+            } else if (type === 'text') {
+                callback = textToFeatureInfo;
+            }
+            //>>includeStart('debug', pragmas.debug);
+            else {
+                throw new DeveloperError('callback is required when type is not "json", "xml", "html", or "text".');
+            }
+            //>>includeEnd('debug');
+        }
+
+        this.callback = callback;
+    };
+
+    function geoJsonToFeatureInfo(json) {
+        var result = [];
+
+        var features = json.features;
+        for (var i = 0; i < features.length; ++i) {
+            var feature = features[i];
+
+            var featureInfo = new ImageryLayerFeatureInfo();
+            featureInfo.data = feature;
+            featureInfo.properties = feature.properties;
+            featureInfo.configureNameFromProperties(feature.properties);
+            featureInfo.configureDescriptionFromProperties(feature.properties);
+
+            // If this is a point feature, use the coordinates of the point.
+            if (feature.geometry && feature.geometry.type === 'Point') {
+                var longitude = feature.geometry.coordinates[0];
+                var latitude = feature.geometry.coordinates[1];
+                featureInfo.position = Cartographic.fromDegrees(longitude, latitude);
+            }
+
+            result.push(featureInfo);
+        }
+
+        return result;
+    }
+
+    var mapInfoMxpNamespace = 'http://www.mapinfo.com/mxp';
+    var esriWmsNamespace = 'http://www.esri.com/wms';
+    var wfsNamespace = 'http://www.opengis.net/wfs';
+    var gmlNamespace = 'http://www.opengis.net/gml';
+
+    function xmlToFeatureInfo(xml) {
+        var documentElement = xml.documentElement;
+        if (documentElement.localName === 'MultiFeatureCollection' && documentElement.namespaceURI === mapInfoMxpNamespace) {
+            // This looks like a MapInfo MXP response
+            return mapInfoXmlToFeatureInfo(xml);
+        } else if (documentElement.localName === 'FeatureInfoResponse' && documentElement.namespaceURI === esriWmsNamespace) {
+            // This looks like an Esri WMS response
+            return esriXmlToFeatureInfo(xml);
+        } else if (documentElement.localName === 'FeatureCollection' && documentElement.namespaceURI === wfsNamespace) {
+            // This looks like a WFS/GML response.
+            return gmlToFeatureInfo(xml);
+        } else if (documentElement.localName === 'ServiceExceptionReport') {
+            // This looks like a WMS server error, so no features picked.
+            throw new RuntimeError(new XMLSerializer().serializeToString(documentElement));
+        } else {
+            // Unknown response type, so just dump the XML itself into the description.
+            return unknownXmlToFeatureInfo(xml);
+        }
+    }
+
+    function mapInfoXmlToFeatureInfo(xml) {
+        var result = [];
+
+        var multiFeatureCollection = xml.documentElement;
+
+        var features = multiFeatureCollection.getElementsByTagNameNS(mapInfoMxpNamespace, 'Feature');
+        for (var featureIndex = 0; featureIndex < features.length; ++featureIndex) {
+            var feature = features[featureIndex];
+
+            var properties = {};
+
+            var propertyElements = feature.getElementsByTagNameNS(mapInfoMxpNamespace, 'Val');
+            for (var propertyIndex = 0; propertyIndex < propertyElements.length; ++propertyIndex) {
+                var propertyElement = propertyElements[propertyIndex];
+                if (propertyElement.hasAttribute('ref')) {
+                    var name = propertyElement.getAttribute('ref');
+                    var value = propertyElement.textContent.trim();
+                    properties[name] = value;
+                }
+            }
+
+            var featureInfo = new ImageryLayerFeatureInfo();
+            featureInfo.data = feature;
+            featureInfo.properties = properties;
+            featureInfo.configureNameFromProperties(properties);
+            featureInfo.configureDescriptionFromProperties(properties);
+            result.push(featureInfo);
+        }
+
+        return result;
+    }
+
+    function esriXmlToFeatureInfo(xml) {
+        var result = [];
+
+        var featureInfoResponse = xml.documentElement;
+
+        var features = featureInfoResponse.getElementsByTagNameNS(esriWmsNamespace, 'FIELDS');
+        for (var featureIndex = 0; featureIndex < features.length; ++featureIndex) {
+            var feature = features[featureIndex];
+
+            var properties = {};
+
+            var propertyAttributes = feature.attributes;
+            for (var attributeIndex = 0; attributeIndex < propertyAttributes.length; ++attributeIndex) {
+                var attribute = propertyAttributes[attributeIndex];
+                properties[attribute.name] = attribute.value;
+            }
+
+            var featureInfo = new ImageryLayerFeatureInfo();
+            featureInfo.data = feature;
+            featureInfo.properties = properties;
+            featureInfo.configureNameFromProperties(properties);
+            featureInfo.configureDescriptionFromProperties(properties);
+            result.push(featureInfo);
+        }
+
+        return result;
+    }
+
+    function gmlToFeatureInfo(xml) {
+        var result = [];
+
+        var featureCollection = xml.documentElement;
+
+        var featureMembers = featureCollection.getElementsByTagNameNS(gmlNamespace, 'featureMember');
+        for (var featureIndex = 0; featureIndex < featureMembers.length; ++featureIndex) {
+            var featureMember = featureMembers[featureIndex];
+
+            var properties = {};
+
+            getGmlPropertiesRecursively(featureMember, properties);
+
+            var featureInfo = new ImageryLayerFeatureInfo();
+            featureInfo.data = featureMember;
+            featureInfo.properties = properties;
+            featureInfo.configureNameFromProperties(properties);
+            featureInfo.configureDescriptionFromProperties(properties);
+            result.push(featureInfo);
+        }
+
+        return result;
+    }
+
+    function getGmlPropertiesRecursively(gmlNode, properties) {
+        var isSingleValue = true;
+
+        for (var i = 0; i < gmlNode.children.length; ++i) {
+            var child = gmlNode.children[i];
+
+            if (child.nodeType === Node.ELEMENT_NODE) {
+                isSingleValue = false;
+            }
+
+            if (child.localName === 'Point' || child.localName === 'LineString' || child.localName === 'Polygon') {
+                continue;
+            }
+
+            if (child.hasChildNodes() && getGmlPropertiesRecursively(child, properties)) {
+                properties[child.localName] = child.textContent;
+            }
+        }
+
+        return isSingleValue;
+    }
+
+    function unknownXmlToFeatureInfo(xml) {
+        var xmlText = new XMLSerializer().serializeToString(xml);
+
+        var element = document.createElement('div');
+        var pre = document.createElement('pre');
+        pre.textContent = xmlText;
+        element.appendChild(pre);
+
+        var featureInfo = new ImageryLayerFeatureInfo();
+        featureInfo.data = xml;
+        featureInfo.description = element.innerHTML;
+        return [featureInfo];
+    }
+
+    var emptyBodyRegex= /<body>\s*<\/body>/im;
+    var titleRegex = /<title>([^]*)<\/title>/im;
+
+    function textToFeatureInfo(text) {
+        // If the text is HTML and it has an empty body tag, assume it means no features were found.
+        if (emptyBodyRegex.test(text)) {
+            return undefined;
+        }
+
+        // If the text has a <title> element, use it as the name.
+        var name;
+        var title = titleRegex.exec(text);
+        if (title && title.length > 1) {
+            name = title[1];
+        }
+
+        var featureInfo = new ImageryLayerFeatureInfo();
+        featureInfo.name = name;
+        featureInfo.description = text;
+        featureInfo.data = text;
+        return [featureInfo];
+    }
+
+    return GetFeatureInfoFormat;
+});

--- a/Source/Scene/WebMapServiceImageryProvider.js
+++ b/Source/Scene/WebMapServiceImageryProvider.js
@@ -139,7 +139,7 @@ define([
         this._enablePickFeatures = defaultValue(options.enablePickFeatures, true);
         this._getFeatureInfoFormats = defaultValue(options.getFeatureInfoFormats, WebMapServiceImageryProvider.DefaultGetFeatureInfoFormats);
 
-        if (defined(options.getFeatureInfoAsGeoJson) || defined(options.getFeatureInfoAsXml) || defined(options.getFeatureInfoXmlContentType)) {
+        if (defined(options.getFeatureInfoAsGeoJson) || defined(options.getFeatureInfoAsXml)) {
             deprecationWarning('WebMapServiceImageryProvider.getFeatureInfo', 'The options.getFeatureInfoAsGeoJson and getFeatureInfoAsXml parameters to WebMapServiceImageryProvider were deprecated in Cesium 1.10 and will be removed in 1.13.  Use options.getFeatureInfoFormats instead.');
 
             //>>includeStart('debug', pragmas.debug);

--- a/Source/Scene/WebMapServiceImageryProvider.js
+++ b/Source/Scene/WebMapServiceImageryProvider.js
@@ -149,10 +149,10 @@ define([
             //>>includeEnd('debug');
 
             this._getFeatureInfoFormats = [];
-            if (options.getFeatureInfoAsGeoJson) {
+            if (defaultValue(options.getFeatureInfoAsGeoJson, true)) {
                 this._getFeatureInfoFormats.push(new GetFeatureInfoFormat('json', 'application/json'));
             }
-            if (options.getFeatureInfoAsXml) {
+            if (defaultValue(options.getFeatureInfoAsXml, true)) {
                 this._getFeatureInfoFormats.push(new GetFeatureInfoFormat('xml', 'text/xml'));
             }
         }
@@ -474,7 +474,7 @@ define([
         }
         //>>includeEnd('debug');
 
-        if (!this._enablePickFeatures) {
+        if (!this._enablePickFeatures || this._getFeatureInfoFormats.length === 0) {
             return undefined;
         }
 

--- a/Source/Scene/WebMapServiceImageryProvider.js
+++ b/Source/Scene/WebMapServiceImageryProvider.js
@@ -7,11 +7,14 @@ define([
         '../Core/defaultValue',
         '../Core/defined',
         '../Core/defineProperties',
+        '../Core/deprecationWarning',
         '../Core/DeveloperError',
         '../Core/Event',
         '../Core/freezeObject',
         '../Core/GeographicTilingScheme',
         '../Core/loadJson',
+        '../Core/loadText',
+        '../Core/loadWithXhr',
         '../Core/loadXML',
         '../Core/Math',
         '../Core/objectToQuery',
@@ -20,6 +23,7 @@ define([
         '../Core/WebMercatorTilingScheme',
         '../ThirdParty/Uri',
         '../ThirdParty/when',
+        './GetFeatureInfoFormat',
         './ImageryLayerFeatureInfo',
         './ImageryProvider'
     ], function(
@@ -30,11 +34,14 @@ define([
         defaultValue,
         defined,
         defineProperties,
+        deprecationWarning,
         DeveloperError,
         Event,
         freezeObject,
         GeographicTilingScheme,
         loadJson,
+        loadText,
+        loadWithXhr,
         loadXML,
         CesiumMath,
         objectToQuery,
@@ -43,6 +50,7 @@ define([
         WebMercatorTilingScheme,
         Uri,
         when,
+        GetFeatureInfoFormat,
         ImageryLayerFeatureInfo,
         ImageryProvider) {
     "use strict";
@@ -75,14 +83,8 @@ define([
      *        {@link WebMapServiceImageryProvider#pickFeatures} will immediately return undefined (indicating no pickable features)
      *        without communicating with the server.  Set this property to false if you know your WMS server does not support
      *        GetFeatureInfo or if you don't want this provider's features to be pickable.
-     * @param {Boolean} [options.getFeatureInfoAsGeoJson=true] true if {@link WebMapServiceImageryProvider#pickFeatures} should
-     *        try requesting feature info in GeoJSON format. If getFeatureInfoAsXml is true as well, feature information will be
-     *        requested first as GeoJSON, and then as XML if the GeoJSON request fails.  If both are false, this instance will
-     *        not support feature picking at all.
-     * @param {Boolean} [options.getFeatureInfoAsXml=true] true if {@link WebMapServiceImageryProvider#pickFeatures} should try
-     *        requesting feature info in XML format. If getFeatureInfoAsGeoJson is true as well, feature information will be
-     *        requested first as GeoJSON, and then as XML if the GeoJSON request fails.  If both are false, this instance
-     *        will not support feature picking at all.
+     * @param {GetFeatureInfoFormat[]} [options.getFeatureInfoFormats=WebMapServiceImageryProvider.DefaultGetFeatureInfoFormats] The formats
+     *        in which to try WMS GetFeatureInfo requests.
      * @param {Rectangle} [options.rectangle=Rectangle.MAX_VALUE] The rectangle of the layer.
      * @param {TilingScheme} [options.tilingScheme=new GeographicTilingScheme()] The tiling scheme to use to divide the world into tiles.
      * @param {Ellipsoid} [options.ellipsoid] The ellipsoid.  If the tilingScheme is specified,
@@ -135,8 +137,25 @@ define([
         this._proxy = options.proxy;
         this._layers = options.layers;
         this._enablePickFeatures = defaultValue(options.enablePickFeatures, true);
-        this._getFeatureInfoAsGeoJson = defaultValue(options.getFeatureInfoAsGeoJson, true);
-        this._getFeatureInfoAsXml = defaultValue(options.getFeatureInfoAsXml, true);
+        this._getFeatureInfoFormats = defaultValue(options.getFeatureInfoFormats, WebMapServiceImageryProvider.DefaultGetFeatureInfoFormats);
+
+        if (defined(options.getFeatureInfoAsGeoJson) || defined(options.getFeatureInfoAsXml) || defined(options.getFeatureInfoXmlContentType)) {
+            deprecationWarning('WebMapServiceImageryProvider.getFeatureInfo', 'The options.getFeatureInfoAsGeoJson and getFeatureInfoAsXml parameters to WebMapServiceImageryProvider were deprecated in Cesium 1.10 and will be removed in 1.13.  Use options.getFeatureInfoFormats instead.');
+
+            //>>includeStart('debug', pragmas.debug);
+            if (defined(options.getFeatureInfoFormats)) {
+                throw new DeveloperError('options.getFeatureInfoFormats must not be specified if options.getFeatureInfoAsGeoJson or options.getFeatureInfoAsXml are specified.');
+            }
+            //>>includeEnd('debug');
+
+            this._getFeatureInfoFormats = [];
+            if (options.getFeatureInfoAsGeoJson) {
+                this._getFeatureInfoFormats.push(new GetFeatureInfoFormat('json', 'application/json'));
+            }
+            if (options.getFeatureInfoAsXml) {
+                this._getFeatureInfoFormats.push(new GetFeatureInfoFormat('xml', 'text/xml'));
+            }
+        }
 
         // Merge the parameters with the defaults, and make all parameter names lowercase
         this._parameters = combine(objectToLowercase(defaultValue(options.parameters, defaultValue.EMPTY_OBJECT)), WebMapServiceImageryProvider.DefaultParameters);
@@ -479,33 +498,40 @@ define([
 
         var url;
 
-        if (this._getFeatureInfoAsGeoJson) {
-            url = buildGetFeatureInfoUrl(this, 'application/json', x, y, level, i, j);
+        var formatIndex = 0;
 
-            var that = this;
-            return when(loadJson(url), function(json) {
-                return geoJsonToFeatureInfo(json);
-            }, function(e) {
-                // GeoJSON failed, try XML.
-                if (!that._getFeatureInfoAsXml) {
-                    return when.reject(e);
-                }
+        var that = this;
 
-                url = buildGetFeatureInfoUrl(that, 'text/xml', x, y, level, i, j);
-
-                return when(loadXML(url), function(xml) {
-                    return xmlToFeatureInfo(xml);
-                });
-            });
-        } else if (this._getFeatureInfoAsXml) {
-            url = buildGetFeatureInfoUrl(this, 'text/xml', x, y, level, i, j);
-
-            return when(loadXML(url), function(xml) {
-                return xmlToFeatureInfo(xml);
-            });
-        } else {
-            return undefined;
+        function handleResponse(format, data) {
+            return format.callback(data);
         }
+
+        function doRequest() {
+            if (formatIndex >= that._getFeatureInfoFormats.length) {
+                // No valid formats, so no features picked.
+                return when([]);
+            }
+
+            var format = that._getFeatureInfoFormats[formatIndex];
+            var url = buildGetFeatureInfoUrl(that, format.format, x, y, level, i, j);
+
+            ++formatIndex;
+
+            if (format.type === 'json') {
+                return loadJson(url).then(format.callback).otherwise(doRequest);
+            } else if (format.type === 'xml') {
+                return loadXML(url).then(format.callback).otherwise(doRequest);
+            } else if (format.type === 'text' || format.type === 'html') {
+                return loadText(url).then(format.callback).otherwise(doRequest);
+            } else {
+                return loadWithXhr({
+                    url: url,
+                    responseType: format.format
+                }).then(handleResponse.bind(undefined, format)).otherwise(doRequest);
+            }
+        }
+
+        return doRequest();
     };
 
     /**
@@ -539,6 +565,12 @@ define([
         version : '1.1.1',
         request : 'GetFeatureInfo'
     });
+
+    WebMapServiceImageryProvider.DefaultGetFeatureInfoFormats = freezeObject([
+        freezeObject(new GetFeatureInfoFormat('json', 'application/json')),
+        freezeObject(new GetFeatureInfoFormat('xml', 'text/xml')),
+        freezeObject(new GetFeatureInfoFormat('text', 'text/html'))
+    ]);
 
     function buildImageUrl(imageryProvider, x, y, level) {
         var uri = new Uri(imageryProvider._url);
@@ -632,123 +664,6 @@ define([
         }
 
         return url;
-    }
-
-    function geoJsonToFeatureInfo(json) {
-        var result = [];
-
-        var features = json.features;
-        for (var i = 0; i < features.length; ++i) {
-            var feature = features[i];
-
-            var featureInfo = new ImageryLayerFeatureInfo();
-            featureInfo.data = feature;
-            featureInfo.configureNameFromProperties(feature.properties);
-            featureInfo.configureDescriptionFromProperties(feature.properties);
-
-            // If this is a point feature, use the coordinates of the point.
-            if (feature.geometry.type === 'Point') {
-                var longitude = feature.geometry.coordinates[0];
-                var latitude = feature.geometry.coordinates[1];
-                featureInfo.position = Cartographic.fromDegrees(longitude, latitude);
-            }
-
-            result.push(featureInfo);
-        }
-
-        return result;
-    }
-
-    var mapInfoMxpNamespace = 'http://www.mapinfo.com/mxp';
-    var esriWmsNamespace = 'http://www.esri.com/wms';
-
-    function xmlToFeatureInfo(xml) {
-        var documentElement = xml.documentElement;
-        if (documentElement.localName === 'MultiFeatureCollection' && documentElement.namespaceURI === mapInfoMxpNamespace) {
-            // This looks like a MapInfo MXP response
-            return mapInfoXmlToFeatureInfo(xml);
-        } else if (documentElement.localName === 'FeatureInfoResponse' && documentElement.namespaceURI === esriWmsNamespace) {
-            // This looks like an Esri WMS response
-            return esriXmlToFeatureInfo(xml);
-        } else if (documentElement.localName === 'ServiceExceptionReport') {
-            // This looks like a WMS server error, so no features picked.
-            return undefined;
-        } else {
-            // Unknown response type, so just dump the XML itself into the description.
-            return unknownXmlToFeatureInfo(xml);
-        }
-    }
-
-    function mapInfoXmlToFeatureInfo(xml) {
-        var result = [];
-
-        var multiFeatureCollection = xml.documentElement;
-
-        var features = multiFeatureCollection.getElementsByTagNameNS(mapInfoMxpNamespace, 'Feature');
-        for (var featureIndex = 0; featureIndex < features.length; ++featureIndex) {
-            var feature = features[featureIndex];
-
-            var properties = {};
-
-            var propertyElements = feature.getElementsByTagNameNS(mapInfoMxpNamespace, 'Val');
-            for (var propertyIndex = 0; propertyIndex < propertyElements.length; ++propertyIndex) {
-                var propertyElement = propertyElements[propertyIndex];
-                if (propertyElement.hasAttribute('ref')) {
-                    var name = propertyElement.getAttribute('ref');
-                    var value = propertyElement.textContent.trim();
-                    properties[name] = value;
-                }
-            }
-
-            var featureInfo = new ImageryLayerFeatureInfo();
-            featureInfo.data = feature;
-            featureInfo.configureNameFromProperties(properties);
-            featureInfo.configureDescriptionFromProperties(properties);
-            result.push(featureInfo);
-        }
-
-        return result;
-    }
-
-    function esriXmlToFeatureInfo(xml) {
-        var result = [];
-
-        var featureInfoResponse = xml.documentElement;
-
-        var features = featureInfoResponse.getElementsByTagNameNS(esriWmsNamespace, 'FIELDS');
-        for (var featureIndex = 0; featureIndex < features.length; ++featureIndex) {
-            var feature = features[featureIndex];
-
-            var properties = {};
-
-            var propertyAttributes = feature.attributes;
-            for (var attributeIndex = 0; attributeIndex < propertyAttributes.length; ++attributeIndex) {
-                var attribute = propertyAttributes[attributeIndex];
-                properties[attribute.name] = attribute.value;
-            }
-
-            var featureInfo = new ImageryLayerFeatureInfo();
-            featureInfo.data = feature;
-            featureInfo.configureNameFromProperties(properties);
-            featureInfo.configureDescriptionFromProperties(properties);
-            result.push(featureInfo);
-        }
-
-        return result;
-    }
-
-    function unknownXmlToFeatureInfo(xml) {
-        var xmlText = new XMLSerializer().serializeToString(xml);
-
-        var element = document.createElement('div');
-        var pre = document.createElement('pre');
-        pre.textContent = xmlText;
-        element.appendChild(pre);
-
-        var featureInfo = new ImageryLayerFeatureInfo();
-        featureInfo.data = xml;
-        featureInfo.description = element.innerHTML;
-        return [featureInfo];
     }
 
     return WebMapServiceImageryProvider;

--- a/Specs/Data/WMS/GetFeatureInfo-Custom.json
+++ b/Specs/Data/WMS/GetFeatureInfo-Custom.json
@@ -1,0 +1,3 @@
+{
+    "custom": true
+}

--- a/Specs/Data/WMS/GetFeatureInfo.html
+++ b/Specs/Data/WMS/GetFeatureInfo.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>HTML yeah!</title>
+    </head>
+    <body>
+        This is some great information about this feature.
+    </body>
+</html>

--- a/Specs/Scene/WebMapServiceImageryProviderSpec.js
+++ b/Specs/Scene/WebMapServiceImageryProviderSpec.js
@@ -12,6 +12,7 @@ defineSuite([
         'Core/queryToObject',
         'Core/Rectangle',
         'Core/WebMercatorTilingScheme',
+        'Scene/GetFeatureInfoFormat',
         'Scene/Imagery',
         'Scene/ImageryLayer',
         'Scene/ImageryLayerFeatureInfo',
@@ -33,6 +34,7 @@ defineSuite([
         queryToObject,
         Rectangle,
         WebMercatorTilingScheme,
+        GetFeatureInfoFormat,
         Imagery,
         ImageryLayer,
         ImageryLayerFeatureInfo,
@@ -564,12 +566,26 @@ defineSuite([
             });
         });
 
-        it('returns undefined if getFeatureInfoAsGeoJson and getFeatureInfoAsXml are false', function() {
+        it('Backward compatibility: returns undefined if getFeatureInfoAsGeoJson and getFeatureInfoAsXml are false', function() {
             var provider = new WebMapServiceImageryProvider({
                 url : 'made/up/wms/server',
                 layers : 'someLayer',
                 getFeatureInfoAsGeoJson : false,
                 getFeatureInfoAsXml : false
+            });
+
+            return pollToPromise(function() {
+                return provider.ready;
+            }).then(function() {
+                expect(provider.pickFeatures(0, 0, 0, 0.5, 0.5)).toBeUndefined();
+            });
+        });
+
+        it('returns undefined if list of feature info formats is empty', function() {
+            var provider = new WebMapServiceImageryProvider({
+                url : 'made/up/wms/server',
+                layers : 'someLayer',
+                getFeatureInfoFormats : []
             });
 
             return pollToPromise(function() {
@@ -593,7 +609,7 @@ defineSuite([
             });
         });
 
-        it('requests XML exclusively if getFeatureInfoAsGeoJson is false', function() {
+        it('Backward compatibility: requests XML exclusively if getFeatureInfoAsGeoJson is false', function() {
             var provider = new WebMapServiceImageryProvider({
                 url : 'made/up/wms/server',
                 layers : 'someLayer',
@@ -620,7 +636,36 @@ defineSuite([
             });
         });
 
-        it('requests GeoJSON exclusively if getFeatureInfoAsXml is false', function() {
+        it('requests XML exclusively if specified in getFeatureInfoFormats', function() {
+            var provider = new WebMapServiceImageryProvider({
+                url : 'made/up/wms/server',
+                layers : 'someLayer',
+                getFeatureInfoFormats : [
+                    new GetFeatureInfoFormat('xml')
+                ]
+            });
+
+            loadWithXhr.load = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
+                expect(url).toContain('GetFeatureInfo');
+                expect(url).not.toContain('json');
+                loadWithXhr.defaultLoad('Data/WMS/GetFeatureInfo-MapInfoMXP.xml', responseType, method, data, headers, deferred, overrideMimeType);
+            };
+
+            return pollToPromise(function() {
+                return provider.ready;
+            }).then(function() {
+                return provider.pickFeatures(0, 0, 0, 0.5, 0.5).then(function(pickResult) {
+                    expect(pickResult.length).toBe(1);
+
+                    var firstResult = pickResult[0];
+                    expect(firstResult).toBeInstanceOf(ImageryLayerFeatureInfo);
+                    expect(firstResult.name).toBe('SPRINGWOOD');
+                    expect(firstResult.description).toContain('NSW');
+                });
+            });
+        });
+
+        it('Backward compatibility: requests GeoJSON exclusively if getFeatureInfoAsXml is false', function() {
             var provider = new WebMapServiceImageryProvider({
                 url : 'made/up/wms/server',
                 layers : 'someLayer',
@@ -641,9 +686,104 @@ defineSuite([
                     }
                 };
 
-                return provider.pickFeatures(0, 0, 0, 0.5, 0.5).then(function() {
-                    fail('should not be called');
+                return provider.pickFeatures(0, 0, 0, 0.5, 0.5).then(function(features) {
+                    expect(features.length).toBe(0);
                 }).otherwise(function() {
+                });
+            });
+        });
+
+        it('requests GeoJSON exclusively if specified in getFeatureInfoFormats', function() {
+            var provider = new WebMapServiceImageryProvider({
+                url : 'made/up/wms/server',
+                layers : 'someLayer',
+                getFeatureInfoFormats : [
+                    new GetFeatureInfoFormat('json')
+                ]
+            });
+
+            return pollToPromise(function() {
+                return provider.ready;
+            }).then(function() {
+                loadWithXhr.load = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
+                    expect(url).toContain('GetFeatureInfo');
+
+                    if (url.indexOf('json') >= 0) {
+                        deferred.reject();
+                    } else {
+                        // this should not happen
+                        loadWithXhr.defaultLoad('Data/WMS/GetFeatureInfo-MapInfoMXP.xml', responseType, method, data, headers, deferred, overrideMimeType);
+                    }
+                };
+
+                return provider.pickFeatures(0, 0, 0, 0.5, 0.5).then(function(features) {
+                    expect(features.length).toBe(0);
+                }).otherwise(function() {
+                });
+            });
+        });
+
+        it('uses custom GetFeatureInfo handling function if specified', function() {
+            function fooProcessor(response) {
+                var json = JSON.parse(response);
+                expect(json.custom).toBe(true);
+                var feature = new ImageryLayerFeatureInfo();
+                feature.name = 'Foo processed!';
+                return [feature];
+            }
+
+            var provider = new WebMapServiceImageryProvider({
+                url : 'made/up/wms/server',
+                layers : 'someLayer',
+                getFeatureInfoFormats : [
+                    new GetFeatureInfoFormat('foo', 'application/foo', fooProcessor)
+                ]
+            });
+
+            return pollToPromise(function() {
+                return provider.ready;
+            }).then(function() {
+                loadWithXhr.load = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
+                    expect(url).toContain('GetFeatureInfo');
+
+                    if (url.indexOf(encodeURIComponent('application/foo')) < 0) {
+                        deferred.reject();
+                    }
+
+                    return loadWithXhr.defaultLoad('Data/WMS/GetFeatureInfo-Custom.json', responseType, method, data, headers, deferred, overrideMimeType);
+                };
+
+                return provider.pickFeatures(0, 0, 0, 0.5, 0.5).then(function(features) {
+                    expect(features.length).toBe(1);
+                    expect(features[0].name).toEqual('Foo processed!');
+                });
+            });
+        });
+
+        it('works with HTML response', function() {
+            var provider = new WebMapServiceImageryProvider({
+                url : 'made/up/wms/server',
+                layers : 'someLayer'
+            });
+
+            loadWithXhr.load = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
+                expect(url).toContain('GetFeatureInfo');
+                if (url.indexOf(encodeURIComponent('text/html')) < 0) {
+                    deferred.reject();
+                }
+                loadWithXhr.defaultLoad('Data/WMS/GetFeatureInfo.html', responseType, method, data, headers, deferred, overrideMimeType);
+            };
+
+            return pollToPromise(function() {
+                return provider.ready;
+            }).then(function() {
+                return provider.pickFeatures(0, 0, 0, 0.5, 0.5).then(function(pickResult) {
+                    expect(pickResult.length).toBe(1);
+
+                    var firstResult = pickResult[0];
+                    expect(firstResult).toBeInstanceOf(ImageryLayerFeatureInfo);
+                    expect(firstResult.name).toBe('HTML yeah!');
+                    expect(firstResult.description).toContain('great information');
                 });
             });
         });


### PR DESCRIPTION
* Break out the handling of feature information in various formats to `GetFeatureInfoFormat.js`.
* Add support for WMS servers, such as Google Maps Engine, that can only return feature information in HTML format.
* `WebMapServiceImageryProvider` now accepts an array of `GetFeatureInfoFormat` instances that it will use to obtain information about the features at a given position on the globe.  This enables an arbitrary `info_format` to be passed to the WMS server, and an arbitrary JavaScript function to be used to interpret the response.
