### PR TITLE
Also bind tilt to ctrl-right-drag.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,7 +12,7 @@ Change Log
 * Added ArcGIS token-based authentication support to `ArcGisMapServerImageryProvider`.
 * `ArcGisMapServerImageryProvider` now supports a proxy for `pickFeatures` requests.
 * Added `MapboxImageryProvider` to load imagery from [Mapbox](https://www.mapbox.com).
-* The default `CTRL + Left Click Drag` mouse behavior is now also mapped to `CTRL + Right Click Drag` compatibility with Firefox for Mac OS [#2872](https://github.com/AnalyticalGraphicsInc/cesium/pull/2913).
+* The default `CTRL + Left Click Drag` mouse behavior is now duplicated for `CTRL + Right Click Drag` for better compatibility with Firefox on Mac OS [#2872](https://github.com/AnalyticalGraphicsInc/cesium/pull/2913).
 * Fixed incorrect texture coordinates for `WallGeometry` [#2872](https://github.com/AnalyticalGraphicsInc/cesium/issues/2872)
 * Fixed `WallGeometry` bug that caused walls covering a short distance not to render. [#2897](https://github.com/AnalyticalGraphicsInc/cesium/issues/2897)
 * Fixed `PolygonGeometry` clockwise winding order bug. 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@ Change Log
 * Added ArcGIS token-based authentication support to `ArcGisMapServerImageryProvider`.
 * `ArcGisMapServerImageryProvider` now supports a proxy for `pickFeatures` requests.
 * Added `MapboxImageryProvider` to load imagery from [Mapbox](https://www.mapbox.com).
+* The default `CTRL + Left Click Drag` mouse behavior is now also mapped to `CTRL + Right Click Drag` compatibility with Firefox for Mac OS [#2872](https://github.com/AnalyticalGraphicsInc/cesium/pull/2913).
 * Fixed incorrect texture coordinates for `WallGeometry` [#2872](https://github.com/AnalyticalGraphicsInc/cesium/issues/2872)
 * Fixed `WallGeometry` bug that caused walls covering a short distance not to render. [#2897](https://github.com/AnalyticalGraphicsInc/cesium/issues/2897)
 * Fixed `PolygonGeometry` clockwise winding order bug. 

--- a/Source/Scene/ScreenSpaceCameraController.js
+++ b/Source/Scene/ScreenSpaceCameraController.js
@@ -206,10 +206,16 @@ define([
          * @default [{@link CameraEventType.MIDDLE_DRAG}, {@link CameraEventType.PINCH}, {
          *     eventType : {@link CameraEventType.LEFT_DRAG},
          *     modifier : {@link KeyboardEventModifier.CTRL}
+         * }, {
+         *     eventType : {@link CameraEventType.RIGHT_DRAG},
+         *     modifier : {@link KeyboardEventModifier.CTRL}
          * }]
          */
         this.tiltEventTypes = [CameraEventType.MIDDLE_DRAG, CameraEventType.PINCH, {
             eventType : CameraEventType.LEFT_DRAG,
+            modifier : KeyboardEventModifier.CTRL
+        }, {
+            eventType : CameraEventType.RIGHT_DRAG,
             modifier : KeyboardEventModifier.CTRL
         }];
         /**

--- a/Source/Widgets/NavigationHelpButton/NavigationHelpButton.js
+++ b/Source/Widgets/NavigationHelpButton/NavigationHelpButton.js
@@ -130,7 +130,7 @@ cesiumSvgPath: { path: _svgPath, width: 32, height: 32 }');
                     <td>\
                         <div class="cesium-navigation-help-rotate">Rotate view</div>\
                         <div class="cesium-navigation-help-details">Middle click + drag, or</div>\
-                        <div class="cesium-navigation-help-details">CTRL + Left click + drag</div>\
+                        <div class="cesium-navigation-help-details">CTRL + Left/Right click + drag</div>\
                     </td>\
                 </tr>\
             </table>';


### PR DESCRIPTION
On Firefox, on OS X, it is impossible to ctrl-left-click, on a laptop with a trackpad.  Because OS X typically interprets ctrl-click as a secondary ("right") click, Firefox "helpfully" decides to send a right-click JS mouse event, unlike both Chrome and Safari.

This new mouse binding affects all platforms, but ctrl-right-drag wasn't bound to anything by default anyway.