### PR TITLE
Oriented bounding box & frustum culling optimizations

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@ Change Log
 * Fixed an issue where `Camera` functions would throw an exception if used from within a `Scene.morphComplete` callback [#2776](https://github.com/AnalyticalGraphicsInc/cesium/issues/2776).
 * `Model` can now load Binary glTF from a Uint8Array.
 * Added a new camera mode for horizon views. When the camera is looking at the horizon and a point on terrain above the camera is picked, the camera moves in the plane containing the camera position, up and right vectors.
+* Added `Matrix2`/`Matrix3`/`Matrix4.ZERO` constants for zero matrices.
 
 ### 1.10 - 2015-06-01
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,8 @@ Change Log
 
 ### 1.11 - 2015-07-01
 
+* Deprecated
+  * Deprecated `AxisAlignedBoundingBox.intersect` and `BoundingSphere.intersect`.  These will be removed in 1.13.  Use `.intersectPlane` and, if necessary, `Plane.fromCartesian4`.
 * Improved the algorithm that `Camera.viewRectangle` uses to select the position of the camera, so that the specified rectangle is now better centered on the screen [#2764](https://github.com/AnalyticalGraphicsInc/cesium/issues/2764).
 * The performance statistics displayed by setting `scene.debugShowFramesPerSecond` to `true` can now be styled using the `cesium-performanceDisplay` CSS classes in `shared.css` [#2779](https://github.com/AnalyticalGraphicsInc/cesium/issues/2779).
 * Fixed a crash when `viewer.zoomTo` or `viewer.flyTo` were called immediately before or during a scene morph [#2775](https://github.com/AnalyticalGraphicsInc/cesium/issues/2775).

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@ Change Log
 
 * Deprecated
   * Deprecated `AxisAlignedBoundingBox.intersect` and `BoundingSphere.intersect`.  These will be removed in 1.13.  Use `.intersectPlane` and, if necessary, `Plane.fromCartesian4`.
+  * Deprecated the `ObjectOrientedBoundingBox` class.  It will be removed in 1.12.  If possible, `OrientedBoundingBox`, which is very similar.
 * Improved the algorithm that `Camera.viewRectangle` uses to select the position of the camera, so that the specified rectangle is now better centered on the screen [#2764](https://github.com/AnalyticalGraphicsInc/cesium/issues/2764).
 * The performance statistics displayed by setting `scene.debugShowFramesPerSecond` to `true` can now be styled using the `cesium-performanceDisplay` CSS classes in `shared.css` [#2779](https://github.com/AnalyticalGraphicsInc/cesium/issues/2779).
 * Fixed a crash when `viewer.zoomTo` or `viewer.flyTo` were called immediately before or during a scene morph [#2775](https://github.com/AnalyticalGraphicsInc/cesium/issues/2775).

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,7 +25,7 @@ Change Log
 * Added `EllipsoidTangentPlane.xAxis`/`yAxis`/`zAxis` properties to get the local coordinate system of the tangent plane.
 * Add `QuantizedMeshTerrainData` constructor argument `orientedBoundingBox`.
 * Add `TerrainMesh.orientedBoundingBox` which holds the `OrientedBoundingBox` for the mesh for a single terrain tile.
-* Use `OrientedBoundingBox` when rendering terrain to improve performance of terrain rendering (by **TODO**%) and loading (by **TODO**%).
+* Use `OrientedBoundingBox` when rendering terrain to improve performance of terrain rendering and loading (by up to 50% of terrain tiles, depending on camera view).
 
 ### 1.10 - 2015-06-01
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,7 +25,7 @@ Change Log
 * Added `EllipsoidTangentPlane.xAxis`/`yAxis`/`zAxis` properties to get the local coordinate system of the tangent plane.
 * Add `QuantizedMeshTerrainData` constructor argument `orientedBoundingBox`.
 * Add `TerrainMesh.orientedBoundingBox` which holds the `OrientedBoundingBox` for the mesh for a single terrain tile.
-* Use `OrientedBoundingBox` when rendering terrain to improve performance of terrain rendering and loading (by up to 50% of terrain tiles, depending on camera view).
+* Use `OrientedBoundingBox` when rendering terrain and imagery to improve performance of rendering and loading (by up to 50% of terrain/imagery tiles, depending on camera view).
 
 ### 1.10 - 2015-06-01
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,14 +5,24 @@ Change Log
 
 * Deprecated
   * Deprecated `AxisAlignedBoundingBox.intersect` and `BoundingSphere.intersect`.  These will be removed in 1.13.  Use `.intersectPlane` and, if necessary, `Plane.fromCartesian4`.
-  * Deprecated the `ObjectOrientedBoundingBox` class.  It will be removed in 1.12.  If possible, `OrientedBoundingBox`, which is very similar.
+  * Deprecated the `ObjectOrientedBoundingBox` class.  It will be removed in 1.12.  Use `OrientedBoundingBox` instead.
 * Improved the algorithm that `Camera.viewRectangle` uses to select the position of the camera, so that the specified rectangle is now better centered on the screen [#2764](https://github.com/AnalyticalGraphicsInc/cesium/issues/2764).
 * The performance statistics displayed by setting `scene.debugShowFramesPerSecond` to `true` can now be styled using the `cesium-performanceDisplay` CSS classes in `shared.css` [#2779](https://github.com/AnalyticalGraphicsInc/cesium/issues/2779).
 * Fixed a crash when `viewer.zoomTo` or `viewer.flyTo` were called immediately before or during a scene morph [#2775](https://github.com/AnalyticalGraphicsInc/cesium/issues/2775).
 * Fixed an issue where `Camera` functions would throw an exception if used from within a `Scene.morphComplete` callback [#2776](https://github.com/AnalyticalGraphicsInc/cesium/issues/2776).
 * `Model` can now load Binary glTF from a Uint8Array.
 * Added a new camera mode for horizon views. When the camera is looking at the horizon and a point on terrain above the camera is picked, the camera moves in the plane containing the camera position, up and right vectors.
+* Added `Plane.fromCartesian4` to convert old `Cartesian4` plane representations to the new `Plane` format.
+* Added `Plane.ORIGIN_XY_PLANE`/`ORIGIN_YZ_PLANE`/`ORIGIN_ZX_PLANE` constants for commonly-used planes.
 * Added `Matrix2`/`Matrix3`/`Matrix4.ZERO` constants for zero matrices.
+* Added `Matrix2`/`Matrix3.multiplyByScale` for multiplying against non-uniform scales.
+* Added `projectPointToNearestOnPlane` and `projectPointsToNearestOnPlane` to `EllipsoidTangentPlane` to project 3D points to the nearest 2D point on an `EllipsoidTangentPlane`.
+* Added `OrientedBoundingBox` class.
+* Added `EllipsoidTangentPlane.plane` property to get the `Plane` for the tangent plane.
+* Added `EllipsoidTangentPlane.xAxis`/`yAxis`/`zAxis` properties to get the local coordinate system of the tangent plane.
+* Add `QuantizedMeshTerrainData` constructor argument `orientedBoundingBox`.
+* Add `TerrainMesh.orientedBoundingBox` which holds the `OrientedBoundingBox` for the mesh for a single terrain tile.
+* Use `OrientedBoundingBox` when rendering terrain to improve performance of terrain rendering (by **TODO**%) and loading (by **TODO**%).
 
 ### 1.10 - 2015-06-01
 

--- a/Source/Core/AxisAlignedBoundingBox.js
+++ b/Source/Core/AxisAlignedBoundingBox.js
@@ -3,6 +3,7 @@ define([
         './Cartesian3',
         './defaultValue',
         './defined',
+        './deprecationWarning',
         './DeveloperError',
         './Intersect',
         './Plane'
@@ -10,6 +11,7 @@ define([
         Cartesian3,
         defaultValue,
         defined,
+        deprecationWarning,
         DeveloperError,
         Intersect,
         Plane) {
@@ -213,6 +215,7 @@ define([
      *                      intersects the plane.
      */
     AxisAlignedBoundingBox.intersect = function(box, plane) {
+        deprecationWarning('AxisAlignedBoundingBox.intersect', 'AxisAlignedBoundingBox.intersect() was deprecated in Cesium 1.11.  It will be removed in 1.12.  Use AxisAlignedBoundingBox.intersectPlane() instead.');
         var p = Plane.fromCartesian4(plane, scratchPlane);
         return AxisAlignedBoundingBox.intersectPlane(box, p);
     };

--- a/Source/Core/BoundingSphere.js
+++ b/Source/Core/BoundingSphere.js
@@ -10,6 +10,7 @@ define([
         './Intersect',
         './Interval',
         './Matrix4',
+        './Plane',
         './Rectangle'
     ], function(
         Cartesian3,
@@ -22,6 +23,7 @@ define([
         Intersect,
         Interval,
         Matrix4,
+        Plane,
         Rectangle) {
     "use strict";
 
@@ -742,16 +744,13 @@ define([
      * Determines which side of a plane a sphere is located.
      *
      * @param {BoundingSphere} sphere The bounding sphere to test.
-     * @param {Cartesian4} plane The coefficients of the plane in Hessian Normal Form, as `ax + by + cz + d = 0`,
-     *                           where (a, b, c) must be a unit normal vector.
-     *                           The coefficients a, b, c, and d are the components x, y, z,
-     *                           and w of the {@link Cartesian4}, respectively.
+     * @param {Plane} plane The plane to test against.
      * @returns {Intersect} {@link Intersect.INSIDE} if the entire sphere is on the side of the plane
      *                      the normal is pointing, {@link Intersect.OUTSIDE} if the entire sphere is
      *                      on the opposite side, and {@link Intersect.INTERSECTING} if the sphere
      *                      intersects the plane.
      */
-    BoundingSphere.intersect = function(sphere, plane) {
+    BoundingSphere.intersectPlane = function(sphere, plane) {
         //>>includeStart('debug', pragmas.debug);
         if (!defined(sphere)) {
             throw new DeveloperError('sphere is required.');
@@ -764,7 +763,8 @@ define([
 
         var center = sphere.center;
         var radius = sphere.radius;
-        var distanceToPlane = Cartesian3.dot(plane, center) + plane.w;
+        var normal = plane.normal;
+        var distanceToPlane = Cartesian3.dot(normal, center) + plane.distance;
 
         if (distanceToPlane < -radius) {
             // The center point is negative side of the plane normal
@@ -774,6 +774,26 @@ define([
             return Intersect.INTERSECTING;
         }
         return Intersect.INSIDE;
+    };
+
+    var scratchPlane = new Plane(new Cartesian3(), 0.0);
+    /**
+     * Determines which side of a plane a sphere is located.
+     *
+     * @deprecated
+     * @param {BoundingSphere} sphere The bounding sphere to test.
+     * @param {Cartesian4} plane The coefficients of the plane in Hessian Normal Form, as `ax + by + cz + d = 0`,
+     *                           where (a, b, c) must be a unit normal vector.
+     *                           The coefficients a, b, c, and d are the components x, y, z,
+     *                           and w of the {@link Cartesian4}, respectively.
+     * @returns {Intersect} {@link Intersect.INSIDE} if the entire sphere is on the side of the plane
+     *                      the normal is pointing, {@link Intersect.OUTSIDE} if the entire sphere is
+     *                      on the opposite side, and {@link Intersect.INTERSECTING} if the sphere
+     *                      intersects the plane.
+     */
+    BoundingSphere.intersect = function(sphere, plane) {
+        var p = Plane.fromCartesian4(plane, scratchPlane);
+        return BoundingSphere.intersectPlane(sphere, p);
     };
 
     /**
@@ -1042,6 +1062,20 @@ define([
     /**
      * Determines which side of a plane the sphere is located.
      *
+     * @param {Plane} plane The plane to test against.
+     * @returns {Intersect} {@link Intersect.INSIDE} if the entire sphere is on the side of the plane
+     *                      the normal is pointing, {@link Intersect.OUTSIDE} if the entire sphere is
+     *                      on the opposite side, and {@link Intersect.INTERSECTING} if the sphere
+     *                      intersects the plane.
+     */
+    BoundingSphere.prototype.intersectPlane = function(plane) {
+        return BoundingSphere.intersectPlane(this, plane);
+    };
+
+    /**
+     * Determines which side of a plane the sphere is located.
+     *
+     * @deprecated
      * @param {Cartesian4} plane The coefficients of the plane in the for ax + by + cz + d = 0
      *                           where the coefficients a, b, c, and d are the components x, y, z,
      *                           and w of the {@link Cartesian4}, respectively.

--- a/Source/Core/BoundingSphere.js
+++ b/Source/Core/BoundingSphere.js
@@ -4,6 +4,7 @@ define([
         './Cartographic',
         './defaultValue',
         './defined',
+        './deprecationWarning',
         './DeveloperError',
         './Ellipsoid',
         './GeographicProjection',
@@ -17,6 +18,7 @@ define([
         Cartographic,
         defaultValue,
         defined,
+        deprecationWarning,
         DeveloperError,
         Ellipsoid,
         GeographicProjection,
@@ -792,6 +794,7 @@ define([
      *                      intersects the plane.
      */
     BoundingSphere.intersect = function(sphere, plane) {
+        deprecationWarning('BoundingSphere.intersect', 'BoundingSphere.intersect() was deprecated in Cesium 1.11.  It will be removed in 1.12.  Use BoundingSphere.intersectPlane() instead.');
         var p = Plane.fromCartesian4(plane, scratchPlane);
         return BoundingSphere.intersectPlane(sphere, p);
     };

--- a/Source/Core/CesiumTerrainProvider.js
+++ b/Source/Core/CesiumTerrainProvider.js
@@ -10,12 +10,16 @@ define([
         './defined',
         './defineProperties',
         './DeveloperError',
+        './EllipsoidTangentPlane',
         './Event',
         './GeographicTilingScheme',
         './HeightmapTerrainData',
         './IndexDatatype',
         './loadArrayBuffer',
         './loadJson',
+        './Math',
+        './Matrix3',
+        './OrientedBoundingBox',
         './QuantizedMeshTerrainData',
         './RuntimeError',
         './TerrainProvider',
@@ -32,12 +36,16 @@ define([
         defined,
         defineProperties,
         DeveloperError,
+        EllipsoidTangentPlane,
         Event,
         GeographicTilingScheme,
         HeightmapTerrainData,
         IndexDatatype,
         loadArrayBuffer,
         loadJson,
+        CesiumMath,
+        Matrix3,
+        OrientedBoundingBox,
         QuantizedMeshTerrainData,
         RuntimeError,
         TerrainProvider,
@@ -417,11 +425,19 @@ define([
 
         var skirtHeight = provider.getLevelMaximumGeometricError(level) * 5.0;
 
+        var rectangle = provider._tilingScheme.tileXYToRectangle(x, y, level);
+        var boundingOBB;
+        if (rectangle.width < CesiumMath.PI_OVER_TWO + 0.001) {
+            var tangentPlane = new EllipsoidTangentPlane(center, provider._tilingScheme.ellipsoid);
+            boundingOBB = OrientedBoundingBox.fromRectangleTangentPlane(rectangle, tangentPlane, minimumHeight, maximumHeight);
+        }
+
         return new QuantizedMeshTerrainData({
             center : center,
             minimumHeight : minimumHeight,
             maximumHeight : maximumHeight,
             boundingSphere : boundingSphere,
+            boundingOBB : boundingOBB,
             horizonOcclusionPoint : horizonOcclusionPoint,
             quantizedVertices : encodedVertexBuffer,
             encodedNormals : encodedNormalBuffer,

--- a/Source/Core/CesiumTerrainProvider.js
+++ b/Source/Core/CesiumTerrainProvider.js
@@ -10,7 +10,6 @@ define([
         './defined',
         './defineProperties',
         './DeveloperError',
-        './EllipsoidTangentPlane',
         './Event',
         './GeographicTilingScheme',
         './HeightmapTerrainData',
@@ -36,7 +35,6 @@ define([
         defined,
         defineProperties,
         DeveloperError,
-        EllipsoidTangentPlane,
         Event,
         GeographicTilingScheme,
         HeightmapTerrainData,
@@ -426,10 +424,11 @@ define([
         var skirtHeight = provider.getLevelMaximumGeometricError(level) * 5.0;
 
         var rectangle = provider._tilingScheme.tileXYToRectangle(x, y, level);
-        var boundingOBB;
-        if (rectangle.width < CesiumMath.PI_OVER_TWO + 0.001) {
-            var tangentPlane = new EllipsoidTangentPlane(center, provider._tilingScheme.ellipsoid);
-            boundingOBB = OrientedBoundingBox.fromRectangleTangentPlane(rectangle, tangentPlane, minimumHeight, maximumHeight);
+        var orientedBoundingBox;
+        if (rectangle.width < CesiumMath.PI_OVER_TWO + CesiumMath.EPSILON5) {
+            // Here, rectangle.width < pi/2, and rectangle.height < pi
+            // (though it would still work with rectangle.width up to pi)
+            orientedBoundingBox = OrientedBoundingBox.fromEllipsoidRectangle(provider._tilingScheme.ellipsoid, rectangle, minimumHeight, maximumHeight);
         }
 
         return new QuantizedMeshTerrainData({
@@ -437,7 +436,7 @@ define([
             minimumHeight : minimumHeight,
             maximumHeight : maximumHeight,
             boundingSphere : boundingSphere,
-            boundingOBB : boundingOBB,
+            orientedBoundingBox : orientedBoundingBox,
             horizonOcclusionPoint : horizonOcclusionPoint,
             quantizedVertices : encodedVertexBuffer,
             encodedNormals : encodedNormalBuffer,

--- a/Source/Core/CesiumTerrainProvider.js
+++ b/Source/Core/CesiumTerrainProvider.js
@@ -428,7 +428,7 @@ define([
         if (rectangle.width < CesiumMath.PI_OVER_TWO + CesiumMath.EPSILON5) {
             // Here, rectangle.width < pi/2, and rectangle.height < pi
             // (though it would still work with rectangle.width up to pi)
-            orientedBoundingBox = OrientedBoundingBox.fromEllipsoidRectangle(provider._tilingScheme.ellipsoid, rectangle, minimumHeight, maximumHeight);
+            orientedBoundingBox = OrientedBoundingBox.fromRectangle(rectangle, minimumHeight, maximumHeight, provider._tilingScheme.ellipsoid);
         }
 
         return new QuantizedMeshTerrainData({

--- a/Source/Core/CesiumTerrainProvider.js
+++ b/Source/Core/CesiumTerrainProvider.js
@@ -428,6 +428,12 @@ define([
         if (rectangle.width < CesiumMath.PI_OVER_TWO + CesiumMath.EPSILON5) {
             // Here, rectangle.width < pi/2, and rectangle.height < pi
             // (though it would still work with rectangle.width up to pi)
+
+            // The skirt is not included in the OBB computation. If this ever
+            // causes any rendering artifacts (cracks), they are expected to be
+            // minor and in the corners of the screen. It's possible that this
+            // might need to be changed - just change to `minimumHeight - skirtHeight`
+            // A similar change might also be needed in `upsampleQuantizedTerrainMesh.js`.
             orientedBoundingBox = OrientedBoundingBox.fromRectangle(rectangle, minimumHeight, maximumHeight, provider._tilingScheme.ellipsoid);
         }
 

--- a/Source/Core/GeometryPipeline.js
+++ b/Source/Core/GeometryPipeline.js
@@ -2402,7 +2402,7 @@ define([
         var boundingSphere = geometry.boundingSphere;
         if (defined(boundingSphere)) {
             var minX = boundingSphere.center.x - boundingSphere.radius;
-            if (minX > 0 || BoundingSphere.intersect(boundingSphere, Cartesian4.UNIT_Y) !== Intersect.INTERSECTING) {
+            if (minX > 0 || BoundingSphere.intersectPlane(boundingSphere, Plane.ORIGIN_ZX_PLANE) !== Intersect.INTERSECTING) {
                 return instance;
             }
         }

--- a/Source/Core/HeightmapTerrainData.js
+++ b/Source/Core/HeightmapTerrainData.js
@@ -211,7 +211,9 @@ define([
                     result.minimumHeight,
                     result.maximumHeight,
                     result.boundingSphere3D,
-                    result.occludeePointInScaledSpace);
+                    result.occludeePointInScaledSpace,
+                    6,
+                    result.orientedBoundingBox);
         });
     };
 

--- a/Source/Core/Matrix2.js
+++ b/Source/Core/Matrix2.js
@@ -672,6 +672,41 @@ define([
     };
 
     /**
+     * Computes the product of a matrix times a (non-uniform) scale, as if the scale were a scale matrix.
+     *
+     * @param {Matrix2} matrix The matrix on the left-hand side.
+     * @param {Cartesian2} scale The non-uniform scale on the right-hand side.
+     * @param {Matrix2} result The object onto which to store the result.
+     * @returns {Matrix2} The modified result parameter.
+     *
+     * @see Matrix2.fromScale
+     * @see Matrix2.multiplyByUniformScale
+     *
+     * @example
+     * // Instead of Cesium.Matrix2.multiply(m, Cesium.Matrix2.fromScale(scale), m);
+     * Cesium.Matrix2.multiplyByScale(m, scale, m);
+     */
+    Matrix2.multiplyByScale = function(matrix, scale, result) {
+        //>>includeStart('debug', pragmas.debug);
+        if (!defined(matrix)) {
+            throw new DeveloperError('matrix is required');
+        }
+        if (!defined(scale)) {
+            throw new DeveloperError('scale is required');
+        }
+        if (!defined(result)) {
+            throw new DeveloperError('result is required');
+        }
+        //>>includeEnd('debug');
+
+        result[0] = matrix[0] * scale.x;
+        result[1] = matrix[1] * scale.x;
+        result[2] = matrix[2] * scale.y;
+        result[3] = matrix[3] * scale.y;
+        return result;
+    };
+
+    /**
      * Creates a negated copy of the provided matrix.
      *
      * @param {Matrix2} matrix The matrix to negate.

--- a/Source/Core/Matrix2.js
+++ b/Source/Core/Matrix2.js
@@ -813,6 +813,15 @@ define([
                                                 0.0, 1.0));
 
     /**
+     * An immutable Matrix2 instance initialized to the zero matrix.
+     *
+     * @type {Matrix2}
+     * @constant
+     */
+    Matrix2.ZERO = freezeObject(new Matrix2(0.0, 0.0,
+                                            0.0, 0.0));
+
+    /**
      * The index into Matrix2 for column 0, row 0.
      *
      * @type {Number}

--- a/Source/Core/Matrix3.js
+++ b/Source/Core/Matrix3.js
@@ -962,6 +962,46 @@ define([
     };
 
     /**
+     * Computes the product of a matrix times a (non-uniform) scale, as if the scale were a scale matrix.
+     *
+     * @param {Matrix3} matrix The matrix on the left-hand side.
+     * @param {Cartesian3} scale The non-uniform scale on the right-hand side.
+     * @param {Matrix3} result The object onto which to store the result.
+     * @returns {Matrix3} The modified result parameter.
+     *
+     * @see Matrix3.fromScale
+     * @see Matrix3.multiplyByUniformScale
+     *
+     * @example
+     * // Instead of Cesium.Matrix3.multiply(m, Cesium.Matrix3.fromScale(scale), m);
+     * Cesium.Matrix3.multiplyByScale(m, scale, m);
+     */
+    Matrix3.multiplyByScale = function(matrix, scale, result) {
+        //>>includeStart('debug', pragmas.debug);
+        if (!defined(matrix)) {
+            throw new DeveloperError('matrix is required');
+        }
+        if (!defined(scale)) {
+            throw new DeveloperError('scale is required');
+        }
+        if (!defined(result)) {
+            throw new DeveloperError('result is required');
+        }
+        //>>includeEnd('debug');
+
+        result[0] = matrix[0] * scale.x;
+        result[1] = matrix[1] * scale.x;
+        result[2] = matrix[2] * scale.x;
+        result[3] = matrix[3] * scale.y;
+        result[4] = matrix[4] * scale.y;
+        result[5] = matrix[5] * scale.y;
+        result[6] = matrix[6] * scale.z;
+        result[7] = matrix[7] * scale.z;
+        result[8] = matrix[8] * scale.z;
+        return result;
+    };
+
+    /**
      * Creates a negated copy of the provided matrix.
      *
      * @param {Matrix3} matrix The matrix to negate.

--- a/Source/Core/Matrix3.js
+++ b/Source/Core/Matrix3.js
@@ -1355,6 +1355,16 @@ define([
                                                 0.0, 0.0, 1.0));
 
     /**
+     * An immutable Matrix3 instance initialized to the zero matrix.
+     *
+     * @type {Matrix3}
+     * @constant
+     */
+    Matrix3.ZERO = freezeObject(new Matrix3(0.0, 0.0, 0.0,
+                                            0.0, 0.0, 0.0,
+                                            0.0, 0.0, 0.0));
+
+    /**
      * The index into Matrix3 for column 0, row 0.
      *
      * @type {Number}

--- a/Source/Core/Matrix4.js
+++ b/Source/Core/Matrix4.js
@@ -2545,6 +2545,17 @@ define([
                                                 0.0, 0.0, 0.0, 1.0));
 
     /**
+     * An immutable Matrix4 instance initialized to the zero matrix.
+     *
+     * @type {Matrix4}
+     * @constant
+     */
+    Matrix4.ZERO = freezeObject(new Matrix4(0.0, 0.0, 0.0, 0.0,
+                                            0.0, 0.0, 0.0, 0.0,
+                                            0.0, 0.0, 0.0, 0.0,
+                                            0.0, 0.0, 0.0, 0.0));
+
+    /**
      * The index into Matrix4 for column 0, row 0.
      *
      * @type {Number}

--- a/Source/Core/ObjectOrientedBoundingBox.js
+++ b/Source/Core/ObjectOrientedBoundingBox.js
@@ -4,12 +4,14 @@ define([
         './defaultValue',
         './defined',
         './DeveloperError',
+        './deprecationWarning',
         './Matrix3'
     ], function(
         Cartesian3,
         defaultValue,
         defined,
         DeveloperError,
+        deprecationWarning,
         Matrix3) {
     "use strict";
 
@@ -19,6 +21,7 @@ define([
      * It is oriented, so it can provide an optimum fit, it can bound more tightly.
      * @alias ObjectOrientedBoundingBox
      * @constructor
+     * @deprecated
      *
      * @param {Matrix3} [rotation=Matrix3.IDENTITY] The transformation matrix, to rotate the box to the right position.
      * @param {Cartesian3} [translation=Cartesian3.ZERO] The position of the box.
@@ -38,6 +41,8 @@ define([
      * var oobb = new Cesium.ObjectOrientedBoundingBox(rotation, translation, scale);
      */
     var ObjectOrientedBoundingBox = function(rotation, translation, scale) {
+        deprecationWarning('ObjectOrientedBoundingBox', 'ObjectOrientedBoundingBox was deprecated in Cesium 1.11.  It will be removed in 1.12.  Use OrientedBoundingBox instead.');
+
         /**
          * The transformation matrix, to rotate the box to the right position.
          * @type {Matrix3}

--- a/Source/Core/ObjectOrientedBoundingBox.js
+++ b/Source/Core/ObjectOrientedBoundingBox.js
@@ -362,9 +362,9 @@ define([
         return (left === right) ||
                 ((defined(left)) &&
                  (defined(right)) &&
-                 Cartesian3.equals(left.transformedPosition, right.transformedPosition) &&
-                 Matrix3.equals(left.transformMatrix, right.transformMatrix) &&
-                 Cartesian3.equals(left.rectangle, right.rectangle));
+                 Cartesian3.equals(left.translation, right.translation) &&
+                 Matrix3.equals(left.rotation, right.rotation) &&
+                 Cartesian3.equals(left.scale, right.scale));
     };
 
     /**

--- a/Source/Core/OrientedBoundingBox.js
+++ b/Source/Core/OrientedBoundingBox.js
@@ -262,10 +262,11 @@ define([
 
         var center = box.center;
         var normal = plane.normal;
+        var halfAxes = box.halfAxes;
         // plane is used as if it is its normal; the first three components are assumed to be normalized
-        var radEffective = Math.abs(Cartesian3.dot(normal, Matrix3.getColumn(box.halfAxes, 0, scratchCartesian1))) +
-                           Math.abs(Cartesian3.dot(normal, Matrix3.getColumn(box.halfAxes, 1, scratchCartesian2))) +
-                           Math.abs(Cartesian3.dot(normal, Matrix3.getColumn(box.halfAxes, 2, scratchCartesian3)));
+        var radEffective = Math.abs(normal.x * halfAxes[Matrix3.COLUMN0ROW0] + normal.y * halfAxes[Matrix3.COLUMN0ROW1] + normal.z * halfAxes[Matrix3.COLUMN0ROW2]) +
+                           Math.abs(normal.x * halfAxes[Matrix3.COLUMN1ROW0] + normal.y * halfAxes[Matrix3.COLUMN1ROW1] + normal.z * halfAxes[Matrix3.COLUMN1ROW2]) +
+                           Math.abs(normal.x * halfAxes[Matrix3.COLUMN2ROW0] + normal.y * halfAxes[Matrix3.COLUMN2ROW1] + normal.z * halfAxes[Matrix3.COLUMN2ROW2]);
         var distanceToPlane = Cartesian3.dot(normal, center) + plane.distance;
 
         if (distanceToPlane <= -radEffective) {

--- a/Source/Core/OrientedBoundingBox.js
+++ b/Source/Core/OrientedBoundingBox.js
@@ -136,6 +136,7 @@ define([
      *
      * @exception {DeveloperError} rectangle.width must be between 0 and pi.
      * @exception {DeveloperError} rectangle.height must be between 0 and pi.
+     * @exception {DeveloperError} ellipsoid must be an ellipsoid of revolution (<code>radii.x == radii.y</code>)
      */
     OrientedBoundingBox.fromRectangle = function(rectangle, minimumHeight, maximumHeight, ellipsoid, result) {
         //>>includeStart('debug', pragmas.debug);
@@ -147,6 +148,9 @@ define([
         }
         if (rectangle.height < 0.0 || rectangle.height > CesiumMath.PI) {
             throw new DeveloperError('Rectangle height must be between 0 and pi');
+        }
+        if (defined(ellipsoid) && !CesiumMath.equalsEpsilon(ellipsoid.radii.x, ellipsoid.radii.y, CesiumMath.EPSILON15)) {
+            throw new DeveloperError('Ellipsoid must be an ellipsoid of revolution (radii.x == radii.y)');
         }
         //>>includeEnd('debug');
 

--- a/Source/Core/OrientedBoundingBox.js
+++ b/Source/Core/OrientedBoundingBox.js
@@ -158,13 +158,8 @@ define([
         maximumHeight = defaultValue(maximumHeight, 0.0);
         ellipsoid = defaultValue(ellipsoid, Ellipsoid.WGS84);
 
-        // If the rectangle does not span the equator, then the bounding box will be aligned with the tangent plane at the center of the rectangle.
-        // If the rectangle does span the equator, then the bounding box will be aligned with the tangent plane to the equator at the longitudinal center of the rectangle.
+        // The bounding box will be aligned with the tangent plane at the center of the rectangle.
         var tangentPointCartographic = Rectangle.center(rectangle, scratchRectangleCenterCartographic);
-        if (rectangle.south < 0.0 && rectangle.north > 0.0) {
-            // The rectangle spans the equator
-            tangentPointCartographic.latitude = 0.0;
-        }
         var tangentPoint = ellipsoid.cartographicToCartesian(tangentPointCartographic, scratchRectangleCenter);
         var tangentPlane = new EllipsoidTangentPlane(tangentPoint, ellipsoid);
         var plane = tangentPlane.plane;
@@ -175,8 +170,8 @@ define([
         // W/-x [7]     [3] E/+x
         //      [6] [5] [4]
         //          S/-y
-        // "C" refers to the central lat/long which always align with the tangent point (above).
-        // If the rectangle spans the equator, CW and CE are aligned with the equator; otherwise, they're centered in latitude.
+        // "C" refers to the central lat/long, which by default aligns with the tangent point (above).
+        // If the rectangle spans the equator, CW and CE are instead aligned with the equator.
         var perimeterNW = perimeterCartographicScratch[0];
         var perimeterNC = perimeterCartographicScratch[1];
         var perimeterNE = perimeterCartographicScratch[2];
@@ -187,7 +182,7 @@ define([
         var perimeterCW = perimeterCartographicScratch[7];
 
         var lonCenter = tangentPointCartographic.longitude;
-        var latCenter = tangentPointCartographic.latitude;
+        var latCenter = (rectangle.south < 0.0 && rectangle.north > 0.0) ? 0.0 : tangentPointCartographic.latitude;
         perimeterSW.latitude = perimeterSC.latitude = perimeterSE.latitude = rectangle.south;
         perimeterCW.latitude = perimeterCE.latitude = latCenter;
         perimeterNW.latitude = perimeterNC.latitude = perimeterNE.latitude = rectangle.north;
@@ -203,7 +198,7 @@ define([
         // See the `perimeterXX` definitions above for what these are
         var minX = Math.min(perimeterProjectedScratch[6].x, perimeterProjectedScratch[7].x, perimeterProjectedScratch[0].x);
         var maxX = Math.max(perimeterProjectedScratch[2].x, perimeterProjectedScratch[3].x, perimeterProjectedScratch[4].x);
-        var minY = Math.min(perimeterProjectedScratch[4].y, perimeterProjectedScratch[6].y, perimeterProjectedScratch[6].y);
+        var minY = Math.min(perimeterProjectedScratch[4].y, perimeterProjectedScratch[5].y, perimeterProjectedScratch[6].y);
         var maxY = Math.max(perimeterProjectedScratch[0].y, perimeterProjectedScratch[1].y, perimeterProjectedScratch[2].y);
 
         // Compute minimum Z using the rectangle at minimum height

--- a/Source/Core/OrientedBoundingBox.js
+++ b/Source/Core/OrientedBoundingBox.js
@@ -1,0 +1,305 @@
+/*global define*/
+define([
+        './Cartesian2',
+        './Cartesian3',
+        './Cartographic',
+        './defaultValue',
+        './defined',
+        './DeveloperError',
+        './Ellipsoid',
+        './Intersect',
+        './Plane',
+        './Rectangle',
+        './Math',
+        './Matrix3'
+    ], function(
+        Cartesian2,
+        Cartesian3,
+        Cartographic,
+        defaultValue,
+        defined,
+        DeveloperError,
+        Ellipsoid,
+        Intersect,
+        Plane,
+        Rectangle,
+        CesiumMath,
+        Matrix3) {
+    "use strict";
+
+    /**
+     * Creates an instance of an OrientedBoundingBox.
+     * An OrientedBoundingBox model of an object or set of objects, is a closed volume (a cuboid), which completely contains the object or the set of objects.
+     * It is oriented, so it can provide an optimum fit, it can bound more tightly.
+     * @alias OrientedBoundingBox
+     * @constructor
+     *
+     * @param {Cartesian3} [center=Cartesian3.ZERO] The center of the box.
+     * @param {Matrix3} [halfAxes=Matrix3.ZERO] The three orthogonal half-axes of the bounding box.
+     *                                          Equivalently, the transformation matrix, to rotate and scale a 2x2x2
+     *                                          cube centered at the origin.
+     *
+     * @see OrientedBoundingBox.fromBoundingRectangle
+     * @see BoundingSphere
+     * @see BoundingRectangle
+     * @see ObjectOrientedBoundingBox
+     *
+     * @example
+     * // Create an OrientedBoundingBox using a transformation matrix, a position where the box will be translated, and a scale.
+     * var center = new Cesium.Cartesian3(1,0,0);
+     * var halfAxes = Cesium.Matrix3.clone(Cesium.Matrix3.fromScale(new Cartesian3(1.0, 3.0, 2.0)));
+     *
+     * var obb = new Cesium.OrientedBoundingBox(center, halfAxes);
+     */
+    var OrientedBoundingBox = function(center, halfAxes) {
+        /**
+         * The center of the box.
+         * @type {Cartesian3}
+         * @default {@link Cartesian3.ZERO}
+         */
+        this.center = Cartesian3.clone(defaultValue(center, Cartesian3.ZERO));
+        /**
+         * The transformation matrix, to rotate the box to the right position.
+         * @type {Matrix3}
+         * @default {@link Matrix3.IDENTITY}
+         */
+        this.halfAxes = Matrix3.clone(defaultValue(halfAxes, Matrix3.ZERO));
+    };
+
+    var scratchCartesian1 = new Cartesian3();
+    var scratchCartesian2 = new Cartesian3();
+    var scratchCartesian3 = new Cartesian3();
+
+    var scratchRotation = new Matrix3();
+    /**
+     * Computes an OrientedBoundingBox from a BoundingRectangle.
+     * The BoundingRectangle is placed on the XY plane.
+     *
+     * @param {BoundingRectangle} boundingRectangle A bounding rectangle.
+     * @param {Number} [rotation=0.0] The rotation of the bounding box in radians.
+     * @param {OrientedBoundingBox} [result] The object onto which to store the result.
+     * @returns {OrientedBoundingBox} The modified result parameter or a new OrientedBoundingBox instance if one was not provided.
+     *
+     * @example
+     * // Compute an object oriented bounding box enclosing two points.
+     * var box = Cesium.OrientedBoundingBox.fromBoundingRectangle(boundingRectangle, 0.0);
+     */
+    OrientedBoundingBox.fromBoundingRectangle = function(boundingRectangle, rotation, result) {
+        //>>includeStart('debug', pragmas.debug);
+        if (!defined(boundingRectangle)) {
+            throw new DeveloperError('boundingRectangle is required');
+        }
+        //>>includeEnd('debug');
+
+        if (!defined(result)) {
+            result = new OrientedBoundingBox();
+        }
+
+        var rotMat;
+        if (defined(rotation)) {
+            rotMat = Matrix3.fromRotationZ(rotation, scratchRotation);
+        } else {
+            rotMat = Matrix3.clone(Matrix3.IDENTITY, scratchRotation);
+        }
+
+        var scale = scratchCartesian1;
+        scale.x = boundingRectangle.width * 0.5;
+        scale.y = boundingRectangle.height * 0.5;
+        scale.z = 0.0;
+        Matrix3.multiplyByScale(rotMat, scale, result.halfAxes);
+
+        var translation = Matrix3.multiplyByVector(rotMat, scale, result.center);
+        translation.x += boundingRectangle.x;
+        translation.y += boundingRectangle.y;
+
+        return result;
+    };
+
+    var cornersCartographicScratch = [new Cartographic(), new Cartographic(), new Cartographic(), new Cartographic(), new Cartographic(), new Cartographic()];
+    var cornersCartesianScratch = [new Cartesian3(), new Cartesian3(), new Cartesian3(), new Cartesian3(), new Cartesian3(), new Cartesian3()];
+    var cornersProjectedScratch = [new Cartesian2(), new Cartesian2(), new Cartesian2(), new Cartesian2(), new Cartesian2(), new Cartesian2()];
+    /**
+     * Computes an OrientedBoundingBox from a surface {@link Rectangle} aligned with a specified {@link EllipsoidTangentPlane}.
+     *
+     * @param {Rectangle} rectangle The valid rectangle used to create a bounding box.
+     * @param {EllipsoidTangentPlane} tangentPlane A tangent plane with which the bounding box will be aligned.
+     * @param {Number} [minHeight=0.0] The minimum height (elevation) within the tile.
+     * @param {Number} [maxHeight=0.0] The maximum height (elevation) within the tile.
+     * @param {OrientedBoundingBox} [result] The object onto which to store the result.
+     * @returns {OrientedBoundingBox} The modified result parameter or a new OrientedBoundingBox instance if none was provided.
+     */
+    OrientedBoundingBox.fromRectangleTangentPlane = function(rectangle, tangentPlane, minHeight, maxHeight, result) {
+        //>>includeStart('debug', pragmas.debug);
+        if (!defined(rectangle)) {
+            throw new DeveloperError('rectangle is required');
+        }
+        if (!defined(tangentPlane)) {
+            throw new DeveloperError('tangentPlane is required');
+        }
+        (function() {
+            var rw = rectangle.width;
+            var rh = rectangle.height;
+            if (rw < 0.0 || rw > CesiumMath.PI) {
+                throw new DeveloperError('Rectangle width must be between 0 and pi')
+            }
+            if (rh < 0.0 || rh > CesiumMath.PI) {
+                throw new DeveloperError('Rectangle height must be between 0 and pi')
+            }
+        })();
+        //>>includeEnd('debug');
+
+        minHeight = defaultValue(minHeight, 0.0);
+        maxHeight = defaultValue(maxHeight, 0.0);
+
+        var plane = tangentPlane.plane;
+
+        // Rectangle at maximum height
+        var cornerNE = cornersCartographicScratch[0];
+        var cornerNW = cornersCartographicScratch[1];
+        var cornerSE = cornersCartographicScratch[2];
+        var cornerSW = cornersCartographicScratch[3];
+        var cornerNC = cornersCartographicScratch[4];
+        var cornerSC = cornersCartographicScratch[5];
+
+        var lonWest = rectangle.west;
+        var lonEast = rectangle.east;
+        var lonCenter = lonWest + 0.5 * rectangle.width;
+        cornerSW.latitude = cornerSC.latitude = cornerSE.latitude = rectangle.south;
+        cornerNW.latitude = cornerNC.latitude = cornerNE.latitude = rectangle.north;
+        cornerSW.longitude = cornerNW.longitude = lonWest;
+        cornerSC.longitude = cornerNC.longitude = lonCenter;
+        cornerSE.longitude = cornerNE.longitude = lonEast;
+
+        cornerNE.height = cornerNW.height = cornerSE.height = cornerSW.height = cornerNC.height = cornerSC.height = maxHeight;
+
+        tangentPlane.ellipsoid.cartographicArrayToCartesianArray(cornersCartographicScratch, cornersCartesianScratch);
+        tangentPlane.projectPointsToNearestOnPlane(cornersCartesianScratch, cornersProjectedScratch);
+        var minX = Math.min(cornersProjectedScratch[1].x, cornersProjectedScratch[3].x);
+        var maxX = Math.max(cornersProjectedScratch[0].x, cornersProjectedScratch[2].x);
+        var minY = Math.min(cornersProjectedScratch[2].y, cornersProjectedScratch[3].y, cornersProjectedScratch[5].y);
+        var maxY = Math.max(cornersProjectedScratch[0].y, cornersProjectedScratch[1].y, cornersProjectedScratch[4].y);
+
+        cornerNE.height = cornerNW.height = cornerSE.height = cornerSW.height = minHeight;
+        tangentPlane.ellipsoid.cartographicArrayToCartesianArray(cornersCartographicScratch, cornersCartesianScratch);
+        var minZ = Math.min(Plane.getPointDistance(plane, cornersCartesianScratch[0]),
+                            Plane.getPointDistance(plane, cornersCartesianScratch[1]),
+                            Plane.getPointDistance(plane, cornersCartesianScratch[2]),
+                            Plane.getPointDistance(plane, cornersCartesianScratch[3]));
+        var maxZ = maxHeight;  // Since the tangent plane touches the surface at height = 0, this is okay
+
+        return tangentPlane.extentsToOrientedBoundingBox(minX, maxX, minY, maxY, minZ, maxZ, result);
+    };
+
+    /**
+     * Duplicates a OrientedBoundingBox instance.
+     *
+     * @param {OrientedBoundingBox} box The bounding box to duplicate.
+     * @param {OrientedBoundingBox} [result] The object onto which to store the result.
+     * @returns {OrientedBoundingBox} The modified result parameter or a new OrientedBoundingBox instance if none was provided. (Returns undefined if box is undefined)
+     */
+    OrientedBoundingBox.clone = function(box, result) {
+        if (!defined(box)) {
+            return undefined;
+        }
+
+        if (!defined(result)) {
+            return new OrientedBoundingBox(box.center, box.halfAxes);
+        }
+
+        Cartesian3.clone(box.center, result.center);
+        Matrix3.clone(box.halfAxes, result.halfAxes);
+
+        return result;
+    };
+
+    /**
+     * Determines which side of a plane the oriented bounding box is located.
+     *
+     * @param {OrientedBoundingBox} box The oriented bounding box to test.
+     * @param {Plane} plane The plane to test against.
+     * @returns {Intersect} {@link Intersect.INSIDE} if the entire box is on the side of the plane
+     *                      the normal is pointing, {@link Intersect.OUTSIDE} if the entire box is
+     *                      on the opposite side, and {@link Intersect.INTERSECTING} if the box
+     *                      intersects the plane.
+     */
+    OrientedBoundingBox.intersectPlane = function(box, plane) {
+        //>>includeStart('debug', pragmas.debug);
+        if (!defined(box)) {
+            throw new DeveloperError('box is required.');
+        }
+
+        if (!defined(plane)) {
+            throw new DeveloperError('plane is required.');
+        }
+        //>>includeEnd('debug');
+
+        var center = box.center;
+        var normal = plane.normal;
+        // plane is used as if it is its normal; the first three components are assumed to be normalized
+        var radEffective = Math.abs(Cartesian3.dot(normal, Matrix3.getColumn(box.halfAxes, 0, scratchCartesian1))) +
+                           Math.abs(Cartesian3.dot(normal, Matrix3.getColumn(box.halfAxes, 1, scratchCartesian2))) +
+                           Math.abs(Cartesian3.dot(normal, Matrix3.getColumn(box.halfAxes, 2, scratchCartesian3)));
+        var distanceToPlane = Cartesian3.dot(normal, center) + plane.distance;
+
+        if (distanceToPlane <= -radEffective) {
+            // The entire box is on the negative side of the plane normal
+            return Intersect.OUTSIDE;
+        } else if (distanceToPlane >= radEffective) {
+            // The entire box is on the positive side of the plane normal
+            return Intersect.INSIDE;
+        }
+        return Intersect.INTERSECTING;
+    };
+
+    /**
+     * Determines which side of a plane the oriented bounding box is located.
+     *
+     * @param {Plane} plane The plane to test against.
+     * @returns {Intersect} {@link Intersect.INSIDE} if the entire box is on the side of the plane
+     *                      the normal is pointing, {@link Intersect.OUTSIDE} if the entire box is
+     *                      on the opposite side, and {@link Intersect.INTERSECTING} if the box
+     *                      intersects the plane.
+     */
+    OrientedBoundingBox.prototype.intersectPlane = function(plane) {
+        return OrientedBoundingBox.intersectPlane(this, plane);
+    };
+
+    /**
+     * Compares the provided OrientedBoundingBox componentwise and returns
+     * <code>true</code> if they are equal, <code>false</code> otherwise.
+     *
+     * @param {OrientedBoundingBox} left The first OrientedBoundingBox.
+     * @param {OrientedBoundingBox} right The second OrientedBoundingBox.
+     * @returns {Boolean} <code>true</code> if left and right are equal, <code>false</code> otherwise.
+     */
+    OrientedBoundingBox.equals = function(left, right) {
+        return (left === right) ||
+                ((defined(left)) &&
+                 (defined(right)) &&
+                 Cartesian3.equals(left.center, right.center) &&
+                 Matrix3.equals(left.halfAxes, right.halfAxes));
+    };
+
+    /**
+     * Duplicates this OrientedBoundingBox instance.
+     *
+     * @param {OrientedBoundingBox} [result] The object onto which to store the result.
+     * @returns {OrientedBoundingBox} The modified result parameter or a new OrientedBoundingBox instance if one was not provided.
+     */
+    OrientedBoundingBox.prototype.clone = function(result) {
+        return OrientedBoundingBox.clone(this, result);
+    };
+
+    /**
+     * Compares this OrientedBoundingBox against the provided OrientedBoundingBox componentwise and returns
+     * <code>true</code> if they are equal, <code>false</code> otherwise.
+     *
+     * @param {OrientedBoundingBox} [right] The right hand side OrientedBoundingBox.
+     * @returns {Boolean} <code>true</code> if they are equal, <code>false</code> otherwise.
+     */
+    OrientedBoundingBox.prototype.equals = function(right) {
+        return OrientedBoundingBox.equals(this, right);
+    };
+
+    return OrientedBoundingBox;
+});

--- a/Source/Core/OrientedBoundingBox.js
+++ b/Source/Core/OrientedBoundingBox.js
@@ -173,6 +173,8 @@ define([
         // W/-x [7]     [3] E/+x
         //      [6] [5] [4]
         //          S/-y
+        // "C" refers to the central lat/long which always align with the tangent point (above).
+        // If the rectangle spans the equator, CW and CE are aligned with the equator; otherwise, they're centered in latitude.
         var perimeterNW = perimeterCartographicScratch[0];
         var perimeterNC = perimeterCartographicScratch[1];
         var perimeterNE = perimeterCartographicScratch[2];
@@ -206,9 +208,9 @@ define([
         perimeterNE.height = perimeterNW.height = perimeterSE.height = perimeterSW.height = minimumHeight;
         ellipsoid.cartographicArrayToCartesianArray(perimeterCartographicScratch, perimeterCartesianScratch);
         var minZ = Math.min(Plane.getPointDistance(plane, perimeterCartesianScratch[0]),
-                            Plane.getPointDistance(plane, perimeterCartesianScratch[1]),
                             Plane.getPointDistance(plane, perimeterCartesianScratch[2]),
-                            Plane.getPointDistance(plane, perimeterCartesianScratch[3]));
+                            Plane.getPointDistance(plane, perimeterCartesianScratch[4]),
+                            Plane.getPointDistance(plane, perimeterCartesianScratch[6]));
         var maxZ = maximumHeight;  // Since the tangent plane touches the surface at height = 0, this is okay
 
         return fromTangentPlaneExtents(tangentPlane, minX, maxX, minY, maxY, minZ, maxZ, result);

--- a/Source/Core/OrientedBoundingBox.js
+++ b/Source/Core/OrientedBoundingBox.js
@@ -191,7 +191,7 @@ define([
         perimeterSE.longitude = perimeterCE.longitude = perimeterNE.longitude = rectangle.east;
 
         // Compute XY extents using the rectangle at maximum height
-        perimeterNE.height = perimeterNW.height = perimeterSE.height = perimeterSW.height = perimeterNC.height = perimeterSC.height = maximumHeight;
+        perimeterNE.height = perimeterNC.height = perimeterNW.height = perimeterCW.height = perimeterSW.height = perimeterSC.height = perimeterSE.height = perimeterCE.height = maximumHeight;
 
         ellipsoid.cartographicArrayToCartesianArray(perimeterCartographicScratch, perimeterCartesianScratch);
         tangentPlane.projectPointsToNearestOnPlane(perimeterCartesianScratch, perimeterProjectedScratch);

--- a/Source/Core/OrientedBoundingBox.js
+++ b/Source/Core/OrientedBoundingBox.js
@@ -235,9 +235,6 @@ define([
         return result;
     };
 
-    var scratchCartesian1 = new Cartesian3();
-    var scratchCartesian2 = new Cartesian3();
-    var scratchCartesian3 = new Cartesian3();
     /**
      * Determines which side of a plane the oriented bounding box is located.
      *
@@ -262,10 +259,11 @@ define([
         var center = box.center;
         var normal = plane.normal;
         var halfAxes = box.halfAxes;
+        var normalX = normal.x, normalY = normal.y, normalZ = normal.z;
         // plane is used as if it is its normal; the first three components are assumed to be normalized
-        var radEffective = Math.abs(normal.x * halfAxes[Matrix3.COLUMN0ROW0] + normal.y * halfAxes[Matrix3.COLUMN0ROW1] + normal.z * halfAxes[Matrix3.COLUMN0ROW2]) +
-                           Math.abs(normal.x * halfAxes[Matrix3.COLUMN1ROW0] + normal.y * halfAxes[Matrix3.COLUMN1ROW1] + normal.z * halfAxes[Matrix3.COLUMN1ROW2]) +
-                           Math.abs(normal.x * halfAxes[Matrix3.COLUMN2ROW0] + normal.y * halfAxes[Matrix3.COLUMN2ROW1] + normal.z * halfAxes[Matrix3.COLUMN2ROW2]);
+        var radEffective = Math.abs(normalX * halfAxes[Matrix3.COLUMN0ROW0] + normalY * halfAxes[Matrix3.COLUMN0ROW1] + normalZ * halfAxes[Matrix3.COLUMN0ROW2]) +
+                           Math.abs(normalX * halfAxes[Matrix3.COLUMN1ROW0] + normalY * halfAxes[Matrix3.COLUMN1ROW1] + normalZ * halfAxes[Matrix3.COLUMN1ROW2]) +
+                           Math.abs(normalX * halfAxes[Matrix3.COLUMN2ROW0] + normalY * halfAxes[Matrix3.COLUMN2ROW1] + normalZ * halfAxes[Matrix3.COLUMN2ROW2]);
         var distanceToPlane = Cartesian3.dot(normal, center) + plane.distance;
 
         if (distanceToPlane <= -radEffective) {

--- a/Source/Core/OrientedBoundingBox.js
+++ b/Source/Core/OrientedBoundingBox.js
@@ -127,21 +127,18 @@ define([
      * Computes an OrientedBoundingBox that bounds a {@link Rectangle} on the surface of an {@link Ellipsoid}.
      * There are no guarantees about the orientation of the bounding box.
      *
-     * @param {Ellipsoid} ellipsoid The ellipsoid on which the rectangle is defined.
      * @param {Rectangle} rectangle The cartographic rectangle on the surface of the ellipsoid.
      * @param {Number} [minimumHeight=0.0] The minimum height (elevation) within the tile.
      * @param {Number} [maximumHeight=0.0] The maximum height (elevation) within the tile.
+     * @param {Ellipsoid} [ellipsoid=Ellipsoid.WGS84] The ellipsoid on which the rectangle is defined.
      * @param {OrientedBoundingBox} [result] The object onto which to store the result.
      * @returns {OrientedBoundingBox} The modified result parameter or a new OrientedBoundingBox instance if none was provided.
      *
      * @exception {DeveloperError} rectangle.width must be between 0 and pi.
      * @exception {DeveloperError} rectangle.height must be between 0 and pi.
      */
-    OrientedBoundingBox.fromEllipsoidRectangle = function(ellipsoid, rectangle, minimumHeight, maximumHeight, result) {
+    OrientedBoundingBox.fromRectangle = function(rectangle, minimumHeight, maximumHeight, ellipsoid, result) {
         //>>includeStart('debug', pragmas.debug);
-        if (!defined(ellipsoid)) {
-            throw new DeveloperError('ellipsoid is required');
-        }
         if (!defined(rectangle)) {
             throw new DeveloperError('rectangle is required');
         }
@@ -155,6 +152,7 @@ define([
 
         minimumHeight = defaultValue(minimumHeight, 0.0);
         maximumHeight = defaultValue(maximumHeight, 0.0);
+        ellipsoid = defaultValue(ellipsoid, Ellipsoid.WGS84);
 
         // If the rectangle does not span the equator, then the bounding box will be aligned with the tangent plane at the center of the rectangle.
         // If the rectangle does span the equator, then the bounding box will be aligned with the tangent plane to the equator at the longitudinal center of the rectangle.

--- a/Source/Core/Plane.js
+++ b/Source/Core/Plane.js
@@ -2,11 +2,13 @@
 define([
         './Cartesian3',
         './defined',
-        './DeveloperError'
+        './DeveloperError',
+        './freezeObject'
     ], function(
         Cartesian3,
         defined,
-        DeveloperError) {
+        DeveloperError,
+        freezeObject) {
     "use strict";
 
     /**
@@ -95,6 +97,33 @@ define([
         return result;
     };
 
+    var scratchNormal = new Cartesian3();
+    /**
+     * Creates a plane from the general equation
+     *
+     * @param {Cartesian4} coefficients The plane's normal (normalized).
+     * @param {Plane} [result] The object onto which to store the result.
+     * @returns {Plane} A new plane instance or the modified result parameter.
+     */
+    Plane.fromCartesian4 = function(coefficients, result) {
+        //>>includeStart('debug', pragmas.debug);
+        if (!defined(coefficients)) {
+            throw new DeveloperError('coefficients is required.');
+        }
+        //>>includeEnd('debug');
+
+        var normal = Cartesian3.fromCartesian4(coefficients, scratchNormal);
+        var distance = coefficients.w;
+
+        if (!defined(result)) {
+            return new Plane(normal, distance);
+        } else {
+            Cartesian3.clone(normal, result.normal);
+            result.distance = distance;
+            return result;
+        }
+    };
+
     /**
      * Computes the signed shortest distance of a point to a plane.
      * The sign of the distance determines which side of the plane the point
@@ -118,6 +147,30 @@ define([
 
         return Cartesian3.dot(plane.normal, point) + plane.distance;
     };
+
+    /**
+     * A constant initialized to the XY plane passing through the origin, with normal in positive Z.
+     *
+     * @type {Plane}
+     * @constant
+     */
+    Plane.ORIGIN_XY_PLANE = freezeObject(new Plane(Cartesian3.UNIT_Z, 0.0));
+
+    /**
+     * A constant initialized to the YZ plane passing through the origin, with normal in positive X.
+     *
+     * @type {Plane}
+     * @constant
+     */
+    Plane.ORIGIN_YZ_PLANE = freezeObject(new Plane(Cartesian3.UNIT_X, 0.0));
+
+    /**
+     * A constant initialized to the ZX plane passing through the origin, with normal in positive Y.
+     *
+     * @type {Plane}
+     * @constant
+     */
+    Plane.ORIGIN_ZX_PLANE = freezeObject(new Plane(Cartesian3.UNIT_Y, 0.0));
 
     return Plane;
 });

--- a/Source/Core/QuantizedMeshTerrainData.js
+++ b/Source/Core/QuantizedMeshTerrainData.js
@@ -46,7 +46,7 @@ define([
      * @param {Number} options.minimumHeight The minimum terrain height within the tile, in meters above the ellipsoid.
      * @param {Number} options.maximumHeight The maximum terrain height within the tile, in meters above the ellipsoid.
      * @param {BoundingSphere} options.boundingSphere A sphere bounding all of the vertices in the mesh.
-     * @param {OrientedBoundingBox} [options.boundingOBB] An OrientedBoundingBox bounding all of the vertices in the mesh.
+     * @param {OrientedBoundingBox} [options.orientedBoundingBox] An OrientedBoundingBox bounding all of the vertices in the mesh.
      * @param {Cartesian3} options.horizonOcclusionPoint The horizon occlusion point of the mesh.  If this point
      *                      is below the horizon, the entire tile is assumed to be below the horizon as well.
      *                      The point is expressed in ellipsoid-scaled coordinates.
@@ -91,7 +91,7 @@ define([
      *     indices : new Uint16Array([0, 3, 1,
      *                                0, 2, 3]),
      *     boundingSphere : new Cesium.BoundingSphere(new Cesium.Cartesian3(1.0, 2.0, 3.0), 10000),
-     *     boundingOBB : new Cesium.OrientedBoundingBox(new Cesium.Cartesian3(1.0, 2.0, 3.0), Matrix3.fromRotationX(Cesium.Math.PI, new Matrix3())),
+     *     orientedBoundingBox : new Cesium.OrientedBoundingBox(new Cesium.Cartesian3(1.0, 2.0, 3.0), Matrix3.fromRotationX(Cesium.Math.PI, new Matrix3())),
      *     horizonOcclusionPoint : new Cesium.Cartesian3(3.0, 2.0, 1.0),
      *     westIndices : [0, 1],
      *     southIndices : [0, 1],
@@ -158,7 +158,7 @@ define([
         this._minimumHeight = options.minimumHeight;
         this._maximumHeight = options.maximumHeight;
         this._boundingSphere = options.boundingSphere;
-        this._boundingOBB = options.boundingOBB;
+        this._orientedBoundingBox = options.orientedBoundingBox;
         this._horizonOcclusionPoint = options.horizonOcclusionPoint;
 
         var vertexCount = this._quantizedVertices.length / 3;
@@ -297,7 +297,7 @@ define([
                     that._boundingSphere,
                     that._horizonOcclusionPoint,
                     defined(that._encodedNormals) ? 7 : 6,
-                    that._boundingOBB);
+                    that._orientedBoundingBox);
         });
     };
 
@@ -394,7 +394,7 @@ define([
                 minimumHeight : result.minimumHeight,
                 maximumHeight : result.maximumHeight,
                 boundingSphere : BoundingSphere.clone(result.boundingSphere),
-                boundingOBB : OrientedBoundingBox.clone(result.boundingOBB),
+                orientedBoundingBox : OrientedBoundingBox.clone(result.orientedBoundingBox),
                 horizonOcclusionPoint : Cartesian3.clone(result.horizonOcclusionPoint),
                 westIndices : result.westIndices,
                 southIndices : result.southIndices,

--- a/Source/Core/QuantizedMeshTerrainData.js
+++ b/Source/Core/QuantizedMeshTerrainData.js
@@ -10,6 +10,7 @@ define([
         './IndexDatatype',
         './Intersections2D',
         './Math',
+        './OrientedBoundingBox',
         './TaskProcessor',
         './TerrainMesh'
     ], function(
@@ -23,6 +24,7 @@ define([
         IndexDatatype,
         Intersections2D,
         CesiumMath,
+        OrientedBoundingBox,
         TaskProcessor,
         TerrainMesh) {
     "use strict";
@@ -44,6 +46,7 @@ define([
      * @param {Number} options.minimumHeight The minimum terrain height within the tile, in meters above the ellipsoid.
      * @param {Number} options.maximumHeight The maximum terrain height within the tile, in meters above the ellipsoid.
      * @param {BoundingSphere} options.boundingSphere A sphere bounding all of the vertices in the mesh.
+     * @param {OrientedBoundingBox} [options.boundingOBB] An OrientedBoundingBox bounding all of the vertices in the mesh.
      * @param {Cartesian3} options.horizonOcclusionPoint The horizon occlusion point of the mesh.  If this point
      *                      is below the horizon, the entire tile is assumed to be below the horizon as well.
      *                      The point is expressed in ellipsoid-scaled coordinates.
@@ -88,6 +91,7 @@ define([
      *     indices : new Uint16Array([0, 3, 1,
      *                                0, 2, 3]),
      *     boundingSphere : new Cesium.BoundingSphere(new Cesium.Cartesian3(1.0, 2.0, 3.0), 10000),
+     *     boundingOBB : new Cesium.OrientedBoundingBox(new Cesium.Cartesian3(1.0, 2.0, 3.0), Matrix3.fromRotationX(Cesium.Math.PI, new Matrix3())),
      *     horizonOcclusionPoint : new Cesium.Cartesian3(3.0, 2.0, 1.0),
      *     westIndices : [0, 1],
      *     southIndices : [0, 1],
@@ -154,6 +158,7 @@ define([
         this._minimumHeight = options.minimumHeight;
         this._maximumHeight = options.maximumHeight;
         this._boundingSphere = options.boundingSphere;
+        this._boundingOBB = options.boundingOBB;
         this._horizonOcclusionPoint = options.horizonOcclusionPoint;
 
         var vertexCount = this._quantizedVertices.length / 3;
@@ -291,7 +296,8 @@ define([
                     that._maximumHeight,
                     that._boundingSphere,
                     that._horizonOcclusionPoint,
-                    defined(that._encodedNormals) ? 7 : 6);
+                    defined(that._encodedNormals) ? 7 : 6,
+                    that._boundingOBB);
         });
     };
 
@@ -388,6 +394,7 @@ define([
                 minimumHeight : result.minimumHeight,
                 maximumHeight : result.maximumHeight,
                 boundingSphere : BoundingSphere.clone(result.boundingSphere),
+                boundingOBB : OrientedBoundingBox.clone(result.boundingOBB),
                 horizonOcclusionPoint : Cartesian3.clone(result.horizonOcclusionPoint),
                 westIndices : result.westIndices,
                 southIndices : result.southIndices,

--- a/Source/Core/TerrainMesh.js
+++ b/Source/Core/TerrainMesh.js
@@ -25,9 +25,9 @@ define([
       *                     scaled space, and used for horizon culling.  If this point is below the horizon,
       *                     the tile is considered to be entirely below the horizon.
       * @param {Number} [vertexStride=6] The number of components in each vertex.
-      * @param {OrientedBoundingBox} [boundingOBB=undefined] A bounding sphere that completely contains the tile.
+      * @param {OrientedBoundingBox} [orientedBoundingBox] A bounding sphere that completely contains the tile.
       */
-    var TerrainMesh = function TerrainMesh(center, vertices, indices, minimumHeight, maximumHeight, boundingSphere3D, occludeePointInScaledSpace, vertexStride, boundingOBB) {
+    var TerrainMesh = function TerrainMesh(center, vertices, indices, minimumHeight, maximumHeight, boundingSphere3D, occludeePointInScaledSpace, vertexStride, orientedBoundingBox) {
         /**
          * The center of the tile.  Vertex positions are specified relative to this center.
          * @type {Cartesian3}
@@ -88,7 +88,7 @@ define([
          * A bounding box that completely contains the tile.
          * @type {OrientedBoundingBox}
          */
-        this.boundingOBB = boundingOBB;
+        this.orientedBoundingBox = orientedBoundingBox;
     };
 
     return TerrainMesh;

--- a/Source/Core/TerrainMesh.js
+++ b/Source/Core/TerrainMesh.js
@@ -25,8 +25,9 @@ define([
       *                     scaled space, and used for horizon culling.  If this point is below the horizon,
       *                     the tile is considered to be entirely below the horizon.
       * @param {Number} [vertexStride=6] The number of components in each vertex.
+      * @param {OrientedBoundingBox} [boundingOBB=undefined] A bounding sphere that completely contains the tile.
       */
-    var TerrainMesh = function TerrainMesh(center, vertices, indices, minimumHeight, maximumHeight, boundingSphere3D, occludeePointInScaledSpace, vertexStride) {
+    var TerrainMesh = function TerrainMesh(center, vertices, indices, minimumHeight, maximumHeight, boundingSphere3D, occludeePointInScaledSpace, vertexStride, boundingOBB) {
         /**
          * The center of the tile.  Vertex positions are specified relative to this center.
          * @type {Cartesian3}
@@ -82,6 +83,12 @@ define([
          * @type {Cartesian3}
          */
         this.occludeePointInScaledSpace = occludeePointInScaledSpace;
+
+        /**
+         * A bounding box that completely contains the tile.
+         * @type {OrientedBoundingBox}
+         */
+        this.boundingOBB = boundingOBB;
     };
 
     return TerrainMesh;

--- a/Source/Renderer/DrawCommand.js
+++ b/Source/Renderer/DrawCommand.js
@@ -40,7 +40,7 @@ define([
          *
          * @see DrawCommand#debugShowBoundingVolume
          */
-        this.boundingOBB = options.boundingOBB;
+        this.orientedBoundingBox = options.orientedBoundingBox;
 
         /**
          * When <code>true</code>, the renderer frustum and horizon culls the command based on its {@link DrawCommand#boundingVolume}.

--- a/Source/Renderer/DrawCommand.js
+++ b/Source/Renderer/DrawCommand.js
@@ -32,6 +32,17 @@ define([
         this.boundingVolume = options.boundingVolume;
 
         /**
+         * The oriented bounding box of the geometry in world space. If this is defined, it is used instead of
+         * {@link DrawCommand#boundingVolume} for plane intersection testing.
+         *
+         * @type {OrientedBoundingBox}
+         * @default undefined
+         *
+         * @see DrawCommand#debugShowBoundingVolume
+         */
+        this.boundingOBB = options.boundingOBB;
+
+        /**
          * When <code>true</code>, the renderer frustum and horizon culls the command based on its {@link DrawCommand#boundingVolume}.
          * If the command was already culled, set this to <code>false</code> for a performance improvement.
          *

--- a/Source/Scene/CullingVolume.js
+++ b/Source/Scene/CullingVolume.js
@@ -2,13 +2,17 @@
 define([
         '../Core/defaultValue',
         '../Core/defined',
+        '../Core/Cartesian3',
         '../Core/DeveloperError',
-        '../Core/Intersect'
+        '../Core/Intersect',
+        '../Core/Plane'
     ], function(
         defaultValue,
         defined,
+        Cartesian3,
         DeveloperError,
-        Intersect) {
+        Intersect,
+        Plane) {
     "use strict";
 
     /**
@@ -30,6 +34,7 @@ define([
         this.planes = defaultValue(planes, []);
     };
 
+    var scratchPlane = new Plane(new Cartesian3(), 0.0);
     /**
      * Determines whether a bounding volume intersects the culling volume.
      *
@@ -46,7 +51,7 @@ define([
         var planes = this.planes;
         var intersecting = false;
         for (var k = 0, len = planes.length; k < len; ++k) {
-            var result = boundingVolume.intersect(planes[k]);
+            var result = boundingVolume.intersectPlane(Plane.fromCartesian4(planes[k], scratchPlane));
             if (result === Intersect.OUTSIDE) {
                 return Intersect.OUTSIDE;
             } else if (result === Intersect.INTERSECTING) {

--- a/Source/Scene/GlobeSurfaceTile.js
+++ b/Source/Scene/GlobeSurfaceTile.js
@@ -8,7 +8,6 @@ define([
         '../Core/defined',
         '../Core/defineProperties',
         '../Core/IntersectionTests',
-        '../Core/OrientedBoundingBox',
         '../Core/PixelFormat',
         '../Core/Rectangle',
         '../Renderer/PixelDatatype',
@@ -29,7 +28,6 @@ define([
         defined,
         defineProperties,
         IntersectionTests,
-        OrientedBoundingBox,
         PixelFormat,
         Rectangle,
         PixelDatatype,
@@ -126,7 +124,7 @@ define([
         this.maximumHeight = 0.0;
         this.boundingSphere3D = new BoundingSphere();
         this.boundingSphere2D = new BoundingSphere();
-        this.boundingOBB = undefined;
+        this.orientedBoundingBox = undefined;
         this.occludeePointInScaledSpace = new Cartesian3();
 
         this.loadedTerrain = undefined;

--- a/Source/Scene/GlobeSurfaceTile.js
+++ b/Source/Scene/GlobeSurfaceTile.js
@@ -8,6 +8,7 @@ define([
         '../Core/defined',
         '../Core/defineProperties',
         '../Core/IntersectionTests',
+        '../Core/OrientedBoundingBox',
         '../Core/PixelFormat',
         '../Core/Rectangle',
         '../Renderer/PixelDatatype',
@@ -28,6 +29,7 @@ define([
         defined,
         defineProperties,
         IntersectionTests,
+        OrientedBoundingBox,
         PixelFormat,
         Rectangle,
         PixelDatatype,
@@ -124,6 +126,7 @@ define([
         this.maximumHeight = 0.0;
         this.boundingSphere3D = new BoundingSphere();
         this.boundingSphere2D = new BoundingSphere();
+        this.boundingOBB = undefined;
         this.occludeePointInScaledSpace = new Cartesian3();
 
         this.loadedTerrain = undefined;

--- a/Source/Scene/GlobeSurfaceTileProvider.js
+++ b/Source/Scene/GlobeSurfaceTileProvider.js
@@ -810,8 +810,8 @@ define([
         return context.createVertexArray(vertexArray._attributes, wireframeIndexBuffer);
     }
 
-    var createDebugOrientedBoundingBox;
-    var createDebugBoundingSphere;
+    var getDebugOrientedBoundingBox;
+    var getDebugBoundingSphere;
     var debugDestroyPrimitive;
 
     (function() {
@@ -836,7 +836,7 @@ define([
             });
         }
 
-        createDebugOrientedBoundingBox = function(obb, color) {
+        getDebugOrientedBoundingBox = function(obb, color) {
             if (obb === previousVolume) {
                 return primitive;
             }
@@ -852,7 +852,7 @@ define([
             return primitive;
         };
 
-        createDebugBoundingSphere = function(sphere, color) {
+        getDebugBoundingSphere = function(sphere, color) {
             if (sphere === previousVolume) {
                 return primitive;
             }
@@ -997,10 +997,13 @@ define([
             ++tileProvider._usedDrawCommands;
 
             if (tile === tileProvider._debug.boundingSphereTile) {
+                // If a debug primitive already exists for this tile, it will not be
+                // re-created, to avoid allocation every frame. If it were possible
+                // to have more than one selected tile, this would have to change.
                 if (defined(surfaceTile.orientedBoundingBox)) {
-                    createDebugOrientedBoundingBox(surfaceTile.orientedBoundingBox, Color.RED).update(context, frameState, commandList);
+                    getDebugOrientedBoundingBox(surfaceTile.orientedBoundingBox, Color.RED).update(context, frameState, commandList);
                 } else if (defined(surfaceTile.boundingSphere3D)) {
-                    createDebugBoundingSphere(surfaceTile.boundingSphere3D, Color.RED).update(context, frameState, commandList);
+                    getDebugBoundingSphere(surfaceTile.boundingSphere3D, Color.RED).update(context, frameState, commandList);
                 }
             }
 

--- a/Source/Scene/GlobeSurfaceTileProvider.js
+++ b/Source/Scene/GlobeSurfaceTileProvider.js
@@ -872,6 +872,8 @@ define([
         debugDestroyPrimitive = function() {
             if (defined(primitive)) {
                 primitive.destroy();
+                primitive = undefined;
+                previousVolume = undefined;
             }
         };
     })();

--- a/Source/Scene/GlobeSurfaceTileProvider.js
+++ b/Source/Scene/GlobeSurfaceTileProvider.js
@@ -5,6 +5,7 @@ define([
         '../Core/Cartesian3',
         '../Core/Cartesian4',
         '../Core/Color',
+        '../Core/defaultValue',
         '../Core/defined',
         '../Core/defineProperties',
         '../Core/destroyObject',
@@ -15,6 +16,7 @@ define([
         '../Core/IndexDatatype',
         '../Core/Intersect',
         '../Core/Matrix4',
+        '../Core/OrientedBoundingBox',
         '../Core/PrimitiveType',
         '../Core/Rectangle',
         '../Core/Visibility',
@@ -36,6 +38,7 @@ define([
         Cartesian3,
         Cartesian4,
         Color,
+        defaultValue,
         defined,
         defineProperties,
         destroyObject,
@@ -46,6 +49,7 @@ define([
         IndexDatatype,
         Intersect,
         Matrix4,
+        OrientedBoundingBox,
         PrimitiveType,
         Rectangle,
         Visibility,
@@ -395,7 +399,7 @@ define([
 
         var cullingVolume = frameState.cullingVolume;
 
-        var boundingVolume = surfaceTile.boundingSphere3D;
+        var boundingVolume = defaultValue(surfaceTile.boundingOBB, surfaceTile.boundingSphere3D);
 
         if (frameState.mode !== SceneMode.SCENE3D) {
             boundingVolume = boundingSphereScratch;
@@ -893,6 +897,7 @@ define([
                 command.owner = tile;
                 command.cull = false;
                 command.boundingVolume = new BoundingSphere();
+                command.boundingOBB = undefined;
 
                 uniformMap = createTileUniformMap();
 
@@ -1002,6 +1007,7 @@ define([
             }
 
             var boundingVolume = command.boundingVolume;
+            var boundingOBB = command.boundingOBB;
 
             if (frameState.mode !== SceneMode.SCENE3D) {
                 BoundingSphere.fromRectangleWithHeights2D(tile.rectangle, frameState.mapProjection, surfaceTile.minimumHeight, surfaceTile.maximumHeight, boundingVolume);
@@ -1011,7 +1017,8 @@ define([
                     boundingVolume = BoundingSphere.union(surfaceTile.boundingSphere3D, boundingVolume, boundingVolume);
                 }
             } else {
-                BoundingSphere.clone(surfaceTile.boundingSphere3D, boundingVolume);
+                command.boundingVolume = BoundingSphere.clone(surfaceTile.boundingSphere3D, boundingVolume);
+                command.boundingOBB = OrientedBoundingBox.clone(surfaceTile.boundingOBB, boundingOBB);
             }
 
             commandList.push(command);

--- a/Source/Scene/GlobeSurfaceTileProvider.js
+++ b/Source/Scene/GlobeSurfaceTileProvider.js
@@ -399,7 +399,7 @@ define([
 
         var cullingVolume = frameState.cullingVolume;
 
-        var boundingVolume = defaultValue(surfaceTile.boundingOBB, surfaceTile.boundingSphere3D);
+        var boundingVolume = defaultValue(surfaceTile.orientedBoundingBox, surfaceTile.boundingSphere3D);
 
         if (frameState.mode !== SceneMode.SCENE3D) {
             boundingVolume = boundingSphereScratch;
@@ -897,7 +897,7 @@ define([
                 command.owner = tile;
                 command.cull = false;
                 command.boundingVolume = new BoundingSphere();
-                command.boundingOBB = undefined;
+                command.orientedBoundingBox = undefined;
 
                 uniformMap = createTileUniformMap();
 
@@ -1007,7 +1007,7 @@ define([
             }
 
             var boundingVolume = command.boundingVolume;
-            var boundingOBB = command.boundingOBB;
+            var orientedBoundingBox = command.orientedBoundingBox;
 
             if (frameState.mode !== SceneMode.SCENE3D) {
                 BoundingSphere.fromRectangleWithHeights2D(tile.rectangle, frameState.mapProjection, surfaceTile.minimumHeight, surfaceTile.maximumHeight, boundingVolume);
@@ -1018,7 +1018,7 @@ define([
                 }
             } else {
                 command.boundingVolume = BoundingSphere.clone(surfaceTile.boundingSphere3D, boundingVolume);
-                command.boundingOBB = OrientedBoundingBox.clone(surfaceTile.boundingOBB, boundingOBB);
+                command.orientedBoundingBox = OrientedBoundingBox.clone(surfaceTile.orientedBoundingBox, orientedBoundingBox);
             }
 
             commandList.push(command);

--- a/Source/Scene/PolylineCollection.js
+++ b/Source/Scene/PolylineCollection.js
@@ -16,6 +16,7 @@ define([
         '../Core/Intersect',
         '../Core/Math',
         '../Core/Matrix4',
+        '../Core/Plane',
         '../Renderer/BufferUsage',
         '../Renderer/DrawCommand',
         '../Renderer/ShaderSource',
@@ -44,6 +45,7 @@ define([
         Intersect,
         CesiumMath,
         Matrix4,
+        Plane,
         BufferUsage,
         DrawCommand,
         ShaderSource,
@@ -1046,7 +1048,7 @@ define([
 
     function intersectsIDL(polyline) {
         return Cartesian3.dot(Cartesian3.UNIT_X, polyline._boundingVolume.center) < 0 ||
-            polyline._boundingVolume.intersect(Cartesian4.UNIT_Y) === Intersect.INTERSECTING;
+            polyline._boundingVolume.intersectPlane(Plane.ORIGIN_ZX_PLANE) === Intersect.INTERSECTING;
     }
 
     PolylineBucket.prototype.getPolylinePositionsLength = function(polyline) {

--- a/Source/Scene/Scene.js
+++ b/Source/Scene/Scene.js
@@ -1210,16 +1210,16 @@ define([
             var modelMatrix = new Matrix4();
 
             var geometry;
-            if (defined(command.boundingOBB)) {
+            if (defined(command.orientedBoundingBox)) {
                 // Assumes bounding volume is an OrientedBoundingBox.
-                var boundingOBB = command.boundingOBB;
+                var orientedBoundingBox = command.orientedBoundingBox;
 
                 geometry = BoxOutlineGeometry.createGeometry(BoxOutlineGeometry.fromDimensions({
                     dimensions: new Cartesian3(2.0, 2.0, 2.0),
                     vertexFormat: PerInstanceColorAppearance.FLAT_VERTEX_FORMAT
                 }));
 
-                Matrix4.fromRotationTranslation(boundingOBB.halfAxes, boundingOBB.center, modelMatrix);
+                Matrix4.fromRotationTranslation(orientedBoundingBox.halfAxes, orientedBoundingBox.center, modelMatrix);
             } else if (defined(command.boundingVolume)) {
                 // Assumes bounding volume is a bounding sphere.
 

--- a/Source/Scene/TileTerrain.js
+++ b/Source/Scene/TileTerrain.js
@@ -6,6 +6,7 @@ define([
         '../Core/defined',
         '../Core/DeveloperError',
         '../Core/IndexDatatype',
+        '../Core/OrientedBoundingBox',
         '../Core/TileProviderError',
         '../Renderer/BufferUsage',
         '../ThirdParty/when',
@@ -18,6 +19,7 @@ define([
         defined,
         DeveloperError,
         IndexDatatype,
+        OrientedBoundingBox,
         TileProviderError,
         BufferUsage,
         when,
@@ -78,6 +80,7 @@ define([
         surfaceTile.minimumHeight = mesh.minimumHeight;
         surfaceTile.maximumHeight = mesh.maximumHeight;
         surfaceTile.boundingSphere3D = BoundingSphere.clone(mesh.boundingSphere3D, surfaceTile.boundingSphere3D);
+        surfaceTile.boundingOBB = OrientedBoundingBox.clone(mesh.boundingOBB, surfaceTile.boundingOBB);
 
         tile.data.occludeePointInScaledSpace = Cartesian3.clone(mesh.occludeePointInScaledSpace, surfaceTile.occludeePointInScaledSpace);
 

--- a/Source/Scene/TileTerrain.js
+++ b/Source/Scene/TileTerrain.js
@@ -80,7 +80,7 @@ define([
         surfaceTile.minimumHeight = mesh.minimumHeight;
         surfaceTile.maximumHeight = mesh.maximumHeight;
         surfaceTile.boundingSphere3D = BoundingSphere.clone(mesh.boundingSphere3D, surfaceTile.boundingSphere3D);
-        surfaceTile.boundingOBB = OrientedBoundingBox.clone(mesh.boundingOBB, surfaceTile.boundingOBB);
+        surfaceTile.orientedBoundingBox = OrientedBoundingBox.clone(mesh.orientedBoundingBox, surfaceTile.orientedBoundingBox);
 
         tile.data.occludeePointInScaledSpace = Cartesian3.clone(mesh.occludeePointInScaledSpace, surfaceTile.occludeePointInScaledSpace);
 

--- a/Source/Widgets/CesiumInspector/CesiumInspector.js
+++ b/Source/Widgets/CesiumInspector/CesiumInspector.js
@@ -301,7 +301,7 @@ define([
         tbsCheck.type = 'checkbox';
         tbsCheck.setAttribute('data-bind', 'checked: tileBoundingSphere, enable: hasPickedTile, click: showTileBoundingSphere');
         tileBoundingSphere.appendChild(tbsCheck);
-        tileBoundingSphere.appendChild(document.createTextNode('Show bounding sphere'));
+        tileBoundingSphere.appendChild(document.createTextNode('Show bounding volume'));
 
         var renderTile = document.createElement('div');
         pickTileRequired.appendChild(renderTile);

--- a/Source/Workers/createVerticesFromHeightmap.js
+++ b/Source/Workers/createVerticesFromHeightmap.js
@@ -4,6 +4,8 @@ define([
         '../Core/Ellipsoid',
         '../Core/EllipsoidalOccluder',
         '../Core/HeightmapTessellator',
+        '../Core/Math',
+        '../Core/OrientedBoundingBox',
         '../Core/Rectangle',
         './createTaskProcessorWorker'
     ], function(
@@ -11,6 +13,8 @@ define([
         Ellipsoid,
         EllipsoidalOccluder,
         HeightmapTessellator,
+        CesiumMath,
+        OrientedBoundingBox,
         Rectangle,
         createTaskProcessorWorker) {
     "use strict";
@@ -36,6 +40,12 @@ define([
 
         var statistics = HeightmapTessellator.computeVertices(parameters);
         var boundingSphere3D = BoundingSphere.fromVertices(vertices, parameters.relativeToCenter, numberOfAttributes);
+        var orientedBoundingBox;
+        if (parameters.rectangle.width < CesiumMath.PI_OVER_TWO + CesiumMath.EPSILON5) {
+            // Here, rectangle.width < pi/2, and rectangle.height < pi
+            // (though it would still work with rectangle.width up to pi)
+            orientedBoundingBox = OrientedBoundingBox.fromRectangle(parameters.rectangle, statistics.minimumHeight, statistics.maximumHeight, parameters.ellipsoid);
+        }
 
         var ellipsoid = parameters.ellipsoid;
         var occluder = new EllipsoidalOccluder(ellipsoid);
@@ -49,6 +59,7 @@ define([
             gridWidth : arrayWidth,
             gridHeight : arrayHeight,
             boundingSphere3D : boundingSphere3D,
+            orientedBoundingBox : orientedBoundingBox,
             occludeePointInScaledSpace : occludeePointInScaledSpace
         };
     }

--- a/Source/Workers/upsampleQuantizedTerrainMesh.js
+++ b/Source/Workers/upsampleQuantizedTerrainMesh.js
@@ -11,6 +11,7 @@ define([
         '../Core/IndexDatatype',
         '../Core/Intersections2D',
         '../Core/Math',
+        '../Core/OrientedBoundingBox',
         './createTaskProcessorWorker'
     ], function(
         AttributeCompression,
@@ -24,6 +25,7 @@ define([
         IndexDatatype,
         Intersections2D,
         CesiumMath,
+        OrientedBoundingBox,
         createTaskProcessorWorker) {
     "use strict";
 
@@ -42,6 +44,7 @@ define([
     var normalsScratch = [];
     var horizonOcclusionPointScratch = new Cartesian3();
     var boundingSphereScratch = new BoundingSphere();
+    var orientedBoundingBoxScratch = new OrientedBoundingBox();
 
     function upsampleQuantizedTerrainMesh(parameters, transferableObjects) {
         var isEastChild = parameters.isEastChild;
@@ -239,6 +242,7 @@ define([
         }
 
         var boundingSphere = BoundingSphere.fromVertices(cartesianVertices, Cartesian3.ZERO, 3, boundingSphereScratch);
+        var orientedBoundingBox = OrientedBoundingBox.fromRectangle(rectangle, minimumHeight, maximumHeight, ellipsoid, orientedBoundingBoxScratch);
 
         var occluder = new EllipsoidalOccluder(ellipsoid);
         var horizonOcclusionPoint = occluder.computeHorizonCullingPointFromVertices(boundingSphere.center, cartesianVertices, 3, boundingSphere.center, horizonOcclusionPointScratch);
@@ -285,6 +289,7 @@ define([
             eastIndices : eastIndices,
             northIndices : northIndices,
             boundingSphere : boundingSphere,
+            orientedBoundingBox : orientedBoundingBox,
             horizonOcclusionPoint : horizonOcclusionPoint
         };
     }

--- a/Specs/Core/AxisAlignedBoundingBoxSpec.js
+++ b/Specs/Core/AxisAlignedBoundingBoxSpec.js
@@ -3,12 +3,14 @@ defineSuite([
         'Core/AxisAlignedBoundingBox',
         'Core/Cartesian3',
         'Core/Cartesian4',
-        'Core/Intersect'
+        'Core/Intersect',
+        'Core/Plane'
     ], function(
         AxisAlignedBoundingBox,
         Cartesian3,
         Cartesian4,
-        Intersect) {
+        Intersect,
+        Plane) {
     "use strict";
     /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn*/
 
@@ -115,45 +117,53 @@ defineSuite([
         expect(box.center).toEqual(positions[0]);
     });
 
-    it('intersect works with box on the positive side of a plane', function() {
+    it('intersectPlane works with box on the positive side of a plane', function() {
         var box = new AxisAlignedBoundingBox(Cartesian3.negate(Cartesian3.UNIT_X, new Cartesian3()), Cartesian3.ZERO);
         var normal = Cartesian3.negate(Cartesian3.UNIT_X, new Cartesian3());
         var position = Cartesian3.UNIT_X;
-        var plane = new Cartesian4(normal.x, normal.y, normal.z, -Cartesian3.dot(normal, position));
-        expect(box.intersect(plane)).toEqual(Intersect.INSIDE);
+        var plane = new Plane(normal, -Cartesian3.dot(normal, position));
+        expect(box.intersectPlane(plane)).toEqual(Intersect.INSIDE);
     });
 
-    it('intersect works with box on the negative side of a plane', function() {
+    it('intersectPlane works with box on the negative side of a plane', function() {
         var box = new AxisAlignedBoundingBox(Cartesian3.negate(Cartesian3.UNIT_X, new Cartesian3()), Cartesian3.ZERO);
         var normal = Cartesian3.UNIT_X;
         var position = Cartesian3.UNIT_X;
-        var plane = new Cartesian4(normal.x, normal.y, normal.z, -Cartesian3.dot(normal, position));
-        expect(box.intersect(plane)).toEqual(Intersect.OUTSIDE);
+        var plane = new Plane(normal, -Cartesian3.dot(normal, position));
+        expect(box.intersectPlane(plane)).toEqual(Intersect.OUTSIDE);
     });
 
-    it('intersect works with box intersecting a plane', function() {
+    it('intersectPlane works with box intersecting a plane', function() {
         var box = new AxisAlignedBoundingBox(Cartesian3.ZERO, Cartesian3.multiplyByScalar(Cartesian3.UNIT_X, 2.0, new Cartesian3()));
         var normal = Cartesian3.UNIT_X;
         var position = Cartesian3.UNIT_X;
-        var plane = new Cartesian4(normal.x, normal.y, normal.z, -Cartesian3.dot(normal, position));
-        expect(box.intersect(plane)).toEqual(Intersect.INTERSECTING);
+        var plane = new Plane(normal, -Cartesian3.dot(normal, position));
+        expect(box.intersectPlane(plane)).toEqual(Intersect.INTERSECTING);
+    });
+
+    it('intersect works the same as intersectPlane in one case', function() {
+        var box = new AxisAlignedBoundingBox(Cartesian3.ZERO, Cartesian3.multiplyByScalar(Cartesian3.UNIT_X, 2.0, new Cartesian3()));
+        var normal = Cartesian3.UNIT_X;
+        var position = Cartesian3.UNIT_X;
+        var plane = new Plane(normal, -Cartesian3.dot(normal, position));
+        expect(box.intersect(new Cartesian4(1.0, 0.0, 0.0, -1.0))).toEqual(box.intersectPlane(plane));
     });
 
     it('clone returns undefined with no parameter', function() {
         expect(AxisAlignedBoundingBox.clone()).toBeUndefined();
     });
 
-    it('intersect throws without a box', function() {
-        var plane = new Cartesian4();
+    it('intersectPlane throws without a box', function() {
+        var plane = new Plane(Cartesian3.UNIT_X, 0.0);
         expect(function() {
-            AxisAlignedBoundingBox.intersect(undefined, plane);
+            AxisAlignedBoundingBox.intersectPlane(undefined, plane);
         }).toThrowDeveloperError();
     });
 
-    it('intersect throws without a plane', function() {
+    it('intersectPlane throws without a plane', function() {
         var box = new AxisAlignedBoundingBox();
         expect(function() {
-            AxisAlignedBoundingBox.intersect(box, undefined);
+            AxisAlignedBoundingBox.intersectPlane(box, undefined);
         }).toThrowDeveloperError();
     });
 });

--- a/Specs/Core/BoundingSphereSpec.js
+++ b/Specs/Core/BoundingSphereSpec.js
@@ -10,6 +10,7 @@ defineSuite([
         'Core/Interval',
         'Core/Math',
         'Core/Matrix4',
+        'Core/Plane',
         'Core/Rectangle',
         'Specs/createPackableSpecs'
     ], function(
@@ -23,6 +24,7 @@ defineSuite([
         Interval,
         CesiumMath,
         Matrix4,
+        Plane,
         Rectangle,
         createPackableSpecs) {
     "use strict";
@@ -384,28 +386,36 @@ defineSuite([
         expect(sphere).toEqual(expected);
     });
 
-    it('sphere on the positive side of a plane', function() {
+    it('intersectPlane with sphere on the positive side of a plane', function() {
         var sphere = new BoundingSphere(Cartesian3.ZERO, 0.5);
         var normal = Cartesian3.negate(Cartesian3.UNIT_X, new Cartesian3());
         var position = Cartesian3.UNIT_X;
-        var plane = new Cartesian4(normal.x, normal.y, normal.z, -Cartesian3.dot(normal, position));
-        expect(sphere.intersect(plane)).toEqual(Intersect.INSIDE);
+        var plane = new Plane(normal, -Cartesian3.dot(normal, position));
+        expect(sphere.intersectPlane(plane)).toEqual(Intersect.INSIDE);
     });
 
-    it('sphere on the negative side of a plane', function() {
+    it('intersectPlane with sphere on the negative side of a plane', function() {
         var sphere = new BoundingSphere(Cartesian3.ZERO, 0.5);
         var normal = Cartesian3.UNIT_X;
         var position = Cartesian3.UNIT_X;
-        var plane = new Cartesian4(normal.x, normal.y, normal.z, -Cartesian3.dot(normal, position));
-        expect(sphere.intersect(plane)).toEqual(Intersect.OUTSIDE);
+        var plane = new Plane(normal, -Cartesian3.dot(normal, position));
+        expect(sphere.intersectPlane(plane)).toEqual(Intersect.OUTSIDE);
     });
 
-    it('sphere intersecting a plane', function() {
+    it('intersectPlane with sphere intersecting a plane', function() {
         var sphere = new BoundingSphere(Cartesian3.UNIT_X, 0.5);
         var normal = Cartesian3.UNIT_X;
         var position = Cartesian3.UNIT_X;
-        var plane = new Cartesian4(normal.x, normal.y, normal.z, -Cartesian3.dot(normal, position));
-        expect(sphere.intersect(plane)).toEqual(Intersect.INTERSECTING);
+        var plane = new Plane(normal, -Cartesian3.dot(normal, position));
+        expect(sphere.intersectPlane(plane)).toEqual(Intersect.INTERSECTING);
+    });
+
+    it('intersect works the same as intersectPlane in one case', function() {
+        var sphere = new BoundingSphere(Cartesian3.UNIT_X, 0.5);
+        var normal = Cartesian3.UNIT_X;
+        var position = Cartesian3.UNIT_X;
+        var plane = new Plane(normal, -Cartesian3.dot(normal, position));
+        expect(sphere.intersect(new Cartesian4(1.0, 0.0, 0.0, -1.0))).toEqual(sphere.intersectPlane(plane));
     });
 
     it('expands to contain another sphere', function() {
@@ -599,17 +609,17 @@ defineSuite([
         }).toThrowDeveloperError();
     });
 
-    it('intersect throws without a sphere', function() {
-        var plane = new Cartesian4();
+    it('intersectPlane throws without a sphere', function() {
+        var plane = new Plane(Cartesian3.UNIT_X, 0.0);
         expect(function() {
-            BoundingSphere.intersect(undefined, plane);
+            BoundingSphere.intersectPlane(undefined, plane);
         }).toThrowDeveloperError();
     });
 
-    it('intersect throws without a plane', function() {
+    it('intersectPlane throws without a plane', function() {
         var sphere = new BoundingSphere();
         expect(function() {
-            BoundingSphere.intersect(sphere, undefined);
+            BoundingSphere.intersectPlane(sphere, undefined);
         }).toThrowDeveloperError();
     });
 

--- a/Specs/Core/EllipsoidTangentPlaneSpec.js
+++ b/Specs/Core/EllipsoidTangentPlaneSpec.js
@@ -38,7 +38,7 @@ defineSuite([
         expect(tangentPlane.origin).toEqual(Cartesian3.UNIT_X);
     });
 
-    it('projectPointOntoPlane returns undefined for points not on the plane', function () {
+    it('projectPointOntoPlane returns undefined for unsolvable projections', function () {
         var ellipsoid = Ellipsoid.UNIT_SPHERE;
         var origin = new Cartesian3(1, 0, 0);
         var tangentPlane = new EllipsoidTangentPlane(origin, ellipsoid);
@@ -98,7 +98,7 @@ defineSuite([
         expect(returnedResults).toEqual(expectedResults);
     });
 
-    it('projectPointsOntoPlane works when some points not on plane', function () {
+    it('projectPointsOntoPlane works when some points cannot be projected', function () {
         var ellipsoid = Ellipsoid.UNIT_SPHERE;
         var origin = new Cartesian3(1, 0, 0);
         var tangentPlane = new EllipsoidTangentPlane(origin, ellipsoid);
@@ -135,25 +135,66 @@ defineSuite([
         expect(returnedResults).toEqual(expectedResults);
     });
 
-    it('extentsToOrientedBoundingBox works with a result parameter', function() {
+    it('projectPointToNearestOnPlane works without a result parameter', function () {
         var ellipsoid = Ellipsoid.UNIT_SPHERE;
-        var origin = Cartesian3.UNIT_X;
-        var pl = new EllipsoidTangentPlane(origin, ellipsoid);
-        var result = new OrientedBoundingBox();
-        result = pl.extentsToOrientedBoundingBox(-0.5, 0.5, -0.5, 0.5, -0.5, 0.5, result);
-        var expected = new OrientedBoundingBox(origin,
-            new Matrix3(0.0, 0.0, 0.5, 0.5, 0.0, 0.0, 0.0, 0.5, 0.0));
-        expect(result).toEqual(expected);
+        var origin = new Cartesian3(1, 0, 0);
+        var tangentPlane = new EllipsoidTangentPlane(origin, ellipsoid);
+
+        var positions = new Cartesian3(1, 0, 1);
+        var expectedResult = new Cartesian2(0, 1);
+        var returnedResult = tangentPlane.projectPointToNearestOnPlane(positions);
+        expect(returnedResult).toEqual(expectedResult);
     });
 
-    it('extentsToOrientedBoundingBox works without a result parameter', function() {
+    it('projectPointToNearestOnPlane works projecting from various distances', function () {
+        var ellipsoid = Ellipsoid.ZERO;
+        var origin = new Cartesian3(1, 0, 0);
+        var tangentPlane = new EllipsoidTangentPlane(origin, ellipsoid);
+
+        expect(tangentPlane.projectPointToNearestOnPlane(new Cartesian3(2, 0, 0))).toEqual(new Cartesian2(0, 0));
+        expect(tangentPlane.projectPointToNearestOnPlane(new Cartesian3(1, 0, 0))).toEqual(new Cartesian2(0, 0));
+        expect(tangentPlane.projectPointToNearestOnPlane(new Cartesian3(0, 0, 0))).toEqual(new Cartesian2(0, 0));
+        expect(tangentPlane.projectPointToNearestOnPlane(new Cartesian3(-1, 0, 0))).toEqual(new Cartesian2(0, 0));
+    });
+
+    it('projectPointToNearestOnPlane works with a result parameter', function () {
         var ellipsoid = Ellipsoid.UNIT_SPHERE;
-        var origin = Cartesian3.UNIT_X;
-        var pl = new EllipsoidTangentPlane(origin, ellipsoid);
-        var result = pl.extentsToOrientedBoundingBox(-0.5, 0.5, -0.5, 0.5, -0.5, 0.5);
-        var expected = new OrientedBoundingBox(origin,
-            new Matrix3(0.0, 0.0, 0.5, 0.5, 0.0, 0.0, 0.0, 0.5, 0.0));
-        expect(result).toEqual(expected);
+        var origin = new Cartesian3(1, 0, 0);
+        var tangentPlane = new EllipsoidTangentPlane(origin, ellipsoid);
+
+        var positions = new Cartesian3(1, 0, 1);
+        var expectedResult = new Cartesian2(0, 1);
+        var result = new Cartesian2();
+        var returnedResult = tangentPlane.projectPointToNearestOnPlane(positions, result);
+        expect(result).toBe(returnedResult);
+        expect(returnedResult).toEqual(expectedResult);
+    });
+
+    it('projectPointsToNearestOnPlane works without a result parameter', function () {
+        var ellipsoid = Ellipsoid.UNIT_SPHERE;
+        var origin = new Cartesian3(1, 0, 0);
+        var tangentPlane = new EllipsoidTangentPlane(origin, ellipsoid);
+
+        var positions = [new Cartesian3(1, 0, 1), new Cartesian3(1, 0, 0), new Cartesian3(1, 1, 0)];
+        var expectedResults = [new Cartesian2(0, 1), new Cartesian2(0, 0), new Cartesian2(1, 0)];
+        var returnedResults = tangentPlane.projectPointsToNearestOnPlane(positions);
+        expect(returnedResults).toEqual(expectedResults);
+    });
+
+    it('projectPointsToNearestOnPlane works with a result parameter', function () {
+        var ellipsoid = Ellipsoid.UNIT_SPHERE;
+        var origin = new Cartesian3(1, 0, 0);
+        var tangentPlane = new EllipsoidTangentPlane(origin, ellipsoid);
+
+        var positions = [new Cartesian3(1, 0, 1), new Cartesian3(1, 0, 0), new Cartesian3(1, 1, 0)];
+        var expectedResults = [new Cartesian2(0, 1), new Cartesian2(0, 0), new Cartesian2(1, 0)];
+
+        var index0 = new Cartesian2();
+        var result = [index0];
+        var returnedResults = tangentPlane.projectPointsToNearestOnPlane(positions, result);
+        expect(result).toBe(returnedResults);
+        expect(result[0]).toBe(index0);
+        expect(returnedResults).toEqual(expectedResults);
     });
 
     it('constructor throws without origin', function() {
@@ -209,19 +250,6 @@ defineSuite([
         }).toThrowDeveloperError();
     });
 
-    it('extentsToOrientedBoundingBox throws missing any of the dimensional parameters', function() {
-        var ellipsoid = Ellipsoid.UNIT_SPHERE;
-        var origin = new Cartesian3(1.0, 0.0, 0.0);
-        var pl = new EllipsoidTangentPlane(origin, ellipsoid);
-        var result = new OrientedBoundingBox();
-        expect(function() { pl.extentsToOrientedBoundingBox(undefined, 0.5, -0.5, 0.5, -0.5, 0.5, result);  }).toThrowDeveloperError();
-        expect(function() { pl.extentsToOrientedBoundingBox(-0.5, undefined, -0.5, 0.5, -0.5, 0.5, result); }).toThrowDeveloperError();
-        expect(function() { pl.extentsToOrientedBoundingBox(-0.5, 0.5, undefined, 0.5, -0.5, 0.5, result);  }).toThrowDeveloperError();
-        expect(function() { pl.extentsToOrientedBoundingBox(-0.5, 0.5, -0.5, undefined, -0.5, 0.5, result); }).toThrowDeveloperError();
-        expect(function() { pl.extentsToOrientedBoundingBox(-0.5, 0.5, -0.5, 0.5, undefined, 0.5, result);  }).toThrowDeveloperError();
-        expect(function() { pl.extentsToOrientedBoundingBox(-0.5, 0.5, -0.5, 0.5, -0.5, undefined, result); }).toThrowDeveloperError();
-    });
-
     it('projectPointsOntoEllipsoid works with an arbitrary ellipsoid using fromPoints', function () {
         var points = Cartesian3.fromDegreesArray([
             -72.0, 40.0,
@@ -238,36 +266,5 @@ defineSuite([
         expect(positionsBack[0].x).toBeCloseTo(points[0].x);
         expect(positionsBack[0].y).toBeCloseTo(points[0].y);
         expect(positionsBack[0].z).toBeCloseTo(points[0].z);
-    });
-
-    it('extentsToOrientedBoundingBox works with some edge-ish cases', function() {
-        var res, exp;
-        var result = new OrientedBoundingBox();
-        var ellipsoid;
-
-        ellipsoid = Ellipsoid.UNIT_SPHERE;
-        res = new EllipsoidTangentPlane(Cartesian3.UNIT_X, ellipsoid).extentsToOrientedBoundingBox(-0.3, 0.3, -0.3, 0.3, -0.3, 0.3, res);
-        exp = new OrientedBoundingBox(Cartesian3.UNIT_X,
-            new Matrix3(0.0, 0.0, 0.3, 0.3, 0.0, 0.0, 0.0, 0.3, 0.0));
-        expect(res.center).toEqualEpsilon(exp.center, CesiumMath.EPSILON15);
-        expect(res.halfAxes).toEqualEpsilon(exp.halfAxes, CesiumMath.EPSILON15);
-
-        ellipsoid = Ellipsoid.UNIT_SPHERE;
-        res = new EllipsoidTangentPlane(Cartesian3.UNIT_Z, ellipsoid).extentsToOrientedBoundingBox(-0.3, 0.3, -0.3, 0.3, -0.3, 0.3, res);
-        expect(res.center).toEqualEpsilon(Cartesian3.UNIT_Z, CesiumMath.EPSILON15);
-
-        ellipsoid = Ellipsoid.UNIT_SPHERE;
-        res = new EllipsoidTangentPlane(Cartesian3.UNIT_Y, ellipsoid).extentsToOrientedBoundingBox(-0.3, 0.3, -0.3, 0.3, -0.3, 0.3, res);
-        exp = new OrientedBoundingBox(Cartesian3.UNIT_Y,
-            new Matrix3(-0.3, 0.0, 0.0, 0.0, 0.0, 0.3, 0.0, 0.3, 0.0));
-        expect(res.center).toEqualEpsilon(exp.center, CesiumMath.EPSILON15);
-        expect(res.halfAxes).toEqualEpsilon(exp.halfAxes, CesiumMath.EPSILON15);
-
-        ellipsoid = Ellipsoid.UNIT_SPHERE;
-        res = new EllipsoidTangentPlane(Cartesian3.UNIT_X, ellipsoid).extentsToOrientedBoundingBox(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, res);
-        exp = new OrientedBoundingBox(Cartesian3.UNIT_X,
-                new Matrix3(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0));
-        expect(res.center).toEqualEpsilon(exp.center, CesiumMath.EPSILON15);
-        expect(res.halfAxes).toEqualEpsilon(exp.halfAxes, CesiumMath.EPSILON15);
     });
 });

--- a/Specs/Core/EllipsoidTangentPlaneSpec.js
+++ b/Specs/Core/EllipsoidTangentPlaneSpec.js
@@ -161,6 +161,20 @@ defineSuite([
         }).toThrowDeveloperError();
     });
 
+    it('projectPointToNearestOnPlane throws without cartesian', function() {
+        var tangentPlane = new EllipsoidTangentPlane(Cartesian3.UNIT_X, Ellipsoid.UNIT_SPHERE);
+        expect(function() {
+            return tangentPlane.projectPointToNearestOnPlane(undefined);
+        }).toThrowDeveloperError();
+    });
+
+    it('projectPointsToNearestOnPlane throws without cartesians', function() {
+        var tangentPlane = new EllipsoidTangentPlane(Cartesian3.UNIT_X, Ellipsoid.UNIT_SPHERE);
+        expect(function() {
+            return tangentPlane.projectPointsToNearestOnPlane(undefined);
+        }).toThrowDeveloperError();
+    });
+
     it('projectPointsOntoEllipsoid throws without cartesians', function() {
         var tangentPlane = new EllipsoidTangentPlane(Cartesian3.UNIT_X, Ellipsoid.UNIT_SPHERE);
         expect(function() {

--- a/Specs/Core/Matrix2Spec.js
+++ b/Specs/Core/Matrix2Spec.js
@@ -367,6 +367,25 @@ defineSuite([
         expect(left).toEqual(expected);
     });
 
+    it('multiplyByScale works', function() {
+        var m = new Matrix2(2, 3, 6, 7);
+        var scale = new Cartesian2(2.0, 3.0);
+        var expected = Matrix2.multiply(m, Matrix2.fromScale(scale), new Matrix2());
+        var result = new Matrix2();
+        var returnedResult = Matrix2.multiplyByScale(m, scale, result);
+        expect(returnedResult).toBe(result);
+        expect(result).toEqual(expected);
+    });
+
+    it('multiplyByScale works with "this" result parameter', function() {
+        var m = new Matrix2(1, 2, 5, 6);
+        var scale = new Cartesian2(1.0, 2.0);
+        var expected = Matrix2.multiply(m, Matrix2.fromScale(scale), new Matrix2());
+        var returnedResult = Matrix2.multiplyByScale(m, scale, m);
+        expect(returnedResult).toBe(m);
+        expect(m).toEqual(expected);
+    });
+
     it('multiplyByVector works', function() {
         var left = new Matrix2(1, 2, 3, 4);
         var right = new Cartesian2(5, 6);
@@ -656,6 +675,19 @@ defineSuite([
         }).toThrowDeveloperError();
     });
 
+    it('multiplyByScale throws with no matrix parameter', function() {
+        expect(function() {
+            Matrix2.multiplyByScale(undefined, new Cartesian2());
+        }).toThrowDeveloperError();
+    });
+
+    it('multiplyByScale throws with no scale parameter', function() {
+        var m = new Matrix2();
+        expect(function() {
+            Matrix2.multiplyByScale(m, undefined);
+        }).toThrowDeveloperError();
+    });
+
     it('multiplyByVector throws with no matrix parameter', function() {
         var cartesian = new Cartesian2();
         expect(function() {
@@ -734,6 +766,12 @@ defineSuite([
     it('multiply throws without result parameter', function() {
         expect(function() {
             Matrix2.multiply(new Matrix2(), new Matrix2());
+        }).toThrowDeveloperError();
+    });
+
+    it('multiplyByScale throws without result parameter', function() {
+        expect(function() {
+            Matrix2.multiplyByScale(new Matrix2(), new Cartesian2());
         }).toThrowDeveloperError();
     });
 

--- a/Specs/Core/Matrix3Spec.js
+++ b/Specs/Core/Matrix3Spec.js
@@ -530,6 +530,25 @@ defineSuite([
         expect(left).toEqual(expected);
     });
 
+    it('multiplyByScale works', function() {
+        var m = new Matrix3(2, 3, 4, 6, 7, 8, 10, 11, 12);
+        var scale = new Cartesian3(2.0, 3.0, 4.0);
+        var expected = Matrix3.multiply(m, Matrix3.fromScale(scale), new Matrix3());
+        var result = new Matrix3();
+        var returnedResult = Matrix3.multiplyByScale(m, scale, result);
+        expect(returnedResult).toBe(result);
+        expect(result).toEqual(expected);
+    });
+
+    it('multiplyByScale works with "this" result parameter', function() {
+        var m = new Matrix3(1, 2, 3, 5, 6, 7, 9, 10, 11);
+        var scale = new Cartesian3(1.0, 2.0, 3.0);
+        var expected = Matrix3.multiply(m, Matrix3.fromScale(scale), new Matrix3());
+        var returnedResult = Matrix3.multiplyByScale(m, scale, m);
+        expect(returnedResult).toBe(m);
+        expect(m).toEqual(expected);
+    });
+
     it('multiplyByVector works', function() {
         var left = new Matrix3(1, 2, 3, 4, 5, 6, 7, 8, 9);
         var right = new Cartesian3(10, 11, 12);
@@ -937,6 +956,19 @@ defineSuite([
         }).toThrowDeveloperError();
     });
 
+    it('multiplyByScale throws with no matrix parameter', function() {
+        expect(function() {
+            Matrix3.multiplyByScale(undefined, new Cartesian3());
+        }).toThrowDeveloperError();
+    });
+
+    it('multiplyByScale throws with no scale parameter', function() {
+        var m = new Matrix3();
+        expect(function() {
+            Matrix3.multiplyByScale(m, undefined);
+        }).toThrowDeveloperError();
+    });
+
     it('multiplyByVector throws with no matrix parameter', function() {
         var cartesian = new Cartesian3();
         expect(function() {
@@ -1051,6 +1083,12 @@ defineSuite([
     it('multiply throws without result parameter', function() {
         expect(function() {
             Matrix3.multiply(new Matrix3(), new Matrix3());
+        }).toThrowDeveloperError();
+    });
+
+    it('multiplyByScale throws without result parameter', function() {
+        expect(function() {
+            Matrix3.multiplyByScale(new Matrix3(), new Cartesian3());
         }).toThrowDeveloperError();
     });
 

--- a/Specs/Core/Matrix4Spec.js
+++ b/Specs/Core/Matrix4Spec.js
@@ -662,6 +662,14 @@ defineSuite([
         var returnedResult = Matrix4.multiplyByScale(m, scale, result);
         expect(returnedResult).toBe(result);
         expect(result).toEqual(expected);
+
+        m = new Matrix4(2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 0, 0, 0, 1);
+        scale = new Cartesian3(2.0, 3.0, 4.0);
+        expected = Matrix4.multiply(m, Matrix4.fromScale(scale), new Matrix4());
+        result = new Matrix4();
+        returnedResult = Matrix4.multiplyByScale(m, scale, result);
+        expect(returnedResult).toBe(result);
+        expect(result).toEqual(expected);
     });
 
     it('multiplyByScale works with "this" result parameter', function() {

--- a/Specs/Core/OrientedBoundingBoxSpec.js
+++ b/Specs/Core/OrientedBoundingBoxSpec.js
@@ -117,6 +117,12 @@ defineSuite([
         expect(function() { return OrientedBoundingBox.fromRectangle(new Rectangle(-2.0, -1.0, 2.0, 2.0), 0.0, 0.0, ellipsoid); }).toThrowDeveloperError();
     });
 
+    it('fromRectangle throws with non-revolution ellipsoids', function() {
+        var rectangle = new Rectangle(0.0, 0.0, 0.0, 0.0);
+        expect(function() { return OrientedBoundingBox.fromRectangle(rectangle, 0.0, 0.0, new Ellipsoid(1.01, 1.00, 1.01)); }).toThrowDeveloperError();
+        expect(function() { return OrientedBoundingBox.fromRectangle(rectangle, 0.0, 0.0, new Ellipsoid(1.00, 1.01, 1.01)); }).toThrowDeveloperError();
+    });
+
     it('fromRectangle creates an OrientedBoundingBox without a result parameter', function() {
         var ellipsoid = Ellipsoid.UNIT_SPHERE;
         var rectangle = new Rectangle(0.0, 0.0, 0.0, 0.0);

--- a/Specs/Core/OrientedBoundingBoxSpec.js
+++ b/Specs/Core/OrientedBoundingBoxSpec.js
@@ -186,6 +186,18 @@ defineSuite([
         expect(box.center).toEqualEpsilon(new Cartesian3(0.1875 * sqrt3, 0.0, 0.1875), CesiumMath.EPSILON15);
         expect(box.halfAxes).toEqualEpsilon(new Matrix3(0, -sqrt3/4, 5*sqrt3/16, 1, 0, 0, 0, 3/4, 5/16), CesiumMath.EPSILON15);
 
+        box = OrientedBoundingBox.fromRectangle(new Rectangle(-d90, -d90, d90, d30), 0.0, 0.0, Ellipsoid.UNIT_SPHERE);
+        expect(box.center).toEqualEpsilon(new Cartesian3(0.1875 * sqrt3, 0.0, -0.1875), CesiumMath.EPSILON15);
+        expect(box.halfAxes).toEqualEpsilon(new Matrix3(0, sqrt3/4, 5*sqrt3/16, 1, 0, 0, 0, 3/4, -5/16), CesiumMath.EPSILON15);
+
+        box = OrientedBoundingBox.fromRectangle(new Rectangle(0.0, -d30, d180, d90), 0.0, 0.0, Ellipsoid.UNIT_SPHERE);
+        expect(box.center).toEqualEpsilon(new Cartesian3(0.0, 0.1875 * sqrt3, 0.1875), CesiumMath.EPSILON15);
+        expect(box.halfAxes).toEqualEpsilon(new Matrix3(-1, 0, 0, 0, -sqrt3/4, 5*sqrt3/16, 0, 3/4, 5/16), CesiumMath.EPSILON15);
+
+        box = OrientedBoundingBox.fromRectangle(new Rectangle(0.0, -d90, d180, d30), 0.0, 0.0, Ellipsoid.UNIT_SPHERE);
+        expect(box.center).toEqualEpsilon(new Cartesian3(0.0, 0.1875 * sqrt3, -0.1875), CesiumMath.EPSILON15);
+        expect(box.halfAxes).toEqualEpsilon(new Matrix3(-1, 0, 0, 0, sqrt3/4, 5*sqrt3/16, 0, 3/4, -5/16), CesiumMath.EPSILON15);
+
         box = OrientedBoundingBox.fromRectangle(new Rectangle(-d45, 0.0, d45, 0.0), 0.0, 0.0, Ellipsoid.UNIT_SPHERE);
         expect(box.center).toEqualEpsilon(new Cartesian3((1.0 + Math.SQRT1_2) / 2.0, 0.0, 0.0), CesiumMath.EPSILON15);
         expect(box.halfAxes).toEqualEpsilon(new Matrix3(0.0, 0.0, 0.5 * (1.0 - Math.SQRT1_2), Math.SQRT1_2, 0.0, 0.0, 0.0, 0.0, 0.0), CesiumMath.EPSILON15);

--- a/Specs/Core/OrientedBoundingBoxSpec.js
+++ b/Specs/Core/OrientedBoundingBoxSpec.js
@@ -77,63 +77,32 @@ defineSuite([
         expect(box.halfAxes).toEqual(Matrix3.ZERO);
     });
 
-    it('fromBoundingRectangle throws without rectangle', function() {
+    it('fromEllipsoidRectangle throws without ellipsoid', function() {
+        var rectangle = new Rectangle(0.0, 0.0, 0.0, 0.0);
         expect(function() {
-            OrientedBoundingBox.fromBoundingRectangle();
+            OrientedBoundingBox.fromEllipsoidRectangle(undefined, rectangle, 0.0, 0.0);
         }).toThrowDeveloperError();
     });
 
-    it('fromBoundingRectangle returns zero-size OrientedBoundingBox given a zero-size BoundingRectangle', function() {
-        var box = OrientedBoundingBox.fromBoundingRectangle(new BoundingRectangle());
-        expect(box.center).toEqual(Cartesian3.ZERO);
-        expect(box.halfAxes).toEqual(Matrix3.ZERO);
-    });
-
-    it('fromBoundingRectangle creates an OrientedBoundingBox without a result parameter', function() {
-        var rect = new BoundingRectangle(1.0, 2.0, 3.0, 4.0);
-        var angle = CesiumMath.PI_OVER_TWO;
-        var box = OrientedBoundingBox.fromBoundingRectangle(rect, angle);
-        var rotation = Matrix3.fromRotationZ(angle);
-        expect(box.center).toEqual(new Cartesian3(-1.0, 3.5, 0.0));
-
-        var rotScale = new Matrix3();
-        Matrix3.multiply(rotation, Matrix3.fromScale(new Cartesian3(1.5, 2.0, 0.0)), rotScale);
-        expect(box.halfAxes).toEqualEpsilon(rotScale, CesiumMath.EPSILON15);
-    });
-
-    it('fromBoundingRectangle creates an OrientedBoundingBox with a result parameter', function() {
-        var rect = new BoundingRectangle(1.0, 2.0, 3.0, 4.0);
-        var angle = CesiumMath.PI_OVER_TWO;
-        var result = new OrientedBoundingBox();
-        var box = OrientedBoundingBox.fromBoundingRectangle(rect, angle, result);
-        expect(box).toBe(result);
-        var rotation = Matrix3.fromRotationZ(angle);
-
-        expect(box.center).toEqual(new Cartesian3(-1.0, 3.5, 0.0));
-
-        var rotScale = new Matrix3();
-        Matrix3.multiply(rotation, Matrix3.fromScale(new Cartesian3(1.5, 2.0, 0.0)), rotScale);
-        expect(box.halfAxes).toEqualEpsilon(rotScale, CesiumMath.EPSILON15);
-    });
-
-    it('fromRectangleTangentPlane throws without rectangle', function() {
-        var pl = new EllipsoidTangentPlane(Cartesian3.UNIT_X, Ellipsoid.UNIT_SPHERE);
+    it('fromEllipsoidRectangle throws without rectangle', function() {
+        var ellipsoid = Ellipsoid.UNIT_SPHERE;
         expect(function() {
-            return OrientedBoundingBox.fromRectangleTangentPlane(undefined, pl, 0.0, 0.0);
+            OrientedBoundingBox.fromEllipsoidRectangle(ellipsoid, undefined, 0.0, 0.0);
         }).toThrowDeveloperError();
     });
 
-    it('fromRectangleTangentPlane throws without tangentPlane', function() {
-        var rect = new BoundingRectangle(1.0, 2.0, 3.0, 4.0);
-        expect(function() {
-            return OrientedBoundingBox.fromRectangleTangentPlane(rect, undefined, 0.0, 0.0);
-        }).toThrowDeveloperError();
+    it('fromEllipsoidRectangle throws with invalid rectangles', function() {
+        var ellipsoid = Ellipsoid.UNIT_SPHERE;
+        expect(function() { return OrientedBoundingBox.fromEllipsoidRectangle(ellipsoid, new Rectangle(1.0, -1.0, -1.0, 1.0), 0.0, 0.0); }).toThrowDeveloperError();
+        expect(function() { return OrientedBoundingBox.fromEllipsoidRectangle(ellipsoid, new Rectangle(-1.0, 1.0, 1.0, -1.0), 0.0, 0.0); }).toThrowDeveloperError();
+        expect(function() { return OrientedBoundingBox.fromEllipsoidRectangle(ellipsoid, new Rectangle(-1.0, 1.0, -2.0, 2.0), 0.0, 0.0); }).toThrowDeveloperError();
+        expect(function() { return OrientedBoundingBox.fromEllipsoidRectangle(ellipsoid, new Rectangle(-2.0, 2.0, -1.0, 1.0), 0.0, 0.0); }).toThrowDeveloperError();
     });
 
-    it('fromRectangleTangentPlane creates an OrientedBoundingBox without a result parameter', function() {
-        var rect = new Rectangle(0.0, 0.0, 0.0, 0.0);
-        var pl = new EllipsoidTangentPlane(Cartesian3.UNIT_X, Ellipsoid.UNIT_SPHERE);
-        var box = OrientedBoundingBox.fromRectangleTangentPlane(rect, pl, 0.0, 0.0);
+    it('fromEllipsoidRectangle creates an OrientedBoundingBox without a result parameter', function() {
+        var ellipsoid = Ellipsoid.UNIT_SPHERE;
+        var rectangle = new Rectangle(0.0, 0.0, 0.0, 0.0);
+        var box = OrientedBoundingBox.fromEllipsoidRectangle(ellipsoid, rectangle, 0.0, 0.0);
 
         expect(box.center).toEqualEpsilon(new Cartesian3(1.0, 0.0, 0.0), CesiumMath.EPSILON15);
 
@@ -141,11 +110,11 @@ defineSuite([
         expect(box.halfAxes).toEqualEpsilon(rotScale, CesiumMath.EPSILON15);
     });
 
-    it('fromRectangleTangentPlane creates an OrientedBoundingBox with a result parameter', function() {
-        var rect = new Rectangle(0.0, 0.0, 0.0, 0.0);
-        var pl = new EllipsoidTangentPlane(Cartesian3.UNIT_X, Ellipsoid.UNIT_SPHERE);
+    it('fromEllipsoidRectangle creates an OrientedBoundingBox with a result parameter', function() {
+        var ellipsoid = Ellipsoid.UNIT_SPHERE;
+        var rectangle = new Rectangle(0.0, 0.0, 0.0, 0.0);
         var result = new OrientedBoundingBox();
-        var box = OrientedBoundingBox.fromRectangleTangentPlane(rect, pl, 0.0, 0.0, result);
+        var box = OrientedBoundingBox.fromEllipsoidRectangle(ellipsoid, rectangle, 0.0, 0.0, result);
         expect(box).toBe(result);
 
         expect(box.center).toEqualEpsilon(new Cartesian3(1.0, 0.0, 0.0), CesiumMath.EPSILON15);
@@ -154,66 +123,130 @@ defineSuite([
         expect(box.halfAxes).toEqualEpsilon(rotScale, CesiumMath.EPSILON15);
     });
 
-    it('fromRectangleTangentPlane from a degenerate rectangle from (-45, 0) to (45, 0)', function() {
+    it('fromEllipsoidRectangle for interesting, degenerate, and edge-case rectangles', function() {
         var d45 = CesiumMath.PI_OVER_FOUR;
-        var rect = new Rectangle(-d45, 0.0, d45, 0.0);
-        var pl = new EllipsoidTangentPlane(Cartesian3.UNIT_X, Ellipsoid.UNIT_SPHERE);
-        var result = new OrientedBoundingBox();
-        var box = OrientedBoundingBox.fromRectangleTangentPlane(rect, pl, 0.0, 0.0, result);
-        expect(box).toBe(result);
-
-        expect(box.center).toEqualEpsilon(new Cartesian3((1.0 + Math.SQRT1_2) / 2.0, 0.0, 0.0), CesiumMath.EPSILON15);
-
-        var rotScale = new Matrix3(0.0, 0.0, 0.5 * (1.0 - Math.SQRT1_2), Math.SQRT1_2, 0.0, 0.0, 0.0, 0.0, 0.0);
-        expect(box.halfAxes).toEqualEpsilon(rotScale, CesiumMath.EPSILON15);
-    });
-
-    it('fromRectangleTangentPlane from a degenerate rectangle from (135, 0) to (-135, 0)', function() {
+        var d90 = CesiumMath.PI_OVER_TWO;
         var d135 = 3 * CesiumMath.PI_OVER_FOUR;
-        var rect = new Rectangle(d135, 0.0, -d135, 0.0);
-        var pl = new EllipsoidTangentPlane(new Cartesian3(-1.0, 0.0, 0.0), Ellipsoid.UNIT_SPHERE);
-        var result = new OrientedBoundingBox();
-        var box = OrientedBoundingBox.fromRectangleTangentPlane(rect, pl, 0.0, 0.0, result);
-        expect(box).toBe(result);
+        var d180 = CesiumMath.PI;
 
-        expect(box.center).toEqualEpsilon(new Cartesian3(-(1.0 + Math.SQRT1_2) / 2.0, 0.0, 0.0), CesiumMath.EPSILON15);
+        var box;
 
-        var rotScale = new Matrix3(0.0, 0.0, -0.5 * (1.0 - Math.SQRT1_2), -Math.SQRT1_2, 0.0, 0.0, 0.0, 0.0, 0.0);
-        expect(box.halfAxes).toEqualEpsilon(rotScale, CesiumMath.EPSILON15);
-    });
+        box = OrientedBoundingBox.fromEllipsoidRectangle(Ellipsoid.UNIT_SPHERE,new Rectangle(0.0, 0.0, 0.0, 0.0), 0.0, 0.0);
+        expect(box.center).toEqualEpsilon(new Cartesian3(1.0, 0.0, 0.0), CesiumMath.EPSILON15);
+        expect(box.halfAxes).toEqualEpsilon(Matrix3.ZERO, CesiumMath.EPSILON15);
 
-    it('fromRectangleTangentPlane from a degenerate rectangle from (0, -45) to (0, 45)', function() {
-        var d45 = CesiumMath.PI_OVER_FOUR;
-        var rect = new Rectangle(0.0, -d45, 0.0, d45);
-        var pl = new EllipsoidTangentPlane(Cartesian3.UNIT_X, Ellipsoid.UNIT_SPHERE);
-        var result = new OrientedBoundingBox();
-        var box = OrientedBoundingBox.fromRectangleTangentPlane(rect, pl, 0.0, 0.0, result);
-        expect(box).toBe(result);
+        box = OrientedBoundingBox.fromEllipsoidRectangle(Ellipsoid.UNIT_SPHERE, new Rectangle(d180, 0.0, -d180, 0.0), 0.0, 0.0);
+        expect(box.center).toEqualEpsilon(new Cartesian3(-1.0, 0.0, 0.0), CesiumMath.EPSILON15);
+        expect(box.halfAxes).toEqualEpsilon(Matrix3.ZERO, CesiumMath.EPSILON15);
 
+        box = OrientedBoundingBox.fromEllipsoidRectangle(Ellipsoid.UNIT_SPHERE, new Rectangle(d180, 0.0, d180, 0.0), 0.0, 0.0);
+        expect(box.center).toEqualEpsilon(new Cartesian3(-1.0, 0.0, 0.0), CesiumMath.EPSILON15);
+        expect(box.halfAxes).toEqualEpsilon(Matrix3.ZERO, CesiumMath.EPSILON15);
+
+        box = OrientedBoundingBox.fromEllipsoidRectangle(Ellipsoid.UNIT_SPHERE, new Rectangle(0.0, d90, 0.0, d90), 0.0, 0.0);
+        expect(box.center).toEqualEpsilon(new Cartesian3(0.0, 0.0, 1.0), CesiumMath.EPSILON15);
+        expect(box.halfAxes).toEqualEpsilon(Matrix3.ZERO, CesiumMath.EPSILON15);
+
+        box = OrientedBoundingBox.fromEllipsoidRectangle(Ellipsoid.UNIT_SPHERE, new Rectangle(0.0, 0.0, d180, 0.0), 0.0, 0.0);
+        expect(box.center).toEqualEpsilon(new Cartesian3(0.0, 0.5, 0.0), CesiumMath.EPSILON15);
+        expect(box.halfAxes).toEqualEpsilon(new Matrix3(-1.0, 0.0, 0.0, 0.0, 0.0, 0.5, 0.0, 0.0, 0.0), CesiumMath.EPSILON15);
+
+        box = OrientedBoundingBox.fromEllipsoidRectangle(Ellipsoid.UNIT_SPHERE, new Rectangle(-d90, -d90, d90, d90), 0.0, 0.0);
+        expect(box.center).toEqualEpsilon(new Cartesian3(0.5, 0.0, 0.0), CesiumMath.EPSILON15);
+        expect(box.halfAxes).toEqualEpsilon(new Matrix3(0.0, 0.0, 0.5, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0), CesiumMath.EPSILON15);
+
+        box = OrientedBoundingBox.fromEllipsoidRectangle(Ellipsoid.UNIT_SPHERE, new Rectangle(-d90, -d45, d90, d90), 0.0, 0.0);
+        expect(box.center).toEqualEpsilon(new Cartesian3(0.5, 0.0, 0.5 * (1.0 - Math.SQRT1_2)), CesiumMath.EPSILON15);
+        expect(box.halfAxes).toEqualEpsilon(new Matrix3(0.0, 0.0, 0.5, 1.0, 0.0, 0.0, 0.0, 0.5 * (1.0 + Math.SQRT1_2), 0.0), CesiumMath.EPSILON15);
+
+        box = OrientedBoundingBox.fromEllipsoidRectangle(Ellipsoid.UNIT_SPHERE, new Rectangle(-d45, 0.0, d45, 0.0), 0.0, 0.0);
         expect(box.center).toEqualEpsilon(new Cartesian3((1.0 + Math.SQRT1_2) / 2.0, 0.0, 0.0), CesiumMath.EPSILON15);
+        expect(box.halfAxes).toEqualEpsilon(new Matrix3(0.0, 0.0, 0.5 * (1.0 - Math.SQRT1_2), Math.SQRT1_2, 0.0, 0.0, 0.0, 0.0, 0.0), CesiumMath.EPSILON15);
 
-        var rotScale = new Matrix3(0.0, 0.0, 0.5 * (1.0 - Math.SQRT1_2), 0.0, 0.0, 0.0, 0.0, Math.SQRT1_2, 0.0);
-        expect(box.halfAxes).toEqualEpsilon(rotScale, CesiumMath.EPSILON15);
-    });
-
-    it('fromRectangleTangentPlane from a degenerate rectangle from (0, 135) to (0, -135)', function() {
-        var d135 = 3 * CesiumMath.PI_OVER_FOUR;
-        var rect = new Rectangle(0.0, d135, 0.0, -d135);
-        var pl = new EllipsoidTangentPlane(new Cartesian3(-1.0, 0.0, 0.0), Ellipsoid.UNIT_SPHERE);
-        var result = new OrientedBoundingBox();
-        var box = OrientedBoundingBox.fromRectangleTangentPlane(rect, pl, 0.0, 0.0, result);
-        expect(box).toBe(result);
-
+        box = OrientedBoundingBox.fromEllipsoidRectangle(Ellipsoid.UNIT_SPHERE, new Rectangle(d135, 0.0, -d135, 0.0), 0.0, 0.0);
         expect(box.center).toEqualEpsilon(new Cartesian3(-(1.0 + Math.SQRT1_2) / 2.0, 0.0, 0.0), CesiumMath.EPSILON15);
+        expect(box.halfAxes).toEqualEpsilon(new Matrix3(0.0, 0.0, -0.5 * (1.0 - Math.SQRT1_2), -Math.SQRT1_2, 0.0, 0.0, 0.0, 0.0, 0.0), CesiumMath.EPSILON15);
 
-        var rotScale = new Matrix3(0.0, 0.0, -0.5 * (1.0 - Math.SQRT1_2), 0.0, 0.0, 0.0, 0.0, -Math.SQRT1_2, 0.0);
-        expect(box.halfAxes).toEqualEpsilon(rotScale, CesiumMath.EPSILON15);
+        box = OrientedBoundingBox.fromEllipsoidRectangle(Ellipsoid.UNIT_SPHERE, new Rectangle(0.0, -d45, 0.0, d45), 0.0, 0.0);
+        expect(box.center).toEqualEpsilon(new Cartesian3((1.0 + Math.SQRT1_2) / 2.0, 0.0, 0.0), CesiumMath.EPSILON15);
+        expect(box.halfAxes).toEqualEpsilon(new Matrix3(0.0, 0.0, 0.5 * (1.0 - Math.SQRT1_2), 0.0, 0.0, 0.0, 0.0, Math.SQRT1_2, 0.0), CesiumMath.EPSILON15);
+
+        box = OrientedBoundingBox.fromEllipsoidRectangle(Ellipsoid.UNIT_SPHERE, new Rectangle(-d90, 0.0, d90, 0.0), 0.0, 0.0);
+        expect(box.center).toEqualEpsilon(new Cartesian3(0.5, 0.0, 0.0), CesiumMath.EPSILON15);
+        expect(box.halfAxes).toEqualEpsilon(new Matrix3(0.0, 0.0, 0.5, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0), CesiumMath.EPSILON15);
+
+        box = OrientedBoundingBox.fromEllipsoidRectangle(Ellipsoid.UNIT_SPHERE, new Rectangle(0.0, -d90, 0.0, d90), 0.0, 0.0);
+        expect(box.center).toEqualEpsilon(new Cartesian3(0.5, 0.0, 0.0), CesiumMath.EPSILON15);
+        expect(box.halfAxes).toEqualEpsilon(new Matrix3(0.0, 0.0, 0.5, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0), CesiumMath.EPSILON15);
     });
 
-    /**
-     * @param {Cartesian3} center
-     * @param {Matrix3} axes
-     */
+    /*
+    it('extentsToOrientedBoundingBox works with a result parameter', function() {
+        var ellipsoid = Ellipsoid.UNIT_SPHERE;
+        var origin = Cartesian3.UNIT_X;
+        var pl = new EllipsoidTangentPlane(origin, ellipsoid);
+        var result = new OrientedBoundingBox();
+        result = pl.extentsToOrientedBoundingBox(-0.5, 0.5, -0.5, 0.5, -0.5, 0.5, result);
+        var expected = new OrientedBoundingBox(origin,
+            new Matrix3(0.0, 0.0, 0.5, 0.5, 0.0, 0.0, 0.0, 0.5, 0.0));
+        expect(result).toEqual(expected);
+    });
+
+    it('extentsToOrientedBoundingBox works without a result parameter', function() {
+        var ellipsoid = Ellipsoid.UNIT_SPHERE;
+        var origin = Cartesian3.UNIT_X;
+        var pl = new EllipsoidTangentPlane(origin, ellipsoid);
+        var result = pl.extentsToOrientedBoundingBox(-0.5, 0.5, -0.5, 0.5, -0.5, 0.5);
+        var expected = new OrientedBoundingBox(origin,
+            new Matrix3(0.0, 0.0, 0.5, 0.5, 0.0, 0.0, 0.0, 0.5, 0.0));
+        expect(result).toEqual(expected);
+    });
+
+    it('extentsToOrientedBoundingBox throws missing any of the dimensional parameters', function() {
+        var ellipsoid = Ellipsoid.UNIT_SPHERE;
+        var origin = new Cartesian3(1.0, 0.0, 0.0);
+        var pl = new EllipsoidTangentPlane(origin, ellipsoid);
+        var result = new OrientedBoundingBox();
+        expect(function() { pl.extentsToOrientedBoundingBox(undefined, 0.5, -0.5, 0.5, -0.5, 0.5, result);  }).toThrowDeveloperError();
+        expect(function() { pl.extentsToOrientedBoundingBox(-0.5, undefined, -0.5, 0.5, -0.5, 0.5, result); }).toThrowDeveloperError();
+        expect(function() { pl.extentsToOrientedBoundingBox(-0.5, 0.5, undefined, 0.5, -0.5, 0.5, result);  }).toThrowDeveloperError();
+        expect(function() { pl.extentsToOrientedBoundingBox(-0.5, 0.5, -0.5, undefined, -0.5, 0.5, result); }).toThrowDeveloperError();
+        expect(function() { pl.extentsToOrientedBoundingBox(-0.5, 0.5, -0.5, 0.5, undefined, 0.5, result);  }).toThrowDeveloperError();
+        expect(function() { pl.extentsToOrientedBoundingBox(-0.5, 0.5, -0.5, 0.5, -0.5, undefined, result); }).toThrowDeveloperError();
+    });
+
+    it('extentsToOrientedBoundingBox works with some edge-ish cases', function() {
+        var res, exp;
+        var result = new OrientedBoundingBox();
+        var ellipsoid;
+
+        ellipsoid = Ellipsoid.UNIT_SPHERE;
+        res = new EllipsoidTangentPlane(Cartesian3.UNIT_X, ellipsoid).extentsToOrientedBoundingBox(-0.3, 0.3, -0.3, 0.3, -0.3, 0.3, res);
+        exp = new OrientedBoundingBox(Cartesian3.UNIT_X,
+            new Matrix3(0.0, 0.0, 0.3, 0.3, 0.0, 0.0, 0.0, 0.3, 0.0));
+        expect(res.center).toEqualEpsilon(exp.center, CesiumMath.EPSILON15);
+        expect(res.halfAxes).toEqualEpsilon(exp.halfAxes, CesiumMath.EPSILON15);
+
+        ellipsoid = Ellipsoid.UNIT_SPHERE;
+        res = new EllipsoidTangentPlane(Cartesian3.UNIT_Z, ellipsoid).extentsToOrientedBoundingBox(-0.3, 0.3, -0.3, 0.3, -0.3, 0.3, res);
+        expect(res.center).toEqualEpsilon(Cartesian3.UNIT_Z, CesiumMath.EPSILON15);
+
+        ellipsoid = Ellipsoid.UNIT_SPHERE;
+        res = new EllipsoidTangentPlane(Cartesian3.UNIT_Y, ellipsoid).extentsToOrientedBoundingBox(-0.3, 0.3, -0.3, 0.3, -0.3, 0.3, res);
+        exp = new OrientedBoundingBox(Cartesian3.UNIT_Y,
+            new Matrix3(-0.3, 0.0, 0.0, 0.0, 0.0, 0.3, 0.0, 0.3, 0.0));
+        expect(res.center).toEqualEpsilon(exp.center, CesiumMath.EPSILON15);
+        expect(res.halfAxes).toEqualEpsilon(exp.halfAxes, CesiumMath.EPSILON15);
+
+        ellipsoid = Ellipsoid.UNIT_SPHERE;
+        res = new EllipsoidTangentPlane(Cartesian3.UNIT_X, ellipsoid).extentsToOrientedBoundingBox(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, res);
+        exp = new OrientedBoundingBox(Cartesian3.UNIT_X,
+            new Matrix3(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0));
+        expect(res.center).toEqualEpsilon(exp.center, CesiumMath.EPSILON15);
+        expect(res.halfAxes).toEqualEpsilon(exp.halfAxes, CesiumMath.EPSILON15);
+    });
+    */
+
     var intersectPlaneTestCornersEdgesFaces = function(center, axes) {
         var SQRT1_2 = Math.pow(1.0 / 2.0, 1 / 2.0);
         var SQRT1_3 = Math.pow(1.0 / 3.0, 1 / 2.0);
@@ -248,7 +281,6 @@ defineSuite([
 
         var pl;
 
-
         // Tests against faces
 
         pl = planeNormXform(+1.0, +0.0, +0.0,  0.50001); if (pl) { expect(box.intersectPlane(pl)).toEqual(Intersect.INSIDE); }
@@ -278,7 +310,6 @@ defineSuite([
         pl = planeNormXform(+0.0, -1.0, +0.0, -0.50001); if (pl) { expect(box.intersectPlane(pl)).toEqual(Intersect.OUTSIDE); }
         pl = planeNormXform(+0.0, +0.0, +1.0, -0.50001); if (pl) { expect(box.intersectPlane(pl)).toEqual(Intersect.OUTSIDE); }
         pl = planeNormXform(+0.0, +0.0, -1.0, -0.50001); if (pl) { expect(box.intersectPlane(pl)).toEqual(Intersect.OUTSIDE); }
-
 
         // Tests against edges
 
@@ -333,7 +364,6 @@ defineSuite([
         pl = planeNormXform(+0.0, +1.0, -1.0, -SQRT1_2 - 0.00001); if (pl) { expect(box.intersectPlane(pl)).toEqual(Intersect.OUTSIDE); }
         pl = planeNormXform(+0.0, -1.0, +1.0, -SQRT1_2 - 0.00001); if (pl) { expect(box.intersectPlane(pl)).toEqual(Intersect.OUTSIDE); }
         pl = planeNormXform(+0.0, -1.0, -1.0, -SQRT1_2 - 0.00001); if (pl) { expect(box.intersectPlane(pl)).toEqual(Intersect.OUTSIDE); }
-
 
         // Tests against corners
 

--- a/Specs/Core/OrientedBoundingBoxSpec.js
+++ b/Specs/Core/OrientedBoundingBoxSpec.js
@@ -111,6 +111,10 @@ defineSuite([
         expect(function() { return OrientedBoundingBox.fromRectangle(new Rectangle(-1.0, 1.0, 1.0, -1.0), 0.0, 0.0, ellipsoid); }).toThrowDeveloperError();
         expect(function() { return OrientedBoundingBox.fromRectangle(new Rectangle(-1.0, 1.0, -2.0, 2.0), 0.0, 0.0, ellipsoid); }).toThrowDeveloperError();
         expect(function() { return OrientedBoundingBox.fromRectangle(new Rectangle(-2.0, 2.0, -1.0, 1.0), 0.0, 0.0, ellipsoid); }).toThrowDeveloperError();
+        expect(function() { return OrientedBoundingBox.fromRectangle(new Rectangle(-2.0, -2.0, 2.0, 1.0), 0.0, 0.0, ellipsoid); }).toThrowDeveloperError();
+        expect(function() { return OrientedBoundingBox.fromRectangle(new Rectangle(-2.0, -2.0, 1.0, 2.0), 0.0, 0.0, ellipsoid); }).toThrowDeveloperError();
+        expect(function() { return OrientedBoundingBox.fromRectangle(new Rectangle(-1.0, -2.0, 2.0, 2.0), 0.0, 0.0, ellipsoid); }).toThrowDeveloperError();
+        expect(function() { return OrientedBoundingBox.fromRectangle(new Rectangle(-2.0, -1.0, 2.0, 2.0), 0.0, 0.0, ellipsoid); }).toThrowDeveloperError();
     });
 
     it('fromRectangle creates an OrientedBoundingBox without a result parameter', function() {

--- a/Specs/Core/OrientedBoundingBoxSpec.js
+++ b/Specs/Core/OrientedBoundingBoxSpec.js
@@ -77,6 +77,17 @@ defineSuite([
         expect(box.halfAxes).toEqual(Matrix3.ZERO);
     });
 
+    it('fromEllipsoidRectangle sets correct default heights', function() {
+        var ellipsoid = Ellipsoid.UNIT_SPHERE;
+        var rectangle = new Rectangle(0.0, 0.0, 0.0, 0.0);
+        var box = OrientedBoundingBox.fromEllipsoidRectangle(ellipsoid, rectangle);
+
+        expect(box.center).toEqualEpsilon(new Cartesian3(1.0, 0.0, 0.0), CesiumMath.EPSILON15);
+
+        var rotScale = Matrix3.ZERO;
+        expect(box.halfAxes).toEqualEpsilon(rotScale, CesiumMath.EPSILON15);
+    });
+
     it('fromEllipsoidRectangle throws without ellipsoid', function() {
         var rectangle = new Rectangle(0.0, 0.0, 0.0, 0.0);
         expect(function() {
@@ -179,73 +190,6 @@ defineSuite([
         expect(box.center).toEqualEpsilon(new Cartesian3(0.5, 0.0, 0.0), CesiumMath.EPSILON15);
         expect(box.halfAxes).toEqualEpsilon(new Matrix3(0.0, 0.0, 0.5, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0), CesiumMath.EPSILON15);
     });
-
-    /*
-    it('extentsToOrientedBoundingBox works with a result parameter', function() {
-        var ellipsoid = Ellipsoid.UNIT_SPHERE;
-        var origin = Cartesian3.UNIT_X;
-        var pl = new EllipsoidTangentPlane(origin, ellipsoid);
-        var result = new OrientedBoundingBox();
-        result = pl.extentsToOrientedBoundingBox(-0.5, 0.5, -0.5, 0.5, -0.5, 0.5, result);
-        var expected = new OrientedBoundingBox(origin,
-            new Matrix3(0.0, 0.0, 0.5, 0.5, 0.0, 0.0, 0.0, 0.5, 0.0));
-        expect(result).toEqual(expected);
-    });
-
-    it('extentsToOrientedBoundingBox works without a result parameter', function() {
-        var ellipsoid = Ellipsoid.UNIT_SPHERE;
-        var origin = Cartesian3.UNIT_X;
-        var pl = new EllipsoidTangentPlane(origin, ellipsoid);
-        var result = pl.extentsToOrientedBoundingBox(-0.5, 0.5, -0.5, 0.5, -0.5, 0.5);
-        var expected = new OrientedBoundingBox(origin,
-            new Matrix3(0.0, 0.0, 0.5, 0.5, 0.0, 0.0, 0.0, 0.5, 0.0));
-        expect(result).toEqual(expected);
-    });
-
-    it('extentsToOrientedBoundingBox throws missing any of the dimensional parameters', function() {
-        var ellipsoid = Ellipsoid.UNIT_SPHERE;
-        var origin = new Cartesian3(1.0, 0.0, 0.0);
-        var pl = new EllipsoidTangentPlane(origin, ellipsoid);
-        var result = new OrientedBoundingBox();
-        expect(function() { pl.extentsToOrientedBoundingBox(undefined, 0.5, -0.5, 0.5, -0.5, 0.5, result);  }).toThrowDeveloperError();
-        expect(function() { pl.extentsToOrientedBoundingBox(-0.5, undefined, -0.5, 0.5, -0.5, 0.5, result); }).toThrowDeveloperError();
-        expect(function() { pl.extentsToOrientedBoundingBox(-0.5, 0.5, undefined, 0.5, -0.5, 0.5, result);  }).toThrowDeveloperError();
-        expect(function() { pl.extentsToOrientedBoundingBox(-0.5, 0.5, -0.5, undefined, -0.5, 0.5, result); }).toThrowDeveloperError();
-        expect(function() { pl.extentsToOrientedBoundingBox(-0.5, 0.5, -0.5, 0.5, undefined, 0.5, result);  }).toThrowDeveloperError();
-        expect(function() { pl.extentsToOrientedBoundingBox(-0.5, 0.5, -0.5, 0.5, -0.5, undefined, result); }).toThrowDeveloperError();
-    });
-
-    it('extentsToOrientedBoundingBox works with some edge-ish cases', function() {
-        var res, exp;
-        var result = new OrientedBoundingBox();
-        var ellipsoid;
-
-        ellipsoid = Ellipsoid.UNIT_SPHERE;
-        res = new EllipsoidTangentPlane(Cartesian3.UNIT_X, ellipsoid).extentsToOrientedBoundingBox(-0.3, 0.3, -0.3, 0.3, -0.3, 0.3, res);
-        exp = new OrientedBoundingBox(Cartesian3.UNIT_X,
-            new Matrix3(0.0, 0.0, 0.3, 0.3, 0.0, 0.0, 0.0, 0.3, 0.0));
-        expect(res.center).toEqualEpsilon(exp.center, CesiumMath.EPSILON15);
-        expect(res.halfAxes).toEqualEpsilon(exp.halfAxes, CesiumMath.EPSILON15);
-
-        ellipsoid = Ellipsoid.UNIT_SPHERE;
-        res = new EllipsoidTangentPlane(Cartesian3.UNIT_Z, ellipsoid).extentsToOrientedBoundingBox(-0.3, 0.3, -0.3, 0.3, -0.3, 0.3, res);
-        expect(res.center).toEqualEpsilon(Cartesian3.UNIT_Z, CesiumMath.EPSILON15);
-
-        ellipsoid = Ellipsoid.UNIT_SPHERE;
-        res = new EllipsoidTangentPlane(Cartesian3.UNIT_Y, ellipsoid).extentsToOrientedBoundingBox(-0.3, 0.3, -0.3, 0.3, -0.3, 0.3, res);
-        exp = new OrientedBoundingBox(Cartesian3.UNIT_Y,
-            new Matrix3(-0.3, 0.0, 0.0, 0.0, 0.0, 0.3, 0.0, 0.3, 0.0));
-        expect(res.center).toEqualEpsilon(exp.center, CesiumMath.EPSILON15);
-        expect(res.halfAxes).toEqualEpsilon(exp.halfAxes, CesiumMath.EPSILON15);
-
-        ellipsoid = Ellipsoid.UNIT_SPHERE;
-        res = new EllipsoidTangentPlane(Cartesian3.UNIT_X, ellipsoid).extentsToOrientedBoundingBox(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, res);
-        exp = new OrientedBoundingBox(Cartesian3.UNIT_X,
-            new Matrix3(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0));
-        expect(res.center).toEqualEpsilon(exp.center, CesiumMath.EPSILON15);
-        expect(res.halfAxes).toEqualEpsilon(exp.halfAxes, CesiumMath.EPSILON15);
-    });
-    */
 
     var intersectPlaneTestCornersEdgesFaces = function(center, axes) {
         var SQRT1_2 = Math.pow(1.0 / 2.0, 1 / 2.0);

--- a/Specs/Core/OrientedBoundingBoxSpec.js
+++ b/Specs/Core/OrientedBoundingBoxSpec.js
@@ -77,10 +77,20 @@ defineSuite([
         expect(box.halfAxes).toEqual(Matrix3.ZERO);
     });
 
-    it('fromEllipsoidRectangle sets correct default heights', function() {
-        var ellipsoid = Ellipsoid.UNIT_SPHERE;
+    it('fromRectangle sets correct default ellipsoid', function() {
+        var rectangle = new Rectangle(-0.9, -1.2, 0.5, 0.7);
+        var box1 = OrientedBoundingBox.fromRectangle(rectangle, 0.0, 0.0);
+        var box2 = OrientedBoundingBox.fromRectangle(rectangle, 0.0, 0.0, Ellipsoid.WGS84);
+
+        expect(box1.center).toEqualEpsilon(box2.center, CesiumMath.EPSILON15);
+
+        var rotScale = Matrix3.ZERO;
+        expect(box1.halfAxes).toEqualEpsilon(box2.halfAxes, CesiumMath.EPSILON15);
+    });
+
+    it('fromRectangle sets correct default heights', function() {
         var rectangle = new Rectangle(0.0, 0.0, 0.0, 0.0);
-        var box = OrientedBoundingBox.fromEllipsoidRectangle(ellipsoid, rectangle);
+        var box = OrientedBoundingBox.fromRectangle(rectangle, undefined, undefined, Ellipsoid.UNIT_SPHERE);
 
         expect(box.center).toEqualEpsilon(new Cartesian3(1.0, 0.0, 0.0), CesiumMath.EPSILON15);
 
@@ -88,32 +98,25 @@ defineSuite([
         expect(box.halfAxes).toEqualEpsilon(rotScale, CesiumMath.EPSILON15);
     });
 
-    it('fromEllipsoidRectangle throws without ellipsoid', function() {
-        var rectangle = new Rectangle(0.0, 0.0, 0.0, 0.0);
+    it('fromRectangle throws without rectangle', function() {
+        var ellipsoid = Ellipsoid.UNIT_SPHERE;
         expect(function() {
-            OrientedBoundingBox.fromEllipsoidRectangle(undefined, rectangle, 0.0, 0.0);
+            OrientedBoundingBox.fromRectangle(undefined, 0.0, 0.0, ellipsoid);
         }).toThrowDeveloperError();
     });
 
-    it('fromEllipsoidRectangle throws without rectangle', function() {
+    it('fromRectangle throws with invalid rectangles', function() {
         var ellipsoid = Ellipsoid.UNIT_SPHERE;
-        expect(function() {
-            OrientedBoundingBox.fromEllipsoidRectangle(ellipsoid, undefined, 0.0, 0.0);
-        }).toThrowDeveloperError();
+        expect(function() { return OrientedBoundingBox.fromRectangle(new Rectangle(1.0, -1.0, -1.0, 1.0), 0.0, 0.0, ellipsoid); }).toThrowDeveloperError();
+        expect(function() { return OrientedBoundingBox.fromRectangle(new Rectangle(-1.0, 1.0, 1.0, -1.0), 0.0, 0.0, ellipsoid); }).toThrowDeveloperError();
+        expect(function() { return OrientedBoundingBox.fromRectangle(new Rectangle(-1.0, 1.0, -2.0, 2.0), 0.0, 0.0, ellipsoid); }).toThrowDeveloperError();
+        expect(function() { return OrientedBoundingBox.fromRectangle(new Rectangle(-2.0, 2.0, -1.0, 1.0), 0.0, 0.0, ellipsoid); }).toThrowDeveloperError();
     });
 
-    it('fromEllipsoidRectangle throws with invalid rectangles', function() {
-        var ellipsoid = Ellipsoid.UNIT_SPHERE;
-        expect(function() { return OrientedBoundingBox.fromEllipsoidRectangle(ellipsoid, new Rectangle(1.0, -1.0, -1.0, 1.0), 0.0, 0.0); }).toThrowDeveloperError();
-        expect(function() { return OrientedBoundingBox.fromEllipsoidRectangle(ellipsoid, new Rectangle(-1.0, 1.0, 1.0, -1.0), 0.0, 0.0); }).toThrowDeveloperError();
-        expect(function() { return OrientedBoundingBox.fromEllipsoidRectangle(ellipsoid, new Rectangle(-1.0, 1.0, -2.0, 2.0), 0.0, 0.0); }).toThrowDeveloperError();
-        expect(function() { return OrientedBoundingBox.fromEllipsoidRectangle(ellipsoid, new Rectangle(-2.0, 2.0, -1.0, 1.0), 0.0, 0.0); }).toThrowDeveloperError();
-    });
-
-    it('fromEllipsoidRectangle creates an OrientedBoundingBox without a result parameter', function() {
+    it('fromRectangle creates an OrientedBoundingBox without a result parameter', function() {
         var ellipsoid = Ellipsoid.UNIT_SPHERE;
         var rectangle = new Rectangle(0.0, 0.0, 0.0, 0.0);
-        var box = OrientedBoundingBox.fromEllipsoidRectangle(ellipsoid, rectangle, 0.0, 0.0);
+        var box = OrientedBoundingBox.fromRectangle(rectangle, 0.0, 0.0, ellipsoid);
 
         expect(box.center).toEqualEpsilon(new Cartesian3(1.0, 0.0, 0.0), CesiumMath.EPSILON15);
 
@@ -121,11 +124,11 @@ defineSuite([
         expect(box.halfAxes).toEqualEpsilon(rotScale, CesiumMath.EPSILON15);
     });
 
-    it('fromEllipsoidRectangle creates an OrientedBoundingBox with a result parameter', function() {
+    it('fromRectangle creates an OrientedBoundingBox with a result parameter', function() {
         var ellipsoid = Ellipsoid.UNIT_SPHERE;
         var rectangle = new Rectangle(0.0, 0.0, 0.0, 0.0);
         var result = new OrientedBoundingBox();
-        var box = OrientedBoundingBox.fromEllipsoidRectangle(ellipsoid, rectangle, 0.0, 0.0, result);
+        var box = OrientedBoundingBox.fromRectangle(rectangle, 0.0, 0.0, ellipsoid, result);
         expect(box).toBe(result);
 
         expect(box.center).toEqualEpsilon(new Cartesian3(1.0, 0.0, 0.0), CesiumMath.EPSILON15);
@@ -134,7 +137,7 @@ defineSuite([
         expect(box.halfAxes).toEqualEpsilon(rotScale, CesiumMath.EPSILON15);
     });
 
-    it('fromEllipsoidRectangle for interesting, degenerate, and edge-case rectangles', function() {
+    it('fromRectangle for interesting, degenerate, and edge-case rectangles', function() {
         var d45 = CesiumMath.PI_OVER_FOUR;
         var d90 = CesiumMath.PI_OVER_TWO;
         var d135 = 3 * CesiumMath.PI_OVER_FOUR;
@@ -142,51 +145,51 @@ defineSuite([
 
         var box;
 
-        box = OrientedBoundingBox.fromEllipsoidRectangle(Ellipsoid.UNIT_SPHERE,new Rectangle(0.0, 0.0, 0.0, 0.0), 0.0, 0.0);
+        box = OrientedBoundingBox.fromRectangle(new Rectangle(0.0, 0.0, 0.0, 0.0), 0.0, 0.0, Ellipsoid.UNIT_SPHERE);
         expect(box.center).toEqualEpsilon(new Cartesian3(1.0, 0.0, 0.0), CesiumMath.EPSILON15);
         expect(box.halfAxes).toEqualEpsilon(Matrix3.ZERO, CesiumMath.EPSILON15);
 
-        box = OrientedBoundingBox.fromEllipsoidRectangle(Ellipsoid.UNIT_SPHERE, new Rectangle(d180, 0.0, -d180, 0.0), 0.0, 0.0);
+        box = OrientedBoundingBox.fromRectangle(new Rectangle(d180, 0.0, -d180, 0.0), 0.0, 0.0, Ellipsoid.UNIT_SPHERE);
         expect(box.center).toEqualEpsilon(new Cartesian3(-1.0, 0.0, 0.0), CesiumMath.EPSILON15);
         expect(box.halfAxes).toEqualEpsilon(Matrix3.ZERO, CesiumMath.EPSILON15);
 
-        box = OrientedBoundingBox.fromEllipsoidRectangle(Ellipsoid.UNIT_SPHERE, new Rectangle(d180, 0.0, d180, 0.0), 0.0, 0.0);
+        box = OrientedBoundingBox.fromRectangle(new Rectangle(d180, 0.0, d180, 0.0), 0.0, 0.0, Ellipsoid.UNIT_SPHERE);
         expect(box.center).toEqualEpsilon(new Cartesian3(-1.0, 0.0, 0.0), CesiumMath.EPSILON15);
         expect(box.halfAxes).toEqualEpsilon(Matrix3.ZERO, CesiumMath.EPSILON15);
 
-        box = OrientedBoundingBox.fromEllipsoidRectangle(Ellipsoid.UNIT_SPHERE, new Rectangle(0.0, d90, 0.0, d90), 0.0, 0.0);
+        box = OrientedBoundingBox.fromRectangle(new Rectangle(0.0, d90, 0.0, d90), 0.0, 0.0, Ellipsoid.UNIT_SPHERE);
         expect(box.center).toEqualEpsilon(new Cartesian3(0.0, 0.0, 1.0), CesiumMath.EPSILON15);
         expect(box.halfAxes).toEqualEpsilon(Matrix3.ZERO, CesiumMath.EPSILON15);
 
-        box = OrientedBoundingBox.fromEllipsoidRectangle(Ellipsoid.UNIT_SPHERE, new Rectangle(0.0, 0.0, d180, 0.0), 0.0, 0.0);
+        box = OrientedBoundingBox.fromRectangle(new Rectangle(0.0, 0.0, d180, 0.0), 0.0, 0.0, Ellipsoid.UNIT_SPHERE);
         expect(box.center).toEqualEpsilon(new Cartesian3(0.0, 0.5, 0.0), CesiumMath.EPSILON15);
         expect(box.halfAxes).toEqualEpsilon(new Matrix3(-1.0, 0.0, 0.0, 0.0, 0.0, 0.5, 0.0, 0.0, 0.0), CesiumMath.EPSILON15);
 
-        box = OrientedBoundingBox.fromEllipsoidRectangle(Ellipsoid.UNIT_SPHERE, new Rectangle(-d90, -d90, d90, d90), 0.0, 0.0);
+        box = OrientedBoundingBox.fromRectangle(new Rectangle(-d90, -d90, d90, d90), 0.0, 0.0, Ellipsoid.UNIT_SPHERE);
         expect(box.center).toEqualEpsilon(new Cartesian3(0.5, 0.0, 0.0), CesiumMath.EPSILON15);
         expect(box.halfAxes).toEqualEpsilon(new Matrix3(0.0, 0.0, 0.5, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0), CesiumMath.EPSILON15);
 
-        box = OrientedBoundingBox.fromEllipsoidRectangle(Ellipsoid.UNIT_SPHERE, new Rectangle(-d90, -d45, d90, d90), 0.0, 0.0);
+        box = OrientedBoundingBox.fromRectangle(new Rectangle(-d90, -d45, d90, d90), 0.0, 0.0, Ellipsoid.UNIT_SPHERE);
         expect(box.center).toEqualEpsilon(new Cartesian3(0.5, 0.0, 0.5 * (1.0 - Math.SQRT1_2)), CesiumMath.EPSILON15);
         expect(box.halfAxes).toEqualEpsilon(new Matrix3(0.0, 0.0, 0.5, 1.0, 0.0, 0.0, 0.0, 0.5 * (1.0 + Math.SQRT1_2), 0.0), CesiumMath.EPSILON15);
 
-        box = OrientedBoundingBox.fromEllipsoidRectangle(Ellipsoid.UNIT_SPHERE, new Rectangle(-d45, 0.0, d45, 0.0), 0.0, 0.0);
+        box = OrientedBoundingBox.fromRectangle(new Rectangle(-d45, 0.0, d45, 0.0), 0.0, 0.0, Ellipsoid.UNIT_SPHERE);
         expect(box.center).toEqualEpsilon(new Cartesian3((1.0 + Math.SQRT1_2) / 2.0, 0.0, 0.0), CesiumMath.EPSILON15);
         expect(box.halfAxes).toEqualEpsilon(new Matrix3(0.0, 0.0, 0.5 * (1.0 - Math.SQRT1_2), Math.SQRT1_2, 0.0, 0.0, 0.0, 0.0, 0.0), CesiumMath.EPSILON15);
 
-        box = OrientedBoundingBox.fromEllipsoidRectangle(Ellipsoid.UNIT_SPHERE, new Rectangle(d135, 0.0, -d135, 0.0), 0.0, 0.0);
+        box = OrientedBoundingBox.fromRectangle(new Rectangle(d135, 0.0, -d135, 0.0), 0.0, 0.0, Ellipsoid.UNIT_SPHERE);
         expect(box.center).toEqualEpsilon(new Cartesian3(-(1.0 + Math.SQRT1_2) / 2.0, 0.0, 0.0), CesiumMath.EPSILON15);
         expect(box.halfAxes).toEqualEpsilon(new Matrix3(0.0, 0.0, -0.5 * (1.0 - Math.SQRT1_2), -Math.SQRT1_2, 0.0, 0.0, 0.0, 0.0, 0.0), CesiumMath.EPSILON15);
 
-        box = OrientedBoundingBox.fromEllipsoidRectangle(Ellipsoid.UNIT_SPHERE, new Rectangle(0.0, -d45, 0.0, d45), 0.0, 0.0);
+        box = OrientedBoundingBox.fromRectangle(new Rectangle(0.0, -d45, 0.0, d45), 0.0, 0.0, Ellipsoid.UNIT_SPHERE);
         expect(box.center).toEqualEpsilon(new Cartesian3((1.0 + Math.SQRT1_2) / 2.0, 0.0, 0.0), CesiumMath.EPSILON15);
         expect(box.halfAxes).toEqualEpsilon(new Matrix3(0.0, 0.0, 0.5 * (1.0 - Math.SQRT1_2), 0.0, 0.0, 0.0, 0.0, Math.SQRT1_2, 0.0), CesiumMath.EPSILON15);
 
-        box = OrientedBoundingBox.fromEllipsoidRectangle(Ellipsoid.UNIT_SPHERE, new Rectangle(-d90, 0.0, d90, 0.0), 0.0, 0.0);
+        box = OrientedBoundingBox.fromRectangle(new Rectangle(-d90, 0.0, d90, 0.0), 0.0, 0.0, Ellipsoid.UNIT_SPHERE);
         expect(box.center).toEqualEpsilon(new Cartesian3(0.5, 0.0, 0.0), CesiumMath.EPSILON15);
         expect(box.halfAxes).toEqualEpsilon(new Matrix3(0.0, 0.0, 0.5, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0), CesiumMath.EPSILON15);
 
-        box = OrientedBoundingBox.fromEllipsoidRectangle(Ellipsoid.UNIT_SPHERE, new Rectangle(0.0, -d90, 0.0, d90), 0.0, 0.0);
+        box = OrientedBoundingBox.fromRectangle(new Rectangle(0.0, -d90, 0.0, d90), 0.0, 0.0, Ellipsoid.UNIT_SPHERE);
         expect(box.center).toEqualEpsilon(new Cartesian3(0.5, 0.0, 0.0), CesiumMath.EPSILON15);
         expect(box.halfAxes).toEqualEpsilon(new Matrix3(0.0, 0.0, 0.5, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0), CesiumMath.EPSILON15);
     });

--- a/Specs/Core/OrientedBoundingBoxSpec.js
+++ b/Specs/Core/OrientedBoundingBoxSpec.js
@@ -147,11 +147,40 @@ defineSuite([
         expect(box.halfAxes).toEqualEpsilon(rotScale, CesiumMath.EPSILON15);
     });
 
+    it('fromRectangle for rectangles with heights', function() {
+        var d90 = CesiumMath.PI_OVER_TWO;
+
+        var box;
+
+        box = OrientedBoundingBox.fromRectangle(new Rectangle(0.0, 0.0, 0.0, 0.0), 1.0, 1.0, Ellipsoid.UNIT_SPHERE);
+        expect(box.center).toEqualEpsilon(new Cartesian3(2.0, 0.0, 0.0), CesiumMath.EPSILON15);
+        expect(box.halfAxes).toEqualEpsilon(Matrix3.ZERO, CesiumMath.EPSILON15);
+
+        box = OrientedBoundingBox.fromRectangle(new Rectangle(0.0, 0.0, 0.0, 0.0), -1.0, -1.0, Ellipsoid.UNIT_SPHERE);
+        expect(box.center).toEqualEpsilon(new Cartesian3(0.0, 0.0, 0.0), CesiumMath.EPSILON15);
+        expect(box.halfAxes).toEqualEpsilon(Matrix3.ZERO, CesiumMath.EPSILON15);
+
+        box = OrientedBoundingBox.fromRectangle(new Rectangle(0.0, 0.0, 0.0, 0.0), -1.0, 1.0, Ellipsoid.UNIT_SPHERE);
+        expect(box.center).toEqualEpsilon(new Cartesian3(1.0, 0.0, 0.0), CesiumMath.EPSILON15);
+        expect(box.halfAxes).toEqualEpsilon(new Matrix3(0, 0, 1, 0, 0, 0, 0, 0, 0), CesiumMath.EPSILON15);
+
+        box = OrientedBoundingBox.fromRectangle(new Rectangle(-d90, -d90, d90, d90), 0.0, 1.0, Ellipsoid.UNIT_SPHERE);
+        expect(box.center).toEqualEpsilon(new Cartesian3(1.0, 0.0, 0.0), CesiumMath.EPSILON15);
+        expect(box.halfAxes).toEqualEpsilon(new Matrix3(0, 0, 1, 2, 0, 0, 0, 2, 0), CesiumMath.EPSILON15);
+
+        box = OrientedBoundingBox.fromRectangle(new Rectangle(-d90, -d90, d90, d90), -1.0, -1.0, Ellipsoid.UNIT_SPHERE);
+        expect(box.center).toEqualEpsilon(new Cartesian3(0.0, 0.0, 0.0), CesiumMath.EPSILON15);
+        expect(box.halfAxes).toEqualEpsilon(Matrix3.ZERO, CesiumMath.EPSILON15);
+
+        box = OrientedBoundingBox.fromRectangle(new Rectangle(-d90, -d90, d90, d90), -1.0, 0.0, Ellipsoid.UNIT_SPHERE);
+        expect(box.center).toEqualEpsilon(new Cartesian3(0.5, 0.0, 0.0), CesiumMath.EPSILON15);
+        expect(box.halfAxes).toEqualEpsilon(new Matrix3(0, 0, 0.5, 1, 0, 0, 0, 1, 0), CesiumMath.EPSILON15);
+    });
+
     it('fromRectangle for interesting, degenerate, and edge-case rectangles', function() {
         var d45 = CesiumMath.PI_OVER_FOUR;
         var d30 = CesiumMath.PI_OVER_SIX;
         var d90 = CesiumMath.PI_OVER_TWO;
-        var d60 = CesiumMath.PI_OVER_THREE;
         var d135 = 3 * CesiumMath.PI_OVER_FOUR;
         var d180 = CesiumMath.PI;
         var sqrt3 = Math.sqrt(3.0);

--- a/Specs/Core/OrientedBoundingBoxSpec.js
+++ b/Specs/Core/OrientedBoundingBoxSpec.js
@@ -1,0 +1,457 @@
+/*global defineSuite*/
+defineSuite([
+        'Core/OrientedBoundingBox',
+        'Core/BoundingRectangle',
+        'Core/Cartesian3',
+        'Core/Cartesian4',
+        'Core/Ellipsoid',
+        'Core/EllipsoidTangentPlane',
+        'Core/Intersect',
+        'Core/Math',
+        'Core/Matrix3',
+        'Core/Plane',
+        'Core/Quaternion',
+        'Core/Rectangle'
+    ], function(
+        OrientedBoundingBox,
+        BoundingRectangle,
+        Cartesian3,
+        Cartesian4,
+        Ellipsoid,
+        EllipsoidTangentPlane,
+        Intersect,
+        CesiumMath,
+        Matrix3,
+        Plane,
+        Quaternion,
+        Rectangle) {
+    "use strict";
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn*/
+
+    var positions = [
+        new Cartesian3(2.0, 0.0, 0.0),
+        new Cartesian3(0.0, 3.0, 0.0),
+        new Cartesian3(0.0, 0.0, 4.0),
+        new Cartesian3(-2.0, 0.0, 0.0),
+        new Cartesian3(0.0, -3.0, 0.0),
+        new Cartesian3(0.0, 0.0, -4.0)
+    ];
+
+    var positions2 = [
+        new Cartesian3(4.0, 0.0, 0.0),
+        new Cartesian3(0.0, 3.0, 0.0),
+        new Cartesian3(0.0, 0.0, 2.0),
+        new Cartesian3(-4.0, 0.0, 0.0),
+        new Cartesian3(0.0, -3.0, 0.0),
+        new Cartesian3(0.0, 0.0, -2.0)
+    ];
+
+    function rotatePositions(positions, axis, angle) {
+        var points = [];
+
+        var quaternion = Quaternion.fromAxisAngle(axis, angle);
+        var rotation = Matrix3.fromQuaternion(quaternion);
+
+        for (var i = 0; i < positions.length; ++i) {
+            points.push(Matrix3.multiplyByVector(rotation, positions[i], new Cartesian3()));
+        }
+
+        return {
+            points : points,
+            rotation : rotation
+        };
+    }
+
+    function translatePositions(positions, translation) {
+        var points = [];
+        for (var i = 0; i < positions.length; ++i) {
+            points.push(Cartesian3.add(translation, positions[i], new Cartesian3()));
+        }
+
+        return points;
+    }
+
+    it('constructor sets expected default values', function() {
+        var box = new OrientedBoundingBox();
+        expect(box.center).toEqual(Cartesian3.ZERO);
+        expect(box.halfAxes).toEqual(Matrix3.ZERO);
+    });
+
+    it('fromBoundingRectangle throws without rectangle', function() {
+        expect(function() {
+            OrientedBoundingBox.fromBoundingRectangle();
+        }).toThrowDeveloperError();
+    });
+
+    it('fromBoundingRectangle returns zero-size OrientedBoundingBox given a zero-size BoundingRectangle', function() {
+        var box = OrientedBoundingBox.fromBoundingRectangle(new BoundingRectangle());
+        expect(box.center).toEqual(Cartesian3.ZERO);
+        expect(box.halfAxes).toEqual(Matrix3.ZERO);
+    });
+
+    it('fromBoundingRectangle creates an OrientedBoundingBox without a result parameter', function() {
+        var rect = new BoundingRectangle(1.0, 2.0, 3.0, 4.0);
+        var angle = CesiumMath.PI_OVER_TWO;
+        var box = OrientedBoundingBox.fromBoundingRectangle(rect, angle);
+        var rotation = Matrix3.fromRotationZ(angle);
+        expect(box.center).toEqual(new Cartesian3(-1.0, 3.5, 0.0));
+
+        var rotScale = new Matrix3();
+        Matrix3.multiply(rotation, Matrix3.fromScale(new Cartesian3(1.5, 2.0, 0.0)), rotScale);
+        expect(box.halfAxes).toEqualEpsilon(rotScale, CesiumMath.EPSILON15);
+    });
+
+    it('fromBoundingRectangle creates an OrientedBoundingBox with a result parameter', function() {
+        var rect = new BoundingRectangle(1.0, 2.0, 3.0, 4.0);
+        var angle = CesiumMath.PI_OVER_TWO;
+        var result = new OrientedBoundingBox();
+        var box = OrientedBoundingBox.fromBoundingRectangle(rect, angle, result);
+        expect(box).toBe(result);
+        var rotation = Matrix3.fromRotationZ(angle);
+
+        expect(box.center).toEqual(new Cartesian3(-1.0, 3.5, 0.0));
+
+        var rotScale = new Matrix3();
+        Matrix3.multiply(rotation, Matrix3.fromScale(new Cartesian3(1.5, 2.0, 0.0)), rotScale);
+        expect(box.halfAxes).toEqualEpsilon(rotScale, CesiumMath.EPSILON15);
+    });
+
+    it('fromRectangleTangentPlane throws without rectangle', function() {
+        var pl = new EllipsoidTangentPlane(Cartesian3.UNIT_X, Ellipsoid.UNIT_SPHERE);
+        expect(function() {
+            return OrientedBoundingBox.fromRectangleTangentPlane(undefined, pl, 0.0, 0.0);
+        }).toThrowDeveloperError();
+    });
+
+    it('fromRectangleTangentPlane throws without tangentPlane', function() {
+        var rect = new BoundingRectangle(1.0, 2.0, 3.0, 4.0);
+        expect(function() {
+            return OrientedBoundingBox.fromRectangleTangentPlane(rect, undefined, 0.0, 0.0);
+        }).toThrowDeveloperError();
+    });
+
+    it('fromRectangleTangentPlane creates an OrientedBoundingBox without a result parameter', function() {
+        var rect = new Rectangle(0.0, 0.0, 0.0, 0.0);
+        var pl = new EllipsoidTangentPlane(Cartesian3.UNIT_X, Ellipsoid.UNIT_SPHERE);
+        var box = OrientedBoundingBox.fromRectangleTangentPlane(rect, pl, 0.0, 0.0);
+
+        expect(box.center).toEqualEpsilon(new Cartesian3(1.0, 0.0, 0.0), CesiumMath.EPSILON15);
+
+        var rotScale = Matrix3.ZERO;
+        expect(box.halfAxes).toEqualEpsilon(rotScale, CesiumMath.EPSILON15);
+    });
+
+    it('fromRectangleTangentPlane creates an OrientedBoundingBox with a result parameter', function() {
+        var rect = new Rectangle(0.0, 0.0, 0.0, 0.0);
+        var pl = new EllipsoidTangentPlane(Cartesian3.UNIT_X, Ellipsoid.UNIT_SPHERE);
+        var result = new OrientedBoundingBox();
+        var box = OrientedBoundingBox.fromRectangleTangentPlane(rect, pl, 0.0, 0.0, result);
+        expect(box).toBe(result);
+
+        expect(box.center).toEqualEpsilon(new Cartesian3(1.0, 0.0, 0.0), CesiumMath.EPSILON15);
+
+        var rotScale = Matrix3.ZERO;
+        expect(box.halfAxes).toEqualEpsilon(rotScale, CesiumMath.EPSILON15);
+    });
+
+    it('fromRectangleTangentPlane from a degenerate rectangle from (-45, 0) to (45, 0)', function() {
+        var d45 = CesiumMath.PI_OVER_FOUR;
+        var rect = new Rectangle(-d45, 0.0, d45, 0.0);
+        var pl = new EllipsoidTangentPlane(Cartesian3.UNIT_X, Ellipsoid.UNIT_SPHERE);
+        var result = new OrientedBoundingBox();
+        var box = OrientedBoundingBox.fromRectangleTangentPlane(rect, pl, 0.0, 0.0, result);
+        expect(box).toBe(result);
+
+        expect(box.center).toEqualEpsilon(new Cartesian3((1.0 + Math.SQRT1_2) / 2.0, 0.0, 0.0), CesiumMath.EPSILON15);
+
+        var rotScale = new Matrix3(0.0, 0.0, 0.5 * (1.0 - Math.SQRT1_2), Math.SQRT1_2, 0.0, 0.0, 0.0, 0.0, 0.0);
+        expect(box.halfAxes).toEqualEpsilon(rotScale, CesiumMath.EPSILON15);
+    });
+
+    it('fromRectangleTangentPlane from a degenerate rectangle from (135, 0) to (-135, 0)', function() {
+        var d135 = 3 * CesiumMath.PI_OVER_FOUR;
+        var rect = new Rectangle(d135, 0.0, -d135, 0.0);
+        var pl = new EllipsoidTangentPlane(new Cartesian3(-1.0, 0.0, 0.0), Ellipsoid.UNIT_SPHERE);
+        var result = new OrientedBoundingBox();
+        var box = OrientedBoundingBox.fromRectangleTangentPlane(rect, pl, 0.0, 0.0, result);
+        expect(box).toBe(result);
+
+        expect(box.center).toEqualEpsilon(new Cartesian3(-(1.0 + Math.SQRT1_2) / 2.0, 0.0, 0.0), CesiumMath.EPSILON15);
+
+        var rotScale = new Matrix3(0.0, 0.0, -0.5 * (1.0 - Math.SQRT1_2), -Math.SQRT1_2, 0.0, 0.0, 0.0, 0.0, 0.0);
+        expect(box.halfAxes).toEqualEpsilon(rotScale, CesiumMath.EPSILON15);
+    });
+
+    it('fromRectangleTangentPlane from a degenerate rectangle from (0, -45) to (0, 45)', function() {
+        var d45 = CesiumMath.PI_OVER_FOUR;
+        var rect = new Rectangle(0.0, -d45, 0.0, d45);
+        var pl = new EllipsoidTangentPlane(Cartesian3.UNIT_X, Ellipsoid.UNIT_SPHERE);
+        var result = new OrientedBoundingBox();
+        var box = OrientedBoundingBox.fromRectangleTangentPlane(rect, pl, 0.0, 0.0, result);
+        expect(box).toBe(result);
+
+        expect(box.center).toEqualEpsilon(new Cartesian3((1.0 + Math.SQRT1_2) / 2.0, 0.0, 0.0), CesiumMath.EPSILON15);
+
+        var rotScale = new Matrix3(0.0, 0.0, 0.5 * (1.0 - Math.SQRT1_2), 0.0, 0.0, 0.0, 0.0, Math.SQRT1_2, 0.0);
+        expect(box.halfAxes).toEqualEpsilon(rotScale, CesiumMath.EPSILON15);
+    });
+
+    it('fromRectangleTangentPlane from a degenerate rectangle from (0, 135) to (0, -135)', function() {
+        var d135 = 3 * CesiumMath.PI_OVER_FOUR;
+        var rect = new Rectangle(0.0, d135, 0.0, -d135);
+        var pl = new EllipsoidTangentPlane(new Cartesian3(-1.0, 0.0, 0.0), Ellipsoid.UNIT_SPHERE);
+        var result = new OrientedBoundingBox();
+        var box = OrientedBoundingBox.fromRectangleTangentPlane(rect, pl, 0.0, 0.0, result);
+        expect(box).toBe(result);
+
+        expect(box.center).toEqualEpsilon(new Cartesian3(-(1.0 + Math.SQRT1_2) / 2.0, 0.0, 0.0), CesiumMath.EPSILON15);
+
+        var rotScale = new Matrix3(0.0, 0.0, -0.5 * (1.0 - Math.SQRT1_2), 0.0, 0.0, 0.0, 0.0, -Math.SQRT1_2, 0.0);
+        expect(box.halfAxes).toEqualEpsilon(rotScale, CesiumMath.EPSILON15);
+    });
+
+    /**
+     * @param {Cartesian3} center
+     * @param {Matrix3} axes
+     */
+    var intersectPlaneTestCornersEdgesFaces = function(center, axes) {
+        var SQRT1_2 = Math.pow(1.0 / 2.0, 1 / 2.0);
+        var SQRT1_3 = Math.pow(1.0 / 3.0, 1 / 2.0);
+        var SQRT3_4 = Math.pow(3.0 / 4.0, 1 / 2.0);
+
+        var box = new OrientedBoundingBox(center, Matrix3.multiplyByScalar(axes, 0.5, new Matrix3()));
+
+        var planeNormXform = function(nx, ny, nz, dist) {
+            var n = new Cartesian3(nx, ny, nz);
+            var arb = new Cartesian3(357, 924, 258);
+            var p0 = Cartesian3.normalize(n, new Cartesian3());
+            Cartesian3.multiplyByScalar(p0, -dist, p0);
+            var tang = Cartesian3.cross(n, arb, new Cartesian3());
+            Cartesian3.normalize(tang, tang);
+            var binorm = Cartesian3.cross(n, tang, new Cartesian3());
+            Cartesian3.normalize(binorm, binorm);
+
+            Matrix3.multiplyByVector(axes, p0, p0);
+            Matrix3.multiplyByVector(axes, tang, tang);
+            Matrix3.multiplyByVector(axes, binorm, binorm);
+            Cartesian3.cross(tang, binorm, n);
+            Cartesian3.normalize(n, n);
+
+            Cartesian3.add(p0, center, p0);
+            var d = -Cartesian3.dot(p0, n);
+            if (Math.abs(d) > 0.0001 && Cartesian3.magnitudeSquared(n) > 0.0001) {
+                return new Plane(n, d);
+            } else {
+                return undefined;
+            }
+        };
+
+        var pl;
+
+
+        // Tests against faces
+
+        pl = planeNormXform(+1.0, +0.0, +0.0,  0.50001); if (pl) { expect(box.intersectPlane(pl)).toEqual(Intersect.INSIDE); }
+        pl = planeNormXform(-1.0, +0.0, +0.0,  0.50001); if (pl) { expect(box.intersectPlane(pl)).toEqual(Intersect.INSIDE); }
+        pl = planeNormXform(+0.0, +1.0, +0.0,  0.50001); if (pl) { expect(box.intersectPlane(pl)).toEqual(Intersect.INSIDE); }
+        pl = planeNormXform(+0.0, -1.0, +0.0,  0.50001); if (pl) { expect(box.intersectPlane(pl)).toEqual(Intersect.INSIDE); }
+        pl = planeNormXform(+0.0, +0.0, +1.0,  0.50001); if (pl) { expect(box.intersectPlane(pl)).toEqual(Intersect.INSIDE); }
+        pl = planeNormXform(+0.0, +0.0, -1.0,  0.50001); if (pl) { expect(box.intersectPlane(pl)).toEqual(Intersect.INSIDE); }
+
+        pl = planeNormXform(+1.0, +0.0, +0.0,  0.49999); if (pl) { expect(box.intersectPlane(pl)).toEqual(Intersect.INTERSECTING); }
+        pl = planeNormXform(-1.0, +0.0, +0.0,  0.49999); if (pl) { expect(box.intersectPlane(pl)).toEqual(Intersect.INTERSECTING); }
+        pl = planeNormXform(+0.0, +1.0, +0.0,  0.49999); if (pl) { expect(box.intersectPlane(pl)).toEqual(Intersect.INTERSECTING); }
+        pl = planeNormXform(+0.0, -1.0, +0.0,  0.49999); if (pl) { expect(box.intersectPlane(pl)).toEqual(Intersect.INTERSECTING); }
+        pl = planeNormXform(+0.0, +0.0, +1.0,  0.49999); if (pl) { expect(box.intersectPlane(pl)).toEqual(Intersect.INTERSECTING); }
+        pl = planeNormXform(+0.0, +0.0, -1.0,  0.49999); if (pl) { expect(box.intersectPlane(pl)).toEqual(Intersect.INTERSECTING); }
+
+        pl = planeNormXform(+1.0, +0.0, +0.0, -0.49999); if (pl) { expect(box.intersectPlane(pl)).toEqual(Intersect.INTERSECTING); }
+        pl = planeNormXform(-1.0, +0.0, +0.0, -0.49999); if (pl) { expect(box.intersectPlane(pl)).toEqual(Intersect.INTERSECTING); }
+        pl = planeNormXform(+0.0, +1.0, +0.0, -0.49999); if (pl) { expect(box.intersectPlane(pl)).toEqual(Intersect.INTERSECTING); }
+        pl = planeNormXform(+0.0, -1.0, +0.0, -0.49999); if (pl) { expect(box.intersectPlane(pl)).toEqual(Intersect.INTERSECTING); }
+        pl = planeNormXform(+0.0, +0.0, +1.0, -0.49999); if (pl) { expect(box.intersectPlane(pl)).toEqual(Intersect.INTERSECTING); }
+        pl = planeNormXform(+0.0, +0.0, -1.0, -0.49999); if (pl) { expect(box.intersectPlane(pl)).toEqual(Intersect.INTERSECTING); }
+
+        pl = planeNormXform(+1.0, +0.0, +0.0, -0.50001); if (pl) { expect(box.intersectPlane(pl)).toEqual(Intersect.OUTSIDE); }
+        pl = planeNormXform(-1.0, +0.0, +0.0, -0.50001); if (pl) { expect(box.intersectPlane(pl)).toEqual(Intersect.OUTSIDE); }
+        pl = planeNormXform(+0.0, +1.0, +0.0, -0.50001); if (pl) { expect(box.intersectPlane(pl)).toEqual(Intersect.OUTSIDE); }
+        pl = planeNormXform(+0.0, -1.0, +0.0, -0.50001); if (pl) { expect(box.intersectPlane(pl)).toEqual(Intersect.OUTSIDE); }
+        pl = planeNormXform(+0.0, +0.0, +1.0, -0.50001); if (pl) { expect(box.intersectPlane(pl)).toEqual(Intersect.OUTSIDE); }
+        pl = planeNormXform(+0.0, +0.0, -1.0, -0.50001); if (pl) { expect(box.intersectPlane(pl)).toEqual(Intersect.OUTSIDE); }
+
+
+        // Tests against edges
+
+        pl = planeNormXform(+1.0, +1.0, +0.0,  SQRT1_2 + 0.00001); if (pl) { expect(box.intersectPlane(pl)).toEqual(Intersect.INSIDE); }
+        pl = planeNormXform(+1.0, -1.0, +0.0,  SQRT1_2 + 0.00001); if (pl) { expect(box.intersectPlane(pl)).toEqual(Intersect.INSIDE); }
+        pl = planeNormXform(-1.0, +1.0, +0.0,  SQRT1_2 + 0.00001); if (pl) { expect(box.intersectPlane(pl)).toEqual(Intersect.INSIDE); }
+        pl = planeNormXform(-1.0, -1.0, +0.0,  SQRT1_2 + 0.00001); if (pl) { expect(box.intersectPlane(pl)).toEqual(Intersect.INSIDE); }
+        pl = planeNormXform(+1.0, +0.0, +1.0,  SQRT1_2 + 0.00001); if (pl) { expect(box.intersectPlane(pl)).toEqual(Intersect.INSIDE); }
+        pl = planeNormXform(+1.0, +0.0, -1.0,  SQRT1_2 + 0.00001); if (pl) { expect(box.intersectPlane(pl)).toEqual(Intersect.INSIDE); }
+        pl = planeNormXform(-1.0, +0.0, +1.0,  SQRT1_2 + 0.00001); if (pl) { expect(box.intersectPlane(pl)).toEqual(Intersect.INSIDE); }
+        pl = planeNormXform(-1.0, +0.0, -1.0,  SQRT1_2 + 0.00001); if (pl) { expect(box.intersectPlane(pl)).toEqual(Intersect.INSIDE); }
+        pl = planeNormXform(+0.0, +1.0, +1.0,  SQRT1_2 + 0.00001); if (pl) { expect(box.intersectPlane(pl)).toEqual(Intersect.INSIDE); }
+        pl = planeNormXform(+0.0, +1.0, -1.0,  SQRT1_2 + 0.00001); if (pl) { expect(box.intersectPlane(pl)).toEqual(Intersect.INSIDE); }
+        pl = planeNormXform(+0.0, -1.0, +1.0,  SQRT1_2 + 0.00001); if (pl) { expect(box.intersectPlane(pl)).toEqual(Intersect.INSIDE); }
+        pl = planeNormXform(+0.0, -1.0, -1.0,  SQRT1_2 + 0.00001); if (pl) { expect(box.intersectPlane(pl)).toEqual(Intersect.INSIDE); }
+
+        pl = planeNormXform(+1.0, +1.0, +0.0,  SQRT1_2 - 0.00001); if (pl) { expect(box.intersectPlane(pl)).toEqual(Intersect.INTERSECTING); }
+        pl = planeNormXform(+1.0, -1.0, +0.0,  SQRT1_2 - 0.00001); if (pl) { expect(box.intersectPlane(pl)).toEqual(Intersect.INTERSECTING); }
+        pl = planeNormXform(-1.0, +1.0, +0.0,  SQRT1_2 - 0.00001); if (pl) { expect(box.intersectPlane(pl)).toEqual(Intersect.INTERSECTING); }
+        pl = planeNormXform(-1.0, -1.0, +0.0,  SQRT1_2 - 0.00001); if (pl) { expect(box.intersectPlane(pl)).toEqual(Intersect.INTERSECTING); }
+        pl = planeNormXform(+1.0, +0.0, +1.0,  SQRT1_2 - 0.00001); if (pl) { expect(box.intersectPlane(pl)).toEqual(Intersect.INTERSECTING); }
+        pl = planeNormXform(+1.0, +0.0, -1.0,  SQRT1_2 - 0.00001); if (pl) { expect(box.intersectPlane(pl)).toEqual(Intersect.INTERSECTING); }
+        pl = planeNormXform(-1.0, +0.0, +1.0,  SQRT1_2 - 0.00001); if (pl) { expect(box.intersectPlane(pl)).toEqual(Intersect.INTERSECTING); }
+        pl = planeNormXform(-1.0, +0.0, -1.0,  SQRT1_2 - 0.00001); if (pl) { expect(box.intersectPlane(pl)).toEqual(Intersect.INTERSECTING); }
+        pl = planeNormXform(+0.0, +1.0, +1.0,  SQRT1_2 - 0.00001); if (pl) { expect(box.intersectPlane(pl)).toEqual(Intersect.INTERSECTING); }
+        pl = planeNormXform(+0.0, +1.0, -1.0,  SQRT1_2 - 0.00001); if (pl) { expect(box.intersectPlane(pl)).toEqual(Intersect.INTERSECTING); }
+        pl = planeNormXform(+0.0, -1.0, +1.0,  SQRT1_2 - 0.00001); if (pl) { expect(box.intersectPlane(pl)).toEqual(Intersect.INTERSECTING); }
+        pl = planeNormXform(+0.0, -1.0, -1.0,  SQRT1_2 - 0.00001); if (pl) { expect(box.intersectPlane(pl)).toEqual(Intersect.INTERSECTING); }
+
+        pl = planeNormXform(+1.0, +1.0, +0.0, -SQRT1_2 + 0.00001); if (pl) { expect(box.intersectPlane(pl)).toEqual(Intersect.INTERSECTING); }
+        pl = planeNormXform(+1.0, -1.0, +0.0, -SQRT1_2 + 0.00001); if (pl) { expect(box.intersectPlane(pl)).toEqual(Intersect.INTERSECTING); }
+        pl = planeNormXform(-1.0, +1.0, +0.0, -SQRT1_2 + 0.00001); if (pl) { expect(box.intersectPlane(pl)).toEqual(Intersect.INTERSECTING); }
+        pl = planeNormXform(-1.0, -1.0, +0.0, -SQRT1_2 + 0.00001); if (pl) { expect(box.intersectPlane(pl)).toEqual(Intersect.INTERSECTING); }
+        pl = planeNormXform(+1.0, +0.0, +1.0, -SQRT1_2 + 0.00001); if (pl) { expect(box.intersectPlane(pl)).toEqual(Intersect.INTERSECTING); }
+        pl = planeNormXform(+1.0, +0.0, -1.0, -SQRT1_2 + 0.00001); if (pl) { expect(box.intersectPlane(pl)).toEqual(Intersect.INTERSECTING); }
+        pl = planeNormXform(-1.0, +0.0, +1.0, -SQRT1_2 + 0.00001); if (pl) { expect(box.intersectPlane(pl)).toEqual(Intersect.INTERSECTING); }
+        pl = planeNormXform(-1.0, +0.0, -1.0, -SQRT1_2 + 0.00001); if (pl) { expect(box.intersectPlane(pl)).toEqual(Intersect.INTERSECTING); }
+        pl = planeNormXform(+0.0, +1.0, +1.0, -SQRT1_2 + 0.00001); if (pl) { expect(box.intersectPlane(pl)).toEqual(Intersect.INTERSECTING); }
+        pl = planeNormXform(+0.0, +1.0, -1.0, -SQRT1_2 + 0.00001); if (pl) { expect(box.intersectPlane(pl)).toEqual(Intersect.INTERSECTING); }
+        pl = planeNormXform(+0.0, -1.0, +1.0, -SQRT1_2 + 0.00001); if (pl) { expect(box.intersectPlane(pl)).toEqual(Intersect.INTERSECTING); }
+        pl = planeNormXform(+0.0, -1.0, -1.0, -SQRT1_2 + 0.00001); if (pl) { expect(box.intersectPlane(pl)).toEqual(Intersect.INTERSECTING); }
+
+        pl = planeNormXform(+1.0, +1.0, +0.0, -SQRT1_2 - 0.00001); if (pl) { expect(box.intersectPlane(pl)).toEqual(Intersect.OUTSIDE); }
+        pl = planeNormXform(+1.0, -1.0, +0.0, -SQRT1_2 - 0.00001); if (pl) { expect(box.intersectPlane(pl)).toEqual(Intersect.OUTSIDE); }
+        pl = planeNormXform(-1.0, +1.0, +0.0, -SQRT1_2 - 0.00001); if (pl) { expect(box.intersectPlane(pl)).toEqual(Intersect.OUTSIDE); }
+        pl = planeNormXform(-1.0, -1.0, +0.0, -SQRT1_2 - 0.00001); if (pl) { expect(box.intersectPlane(pl)).toEqual(Intersect.OUTSIDE); }
+        pl = planeNormXform(+1.0, +0.0, +1.0, -SQRT1_2 - 0.00001); if (pl) { expect(box.intersectPlane(pl)).toEqual(Intersect.OUTSIDE); }
+        pl = planeNormXform(+1.0, +0.0, -1.0, -SQRT1_2 - 0.00001); if (pl) { expect(box.intersectPlane(pl)).toEqual(Intersect.OUTSIDE); }
+        pl = planeNormXform(-1.0, +0.0, +1.0, -SQRT1_2 - 0.00001); if (pl) { expect(box.intersectPlane(pl)).toEqual(Intersect.OUTSIDE); }
+        pl = planeNormXform(-1.0, +0.0, -1.0, -SQRT1_2 - 0.00001); if (pl) { expect(box.intersectPlane(pl)).toEqual(Intersect.OUTSIDE); }
+        pl = planeNormXform(+0.0, +1.0, +1.0, -SQRT1_2 - 0.00001); if (pl) { expect(box.intersectPlane(pl)).toEqual(Intersect.OUTSIDE); }
+        pl = planeNormXform(+0.0, +1.0, -1.0, -SQRT1_2 - 0.00001); if (pl) { expect(box.intersectPlane(pl)).toEqual(Intersect.OUTSIDE); }
+        pl = planeNormXform(+0.0, -1.0, +1.0, -SQRT1_2 - 0.00001); if (pl) { expect(box.intersectPlane(pl)).toEqual(Intersect.OUTSIDE); }
+        pl = planeNormXform(+0.0, -1.0, -1.0, -SQRT1_2 - 0.00001); if (pl) { expect(box.intersectPlane(pl)).toEqual(Intersect.OUTSIDE); }
+
+
+        // Tests against corners
+
+        pl = planeNormXform(+1.0, +1.0, +1.0,  SQRT3_4 + 0.00001); if (pl) { expect(box.intersectPlane(pl)).toEqual(Intersect.INSIDE); }
+        pl = planeNormXform(+1.0, +1.0, -1.0,  SQRT3_4 + 0.00001); if (pl) { expect(box.intersectPlane(pl)).toEqual(Intersect.INSIDE); }
+        pl = planeNormXform(+1.0, -1.0, +1.0,  SQRT3_4 + 0.00001); if (pl) { expect(box.intersectPlane(pl)).toEqual(Intersect.INSIDE); }
+        pl = planeNormXform(+1.0, -1.0, -1.0,  SQRT3_4 + 0.00001); if (pl) { expect(box.intersectPlane(pl)).toEqual(Intersect.INSIDE); }
+        pl = planeNormXform(-1.0, +1.0, +1.0,  SQRT3_4 + 0.00001); if (pl) { expect(box.intersectPlane(pl)).toEqual(Intersect.INSIDE); }
+        pl = planeNormXform(-1.0, +1.0, -1.0,  SQRT3_4 + 0.00001); if (pl) { expect(box.intersectPlane(pl)).toEqual(Intersect.INSIDE); }
+        pl = planeNormXform(-1.0, -1.0, +1.0,  SQRT3_4 + 0.00001); if (pl) { expect(box.intersectPlane(pl)).toEqual(Intersect.INSIDE); }
+        pl = planeNormXform(-1.0, -1.0, -1.0,  SQRT3_4 + 0.00001); if (pl) { expect(box.intersectPlane(pl)).toEqual(Intersect.INSIDE); }
+
+        pl = planeNormXform(+1.0, +1.0, +1.0,  SQRT3_4 - 0.00001); if (pl) { expect(box.intersectPlane(pl)).toEqual(Intersect.INTERSECTING); }
+        pl = planeNormXform(+1.0, +1.0, -1.0,  SQRT3_4 - 0.00001); if (pl) { expect(box.intersectPlane(pl)).toEqual(Intersect.INTERSECTING); }
+        pl = planeNormXform(+1.0, -1.0, +1.0,  SQRT3_4 - 0.00001); if (pl) { expect(box.intersectPlane(pl)).toEqual(Intersect.INTERSECTING); }
+        pl = planeNormXform(+1.0, -1.0, -1.0,  SQRT3_4 - 0.00001); if (pl) { expect(box.intersectPlane(pl)).toEqual(Intersect.INTERSECTING); }
+        pl = planeNormXform(-1.0, +1.0, +1.0,  SQRT3_4 - 0.00001); if (pl) { expect(box.intersectPlane(pl)).toEqual(Intersect.INTERSECTING); }
+        pl = planeNormXform(-1.0, +1.0, -1.0,  SQRT3_4 - 0.00001); if (pl) { expect(box.intersectPlane(pl)).toEqual(Intersect.INTERSECTING); }
+        pl = planeNormXform(-1.0, -1.0, +1.0,  SQRT3_4 - 0.00001); if (pl) { expect(box.intersectPlane(pl)).toEqual(Intersect.INTERSECTING); }
+        pl = planeNormXform(-1.0, -1.0, -1.0,  SQRT3_4 - 0.00001); if (pl) { expect(box.intersectPlane(pl)).toEqual(Intersect.INTERSECTING); }
+
+        pl = planeNormXform(+1.0, +1.0, +1.0, -SQRT3_4 + 0.00001); if (pl) { expect(box.intersectPlane(pl)).toEqual(Intersect.INTERSECTING); }
+        pl = planeNormXform(+1.0, +1.0, -1.0, -SQRT3_4 + 0.00001); if (pl) { expect(box.intersectPlane(pl)).toEqual(Intersect.INTERSECTING); }
+        pl = planeNormXform(+1.0, -1.0, +1.0, -SQRT3_4 + 0.00001); if (pl) { expect(box.intersectPlane(pl)).toEqual(Intersect.INTERSECTING); }
+        pl = planeNormXform(+1.0, -1.0, -1.0, -SQRT3_4 + 0.00001); if (pl) { expect(box.intersectPlane(pl)).toEqual(Intersect.INTERSECTING); }
+        pl = planeNormXform(-1.0, +1.0, +1.0, -SQRT3_4 + 0.00001); if (pl) { expect(box.intersectPlane(pl)).toEqual(Intersect.INTERSECTING); }
+        pl = planeNormXform(-1.0, +1.0, -1.0, -SQRT3_4 + 0.00001); if (pl) { expect(box.intersectPlane(pl)).toEqual(Intersect.INTERSECTING); }
+        pl = planeNormXform(-1.0, -1.0, +1.0, -SQRT3_4 + 0.00001); if (pl) { expect(box.intersectPlane(pl)).toEqual(Intersect.INTERSECTING); }
+        pl = planeNormXform(-1.0, -1.0, -1.0, -SQRT3_4 + 0.00001); if (pl) { expect(box.intersectPlane(pl)).toEqual(Intersect.INTERSECTING); }
+
+        pl = planeNormXform(+1.0, +1.0, +1.0, -SQRT3_4 - 0.00001); if (pl) { expect(box.intersectPlane(pl)).toEqual(Intersect.OUTSIDE); }
+        pl = planeNormXform(+1.0, +1.0, -1.0, -SQRT3_4 - 0.00001); if (pl) { expect(box.intersectPlane(pl)).toEqual(Intersect.OUTSIDE); }
+        pl = planeNormXform(+1.0, -1.0, +1.0, -SQRT3_4 - 0.00001); if (pl) { expect(box.intersectPlane(pl)).toEqual(Intersect.OUTSIDE); }
+        pl = planeNormXform(+1.0, -1.0, -1.0, -SQRT3_4 - 0.00001); if (pl) { expect(box.intersectPlane(pl)).toEqual(Intersect.OUTSIDE); }
+        pl = planeNormXform(-1.0, +1.0, +1.0, -SQRT3_4 - 0.00001); if (pl) { expect(box.intersectPlane(pl)).toEqual(Intersect.OUTSIDE); }
+        pl = planeNormXform(-1.0, +1.0, -1.0, -SQRT3_4 - 0.00001); if (pl) { expect(box.intersectPlane(pl)).toEqual(Intersect.OUTSIDE); }
+        pl = planeNormXform(-1.0, -1.0, +1.0, -SQRT3_4 - 0.00001); if (pl) { expect(box.intersectPlane(pl)).toEqual(Intersect.OUTSIDE); }
+        pl = planeNormXform(-1.0, -1.0, -1.0, -SQRT3_4 - 0.00001); if (pl) { expect(box.intersectPlane(pl)).toEqual(Intersect.OUTSIDE); }
+
+    };
+
+    it('intersectPlane works with untransformed box', function() {
+        intersectPlaneTestCornersEdgesFaces(Cartesian3.ZERO, Matrix3.IDENTITY);
+    });
+
+    it('intersectPlane works with off-center box', function() {
+        intersectPlaneTestCornersEdgesFaces(new Cartesian3(1.0, 0.0, 0.0), Matrix3.IDENTITY);
+        intersectPlaneTestCornersEdgesFaces(new Cartesian3(0.7, -1.8, 12.0), Matrix3.IDENTITY);
+    });
+
+    it('intersectPlane works with rotated box', function() {
+        intersectPlaneTestCornersEdgesFaces(Cartesian3.ZERO,
+                Matrix3.fromQuaternion(Quaternion.fromAxisAngle(new Cartesian3(0.5, 1.5, -1.2), 1.2), new Matrix3()));
+    });
+
+    it('intersectPlane works with scaled box', function() {
+        var m = new Matrix3();
+        intersectPlaneTestCornersEdgesFaces(Cartesian3.ZERO, Matrix3.fromScale(new Cartesian3(1.5, 0.4, 20.6), m));
+        intersectPlaneTestCornersEdgesFaces(Cartesian3.ZERO, Matrix3.fromScale(new Cartesian3(0.0, 0.4, 20.6), m));
+        intersectPlaneTestCornersEdgesFaces(Cartesian3.ZERO, Matrix3.fromScale(new Cartesian3(1.5, 0.0, 20.6), m));
+        intersectPlaneTestCornersEdgesFaces(Cartesian3.ZERO, Matrix3.fromScale(new Cartesian3(1.5, 0.4, 0.0), m));
+        intersectPlaneTestCornersEdgesFaces(Cartesian3.ZERO, Matrix3.fromScale(new Cartesian3(0.0, 0.0, 0.0), m));
+    });
+
+    it('intersectPlane works with this arbitrary box', function() {
+        var m = Matrix3.fromScale(new Cartesian3(1.5, 80.4, 2.6), new Matrix3());
+        var n = Matrix3.fromQuaternion(Quaternion.fromAxisAngle(new Cartesian3(0.5, 1.5, -1.2), 1.2), new Matrix3());
+        Matrix3.multiply(m, n, n);
+        intersectPlaneTestCornersEdgesFaces(new Cartesian3(-5.1, 0.0, 0.1), n);
+    });
+
+    it('intersectPlane fails without box parameter', function() {
+        var plane = new Cartesian4(1.0, 0.0, 0.0, 0.0);
+        expect(function() {
+            OrientedBoundingBox.intersectPlane(undefined, plane);
+        }).toThrowDeveloperError();
+    });
+
+    it('intersectPlane fails without plane parameter', function() {
+        var box = new OrientedBoundingBox(Cartesian3.IDENTITY, Matrix3.ZERO);
+        expect(function() {
+            OrientedBoundingBox.intersectPlane(box, undefined);
+        }).toThrowDeveloperError();
+    });
+
+    it('clone without a result parameter', function() {
+        var box = new OrientedBoundingBox();
+        var result = OrientedBoundingBox.clone(box);
+        expect(box).not.toBe(result);
+        expect(box).toEqual(result);
+        expect(box.clone()).toEqual(box);
+    });
+
+    it('clone with a result parameter', function() {
+        var box = new OrientedBoundingBox();
+        var box2 = new OrientedBoundingBox();
+        var result = new OrientedBoundingBox();
+        var returnedResult = OrientedBoundingBox.clone(box, result);
+        expect(result).toBe(returnedResult);
+        expect(box).not.toBe(result);
+        expect(box).toEqual(result);
+        expect(box.clone(box2)).toBe(box2);
+        expect(box.clone(box2)).toEqual(box2);
+    });
+
+    it('clone undefined OBB with a result parameter', function() {
+        var box = new OrientedBoundingBox();
+        var box2 = new OrientedBoundingBox();
+        expect(OrientedBoundingBox.clone(undefined, box)).toBe(undefined);
+    });
+
+    it('clone undefined OBB without a result parameter', function() {
+        expect(OrientedBoundingBox.clone(undefined)).toBe(undefined);
+    });
+
+    it('equals works in all cases', function() {
+        var box = new OrientedBoundingBox();
+        expect(box.equals(new OrientedBoundingBox())).toEqual(true);
+        expect(box.equals(undefined)).toEqual(false);
+    });
+});

--- a/Specs/Core/OrientedBoundingBoxSpec.js
+++ b/Specs/Core/OrientedBoundingBoxSpec.js
@@ -149,9 +149,12 @@ defineSuite([
 
     it('fromRectangle for interesting, degenerate, and edge-case rectangles', function() {
         var d45 = CesiumMath.PI_OVER_FOUR;
+        var d30 = CesiumMath.PI_OVER_SIX;
         var d90 = CesiumMath.PI_OVER_TWO;
+        var d60 = CesiumMath.PI_OVER_THREE;
         var d135 = 3 * CesiumMath.PI_OVER_FOUR;
         var d180 = CesiumMath.PI;
+        var sqrt3 = Math.sqrt(3.0);
 
         var box;
 
@@ -179,9 +182,9 @@ defineSuite([
         expect(box.center).toEqualEpsilon(new Cartesian3(0.5, 0.0, 0.0), CesiumMath.EPSILON15);
         expect(box.halfAxes).toEqualEpsilon(new Matrix3(0.0, 0.0, 0.5, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0), CesiumMath.EPSILON15);
 
-        box = OrientedBoundingBox.fromRectangle(new Rectangle(-d90, -d45, d90, d90), 0.0, 0.0, Ellipsoid.UNIT_SPHERE);
-        expect(box.center).toEqualEpsilon(new Cartesian3(0.5, 0.0, 0.5 * (1.0 - Math.SQRT1_2)), CesiumMath.EPSILON15);
-        expect(box.halfAxes).toEqualEpsilon(new Matrix3(0.0, 0.0, 0.5, 1.0, 0.0, 0.0, 0.0, 0.5 * (1.0 + Math.SQRT1_2), 0.0), CesiumMath.EPSILON15);
+        box = OrientedBoundingBox.fromRectangle(new Rectangle(-d90, -d30, d90, d90), 0.0, 0.0, Ellipsoid.UNIT_SPHERE);
+        expect(box.center).toEqualEpsilon(new Cartesian3(0.1875 * sqrt3, 0.0, 0.1875), CesiumMath.EPSILON15);
+        expect(box.halfAxes).toEqualEpsilon(new Matrix3(0, -sqrt3/4, 5*sqrt3/16, 1, 0, 0, 0, 3/4, 5/16), CesiumMath.EPSILON15);
 
         box = OrientedBoundingBox.fromRectangle(new Rectangle(-d45, 0.0, d45, 0.0), 0.0, 0.0, Ellipsoid.UNIT_SPHERE);
         expect(box.center).toEqualEpsilon(new Cartesian3((1.0 + Math.SQRT1_2) / 2.0, 0.0, 0.0), CesiumMath.EPSILON15);
@@ -206,7 +209,6 @@ defineSuite([
 
     var intersectPlaneTestCornersEdgesFaces = function(center, axes) {
         var SQRT1_2 = Math.pow(1.0 / 2.0, 1 / 2.0);
-        var SQRT1_3 = Math.pow(1.0 / 3.0, 1 / 2.0);
         var SQRT3_4 = Math.pow(3.0 / 4.0, 1 / 2.0);
 
         var box = new OrientedBoundingBox(center, Matrix3.multiplyByScalar(axes, 0.5, new Matrix3()));

--- a/Specs/Core/PlaneSpec.js
+++ b/Specs/Core/PlaneSpec.js
@@ -1,10 +1,12 @@
 /*global defineSuite*/
 defineSuite([
         'Core/Plane',
-        'Core/Cartesian3'
+        'Core/Cartesian3',
+        'Core/Cartesian4'
     ], function(
         Plane,
-        Cartesian3) {
+        Cartesian3,
+        Cartesian4) {
     "use strict";
     /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn*/
 
@@ -47,6 +49,21 @@ defineSuite([
         expect(plane.distance).toEqual(-Cartesian3.dot(normal, point));
     });
 
+    it('constructs from a Cartesian4 without result', function() {
+        var result = Plane.fromCartesian4(Cartesian4.UNIT_X);
+
+        expect(result.normal).toEqual(Cartesian3.UNIT_X);
+        expect(result.distance).toEqual(0.0);
+    });
+
+    it('constructs from a Cartesian4 with result', function() {
+        var result = new Plane(Cartesian3.UNIT_X, 0.0);
+        Plane.fromCartesian4(Cartesian4.UNIT_X, result);
+
+        expect(result.normal).toEqual(Cartesian3.UNIT_X);
+        expect(result.distance).toEqual(0.0);
+    });
+
     it('fromPointNormal throws without a point', function() {
         expect(function() {
             return Plane.fromPointNormal(undefined, Cartesian3.UNIT_X);
@@ -59,6 +76,12 @@ defineSuite([
         }).toThrowDeveloperError();
     });
 
+    it('fromCartesian4 throws without coefficients', function() {
+        expect(function() {
+            return Plane.fromCartesian4(undefined);
+        }).toThrowDeveloperError();
+    });
+
     it('gets the distance to a point', function() {
         var plane = new Plane(new Cartesian3(1.0, 2.0, 3.0), 12.34);
         var point = new Cartesian3(4.0, 5.0, 6.0);
@@ -66,10 +89,17 @@ defineSuite([
         expect(Plane.getPointDistance(plane, point)).toEqual(Cartesian3.dot(plane.normal, point) + plane.distance);
     });
 
+    it('getPointDistance throws without a plane', function() {
+        var point = Cartesian3.ZERO;
+        expect(function() {
+            return Plane.getPointDistance(undefined, point);
+        }).toThrowDeveloperError();
+    });
+
     it('getPointDistance throws without a point', function() {
         var plane = new Plane(Cartesian3.UNIT_X, 0.0);
         expect(function() {
-            return Plane.getPointDistance();
+            return Plane.getPointDistance(plane, undefined);
         }).toThrowDeveloperError();
     });
 });


### PR DESCRIPTION
(Do not merge. Will be tested with 3D buildings first.)

In review & editing.

* [x] Further testing of rectangles which span the equator
* [x] Overall (rendering and network) performance benchmarking.  Update the TODO in `CHANGES.md`.

Future:

* [x] Hook up to heightmapped terrain (and flat terrain, if that's separate); not just quantized meshes
* [ ] Hook up to 2D and Columbus view rendering modes