### PR TITLE
Remove .intersect from AxisAlignedBoundingBox and BoundingSphere

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@ Change Log
 ### 1.13 - 2015-09-01
 
 * Breaking changes
-  *
+  * Remove deprecated `AxisAlignedBoundingBox.intersect` and `BoundingSphere.intersect`. Use `.intersectPlane` instead.
 * Deprecated
   *
 * Fix issue where extruded `PolygonGeometry` was always extruding to the ellipsoid surface instead of specified height.

--- a/Source/Core/AxisAlignedBoundingBox.js
+++ b/Source/Core/AxisAlignedBoundingBox.js
@@ -200,26 +200,6 @@ define([
         return Intersect.INTERSECTING;
     };
 
-    var scratchPlane = new Plane(new Cartesian3(), 0.0);
-    /**
-     * Determines which side of a plane a box is located.
-     *
-     * @deprecated
-     * @param {AxisAlignedBoundingBox} box The bounding box to test.
-     * @param {Cartesian4} plane The coefficients of the plane in the form <code>ax + by + cz + d = 0</code>
-     *                           where the coefficients a, b, c, and d are the components x, y, z, and w
-     *                           of the {@link Cartesian4}, respectively.
-     * @returns {Intersect} {@link Intersect.INSIDE} if the entire box is on the side of the plane
-     *                      the normal is pointing, {@link Intersect.OUTSIDE} if the entire box is
-     *                      on the opposite side, and {@link Intersect.INTERSECTING} if the box
-     *                      intersects the plane.
-     */
-    AxisAlignedBoundingBox.intersect = function(box, plane) {
-        deprecationWarning('AxisAlignedBoundingBox.intersect', 'AxisAlignedBoundingBox.intersect() was deprecated in Cesium 1.11.  It will be removed in 1.12.  Use AxisAlignedBoundingBox.intersectPlane() instead.');
-        var p = Plane.fromCartesian4(plane, scratchPlane);
-        return AxisAlignedBoundingBox.intersectPlane(box, p);
-    };
-
     /**
      * Duplicates this AxisAlignedBoundingBox instance.
      *
@@ -241,22 +221,6 @@ define([
      */
     AxisAlignedBoundingBox.prototype.intersectPlane = function(plane) {
         return AxisAlignedBoundingBox.intersectPlane(this, plane);
-    };
-
-    /**
-     * Determines which side of a plane this box is located.
-     *
-     * @deprecated
-     * @param {Cartesian4} plane The coefficients of the plane in the form <code>ax + by + cz + d = 0</code>
-     *                           where the coefficients a, b, c, and d are the components x, y, z, and w
-     *                           of the {@link Cartesian4}, respectively.
-     * @returns {Intersect} {@link Intersect.INSIDE} if the entire box is on the side of the plane
-     *                      the normal is pointing, {@link Intersect.OUTSIDE} if the entire box is
-     *                      on the opposite side, and {@link Intersect.INTERSECTING} if the box
-     *                      intersects the plane.
-     */
-    AxisAlignedBoundingBox.prototype.intersect = function(plane) {
-        return AxisAlignedBoundingBox.intersect(this, plane);
     };
 
     /**

--- a/Source/Core/BoundingSphere.js
+++ b/Source/Core/BoundingSphere.js
@@ -797,27 +797,6 @@ define([
         return Intersect.INSIDE;
     };
 
-    var scratchPlane = new Plane(new Cartesian3(), 0.0);
-    /**
-     * Determines which side of a plane a sphere is located.
-     *
-     * @deprecated
-     * @param {BoundingSphere} sphere The bounding sphere to test.
-     * @param {Cartesian4} plane The coefficients of the plane in Hessian Normal Form, as `ax + by + cz + d = 0`,
-     *                           where (a, b, c) must be a unit normal vector.
-     *                           The coefficients a, b, c, and d are the components x, y, z,
-     *                           and w of the {@link Cartesian4}, respectively.
-     * @returns {Intersect} {@link Intersect.INSIDE} if the entire sphere is on the side of the plane
-     *                      the normal is pointing, {@link Intersect.OUTSIDE} if the entire sphere is
-     *                      on the opposite side, and {@link Intersect.INTERSECTING} if the sphere
-     *                      intersects the plane.
-     */
-    BoundingSphere.intersect = function(sphere, plane) {
-        deprecationWarning('BoundingSphere.intersect', 'BoundingSphere.intersect() was deprecated in Cesium 1.11.  It will be removed in 1.12.  Use BoundingSphere.intersectPlane() instead.');
-        var p = Plane.fromCartesian4(plane, scratchPlane);
-        return BoundingSphere.intersectPlane(sphere, p);
-    };
-
     /**
      * Applies a 4x4 affine transformation matrix to a bounding sphere.
      *
@@ -1092,22 +1071,6 @@ define([
      */
     BoundingSphere.prototype.intersectPlane = function(plane) {
         return BoundingSphere.intersectPlane(this, plane);
-    };
-
-    /**
-     * Determines which side of a plane the sphere is located.
-     *
-     * @deprecated
-     * @param {Cartesian4} plane The coefficients of the plane in the for ax + by + cz + d = 0
-     *                           where the coefficients a, b, c, and d are the components x, y, z,
-     *                           and w of the {@link Cartesian4}, respectively.
-     * @returns {Intersect} {@link Intersect.INSIDE} if the entire sphere is on the side of the plane
-     *                      the normal is pointing, {@link Intersect.OUTSIDE} if the entire sphere is
-     *                      on the opposite side, and {@link Intersect.INTERSECTING} if the sphere
-     *                      intersects the plane.
-     */
-    BoundingSphere.prototype.intersect = function(plane) {
-        return BoundingSphere.intersect(this, plane);
     };
 
     /**

--- a/Specs/Core/AxisAlignedBoundingBoxSpec.js
+++ b/Specs/Core/AxisAlignedBoundingBoxSpec.js
@@ -141,14 +141,6 @@ defineSuite([
         expect(box.intersectPlane(plane)).toEqual(Intersect.INTERSECTING);
     });
 
-    it('intersect works the same as intersectPlane in one case', function() {
-        var box = new AxisAlignedBoundingBox(Cartesian3.ZERO, Cartesian3.multiplyByScalar(Cartesian3.UNIT_X, 2.0, new Cartesian3()));
-        var normal = Cartesian3.UNIT_X;
-        var position = Cartesian3.UNIT_X;
-        var plane = new Plane(normal, -Cartesian3.dot(normal, position));
-        expect(box.intersect(new Cartesian4(1.0, 0.0, 0.0, -1.0))).toEqual(box.intersectPlane(plane));
-    });
-
     it('clone returns undefined with no parameter', function() {
         expect(AxisAlignedBoundingBox.clone()).toBeUndefined();
     });

--- a/Specs/Core/BoundingSphereSpec.js
+++ b/Specs/Core/BoundingSphereSpec.js
@@ -410,14 +410,6 @@ defineSuite([
         expect(sphere.intersectPlane(plane)).toEqual(Intersect.INTERSECTING);
     });
 
-    it('intersect works the same as intersectPlane in one case', function() {
-        var sphere = new BoundingSphere(Cartesian3.UNIT_X, 0.5);
-        var normal = Cartesian3.UNIT_X;
-        var position = Cartesian3.UNIT_X;
-        var plane = new Plane(normal, -Cartesian3.dot(normal, position));
-        expect(sphere.intersect(new Cartesian4(1.0, 0.0, 0.0, -1.0))).toEqual(sphere.intersectPlane(plane));
-    });
-
     it('expands to contain another sphere', function() {
         var bs1 = new BoundingSphere(Cartesian3.negate(Cartesian3.UNIT_X, new Cartesian3()), 1.0);
         var bs2 = new BoundingSphere(Cartesian3.UNIT_X, 1.0);


### PR DESCRIPTION
For 1.13 release. Closes #2807. @pjcozzi