### PR TITLE
Model scaled bounding sphere

### DIFF
--- a/Source/Scene/Model.js
+++ b/Source/Scene/Model.js
@@ -2496,11 +2496,16 @@ define([
      * @param {Scene} scene The scene.
      *
      * @returns {Number} The radius of the bounding sphere scaled to maintain a minimum pixel size.
+     *
+     * @exception {DeveloperError} The model is not loaded.  Use Model.readyPromise or wait for Model.ready to be true.
      */
     Model.prototype.getScaledBoundingSphereRadius = function(scene) {
         //>>includeStart('debug', pragmas.debug);
         if (this._state !== ModelState.LOADED) {
             throw new DeveloperError('The model is not loaded.  Use Model.readyPromise or wait for Model.ready to be true.');
+        }
+        if (!defined(scene)) {
+            throw new DeveloperError('scene is required.');
         }
         //>>includeEnd('debug');
 

--- a/Source/Scene/Model.js
+++ b/Source/Scene/Model.js
@@ -2490,6 +2490,26 @@ define([
     ///////////////////////////////////////////////////////////////////////////
 
     /**
+     * If the minimum pixel size of the model is not set, this will return the radius of the bounding sphere.
+     * If the minimum pixel size is set, this will return the true size of the bounding sphere used when drawing the model.
+     *
+     * @param {Scene} scene The scene.
+     *
+     * @returns {Number} The radius of the bounding sphere scaled to maintain a minimum pixel size.
+     */
+    Model.prototype.getScaledBoundingSphereRadius = function(scene) {
+        //>>includeStart('debug', pragmas.debug);
+        if (this._state !== ModelState.LOADED) {
+            throw new DeveloperError('The model is not loaded.  Use Model.readyPromise or wait for Model.ready to be true.');
+        }
+        //>>includeEnd('debug');
+
+        var context = scene.context;
+        var frameState = scene.frameState;
+        return getScale(this, context, frameState) * this.boundingSphere.radius;
+    };
+
+    /**
      * Called when {@link Viewer} or {@link CesiumWidget} render the scene to
      * get the draw commands needed to render this primitive.
      * <p>

--- a/Specs/Scene/ModelSpec.js
+++ b/Specs/Scene/ModelSpec.js
@@ -430,6 +430,29 @@ defineSuite([
         texturedBoxModel.modelMatrix = originalMatrix;
     });
 
+    it('getScaledBoundingSphereRadius gets scaled radius', function() {
+        texturedBoxModel.zoomTo();
+        expect(texturedBoxModel.getScaledBoundingSphereRadius(scene)).toEqual(texturedBoxModel.boundingSphere.radius);
+
+        texturedBoxModel.minimumPixelSize = 128.0;
+        expect(texturedBoxModel.getScaledBoundingSphereRadius(scene)).toBeGreaterThan(texturedBoxModel.boundingSphere.radius);
+
+        texturedBoxModel.minimumPixelSize = 0.0;
+    });
+
+    it('getScaledBoundingSphereRadius throws without scene', function() {
+        expect(function() {
+            return texturedBoxModel.getScaledBoundingSphereRadius();
+        }).toThrowDeveloperError();
+    });
+
+    it('getScaledBoundingSphereRadius throws when model is not loaded', function() {
+        var m = new Model();
+        expect(function() {
+            return m.getScaledBoundingSphereRadius(scene);
+        }).toThrowDeveloperError();
+    });
+
     it('destroys', function() {
         return loadModel(boxUrl).then(function(m) {
             expect(m.isDestroyed()).toEqual(false);


### PR DESCRIPTION
Adds `Model.getScaledBoundingSphereRadius` to get the radius of the bounding sphere when `minimumPixelSize` is set.