### PR TITLE
Use tms Y coordinate in tile label display

### DIFF
--- a/Source/Scene/TileCoordinatesImageryProvider.js
+++ b/Source/Scene/TileCoordinatesImageryProvider.js
@@ -241,8 +241,11 @@ define([
         context.strokeStyle = cssColor;
         context.lineWidth = 2;
         context.strokeRect(1, 1, 255, 255);
+        
+        var yTiles = this._tilingScheme.getNumberOfYTilesAtLevel(level);
+        var tmsY = (yTiles - y - 1);
 
-        var label = 'L' + level + 'X' + x + 'Y' + y;
+        var label = 'L' + level + 'X' + x + 'Y' + tmsY;
         context.font = 'bold 25px Arial';
         context.textAlign = 'center';
         context.fillStyle = 'black';


### PR DESCRIPTION
The Cesium Inspector allows you to display the tile coordinates onto the scene. This is a great feature and helps tremendously for debugging purposes.

Anyhow, the Y coordinate of the label does not correspond to the actual Tile URL that is loaded. When the CesiumTerrainProvider loads the tile, it transforms the Y coordinate into the TMS system per default [1]. This transformation was missing when creating the label for the Cesium inspector.

This PR does the same transformation when creating the label that is displayed in the scene.

[1] https://github.com/AnalyticalGraphicsInc/cesium/blob/17dbf0560683701e6742f9af7c3b72c15386941c/Source/Core/CesiumTerrainProvider.js#L493