### PR TITLE
Don't use a stale extent for a non-global base layer

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@ Change Log
 * `Model` can now load Binary glTF from a Uint8Array.
 * Added a new camera mode for horizon views. When the camera is looking at the horizon and a point on terrain above the camera is picked, the camera moves in the plane containing the camera position, up and right vectors.
 * Added `UrlTemplateImageryProvider`.  This new imagery provider allows access to a wide variety of imagery sources, including OpenStreetMap, TMS, WMTS, WMS, WMS-C, and various custom schemes, by specifying a URL template to use to request imagery tiles.
+* Fixed a bug in `ImageryLayer` that could cause an exception and the render loop to stop when the base layer did not cover the entire globe.
 
 ### 1.10 - 2015-06-01
 

--- a/Source/Scene/ImageryLayer.js
+++ b/Source/Scene/ImageryLayer.js
@@ -395,12 +395,18 @@ define([
                 rectangle.north = rectangle.south = baseImageryRectangle.north;
             } else if (baseTerrainRectangle.north <= baseImageryRectangle.south) {
                 rectangle.north = rectangle.south = baseImageryRectangle.south;
+            } else {
+                rectangle.south = Math.max(baseTerrainRectangle.south, baseImageryRectangle.south);
+                rectangle.north = Math.min(baseTerrainRectangle.north, baseImageryRectangle.north);
             }
 
             if (baseTerrainRectangle.west >= baseImageryRectangle.east) {
                 rectangle.west = rectangle.east = baseImageryRectangle.east;
             } else if (baseTerrainRectangle.east <= baseImageryRectangle.west) {
                 rectangle.west = rectangle.east = baseImageryRectangle.west;
+            } else {
+                rectangle.west = Math.max(baseTerrainRectangle.west, baseImageryRectangle.west);
+                rectangle.east = Math.min(baseTerrainRectangle.east, baseImageryRectangle.east);
             }
         }
 

--- a/Specs/Scene/ImageryLayerSpec.js
+++ b/Specs/Scene/ImageryLayerSpec.js
@@ -318,29 +318,6 @@ defineSuite([
             });
         });
 
-        /*it('does not get confused when base layer imagery overlaps in one direction but not the other', function() {
-            
-            // Prime the pump with some bad data.
-            var wholeWorldProvider = new SingleTileImageryProvider({
-                url : 'Data/Images/Blue.png'
-            });
-
-            var smallProvider = new TileMapServiceImageryProvider({
-                url : 'Data/Images/Green.png',
-                tilingScheme : new WebMercatorTilingScheme(),
-                rectangle : new Rectangle(0.1, 0.2, 0.1, 0.2);
-            });
-
-            return pollToPromise(function() {
-                return wholeWorldProvider.ready && smallProvider.ready;
-            }).then(function() {
-                var tiles = QuadtreeTile.createLevelZeroTiles(terrainProvider.tilingScheme);
-                tiles[0].data = new GlobeSurfaceTile();
-
-                layer._createTileImagerySkeletons(tiles[0], terrainProvider);
-            });
-        });*/
-
         it('handles a non-base layer that does not cover the entire globe', function() {
             var baseProvider = new SingleTileImageryProvider({
                 url : 'Data/Images/Green4x4.png'

--- a/Specs/Scene/ImageryLayerSpec.js
+++ b/Specs/Scene/ImageryLayerSpec.js
@@ -267,6 +267,80 @@ defineSuite([
             });
         });
 
+        it('does not get confused when base layer imagery overlaps in one direction but not the other', function() {
+            // This is a pretty specific test targeted at https://github.com/AnalyticalGraphicsInc/cesium/issues/2815
+            // It arranges for tileImageryBoundsScratch to be a rectangle that is invalid in the WebMercator projection.
+            // Then, it triggers issue #2815 where that stale data is used in a later call.  Prior to the fix this
+            // triggers an exception (use of an undefined reference).
+
+            var wholeWorldProvider = new SingleTileImageryProvider({
+                url : 'Data/Images/Blue.png'
+            });
+
+            var provider = new TileMapServiceImageryProvider({
+                url : 'Data/TMS/SmallArea'
+            });
+
+            var layers = new ImageryLayerCollection();
+            var wholeWorldLayer = layers.addImageryProvider(wholeWorldProvider);
+            var terrainProvider = new EllipsoidTerrainProvider();
+
+            return pollToPromise(function() {
+                return wholeWorldProvider.ready && provider.ready && terrainProvider.ready;
+            }).then(function() {
+                var tiles = QuadtreeTile.createLevelZeroTiles(terrainProvider.tilingScheme);
+                tiles[0].data = new GlobeSurfaceTile();
+                tiles[1].data = new GlobeSurfaceTile();
+
+                wholeWorldLayer._createTileImagerySkeletons(tiles[0], terrainProvider);
+                wholeWorldLayer._createTileImagerySkeletons(tiles[1], terrainProvider);
+
+                layers.removeAll();
+                var layer = layers.addImageryProvider(provider);
+
+                // Use separate tiles for the small area provider.
+                tiles = QuadtreeTile.createLevelZeroTiles(terrainProvider.tilingScheme);
+                tiles[0].data = new GlobeSurfaceTile();
+                tiles[1].data = new GlobeSurfaceTile();
+
+                // The stale data was used in this call prior to the fix.
+                layer._createTileImagerySkeletons(tiles[1], terrainProvider);
+
+                // Same assertions as above as in 'handles a base layer that does not cover the entire globe'
+                // as a sanity check.  Really we're just testing that the call above doesn't throw.
+                expect(tiles[1].data.imagery.length).toBe(2);
+                expect(tiles[1].data.imagery[0].textureCoordinateRectangle.x).toBe(0.0);
+                expect(tiles[1].data.imagery[0].textureCoordinateRectangle.w).toBe(1.0);
+                expect(tiles[1].data.imagery[0].textureCoordinateRectangle.z).toBe(1.0);
+                expect(tiles[1].data.imagery[1].textureCoordinateRectangle.x).toBe(0.0);
+                expect(tiles[1].data.imagery[1].textureCoordinateRectangle.y).toBe(0.0);
+                expect(tiles[1].data.imagery[1].textureCoordinateRectangle.z).toBe(1.0);
+            });
+        });
+
+        /*it('does not get confused when base layer imagery overlaps in one direction but not the other', function() {
+            
+            // Prime the pump with some bad data.
+            var wholeWorldProvider = new SingleTileImageryProvider({
+                url : 'Data/Images/Blue.png'
+            });
+
+            var smallProvider = new TileMapServiceImageryProvider({
+                url : 'Data/Images/Green.png',
+                tilingScheme : new WebMercatorTilingScheme(),
+                rectangle : new Rectangle(0.1, 0.2, 0.1, 0.2);
+            });
+
+            return pollToPromise(function() {
+                return wholeWorldProvider.ready && smallProvider.ready;
+            }).then(function() {
+                var tiles = QuadtreeTile.createLevelZeroTiles(terrainProvider.tilingScheme);
+                tiles[0].data = new GlobeSurfaceTile();
+
+                layer._createTileImagerySkeletons(tiles[0], terrainProvider);
+            });
+        });*/
+
         it('handles a non-base layer that does not cover the entire globe', function() {
             var baseProvider = new SingleTileImageryProvider({
                 url : 'Data/Images/Green4x4.png'


### PR DESCRIPTION
Broken logic could leave a rectangle in `_createTileImagerySkeletons` with stale data.  Mostly this was harmless-ish, but if the stale data happened to lie outside the valid bounds of the imagery layer's tiling scheme, it could cause the exception seen in #2815.

Fixes #2815