### PR TITLE
Update NPM packages to their latest versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,10 +9,10 @@
         "url": "https://github.com/AnalyticalGraphicsInc/cesium.git"
     },
     "devDependencies": {
-        "jsdoc": "3.3.0-beta3",
-        "express": "4.12.3",
-        "compression": "1.4.3",
-        "request": "2.55.0",
-        "yargs": "3.8.0"
+        "jsdoc": "3.3.2",
+        "express": "4.13.1",
+        "compression": "1.5.1",
+        "request": "2.58.0",
+        "yargs": "3.15.0"
     }
 }


### PR DESCRIPTION
No code changes needed.  This finally puts us on an official release of jsdoc, we've been using the alpha/betas forever.