### PR TITLE
Make most tests pass on IE11

### DIFF
--- a/Source/Scene/Scene.js
+++ b/Source/Scene/Scene.js
@@ -597,7 +597,7 @@ define([
          */
         pickPositionSupported : {
             get : function() {
-                return this._context.depthTexture;
+                return defined(this._context.depthTexture) && defined(this._globeDepth);
             }
         },
 
@@ -2068,7 +2068,10 @@ define([
 
         this._transitioner.destroy();
 
-        this._globeDepth.destroy();
+        if (defined(this._globeDepth)) {
+            this._globeDepth.destroy();
+        }
+
         if (defined(this._oit)) {
             this._oit.destroy();
         }

--- a/Source/Scene/Scene.js
+++ b/Source/Scene/Scene.js
@@ -597,7 +597,7 @@ define([
          */
         pickPositionSupported : {
             get : function() {
-                return defined(this._context.depthTexture) && defined(this._globeDepth);
+                return this._context.depthTexture;
             }
         },
 

--- a/Specs/DomEventSimulator.js
+++ b/Specs/DomEventSimulator.js
@@ -1,8 +1,10 @@
 /*global define*/
 define([
-        'Core/defaultValue'
+        'Core/defaultValue',
+        'Core/FeatureDetection'
     ], function(
-        defaultValue) {
+        defaultValue,
+        FeatureDetection) {
     "use strict";
 
     function createMouseEvent(type, options) {

--- a/Specs/DomEventSimulator.js
+++ b/Specs/DomEventSimulator.js
@@ -1,10 +1,8 @@
 /*global define*/
 define([
-        'Core/defaultValue',
-        'Core/FeatureDetection'
+        'Core/defaultValue'
     ], function(
-        defaultValue,
-        FeatureDetection) {
+        defaultValue) {
     "use strict";
 
     function createMouseEvent(type, options) {

--- a/Specs/Scene/BillboardCollectionSpec.js
+++ b/Specs/Scene/BillboardCollectionSpec.js
@@ -6,6 +6,7 @@ defineSuite([
         'Core/Cartesian2',
         'Core/Cartesian3',
         'Core/Color',
+        'Core/defined',
         'Core/Ellipsoid',
         'Core/loadImage',
         'Core/Math',
@@ -25,6 +26,7 @@ defineSuite([
         Cartesian2,
         Cartesian3,
         Color,
+        defined,
         Ellipsoid,
         loadImage,
         CesiumMath,
@@ -55,7 +57,7 @@ defineSuite([
         scene = createScene();
         camera = scene.camera;
 
-        heightReferenceSupported = scene._globeDepth.supported && scene.context.maximumVertexTextureImageUnits > 0;
+        heightReferenceSupported = defined(scene._globeDepth) && scene._globeDepth.supported && scene.context.maximumVertexTextureImageUnits > 0;
 
         return when.join(
             loadImage('./Data/Images/Green.png').then(function(result) {

--- a/Specs/Scene/LabelCollectionSpec.js
+++ b/Specs/Scene/LabelCollectionSpec.js
@@ -5,6 +5,7 @@ defineSuite([
         'Core/Cartesian2',
         'Core/Cartesian3',
         'Core/Color',
+        'Core/defined',
         'Core/Ellipsoid',
         'Core/Math',
         'Core/NearFarScalar',
@@ -20,6 +21,7 @@ defineSuite([
         Cartesian2,
         Cartesian3,
         Color,
+        defined,
         Ellipsoid,
         CesiumMath,
         NearFarScalar,
@@ -44,7 +46,7 @@ defineSuite([
         scene = createScene();
         camera = scene.camera;
 
-        heightReferenceSupported = scene._globeDepth.supported && scene.context.maximumVertexTextureImageUnits > 0;
+        heightReferenceSupported = defined(scene._globeDepth) && scene._globeDepth.supported && scene.context.maximumVertexTextureImageUnits > 0;
     });
 
     afterAll(function() {

--- a/Specs/Scene/SceneSpec.js
+++ b/Specs/Scene/SceneSpec.js
@@ -4,6 +4,7 @@ defineSuite([
         'Core/Cartesian2',
         'Core/Cartesian3',
         'Core/Color',
+        'Core/defined',
         'Core/Ellipsoid',
         'Core/GeographicProjection',
         'Core/PixelFormat',
@@ -30,6 +31,7 @@ defineSuite([
         Cartesian2,
         Cartesian3,
         Color,
+        defined,
         Ellipsoid,
         GeographicProjection,
         PixelFormat,
@@ -232,6 +234,10 @@ defineSuite([
     });
 
     it('debugShowGlobeDepth', function() {
+        if(!defined(scene._globeDepth)){
+            return;
+        }
+
         var rectangle = Rectangle.fromDegrees(-100.0, 30.0, -90.0, 40.0);
         scene.camera.viewRectangle(rectangle);
 
@@ -393,8 +399,11 @@ defineSuite([
         }
 
         var s = createScene();
-        s._oit._translucentMRTSupport = false;
-        s._oit._translucentMultipassSupport = false;
+
+        if (defined(s._oit)) {
+            s._oit._translucentMRTSupport = false;
+            s._oit._translucentMultipassSupport = false;
+        }
 
         s.fxaa = true;
 
@@ -463,35 +472,40 @@ defineSuite([
     it('renders with multipass OIT if MRT is available', function() {
         if (scene.context.drawBuffers) {
             var s = createScene();
-            s._oit._translucentMRTSupport = false;
-            s._oit._translucentMultipassSupport = true;
+            if (defined(s._oit)) {
+                s._oit._translucentMRTSupport = false;
+                s._oit._translucentMultipassSupport = true;
 
-            var rectangle = Rectangle.fromDegrees(-100.0, 30.0, -90.0, 40.0);
+                var rectangle = Rectangle.fromDegrees(-100.0, 30.0, -90.0, 40.0);
 
-            var rectanglePrimitive = new RectanglePrimitive({
-                rectangle : rectangle,
-                height : 1000.0,
-                asynchronous : false
-            });
-            rectanglePrimitive.material.uniforms.color = new Color(1.0, 0.0, 0.0, 0.5);
+                var rectanglePrimitive = new RectanglePrimitive({
+                    rectangle : rectangle,
+                    height : 1000.0,
+                    asynchronous : false
+                });
+                rectanglePrimitive.material.uniforms.color = new Color(1.0, 0.0, 0.0, 0.5);
 
-            var primitives = s.primitives;
-            primitives.add(rectanglePrimitive);
+                var primitives = s.primitives;
+                primitives.add(rectanglePrimitive);
 
-            s.camera.viewRectangle(rectangle);
+                s.camera.viewRectangle(rectangle);
 
-            var pixels = s.renderForSpecs();
-            expect(pixels[0]).not.toEqual(0);
-            expect(pixels[1]).toEqual(0);
-            expect(pixels[2]).toEqual(0);
+                var pixels = s.renderForSpecs();
+                expect(pixels[0]).not.toEqual(0);
+                expect(pixels[1]).toEqual(0);
+                expect(pixels[2]).toEqual(0);
+            }
 
             s.destroyForSpecs();
         }
     });
 
     it('renders with alpha blending if floating point textures are available', function() {
-        if (scene.context.floatingPointTexture) {
-            var s = createScene();
+        if (!scene.context.floatingPointTexture) {
+            return;
+        }
+        var s = createScene();
+        if (defined(s._oit)) {
             s._oit._translucentMRTSupport = false;
             s._oit._translucentMultipassSupport = false;
 
@@ -513,39 +527,45 @@ defineSuite([
             expect(pixels[0]).not.toEqual(0);
             expect(pixels[1]).toEqual(0);
             expect(pixels[2]).toEqual(0);
-
-            s.destroyForSpecs();
         }
+        s.destroyForSpecs();
     });
 
     it('copies the globe depth', function() {
         var scene = createScene();
+        if (defined(scene._globeDepth)) {
+            var rectangle = Rectangle.fromDegrees(-100.0, 30.0, -90.0, 40.0);
 
-        var rectangle = Rectangle.fromDegrees(-100.0, 30.0, -90.0, 40.0);
+            var rectanglePrimitive = new RectanglePrimitive({
+                rectangle : rectangle,
+                height : 1000.0,
+                asynchronous : false
+            });
+            rectanglePrimitive.material.uniforms.color = new Color(1.0, 0.0, 0.0, 0.5);
 
-        var rectanglePrimitive = new RectanglePrimitive({
-            rectangle : rectangle,
-            height : 1000.0,
-            asynchronous : false
-        });
-        rectanglePrimitive.material.uniforms.color = new Color(1.0, 0.0, 0.0, 0.5);
+            var primitives = scene.primitives;
+            primitives.add(rectanglePrimitive);
 
-        var primitives = scene.primitives;
-        primitives.add(rectanglePrimitive);
+            scene.camera.viewRectangle(rectangle);
 
-        scene.camera.viewRectangle(rectangle);
+            var uniformState = scene.context.uniformState;
 
-        var uniformState = scene.context.uniformState;
+            scene.renderForSpecs();
+            expect(uniformState.globeDepthTexture).not.toBeDefined();
 
-        scene.renderForSpecs();
-        expect(uniformState.globeDepthTexture).not.toBeDefined();
+            scene.copyGlobeDepth = true;
+            scene.renderForSpecs();
+            expect(uniformState.globeDepthTexture).toBeDefined();
+        }
 
-        scene.copyGlobeDepth = true;
-        scene.renderForSpecs();
-        expect(uniformState.globeDepthTexture).toBeDefined();
+        scene.destroyForSpecs();
     });
 
     it('pickPosition', function() {
+        if (!scene.pickPositionSupported) {
+            return;
+        }
+
         var rectangle = Rectangle.fromDegrees(-100.0, 30.0, -90.0, 40.0);
         scene.camera.viewRectangle(rectangle);
 

--- a/Specs/Widgets/CesiumWidget/CesiumWidgetSpec.js
+++ b/Specs/Widgets/CesiumWidget/CesiumWidgetSpec.js
@@ -215,13 +215,6 @@ defineSuite([
         expect(contextAttributes.preserveDrawingBuffer).toEqual(webglOptions.preserveDrawingBuffer);
     });
 
-    it('can enable Order Independent Translucency', function() {
-        widget = new CesiumWidget(container, {
-            orderIndependentTranslucency : true
-        });
-        expect(widget.scene.orderIndependentTranslucency).toBe(true);
-    });
-
     it('can disable Order Independent Translucency', function() {
         widget = new CesiumWidget(container, {
             orderIndependentTranslucency : false

--- a/Specs/Widgets/NavigationHelpButton/NavigationHelpButtonSpec.js
+++ b/Specs/Widgets/NavigationHelpButton/NavigationHelpButtonSpec.js
@@ -1,9 +1,11 @@
 /*global defineSuite*/
 defineSuite([
         'Widgets/NavigationHelpButton/NavigationHelpButton',
+        'Core/FeatureDetection',
         'Specs/DomEventSimulator'
     ], function(
         NavigationHelpButton,
+        FeatureDetection,
         DomEventSimulator) {
     "use strict";
     /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn*/
@@ -42,47 +44,35 @@ defineSuite([
         widget.destroy();
     });
 
-    it('mousedown event closes dropdown if target is not inside container', function() {
-        var container = document.createElement('span');
-        container.id = 'testContainer';
-        document.body.appendChild(container);
+    function addCloseOnInputSpec(name, func) {
+        it(name + ' event closes dropdown if target is not inside container', function() {
+            var container = document.createElement('span');
+            container.id = 'testContainer';
+            document.body.appendChild(container);
 
-        var widget = new NavigationHelpButton({
-            container : 'testContainer'
+            var widget = new NavigationHelpButton({
+                container : 'testContainer'
+            });
+
+            widget.viewModel.showInstructions = true;
+            func(document.body);
+            expect(widget.viewModel.showInstructions).toEqual(false);
+
+            widget.viewModel.showInstructions = true;
+            func(container.firstChild);
+            expect(widget.viewModel.showInstructions).toEqual(true);
+
+            widget.destroy();
+            document.body.removeChild(container);
         });
+    }
 
-        widget.viewModel.showInstructions = true;
-        DomEventSimulator.fireMouseDown(document.body);
-        expect(widget.viewModel.showInstructions).toEqual(false);
-
-        widget.viewModel.showInstructions = true;
-        DomEventSimulator.fireMouseDown(container.firstChild);
-        expect(widget.viewModel.showInstructions).toEqual(true);
-
-        widget.destroy();
-        document.body.removeChild(container);
-    });
-
-    it('touchstart event closes dropdown if target is not inside container', function() {
-        var container = document.createElement('span');
-        container.id = 'testContainer';
-        document.body.appendChild(container);
-
-        var widget = new NavigationHelpButton({
-            container : 'testContainer'
-        });
-
-        widget.viewModel.showInstructions = true;
-        DomEventSimulator.fireTouchStart(document.body);
-        expect(widget.viewModel.showInstructions).toEqual(false);
-
-        widget.viewModel.showInstructions = true;
-        DomEventSimulator.fireTouchStart(container.firstChild);
-        expect(widget.viewModel.showInstructions).toEqual(true);
-
-        widget.destroy();
-        document.body.removeChild(container);
-    });
+    if (FeatureDetection.supportsPointerEvents()) {
+        addCloseOnInputSpec('pointerDown', DomEventSimulator.firePointerDown);
+    } else {
+        addCloseOnInputSpec('mousedown', DomEventSimulator.fireMouseDown);
+        addCloseOnInputSpec('touchstart', DomEventSimulator.fireTouchStart);
+    }
 
     it('throws if container is undefined', function() {
         expect(function() {

--- a/Specs/Widgets/SceneModePicker/SceneModePickerSpec.js
+++ b/Specs/Widgets/SceneModePicker/SceneModePickerSpec.js
@@ -1,10 +1,12 @@
 /*global defineSuite*/
 defineSuite([
         'Widgets/SceneModePicker/SceneModePicker',
+        'Core/FeatureDetection',
         'Specs/createScene',
         'Specs/DomEventSimulator'
     ], function(
         SceneModePicker,
+        FeatureDetection,
         createScene,
         DomEventSimulator) {
     "use strict";
@@ -35,43 +37,33 @@ defineSuite([
         document.body.removeChild(container);
     });
 
-    it('mousedown event closes dropdown if target is not inside container', function() {
-        var container = document.createElement('span');
-        container.id = 'testContainer';
-        document.body.appendChild(container);
+    function addCloseOnInputSpec(name, func) {
+        it(name + ' event closes dropdown if target is not inside container', function() {
+            var container = document.createElement('span');
+            container.id = 'testContainer';
+            document.body.appendChild(container);
 
-        var widget = new SceneModePicker('testContainer', scene);
+            var widget = new SceneModePicker('testContainer', scene);
 
-        widget.viewModel.dropDownVisible = true;
-        DomEventSimulator.fireMouseDown(document.body);
-        expect(widget.viewModel.dropDownVisible).toEqual(false);
+            widget.viewModel.dropDownVisible = true;
+            func(document.body);
+            expect(widget.viewModel.dropDownVisible).toEqual(false);
 
-        widget.viewModel.dropDownVisible = true;
-        DomEventSimulator.fireMouseDown(container.firstChild);
-        expect(widget.viewModel.dropDownVisible).toEqual(true);
+            widget.viewModel.dropDownVisible = true;
+            func(container.firstChild);
+            expect(widget.viewModel.dropDownVisible).toEqual(true);
 
-        widget.destroy();
-        document.body.removeChild(container);
-    });
+            widget.destroy();
+            document.body.removeChild(container);
+        });
+    }
 
-    it('touchstart event closes dropdown if target is not inside container', function() {
-        var container = document.createElement('span');
-        container.id = 'testContainer';
-        document.body.appendChild(container);
-
-        var widget = new SceneModePicker('testContainer', scene);
-
-        widget.viewModel.dropDownVisible = true;
-        DomEventSimulator.fireTouchStart(document.body);
-        expect(widget.viewModel.dropDownVisible).toEqual(false);
-
-        widget.viewModel.dropDownVisible = true;
-        DomEventSimulator.fireTouchStart(container.firstChild);
-        expect(widget.viewModel.dropDownVisible).toEqual(true);
-
-        widget.destroy();
-        document.body.removeChild(container);
-    });
+    if (FeatureDetection.supportsPointerEvents()) {
+        addCloseOnInputSpec('pointerDown', DomEventSimulator.firePointerDown);
+    } else {
+        addCloseOnInputSpec('mousedown', DomEventSimulator.fireMouseDown);
+        addCloseOnInputSpec('touchstart', DomEventSimulator.fireTouchStart);
+    }
 
     it('constructor throws with no transitioner', function() {
         expect(function() {

--- a/Specs/Widgets/Viewer/ViewerSpec.js
+++ b/Specs/Widgets/Viewer/ViewerSpec.js
@@ -374,13 +374,6 @@ defineSuite([
         expect(contextAttributes.preserveDrawingBuffer).toEqual(webglOptions.preserveDrawingBuffer);
     });
 
-    it('can enable Order Independent Translucency', function() {
-        viewer = new Viewer(container, {
-            orderIndependentTranslucency : true
-        });
-        expect(viewer.scene.orderIndependentTranslucency).toBe(true);
-    });
-
     it('can disable Order Independent Translucency', function() {
         viewer = new Viewer(container, {
             orderIndependentTranslucency : false


### PR DESCRIPTION
Merge #2858 first.

Apparently the IE 11 test failures we've been seeing for months were actually a bug in Cesium where we try to destroy `scene._globeDepth` even when it was undefined. Fixing that allowed IE11 to once again run tests to compeltion without thousands of errors. This then revealed several other spec-only issues that needed to be fixed as well.

This brings the overall number of failures down to 5, all of which look rendering related.  I'll write up a separate issue for them.