### PR TITLE
Fix failing tests in master.

### DIFF
--- a/Specs/Core/sampleTerrainSpec.js
+++ b/Specs/Core/sampleTerrainSpec.js
@@ -33,7 +33,7 @@ defineSuite([
 
     it('queries heights from Small Terrain', function() {
         var terrainProvider = new CesiumTerrainProvider({
-            url : '//cesiumjs.org/smallterrain'
+            url : '//cesiumweb.cloudapp.net/smallterrain'
         });
 
         var positions = [

--- a/Specs/Scene/GlobeSurfaceTileSpec.js
+++ b/Specs/Scene/GlobeSurfaceTileSpec.js
@@ -89,7 +89,7 @@ defineSuite([
             };
 
             realTerrainProvider = new CesiumTerrainProvider({
-                url : 'http://cesiumjs.org/smallterrain'
+                url : 'http://cesiumweb.cloudapp.net/smallterrain'
             });
         });
 


### PR DESCRIPTION
The URL for the smallterrain data set went away a week early.  This fixes failing tests in master by using a different url that points back to the same old smallterrain set.

smallterrain is supposed to go away completely in 1.11, but I can't find an issue for it, this is just a band-aid so master can pass. 

I tried removing usage of small-terrain from the tests, but `GlobeSurfaceTileSpec` seems heavily tied to it.  @kring or @abwood can you have a look at see what the problem is?  Chaning the url in `GlobeSurfaceTileSpec` causes it to try and access `undefined` on line 218.