### PR TITLE
PolylinePipeline.generateArc accepts empty array

### DIFF
--- a/Source/Core/CorridorGeometry.js
+++ b/Source/Core/CorridorGeometry.js
@@ -803,9 +803,6 @@ define([
         var extrude = (height !== extrudedHeight);
 
         var cleanPositions = PolylinePipeline.removeDuplicates(positions);
-        if (!defined(cleanPositions)) {
-            cleanPositions = positions;
-        }
 
         if (cleanPositions.length < 2) {
             return undefined;

--- a/Source/Core/CorridorOutlineGeometry.js
+++ b/Source/Core/CorridorOutlineGeometry.js
@@ -470,9 +470,6 @@ define([
         var extrude = (height !== extrudedHeight);
 
         var cleanPositions = PolylinePipeline.removeDuplicates(positions);
-        if (!defined(cleanPositions)) {
-            cleanPositions = positions;
-        }
 
         if (cleanPositions.length < 2) {
             return undefined;

--- a/Source/Core/PolygonPipeline.js
+++ b/Source/Core/PolygonPipeline.js
@@ -12,6 +12,7 @@ define([
         './GeometryAttribute',
         './Math',
         './pointInsideTriangle',
+        './PolylinePipeline',
         './PrimitiveType',
         './Queue',
         './WindingOrder'
@@ -28,6 +29,7 @@ define([
         GeometryAttribute,
         CesiumMath,
         pointInsideTriangle,
+        PolylinePipeline,
         PrimitiveType,
         Queue,
         WindingOrder) {
@@ -718,17 +720,10 @@ define([
         }
         //>>includeEnd('debug');
 
-        var length = positions.length;
-        var cleanedPositions = [];
-        for ( var i0 = length - 1, i1 = 0; i1 < length; i0 = i1++) {
-            var v0 = positions[i0];
-            var v1 = positions[i1];
-
-            if (!Cartesian3.equals(v0, v1)) {
-                cleanedPositions.push(v1); // Shallow copy!
-            }
+        var cleanedPositions = PolylinePipeline.removeDuplicates(positions);
+        if (Cartesian3.equals(cleanedPositions[0], cleanedPositions[cleanedPositions.length - 1])) {
+            return cleanedPositions.slice(1);
         }
-
         return cleanedPositions;
     };
 

--- a/Source/Core/PolylineGeometry.js
+++ b/Source/Core/PolylineGeometry.js
@@ -304,9 +304,6 @@ define([
         var k;
 
         var positions = PolylinePipeline.removeDuplicates(polylineGeometry._positions);
-        if (!defined(positions)) {
-            positions = polylineGeometry._positions;
-        }
 
         var positionsLength = positions.length;
         if (positionsLength < 2) {

--- a/Source/Core/PolylinePipeline.js
+++ b/Source/Core/PolylinePipeline.js
@@ -205,7 +205,7 @@ define([
      * Removes adjacent duplicate positions in an array of positions.
      *
      * @param {Cartesian3[]} positions The array of positions.
-     * @returns {Cartesian3[]|undefined} A new array of positions with no adjacent duplicate positions or <code>undefined</code> if no duplicates were found.
+     * @returns {Cartesian3[]|undefined} A new array of positions with no adjacent duplicate positions or the input array if no duplicates were found.
      *
      * @example
      * // Returns [(1.0, 1.0, 1.0), (2.0, 2.0, 2.0)]
@@ -224,7 +224,7 @@ define([
 
         var length = positions.length;
         if (length < 2) {
-            return undefined;
+            return positions;
         }
 
         var i;
@@ -240,7 +240,7 @@ define([
         }
 
         if (i === length) {
-            return undefined;
+            return positions;
         }
 
         var cleanedPositions = positions.slice(0, i);
@@ -286,15 +286,29 @@ define([
         }
         //>>includeEnd('debug');
 
+        var length = positions.length;
         var ellipsoid = defaultValue(options.ellipsoid, Ellipsoid.WGS84);
         var height = defaultValue(options.height, 0);
+
+        if (length < 1) {
+            return [];
+        } else if (length === 1) {
+            var p = ellipsoid.scaleToGeodeticSurface(positions[0], scaleFirst);
+            if (height !== 0) {
+                var n = ellipsoid.geodeticSurfaceNormal(p, cartesian);
+                Cartesian3.multiplyByScalar(n, height, n);
+                Cartesian3.add(p, n, p);
+            }
+
+            return [p.x, p.y, p.z];
+        }
+
         var minDistance = options.minDistance;
         if (!defined(minDistance)) {
             var granularity = defaultValue(options.granularity, CesiumMath.RADIANS_PER_DEGREE);
             minDistance = CesiumMath.chordLength(granularity, ellipsoid.maximumRadius);
         }
 
-        var length = positions.length;
         var numPoints = 0;
         var i;
 

--- a/Source/Scene/Polyline.js
+++ b/Source/Scene/Polyline.js
@@ -62,9 +62,6 @@ define([
 
         this._positions = positions;
         this._actualPositions = PolylinePipeline.removeDuplicates(positions);
-        if (!defined(this._actualPositions)) {
-            this._actualPositions = positions;
-        }
 
         if (this._loop && this._actualPositions.length > 2) {
             if (this._actualPositions === this._positions) {
@@ -160,9 +157,6 @@ define([
                 //>>includeEnd('debug');
 
                 var positions = PolylinePipeline.removeDuplicates(value);
-                if (!defined(positions)) {
-                    positions = value;
-                }
 
                 if (this._loop && positions.length > 2) {
                     if (positions === value) {

--- a/Specs/Core/PolylinePipelineSpec.js
+++ b/Specs/Core/PolylinePipelineSpec.js
@@ -24,6 +24,11 @@ defineSuite([
         expect(segments.lengths[0]).toEqual(2);
     });
 
+    it('wrapLongitude works with empty array', function() {
+        var segments = PolylinePipeline.wrapLongitude([]);
+        expect(segments.lengths.length).toEqual(0);
+    });
+
     it('wrapLongitude breaks polyline into segments', function() {
         var positions = Cartesian3.fromDegreesArray([
             -179.0, 39.0,
@@ -47,10 +52,16 @@ defineSuite([
         expect(segments.lengths[1]).toEqual(2);
     });
 
-    it('removeDuplicates returns false', function() {
+    it('removeDuplicates returns positions if none removed', function() {
         var positions = [Cartesian3.ZERO];
         var noDuplicates = PolylinePipeline.removeDuplicates(positions);
-        expect(noDuplicates).not.toBeDefined();
+        expect(noDuplicates).toBe(positions);
+    });
+
+    it('removeDuplicates returns positions if none removed', function() {
+        var positions = [Cartesian3.ZERO, Cartesian3.UNIT_X, Cartesian3.UNIT_Y, Cartesian3.UNIT_Z];
+        var noDuplicates = PolylinePipeline.removeDuplicates(positions);
+        expect(noDuplicates).toBe(positions);
     });
 
     it('removeDuplicates to remove duplicates', function() {
@@ -68,6 +79,12 @@ defineSuite([
             new Cartesian3(3.0, 3.0, 3.0)];
         var noDuplicates = PolylinePipeline.removeDuplicates(positions);
         expect(noDuplicates).toEqual(expectedPositions);
+    });
+
+    it('removeDuplicates works with empty array', function() {
+        var positions = [];
+        var noDuplicates = PolylinePipeline.removeDuplicates(positions);
+        expect(noDuplicates).toEqual(positions);
     });
 
     it('removeDuplicates to remove positions within absolute epsilon 7', function() {
@@ -140,4 +157,23 @@ defineSuite([
         expect(Cartesian3.equalsEpsilon(p2, p2n, CesiumMath.EPSILON4)).toEqual(true);
         expect(Cartesian3.equalsEpsilon(p3, p3n, CesiumMath.EPSILON4)).toEqual(true);
     });
+
+    it('generateArc works with empty array', function() {
+        var newPositions = PolylinePipeline.generateArc({
+            positions: []
+        });
+
+        expect(newPositions.length).toEqual(0);
+    });
+
+    it('generateArc works one position', function() {
+        var newPositions = PolylinePipeline.generateArc({
+            positions: [Cartesian3.UNIT_Z],
+            ellipsoid: Ellipsoid.UNIT_SPHERE
+        });
+
+        expect(newPositions.length).toEqual(3);
+        expect(newPositions).toEqual([0,0,1]);
+    });
+
 });


### PR DESCRIPTION
This fixes some minor issues with the `PolylinePipeline` I found while working on the measurement widget.

+ `PolylinePipeline.generateArc` works with `positions = []`
+ `PolylinePipeline.removeDuplicates` returns the input array if no duplicates were found instead of returning undefined.  (Every place where this function is called did this anyway.)

And while I was at it, I changed `PolygonPipeline.removeDuplicates` to call `PolylinePipeline.removeDuplicates` then check to see if the first and last points are equal.  This eliminates some duplicated code.