### PR TITLE
Add missing doc

### DIFF
--- a/Source/Core/BingMapsApi.js
+++ b/Source/Core/BingMapsApi.js
@@ -5,6 +5,12 @@ define([
         defined) {
     "use strict";
 
+    /**
+     * Object for setting and retrieving the default BingMaps API key.
+     *
+     * @namespace
+     * @alias BingMapsApi
+     */
     var BingMapsApi = {
     };
 


### PR DESCRIPTION
Fili notices today that the BingMapsApi object was not showing up in the documentation.  The object declaration was missing it's doc.