### PR TITLE
Use generic Proxy type instead of DefaultProxy

### DIFF
--- a/Source/DataSources/KmlDataSource.js
+++ b/Source/DataSources/KmlDataSource.js
@@ -1650,7 +1650,7 @@ define([
      * @alias KmlDataSource
      * @constructor
      *
-     * @param {DefaultProxy} [proxy] A proxy to be used for loading external data.
+     * @param {Proxy} [proxy] A proxy to be used for loading external data.
      *
      * @see {@link http://www.opengeospatial.org/standards/kml/|Open Geospatial Consortium KML Standard}
      * @see {@link https://developers.google.com/kml/|Google KML Documentation}
@@ -1679,7 +1679,7 @@ define([
      *
      * @param {String|Document|Blob} data A url, parsed KML document, or Blob containing binary KMZ data or a parsed KML document.
      * @param {Object} [options] An object with the following properties:
-     * @param {DefaultProxy} [options.proxy] A proxy to be used for loading external data.
+     * @param {Proxy} [options.proxy] A proxy to be used for loading external data.
      * @param {String} [options.sourceUri] Overrides the url to use for resolving relative links and other KML network features.
      * @returns {Promise} A promise that will resolve to a new KmlDataSource instance once the KML is loaded.
      */

--- a/Source/Widgets/Viewer/viewerDragDropMixin.js
+++ b/Source/Widgets/Viewer/viewerDragDropMixin.js
@@ -33,7 +33,7 @@ define([
      * @param {Object} [options] Object with the following properties:
      * @param {Element|String} [options.dropTarget=viewer.container] The DOM element which will serve as the drop target.
      * @param {Boolean} [options.clearOnDrop=true] When true, dropping files will clear all existing data sources first, when false, new data sources will be loaded after the existing ones.
-     * @param {DefaultProxy} [options.proxy] The proxy to be used for KML network links.
+     * @param {Proxy} [options.proxy] The proxy to be used for KML network links.
      *
      * @exception {DeveloperError} Element with id <options.dropTarget> does not exist in the document.
      * @exception {DeveloperError} dropTarget is already defined by another mixin.
@@ -152,7 +152,7 @@ define([
             /**
              * Gets or sets the proxy to be used for KML.
              * @memberof viewerDragDropMixin.prototype
-             * @type {DefaultProxy}
+             * @type {Proxy}
              */
             proxy : {
                 get : function() {


### PR DESCRIPTION
Maybe there should be a `Proxy` @interface definition somewhere.

Something like

``` js
/**
 *  @interface
 */
function Proxy() {
  DeveloperError.throwInstantiationError();
}

/**
 * Get the final URL to use to request a given resource.
 *
 * @param {String} resource The resource to request.
 * @returns {String} proxied resource.
 */
Proxy.prototype.getURL = DeveloperError.throwInstantiationError;
```