### PR TITLE
Document inheritance hierarchy 

### DIFF
--- a/Source/Scene/Appearance.js
+++ b/Source/Scene/Appearance.js
@@ -22,115 +22,9 @@ define([
      * render state used to draw a {@link Primitive}.  All appearances implement
      * this base <code>Appearance</code> interface.
      *
-     * @alias Appearance
      * @interface
-     *
-     * @param {Object} [options] Object with the following properties:
-     * @param {Boolean} [options.translucent=true] When <code>true</code>, the geometry is expected to appear translucent so {@link Appearance#renderState} has alpha blending enabled.
-     * @param {Boolean} [options.closed=false] When <code>true</code>, the geometry is expected to be closed so {@link Appearance#renderState} has backface culling enabled.
-     * @param {Material} [options.material=Material.ColorType] The material used to determine the fragment color.
-     * @param {String} [options.vertexShaderSource] Optional GLSL vertex shader source to override the default vertex shader.
-     * @param {String} [options.fragmentShaderSource] Optional GLSL fragment shader source to override the default fragment shader.
-     * @param {RenderState} [options.renderState] Optional render state to override the default render state.
-     *
-     * @see MaterialAppearance
-     * @see EllipsoidSurfaceAppearance
-     * @see PerInstanceColorAppearance
-     * @see DebugAppearance
-     * @see PolylineColorAppearance
-     * @see PolylineMaterialAppearance
-     *
-     * @demo {@link http://cesiumjs.org/Cesium/Apps/Sandcastle/index.html?src=Geometry%20and%20Appearances.html|Geometry and Appearances Demo}
      */
-    var Appearance = function(options) {
-        options = defaultValue(options, defaultValue.EMPTY_OBJECT);
-
-        /**
-         * The material used to determine the fragment color.  Unlike other {@link Appearance}
-         * properties, this is not read-only, so an appearance's material can change on the fly.
-         *
-         * @type Material
-         *
-         * @see {@link https://github.com/AnalyticalGraphicsInc/cesium/wiki/Fabric|Fabric}
-         */
-        this.material = options.material;
-
-        /**
-         * When <code>true</code>, the geometry is expected to appear translucent.
-         *
-         * @type {Boolean}
-         *
-         * @default true
-         */
-        this.translucent = defaultValue(options.translucent, true);
-
-        this._vertexShaderSource = options.vertexShaderSource;
-        this._fragmentShaderSource = options.fragmentShaderSource;
-        this._renderState = options.renderState;
-        this._closed = defaultValue(options.closed, false);
-    };
-
-    defineProperties(Appearance.prototype, {
-        /**
-         * The GLSL source code for the vertex shader.
-         *
-         * @memberof Appearance.prototype
-         *
-         * @type {String}
-         * @readonly
-         */
-        vertexShaderSource : {
-            get : function() {
-                return this._vertexShaderSource;
-            }
-        },
-
-        /**
-         * The GLSL source code for the fragment shader.  The full fragment shader
-         * source is built procedurally taking into account the {@link Appearance#material}.
-         * Use {@link Appearance#getFragmentShaderSource} to get the full source.
-         *
-         * @memberof Appearance.prototype
-         *
-         * @type {String}
-         * @readonly
-         */
-        fragmentShaderSource : {
-            get : function() {
-                return this._fragmentShaderSource;
-            }
-        },
-
-        /**
-         * The WebGL fixed-function state to use when rendering the geometry.
-         *
-         * @memberof Appearance.prototype
-         *
-         * @type {Object}
-         * @readonly
-         */
-        renderState : {
-            get : function() {
-                return this._renderState;
-            }
-        },
-
-        /**
-         * When <code>true</code>, the geometry is expected to be closed.
-         *
-         * @memberof Appearance.prototype
-         *
-         * @type {Boolean}
-         * @readonly
-         *
-         * @default false
-         */
-        closed : {
-            get : function() {
-                return this._closed;
-            }
-        }
-    });
+    var Appearance = function() {};
 
     /**
      * Procedurally creates the full GLSL fragment shader source for this appearance
@@ -138,30 +32,14 @@ define([
      *
      * @returns {String} The full GLSL fragment shader source.
      */
-    Appearance.prototype.getFragmentShaderSource = function() {
-        var parts = [];
-        if (this.flat) {
-            parts.push('#define FLAT');
-        }
-        if (this.faceForward) {
-            parts.push('#define FACE_FORWARD');
-        }
-        if (defined(this.material)) {
-            parts.push(this.material.shaderSource);
-        }
-        parts.push(this.fragmentShaderSource);
-
-        return parts.join('\n');
-    };
+    Appearance.prototype.getFragmentShaderSource = function() {};
 
     /**
      * Determines if the geometry is translucent based on {@link Appearance#translucent} and {@link Material#isTranslucent}.
      *
      * @returns {Boolean} <code>true</code> if the appearance is translucent.
      */
-    Appearance.prototype.isTranslucent = function() {
-        return (defined(this.material) && this.material.isTranslucent()) || (!defined(this.material) && this.translucent);
-    };
+    Appearance.prototype.isTranslucent = function() {};
 
     /**
      * Creates a render state.  This is not the final render state instance; instead,
@@ -170,46 +48,7 @@ define([
      *
      * @returns {Object} The render state.
      */
-    Appearance.prototype.getRenderState = function() {
-        var translucent = this.isTranslucent();
-        var rs = clone(this.renderState, false);
-        if (translucent) {
-            rs.depthMask = false;
-            rs.blending = BlendingState.ALPHA_BLEND;
-        } else {
-            rs.depthMask = true;
-        }
-        return rs;
-    };
-
-    /**
-     * @private
-     */
-    Appearance.getDefaultRenderState = function(translucent, closed, existing) {
-        var rs = {
-            depthTest : {
-                enabled : true
-            }
-        };
-
-        if (translucent) {
-            rs.depthMask = false;
-            rs.blending = BlendingState.ALPHA_BLEND;
-        }
-
-        if (closed) {
-            rs.cull = {
-                enabled : true,
-                face : CullFace.BACK
-            };
-        }
-
-        if (defined(existing)) {
-            rs = combine(existing, rs, true);
-        }
-
-        return rs;
-    };
+    Appearance.prototype.getRenderState = function() {};
 
     return Appearance;
 });

--- a/Source/Scene/Appearance.js
+++ b/Source/Scene/Appearance.js
@@ -23,7 +23,7 @@ define([
      * this base <code>Appearance</code> interface.
      *
      * @alias Appearance
-     * @constructor
+     * @interface
      *
      * @param {Object} [options] Object with the following properties:
      * @param {Boolean} [options.translucent=true] When <code>true</code>, the geometry is expected to appear translucent so {@link Appearance#renderState} has alpha blending enabled.

--- a/Source/Scene/DebugAppearance.js
+++ b/Source/Scene/DebugAppearance.js
@@ -23,6 +23,7 @@ define([
      *
      * @alias DebugAppearance
      * @constructor
+     * @implements {Appearance}
      *
      * @param {Object} options Object with the following properties:
      * @param {String} options.attributeName The name of the attribute to visualize.

--- a/Source/Scene/EllipsoidSurfaceAppearance.js
+++ b/Source/Scene/EllipsoidSurfaceAppearance.js
@@ -28,6 +28,7 @@ define([
      *
      * @alias EllipsoidSurfaceAppearance
      * @constructor
+     * @implements {Appearance}
      *
      * @param {Object} [options] Object with the following properties:
      * @param {Boolean} [options.flat=false] When <code>true</code>, flat shading is used in the fragment shader, which means lighting is not taking into account.

--- a/Source/Scene/MaterialAppearance.js
+++ b/Source/Scene/MaterialAppearance.js
@@ -35,6 +35,7 @@ define([
      *
      * @alias MaterialAppearance
      * @constructor
+     * @implements {Appearance}
      *
      * @param {Object} [options] Object with the following properties:
      * @param {Boolean} [options.flat=false] When <code>true</code>, flat shading is used in the fragment shader, which means lighting is not taking into account.

--- a/Source/Scene/PerInstanceColorAppearance.js
+++ b/Source/Scene/PerInstanceColorAppearance.js
@@ -26,6 +26,7 @@ define([
      *
      * @alias PerInstanceColorAppearance
      * @constructor
+     * @implements {Appearance}
      *
      * @param {Object} [options] Object with the following properties:
      * @param {Boolean} [options.flat=false] When <code>true</code>, flat shading is used in the fragment shader, which means lighting is not taking into account.

--- a/Source/Scene/PolylineColorAppearance.js
+++ b/Source/Scene/PolylineColorAppearance.js
@@ -27,6 +27,7 @@ define([
      *
      * @alias PolylineColorAppearance
      * @constructor
+     * @implements {Appearance}
      *
      * @param {Object} [options] Object with the following properties:
      * @param {Boolean} [options.translucent=true] When <code>true</code>, the geometry is expected to appear translucent so {@link PolylineColorAppearance#renderState} has alpha blending enabled.

--- a/Source/Scene/PolylineMaterialAppearance.js
+++ b/Source/Scene/PolylineMaterialAppearance.js
@@ -29,6 +29,7 @@ define([
      *
      * @alias PolylineMaterialAppearance
      * @constructor
+     * @implements {Appearance}
      *
      * @param {Object} [options] Object with the following properties:
      * @param {Boolean} [options.translucent=true] When <code>true</code>, the geometry is expected to appear translucent so {@link PolylineMaterialAppearance#renderState} has alpha blending enabled.


### PR DESCRIPTION
You're currently using `@see` tags to [point from the parent to the child](https://github.com/AnalyticalGraphicsInc/cesium/blob/d3eb3015881fcc0071d64d0f97ea8f83a7d9f0ba/Source/Scene/Appearance.js#L36-L41) but not linking the child to the parent in any way.

This is problem for me while generating TypeScript definition files.

``` ts
class Appearance {
    material: Material;
    translucent: boolean;
    vertexShaderSource: string;
    fragmentShaderSource: string;
    renderState: any;
    closed: boolean;
    constructor(options?: { translucent?: boolean; closed?: boolean; material?: Material; vertexShaderSource?: string; fragmentShaderSource?: string; renderState?: RenderState });
    getFragmentShaderSource(): string;
    isTranslucent(): boolean;
    getRenderState(): any;
}

class MaterialAppearance {
    material: Material;
    translucent: boolean;
    vertexShaderSource: string;
    fragmentShaderSource: string;
    renderState: any;
    closed: boolean;
    materialSupport: MaterialAppearance.MaterialSupport;
    vertexFormat: VertexFormat;
    flat: boolean;
    faceForward: boolean;
    constructor(options?: { flat?: boolean; faceForward?: boolean; translucent?: boolean; closed?: boolean; materialSupport?: MaterialAppearance.MaterialSupport; material?: Material; vertexShaderSource?: string; fragmentShaderSource?: string; renderState?: RenderState });
    getFragmentShaderSource();
    isTranslucent(): boolean;
    getRenderState(): any;
}
```

`MaterialAppearance` should `extend` `Appearance` but I have no way of figuring that out from the annotations in your source.

jsdoc has a an [@extends](http://usejsdoc.org/tags-augments.html) tag which can be used to document the relationship between a parent and child class. 

Here's what I looks like in the docs 
![pic](https://cloud.githubusercontent.com/assets/943597/8623718/fa69809e-2700-11e5-8b58-b17694caa3d5.png)

Would you consider accepting a change like this?