### PR TITLE
Fix crash on entity double click.

### DIFF
--- a/Specs/Widgets/Viewer/ViewerSpec.js
+++ b/Specs/Widgets/Viewer/ViewerSpec.js
@@ -866,6 +866,27 @@ defineSuite([
         });
     });
 
+    it('does not crash when tracking an object with a position property whose value is undefined.', function() {
+        viewer = new Viewer(container);
+
+        var entity = new Entity();
+        entity.position = new ConstantProperty(undefined);
+        entity.polyline = {
+            positions : [Cartesian3.fromDegrees(0, 0, 0), Cartesian3.fromDegrees(0, 0, 1)]
+        };
+
+        viewer.entities.add(entity);
+        viewer.trackedEntity = entity;
+
+        spyOn(viewer.scene.renderError, 'raiseEvent');
+        return pollToPromise(function() {
+            viewer.render();
+            return viewer.dataSourceDisplay.update(viewer.clock.currentTime);
+        }).then(function() {
+            expect(viewer.scene.renderError.raiseEvent).not.toHaveBeenCalled();
+        });
+    });
+
     it('removes data source listeners when destroyed', function() {
         viewer = new Viewer(container);
 


### PR DESCRIPTION
When an entity geometry exists forever but its position property is time-limited.  Double clicking on the geometry would attempt to track that position, which is undefined at the current animation time. We now better guard against defined Property instances with undefined values and instead zoom to the extent of the geometry. New test fails in master, passes in this branch.

As reported [on the forum](https://groups.google.com/d/msg/cesium-dev/MeEfM_ou1kI/-LMKgmwFbNkJ) (Sandcastle example is there as well if you want to compare behavior).