### PR TITLE
Adjust the default pitch based on altitude.

### DIFF
--- a/Source/DataSources/EntityView.js
+++ b/Source/DataSources/EntityView.js
@@ -250,6 +250,9 @@ define([
     // Initialize the static property.
     EntityView.defaultOffset3D = new Cartesian3(-14000, 3500, 3500);
 
+    var scratchHeadingPitchRange = new HeadingPitchRange();
+    var scratchCartesian = new Cartesian3();
+
     /**
     * Should be called each animation frame to update the camera
     * to the latest settings.
@@ -302,7 +305,14 @@ define([
             if (!hasViewFrom && defined(sphere)) {
                 var controller = scene.screenSpaceCameraController;
                 controller.minimumZoomDistance = Math.min(controller.minimumZoomDistance, sphere.radius * 0.5);
-                camera.viewBoundingSphere(sphere);
+                scratchHeadingPitchRange.pitch = -CesiumMath.PI_OVER_FOUR;
+                scratchHeadingPitchRange.range = 0;
+                var position = positionProperty.getValue(time, scratchCartesian);
+                if (defined(position)) {
+                    var factor = 2 - 1 / Math.max(1, Cartesian3.magnitude(position) / ellipsoid.maximumRadius);
+                    scratchHeadingPitchRange.pitch *= factor;
+                }
+                camera.viewBoundingSphere(sphere, scratchHeadingPitchRange);
                 this._boundingSphereOffset = Cartesian3.subtract(sphere.center, entity.position.getValue(time), new Cartesian3());
                 updateLookAt = false;
             } else if (!hasViewFrom || !defined(viewFromProperty.getValue(time, offset3D))) {

--- a/Source/DataSources/EntityView.js
+++ b/Source/DataSources/EntityView.js
@@ -305,6 +305,10 @@ define([
             if (!hasViewFrom && defined(sphere)) {
                 var controller = scene.screenSpaceCameraController;
                 controller.minimumZoomDistance = Math.min(controller.minimumZoomDistance, sphere.radius * 0.5);
+
+                //The default HPR is not ideal for high altitude objects so
+                //we scale the pitch as we get further from the earth for a more
+                //downward view.
                 scratchHeadingPitchRange.pitch = -CesiumMath.PI_OVER_FOUR;
                 scratchHeadingPitchRange.range = 0;
                 var position = positionProperty.getValue(time, scratchCartesian);
@@ -312,6 +316,7 @@ define([
                     var factor = 2 - 1 / Math.max(1, Cartesian3.magnitude(position) / ellipsoid.maximumRadius);
                     scratchHeadingPitchRange.pitch *= factor;
                 }
+
                 camera.viewBoundingSphere(sphere, scratchHeadingPitchRange);
                 this._boundingSphereOffset = Cartesian3.subtract(sphere.center, entity.position.getValue(time), new Cartesian3());
                 updateLookAt = false;


### PR DESCRIPTION
Fixes #2765.  This change does NOT modify the default view for any objects sitting anywhere on or below the max radius of the ellipsoid.  Above the max radius, the view gently tips down, the higher you are at the moment you switch the view.  At LEO altitudes it's hard to tell anything has changed.  At Molniya altitudes, the view tips down enough that the Earth is still visible.

I haven't tried GEO yet, I should test that before merge.

Also, note that `camera.viewBoundingSphere` modifies its optional parameter, that might be a separate bug.