### PR TITLE
Don't assume the first element of the KML node is the root feature

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,7 +8,7 @@ Change Log
 * Deprecated
   *
 * Fix issue where extruded `PolygonGeometry` was always extruding to the ellipsoid surface instead of specified height.
- 
+* Fix an issue where non-feature nodes prevented KML documents from loading. [#2945](https://github.com/AnalyticalGraphicsInc/cesium/pull/2945).
 
 ### 1.12 - 2015-08-03
 

--- a/Source/DataSources/KmlDataSource.js
+++ b/Source/DataSources/KmlDataSource.js
@@ -1544,7 +1544,14 @@ define([
         return when.all(processStyles(dataSource, kml, styleCollection, sourceUri, false, uriResolver), function() {
             var element = kml.documentElement;
             if (element.localName === 'kml') {
-                element = element.firstElementChild;
+                var childNodes = element.childNodes;
+                for (var i = 0; i < childNodes.length; i++) {
+                    var tmp = childNodes[i];
+                    if (defined(featureTypes[tmp.localName])) {
+                        element = tmp;
+                        break;
+                    }
+                }
             }
             processFeatureNode(dataSource, element, undefined, entityCollection, styleCollection, sourceUri, uriResolver);
 

--- a/Specs/DataSources/KmlDataSourceSpec.js
+++ b/Specs/DataSources/KmlDataSourceSpec.js
@@ -2833,4 +2833,22 @@ defineSuite([
             expect(entity.polygon.perPositionHeight.getValue()).toEqual(true);
         });
     });
+
+    it('Properly finds the root feature node when it is not the first child of the KML node', function() {
+        var kml = '<?xml version="1.0" encoding="UTF-8"?>\
+            <kml xmlns="http://www.opengis.net/kml/2.2">\
+            <NetworkLinkControl>\
+            </NetworkLinkControl>\
+            <Placemark>\
+            <name>bob</name>\
+            </Placemark>\
+            </kml>';
+
+        return KmlDataSource.load(parser.parseFromString(kml, "text/xml")).then(function(dataSource) {
+            var entity = dataSource.entities.values[0];
+            expect(entity.name).toBe('bob');
+            expect(entity.label).toBeDefined();
+            expect(entity.label.text.getValue()).toBe('bob');
+        });
+    });
 });


### PR DESCRIPTION
NetworkLinkControl elements can be children of the kml root node but do not count as the root feature node.  Instead, we need to iterate all kml child nodes to locate the root feature node.

Reported via [the forum](https://groups.google.com/d/msg/cesium-dev/QalGf6LQw94/HCpgubr3XKQJ).

Below test fails in master, passes in this branch.