### PR TITLE
Billboard depth

### DIFF
--- a/Apps/Sandcastle/gallery/development/BillboardClampToGround.html
+++ b/Apps/Sandcastle/gallery/development/BillboardClampToGround.html
@@ -38,7 +38,7 @@ var cesiumTerrainProviderMeshes = new Cesium.CesiumTerrainProvider({
     url : '//assets.agi.com/stk-terrain/world'
 });
 viewer.terrainProvider = cesiumTerrainProviderMeshes;
-viewer.scene.globe.depthTestAgainstTerrain = false;
+viewer.scene.globe.depthTestAgainstTerrain = true;
 
 var ellipsoid = viewer.scene.globe.ellipsoid;
 var billboardCollection = viewer.scene.primitives.add(new Cesium.BillboardCollection({

--- a/Source/Renderer/AutomaticUniforms.js
+++ b/Source/Renderer/AutomaticUniforms.js
@@ -164,6 +164,8 @@ define([
          * An automatic GLSL uniform representing the depth after
          * only the globe has been rendered and packed into an RGBA texture.
          *
+         * @private
+         *
          * @alias czm_globeDepthTexture
          * @glslUniform
          *

--- a/Source/Scene/Billboard.js
+++ b/Source/Scene/Billboard.js
@@ -103,7 +103,6 @@ define([
         this._translucencyByDistance = options.translucencyByDistance;
         this._pixelOffsetScaleByDistance = options.pixelOffsetScaleByDistance;
         this._heightReference = defaultValue(options.heightReference, HeightReference.NONE);
-        this._ownerSize = new Cartesian2(); // used by labels
         this._id = options.id;
         this._collection = defaultValue(options.collection, billboardCollection);
 
@@ -168,8 +167,7 @@ define([
     var SCALE_BY_DISTANCE_INDEX = Billboard.SCALE_BY_DISTANCE_INDEX = 11;
     var TRANSLUCENCY_BY_DISTANCE_INDEX = Billboard.TRANSLUCENCY_BY_DISTANCE_INDEX = 12;
     var PIXEL_OFFSET_SCALE_BY_DISTANCE_INDEX = Billboard.PIXEL_OFFSET_SCALE_BY_DISTANCE_INDEX = 13;
-    var OWNER_SIZE_INDEX = Billboard.OWNER_SIZE_INDEX = 14;
-    Billboard.NUMBER_OF_PROPERTIES = 15;
+    Billboard.NUMBER_OF_PROPERTIES = 14;
 
     function makeDirty(billboard, propertyChanged) {
         var billboardCollection = billboard._billboardCollection;
@@ -1038,20 +1036,6 @@ define([
         if (!Cartesian2.equals(translate, value)) {
             Cartesian2.clone(value, translate);
             makeDirty(this, PIXEL_OFFSET_INDEX);
-        }
-    };
-
-    Billboard.prototype._setOwnerSize = function(value) {
-        //>>includeStart('debug', pragmas.debug);
-        if (!defined(value)) {
-            throw new DeveloperError('value is required.');
-        }
-        //>>includeEnd('debug');
-
-        var size = this._ownerSize;
-        if (!Cartesian2.equals(size, value)) {
-            Cartesian2.clone(value, size);
-            makeDirty(this, OWNER_SIZE_INDEX);
         }
     };
 

--- a/Source/Scene/BillboardCollection.js
+++ b/Source/Scene/BillboardCollection.js
@@ -1264,7 +1264,7 @@ define([
                     vs.defines.push('EYE_DISTANCE_PIXEL_OFFSET');
                 }
                 if (defined(this._scene)) {
-                    vs.defines.push('TEST_GLOBE_DEPTH');
+                    vs.defines.push('CLAMPED_TO_GROUND');
                 }
 
                 this._sp = context.replaceShaderProgram(this._sp, vs, BillboardCollectionFS, attributeLocations);
@@ -1332,7 +1332,7 @@ define([
                     vs.defines.push('EYE_DISTANCE_PIXEL_OFFSET');
                 }
                 if (defined(this._scene)) {
-                    vs.defines.push('TEST_GLOBE_DEPTH');
+                    vs.defines.push('CLAMPED_TO_GROUND');
                 }
 
                 fs = new ShaderSource({

--- a/Source/Scene/BillboardCollection.js
+++ b/Source/Scene/BillboardCollection.js
@@ -71,7 +71,6 @@ define([
     var SCALE_BY_DISTANCE_INDEX = Billboard.SCALE_BY_DISTANCE_INDEX;
     var TRANSLUCENCY_BY_DISTANCE_INDEX = Billboard.TRANSLUCENCY_BY_DISTANCE_INDEX;
     var PIXEL_OFFSET_SCALE_BY_DISTANCE_INDEX = Billboard.PIXEL_OFFSET_SCALE_BY_DISTANCE_INDEX;
-    var OWNER_SIZE_INDEX = Billboard.OWNER_SIZE_INDEX;
     var NUMBER_OF_PROPERTIES = Billboard.NUMBER_OF_PROPERTIES;
 
     var attributeLocations = {
@@ -82,8 +81,7 @@ define([
         compressedAttribute2 : 4,        // image height, color, pick color, 2 bytes free
         eyeOffset : 5,
         scaleByDistance : 6,
-        pixelOffsetScaleByDistance : 7,
-        ownerSize : 8
+        pixelOffsetScaleByDistance : 7
     };
 
     /**
@@ -251,8 +249,7 @@ define([
                               BufferUsage.STATIC_DRAW, // ALIGNED_AXIS_INDEX
                               BufferUsage.STATIC_DRAW, // SCALE_BY_DISTANCE_INDEX
                               BufferUsage.STATIC_DRAW, // TRANSLUCENCY_BY_DISTANCE_INDEX
-                              BufferUsage.STATIC_DRAW, // PIXEL_OFFSET_SCALE_BY_DISTANCE_INDEX
-                              BufferUsage.STATIC_DRAW  // OWNER_SIZE_INDEX
+                              BufferUsage.STATIC_DRAW  // PIXEL_OFFSET_SCALE_BY_DISTANCE_INDEX
                           ];
 
         var that = this;
@@ -606,11 +603,6 @@ define([
             componentsPerAttribute : 4,
             componentDatatype : ComponentDatatype.FLOAT,
             usage : buffersUsage[PIXEL_OFFSET_SCALE_BY_DISTANCE_INDEX]
-        }, {
-            index : attributeLocations.ownerSize,
-            componentsPerAttribute : 2,
-            componentDatatype : ComponentDatatype.FLOAT,
-            usage : buffersUsage[OWNER_SIZE_INDEX]
         }], 4 * numberOfBillboards); // 4 vertices per billboard
     }
 
@@ -933,17 +925,6 @@ define([
         writer(i + 3, near, nearValue, far, farValue);
     }
 
-    function writeOwnerSize(billboardCollection, context, textureAtlasCoordinates, vafWriters, billboard) {
-        var i = billboard._index * 4;
-        var size = billboard._ownerSize;
-
-        var writer = vafWriters[attributeLocations.ownerSize];
-        writer(i + 0, size.x, size.y);
-        writer(i + 1, size.x, size.y);
-        writer(i + 2, size.x, size.y);
-        writer(i + 3, size.x, size.y);
-    }
-
     function writeBillboard(billboardCollection, context, textureAtlasCoordinates, vafWriters, billboard) {
         writePositionScaleAndRotation(billboardCollection, context, textureAtlasCoordinates, vafWriters, billboard);
         writeCompressedAttrib0(billboardCollection, context, textureAtlasCoordinates, vafWriters, billboard);
@@ -952,7 +933,6 @@ define([
         writeEyeOffset(billboardCollection, context, textureAtlasCoordinates, vafWriters, billboard);
         writeScaleByDistance(billboardCollection, context, textureAtlasCoordinates, vafWriters, billboard);
         writePixelOffsetScaleByDistance(billboardCollection, context, textureAtlasCoordinates, vafWriters, billboard);
-        writeOwnerSize(billboardCollection, context, textureAtlasCoordinates, vafWriters, billboard);
     }
 
     function recomputeActualPositions(billboardCollection, billboards, length, frameState, modelMatrix, recomputeBoundingVolume) {
@@ -1049,11 +1029,6 @@ define([
      * @exception {RuntimeError} image with id must be in the atlas.
      */
     BillboardCollection.prototype.update = function(context, frameState, commandList) {
-        var scene = this._scene;
-        if (defined(scene) && (!defined(scene._globeDepth) || context.maximumVertexTextureImageUnits === 0)) {
-            throw new DeveloperError('Bilboards with a height reference are not supported.');
-        }
-
         removeBillboards(this);
 
         var billboards = this._billboards;
@@ -1153,10 +1128,6 @@ define([
 
                 if (properties[PIXEL_OFFSET_SCALE_BY_DISTANCE_INDEX]) {
                     writers.push(writePixelOffsetScaleByDistance);
-                }
-
-                if (properties[OWNER_SIZE_INDEX]) {
-                    writers.push(writeOwnerSize);
                 }
 
                 var numWriters = writers.length;

--- a/Source/Scene/LabelCollection.js
+++ b/Source/Scene/LabelCollection.js
@@ -210,7 +210,6 @@ define([
 
     // reusable Cartesian2 instance
     var glyphPixelOffset = new Cartesian2();
-    var ownerSize = new Cartesian2();
 
     function repositionAllGlyphs(label, resolutionScale) {
         var glyphs = label._glyphs;
@@ -218,7 +217,6 @@ define([
         var dimensions;
         var totalWidth = 0;
         var maxHeight = 0;
-        var maxWidth = 0;
 
         var glyphIndex = 0;
         var glyphLength = glyphs.length;
@@ -227,7 +225,6 @@ define([
             dimensions = glyph.dimensions;
             totalWidth += dimensions.computedWidth;
             maxHeight = Math.max(maxHeight, dimensions.height);
-            maxWidth = Math.max(maxWidth, dimensions.computedWidth);
         }
 
         var scale = label._scale;
@@ -241,9 +238,6 @@ define([
 
         glyphPixelOffset.x = widthOffset * resolutionScale;
         glyphPixelOffset.y = 0;
-
-        ownerSize.x = maxWidth;
-        ownerSize.y = maxHeight;
 
         var verticalOrigin = label._verticalOrigin;
         for (glyphIndex = 0; glyphIndex < glyphLength; ++glyphIndex) {
@@ -262,7 +256,6 @@ define([
 
             if (defined(glyph.billboard)) {
                 glyph.billboard._setTranslate(glyphPixelOffset);
-                glyph.billboard._setOwnerSize(ownerSize);
             }
 
             glyphPixelOffset.x += dimensions.computedWidth * scale * resolutionScale;

--- a/Source/Scene/Scene.js
+++ b/Source/Scene/Scene.js
@@ -487,6 +487,14 @@ define([
          */
         this.cameraEventWaitTime = 500.0;
 
+        /**
+         * Set to true to copy the depth texture after rendering the globe. Makes czm_globeDepthTexture valid.
+         * @type {Boolean}
+         * @default false
+         * @private
+         */
+        this.copyGlobeDepth = false;
+
         this._performanceDisplay = undefined;
         this._debugSphere = undefined;
 
@@ -1462,13 +1470,13 @@ define([
                 executeCommand(commands[j], scene, context, passState);
             }
 
-            if (defined(globeDepth)) {
+            if (defined(globeDepth) && (scene.copyGlobeDepth || scene.debugShowGlobeDepth)) {
                 globeDepth.update(context);
                 globeDepth.executeCopyDepth(context, passState);
+            }
 
-                if (scene.debugShowGlobeDepth) {
-                    passState.framebuffer = fb;
-                }
+            if (scene.debugShowGlobeDepth && defined(globeDepth)) {
+                passState.framebuffer = fb;
             }
 
             // Execute commands in order by pass up to the translucent pass.

--- a/Source/Shaders/BillboardCollectionVS.glsl
+++ b/Source/Shaders/BillboardCollectionVS.glsl
@@ -212,41 +212,14 @@ void main()
     pixelOffset *= pixelOffsetScale;
 #endif
     
-#ifdef TEST_GLOBE_DEPTH
-    if (-positionEC.z < 50000.0)
-    {
-        vec4 offsetPosition = positionEC;
-        offsetPosition.z *= 0.99;
-        
-	    vec2 directions[4];
-	    directions[0] = vec2(0.0, 0.0);
-	    directions[1] = vec2(0.0, 1.0);
-	    directions[2] = vec2(1.0, 0.0);
-	    directions[3] = vec2(1.0, 1.0);
-	    
-	    vec2 invSize = 1.0 / czm_viewport.zw;
-	    vec2 size = all(equal(vec2(0.0), ownerSize)) ? imageSize : ownerSize;
-	    
-	    bool visible = false;
-	    for (int i = 0; i < 4; ++i)
-	    {
-	        vec4 wc = computePositionWindowCoordinates(offsetPosition, size, scale, directions[i], vec2(0.0, 0.0), vec2(0.0), pixelOffset, alignedAxis, rotation);
-	        float d = czm_unpackDepth(texture2D(czm_globeDepthTexture, wc.xy * invSize));
-	        if (wc.z < d)
-	        {
-	            visible = true;
-	            break;
-	        }
-	    }
-	    
-	    if (!visible)
-	    {
-	        gl_Position = czm_projection[3];
-	        return;
-	    }
-    }
-#endif
+#ifdef CLAMPED_TO_GROUND
+    // move slightly closer to camera to avoid depth issues.
+    positionEC.z *= 0.995;
     
+    // Force bottom vertical origin
+    origin.y = 1.0;
+#endif
+
     vec4 positionWC = computePositionWindowCoordinates(positionEC, imageSize, scale, direction, origin, translate, pixelOffset, alignedAxis, rotation);
     gl_Position = czm_viewportOrthographic * vec4(positionWC.xy, -positionWC.z, 1.0);
     v_textureCoordinates = textureCoordinates;

--- a/Source/Shaders/BillboardCollectionVS.glsl
+++ b/Source/Shaders/BillboardCollectionVS.glsl
@@ -6,7 +6,6 @@ attribute vec4 compressedAttribute2;        // image height, color, pick color, 
 attribute vec3 eyeOffset;                   // eye offset in meters
 attribute vec4 scaleByDistance;             // near, nearScale, far, farScale
 attribute vec4 pixelOffsetScaleByDistance;  // near, nearScale, far, farScale
-attribute vec2 ownerSize;
 
 varying vec2 v_textureCoordinates;
 


### PR DESCRIPTION
* Removes the manual depth test in the vertex shader for clamping billboards to the ground.
* Removes the no longer needed `ownerSize` attribute from billboards.
* Adds a private `copyGlobeDepth` flag to scene to determine whether the globe depth is copied that defaults to `false`.