### PR TITLE
Make renderState better aware of passState during partialApply.

### DIFF
--- a/Source/Renderer/Context.js
+++ b/Source/Renderer/Context.js
@@ -302,6 +302,7 @@ define([
 
         this._us = us;
         this._currentRenderState = rs;
+        this._currentPassState = ps;
         this._currentFramebuffer = undefined;
         this._maxFrameTextureUnitIndex = 0;
 
@@ -1703,12 +1704,11 @@ define([
     }
 
     function applyRenderState(context, renderState, passState) {
-        var previousState = context._currentRenderState;
-        if (previousState !== renderState) {
-            context._currentRenderState = renderState;
-            RenderState.partialApply(context._gl, previousState, renderState, passState);
-         }
-         // else same render state as before so state is already applied.
+        var previousRenderState = context._currentRenderState;
+        var previousPassState = context._currentPassState;
+        context._currentRenderState = renderState;
+        context._currentPassState = passState;
+        RenderState.partialApply(context._gl, previousRenderState, renderState, previousPassState, passState);
     }
 
     var scratchBackBufferArray;


### PR DESCRIPTION
This changes `RenderState.partialApply` to be more careful of specific changes to the passState that affect the current renderState.  It attempts to keep all of the optimizations from the previous implementation except where they were so aggressive as to miss needed state changes.

With this change, the functions that apply the state transition between two renderStates are not allowed access to the passState at all.  The passState is reconciled separately, and is always considered even if the renderStates were identical.

Looks like test coverage is missing from this area of the code, @pjcozzi said it might be hard to test.  Perhaps a mock gl context could be constructed with spy listeners, but that likely won't happen for 1.11.

Fixes #2790
Fixes #2811
