### PR TITLE
Add picking support to UrlTemplateImageryProvider, use it for WMSImageryProvider

### DIFF
--- a/Apps/Sandcastle/gallery/Imagery Layers.html
+++ b/Apps/Sandcastle/gallery/Imagery Layers.html
@@ -28,19 +28,20 @@ function startup(Cesium) {
     "use strict";
 //Sandcastle_Begin
 var viewer = new Cesium.Viewer('cesiumContainer', {
-    imageryProvider : new Cesium.ArcGisMapServerImageryProvider({
-        url : '//server.arcgisonline.com/ArcGIS/rest/services/World_Street_Map/MapServer'
+    imageryProvider : new Cesium.UrlTemplateImageryProvider({
+        url : 'http://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png',
+        credit : 'Map tiles by CartoDB, under CC BY 3.0. Data by OpenStreetMap, under ODbL.'
     }),
     baseLayerPicker : false
 });
 
 var layers = viewer.imageryLayers;
-var blackMarble = layers.addImageryProvider(new Cesium.TileMapServiceImageryProvider({
-    url : '//cesiumjs.org/blackmarble',
-    maximumLevel : 8,
-    credit : 'Black Marble imagery courtesy NASA Earth Observatory'
+var blackMarble = layers.addImageryProvider(new Cesium.UrlTemplateImageryProvider({
+    url : '//cesiumjs.org/tilesets/imagery/blackmarble/{z}/{x}/{reverseY}.png',
+    credit : 'Black Marble imagery courtesy NASA Earth Observatory',
+    maximumLevel : 8
 }));
-blackMarble.alpha = 0.5;
+blackMarble.alpha = 0.2;
 blackMarble.brightness = 2.0;
 
 layers.addImageryProvider(new Cesium.SingleTileImageryProvider({

--- a/Apps/Sandcastle/gallery/Imagery Layers.html
+++ b/Apps/Sandcastle/gallery/Imagery Layers.html
@@ -28,20 +28,19 @@ function startup(Cesium) {
     "use strict";
 //Sandcastle_Begin
 var viewer = new Cesium.Viewer('cesiumContainer', {
-    imageryProvider : new Cesium.UrlTemplateImageryProvider({
-        url : 'http://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png',
-        credit : 'Map tiles by CartoDB, under CC BY 3.0. Data by OpenStreetMap, under ODbL.'
+    imageryProvider : new Cesium.ArcGisMapServerImageryProvider({
+        url : '//server.arcgisonline.com/ArcGIS/rest/services/World_Street_Map/MapServer'
     }),
     baseLayerPicker : false
 });
 
 var layers = viewer.imageryLayers;
-var blackMarble = layers.addImageryProvider(new Cesium.UrlTemplateImageryProvider({
-    url : '//cesiumjs.org/tilesets/imagery/blackmarble/{z}/{x}/{reverseY}.png',
-    credit : 'Black Marble imagery courtesy NASA Earth Observatory',
-    maximumLevel : 8
+var blackMarble = layers.addImageryProvider(new Cesium.TileMapServiceImageryProvider({
+    url : '//cesiumjs.org/blackmarble',
+    maximumLevel : 8,
+    credit : 'Black Marble imagery courtesy NASA Earth Observatory'
 }));
-blackMarble.alpha = 0.2;
+blackMarble.alpha = 0.5;
 blackMarble.brightness = 2.0;
 
 layers.addImageryProvider(new Cesium.SingleTileImageryProvider({

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,7 @@ Change Log
 * Fixed incorrect texture coordinates for `WallGeometry` [#2872](https://github.com/AnalyticalGraphicsInc/cesium/issues/2872)
 * Added `maximumHeight` option to `Viewer.flyTo`. [#2868](https://github.com/AnalyticalGraphicsInc/cesium/issues/2868)
 * Added ArcGIS token-based authentication support to `ArcGisMapServerImageryProvider`
+* Added picking support to `UrlTemplateImageryProvider`.
 
 ### 1.11 - 2015-07-01
 

--- a/Source/Scene/UrlTemplateImageryProvider.js
+++ b/Source/Scene/UrlTemplateImageryProvider.js
@@ -1,7 +1,9 @@
 /*global define*/
 define([
         '../Core/Cartesian2',
+        '../Core/Cartesian3',
         '../Core/Cartographic',
+        '../Core/combine',
         '../Core/Math',
         '../Core/Credit',
         '../Core/defaultValue',
@@ -9,16 +11,23 @@ define([
         '../Core/defineProperties',
         '../Core/DeveloperError',
         '../Core/Event',
+        '../Core/freezeObject',
         '../Core/GeographicTilingScheme',
+        '../Core/loadJson',
+        '../Core/loadText',
+        '../Core/loadWithXhr',
         '../Core/loadXML',
         '../Core/Rectangle',
         '../Core/TileProviderError',
         '../Core/WebMercatorTilingScheme',
         '../ThirdParty/when',
-        './ImageryProvider'
+        './ImageryProvider',
+        './GetFeatureInfoFormat'
     ], function(
         Cartesian2,
+        Cartesian3,
         Cartographic,
+        combine,
         CesiumMath,
         Credit,
         defaultValue,
@@ -26,13 +35,18 @@ define([
         defineProperties,
         DeveloperError,
         Event,
+        freezeObject,
         GeographicTilingScheme,
+        loadJson,
+        loadText,
+        loadWithXhr,
         loadXML,
         Rectangle,
         TileProviderError,
         WebMercatorTilingScheme,
         when,
-        ImageryProvider) {
+        ImageryProvider,
+        GetFeatureInfoFormat) {
     "use strict";
 
     /**
@@ -42,24 +56,39 @@ define([
      * @constructor
      *
      * @param {Object} [options] Object with the following properties:
-     * @param {String} [options.url='']  The URL template to use to request tiles.  It has the following keywords:
+     * @param {String} [options.url]  The URL template to use to request tiles.  It has the following keywords:
      * <ul>
-     *  <li> <code>{z}</code>: The level of the tile in the tiling scheme.  Level zero is the root of the quadtree pyramid.</li>
-     *  <li> <code>{x}</code>: The tile X coordinate in the tiling scheme, where 0 is the Westernmost tile.</li>
-     *  <li> <code>{y}</code>: The tile Y coordinate in the tiling scheme, where 0 is the Northernmost tile.</li>
-     *  <li> <code>{s}</code>: One of the available subdomains, used to overcome browser limits on the number of simultaneous requests per host.</li>
-     *  <li> <code>{reverseX}</code>: The tile X coordinate in the tiling scheme, where 0 is the Easternmost tile.</li>
-     *  <li> <code>{reverseY}</code>: The tile Y coordinate in the tiling scheme, where 0 is the Southernmost tile.</li>
-     *  <li> <code>{westDegrees}</code>: The Western edge of the tile in geodetic degrees.</li>
-     *  <li> <code>{southDegrees}</code>: The Southern edge of the tile in geodetic degrees.</li>
-     *  <li> <code>{eastDegrees}</code>: The Eastern edge of the tile in geodetic degrees.</li>
-     *  <li> <code>{northDegrees}</code>: The Northern edge of the tile in geodetic degrees.</li>
-     *  <li> <code>{westProjected}</code>: The Western edge of the tile in projected coordinates of the tiling scheme.</li>
-     *  <li> <code>{southProjected}</code>: The Southern edge of the tile in projected coordinates of the tiling scheme.</li>
-     *  <li> <code>{eastProjected}</code>: The Eastern edge of the tile in projected coordinates of the tiling scheme.</li>
-     *  <li> <code>{northProjected}</code>: The Northern edge of the tile in projected coordinates of the tiling scheme.</li>
-     *  <li> <code>{width}</code>: The width of a tile in pixels.</li>
-     *  <li> <code>{height}</code>: The height of a tile in pixels.</li>
+     *     <li><code>{z}</code>: The level of the tile in the tiling scheme.  Level zero is the root of the quadtree pyramid.</li>
+     *     <li><code>{x}</code>: The tile X coordinate in the tiling scheme, where 0 is the Westernmost tile.</li>
+     *     <li><code>{y}</code>: The tile Y coordinate in the tiling scheme, where 0 is the Northernmost tile.</li>
+     *     <li><code>{s}</code>: One of the available subdomains, used to overcome browser limits on the number of simultaneous requests per host.</li>
+     *     <li><code>{reverseX}</code>: The tile X coordinate in the tiling scheme, where 0 is the Easternmost tile.</li>
+     *     <li><code>{reverseY}</code>: The tile Y coordinate in the tiling scheme, where 0 is the Southernmost tile.</li>
+     *     <li><code>{westDegrees}</code>: The Western edge of the tile in geodetic degrees.</li>
+     *     <li><code>{southDegrees}</code>: The Southern edge of the tile in geodetic degrees.</li>
+     *     <li><code>{eastDegrees}</code>: The Eastern edge of the tile in geodetic degrees.</li>
+     *     <li><code>{northDegrees}</code>: The Northern edge of the tile in geodetic degrees.</li>
+     *     <li><code>{westProjected}</code>: The Western edge of the tile in projected coordinates of the tiling scheme.</li>
+     *     <li><code>{southProjected}</code>: The Southern edge of the tile in projected coordinates of the tiling scheme.</li>
+     *     <li><code>{eastProjected}</code>: The Eastern edge of the tile in projected coordinates of the tiling scheme.</li>
+     *     <li><code>{northProjected}</code>: The Northern edge of the tile in projected coordinates of the tiling scheme.</li>
+     *     <li><code>{width}</code>: The width of a tile in pixels.</li>
+     *     <li><code>{height}</code>: The height of a tile in pixels.</li>
+     * </ul>
+     * @param {String} [options.pickFeaturesUrl] The URL template to use to pick features.  If this property is not specified,
+     *                 {@see UrlTemplateImageryProvider#pickFeatures} will immediately returned undefined, indicating no
+     *                 features picked.  The URL template supports all of the keywords supported by the <code>url</code>
+     *                 parameter, plus the following:
+     * <ul>
+     *     <li><code>{i}</code>: The pixel column (horizontal coordinate) of the picked position, where the Westernmost pixel is 0.</li>
+     *     <li><code>{j}</code>: The pixel row (vertical coordinate) of the picked position, where the Northernmost pixel is 0.</li>
+     *     <li><code>{reverseI}</code>: The pixel column (horizontal coordinate) of the picked position, where the Easternmost pixel is 0.</li>
+     *     <li><code>{reverseJ}</code>: The pixel row (vertical coordinate) of the picked position, where the Southernmost pixel is 0.</li>
+     *     <li><code>{longitudeDegrees}</code>: The longitude of the picked position in degrees.</li>
+     *     <li><code>{latitudeDegrees}</code>: The latitude of the picked position in degrees.</li>
+     *     <li><code>{longitudeProjected}</code>: The longitude of the picked position in the projected coordinates of the tiling scheme.</li>
+     *     <li><code>{latitudeProjected}</code>: The latitude of the picked position in the projected coordinates of the tiling scheme.</li>
+     *     <li><code>{format}</code>: The format in which to get feature information, as specified in the {@see GetFeatureInfoFormat}.</li>
      * </ul>
      * @param {String|String[]} [options.subdomains='abc'] The subdomains to use for the <code>{s}</code> placeholder in the URL template.
      *                          If this parameter is a single string, each character in the string is a subdomain.  If it is
@@ -84,6 +113,9 @@ define([
      *                  present, will be ignored.  If this property is true, any images without an alpha channel will
      *                  be treated as if their alpha is 1.0 everywhere.  When this property is false, memory usage
      *                  and texture upload time are potentially reduced.
+     * @param {GetFeatureInfoFormat[]} [options.getFeatureInfoFormats] The formats in which to get feature information at a
+     *                                 specific location when {@see UrlTemplateImageryProvider#pickFeatures} is invoked.  If this
+     *                                 parameter is not specified, feature picking is disabled.
      *
      * @see ArcGisMapServerImageryProvider
      * @see BingMapsImageryProvider
@@ -126,8 +158,11 @@ define([
         //>>includeEnd('debug');
 
         this._url = options.url;
+        this._pickFeaturesUrl = options.pickFeaturesUrl;
         this._proxy = options.proxy;
         this._tileDiscardPolicy = options.tileDiscardPolicy;
+        this._getFeatureInfoFormats = options.getFeatureInfoFormats;
+        
         this._errorEvent = new Event();
         
         this._subdomains = options.subdomains;
@@ -154,62 +189,9 @@ define([
         }
         this._credit = credit;
 
-        var url = this._url;
-        var parts = [];
-        var nextIndex = 0;
-        var minIndex;
-        var minTag;
-        var tagList = Object.keys(tags);
-
-        while (nextIndex < url.length) {
-            minIndex = Number.MAX_VALUE;
-            minTag = undefined;
-
-            for (var i = 0; i < tagList.length; ++i) {
-                var thisIndex = url.indexOf(tagList[i], nextIndex);
-                if (thisIndex >= 0 && thisIndex < minIndex) {
-                    minIndex = thisIndex;
-                    minTag = tagList[i];
-                }
-            }
-
-            if (!defined(minTag)) {
-                parts.push(url.substring(nextIndex));
-                nextIndex = url.length;
-            } else {
-                if (nextIndex < minIndex) {
-                    parts.push(url.substring(nextIndex, minIndex));
-                }
-                parts.push(tags[minTag]);
-                nextIndex = minIndex + minTag.length;
-            }
-        }
-
-        this._urlParts = parts;
+        this._urlParts = urlTemplateToParts(this._url, tags);
+        this._pickFeaturesUrlParts = urlTemplateToParts(this._pickFeaturesUrl, pickFeaturesTags);
     };
-
-    function buildImageUrl(imageryProvider, x, y, level) {
-        degreesScratchComputed = false;
-        projectedScratchComputed = false;
-
-        var url = '';
-        var parts = imageryProvider._urlParts;
-        for (var i = 0; i < parts.length; ++i) {
-            var part = parts[i];
-            if (typeof part === 'string') {
-                url += part;
-            } else {
-                url += part(imageryProvider, x, y, level);
-            }
-        }
-
-        var proxy = imageryProvider._proxy;
-        if (defined(proxy)) {
-            url = proxy.getURL(url);
-        }
-
-        return url;
-    }
 
     defineProperties(UrlTemplateImageryProvider.prototype, {
         /**
@@ -458,9 +440,124 @@ define([
      *                   instances.  The array may be empty if no features are found at the given location.
      *                   It may also be undefined if picking is not supported.
      */
-    UrlTemplateImageryProvider.prototype.pickFeatures = function() {
-        return undefined;
+    UrlTemplateImageryProvider.prototype.pickFeatures = function(x, y, level, longitude, latitude) {
+        if (!defined(this._pickFeaturesUrl) || this._getFeatureInfoFormats.length === 0) {
+            return undefined;
+        }
+
+        var formatIndex = 0;
+
+        var that = this;
+
+        function handleResponse(format, data) {
+            return format.callback(data);
+        }
+
+        function doRequest() {
+            if (formatIndex >= that._getFeatureInfoFormats.length) {
+                // No valid formats, so no features picked.
+                return when([]);
+            }
+
+            var format = that._getFeatureInfoFormats[formatIndex];
+            var url = buildPickFeaturesUrl(that, x, y, level, longitude, latitude, format.format);
+
+            ++formatIndex;
+
+            if (format.type === 'json') {
+                return loadJson(url).then(format.callback).otherwise(doRequest);
+            } else if (format.type === 'xml') {
+                return loadXML(url).then(format.callback).otherwise(doRequest);
+            } else if (format.type === 'text' || format.type === 'html') {
+                return loadText(url).then(format.callback).otherwise(doRequest);
+            } else {
+                return loadWithXhr({
+                    url: url,
+                    responseType: format.format
+                }).then(handleResponse.bind(undefined, format)).otherwise(doRequest);
+            }
+        }
+
+        return doRequest();
     };
+
+    function buildImageUrl(imageryProvider, x, y, level) {
+        degreesScratchComputed = false;
+        projectedScratchComputed = false;
+
+        return buildUrl(imageryProvider, imageryProvider._urlParts, function(partFunction) {
+            return partFunction(imageryProvider, x, y, level);
+        });
+    }
+
+    function buildPickFeaturesUrl(imageryProvider, x, y, level, longitude, latitude, format) {
+        degreesScratchComputed = false;
+        projectedScratchComputed = false;
+        ijScratchComputed = false;
+        longitudeLatitudeProjectedScratchComputed = false;
+
+        return buildUrl(imageryProvider, imageryProvider._pickFeaturesUrlParts, function(partFunction) {
+            return partFunction(imageryProvider, x, y, level, longitude, latitude, format);
+        });
+    }
+
+    function buildUrl(imageryProvider, parts, partFunctionInvoker) {
+        var url = '';
+
+        for (var i = 0; i < parts.length; ++i) {
+            var part = parts[i];
+            if (typeof part === 'string') {
+                url += part;
+            } else {
+                url += partFunctionInvoker(part);
+            }
+        }
+
+        var proxy = imageryProvider._proxy;
+        if (defined(proxy)) {
+            url = proxy.getURL(url);
+        }
+
+        return url;
+    }
+
+    function urlTemplateToParts(url, tags) {
+        if (!defined(url)) {
+            return undefined;
+        }
+
+        var parts = [];
+        var nextIndex = 0;
+        var minIndex;
+        var minTag;
+        var tagList = Object.keys(tags);
+
+        while (nextIndex < url.length) {
+            minIndex = Number.MAX_VALUE;
+            minTag = undefined;
+
+            for (var i = 0; i < tagList.length; ++i) {
+                var thisIndex = url.indexOf(tagList[i], nextIndex);
+                if (thisIndex >= 0 && thisIndex < minIndex) {
+                    minIndex = thisIndex;
+                    minTag = tagList[i];
+                }
+            }
+
+            if (!defined(minTag)) {
+                parts.push(url.substring(nextIndex));
+                nextIndex = url.length;
+            } else {
+                if (nextIndex < minIndex) {
+                    parts.push(url.substring(nextIndex, minIndex));
+                }
+                parts.push(tags[minTag]);
+                nextIndex = minIndex + minTag.length;
+            }
+        }
+
+        return parts;
+    }
 
     function xTag(imageryProvider, x, y, level) {
         return x;
@@ -565,6 +662,91 @@ define([
         return imageryProvider.tileHeight;
     }
 
+    var ijScratchComputed = false;
+    var ijScratch = new Cartesian2();
+
+    function iTag(imageryProvider, x, y, level, longitude, latitude, format) {
+        computeIJ(imageryProvider, x, y, level, longitude, latitude);
+        return ijScratch.x;
+    }
+
+    function jTag(imageryProvider, x, y, level, longitude, latitude, format) {
+        computeIJ(imageryProvider, x, y, level, longitude, latitude);
+        return ijScratch.y;
+    }
+
+    function reverseITag(imageryProvider, x, y, level, longitude, latitude, format) {
+        computeIJ(imageryProvider, x, y, level, longitude, latitude);
+        return imageryProvider.tileWidth - ijScratch.x - 1;
+    }
+
+    function reverseJTag(imageryProvider, x, y, level, longitude, latitude, format) {
+        computeIJ(imageryProvider, x, y, level, longitude, latitude);
+        return imageryProvider.tileHeight - ijScratch.y - 1;
+    }
+
+    var rectangleScratch = new Rectangle();
+
+    function computeIJ(imageryProvider, x, y, level, longitude, latitude, format) {
+        if (ijScratchComputed) {
+            return;
+        }
+
+        computeLongitudeLatitudeProjected(imageryProvider, x, y, level, longitude, latitude);
+        var projected = longitudeLatitudeProjectedScratch;
+
+        var rectangle = imageryProvider.tilingScheme.tileXYToNativeRectangle(x, y, level, rectangleScratch);
+        ijScratch.x = (imageryProvider.tileWidth * (projected.x - rectangle.west) / rectangle.width) | 0;
+        ijScratch.y = (imageryProvider.tileHeight * (rectangle.north - projected.y) / rectangle.height) | 0;
+        ijScratchComputed = true;
+    }
+
+    function longitudeDegreesTag(imageryProvider, x, y, level, longitude, latitude, format) {
+        return CesiumMath.toDegrees(longitude);
+    }
+
+    function latitudeDegreesTag(imageryProvider, x, y, level, longitude, latitude, format) {
+        return CesiumMath.toDegrees(latitude);
+    }
+
+    var longitudeLatitudeProjectedScratchComputed = false;
+    var longitudeLatitudeProjectedScratch = new Cartesian3();
+
+    function longitudeProjectedTag(imageryProvider, x, y, level, longitude, latitude, format) {
+        computeLongitudeLatitudeProjected(imageryProvider, x, y, level, longitude, latitude);
+        return longitudeLatitudeProjectedScratch.x;
+    }
+
+    function latitudeProjectedTag(imageryProvider, x, y, level, longitude, latitude, format) {
+        computeLongitudeLatitudeProjected(imageryProvider, x, y, level, longitude, latitude);
+        return longitudeLatitudeProjectedScratch.y;
+    }
+
+    var cartographicScratch = new Cartographic();
+
+    function computeLongitudeLatitudeProjected(imageryProvider, x, y, level, longitude, latitude, format) {
+        if (longitudeLatitudeProjectedScratchComputed) {
+            return;
+        }
+
+        var projected;
+        if (imageryProvider.tilingScheme instanceof GeographicTilingScheme) {
+            longitudeLatitudeProjectedScratch.x = CesiumMath.toDegrees(longitude);
+            longitudeLatitudeProjectedScratch.y = CesiumMath.toDegrees(latitude);
+        } else {
+            var cartographic = cartographicScratch;
+            cartographic.longitude = longitude;
+            cartographic.latitude = latitude;
+            projected = imageryProvider.tilingScheme.projection.project(cartographic, longitudeLatitudeProjectedScratch);
+        }
+
+        longitudeLatitudeProjectedScratchComputed = true;
+    }
+
+    function formatTag(imageryProvider, x, y, level, longitude, latitude, format) {
+        return format;
+    }
+
     var tags = {
         '{x}': xTag,
         '{y}': yTag,
@@ -583,6 +765,18 @@ define([
         '{width}': widthTag,
         '{height}': heightTag
     };
+
+    var pickFeaturesTags = combine(tags, {
+        '{i}' : iTag,
+        '{j}' : jTag,
+        '{reverseI}' : reverseITag,
+        '{reverseJ}' : reverseJTag,
+        '{longitudeDegrees}' : longitudeDegreesTag,
+        '{latitudeDegrees}' : latitudeDegreesTag,
+        '{longitudeProjected}' : longitudeProjectedTag,
+        '{latitudeProjected}' : latitudeProjectedTag,
+        '{format}' : formatTag
+    });
 
     return UrlTemplateImageryProvider;
 });

--- a/Source/Scene/UrlTemplateImageryProvider.js
+++ b/Source/Scene/UrlTemplateImageryProvider.js
@@ -21,8 +21,7 @@ define([
         '../Core/TileProviderError',
         '../Core/WebMercatorTilingScheme',
         '../ThirdParty/when',
-        './ImageryProvider',
-        './GetFeatureInfoFormat'
+        './ImageryProvider'
     ], function(
         Cartesian2,
         Cartesian3,
@@ -45,8 +44,7 @@ define([
         TileProviderError,
         WebMercatorTilingScheme,
         when,
-        ImageryProvider,
-        GetFeatureInfoFormat) {
+        ImageryProvider) {
     "use strict";
 
     /**
@@ -72,8 +70,8 @@ define([
      *     <li><code>{southProjected}</code>: The Southern edge of the tile in projected coordinates of the tiling scheme.</li>
      *     <li><code>{eastProjected}</code>: The Eastern edge of the tile in projected coordinates of the tiling scheme.</li>
      *     <li><code>{northProjected}</code>: The Northern edge of the tile in projected coordinates of the tiling scheme.</li>
-     *     <li><code>{width}</code>: The width of a tile in pixels.</li>
-     *     <li><code>{height}</code>: The height of a tile in pixels.</li>
+     *     <li><code>{width}</code>: The width of each tile in pixels.</li>
+     *     <li><code>{height}</code>: The height of each tile in pixels.</li>
      * </ul>
      * @param {String} [options.pickFeaturesUrl] The URL template to use to pick features.  If this property is not specified,
      *                 {@see UrlTemplateImageryProvider#pickFeatures} will immediately returned undefined, indicating no
@@ -211,8 +209,8 @@ define([
          *  <li> <code>{southProjected}</code>: The Southern edge of the tile in projected coordinates of the tiling scheme.</li>
          *  <li> <code>{eastProjected}</code>: The Eastern edge of the tile in projected coordinates of the tiling scheme.</li>
          *  <li> <code>{northProjected}</code>: The Northern edge of the tile in projected coordinates of the tiling scheme.</li>
-         *  <li> <code>{width}</code>: The width of a tile in pixels.</li>
-         *  <li> <code>{height}</code>: The height of a tile in pixels.</li>
+         *  <li> <code>{width}</code>: The width of each tile in pixels.</li>
+         *  <li> <code>{height}</code>: The height of each tile in pixels.</li>
          * </ul>
          * @memberof UrlTemplateImageryProvider.prototype
          * @type {String}
@@ -221,6 +219,31 @@ define([
         url : {
             get : function() {
                 return this._url;
+            }
+        },
+
+        /**
+         * Gets the URL template to use to use to pick features.  If this property is not specified,
+         * {@see UrlTemplateImageryProvider#pickFeatures} will immediately returned undefined, indicating no
+         * features picked.  The URL template supports all of the keywords supported by the
+         * {@see UrlTemplateImageryProvider#url} property, plus the following:
+         * <ul>
+         *     <li><code>{i}</code>: The pixel column (horizontal coordinate) of the picked position, where the Westernmost pixel is 0.</li>
+         *     <li><code>{j}</code>: The pixel row (vertical coordinate) of the picked position, where the Northernmost pixel is 0.</li>
+         *     <li><code>{reverseI}</code>: The pixel column (horizontal coordinate) of the picked position, where the Easternmost pixel is 0.</li>
+         *     <li><code>{reverseJ}</code>: The pixel row (vertical coordinate) of the picked position, where the Southernmost pixel is 0.</li>
+         *     <li><code>{longitudeDegrees}</code>: The longitude of the picked position in degrees.</li>
+         *     <li><code>{latitudeDegrees}</code>: The latitude of the picked position in degrees.</li>
+         *     <li><code>{longitudeProjected}</code>: The longitude of the picked position in the projected coordinates of the tiling scheme.</li>
+         *     <li><code>{latitudeProjected}</code>: The latitude of the picked position in the projected coordinates of the tiling scheme.</li>
+         *     <li><code>{format}</code>: The format in which to get feature information, as specified in the {@see GetFeatureInfoFormat}.</li>
+         * </ul>
+         * @type {String}
+         * @readonly
+         */
+        pickFeaturesUrl : {
+            get : function() {
+                return this._pickFeaturesUrl;
             }
         },
 

--- a/Source/Scene/UrlTemplateImageryProvider.js
+++ b/Source/Scene/UrlTemplateImageryProvider.js
@@ -58,6 +58,8 @@ define([
      *  <li> <code>{southProjected}</code>: The Southern edge of the tile in projected coordinates of the tiling scheme.</li>
      *  <li> <code>{eastProjected}</code>: The Eastern edge of the tile in projected coordinates of the tiling scheme.</li>
      *  <li> <code>{northProjected}</code>: The Northern edge of the tile in projected coordinates of the tiling scheme.</li>
+     *  <li> <code>{width}</code>: The width of a tile in pixels.</li>
+     *  <li> <code>{height}</code>: The height of a tile in pixels.</li>
      * </ul>
      * @param {String|String[]} [options.subdomains='abc'] The subdomains to use for the <code>{s}</code> placeholder in the URL template.
      *                          If this parameter is a single string, each character in the string is a subdomain.  If it is
@@ -143,6 +145,7 @@ define([
         this._maximumLevel = options.maximumLevel;
         this._tilingScheme = defaultValue(options.tilingScheme, new WebMercatorTilingScheme({ ellipsoid : options.ellipsoid }));
         this._rectangle = defaultValue(options.rectangle, this._tilingScheme.rectangle);
+        this._rectangle = Rectangle.intersection(this._rectangle, this._tilingScheme.rectangle);
         this._hasAlphaChannel = defaultValue(options.hasAlphaChannel, true);
 
         var credit = options.credit;
@@ -226,6 +229,8 @@ define([
          *  <li> <code>{southProjected}</code>: The Southern edge of the tile in projected coordinates of the tiling scheme.</li>
          *  <li> <code>{eastProjected}</code>: The Eastern edge of the tile in projected coordinates of the tiling scheme.</li>
          *  <li> <code>{northProjected}</code>: The Northern edge of the tile in projected coordinates of the tiling scheme.</li>
+         *  <li> <code>{width}</code>: The width of a tile in pixels.</li>
+         *  <li> <code>{height}</code>: The height of a tile in pixels.</li>
          * </ul>
          * @memberof UrlTemplateImageryProvider.prototype
          * @type {String}
@@ -552,6 +557,14 @@ define([
         return projectedScratch.north;
     }
 
+    function widthTag(imageryProvider, x, y, level) {
+        return imageryProvider.tileWidth;
+    }
+
+    function heightTag(imageryProvider, x, y, level) {
+        return imageryProvider.tileHeight;
+    }
+
     var tags = {
         '{x}': xTag,
         '{y}': yTag,
@@ -566,7 +579,9 @@ define([
         '{westProjected}': westProjectedTag,
         '{southProjected}': southProjectedTag,
         '{eastProjected}': eastProjectedTag,
-        '{northProjected}': northProjectedTag
+        '{northProjected}': northProjectedTag,
+        '{width}': widthTag,
+        '{height}': heightTag
     };
 
     return UrlTemplateImageryProvider;

--- a/Source/Scene/UrlTemplateImageryProvider.js
+++ b/Source/Scene/UrlTemplateImageryProvider.js
@@ -509,7 +509,7 @@ define([
             if (typeof part === 'string') {
                 url += part;
             } else {
-                url += partFunctionInvoker(part);
+                url += encodeURIComponent(partFunctionInvoker(part));
             }
         }
 

--- a/Source/Scene/WebMapServiceImageryProvider.js
+++ b/Source/Scene/WebMapServiceImageryProvider.js
@@ -155,6 +155,8 @@ define([
         setParameter('height', '{height}');
 
         uri.query = objectToQuery(queryOptions);
+
+        // objectToQuery escapes the placeholders.  Undo that.
         var templateUrl = uri.toString().replace(/%7B/g, '{').replace(/%7D/g, '}');
 
         var pickFeaturesTemplateUrl;

--- a/Source/Scene/WebMapServiceImageryProvider.js
+++ b/Source/Scene/WebMapServiceImageryProvider.js
@@ -31,16 +31,6 @@ define([
         UrlTemplateImageryProvider) {
     "use strict";
 
-    function objectToLowercase(obj) {
-        var result = {};
-        for ( var key in obj) {
-            if (obj.hasOwnProperty(key)) {
-                result[key.toLowerCase()] = obj[key];
-            }
-        }
-        return result;
-    }
-
     /**
      * Provides tiled imagery hosted by a Web Map Service (WMS) server.
      *
@@ -480,6 +470,16 @@ define([
         freezeObject(new GetFeatureInfoFormat('xml', 'text/xml')),
         freezeObject(new GetFeatureInfoFormat('text', 'text/html'))
     ]);
+
+    function objectToLowercase(obj) {
+        var result = {};
+        for ( var key in obj) {
+            if (obj.hasOwnProperty(key)) {
+                result[key.toLowerCase()] = obj[key];
+            }
+        }
+        return result;
+    }
 
     return WebMapServiceImageryProvider;
 });

--- a/Source/Scene/WebMapServiceImageryProvider.js
+++ b/Source/Scene/WebMapServiceImageryProvider.js
@@ -102,8 +102,8 @@ define([
 
         this._url = options.url;
         this._layers = options.layers;
-        this._enablePickFeatures = defaultValue(options.enablePickFeatures, true);
-        this._getFeatureInfoFormats = defaultValue(options.getFeatureInfoFormats, WebMapServiceImageryProvider.DefaultGetFeatureInfoFormats);
+
+        var getFeatureInfoFormats = defaultValue(options.getFeatureInfoFormats, WebMapServiceImageryProvider.DefaultGetFeatureInfoFormats);
 
         if (defined(options.getFeatureInfoAsGeoJson) || defined(options.getFeatureInfoAsXml)) {
             deprecationWarning('WebMapServiceImageryProvider.getFeatureInfo', 'The options.getFeatureInfoAsGeoJson and getFeatureInfoAsXml parameters to WebMapServiceImageryProvider were deprecated in Cesium 1.10 and will be removed in 1.13.  Use options.getFeatureInfoFormats instead.');
@@ -114,12 +114,12 @@ define([
             }
             //>>includeEnd('debug');
 
-            this._getFeatureInfoFormats = [];
+            getFeatureInfoFormats = [];
             if (defaultValue(options.getFeatureInfoAsGeoJson, true)) {
-                this._getFeatureInfoFormats.push(new GetFeatureInfoFormat('json', 'application/json'));
+                getFeatureInfoFormats.push(new GetFeatureInfoFormat('json', 'application/json'));
             }
             if (defaultValue(options.getFeatureInfoAsXml, true)) {
-                this._getFeatureInfoFormats.push(new GetFeatureInfoFormat('xml', 'text/xml'));
+                getFeatureInfoFormats.push(new GetFeatureInfoFormat('xml', 'text/xml'));
             }
         }
 
@@ -131,7 +131,7 @@ define([
 
         var pickFeaturesUri;
         var pickFeaturesQueryOptions;
-        if (this._enablePickFeatures) {
+        if (defaultValue(options.enablePickFeatures, true)) {
             pickFeaturesUri = new Uri(options.url);
             pickFeaturesQueryOptions = queryToObject(defaultValue(pickFeaturesUri.query, ''));
             var pickFeaturesParameters = combine(objectToLowercase(defaultValue(options.getFeatureInfoParameters, defaultValue.EMPTY_OBJECT)), WebMapServiceImageryProvider.GetFeatureInfoDefaultParameters);
@@ -192,7 +192,7 @@ define([
             proxy : options.proxy,
             tileDiscardPolicy : options.tileDiscardPolicy,
             credit : options.credit,
-            getFeatureInfoFormats : this._getFeatureInfoFormats
+            getFeatureInfoFormats : getFeatureInfoFormats
         });
     };
 

--- a/Source/Scene/WebMapServiceImageryProvider.js
+++ b/Source/Scene/WebMapServiceImageryProvider.js
@@ -139,17 +139,21 @@ define([
         var parameters = combine(objectToLowercase(defaultValue(options.parameters, defaultValue.EMPTY_OBJECT)), WebMapServiceImageryProvider.DefaultParameters);
         queryOptions = combine(parameters, queryOptions);
 
-        var pickFeaturesUri = new Uri(options.url);
-        var pickFeaturesQueryOptions = queryToObject(defaultValue(pickFeaturesUri.query, ''));
-        var pickFeaturesParameters = combine(objectToLowercase(defaultValue(options.getFeatureInfoParameters, defaultValue.EMPTY_OBJECT)), WebMapServiceImageryProvider.GetFeatureInfoDefaultParameters);
-        pickFeaturesQueryOptions = combine(pickFeaturesParameters, pickFeaturesQueryOptions);
+        var pickFeaturesUri;
+        var pickFeaturesQueryOptions;
+        if (this._enablePickFeatures) {
+            pickFeaturesUri = new Uri(options.url);
+            pickFeaturesQueryOptions = queryToObject(defaultValue(pickFeaturesUri.query, ''));
+            var pickFeaturesParameters = combine(objectToLowercase(defaultValue(options.getFeatureInfoParameters, defaultValue.EMPTY_OBJECT)), WebMapServiceImageryProvider.GetFeatureInfoDefaultParameters);
+            pickFeaturesQueryOptions = combine(pickFeaturesParameters, pickFeaturesQueryOptions);
+        }
 
         function setParameter(name, value) {
             if (!defined(queryOptions[name])) {
                 queryOptions[name] = value;
             }
 
-            if (!defined(pickFeaturesQueryOptions[name])) {
+            if (defined(pickFeaturesQueryOptions) && !defined(pickFeaturesQueryOptions[name])) {
                 pickFeaturesQueryOptions[name] = value;
             }
         }
@@ -160,27 +164,27 @@ define([
         setParameter('width', '{width}');
         setParameter('height', '{height}');
 
-        if (!defined(pickFeaturesQueryOptions.query_layers)) {
-            pickFeaturesQueryOptions.query_layers = options.layers;
-        }
-
-        if (!defined(pickFeaturesQueryOptions.x)) {
-            pickFeaturesQueryOptions.x = '{i}';
-        }
-
-        if (!defined(pickFeaturesQueryOptions.y)) {
-            pickFeaturesQueryOptions.y = '{j}';
-        }
-
-        if (!defined(pickFeaturesQueryOptions.info_format)) {
-            pickFeaturesQueryOptions.info_format = '{format}';
-        }
-
         uri.query = objectToQuery(queryOptions);
         var templateUrl = uri.toString().replace(/%7B/g, '{').replace(/%7D/g, '}');
 
         var pickFeaturesTemplateUrl;
-        if (this._enablePickFeatures) {
+        if (defined(pickFeaturesQueryOptions)) {
+            if (!defined(pickFeaturesQueryOptions.query_layers)) {
+                pickFeaturesQueryOptions.query_layers = options.layers;
+            }
+
+            if (!defined(pickFeaturesQueryOptions.x)) {
+                pickFeaturesQueryOptions.x = '{i}';
+            }
+
+            if (!defined(pickFeaturesQueryOptions.y)) {
+                pickFeaturesQueryOptions.y = '{j}';
+            }
+
+            if (!defined(pickFeaturesQueryOptions.info_format)) {
+                pickFeaturesQueryOptions.info_format = '{format}';
+            }
+
             pickFeaturesUri.query = objectToQuery(pickFeaturesQueryOptions);
             pickFeaturesTemplateUrl = pickFeaturesUri.toString().replace(/%7B/g, '{').replace(/%7D/g, '}');
         }

--- a/Specs/Scene/UrlTemplateImageryProviderSpec.js
+++ b/Specs/Scene/UrlTemplateImageryProviderSpec.js
@@ -146,7 +146,7 @@ defineSuite([
             expect(provider.maximumLevel).toBeUndefined();
             expect(provider.minimumLevel).toBe(0);
             expect(provider.tilingScheme).toBeInstanceOf(WebMercatorTilingScheme);
-            expect(provider.rectangle).toEqual(rectangle);
+            expect(provider.rectangle).toEqualEpsilon(rectangle, CesiumMath.EPSILON14);
             expect(provider.tileDiscardPolicy).toBeUndefined();
 
             spyOn(loadImage, 'createImage').and.callFake(function(url, crossOrigin, deferred) {


### PR DESCRIPTION
* Added picking support to `UrlTemplateImageryProvider`.  It uses a URL template for picking (just like it does for tiles) and allows responses to be handled by user-specified `GetFeatureInfoFormat` instances.
* Implemented `WebMapServiceImageryProvider` in terms of `UrlTemplateImageryProvider`.
