### PR TITLE
Don't complete an entity zoom while morphing.

### DIFF
--- a/Source/Widgets/Viewer/Viewer.js
+++ b/Source/Widgets/Viewer/Viewer.js
@@ -1549,7 +1549,7 @@ Either specify options.terrainProvider instead or set options.baseLayerPicker to
 
     function updateZoomTarget(viewer) {
         var entities = viewer._zoomTarget;
-        if (!defined(entities)) {
+        if (!defined(entities) || viewer.scene.mode === SceneMode.MORPHING) {
             return;
         }
 


### PR DESCRIPTION
If viewer.zoomTo found itself in the middle of a morph it would crash. We now wait for the morph to complete.  I couldn't think of a good unit for this because it's a race condition, but there are instructions in the linked issue on reproducing it in Sandcastle.  Fixes #2680