### PR TITLE
normalize camera direction vectors for Camera.flyTo()

### DIFF
--- a/Source/Widgets/HomeButton/HomeButtonViewModel.js
+++ b/Source/Widgets/HomeButton/HomeButtonViewModel.js
@@ -55,6 +55,9 @@ define([
             right = Cartesian3.cross(direction, Cartesian3.UNIT_Z, new Cartesian3());
             up = Cartesian3.cross(right, direction, new Cartesian3());
 
+            Cartesian3.normalize(right, right);
+            Cartesian3.normalize(up, up);
+
             scene.camera.flyTo({
                 destination : destination,
                 orientation : {


### PR DESCRIPTION
Fixes invalid camera orientation when Camera.DEFAULT_VIEW_RECTANGLE is
not default (e.g. when set to `Rectangle.fromDegrees(-10, 40, 10, 50)`).