### PR TITLE
Remove usage of //cesiumjs.org/stk-terrain/world

### DIFF
--- a/Apps/Sandcastle/gallery/Interpolation.html
+++ b/Apps/Sandcastle/gallery/Interpolation.html
@@ -40,7 +40,7 @@ viewer.scene.globe.enableLighting = true;
 
 //Use STK World Terrain
 viewer.terrainProvider = new Cesium.CesiumTerrainProvider({
-    url : '//cesiumjs.org/stk-terrain/world',
+    url : '//assets.agi.com/stk-terrain/world',
     requestWaterMask : true,
     requestVertexNormals : true
 });

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,8 @@ Change Log
 ==========
 
 ### 1.11 - 2015-07-01
-
+* Deprecated
+  * The STK World Terrain url `cesiumjs.org/stk-terrain/world` has been deprecated, use `assets.agi.com/stk-terrain/world` instead.  A redirect will be in place until 1.14.
 * Improved the algorithm that `Camera.viewRectangle` uses to select the position of the camera, so that the specified rectangle is now better centered on the screen [#2764](https://github.com/AnalyticalGraphicsInc/cesium/issues/2764).
 * The performance statistics displayed by setting `scene.debugShowFramesPerSecond` to `true` can now be styled using the `cesium-performanceDisplay` CSS classes in `shared.css` [#2779](https://github.com/AnalyticalGraphicsInc/cesium/issues/2779).
 * Fixed a crash when `viewer.zoomTo` or `viewer.flyTo` were called immediately before or during a scene morph [#2775](https://github.com/AnalyticalGraphicsInc/cesium/issues/2775).


### PR DESCRIPTION
`//cesiumjs.org/stk-terrain/world` is an old url that has not been in the official documentation for some time, but we never officially deprecated it.  The new `cesiumjs.org` server is no longer co-located with `assets.agi.com`, so the redirect we provide will have reduced performance.  Better to remove the whole thing after a few more months.