### PR TITLE
Write globe depth when picking

### DIFF
--- a/Source/Scene/Globe.js
+++ b/Source/Scene/Globe.js
@@ -930,10 +930,17 @@ define([
             }
         }
 
-        if (pass.pick && mode === SceneMode.SCENE3D) {
-            // Not actually pickable, but render depth-only so primitives on the backface
-            // of the globe are not picked.
-            commandList.push(this._depthCommand);
+        if (pass.pick) {
+            if (!this.depthTestAgainstTerrain) {
+                // Render depth plane in 3D so primitives on the backface
+                // of the globe are not picked.
+                if (mode === SceneMode.SCENE3D) {
+                    commandList.push(this._depthCommand);
+                }
+            } else {
+                // Render tile depths for primitives on the ground.
+                surface.update(context, frameState, commandList);
+            }
         }
     };
 

--- a/Source/Scene/GlobeSurfaceShaderSet.js
+++ b/Source/Scene/GlobeSurfaceShaderSet.js
@@ -29,6 +29,39 @@ define([
         this._attributeLocations = terrainAttributeLocations;
 
         this._shadersByTexturesFlags = [];
+        this._pickShaderPrograms = [];
+    }
+
+    function getPositionMode(sceneMode) {
+        var getPosition3DMode = 'vec4 getPosition(vec3 position3DWC) { return getPosition3DMode(position3DWC); }';
+        var getPosition2DMode = 'vec4 getPosition(vec3 position3DWC) { return getPosition2DMode(position3DWC); }';
+        var getPositionColumbusViewMode = 'vec4 getPosition(vec3 position3DWC) { return getPositionColumbusViewMode(position3DWC); }';
+        var getPositionMorphingMode = 'vec4 getPosition(vec3 position3DWC) { return getPositionMorphingMode(position3DWC); }';
+
+        var positionMode;
+
+        switch (sceneMode) {
+        case SceneMode.SCENE3D:
+            positionMode = getPosition3DMode;
+            break;
+        case SceneMode.SCENE2D:
+            positionMode = getPosition2DMode;
+            break;
+        case SceneMode.COLUMBUS_VIEW:
+            positionMode = getPositionColumbusViewMode;
+            break;
+        case SceneMode.MORPHING:
+            positionMode = getPositionMorphingMode;
+            break;
+        }
+
+        return positionMode;
+    }
+
+    function get2DYPositionFraction(useWebMercatorProjection) {
+        var get2DYPositionFractionGeographicProjection = 'float get2DYPositionFraction() { return get2DGeographicYPositionFraction(); }';
+        var get2DYPositionFractionMercatorProjection = 'float get2DYPositionFraction() { return get2DMercatorYPositionFraction(); }';
+        return useWebMercatorProjection ? get2DYPositionFractionMercatorProjection : get2DYPositionFractionGeographicProjection;
     }
 
     GlobeSurfaceShaderSet.prototype.getShaderProgram = function(context, sceneMode, surfaceTile, numberOfDayTextures, applyBrightness, applyContrast, applyHue, applySaturation, applyGamma, applyAlpha, showReflectiveOcean, showOceanWaves, enableLighting, hasVertexNormals, useWebMercatorProjection) {
@@ -131,42 +164,8 @@ define([
 
             fs.sources.push(computeDayColor);
 
-            var getPosition3DMode = 'vec4 getPosition(vec3 position3DWC) { return getPosition3DMode(position3DWC); }';
-            var getPosition2DMode = 'vec4 getPosition(vec3 position3DWC) { return getPosition2DMode(position3DWC); }';
-            var getPositionColumbusViewMode = 'vec4 getPosition(vec3 position3DWC) { return getPositionColumbusViewMode(position3DWC); }';
-            var getPositionMorphingMode = 'vec4 getPosition(vec3 position3DWC) { return getPositionMorphingMode(position3DWC); }';
-
-            var getPositionMode;
-
-            switch (sceneMode) {
-            case SceneMode.SCENE3D:
-                getPositionMode = getPosition3DMode;
-                break;
-            case SceneMode.SCENE2D:
-                getPositionMode = getPosition2DMode;
-                break;
-            case SceneMode.COLUMBUS_VIEW:
-                getPositionMode = getPositionColumbusViewMode;
-                break;
-            case SceneMode.MORPHING:
-                getPositionMode = getPositionMorphingMode;
-                break;
-            }
-
-            vs.sources.push(getPositionMode);
-
-            var get2DYPositionFractionGeographicProjection = 'float get2DYPositionFraction() { return get2DGeographicYPositionFraction(); }';
-            var get2DYPositionFractionMercatorProjection = 'float get2DYPositionFraction() { return get2DMercatorYPositionFraction(); }';
-
-            var get2DYPositionFraction;
-
-            if (useWebMercatorProjection) {
-                get2DYPositionFraction = get2DYPositionFractionMercatorProjection;
-            } else {
-                get2DYPositionFraction = get2DYPositionFractionGeographicProjection;
-            }
-
-            vs.sources.push(get2DYPositionFraction);
+            vs.sources.push(getPositionMode(sceneMode));
+            vs.sources.push(get2DYPositionFraction(useWebMercatorProjection));
 
             var shader = context.createShaderProgram(vs, fs, this._attributeLocations);
             surfaceShader = shadersByFlags[flags] = new GlobeSurfaceShader(numberOfDayTextures, flags, shader);
@@ -174,6 +173,28 @@ define([
 
         surfaceTile.surfaceShader = surfaceShader;
         return surfaceShader.shaderProgram;
+    };
+
+    GlobeSurfaceShaderSet.prototype.getPickShaderProgram = function(context, sceneMode, useWebMercatorProjection) {
+        var flags = sceneMode | (useWebMercatorProjection << 2);
+        var pickShader = this._pickShaderPrograms[flags];
+
+        if (!defined(pickShader)) {
+            var vs = this.baseVertexShaderSource.clone();
+            vs.sources.push(getPositionMode(sceneMode));
+            vs.sources.push(get2DYPositionFraction(useWebMercatorProjection));
+
+            // pass through fragment shader. only depth is rendered for the globe on a pick pass
+            var fs =
+                'void main()\n' +
+                '{\n' +
+                '    gl_FragColor = vec4(1.0, 1.0, 0.0, 1.0);\n' +
+                '}\n';
+
+            pickShader = this._pickShaderPrograms[flags] = context.createShaderProgram(vs, fs, this._attributeLocations);
+        }
+
+        return pickShader;
     };
 
     GlobeSurfaceShaderSet.prototype.destroy = function() {

--- a/Source/Scene/QuadtreePrimitive.js
+++ b/Source/Scene/QuadtreePrimitive.js
@@ -243,13 +243,21 @@ define([
      *        commands to this array during the update call.
      */
     QuadtreePrimitive.prototype.update = function(context, frameState, commandList) {
-        this._tileProvider.beginUpdate(context, frameState, commandList);
+        var passes = frameState.passes;
 
-        selectTilesForRendering(this, context, frameState);
-        processTileLoadQueue(this, context, frameState);
-        createRenderCommandsForSelectedTiles(this, context, frameState, commandList);
+        if (passes.render) {
+            this._tileProvider.beginUpdate(context, frameState, commandList);
 
-        this._tileProvider.endUpdate(context, frameState, commandList);
+            selectTilesForRendering(this, context, frameState);
+            processTileLoadQueue(this, context, frameState);
+            createRenderCommandsForSelectedTiles(this, context, frameState, commandList);
+
+            this._tileProvider.endUpdate(context, frameState, commandList);
+        }
+
+        if (passes.pick && this._tilesToRender.length > 0) {
+            this._tileProvider.endUpdate(context, frameState, commandList);
+        }
     };
 
     /**


### PR DESCRIPTION
The globe used to only draw the depth plane on a pick pass so geometry on the other side of the globe  would not get picked. This change makes the tiles of the previous frame render depth only on a pick.

You can test by:
* Going to the picking Sandcastle example.
* Add the line `scene.globe.depthTestAgainstTerrain = true` to the example
* Run.
* Click the `pick entity button`.
* Rotate so part of the billboard intersects the globe.

When run in master, the billboard will be picked where it is rendered under terrain. In this branch, it will not.