### PR TITLE
Allow GLTF models to be loaded from a Uint8Array.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@ Change Log
 * The performance statistics displayed by setting `scene.debugShowFramesPerSecond` to `true` can now be styled using the `cesium-performanceDisplay` CSS classes in `shared.css` [#2779](https://github.com/AnalyticalGraphicsInc/cesium/issues/2779).
 * Fixed a crash when `viewer.zoomTo` or `viewer.flyTo` were called immediately before or during a scene morph [#2775](https://github.com/AnalyticalGraphicsInc/cesium/issues/2775).
 * Fixed an issue where `Camera` functions would throw an exception if used from within a `Scene.morphComplete` callback [#2776](https://github.com/AnalyticalGraphicsInc/cesium/issues/2776).
+* `Model` can now load Binary glTF from a Uint8Array.
 
 ### 1.10 - 2015-06-01
 

--- a/Source/Core/getStringFromTypedArray.js
+++ b/Source/Core/getStringFromTypedArray.js
@@ -11,22 +11,14 @@ define([
     /**
      * @private
      */
-    var getStringFromTypedArray = function(buffer, byteOffset, length) {
+    var getStringFromTypedArray = function(uint8Array) {
         //>>includeStart('debug', pragmas.debug);
-        if (!defined(buffer)) {
-            throw new DeveloperError('buffer is required.');
-        }
-
-        if (!defined(byteOffset)) {
-            throw new DeveloperError('byteOffset is required.');
-        }
-
-        if (!defined(length)) {
-            throw new DeveloperError('length is required.');
+        if (!defined(uint8Array)) {
+            throw new DeveloperError('uint8Array is required.');
         }
         //>>includeEnd('debug');
 
-        return getStringFromTypedArray.decode(new Uint8Array(buffer, byteOffset, length));
+        return getStringFromTypedArray.decode(uint8Array);
     };
 
     // Exposed functions for testing
@@ -44,7 +36,7 @@ define([
         // fromCharCode will not handle all legal Unicode values (up to 21 bits).  See
         // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/fromCharCode
         for (var i = 0; i < length; ++i) {
-          result += String.fromCharCode(view[i]);
+            result += String.fromCharCode(view[i]);
         }
         return result;
     };

--- a/Source/Core/loadImageFromTypedArray.js
+++ b/Source/Core/loadImageFromTypedArray.js
@@ -3,29 +3,21 @@ define([
         '../ThirdParty/when',
         './defined',
         './DeveloperError',
-        './loadImageViaBlob'
+        './loadImage'
     ], function(
         when,
         defined,
         DeveloperError,
-        loadImageViaBlob) {
+        loadImage) {
     "use strict";
 
     /**
      * @private
      */
-    var loadImageFromTypedArray = function(buffer, byteOffset, length, format) {
+    var loadImageFromTypedArray = function(uint8Array, format) {
         //>>includeStart('debug', pragmas.debug);
-        if (!defined(buffer)) {
-            throw new DeveloperError('buffer is required.');
-        }
-
-        if (!defined(byteOffset)) {
-            throw new DeveloperError('byteOffset is required.');
-        }
-
-        if (!defined(length)) {
-            throw new DeveloperError('length is required.');
+        if (!defined(uint8Array)) {
+            throw new DeveloperError('uint8Array is required.');
         }
 
         if (!defined(format)) {
@@ -33,15 +25,17 @@ define([
         }
         //>>includeEnd('debug');
 
-        var bytes = new Uint8Array(buffer, byteOffset, length);
-        var blob = new Blob([bytes], {
+        var blob = new Blob([uint8Array], {
             type : format
         });
 
         var blobUrl = window.URL.createObjectURL(blob);
-        return loadImageViaBlob(blobUrl).then(function(image){
+        return loadImage(blobUrl, false).then(function(image) {
             window.URL.revokeObjectURL(blobUrl);
             return image;
+        }, function(error) {
+            window.URL.revokeObjectURL(blobUrl);
+            return when.reject(error);
         });
     };
 

--- a/Source/Scene/Model.js
+++ b/Source/Scene/Model.js
@@ -126,6 +126,10 @@ define([
         this.skinnedNodesNames = [];
     }
 
+    LoadResources.prototype.getBuffer = function(bufferView) {
+        return getSubarray(this.buffers[bufferView.buffer], bufferView.byteOffset, bufferView.byteLength);
+    };
+
     LoadResources.prototype.finishedPendingLoads = function() {
         return ((this.pendingBufferLoads === 0) &&
                 (this.pendingShaderLoads === 0) &&
@@ -252,7 +256,7 @@ define([
      * @constructor
      *
      * @param {Object} [options] Object with the following properties:
-     * @param {Object|ArrayBuffer} [options.gltf] The object for the glTF JSON or an arraybuffer of Binary glTF defined by the CESIUM_binary_glTF extension.
+     * @param {Object|ArrayBuffer|Uint8Array} [options.gltf] The object for the glTF JSON or an arraybuffer of Binary glTF defined by the CESIUM_binary_glTF extension.
      * @param {String} [options.basePath=''] The base path that paths in the glTF JSON are relative to.
      * @param {Boolean} [options.show=true] Determines if the model primitive will be shown.
      * @param {Matrix4} [options.modelMatrix=Matrix4.IDENTITY] The 4x4 transformation matrix that transforms the model from model to world coordinates.
@@ -291,6 +295,10 @@ define([
 
             if (defined(gltf)) {
                 if (gltf instanceof ArrayBuffer) {
+                    gltf = new Uint8Array(gltf);
+                }
+
+                if (gltf instanceof Uint8Array) {
                     // Binary glTF
                     cachedGltf = new CachedGltf({
                         gltf : parseBinaryGltfHeader(gltf),
@@ -697,16 +705,30 @@ define([
 
     var sizeOfUint32 = Uint32Array.BYTES_PER_ELEMENT;
 
-    function parseBinaryGltfHeader(arrayBuffer) {
-        var magic = getStringFromTypedArray(arrayBuffer, 0, 4);
-        if (magic !== 'glTF') {
+    /**
+     * This function differs from the normal subarray function
+     * because it takes offset and length, rather than begin and end.
+     */
+    function getSubarray(array, offset, length) {
+        return array.subarray(offset, offset + length);
+    }
+
+    function containsGltfMagic(uint8Array) {
+        if (uint8Array.byteLength < 4) {
+            return false;
+        }
+        return getStringFromTypedArray(uint8Array.subarray(0, 4)) === 'glTF';
+    }
+
+    function parseBinaryGltfHeader(uint8Array) {
+        if (!containsGltfMagic(uint8Array)) {
             throw new DeveloperError('bgltf is not a valid Binary glTF file.');
         }
 
-        var view = new DataView(arrayBuffer);
+        var view = new DataView(uint8Array.buffer, uint8Array.byteOffset, uint8Array.byteLength);
         var byteOffset = 0;
 
-        byteOffset += sizeOfUint32;  // Skip magic number
+        byteOffset += sizeOfUint32; // Skip magic number
 
         //>>includeStart('debug', pragmas.debug);
         var version = view.getUint32(byteOffset, true);
@@ -716,7 +738,7 @@ define([
         //>>includeEnd('debug');
         byteOffset += sizeOfUint32;
 
-        byteOffset += sizeOfUint32;  // Skip length
+        byteOffset += sizeOfUint32; // Skip length
 
         var jsonOffset = view.getUint32(byteOffset, true);
         byteOffset += sizeOfUint32;
@@ -724,7 +746,8 @@ define([
         var jsonLength = view.getUint32(byteOffset, true);
         byteOffset += sizeOfUint32;
 
-        return JSON.parse(getStringFromTypedArray(arrayBuffer, jsonOffset, jsonLength));
+        var json = getStringFromTypedArray(getSubarray(uint8Array, jsonOffset, jsonLength));
+        return JSON.parse(json);
     }
 
     /**
@@ -818,14 +841,14 @@ define([
             gltfCache[cacheKey] = cachedGltf;
 
             loadArrayBuffer(url, options.headers).then(function(arrayBuffer) {
-                var magic = getStringFromTypedArray(arrayBuffer, 0, Math.min(4, arrayBuffer.byteLength));
-                if (magic === 'glTF') {
+                var array = new Uint8Array(arrayBuffer);
+                if (containsGltfMagic(array)) {
                     // Load binary glTF
-                    cachedGltf.makeReady(parseBinaryGltfHeader(arrayBuffer), arrayBuffer);
+                    cachedGltf.makeReady(parseBinaryGltfHeader(array), array);
                 } else {
                     // Load text (JSON) glTF
-                    var data = getStringFromTypedArray(arrayBuffer, 0, arrayBuffer.byteLength);
-                    cachedGltf.makeReady(JSON.parse(data));
+                    var json = getStringFromTypedArray(array);
+                    cachedGltf.makeReady(JSON.parse(json));
                 }
             }).otherwise(getFailedLoadFunction(model, 'model', url));
         } else if (!cachedGltf.ready) {
@@ -979,7 +1002,7 @@ define([
     function bufferLoad(model, name) {
         return function(arrayBuffer) {
             var loadResources = model._loadResources;
-            loadResources.buffers[name] = arrayBuffer;
+            loadResources.buffers[name] = new Uint8Array(arrayBuffer);
             --loadResources.pendingBufferLoads;
          };
     }
@@ -1243,10 +1266,8 @@ define([
             return;
         }
 
-        var raw;
         var bufferView;
         var bufferViews = model.gltf.bufferViews;
-        var buffers = loadResources.buffers;
         var rendererBuffers = model._rendererResources.buffers;
 
         while (loadResources.buffersToCreate.length > 0) {
@@ -1254,8 +1275,7 @@ define([
             bufferView = bufferViews[bufferViewName];
 
             // Only ARRAY_BUFFER here.  ELEMENT_ARRAY_BUFFER created below.
-            raw = new Uint8Array(buffers[bufferView.buffer], bufferView.byteOffset, bufferView.byteLength);
-            var vertexBuffer = context.createVertexBuffer(raw, BufferUsage.STATIC_DRAW);
+            var vertexBuffer = context.createVertexBuffer(loadResources.getBuffer(bufferView), BufferUsage.STATIC_DRAW);
             vertexBuffer.vertexArrayDestroyable = false;
             rendererBuffers[bufferViewName] = vertexBuffer;
         }
@@ -1270,8 +1290,7 @@ define([
                 bufferView = bufferViews[accessor.bufferView];
 
                 if ((bufferView.target === WebGLRenderingContext.ELEMENT_ARRAY_BUFFER) && !defined(rendererBuffers[accessor.bufferView])) {
-                    raw = new Uint8Array(buffers[bufferView.buffer], bufferView.byteOffset, bufferView.byteLength);
-                    var indexBuffer = context.createIndexBuffer(raw, BufferUsage.STATIC_DRAW, accessor.componentType);
+                    var indexBuffer = context.createIndexBuffer(loadResources.getBuffer(bufferView), BufferUsage.STATIC_DRAW, accessor.componentType);
                     indexBuffer.vertexArrayDestroyable = false;
                     rendererBuffers[accessor.bufferView] = indexBuffer;
                     // In theory, several glTF accessors with different componentTypes could
@@ -1298,11 +1317,11 @@ define([
             return shader.source;
         }
 
-        var buffers = model._loadResources.buffers;
+        var loadResources = model._loadResources;
         var gltf = model.gltf;
         var bufferView = gltf.bufferViews[shader.bufferView];
 
-        return getStringFromTypedArray(buffers[bufferView.buffer], bufferView.byteOffset, bufferView.byteLength);
+        return getStringFromTypedArray(loadResources.getBuffer(bufferView));
     }
 
     function createProgram(name, model, context) {
@@ -1377,13 +1396,12 @@ define([
         while (loadResources.texturesToCreateFromBufferView.length > 0) {
             var gltfTexture = loadResources.texturesToCreateFromBufferView.dequeue();
 
-            var buffers = loadResources.buffers;
             var gltf = model.gltf;
             var bufferView = gltf.bufferViews[gltfTexture.bufferView];
 
             var onload = getOnImageCreatedFromTypedArray(loadResources, gltfTexture);
             var onerror = getFailedLoadFunction(model, 'image', 'name: ' + gltfTexture.name + ', bufferView: ' + gltfTexture.bufferView);
-            loadImageFromTypedArray(buffers[bufferView.buffer], bufferView.byteOffset, bufferView.byteLength, gltfTexture.mimeType).
+            loadImageFromTypedArray(loadResources.getBuffer(bufferView), gltfTexture.mimeType).
                 then(onload).otherwise(onerror);
 
             ++loadResources.pendingBufferViewToImage;

--- a/Source/Scene/ModelAnimationCache.js
+++ b/Source/Scene/ModelAnimationCache.js
@@ -52,7 +52,7 @@ define([
 
         if (!defined(values)) {
             // Cache miss
-            var buffers = model._loadResources.buffers;
+            var loadResources = model._loadResources;
             var gltf = model.gltf;
             var bufferViews = gltf.bufferViews;
 
@@ -63,7 +63,8 @@ define([
             var count = accessor.count;
 
             // Convert typed array to Cesium types
-            var typedArray = getModelAccessor(accessor).createArrayBufferView(buffers[bufferView.buffer], bufferView.byteOffset + accessor.byteOffset, count);
+            var buffer = loadResources.getBuffer(bufferView);
+            var typedArray = getModelAccessor(accessor).createArrayBufferView(buffer.buffer, buffer.byteOffset + accessor.byteOffset, count);
             var i;
 
             if ((componentType === WebGLRenderingContext.FLOAT) && (type === 'SCALAR')) {
@@ -162,7 +163,7 @@ define([
         if (!defined(matrices)) {
             // Cache miss
 
-            var buffers = model._loadResources.buffers;
+            var loadResources = model._loadResources;
             var gltf = model.gltf;
             var bufferViews = gltf.bufferViews;
 
@@ -171,7 +172,8 @@ define([
             var componentType = accessor.componentType;
             var type = accessor.type;
             var count = accessor.count;
-            var typedArray = getModelAccessor(accessor).createArrayBufferView(buffers[bufferView.buffer], bufferView.byteOffset + accessor.byteOffset, count);
+            var buffer = loadResources.getBuffer(bufferView);
+            var typedArray = getModelAccessor(accessor).createArrayBufferView(buffer.buffer, buffer.byteOffset + accessor.byteOffset, count);
             matrices =  new Array(count);
 
             if ((componentType === WebGLRenderingContext.FLOAT) && (type === 'MAT4')) {

--- a/Specs/Core/getStringFromTypedArraySpec.js
+++ b/Specs/Core/getStringFromTypedArraySpec.js
@@ -7,17 +7,20 @@ defineSuite([
     /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor*/
 
     function verifyString() {
-        var buffer = new Uint8Array([67, 101, 115, 105, 117, 109]);
-        var string = getStringFromTypedArray(buffer, 0, 6);
+        var arr = new Uint8Array([67, 101, 115, 105, 117, 109]);
+        var string = getStringFromTypedArray(arr);
         expect(string).toEqual('Cesium');
-        expect(getStringFromTypedArray(new Uint8Array(), 0, 0)).toEqual('');
+
+        arr = new Uint8Array();
+        string = getStringFromTypedArray(arr);
+        expect(string).toEqual('');
     }
 
-    it('Returns a string', function() {
+    it('converts a typed array to string', function() {
         verifyString();
     });
 
-    it('Returns a string with fromCharCode', function() {
+    it('converts a typed array to string when forced to use fromCharCode', function() {
         var previous = getStringFromTypedArray.decode;
         getStringFromTypedArray.decode = getStringFromTypedArray.decodeWithFromCharCode;
 
@@ -26,23 +29,9 @@ defineSuite([
         getStringFromTypedArray.decode = previous;
     });
 
-    it('Throws without buffer', function() {
+    it('throws without array', function() {
         expect(function() {
             getStringFromTypedArray();
-        }).toThrowDeveloperError();
-    });
-
-    it('Throws without byteOffset', function() {
-        var buffer = new Uint8Array();
-        expect(function() {
-            getStringFromTypedArray(buffer);
-        }).toThrowDeveloperError();
-    });
-
-    it('Throws without length', function() {
-        var buffer = new Uint8Array();
-        expect(function() {
-            getStringFromTypedArray(buffer, 0);
         }).toThrowDeveloperError();
     });
 });

--- a/Specs/Core/loadImageFromTypedArraySpec.js
+++ b/Specs/Core/loadImageFromTypedArraySpec.js
@@ -13,8 +13,9 @@ defineSuite([
     /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,runs,waits,waitsFor,fail*/
 
     it('can load an image', function() {
-        return loadArrayBuffer('./Data/Images/Blue10x10.png'). then(function(arrayBuffer) {
-            return loadImageFromTypedArray(arrayBuffer, 0, arrayBuffer.byteLength, 'image/png').then(function(image) {
+        return loadArrayBuffer('./Data/Images/Blue10x10.png').then(function(arrayBuffer) {
+            var arr = new Uint8Array(arrayBuffer);
+            return loadImageFromTypedArray(arr, 'image/png').then(function(image) {
                 expect(image.width).toEqual(10);
                 expect(image.height).toEqual(10);
             });
@@ -23,36 +24,21 @@ defineSuite([
 
     it('can not load an invalid image', function() {
         var notApng = new Uint8Array([67, 101, 115, 105, 117, 109]);
-        return loadImageFromTypedArray(notApng, 0, notApng.byteLength, 'image/png').then(function(image) {
+        return loadImageFromTypedArray(notApng, 'image/png').then(function(image) {
             fail('should not be called');
         }).otherwise(function() {
         });
     });
 
-    it('Throws without buffer', function() {
+    it('Throws without array', function() {
         expect(function() {
             loadImageFromTypedArray();
         }).toThrowDeveloperError();
     });
 
-    it('Throws without byteOffset', function() {
-        var buffer = new Uint8Array();
-        expect(function() {
-            loadImageFromTypedArray(buffer);
-        }).toThrowDeveloperError();
-    });
-
-    it('Throws without length', function() {
-        var buffer = new Uint8Array();
-        expect(function() {
-            loadImageFromTypedArray(buffer, 0);
-        }).toThrowDeveloperError();
-    });
-
     it('Throws without format', function() {
-        var buffer = new Uint8Array();
         expect(function() {
-            loadImageFromTypedArray(buffer, 0, buffer.byteLength);
+            loadImageFromTypedArray(new Uint8Array());
         }).toThrowDeveloperError();
     });
 });

--- a/Specs/Scene/ModelSpec.js
+++ b/Specs/Scene/ModelSpec.js
@@ -461,8 +461,8 @@ defineSuite([
         });
     });
 
-    it('loads a model with the CESIUM_binary_glTF using new Model', function() {
-        return loadArrayBuffer(texturedBoxBinaryUrl). then(function(arrayBuffer) {
+    it('loads a model with the CESIUM_binary_glTF extension as an ArrayBuffer using new Model', function() {
+        return loadArrayBuffer(texturedBoxBinaryUrl).then(function(arrayBuffer) {
             var model = primitives.add(new Model({
                 gltf : arrayBuffer,
                 modelMatrix : Transforms.eastNorthUpToFixedFrame(Cartesian3.fromDegrees(0.0, 0.0, 100.0)),
@@ -474,11 +474,34 @@ defineSuite([
                 // Render scene to progressively load the model
                 scene.renderForSpecs();
                 return model.ready;
-            }, { timeout: 10000 }).then(function() {
+            }, {
+                timeout : 10000
+            }).then(function() {
                 verifyRender(model);
                 primitives.remove(model);
             });
+        });
+    });
 
+    it('loads a model with the CESIUM_binary_glTF extension as an Uint8Array using new Model', function() {
+        return loadArrayBuffer(texturedBoxBinaryUrl).then(function(arrayBuffer) {
+            var model = primitives.add(new Model({
+                gltf : new Uint8Array(arrayBuffer),
+                modelMatrix : Transforms.eastNorthUpToFixedFrame(Cartesian3.fromDegrees(0.0, 0.0, 100.0)),
+                show : false
+            }));
+            addZoomTo(model);
+
+            return pollToPromise(function() {
+                // Render scene to progressively load the model
+                scene.renderForSpecs();
+                return model.ready;
+            }, {
+                timeout : 10000
+            }).then(function() {
+                verifyRender(model);
+                primitives.remove(model);
+            });
         });
     });
 


### PR DESCRIPTION
Previously, Model required binary GLTF to be provided as an ArrayBuffer. This precluded the possibility of packing multiple models into a single binary file and loading each model from sub-sections of the binary file (without copying the sub-sections into separate ArrayBuffers).

Now, internally, buffers are always stored as Uint8Arrays after loading, and resources are loaded by using subarray, which does not copy the underlying data buffer.

Also changed getStringFromTypedArray and loadImageFromTypedArray to operate on a Uint8Array (as their name suggests) rather than buffer and offset and length.