### PR TITLE
Clear framebuffer when the skybox doesn't do it

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -33,6 +33,7 @@ Change Log
 * Fixed a bug where moon rendered in front of foreground geometry. [#1964](https://github.com/AnalyticalGraphicsInc/cesium/issue/1964)
 * Added support for the [CESIUM_binary_glTF](https://github.com/KhronosGroup/glTF/blob/new-extensions/extensions/CESIUM_binary_glTF/README.md) extension for loading binary blobs of glTF to `Model`.
 * Added support for the [CESIUM_RTC](https://github.com/KhronosGroup/glTF/blob/new-extensions/extensions/CESIUM_RTC/README.md) glTF extension for high-precision rendering to `Model`.
+* Fixed a bug where the framebuffer was not cleared when there was no skybox. [#1829](https://github.com/AnalyticalGraphicsInc/cesium/issue/1829)
 
 ### 1.9 - 2015-05-01
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -33,7 +33,7 @@ Change Log
 * Fixed a bug where moon rendered in front of foreground geometry. [#1964](https://github.com/AnalyticalGraphicsInc/cesium/issue/1964)
 * Added support for the [CESIUM_binary_glTF](https://github.com/KhronosGroup/glTF/blob/new-extensions/extensions/CESIUM_binary_glTF/README.md) extension for loading binary blobs of glTF to `Model`.
 * Added support for the [CESIUM_RTC](https://github.com/KhronosGroup/glTF/blob/new-extensions/extensions/CESIUM_RTC/README.md) glTF extension for high-precision rendering to `Model`.
-* Fixed a bug where the framebuffer was not cleared when there was no skybox. [#1829](https://github.com/AnalyticalGraphicsInc/cesium/issue/1829)
+* Fixed a bug where the sun was smeared when the skybox/stars was disabled. [#1829](https://github.com/AnalyticalGraphicsInc/cesium/issue/1829)
 
 ### 1.9 - 2015-05-01
 

--- a/Source/Scene/Scene.js
+++ b/Source/Scene/Scene.js
@@ -1238,6 +1238,7 @@ define([
         var moonCommand = (renderPass && defined(scene.moon)) ? scene.moon.update(context, frameState) : undefined;
         var moonVisible = isVisible(moonCommand, frameState);
 
+        // Clear default framebuffer
         var clear = scene._clearColorCommand;
         Color.clone(clearColor, clear.color);
         clear.execute(context, passState);
@@ -1278,6 +1279,10 @@ define([
             passState.framebuffer = opaqueFramebuffer;
         }
 
+        if (defined(passState.framebuffer)) {
+            clear.execute(context, passState);
+        }
+
         // Ideally, we would render the sky box and atmosphere last for
         // early-z, but we would have to draw it in each frustum
         frustum.near = camera.frustum.near;
@@ -1286,8 +1291,6 @@ define([
 
         if (defined(skyBoxCommand)) {
             executeCommand(skyBoxCommand, scene, context, passState);
-        } else {
-            executeCommand(clear, scene, context, passState);
         }
 
         if (defined(skyAtmosphereCommand)) {
@@ -1456,6 +1459,9 @@ define([
         createPotentiallyVisibleSet(scene);
 
         var passState = scene._passState;
+        passState.framebuffer = undefined;
+        passState.blendingEnabled = undefined;
+        passState.scissorTest = undefined;
 
         executeCommands(scene, passState, defaultValue(scene.backgroundColor, Color.BLACK));
         executeOverlayCommands(scene, passState);

--- a/Source/Scene/Scene.js
+++ b/Source/Scene/Scene.js
@@ -1286,6 +1286,8 @@ define([
 
         if (defined(skyBoxCommand)) {
             executeCommand(skyBoxCommand, scene, context, passState);
+        } else {
+            executeCommand(clear, scene, context, passState);
         }
 
         if (defined(skyAtmosphereCommand)) {

--- a/Source/Scene/Scene.js
+++ b/Source/Scene/Scene.js
@@ -222,8 +222,9 @@ define([
 
         this._fxaa = new FXAA();
 
-        this._clearColorCommand = new ClearCommand({
+        this._clearColorDepthCommand = new ClearCommand({
             color : new Color(),
+            depth : 1.0,
             owner : this
         });
         this._depthClearCommand = new ClearCommand({
@@ -1239,7 +1240,7 @@ define([
         var moonVisible = isVisible(moonCommand, frameState);
 
         // Clear default framebuffer
-        var clear = scene._clearColorCommand;
+        var clear = scene._clearColorDepthCommand;
         Color.clone(clearColor, clear.color);
         clear.execute(context, passState);
 
@@ -1337,7 +1338,11 @@ define([
             }
 
             us.updateFrustum(frustum);
-            clearDepth.execute(context, passState);
+            if (i !== 0) {
+                // Depth for the first frustum was cleared when color was cleared - and
+                // no primitives rendered in the entire frustum write depth.
+                clearDepth.execute(context, passState);
+            }
 
             var commands;
             var length;


### PR DESCRIPTION
Fix for Issue #1829.

Not sure whether the clear should be done regardless of whether the skybox is drawn.