### PR TITLE
Bug: PolygonGeometry reverses input positions array

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,7 @@ Change Log
 * Added `maximumHeight` option to `Viewer.flyTo`. [#2868](https://github.com/AnalyticalGraphicsInc/cesium/issues/2868)
 * Added ArcGIS token-based authentication support to `ArcGisMapServerImageryProvider`
 * Added picking support to `UrlTemplateImageryProvider`.
+* Fixed `PolygonGeometry` clockwise winding order bug. 
 
 ### 1.11 - 2015-07-01
 

--- a/Source/Core/PolygonGeometry.js
+++ b/Source/Core/PolygonGeometry.js
@@ -98,7 +98,7 @@ define([
         var originalWindingOrder = PolygonPipeline.computeWindingOrder2D(positions2D);
         if (originalWindingOrder === WindingOrder.CLOCKWISE) {
             positions2D.reverse();
-            positions.reverse();
+            positions = positions.slice().reverse();
         }
 
         var indices = PolygonPipeline.triangulate(positions2D);

--- a/Source/Core/PolygonGeometry.js
+++ b/Source/Core/PolygonGeometry.js
@@ -486,7 +486,7 @@ define([
 
         var windingOrder = PolygonPipeline.computeWindingOrder2D(positions2D);
         if (windingOrder === WindingOrder.CLOCKWISE) {
-            outerRing.reverse();
+            outerRing = outerRing.slice().reverse();
         }
 
         var wallGeo = computeWallIndices(outerRing, ellipsoid, granularity, perPositionHeight);
@@ -503,7 +503,7 @@ define([
 
             windingOrder = PolygonPipeline.computeWindingOrder2D(positions2D);
             if (windingOrder === WindingOrder.COUNTER_CLOCKWISE) {
-                hole.reverse();
+                hole = hole.slice().reverse();
             }
 
             wallGeo = computeWallIndices(hole, ellipsoid, granularity);

--- a/Source/Core/PolygonOutlineGeometry.js
+++ b/Source/Core/PolygonOutlineGeometry.js
@@ -50,7 +50,7 @@ define([
         var originalWindingOrder = PolygonPipeline.computeWindingOrder2D(positions2D);
         if (originalWindingOrder === WindingOrder.CLOCKWISE) {
             positions2D.reverse();
-            positions.reverse();
+            positions = positions.slice().reverse();
         }
 
         var subdividedPositions;
@@ -119,7 +119,7 @@ define([
         var originalWindingOrder = PolygonPipeline.computeWindingOrder2D(positions2D);
         if (originalWindingOrder === WindingOrder.CLOCKWISE) {
             positions2D.reverse();
-            positions.reverse();
+            positions = positions.slice().reverse();
         }
 
         var subdividedPositions;

--- a/Specs/Core/PolygonGeometrySpec.js
+++ b/Specs/Core/PolygonGeometrySpec.js
@@ -253,6 +253,61 @@ defineSuite([
         expect(p.indices.length).toEqual(3 * 10);
     });
 
+    it('doesn\'t reverse clockwise input array', function() {
+        var p = Cartesian3.fromDegreesArray([
+                                             -124.0, 35.0,
+                                             -124.0, 40.0,
+                                             -110.0, 40.0,
+                                             -110.0, 35.0
+                                         ]);
+        var h1 = Cartesian3.fromDegreesArray([
+                                              -122.0, 36.0,
+                                              -112.0, 36.0,
+                                              -112.0, 39.0,
+                                              -122.0, 39.0
+                                          ]);
+        var h2 = Cartesian3.fromDegreesArray([
+                                              -120.0, 36.5,
+                                              -120.0, 38.5,
+                                              -114.0, 38.5,
+                                              -114.0, 36.5
+                                          ]);
+        var hierarchy = {
+            positions : p,
+            holes : [{
+                positions : h1,
+                holes : [{
+                    positions : h2
+                }]
+            }]
+        };
+
+        PolygonGeometry.createGeometry(new PolygonGeometry({
+            vertexformat : VertexFormat.POSITION_ONLY,
+            polygonHierarchy : hierarchy,
+            granularity : CesiumMath.PI_OVER_THREE
+        }));
+
+        expect(p).toEqual(Cartesian3.fromDegreesArray([
+                                                       -124.0, 35.0,
+                                                       -124.0, 40.0,
+                                                       -110.0, 40.0,
+                                                       -110.0, 35.0
+                                                   ]));
+        expect(h1).toEqual(Cartesian3.fromDegreesArray([
+                                                        -122.0, 36.0,
+                                                        -112.0, 36.0,
+                                                        -112.0, 39.0,
+                                                        -122.0, 39.0
+                                                    ]));
+        expect(h2).toEqual(Cartesian3.fromDegreesArray([
+                                                        -120.0, 36.5,
+                                                        -120.0, 38.5,
+                                                        -114.0, 38.5,
+                                                        -114.0, 36.5
+                                                    ]));
+    });
+
     it('computes correct bounding sphere at height 0', function() {
         var p = PolygonGeometry.createGeometry(PolygonGeometry.fromPositions({
             vertexFormat : VertexFormat.ALL,

--- a/Specs/Core/PolygonOutlineGeometrySpec.js
+++ b/Specs/Core/PolygonOutlineGeometrySpec.js
@@ -188,6 +188,60 @@ defineSuite([
         expect(p.indices.length).toEqual(2 * 12);
     });
 
+    it('doesn\'t reverse clockwise input array', function() {
+        var p = Cartesian3.fromDegreesArray([
+                                             -124.0, 35.0,
+                                             -124.0, 40.0,
+                                             -110.0, 40.0,
+                                             -110.0, 35.0
+                                         ]);
+        var h1 = Cartesian3.fromDegreesArray([
+                                              -122.0, 36.0,
+                                              -112.0, 36.0,
+                                              -112.0, 39.0,
+                                              -122.0, 39.0
+                                          ]);
+        var h2 = Cartesian3.fromDegreesArray([
+                                              -120.0, 36.5,
+                                              -120.0, 38.5,
+                                              -114.0, 38.5,
+                                              -114.0, 36.5
+                                          ]);
+        var hierarchy = {
+            positions : p,
+            holes : [{
+                positions : h1,
+                holes : [{
+                    positions : h2
+                }]
+            }]
+        };
+
+        PolygonOutlineGeometry.createGeometry(new PolygonOutlineGeometry({
+            polygonHierarchy : hierarchy,
+            granularity : CesiumMath.PI_OVER_THREE
+        }));
+
+        expect(p).toEqual(Cartesian3.fromDegreesArray([
+                                                       -124.0, 35.0,
+                                                       -124.0, 40.0,
+                                                       -110.0, 40.0,
+                                                       -110.0, 35.0
+                                                   ]));
+        expect(h1).toEqual(Cartesian3.fromDegreesArray([
+                                                        -122.0, 36.0,
+                                                        -112.0, 36.0,
+                                                        -112.0, 39.0,
+                                                        -122.0, 39.0
+                                                    ]));
+        expect(h2).toEqual(Cartesian3.fromDegreesArray([
+                                                        -120.0, 36.5,
+                                                        -120.0, 38.5,
+                                                        -114.0, 38.5,
+                                                        -114.0, 36.5
+                                                    ]));
+    });
+
     it('computes correct bounding sphere at height 0', function() {
         var p = PolygonOutlineGeometry.createGeometry(PolygonOutlineGeometry.fromPositions({
             positions : Cartesian3.fromDegreesArray([


### PR DESCRIPTION
PolygonGeometry and PolygonOutlineGeometry were altering the user's input array when the positions had the wrong winding order.  This makes a copy of the array before reversing it.