### PR TITLE
Move infoBox loading indicator styling into iframe.

### DIFF
--- a/Source/Widgets/InfoBox/InfoBox.css
+++ b/Source/Widgets/InfoBox/InfoBox.css
@@ -101,18 +101,6 @@ button.cesium-infoBox-close:active {
     display: none;
 }
 
-.cesium-infoBox-loadingContainer {
-    margin: 5px;
-    text-align: center;
-}
-
-.cesium-infoBox-loading {
-    display: inline-block;
-    background-image: url(../Images/info-loading.gif);
-    width: 16px;
-    height: 11px;
-}
-
 .cesium-infoBox-iframe {
     border: none;
     width: 100%; /* Fallback */

--- a/Source/Widgets/InfoBox/InfoBoxDescription.css
+++ b/Source/Widgets/InfoBox/InfoBoxDescription.css
@@ -76,3 +76,15 @@ body {
 .cesium-infoBox-defaultTable-lighter tr:nth-child(even) {
     background-color: rgba(179, 179, 179, 0.25);
 }
+
+.cesium-infoBox-loadingContainer {
+    margin: 5px;
+    text-align: center;
+}
+
+.cesium-infoBox-loading {
+    display: inline-block;
+    background-image: url(../Images/info-loading.gif);
+    width: 16px;
+    height: 11px;
+}


### PR DESCRIPTION
The CSS styles for the infoBox loading indicator were never moved to the other stylesheet for use with the new iframe.  Core Cesium no longer directly shows this indicator since the removal of Caja, but the indicator is still available as part of the standard theme supplied with the infoBox for apps to use.