### PR TITLE
Geometry not always obeying Entity.show

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -36,6 +36,7 @@ Change Log
 * Added support for the [CESIUM_binary_glTF](https://github.com/KhronosGroup/glTF/blob/new-extensions/extensions/CESIUM_binary_glTF/README.md) extension for loading binary blobs of glTF to `Model`.
 * Added support for the [CESIUM_RTC](https://github.com/KhronosGroup/glTF/blob/new-extensions/extensions/CESIUM_RTC/README.md) glTF extension for high-precision rendering to `Model`.
 * Fixed a bug where the sun was smeared when the skybox/stars was disabled. [#1829](https://github.com/AnalyticalGraphicsInc/cesium/issue/1829)
+* Fixed a bug that sometimes caused `Entity` instances with `show` set to false to reappear when new `Entity` geometry is added. [#2686](https://github.com/AnalyticalGraphicsInc/cesium/issues/2686) 
 
 ### 1.9 - 2015-05-01
 

--- a/Source/DataSources/BoxGeometryUpdater.js
+++ b/Source/DataSources/BoxGeometryUpdater.js
@@ -304,7 +304,7 @@ define([
         var attributes;
 
         var color;
-        var show = new ShowGeometryInstanceAttribute(isAvailable && this._showProperty.getValue(time) && this._fillProperty.getValue(time));
+        var show = new ShowGeometryInstanceAttribute(isAvailable && entity.isShowing && this._showProperty.getValue(time) && this._fillProperty.getValue(time));
         if (this._materialProperty instanceof ColorMaterialProperty) {
             var currentColor = Color.WHITE;
             if (defined(this._materialProperty.color) && (this._materialProperty.color.isConstant || isAvailable)) {
@@ -357,7 +357,7 @@ define([
             geometry : BoxOutlineGeometry.fromDimensions(this._options),
             modelMatrix : entity._getModelMatrix(Iso8601.MINIMUM_VALUE),
             attributes : {
-                show : new ShowGeometryInstanceAttribute(isAvailable && this._showProperty.getValue(time) && this._showOutlineProperty.getValue(time)),
+                show : new ShowGeometryInstanceAttribute(isAvailable && entity.isShowing && this._showProperty.getValue(time) && this._showOutlineProperty.getValue(time)),
                 color : ColorGeometryInstanceAttribute.fromColor(outlineColor)
             }
         });

--- a/Source/DataSources/CorridorGeometryUpdater.js
+++ b/Source/DataSources/CorridorGeometryUpdater.js
@@ -312,7 +312,7 @@ define([
         var attributes;
 
         var color;
-        var show = new ShowGeometryInstanceAttribute(isAvailable && this._showProperty.getValue(time) && this._fillProperty.getValue(time));
+        var show = new ShowGeometryInstanceAttribute(isAvailable && entity.isShowing && this._showProperty.getValue(time) && this._fillProperty.getValue(time));
         if (this._materialProperty instanceof ColorMaterialProperty) {
             var currentColor = Color.WHITE;
             if (defined(this._materialProperty.color) && (this._materialProperty.color.isConstant || isAvailable)) {
@@ -363,7 +363,7 @@ define([
             id : entity,
             geometry : new CorridorOutlineGeometry(this._options),
             attributes : {
-                show : new ShowGeometryInstanceAttribute(isAvailable && this._showProperty.getValue(time) && this._showOutlineProperty.getValue(time)),
+                show : new ShowGeometryInstanceAttribute(isAvailable && entity.isShowing && this._showProperty.getValue(time) && this._showOutlineProperty.getValue(time)),
                 color : ColorGeometryInstanceAttribute.fromColor(outlineColor)
             }
         });

--- a/Source/DataSources/CylinderGeometryUpdater.js
+++ b/Source/DataSources/CylinderGeometryUpdater.js
@@ -311,7 +311,7 @@ define([
         var attributes;
 
         var color;
-        var show = new ShowGeometryInstanceAttribute(isAvailable && this._showProperty.getValue(time) && this._fillProperty.getValue(time));
+        var show = new ShowGeometryInstanceAttribute(isAvailable && entity.isShowing && this._showProperty.getValue(time) && this._fillProperty.getValue(time));
         if (this._materialProperty instanceof ColorMaterialProperty) {
             var currentColor = Color.WHITE;
             if (defined(this._materialProperty.color) && (this._materialProperty.color.isConstant || isAvailable)) {
@@ -364,7 +364,7 @@ define([
             geometry : new CylinderOutlineGeometry(this._options),
             modelMatrix : entity._getModelMatrix(Iso8601.MINIMUM_VALUE),
             attributes : {
-                show : new ShowGeometryInstanceAttribute(isAvailable && this._showProperty.getValue(time) && this._showOutlineProperty.getValue(time)),
+                show : new ShowGeometryInstanceAttribute(isAvailable && entity.isShowing && this._showProperty.getValue(time) && this._showOutlineProperty.getValue(time)),
                 color : ColorGeometryInstanceAttribute.fromColor(outlineColor)
             }
         });

--- a/Source/DataSources/EllipseGeometryUpdater.js
+++ b/Source/DataSources/EllipseGeometryUpdater.js
@@ -315,7 +315,7 @@ define([
         var attributes;
 
         var color;
-        var show = new ShowGeometryInstanceAttribute(isAvailable && this._showProperty.getValue(time) && this._fillProperty.getValue(time));
+        var show = new ShowGeometryInstanceAttribute(isAvailable && entity.isShowing && this._showProperty.getValue(time) && this._fillProperty.getValue(time));
         if (this._materialProperty instanceof ColorMaterialProperty) {
             var currentColor = Color.WHITE;
             if (defined(this._materialProperty.color) && (this._materialProperty.color.isConstant || isAvailable)) {
@@ -366,7 +366,7 @@ define([
             id : entity,
             geometry : new EllipseOutlineGeometry(this._options),
             attributes : {
-                show : new ShowGeometryInstanceAttribute(isAvailable && this._showProperty.getValue(time) && this._showOutlineProperty.getValue(time)),
+                show : new ShowGeometryInstanceAttribute(isAvailable && entity.isShowing && this._showProperty.getValue(time) && this._showOutlineProperty.getValue(time)),
                 color : ColorGeometryInstanceAttribute.fromColor(outlineColor)
             }
         });

--- a/Source/DataSources/EllipsoidGeometryUpdater.js
+++ b/Source/DataSources/EllipsoidGeometryUpdater.js
@@ -316,7 +316,7 @@ define([
         var attributes;
 
         var color;
-        var show = new ShowGeometryInstanceAttribute(isAvailable && this._showProperty.getValue(time) && this._fillProperty.getValue(time));
+        var show = new ShowGeometryInstanceAttribute(isAvailable && entity.isShowing && this._showProperty.getValue(time) && this._fillProperty.getValue(time));
         if (this._materialProperty instanceof ColorMaterialProperty) {
             var currentColor = Color.WHITE;
             if (defined(this._materialProperty.color) && (this._materialProperty.color.isConstant || isAvailable)) {
@@ -370,7 +370,7 @@ define([
             geometry : new EllipsoidOutlineGeometry(this._options),
             modelMatrix : entity._getModelMatrix(Iso8601.MINIMUM_VALUE),
             attributes : {
-                show : new ShowGeometryInstanceAttribute(isAvailable && this._showProperty.getValue(time) && this._showOutlineProperty.getValue(time)),
+                show : new ShowGeometryInstanceAttribute(isAvailable && entity.isShowing && this._showProperty.getValue(time) && this._showOutlineProperty.getValue(time)),
                 color : ColorGeometryInstanceAttribute.fromColor(outlineColor)
             }
         });

--- a/Source/DataSources/PolygonGeometryUpdater.js
+++ b/Source/DataSources/PolygonGeometryUpdater.js
@@ -316,7 +316,7 @@ define([
         var attributes;
 
         var color;
-        var show = new ShowGeometryInstanceAttribute(isAvailable && this._showProperty.getValue(time) && this._fillProperty.getValue(time));
+        var show = new ShowGeometryInstanceAttribute(isAvailable && entity.isShowing && this._showProperty.getValue(time) && this._fillProperty.getValue(time));
         if (this._materialProperty instanceof ColorMaterialProperty) {
             var currentColor = Color.WHITE;
             if (defined(this._materialProperty.color) && (this._materialProperty.color.isConstant || isAvailable)) {
@@ -367,7 +367,7 @@ define([
             id : entity,
             geometry : new PolygonOutlineGeometry(this._options),
             attributes : {
-                show : new ShowGeometryInstanceAttribute(isAvailable && this._showProperty.getValue(time) && this._showOutlineProperty.getValue(time)),
+                show : new ShowGeometryInstanceAttribute(isAvailable && entity.isShowing && this._showProperty.getValue(time) && this._showOutlineProperty.getValue(time)),
                 color : ColorGeometryInstanceAttribute.fromColor(outlineColor)
             }
         });

--- a/Source/DataSources/PolylineGeometryUpdater.js
+++ b/Source/DataSources/PolylineGeometryUpdater.js
@@ -277,7 +277,7 @@ define([
         var attributes;
         var entity = this._entity;
         var isAvailable = entity.isAvailable(time);
-        var show = new ShowGeometryInstanceAttribute(isAvailable && this._showProperty.getValue(time));
+        var show = new ShowGeometryInstanceAttribute(isAvailable && entity.isShowing && this._showProperty.getValue(time));
 
         if (this._materialProperty instanceof ColorMaterialProperty) {
             var currentColor = Color.WHITE;

--- a/Source/DataSources/PolylineVolumeGeometryUpdater.js
+++ b/Source/DataSources/PolylineVolumeGeometryUpdater.js
@@ -307,7 +307,7 @@ define([
         var attributes;
 
         var color;
-        var show = new ShowGeometryInstanceAttribute(isAvailable && this._showProperty.getValue(time) && this._fillProperty.getValue(time));
+        var show = new ShowGeometryInstanceAttribute(isAvailable && entity.isShowing && this._showProperty.getValue(time) && this._fillProperty.getValue(time));
         if (this._materialProperty instanceof ColorMaterialProperty) {
             var currentColor = Color.WHITE;
             if (defined(this._materialProperty.color) && (this._materialProperty.color.isConstant || isAvailable)) {
@@ -358,7 +358,7 @@ define([
             id : entity,
             geometry : new PolylineVolumeOutlineGeometry(this._options),
             attributes : {
-                show : new ShowGeometryInstanceAttribute(isAvailable && this._showProperty.getValue(time) && this._showOutlineProperty.getValue(time)),
+                show : new ShowGeometryInstanceAttribute(isAvailable && entity.isShowing && this._showProperty.getValue(time) && this._showOutlineProperty.getValue(time)),
                 color : ColorGeometryInstanceAttribute.fromColor(outlineColor)
             }
         });

--- a/Source/DataSources/RectangleGeometryUpdater.js
+++ b/Source/DataSources/RectangleGeometryUpdater.js
@@ -314,7 +314,7 @@ define([
         var attributes;
 
         var color;
-        var show = new ShowGeometryInstanceAttribute(isAvailable && this._showProperty.getValue(time) && this._fillProperty.getValue(time));
+        var show = new ShowGeometryInstanceAttribute(isAvailable && entity.isShowing && this._showProperty.getValue(time) && this._fillProperty.getValue(time));
         if (this._materialProperty instanceof ColorMaterialProperty) {
             var currentColor = Color.WHITE;
             if (defined(this._materialProperty.color) && (this._materialProperty.color.isConstant || isAvailable)) {
@@ -365,7 +365,7 @@ define([
             id : entity,
             geometry : new RectangleOutlineGeometry(this._options),
             attributes : {
-                show : new ShowGeometryInstanceAttribute(isAvailable && this._showProperty.getValue(time) && this._showOutlineProperty.getValue(time)),
+                show : new ShowGeometryInstanceAttribute(isAvailable && entity.isShowing && this._showProperty.getValue(time) && this._showOutlineProperty.getValue(time)),
                 color : ColorGeometryInstanceAttribute.fromColor(outlineColor)
             }
         });

--- a/Source/DataSources/StaticGeometryColorBatch.js
+++ b/Source/DataSources/StaticGeometryColorBatch.js
@@ -71,6 +71,9 @@ define([
         var removedCount = 0;
         var primitive = this.primitive;
         var primitives = this.primitives;
+        var attributes;
+        var i;
+
         if (this.createPrimitive) {
             if (defined(primitive)) {
                 if (!defined(this.oldPrimitive)) {
@@ -79,12 +82,28 @@ define([
                     primitives.remove(primitive);
                 }
             }
-            this.attributes.removeAll();
-            var geometry = this.geometry.values;
-            if (geometry.length > 0) {
+
+            var geometries = this.geometry.values;
+            var geometriesLength = geometries.length;
+            if (geometriesLength > 0) {
+                for (i = 0; i < geometriesLength; i++) {
+                    var geometryItem = geometries[i];
+                    var originalAttributes = geometryItem.attributes;
+                    attributes = this.attributes.get(geometryItem.id.id);
+
+                    if (defined(attributes)) {
+                        if (defined(originalAttributes.show)) {
+                            originalAttributes.show.value = attributes.show;
+                        }
+                        if (defined(originalAttributes.color)) {
+                            originalAttributes.color.value = attributes.color;
+                        }
+                    }
+                }
+
                 primitive = new Primitive({
                     asynchronous : true,
-                    geometryInstances : geometry,
+                    geometryInstances : geometries,
                     appearance : new this.appearanceType({
                         translucent : this.translucent,
                         closed : this.closed
@@ -93,6 +112,8 @@ define([
                 primitives.add(primitive);
                 isUpdated = false;
             }
+
+            this.attributes.removeAll();
             this.primitive = primitive;
             this.createPrimitive = false;
         } else if (defined(primitive) && primitive.ready) {
@@ -102,11 +123,11 @@ define([
             }
             var updatersWithAttributes = this.updatersWithAttributes.values;
             var length = updatersWithAttributes.length;
-            for (var i = 0; i < length; i++) {
+            for (i = 0; i < length; i++) {
                 var updater = updatersWithAttributes[i];
                 var instance = this.geometry.get(updater.entity.id);
 
-                var attributes = this.attributes.get(instance.id.id);
+                attributes = this.attributes.get(instance.id.id);
                 if (!defined(attributes)) {
                     attributes = primitive.getGeometryInstanceAttributes(instance.id);
                     this.attributes.set(instance.id.id, attributes);

--- a/Source/DataSources/StaticGeometryPerMaterialBatch.js
+++ b/Source/DataSources/StaticGeometryPerMaterialBatch.js
@@ -89,6 +89,9 @@ define([
         var primitive = this.primitive;
         var primitives = this.primitives;
         var geometries = this.geometry.values;
+        var attributes;
+        var i;
+
         if (this.createPrimitive) {
             if (defined(primitive)) {
                 if (!defined(this.oldPrimitive)) {
@@ -97,7 +100,24 @@ define([
                     primitives.remove(primitive);
                 }
             }
-            if (geometries.length > 0) {
+
+            var geometriesLength = geometries.length;
+            if (geometriesLength > 0) {
+                for (i = 0; i < geometriesLength; i++) {
+                    var geometry = geometries[i];
+                    var originalAttributes = geometry.attributes;
+                    attributes = this.attributes.get(geometry.id.id);
+
+                    if (defined(attributes)) {
+                        if (defined(originalAttributes.show)) {
+                            originalAttributes.show.value = attributes.show;
+                        }
+                        if (defined(originalAttributes.color)) {
+                            originalAttributes.color.value = attributes.color;
+                        }
+                    }
+                }
+
                 this.material = MaterialProperty.getValue(time, this.materialProperty, this.material);
                 primitive = new Primitive({
                     asynchronous : true,
@@ -112,6 +132,8 @@ define([
                 primitives.add(primitive);
                 isUpdated = false;
             }
+
+            this.attributes.removeAll();
             this.primitive = primitive;
             this.createPrimitive = false;
         } else if (defined(primitive) && primitive.ready) {
@@ -125,12 +147,12 @@ define([
 
             var updatersWithAttributes = this.updatersWithAttributes.values;
             var length = updatersWithAttributes.length;
-            for (var i = 0; i < length; i++) {
+            for (i = 0; i < length; i++) {
                 var updater = updatersWithAttributes[i];
                 var entity = updater.entity;
                 var instance = this.geometry.get(entity.id);
 
-                var attributes = this.attributes.get(instance.id.id);
+                attributes = this.attributes.get(instance.id.id);
                 if (!defined(attributes)) {
                     attributes = primitive.getGeometryInstanceAttributes(instance.id);
                     this.attributes.set(instance.id.id, attributes);

--- a/Source/DataSources/StaticOutlineGeometryBatch.js
+++ b/Source/DataSources/StaticOutlineGeometryBatch.js
@@ -71,8 +71,10 @@ define([
         var removedCount = 0;
         var primitive = this.primitive;
         var primitives = this.primitives;
+        var attributes;
+        var i;
+
         if (this.createPrimitive) {
-            this.attributes.removeAll();
             if (defined(primitive)) {
                 if (!defined(this.oldPrimitive)) {
                     this.oldPrimitive = primitive;
@@ -80,11 +82,27 @@ define([
                     primitives.remove(primitive);
                 }
             }
-            var geometry = this.geometry.values;
-            if (geometry.length > 0) {
+            var geometries = this.geometry.values;
+            var geometriesLength = geometries.length;
+            if (geometriesLength > 0) {
+                for (i = 0; i < geometriesLength; i++) {
+                    var geometryItem = geometries[i];
+                    var originalAttributes = geometryItem.attributes;
+                    attributes = this.attributes.get(geometryItem.id.id);
+
+                    if (defined(attributes)) {
+                        if (defined(originalAttributes.show)) {
+                            originalAttributes.show.value = attributes.show;
+                        }
+                        if (defined(originalAttributes.color)) {
+                            originalAttributes.color.value = attributes.color;
+                        }
+                    }
+                }
+
                 primitive = new Primitive({
                     asynchronous : true,
-                    geometryInstances : geometry,
+                    geometryInstances : geometries,
                     appearance : new PerInstanceColorAppearance({
                         flat : true,
                         translucent : this.translucent,
@@ -97,6 +115,8 @@ define([
                 primitives.add(primitive);
                 isUpdated = false;
             }
+
+            this.attributes.removeAll();
             this.primitive = primitive;
             this.createPrimitive = false;
         } else if (defined(primitive) && primitive.ready) {
@@ -107,11 +127,11 @@ define([
 
             var updatersWithAttributes = this.updatersWithAttributes.values;
             var length = updatersWithAttributes.length;
-            for (var i = 0; i < length; i++) {
+            for (i = 0; i < length; i++) {
                 var updater = updatersWithAttributes[i];
                 var instance = this.geometry.get(updater.entity.id);
 
-                var attributes = this.attributes.get(instance.id.id);
+                attributes = this.attributes.get(instance.id.id);
                 if (!defined(attributes)) {
                     attributes = primitive.getGeometryInstanceAttributes(instance.id);
                     this.attributes.set(instance.id.id, attributes);

--- a/Source/DataSources/WallGeometryUpdater.js
+++ b/Source/DataSources/WallGeometryUpdater.js
@@ -309,7 +309,7 @@ define([
         var attributes;
 
         var color;
-        var show = new ShowGeometryInstanceAttribute(isAvailable && this._showProperty.getValue(time) && this._fillProperty.getValue(time));
+        var show = new ShowGeometryInstanceAttribute(isAvailable && entity.isShowing && this._showProperty.getValue(time) && this._fillProperty.getValue(time));
         if (this._materialProperty instanceof ColorMaterialProperty) {
             var currentColor = Color.WHITE;
             if (defined(this._materialProperty.color) && (this._materialProperty.color.isConstant || isAvailable)) {
@@ -360,7 +360,7 @@ define([
             id : entity,
             geometry : new WallOutlineGeometry(this._options),
             attributes : {
-                show : new ShowGeometryInstanceAttribute(isAvailable && this._showProperty.getValue(time) && this._showOutlineProperty.getValue(time)),
+                show : new ShowGeometryInstanceAttribute(isAvailable && entity.isShowing && this._showProperty.getValue(time) && this._showOutlineProperty.getValue(time)),
                 color : ColorGeometryInstanceAttribute.fromColor(outlineColor)
             }
         });

--- a/Specs/DataSources/BoxGeometryUpdaterSpec.js
+++ b/Specs/DataSources/BoxGeometryUpdaterSpec.js
@@ -275,6 +275,26 @@ defineSuite([
         expect(attributes.show.value).toEqual(ShowGeometryInstanceAttribute.toValue(outline.getValue(time2)));
     });
 
+    it('createFillGeometryInstance obeys Entity.show is false.', function() {
+        var entity = createBasicBox();
+        entity.show = false;
+        entity.box.fill = true;
+        var updater = new BoxGeometryUpdater(entity, scene);
+        var instance = updater.createFillGeometryInstance(new JulianDate());
+        var attributes = instance.attributes;
+        expect(attributes.show.value).toEqual(ShowGeometryInstanceAttribute.toValue(false));
+    });
+
+    it('createOutlineGeometryInstance obeys Entity.show is false.', function() {
+        var entity = createBasicBox();
+        entity.show = false;
+        entity.box.outline = true;
+        var updater = new BoxGeometryUpdater(entity, scene);
+        var instance = updater.createFillGeometryInstance(new JulianDate());
+        var attributes = instance.attributes;
+        expect(attributes.show.value).toEqual(ShowGeometryInstanceAttribute.toValue(false));
+    });
+
     it('dynamic updater sets properties', function() {
         var entity = new Entity();
         entity.position = new ConstantPositionProperty(Cartesian3.fromDegrees(0, 0, 0));

--- a/Specs/DataSources/CorridorGeometryUpdaterSpec.js
+++ b/Specs/DataSources/CorridorGeometryUpdaterSpec.js
@@ -362,6 +362,26 @@ defineSuite([
         expect(attributes.show.value).toEqual(ShowGeometryInstanceAttribute.toValue(outline.getValue(time2)));
     });
 
+    it('createFillGeometryInstance obeys Entity.show is false.', function() {
+        var entity = createBasicCorridor();
+        entity.show = false;
+        entity.corridor.fill = true;
+        var updater = new CorridorGeometryUpdater(entity, scene);
+        var instance = updater.createFillGeometryInstance(new JulianDate());
+        var attributes = instance.attributes;
+        expect(attributes.show.value).toEqual(ShowGeometryInstanceAttribute.toValue(false));
+    });
+
+    it('createOutlineGeometryInstance obeys Entity.show is false.', function() {
+        var entity = createBasicCorridor();
+        entity.show = false;
+        entity.corridor.outline = true;
+        var updater = new CorridorGeometryUpdater(entity, scene);
+        var instance = updater.createFillGeometryInstance(new JulianDate());
+        var attributes = instance.attributes;
+        expect(attributes.show.value).toEqual(ShowGeometryInstanceAttribute.toValue(false));
+    });
+
     it('dynamic updater sets properties', function() {
         var corridor = new CorridorGraphics();
         corridor.positions = createDynamicProperty(Cartesian3.fromRadiansArray([

--- a/Specs/DataSources/CylinderGeometryUpdaterSpec.js
+++ b/Specs/DataSources/CylinderGeometryUpdaterSpec.js
@@ -357,6 +357,26 @@ defineSuite([
         expect(attributes.show.value).toEqual(ShowGeometryInstanceAttribute.toValue(outline.getValue(time2)));
     });
 
+    it('createFillGeometryInstance obeys Entity.show is false.', function() {
+        var entity = createBasicCylinder();
+        entity.show = false;
+        entity.cylinder.fill = true;
+        var updater = new CylinderGeometryUpdater(entity, scene);
+        var instance = updater.createFillGeometryInstance(new JulianDate());
+        var attributes = instance.attributes;
+        expect(attributes.show.value).toEqual(ShowGeometryInstanceAttribute.toValue(false));
+    });
+
+    it('createOutlineGeometryInstance obeys Entity.show is false.', function() {
+        var entity = createBasicCylinder();
+        entity.show = false;
+        entity.cylinder.outline = true;
+        var updater = new CylinderGeometryUpdater(entity, scene);
+        var instance = updater.createFillGeometryInstance(new JulianDate());
+        var attributes = instance.attributes;
+        expect(attributes.show.value).toEqual(ShowGeometryInstanceAttribute.toValue(false));
+    });
+
     it('dynamic updater sets properties', function() {
         var cylinder = new CylinderGraphics();
         cylinder.show = createDynamicProperty(true);

--- a/Specs/DataSources/EllipseGeometryUpdaterSpec.js
+++ b/Specs/DataSources/EllipseGeometryUpdaterSpec.js
@@ -411,6 +411,26 @@ defineSuite([
         expect(attributes.show.value).toEqual(ShowGeometryInstanceAttribute.toValue(outline.getValue(time2)));
     });
 
+    it('createFillGeometryInstance obeys Entity.show is false.', function() {
+        var entity = createBasicEllipse();
+        entity.show = false;
+        entity.ellipse.fill = true;
+        var updater = new EllipseGeometryUpdater(entity, scene);
+        var instance = updater.createFillGeometryInstance(new JulianDate());
+        var attributes = instance.attributes;
+        expect(attributes.show.value).toEqual(ShowGeometryInstanceAttribute.toValue(false));
+    });
+
+    it('createOutlineGeometryInstance obeys Entity.show is false.', function() {
+        var entity = createBasicEllipse();
+        entity.show = false;
+        entity.ellipse.outline = true;
+        var updater = new EllipseGeometryUpdater(entity, scene);
+        var instance = updater.createFillGeometryInstance(new JulianDate());
+        var attributes = instance.attributes;
+        expect(attributes.show.value).toEqual(ShowGeometryInstanceAttribute.toValue(false));
+    });
+
     it('dynamic updater sets properties', function() {
         var ellipse = new EllipseGraphics();
         ellipse.show = createDynamicProperty(true);

--- a/Specs/DataSources/EllipsoidGeometryUpdaterSpec.js
+++ b/Specs/DataSources/EllipsoidGeometryUpdaterSpec.js
@@ -345,6 +345,26 @@ defineSuite([
         expect(attributes.show.value).toEqual(ShowGeometryInstanceAttribute.toValue(outline.getValue(time2)));
     });
 
+    it('createFillGeometryInstance obeys Entity.show is false.', function() {
+        var entity = createBasicEllipsoid();
+        entity.show = false;
+        entity.ellipsoid.fill = true;
+        var updater = new EllipsoidGeometryUpdater(entity, scene);
+        var instance = updater.createFillGeometryInstance(new JulianDate());
+        var attributes = instance.attributes;
+        expect(attributes.show.value).toEqual(ShowGeometryInstanceAttribute.toValue(false));
+    });
+
+    it('createOutlineGeometryInstance obeys Entity.show is false.', function() {
+        var entity = createBasicEllipsoid();
+        entity.show = false;
+        entity.ellipsoid.outline = true;
+        var updater = new EllipsoidGeometryUpdater(entity, scene);
+        var instance = updater.createFillGeometryInstance(new JulianDate());
+        var attributes = instance.attributes;
+        expect(attributes.show.value).toEqual(ShowGeometryInstanceAttribute.toValue(false));
+    });
+
     it('dynamic ellipsoid creates and updates', function() {
         var ellipsoid = new EllipsoidGraphics();
         ellipsoid.show = createDynamicProperty(true);

--- a/Specs/DataSources/PolygonGeometryUpdaterSpec.js
+++ b/Specs/DataSources/PolygonGeometryUpdaterSpec.js
@@ -357,6 +357,26 @@ defineSuite([
         expect(attributes.show.value).toEqual(ShowGeometryInstanceAttribute.toValue(outline.getValue(time2)));
     });
 
+    it('createFillGeometryInstance obeys Entity.show is false.', function() {
+        var entity = createBasicPolygon();
+        entity.show = false;
+        entity.polygon.fill = true;
+        var updater = new PolygonGeometryUpdater(entity, scene);
+        var instance = updater.createFillGeometryInstance(new JulianDate());
+        var attributes = instance.attributes;
+        expect(attributes.show.value).toEqual(ShowGeometryInstanceAttribute.toValue(false));
+    });
+
+    it('createOutlineGeometryInstance obeys Entity.show is false.', function() {
+        var entity = createBasicPolygon();
+        entity.show = false;
+        entity.polygon.outline = true;
+        var updater = new PolygonGeometryUpdater(entity, scene);
+        var instance = updater.createFillGeometryInstance(new JulianDate());
+        var attributes = instance.attributes;
+        expect(attributes.show.value).toEqual(ShowGeometryInstanceAttribute.toValue(false));
+    });
+
     it('dynamic updater sets properties', function() {
         var polygon = new PolygonGraphics();
         polygon.hierarchy = createDynamicProperty(new PolygonHierarchy(Cartesian3.fromRadiansArray([

--- a/Specs/DataSources/PolylineGeometryUpdaterSpec.js
+++ b/Specs/DataSources/PolylineGeometryUpdaterSpec.js
@@ -272,6 +272,16 @@ defineSuite([
         expect(attributes.show.value).toEqual(ShowGeometryInstanceAttribute.toValue(show.getValue(time2)));
     });
 
+    it('createFillGeometryInstance obeys Entity.show is false.', function() {
+        var entity = createBasicPolyline();
+        entity.show = false;
+        entity.polyline.fill = true;
+        var updater = new PolylineGeometryUpdater(entity, scene);
+        var instance = updater.createFillGeometryInstance(new JulianDate());
+        var attributes = instance.attributes;
+        expect(attributes.show.value).toEqual(ShowGeometryInstanceAttribute.toValue(false));
+    });
+
     it('dynamic updater sets properties', function() {
         var entity = new Entity();
         var polyline = new PolylineGraphics();

--- a/Specs/DataSources/PolylineVolumeGeometryUpdaterSpec.js
+++ b/Specs/DataSources/PolylineVolumeGeometryUpdaterSpec.js
@@ -320,6 +320,26 @@ defineSuite([
         expect(attributes.show.value).toEqual(ShowGeometryInstanceAttribute.toValue(outline.getValue(time2)));
     });
 
+    it('createFillGeometryInstance obeys Entity.show is false.', function() {
+        var entity = createBasicPolylineVolume();
+        entity.show = false;
+        entity.polylineVolume.fill = true;
+        var updater = new PolylineVolumeGeometryUpdater(entity, scene);
+        var instance = updater.createFillGeometryInstance(new JulianDate());
+        var attributes = instance.attributes;
+        expect(attributes.show.value).toEqual(ShowGeometryInstanceAttribute.toValue(false));
+    });
+
+    it('createOutlineGeometryInstance obeys Entity.show is false.', function() {
+        var entity = createBasicPolylineVolume();
+        entity.show = false;
+        entity.polylineVolume.outline = true;
+        var updater = new PolylineVolumeGeometryUpdater(entity, scene);
+        var instance = updater.createFillGeometryInstance(new JulianDate());
+        var attributes = instance.attributes;
+        expect(attributes.show.value).toEqual(ShowGeometryInstanceAttribute.toValue(false));
+    });
+
     it('dynamic updater sets properties', function() {
         var polylineVolume = new PolylineVolumeGraphics();
         polylineVolume.positions = createDynamicProperty(Cartesian3.fromRadiansArray([

--- a/Specs/DataSources/RectangleGeometryUpdaterSpec.js
+++ b/Specs/DataSources/RectangleGeometryUpdaterSpec.js
@@ -368,6 +368,26 @@ defineSuite([
         expect(attributes.show.value).toEqual(ShowGeometryInstanceAttribute.toValue(outline.getValue(time2)));
     });
 
+    it('createFillGeometryInstance obeys Entity.show is false.', function() {
+        var entity = createBasicRectangle();
+        entity.show = false;
+        entity.rectangle.fill = true;
+        var updater = new RectangleGeometryUpdater(entity, scene);
+        var instance = updater.createFillGeometryInstance(new JulianDate());
+        var attributes = instance.attributes;
+        expect(attributes.show.value).toEqual(ShowGeometryInstanceAttribute.toValue(false));
+    });
+
+    it('createOutlineGeometryInstance obeys Entity.show is false.', function() {
+        var entity = createBasicRectangle();
+        entity.show = false;
+        entity.rectangle.outline = true;
+        var updater = new RectangleGeometryUpdater(entity, scene);
+        var instance = updater.createFillGeometryInstance(new JulianDate());
+        var attributes = instance.attributes;
+        expect(attributes.show.value).toEqual(ShowGeometryInstanceAttribute.toValue(false));
+    });
+
     it('dynamic updater sets properties', function() {
         var rectangle = new RectangleGraphics();
         rectangle.coordinates = createDynamicProperty(new Rectangle(0, 0, 1, 1));

--- a/Specs/DataSources/WallGeometryUpdaterSpec.js
+++ b/Specs/DataSources/WallGeometryUpdaterSpec.js
@@ -331,6 +331,26 @@ defineSuite([
         expect(attributes.show.value).toEqual(ShowGeometryInstanceAttribute.toValue(outline.getValue(time2)));
     });
 
+    it('createFillGeometryInstance obeys Entity.show is false.', function() {
+        var entity = createBasicWall();
+        entity.show = false;
+        entity.wall.fill = true;
+        var updater = new WallGeometryUpdater(entity, scene);
+        var instance = updater.createFillGeometryInstance(new JulianDate());
+        var attributes = instance.attributes;
+        expect(attributes.show.value).toEqual(ShowGeometryInstanceAttribute.toValue(false));
+    });
+
+    it('createOutlineGeometryInstance obeys Entity.show is false.', function() {
+        var entity = createBasicWall();
+        entity.show = false;
+        entity.wall.outline = true;
+        var updater = new WallGeometryUpdater(entity, scene);
+        var instance = updater.createFillGeometryInstance(new JulianDate());
+        var attributes = instance.attributes;
+        expect(attributes.show.value).toEqual(ShowGeometryInstanceAttribute.toValue(false));
+    });
+
     it('dynamic updater sets properties', function() {
         var wall = new WallGraphics();
         wall.positions = createDynamicProperty(Cartesian3.fromRadiansArray([0, 0, 1, 0, 1, 1, 0, 1]));


### PR DESCRIPTION
This fixes two issues.  First is the simple case where `Entity.show` is set to false at the time entity geometry gets created but the geometry would still show up (because none of the geometry updaters were checking for `entity.isShowing` at creation time.  Second was the current value of geometry attributes being lost when entities were re-batched when new geometry was added.  This is because the instance attributes in the original geometry are not the same instance as the attributes on the created primitive.  Now we loop through current attribute values and transfer them to the new primitive.

In addition to new tests, there' s also a Sandcastle example in #2686 that can reproduce the problem.

Fixes #2686