### PR TITLE
Add ArcGIS's proprietary token-based security to MapServer imagery provider

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@ Change Log
 * Make `ArcGisMapServerImageryprovider` issue `pickFeatures` requests via a proxy if one is specified.
 * Fixed incorrect texture coordinates for `WallGeometry` [#2872](https://github.com/AnalyticalGraphicsInc/cesium/issues/2872)
 * Added `maximumHeight` option to `Viewer.flyTo`. [#2868](https://github.com/AnalyticalGraphicsInc/cesium/issues/2868)
+* Added ArcGIS token-based authentication support to `ArcGisMapServerImageryProvider`
 
 ### 1.11 - 2015-07-01
 

--- a/Source/Scene/ArcGisMapServerImageryProvider.js
+++ b/Source/Scene/ArcGisMapServerImageryProvider.js
@@ -72,7 +72,7 @@ define([
      * @param {Boolean} [options.usePreCachedTilesIfAvailable=true] If true, the server's pre-cached
      *        tiles are used if they are available.  If false, any pre-cached tiles are ignored and the
      *        'export' service is used.
-     * @param {String} [layers] A comma-separated list of the layers to show, or undefined if all layers should be shown.
+     * @param {String} [options.layers] A comma-separated list of the layers to show, or undefined if all layers should be shown.
      * @param {Boolean} [options.enablePickFeatures=true] If true, {@link ArcGisMapServerImageryProvider#pickFeatures} will invoke
      *        the Identify service on the MapServer and return the features included in the response.  If false,
      *        {@link ArcGisMapServerImageryProvider#pickFeatures} will immediately return undefined (indicating no pickable features)

--- a/Specs/Scene/ArcGisMapServerImageryProviderSpec.js
+++ b/Specs/Scene/ArcGisMapServerImageryProviderSpec.js
@@ -5,6 +5,7 @@ defineSuite([
         'Core/Cartesian3',
         'Core/Cartographic',
         'Core/DefaultProxy',
+        'Core/defined',
         'Core/GeographicProjection',
         'Core/GeographicTilingScheme',
         'Core/jsonp',
@@ -28,6 +29,7 @@ defineSuite([
         Cartesian3,
         Cartographic,
         DefaultProxy,
+        defined,
         GeographicProjection,
         GeographicTilingScheme,
         jsonp,
@@ -54,7 +56,7 @@ defineSuite([
         loadWithXhr.load = loadWithXhr.defaultLoad;
     });
 
-    function expectCorrectUrl(expectedBaseUrl, actualUrl, functionName, withProxy) {
+    function expectCorrectUrl(expectedBaseUrl, actualUrl, functionName, withProxy, token) {
         var uri = new Uri(actualUrl);
 
         if (withProxy) {
@@ -68,15 +70,19 @@ defineSuite([
 
         expect(uriWithoutQuery.toString()).toEqual(expectedBaseUrl);
 
-        expect(params).toEqual({
+        var expectedParams = {
             callback : functionName,
             'f' : 'json'
-        });
+        };
+        if (defined(token)) {
+            expectedParams.token = token;
+        }
+        expect(params).toEqual(expectedParams);
     }
 
-    function stubJSONPCall(baseUrl, result, withProxy) {
+    function stubJSONPCall(baseUrl, result, withProxy, token) {
         jsonp.loadAndExecuteScript = function(url, functionName) {
-            expectCorrectUrl(baseUrl, url, functionName, withProxy);
+            expectCorrectUrl(baseUrl, url, functionName, withProxy, token);
             setTimeout(function() {
                 window[functionName](result);
             }, 1);
@@ -354,6 +360,58 @@ defineSuite([
 
                 // Just return any old image.
                 loadImage.defaultCreateImage('Data/Images/Red16x16.png', crossOrigin, deferred);
+            };
+
+            return provider.requestImage(0, 0, 0).then(function(image) {
+                expect(image).toBeInstanceOf(Image);
+            });
+        });
+    });
+
+    it('includes security token in requests if one is specified', function() {
+        var baseUrl = '//tiledArcGisMapServer.invalid',
+            token = '5e(u|2!7Y';
+
+        stubJSONPCall(baseUrl, webMercatorResult, false, token);
+
+        var provider = new ArcGisMapServerImageryProvider({
+            url : baseUrl,
+            token : token
+        });
+
+        expect(provider.url).toEqual(baseUrl);
+        expect(provider.token).toEqual(token);
+
+        return pollToPromise(function() {
+            return provider.ready;
+        }).then(function() {
+            expect(provider.tileWidth).toEqual(128);
+            expect(provider.tileHeight).toEqual(256);
+            expect(provider.maximumLevel).toEqual(2);
+            expect(provider.tilingScheme).toBeInstanceOf(WebMercatorTilingScheme);
+            expect(provider.credit).toBeDefined();
+            expect(provider.tileDiscardPolicy).toBeInstanceOf(DiscardMissingTileImagePolicy);
+            expect(provider.rectangle).toEqual(new WebMercatorTilingScheme().rectangle);
+            expect(provider.usingPrecachedTiles).toEqual(true);
+            expect(provider.hasAlphaChannel).toBeDefined();
+
+            loadImage.createImage = function(url, crossOrigin, deferred) {
+                if (/^blob:/.test(url)) {
+                    // load blob url normally
+                    loadImage.defaultCreateImage(url, crossOrigin, deferred);
+                } else {
+                    expect(url).toEqual(baseUrl + '/tile/0/0/0?token=' + token);
+
+                    // Just return any old image.
+                    loadImage.defaultCreateImage('Data/Images/Red16x16.png', crossOrigin, deferred);
+                }
+            };
+
+            loadWithXhr.load = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
+                expect(url).toEqual(baseUrl + '/tile/0/0/0?token=' + token);
+
+                // Just return any old image.
+                loadWithXhr.defaultLoad('Data/Images/Red16x16.png', responseType, method, data, headers, deferred);
             };
 
             return provider.requestImage(0, 0, 0).then(function(image) {


### PR DESCRIPTION
As the title says; see the commit messages for details (copied below).  Simply put, this adds support for a `securityToken` option to the `ArcGisMapServerImageryProvider` which adds it to outgoing requests if specified.

Suggestions for improvement welcome.  I'm imagining authentication for `ImageryProvider`s and `TerrainProvider`s might be worth considering abstracting further, but I'm unsure.

This also includes a fix (from a merged branch, `fix-arcgismapserverimageryprovider-jsdoc`) for #2822.

> This adds support for ArcGIS's proprietary token-based authentication for
services. [1]
> 
> The solution is not robust: tokens are subject to expiration, after which point
the imagery provider will begin throwing exceptions (rightfully so).
> 
> Abstracting authentication further (outside of ArcGIS MapServer imagery
providers) may be a good idea, but is a larger task worth more thought.
> 
> Further, ArcGIS supports requesting security tokens for a set of credentials
via HTTP (GET, possibly POST as well), though this is not guaranteed to be
enabled on the server.
> 
> [1] http://resources.arcgis.com/en/help/main/10.1/index.html#/About_ArcGIS_tokens/0155000005s0000000/