### PR TITLE
Make Sandcastle tolerant of JSDoc's new static prefixes.

### DIFF
--- a/Apps/Sandcastle/CesiumSandcastle.js
+++ b/Apps/Sandcastle/CesiumSandcastle.js
@@ -243,7 +243,7 @@ require({
                 var member = local.docTypes[lowerText][i];
                 var ele = document.createElement('a');
                 ele.target = '_blank';
-                ele.textContent = member.replace('.html', '').replace('module-', '').replace('#', '.');
+                ele.textContent = member.replace('.html', '').replace('module-', '').replace('#.', '.').replace('#', '.');
                 ele.href = '../../Build/Documentation/' + member;
                 ele.onclick = onDocClick;
                 docMessage.appendChild(ele);
@@ -892,13 +892,13 @@ require({
 
     registry.byId('buttonNewWindow').on('click', function() {
         var baseHref = window.location.href;
-        
+
         //Handle case where demo is in a sub-directory.
         var searchLen = window.location.search.length;
         if (searchLen > 0) {
             baseHref = baseHref.substring(0, baseHref.length - searchLen);
         }
-        
+
         var pos = baseHref.lastIndexOf('/');
         baseHref = baseHref.substring(0, pos) + '/gallery/';
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,7 +3,7 @@ Change Log
 
 ### 1.10 - 2015-06-01
 * Breaking changes
-  *
+  * Existing bookmarks to documentation of static members have changed [#2757](https://github.com/AnalyticalGraphicsInc/cesium/issues/2757).
 * Deprecated
   * Deprecated `Camera.clone`. It will be removed in 1.11.
   * `WebMapServiceImageryProvider` constructor parameters `options.getFeatureInfoAsGeoJson` and `options.getFeatureInfoAsXml` have been deprecated and will be removed in Cesium 1.13.  Use `options.getFeatureInfoFormats` instead.

--- a/Tools/jsdoc/cesium_template/publish.js
+++ b/Tools/jsdoc/cesium_template/publish.js
@@ -404,6 +404,10 @@ exports.publish = function(taffyData, opts, tutorials) {
             members.forEach(function(member) {
                 member = member.id;
                 var memberLower = member.toLowerCase();
+                var firstChar = memberLower.charAt(0);
+                if (firstChar === '.' || firstChar === '~') {
+                    memberLower = memberLower.substring(1);
+                }
 
                 typesJson[memberLower] = typesJson[memberLower] || [];
                 typesJson[memberLower].push(filename + '#' + member);


### PR DESCRIPTION
Fixes #2757.  There are two parts to this fix.  

1. In the generated `types` file, the keys have the prefixes removed (since the keys match lowercase snippets of alphanumeric source code, sans punctuation), but the values are real URLs with the prefixes intact.  Thus, fragments of text can be matched to both static and non-static member URLs.

2. Sandcastle's presentation of the matched links was based on the values, not the keys, in order to display the correct casing.  Thus the presentation was tweaked to not show the new prefix.
