### PR TITLE
Bounding sphere union

### DIFF
--- a/Source/Core/BoundingSphere.js
+++ b/Source/Core/BoundingSphere.js
@@ -715,13 +715,13 @@ define([
 
         // There are two tangent points, one on far side of each sphere.
         var halfDistanceBetweenTangentPoints = (leftRadius + centerSeparation + rightRadius) * 0.5;
-        result.radius = halfDistanceBetweenTangentPoints;
 
         // Compute the center point halfway between the two tangent points.
         var center = Cartesian3.multiplyByScalar(toRightCenter,
                 (-leftRadius + halfDistanceBetweenTangentPoints) / centerSeparation, unionScratchCenter);
         Cartesian3.add(center, leftCenter, center);
         Cartesian3.clone(center, result.center);
+        result.radius = halfDistanceBetweenTangentPoints;
 
         return result;
     };

--- a/Source/Core/BoundingSphere.js
+++ b/Source/Core/BoundingSphere.js
@@ -694,15 +694,33 @@ define([
         }
 
         var leftCenter = left.center;
+        var leftRadius = left.radius;
         var rightCenter = right.center;
+        var rightRadius = right.radius;
 
-        Cartesian3.add(leftCenter, rightCenter, unionScratchCenter);
-        var center = Cartesian3.multiplyByScalar(unionScratchCenter, 0.5, unionScratchCenter);
+        var toRightCenter = Cartesian3.subtract(rightCenter, leftCenter, unionScratch);
+        var centerSeparation = Cartesian3.magnitude(toRightCenter);
 
-        var radius1 = Cartesian3.magnitude(Cartesian3.subtract(leftCenter, center, unionScratch)) + left.radius;
-        var radius2 = Cartesian3.magnitude(Cartesian3.subtract(rightCenter, center, unionScratch)) + right.radius;
+        if (leftRadius >= (centerSeparation + rightRadius)) {
+            // Left sphere wins.
+            left.clone(result);
+            return result;
+        }
 
-        result.radius = Math.max(radius1, radius2);
+        if (rightRadius >= (centerSeparation + leftRadius)) {
+            // Right sphere wins.
+            right.clone(result);
+            return result;
+        }
+
+        // There are two tangent points, one on far side of each sphere.
+        var halfDistanceBetweenTangentPoints = (leftRadius + centerSeparation + rightRadius) * 0.5;
+        result.radius = halfDistanceBetweenTangentPoints;
+
+        // Compute the center point halfway between the two tangent points.
+        var center = Cartesian3.multiplyByScalar(toRightCenter,
+                (-leftRadius + halfDistanceBetweenTangentPoints) / centerSeparation, unionScratchCenter);
+        Cartesian3.add(center, leftCenter, center);
         Cartesian3.clone(center, result.center);
 
         return result;

--- a/Specs/Core/BoundingSphereSpec.js
+++ b/Specs/Core/BoundingSphereSpec.js
@@ -415,10 +415,24 @@ defineSuite([
         expect(BoundingSphere.union(bs1, bs2)).toEqual(expected);
     });
 
-    it('union result parameter is caller', function() {
+    it('union left sphere encloses right', function() {
+        var bs1 = new BoundingSphere(Cartesian3.ZERO, 3.0);
+        var bs2 = new BoundingSphere(Cartesian3.UNIT_X, 1.0);
+        var union = BoundingSphere.union(bs1, bs2);
+        expect(union).toEqual(bs1);
+    });
+
+    it('union of co-located spheres, right sphere encloses left', function() {
+        var bs1 = new BoundingSphere(Cartesian3.UNIT_X, 1.0);
+        var bs2 = new BoundingSphere(Cartesian3.UNIT_X, 2.0);
+        var union = BoundingSphere.union(bs1, bs2);
+        expect(union).toEqual(bs2);
+    });
+
+    it('union result parameter is a tight fit', function() {
         var bs1 = new BoundingSphere(Cartesian3.multiplyByScalar(Cartesian3.negate(Cartesian3.UNIT_X, new Cartesian3()), 3.0, new Cartesian3()), 3.0);
         var bs2 = new BoundingSphere(Cartesian3.UNIT_X, 1.0);
-        var expected = new BoundingSphere(Cartesian3.negate(Cartesian3.UNIT_X, new Cartesian3()), 5.0);
+        var expected = new BoundingSphere(Cartesian3.multiplyByScalar(Cartesian3.negate(Cartesian3.UNIT_X, new Cartesian3()), 2.0, new Cartesian3()), 4.0);
         BoundingSphere.union(bs1, bs2, bs1);
         expect(bs1).toEqual(expected);
     });


### PR DESCRIPTION
This is not for 1.10 (unless you feel lucky).

So on Friday after a discussion of bounding spheres containing smaller bounding spheres, I pointed out what was (to me) an obvious solution to the two-sphere problem.  Sadly this solution does not scale beyond two spheres.  However, Cesium does indeed have a `BoundingSphere.union` function and it currently does not use the optimal containing sphere.  So, I'm proposing my new algorithm as a replacement to the current one.

It's pretty simple:  With only two spheres, the outermost points are the ones that face away from the opposing center points.  The new sphere is centered on these outer points, to contain them exactly.

I've made [an over-simplified gist](https://gist.github.com/emackey/081ad6e4950776af86d2) that will show a pair of bounding spheres in Sandcastle as circles on the surface of the globe.  This is only good for visualizing very small spheres, anything large and the curvature of the Earth will mess up the visualization.  But it's enough to get across the point of how this algorithm works, I believe.  Click to place one of the spheres, or edit the code to change the relative sizes.