### PR TITLE
Upgrade MIME types, fix Model.js to not look at URL file extension.

### DIFF
--- a/Source/Scene/Model.js
+++ b/Source/Scene/Model.js
@@ -797,7 +797,7 @@ define([
         // different relative paths could point to the same model.
         var cacheKey = defaultValue(options.cacheKey, getAbsoluteURL(url));
 
-        options = clone(options);
+        options = clone(options, true);
         options.basePath = getBasePath(url);
         options.cacheKey = cacheKey;
         var model = new Model(options);

--- a/Source/Scene/Model.js
+++ b/Source/Scene/Model.js
@@ -820,7 +820,7 @@ define([
             gltfCache[cacheKey] = cachedGltf;
 
             loadArrayBuffer(url, options.headers).then(function(arrayBuffer) {
-                var magic = getStringFromTypedArray(arrayBuffer, 0, 4);
+                var magic = getStringFromTypedArray(arrayBuffer, 0, Math.min(4, arrayBuffer.byteLength));
                 if (magic === 'glTF') {
                     // Load binary glTF
                     cachedGltf.makeReady(parseBinaryGltfHeader(arrayBuffer), arrayBuffer);

--- a/Source/Scene/Model.js
+++ b/Source/Scene/Model.js
@@ -98,6 +98,8 @@ define([
         FAILED : 3
     };
 
+    var defaultModelAccept = 'model/vnd.gltf.binary,model/vnd.gltf+json;q=0.8,application/json;q=0.2,*/*;q=0.01';
+
     function LoadResources() {
         this.buffersToCreate = new Queue();
         this.buffers = {};
@@ -800,6 +802,13 @@ define([
         options.cacheKey = cacheKey;
         var model = new Model(options);
 
+        if (!defined(options.headers)) {
+            options.headers = {};
+        }
+        if (!defined(options.headers.Accept)) {
+            options.headers.Accept = defaultModelAccept;
+        }
+
         var cachedGltf = gltfCache[cacheKey];
         if (!defined(cachedGltf)) {
             cachedGltf = new CachedGltf({
@@ -810,17 +819,17 @@ define([
             setCachedGltf(model, cachedGltf);
             gltfCache[cacheKey] = cachedGltf;
 
-            if (/\.bgltf$/i.test(url)) {
-                // Load binary glTF
-                loadArrayBuffer(url, options.headers).then(function(arrayBuffer) {
+            loadArrayBuffer(url, options.headers).then(function(arrayBuffer) {
+                var magic = getStringFromTypedArray(arrayBuffer, 0, 4);
+                if (magic === 'glTF') {
+                    // Load binary glTF
                     cachedGltf.makeReady(parseBinaryGltfHeader(arrayBuffer), arrayBuffer);
-                }).otherwise(getFailedLoadFunction(model, 'bgltf', url));
-            } else {
-                // Load text (JSON) glTF
-                loadText(url, options.headers).then(function(data) {
+                } else {
+                    // Load text (JSON) glTF
+                    var data = getStringFromTypedArray(arrayBuffer, 0, arrayBuffer.byteLength);
                     cachedGltf.makeReady(JSON.parse(data));
-                }).otherwise(getFailedLoadFunction(model, 'gltf', url));
-            }
+                }
+            }).otherwise(getFailedLoadFunction(model, 'model', url));
         } else if (!cachedGltf.ready) {
             // Cache hit but the loadArrayBuffer() or loadText() request is still pending
             ++cachedGltf.count;

--- a/server.js
+++ b/server.js
@@ -39,8 +39,9 @@
     // https://github.com/visionmedia/send/commit/d2cb54658ce65948b0ed6e5fb5de69d022bef941
     var mime = express.static.mime;
     mime.define({
-        'application/json' : ['czml', 'json', 'geojson', 'topojson', 'gltf'],
-        'application/vnd.gltf+binary' : ['bgltf'],
+        'application/json' : ['czml', 'json', 'geojson', 'topojson'],
+        'model/vnd.gltf+json' : ['gltf'],
+        'model/vnd.gltf.binary' : ['bgltf'],
         'text/plain' : ['glsl']
     });
 

--- a/web.config
+++ b/web.config
@@ -7,7 +7,7 @@
             <remove fileExtension=".glsl" />
             <mimeMap fileExtension=".glsl" mimeType="text/plain" />
             <remove fileExtension=".gltf" />
-            <mimeMap fileExtension=".gltf" mimeType="application/json" />
+            <mimeMap fileExtension=".gltf" mimeType="model/vnd.gltf+json" />
             <remove fileExtension=".bgltf" />
             <mimeMap fileExtension=".bgltf" mimeType="model/vnd.gltf.binary" />
             <remove fileExtension=".json" />


### PR DESCRIPTION
This addresses @mramato's comment in 3a5eb8551, and also fixes a bug in `Model.js` where the URL itself was being used to distinguish `bgltf` from `gltf`.  Using the URL is incorrect because data-URIs do not contain file extensions.  Likewise, models fetched from a server-side database may not contain a filename with an extension.  So instead, we look at the binary magic number to see which path to take.

Thanks to @shunter for research & advice on this.  We should probably get his approval before merge.