### PR TITLE
Prevent recursion by doing 2 shallow clones instead of 1 deep clone.

### DIFF
--- a/Source/Scene/Model.js
+++ b/Source/Scene/Model.js
@@ -797,14 +797,12 @@ define([
         // different relative paths could point to the same model.
         var cacheKey = defaultValue(options.cacheKey, getAbsoluteURL(url));
 
-        options = clone(options, true);
+        options = clone(options);
         options.basePath = getBasePath(url);
         options.cacheKey = cacheKey;
         var model = new Model(options);
 
-        if (!defined(options.headers)) {
-            options.headers = {};
-        }
+        options.headers = defined(options.headers) ? clone(options.headers) : {};
         if (!defined(options.headers.Accept)) {
             options.headers.Accept = defaultModelAccept;
         }


### PR DESCRIPTION
This fixes a bug that shows up after merging to Cesium Pro, where the `Vector` class puts a reference to itself in the pick information of the model options, and the deep clone ends up recursively calling the vector constructor, causing a stack overflow.