### PR TITLE
use proxy for picking in ArcGIS MapServer provider

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@ Change Log
   *
 * Fixes Cesium.js failing to parse in IE 8 and 9. While Cesium doesn't work in IE versions less than 11, but this allows for more graceful error handling.
 * Fix calling `Scene.pickPosition` after calling `Scene.drillPick`. [#2813](https://github.com/AnalyticalGraphicsInc/cesium/issues/2813)
+* Make ArcGIS MapServer imagery provider issue pickFeature requests via proxy if specified
 
 ### 1.11 - 2015-07-01
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -36,6 +36,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to Cesiu
    * [Evax Software](https://github.com/evax)
 * [Aviture](http://aviture.us.com)
    * [Mike Macaulay](https://github.com/mmacaula)
+   * [Nathan Schulte](https://github.com/nmschulte-aviture)
 * [Inovaworks](http://www.inovaworks.com/)
    * [Sergio Flores](https://github.com/relfos)
 * [CubeWerx Inc.](http://www.cubewerx.com/)

--- a/Source/Scene/ArcGisMapServerImageryProvider.js
+++ b/Source/Scene/ArcGisMapServerImageryProvider.js
@@ -606,6 +606,10 @@ define([
             url += ':' + this._layers;
         }
 
+        if (defined(this._proxy)) {
+            url = this._proxy.getURL(url);
+        }
+
         return loadJson(url).then(function(json) {
             var result = [];
 


### PR DESCRIPTION
causes the pickFeatures method to make pick requests via proxy, if specified
includes a test ensuring the proxy is used if specified

--

Looking at the tests for `ArcGisMapServerImageryProvider`, some of the tests are testing multiple concerns, not quite in line with their description.  I have followed suit here (and in previous PRs), but these tests could probably stand to be a bit more... disciplined/focused in their testing.  Just noting what I saw; not a big issue.