### PR TITLE
Back out change to not clear depth on first frustum.

### DIFF
--- a/Source/Scene/Scene.js
+++ b/Source/Scene/Scene.js
@@ -1479,12 +1479,7 @@ define([
             }
 
             us.updateFrustum(frustum);
-
-            if (i !== 0) {
-                // Depth for the first frustum was cleared when color was cleared - and
-                // no primitives rendered in the entire frustum write depth.
-                clearDepth.execute(context, passState);
-            }
+            clearDepth.execute(context, passState);
 
             var commands = frustumCommands.commands[Pass.GLOBE];
             var length = frustumCommands.indices[Pass.GLOBE];

--- a/Source/Scene/Scene.js
+++ b/Source/Scene/Scene.js
@@ -243,9 +243,8 @@ define([
         this._oit = oit;
         this._fxaa = new FXAA();
 
-        this._clearColorDepthCommand = new ClearCommand({
+        this._clearColorCommand = new ClearCommand({
             color : new Color(),
-            depth : 1.0,
             owner : this
         });
         this._depthClearCommand = new ClearCommand({
@@ -1360,7 +1359,7 @@ define([
         }
 
         // Clear the pass state framebuffer.
-        var clear = scene._clearColorDepthCommand;
+        var clear = scene._clearColorCommand;
         Color.clone(clearColor, clear.color);
         clear.execute(context, passState);
 


### PR DESCRIPTION
Backs out part of #2746. Fixes an artifact in Columbus view:
![image](https://cloud.githubusercontent.com/assets/1494815/7919209/b4d61dae-0864-11e5-8279-825ae70f04d4.png)
