### PR TITLE
Fix for #2813 (scene.drillPick breaks scene.pickPosition)

### DIFF
--- a/Apps/Sandcastle/gallery/Picking.html
+++ b/Apps/Sandcastle/gallery/Picking.html
@@ -36,6 +36,7 @@ var scene = viewer.scene;
 var handler;
 
 Sandcastle.addDefaultToolbarButton('Show Cartographic Position on Mouse Over', function() {
+    scene.camera.viewRectangle(Cesium.Camera.DEFAULT_VIEW_RECTANGLE, scene.mapProjection.ellipsoid);
     var ellipsoid = scene.globe.ellipsoid;
     var entity = viewer.entities.add({
         label : {
@@ -68,6 +69,7 @@ Sandcastle.addToolbarButton('Pick Entity', function() {
             image : '../images/Cesium_Logo_overlay.png'
         }
     });
+    viewer.zoomTo(entity);
 
     // If the mouse is over the billboard, change its scale and color
     handler = new Cesium.ScreenSpaceEventHandler(scene.canvas);
@@ -126,6 +128,8 @@ Sandcastle.addToolbarButton('Drill-Down Picking', function() {
         }
     });
     makeProperty(green, Cesium.Color.GREEN.withAlpha(0.5));
+    
+    viewer.zoomTo(red);
 
     // Move the primitive that the mouse is over to the top.
     handler = new Cesium.ScreenSpaceEventHandler(scene.canvas);

--- a/Source/Scene/Scene.js
+++ b/Source/Scene/Scene.js
@@ -1987,6 +1987,16 @@ define([
             attributes.show = ShowGeometryInstanceAttribute.toValue(true, attributes.show);
         }
 
+        this._commandList.length = 0;
+        updatePrimitives(this);
+        createPotentiallyVisibleSet(this);
+
+        var passState = this._passState;
+        passState.framebuffer = undefined;
+        passState.blendingEnabled = undefined;
+        passState.scissorTest = undefined;
+        executeCommands(this, passState, defaultValue(this.backgroundColor, Color.BLACK));
+
         return result;
     };
 


### PR DESCRIPTION
Fixes #2813 

I don't know if this is the best solution, but I decided to take a guess.

Essentially, `drillPick` was setting the `show` property of primitives to `false`, then calling `pick`, which executes some commands to update the frame state. But when `drillPick` sets the `show` property back to `true`, it doesn't do that same update. So if `pickPosition` is called during the same frame, it thinks the primitives are still hidden.