### PR TITLE
Fix tests failing in master.

### DIFF
--- a/Specs/Core/TransformsSpec.js
+++ b/Specs/Core/TransformsSpec.js
@@ -273,10 +273,7 @@ defineSuite([
     });
 
     it('computeTemeToPseudoFixedMatrix works before noon', function() {
-        var time = JulianDate.now();
-        var secondsDiff = TimeConstants.SECONDS_PER_DAY - time.secondsOfDay;
-        time = JulianDate.addSeconds(time, secondsDiff, new JulianDate());
-
+        var time = JulianDate.fromDate(new Date('June 29, 2015 12:00:00 UTC'));
         var t = Transforms.computeTemeToPseudoFixedMatrix(time);
 
         // rotation matrix determinants are 1.0
@@ -295,9 +292,7 @@ defineSuite([
     });
 
     it('computeTemeToPseudoFixedMatrix works after noon', function() {
-        var time = JulianDate.now();
-        var secondsDiff = TimeConstants.SECONDS_PER_DAY - time.secondsOfDay;
-        time = JulianDate.addSeconds(time, secondsDiff + TimeConstants.SECONDS_PER_DAY * 0.5, new JulianDate());
+        var time = JulianDate.fromDate(new Date('June 29, 2015 12:00:00 UTC'));
 
         var t = Transforms.computeTemeToPseudoFixedMatrix(time);
 
@@ -317,9 +312,7 @@ defineSuite([
     });
 
     it('computeTemeToPseudoFixedMatrix works with a result parameter', function() {
-        var time = JulianDate.now();
-        var secondsDiff = TimeConstants.SECONDS_PER_DAY - time.secondsOfDay;
-        time = JulianDate.addSeconds(time, secondsDiff, new JulianDate());
+        var time = JulianDate.fromDate(new Date('June 29, 2015 12:00:00 UTC'));
 
         var resultT = new Matrix3();
         var t = Transforms.computeTemeToPseudoFixedMatrix(time, resultT);


### PR DESCRIPTION
Either computeTemeToPseudoFixedMatrix (or the 3 tests we have for it) does not work if time is near a leap second.  Rather than using JulianDate.now(), I've hard coded working dates into the tests (which is usually a better practice anyway) and will write up an issue to investigate further.

Submitted: #2846 to determine the real problem in the future.