### PR TITLE
Refactor Buffer creation

### DIFF
--- a/Source/Renderer/Buffer.js
+++ b/Source/Renderer/Buffer.js
@@ -20,33 +20,51 @@ define([
     /**
      * @private
      */
-    var Buffer = function(context, bufferTarget, typedArrayOrSizeInBytes, usage) {
-        var gl = context._gl;
-        var sizeInBytes;
+    var Buffer = function(options) {
+        options = defaultValue(options, defaultValue.EMPTY_OBJECT);
 
-        if (typeof typedArrayOrSizeInBytes === 'number') {
-            sizeInBytes = typedArrayOrSizeInBytes;
-        } else if (typeof typedArrayOrSizeInBytes === 'object' && typeof typedArrayOrSizeInBytes.byteLength === 'number') {
-            sizeInBytes = typedArrayOrSizeInBytes.byteLength;
-        } else {
-            //>>includeStart('debug', pragmas.debug);
-            throw new DeveloperError('typedArrayOrSizeInBytes must be either a typed array or a number.');
-            //>>includeEnd('debug');
+        //>>includeStart('debug', pragmas.debug);
+        if (!defined(options.context)) {
+            throw new DeveloperError('options.context is required.');
+        }
+
+        if (!defined(options.typedArray) && !defined(options.sizeInBytes)) {
+            throw new DeveloperError('Either options.sizeInBytes or options.typedArray is required.');
+        }
+
+        if (defined(options.typedArray) && defined(options.sizeInBytes)) {
+            throw new DeveloperError('Cannot pass in both options.sizeInBytes and options.typedArray.');
+        }
+
+        if (defined(options.typedArray) && !(typeof options.typedArray === 'object' && typeof options.typedArray.byteLength === 'number')) {
+            throw new DeveloperError('options.typedArray must be a typed array');
+        }
+
+        if (!BufferUsage.validate(options.usage)) {
+            throw new DeveloperError('usage is invalid.');
+        }
+        //>>includeEnd('debug');
+
+        var gl = options.context._gl;
+        var bufferTarget = options.bufferTarget;
+        var typedArray = options.typedArray;
+        var sizeInBytes = options.sizeInBytes;
+        var usage = options.usage;
+        var hasArray = defined(typedArray);
+
+        if (hasArray) {
+            sizeInBytes = typedArray.byteLength;
         }
 
         //>>includeStart('debug', pragmas.debug);
         if (sizeInBytes <= 0) {
-            throw new DeveloperError('typedArrayOrSizeInBytes must be greater than zero.');
-        }
-
-        if (!BufferUsage.validate(usage)) {
-            throw new DeveloperError('usage is invalid.');
+            throw new DeveloperError('Buffer size must be greater than zero.');
         }
         //>>includeEnd('debug');
 
         var buffer = gl.createBuffer();
         gl.bindBuffer(bufferTarget, buffer);
-        gl.bufferData(bufferTarget, typedArrayOrSizeInBytes, usage);
+        gl.bufferData(bufferTarget, hasArray ? typedArray : sizeInBytes, usage);
         gl.bindBuffer(bufferTarget, null);
 
         this._gl = gl;
@@ -63,32 +81,53 @@ define([
      * A vertex array defines the actual makeup of a vertex, e.g., positions, normals, texture coordinates,
      * etc., by interpreting the raw data in one or more vertex buffers.
      *
-     * @param {Context} context The context in which to create the buffer
-     * @param {ArrayBufferView|Number} typedArrayOrSizeInBytes A typed array containing the data to copy to the buffer, or a <code>Number</code> defining the size of the buffer in bytes.
-     * @param {BufferUsage} usage Specifies the expected usage pattern of the buffer.  On some GL implementations, this can significantly affect performance.  See {@link BufferUsage}.
+     * @param {Object} options An object containing the following properties:
+     * @param {Context} options.context The context in which to create the buffer
+     * @param {ArrayBufferView} [options.typedArray] A typed array containing the data to copy to the buffer.
+     * @param {Number} [options.sizeInBytes] A <code>Number</code> defining the size of the buffer in bytes. Required if options.typedArray is not given.
+     * @param {BufferUsage} options.usage Specifies the expected usage pattern of the buffer. On some GL implementations, this can significantly affect performance. See {@link BufferUsage}.
      * @returns {VertexBuffer} The vertex buffer, ready to be attached to a vertex array.
      *
-     * @exception {DeveloperError} The size in bytes must be greater than zero.
+     * @exception {DeveloperError} Must specify either <options.typedArray> or <options.sizeInBytes>, but not both.
+     * @exception {DeveloperError} The buffer size must be greater than zero.
      * @exception {DeveloperError} Invalid <code>usage</code>.
      *
-     * @see Buffer#createIndexBuffer
      * @see {@link https://www.khronos.org/opengles/sdk/docs/man/xhtml/glGenBuffer.xml|glGenBuffer}
      * @see {@link https://www.khronos.org/opengles/sdk/docs/man/xhtml/glBindBuffer.xml|glBindBuffer} with <code>ARRAY_BUFFER</code>
      * @see {@link https://www.khronos.org/opengles/sdk/docs/man/xhtml/glBufferData.xml|glBufferData} with <code>ARRAY_BUFFER</code>
      *
      * @example
      * // Example 1. Create a dynamic vertex buffer 16 bytes in size.
-     * var buffer = Buffer.createVertexBuffer(context, 16, BufferUsage.DYNAMIC_DRAW);
+     * var buffer = Buffer.createVertexBuffer({
+     *     context : context,
+     *     sizeInBytes : 16,
+     *     usage : BufferUsage.DYNAMIC_DRAW
+     * });
      *
      * @example
      * // Example 2. Create a dynamic vertex buffer from three floating-point values.
      * // The data copied to the vertex buffer is considered raw bytes until it is
      * // interpreted as vertices using a vertex array.
-     * var positionBuffer = buffer.createVertexBuffer(context, new Float32Array([0, 0, 0]),
-     *     BufferUsage.STATIC_DRAW);
+     * var positionBuffer = buffer.createVertexBuffer({
+     *     context : context,
+     *     typedArray : new Float32Array([0, 0, 0]),
+     *     usage : BufferUsage.STATIC_DRAW
+     * });
      */
-    Buffer.createVertexBuffer = function(context, typedArrayOrSizeInBytes, usage) {
-        return new Buffer(context, context._gl.ARRAY_BUFFER, typedArrayOrSizeInBytes, usage);
+    Buffer.createVertexBuffer = function(options) {
+        //>>includeStart('debug', pragmas.debug);
+        if (!defined(options.context)) {
+            throw new DeveloperError('options.context is required.');
+        }
+        //>>includeEnd('debug');
+
+        return new Buffer({
+            context: options.context,
+            bufferTarget: options.context._gl.ARRAY_BUFFER,
+            typedArray: options.typedArray,
+            sizeInBytes: options.sizeInBytes,
+            usage: options.usage
+        });
     };
 
     /**
@@ -98,19 +137,20 @@ define([
      * <code>Context.draw</code> can render using the entire index buffer or a subset
      * of the index buffer defined by an offset and count.
      *
-     * @param {Context} context The context in which to create the buffer
-     * @param {ArrayBufferView|Number} typedArrayOrSizeInBytes A typed array containing the data to copy to the buffer, or a <code>Number</code> defining the size of the buffer in bytes.
-     * @param {BufferUsage} usage Specifies the expected usage pattern of the buffer.  On some GL implementations, this can significantly affect performance.  See {@link BufferUsage}.
+     * @param {Object} options An object containing the following properties:
+     * @param {Context} options.context The context in which to create the buffer
+     * @param {ArrayBufferView} [options.typedArray] A typed array containing the data to copy to the buffer.
+     * @param {Number} [options.sizeInBytes] A <code>Number</code> defining the size of the buffer in bytes. Required if options.typedArray is not given.
+     * @param {BufferUsage} options.usage Specifies the expected usage pattern of the buffer. On some GL implementations, this can significantly affect performance. See {@link BufferUsage}.
      * @param {IndexDatatype} indexDatatype The datatype of indices in the buffer.
      * @returns {IndexBuffer} The index buffer, ready to be attached to a vertex array.
      *
-     * @exception {DeveloperError} IndexDatatype.UNSIGNED_INT requires OES_element_index_uint, which is not supported on this system.    Check context.elementIndexUint.
+     * @exception {DeveloperError} Must specify either <options.typedArray> or <options.sizeInBytes>, but not both.
+     * @exception {DeveloperError} IndexDatatype.UNSIGNED_INT requires OES_element_index_uint, which is not supported on this system. Check context.elementIndexUint.
      * @exception {DeveloperError} The size in bytes must be greater than zero.
      * @exception {DeveloperError} Invalid <code>usage</code>.
      * @exception {DeveloperError} Invalid <code>indexDatatype</code>.
      *
-     * @see Buffer#createVertexBuffer
-     * @see Context#draw
      * @see {@link https://www.khronos.org/opengles/sdk/docs/man/xhtml/glGenBuffer.xml|glGenBuffer}
      * @see {@link https://www.khronos.org/opengles/sdk/docs/man/xhtml/glBindBuffer.xml|glBindBuffer} with <code>ELEMENT_ARRAY_BUFFER</code>
      * @see {@link https://www.khronos.org/opengles/sdk/docs/man/xhtml/glBufferData.xml|glBufferData} with <code>ELEMENT_ARRAY_BUFFER</code>
@@ -118,27 +158,49 @@ define([
      * @example
      * // Example 1. Create a stream index buffer of unsigned shorts that is
      * // 16 bytes in size.
-     * var buffer = Buffer.createIndexBuffer(context, 16, BufferUsage.STREAM_DRAW,
-     *     IndexDatatype.UNSIGNED_SHORT);
+     * var buffer = Buffer.createIndexBuffer({
+     *     context : context,
+     *     sizeInBytes : 16,
+     *     usage : BufferUsage.STREAM_DRAW,
+     *     indexDatatype : IndexDatatype.UNSIGNED_SHORT
+     * });
      *
      * @example
      * // Example 2. Create a static index buffer containing three unsigned shorts.
-     * var buffer = Buffer.createIndexBuffer(context, new Uint16Array([0, 1, 2]),
-     *     BufferUsage.STATIC_DRAW, IndexDatatype.UNSIGNED_SHORT)
+     * var buffer = Buffer.createIndexBuffer({
+     *     context : context,
+     *     typedArray : new Uint16Array([0, 1, 2]),
+     *     usage : BufferUsage.STATIC_DRAW,
+     *     indexDatatype : IndexDatatype.UNSIGNED_SHORT
+     * });
      */
-    Buffer.createIndexBuffer = function(context, typedArrayOrSizeInBytes, usage, indexDatatype) {
+    Buffer.createIndexBuffer = function(options) {
         //>>includeStart('debug', pragmas.debug);
-        if (!IndexDatatype.validate(indexDatatype)) {
+        if (!defined(options.context)) {
+            throw new DeveloperError('options.context is required.');
+        }
+
+        if (!IndexDatatype.validate(options.indexDatatype)) {
             throw new DeveloperError('Invalid indexDatatype.');
+        }
+
+        if ((options.indexDatatype === IndexDatatype.UNSIGNED_INT) && !options.context.elementIndexUint) {
+            throw new DeveloperError('IndexDatatype.UNSIGNED_INT requires OES_element_index_uint, which is not supported on this system.  Check context.elementIndexUint.');
         }
         //>>includeEnd('debug');
 
-        if ((indexDatatype === IndexDatatype.UNSIGNED_INT) && !context.elementIndexUint) {
-            throw new DeveloperError('IndexDatatype.UNSIGNED_INT requires OES_element_index_uint, which is not supported on this system.  Check context.elementIndexUint.');
-        }
+        var context = options.context;
+        var indexDatatype = options.indexDatatype;
 
         var bytesPerIndex = IndexDatatype.getSizeInBytes(indexDatatype);
-        var buffer = new Buffer(context, context._gl.ELEMENT_ARRAY_BUFFER, typedArrayOrSizeInBytes, usage);
+        var buffer = new Buffer({
+            context : context,
+            bufferTarget : context._gl.ELEMENT_ARRAY_BUFFER,
+            typedArray : options.typedArray,
+            sizeInBytes : options.sizeInBytes,
+            usage : options.usage
+        });
+
         var numberOfIndices = buffer.sizeInBytes / bytesPerIndex;
 
         defineProperties(buffer, {

--- a/Source/Renderer/Buffer.js
+++ b/Source/Renderer/Buffer.js
@@ -1,26 +1,165 @@
 /*global define*/
 define([
         '../Core/defaultValue',
+        '../Core/defined',
         '../Core/defineProperties',
         '../Core/destroyObject',
-        '../Core/DeveloperError'
+        '../Core/DeveloperError',
+        '../Core/IndexDatatype',
+        './BufferUsage'
     ], function(
         defaultValue,
+        defined,
         defineProperties,
         destroyObject,
-        DeveloperError) {
+        DeveloperError,
+        IndexDatatype,
+        BufferUsage) {
     "use strict";
 
     /**
      * @private
      */
-    var Buffer = function(gl, bufferTarget, sizeInBytes, usage, buffer) {
+    var Buffer = function(context, bufferTarget, typedArrayOrSizeInBytes, usage) {
+        var gl = context._gl;
+        var sizeInBytes;
+
+        if (typeof typedArrayOrSizeInBytes === 'number') {
+            sizeInBytes = typedArrayOrSizeInBytes;
+        } else if (typeof typedArrayOrSizeInBytes === 'object' && typeof typedArrayOrSizeInBytes.byteLength === 'number') {
+            sizeInBytes = typedArrayOrSizeInBytes.byteLength;
+        } else {
+            //>>includeStart('debug', pragmas.debug);
+            throw new DeveloperError('typedArrayOrSizeInBytes must be either a typed array or a number.');
+            //>>includeEnd('debug');
+        }
+
+        //>>includeStart('debug', pragmas.debug);
+        if (sizeInBytes <= 0) {
+            throw new DeveloperError('typedArrayOrSizeInBytes must be greater than zero.');
+        }
+
+        if (!BufferUsage.validate(usage)) {
+            throw new DeveloperError('usage is invalid.');
+        }
+        //>>includeEnd('debug');
+
+        var buffer = gl.createBuffer();
+        gl.bindBuffer(bufferTarget, buffer);
+        gl.bufferData(bufferTarget, typedArrayOrSizeInBytes, usage);
+        gl.bindBuffer(bufferTarget, null);
+
         this._gl = gl;
         this._bufferTarget = bufferTarget;
         this._sizeInBytes = sizeInBytes;
         this._usage = usage;
         this._buffer = buffer;
         this.vertexArrayDestroyable = true;
+    };
+
+    /**
+     * Creates a vertex buffer, which contains untyped vertex data in GPU-controlled memory.
+     * <br /><br />
+     * A vertex array defines the actual makeup of a vertex, e.g., positions, normals, texture coordinates,
+     * etc., by interpreting the raw data in one or more vertex buffers.
+     *
+     * @param {Context} context The context in which to create the buffer
+     * @param {ArrayBufferView|Number} typedArrayOrSizeInBytes A typed array containing the data to copy to the buffer, or a <code>Number</code> defining the size of the buffer in bytes.
+     * @param {BufferUsage} usage Specifies the expected usage pattern of the buffer.  On some GL implementations, this can significantly affect performance.  See {@link BufferUsage}.
+     * @returns {VertexBuffer} The vertex buffer, ready to be attached to a vertex array.
+     *
+     * @exception {DeveloperError} The size in bytes must be greater than zero.
+     * @exception {DeveloperError} Invalid <code>usage</code>.
+     *
+     * @see Buffer#createIndexBuffer
+     * @see {@link https://www.khronos.org/opengles/sdk/docs/man/xhtml/glGenBuffer.xml|glGenBuffer}
+     * @see {@link https://www.khronos.org/opengles/sdk/docs/man/xhtml/glBindBuffer.xml|glBindBuffer} with <code>ARRAY_BUFFER</code>
+     * @see {@link https://www.khronos.org/opengles/sdk/docs/man/xhtml/glBufferData.xml|glBufferData} with <code>ARRAY_BUFFER</code>
+     *
+     * @example
+     * // Example 1. Create a dynamic vertex buffer 16 bytes in size.
+     * var buffer = Buffer.createVertexBuffer(context, 16, BufferUsage.DYNAMIC_DRAW);
+     *
+     * @example
+     * // Example 2. Create a dynamic vertex buffer from three floating-point values.
+     * // The data copied to the vertex buffer is considered raw bytes until it is
+     * // interpreted as vertices using a vertex array.
+     * var positionBuffer = buffer.createVertexBuffer(context, new Float32Array([0, 0, 0]),
+     *     BufferUsage.STATIC_DRAW);
+     */
+    Buffer.createVertexBuffer = function(context, typedArrayOrSizeInBytes, usage) {
+        return new Buffer(context, context._gl.ARRAY_BUFFER, typedArrayOrSizeInBytes, usage);
+    };
+
+    /**
+     * Creates an index buffer, which contains typed indices in GPU-controlled memory.
+     * <br /><br />
+     * An index buffer can be attached to a vertex array to select vertices for rendering.
+     * <code>Context.draw</code> can render using the entire index buffer or a subset
+     * of the index buffer defined by an offset and count.
+     *
+     * @param {Context} context The context in which to create the buffer
+     * @param {ArrayBufferView|Number} typedArrayOrSizeInBytes A typed array containing the data to copy to the buffer, or a <code>Number</code> defining the size of the buffer in bytes.
+     * @param {BufferUsage} usage Specifies the expected usage pattern of the buffer.  On some GL implementations, this can significantly affect performance.  See {@link BufferUsage}.
+     * @param {IndexDatatype} indexDatatype The datatype of indices in the buffer.
+     * @returns {IndexBuffer} The index buffer, ready to be attached to a vertex array.
+     *
+     * @exception {DeveloperError} IndexDatatype.UNSIGNED_INT requires OES_element_index_uint, which is not supported on this system.    Check context.elementIndexUint.
+     * @exception {DeveloperError} The size in bytes must be greater than zero.
+     * @exception {DeveloperError} Invalid <code>usage</code>.
+     * @exception {DeveloperError} Invalid <code>indexDatatype</code>.
+     *
+     * @see Buffer#createVertexBuffer
+     * @see Context#draw
+     * @see {@link https://www.khronos.org/opengles/sdk/docs/man/xhtml/glGenBuffer.xml|glGenBuffer}
+     * @see {@link https://www.khronos.org/opengles/sdk/docs/man/xhtml/glBindBuffer.xml|glBindBuffer} with <code>ELEMENT_ARRAY_BUFFER</code>
+     * @see {@link https://www.khronos.org/opengles/sdk/docs/man/xhtml/glBufferData.xml|glBufferData} with <code>ELEMENT_ARRAY_BUFFER</code>
+     *
+     * @example
+     * // Example 1. Create a stream index buffer of unsigned shorts that is
+     * // 16 bytes in size.
+     * var buffer = Buffer.createIndexBuffer(context, 16, BufferUsage.STREAM_DRAW,
+     *     IndexDatatype.UNSIGNED_SHORT);
+     *
+     * @example
+     * // Example 2. Create a static index buffer containing three unsigned shorts.
+     * var buffer = Buffer.createIndexBuffer(context, new Uint16Array([0, 1, 2]),
+     *     BufferUsage.STATIC_DRAW, IndexDatatype.UNSIGNED_SHORT)
+     */
+    Buffer.createIndexBuffer = function(context, typedArrayOrSizeInBytes, usage, indexDatatype) {
+        //>>includeStart('debug', pragmas.debug);
+        if (!IndexDatatype.validate(indexDatatype)) {
+            throw new DeveloperError('Invalid indexDatatype.');
+        }
+        //>>includeEnd('debug');
+
+        if ((indexDatatype === IndexDatatype.UNSIGNED_INT) && !context.elementIndexUint) {
+            throw new DeveloperError('IndexDatatype.UNSIGNED_INT requires OES_element_index_uint, which is not supported on this system.  Check context.elementIndexUint.');
+        }
+
+        var bytesPerIndex = IndexDatatype.getSizeInBytes(indexDatatype);
+        var buffer = new Buffer(context, context._gl.ELEMENT_ARRAY_BUFFER, typedArrayOrSizeInBytes, usage);
+        var numberOfIndices = buffer.sizeInBytes / bytesPerIndex;
+
+        defineProperties(buffer, {
+            indexDatatype: {
+                get : function() {
+                    return indexDatatype;
+                }
+            },
+            bytesPerIndex : {
+                get : function() {
+                    return bytesPerIndex;
+                }
+            },
+            numberOfIndices : {
+                get : function() {
+                    return numberOfIndices;
+                }
+            }
+        });
+
+        return buffer;
     };
 
     defineProperties(Buffer.prototype, {

--- a/Source/Renderer/Context.js
+++ b/Source/Renderer/Context.js
@@ -12,13 +12,11 @@ define([
         '../Core/FeatureDetection',
         '../Core/Geometry',
         '../Core/GeometryAttribute',
-        '../Core/IndexDatatype',
         '../Core/Math',
         '../Core/Matrix4',
         '../Core/PrimitiveType',
         '../Core/RuntimeError',
         '../Shaders/ViewportQuadVS',
-        './Buffer',
         './BufferUsage',
         './ClearCommand',
         './ContextLimits',
@@ -47,13 +45,11 @@ define([
         FeatureDetection,
         Geometry,
         GeometryAttribute,
-        IndexDatatype,
         CesiumMath,
         Matrix4,
         PrimitiveType,
         RuntimeError,
         ViewportQuadVS,
-        Buffer,
         BufferUsage,
         ClearCommand,
         ContextLimits,
@@ -721,142 +717,6 @@ define([
             }
         }
     });
-
-    function createBuffer(gl, bufferTarget, typedArrayOrSizeInBytes, usage) {
-        var sizeInBytes;
-
-        if (typeof typedArrayOrSizeInBytes === 'number') {
-            sizeInBytes = typedArrayOrSizeInBytes;
-        } else if (typeof typedArrayOrSizeInBytes === 'object' && typeof typedArrayOrSizeInBytes.byteLength === 'number') {
-            sizeInBytes = typedArrayOrSizeInBytes.byteLength;
-        } else {
-            //>>includeStart('debug', pragmas.debug);
-            throw new DeveloperError('typedArrayOrSizeInBytes must be either a typed array or a number.');
-            //>>includeEnd('debug');
-        }
-
-        //>>includeStart('debug', pragmas.debug);
-        if (sizeInBytes <= 0) {
-            throw new DeveloperError('typedArrayOrSizeInBytes must be greater than zero.');
-        }
-
-        if (!BufferUsage.validate(usage)) {
-            throw new DeveloperError('usage is invalid.');
-        }
-        //>>includeEnd('debug');
-
-        var buffer = gl.createBuffer();
-        gl.bindBuffer(bufferTarget, buffer);
-        gl.bufferData(bufferTarget, typedArrayOrSizeInBytes, usage);
-        gl.bindBuffer(bufferTarget, null);
-
-        return new Buffer(gl, bufferTarget, sizeInBytes, usage, buffer);
-    }
-
-    /**
-     * Creates a vertex buffer, which contains untyped vertex data in GPU-controlled memory.
-     * <br /><br />
-     * A vertex array defines the actual makeup of a vertex, e.g., positions, normals, texture coordinates,
-     * etc., by interpreting the raw data in one or more vertex buffers.
-     *
-     * @param {ArrayBufferView|Number} typedArrayOrSizeInBytes A typed array containing the data to copy to the buffer, or a <code>Number</code> defining the size of the buffer in bytes.
-     * @param {BufferUsage} usage Specifies the expected usage pattern of the buffer.  On some GL implementations, this can significantly affect performance.  See {@link BufferUsage}.
-     * @returns {VertexBuffer} The vertex buffer, ready to be attached to a vertex array.
-     *
-     * @exception {DeveloperError} The size in bytes must be greater than zero.
-     * @exception {DeveloperError} Invalid <code>usage</code>.
-     *
-     * @see Context#createIndexBuffer
-     * @see {@link https://www.khronos.org/opengles/sdk/docs/man/xhtml/glGenBuffer.xml|glGenBuffer}
-     * @see {@link https://www.khronos.org/opengles/sdk/docs/man/xhtml/glBindBuffer.xml|glBindBuffer} with <code>ARRAY_BUFFER</code>
-     * @see {@link https://www.khronos.org/opengles/sdk/docs/man/xhtml/glBufferData.xml|glBufferData} with <code>ARRAY_BUFFER</code>
-     *
-     * @example
-     * // Example 1. Create a dynamic vertex buffer 16 bytes in size.
-     * var buffer = context.createVertexBuffer(16, BufferUsage.DYNAMIC_DRAW);
-     *
-     * @example
-     * // Example 2. Create a dynamic vertex buffer from three floating-point values.
-     * // The data copied to the vertex buffer is considered raw bytes until it is
-     * // interpreted as vertices using a vertex array.
-     * var positionBuffer = context.createVertexBuffer(new Float32Array([0, 0, 0]),
-     *     BufferUsage.STATIC_DRAW);
-     */
-    Context.prototype.createVertexBuffer = function(typedArrayOrSizeInBytes, usage) {
-        return createBuffer(this._gl, this._gl.ARRAY_BUFFER, typedArrayOrSizeInBytes, usage);
-    };
-
-    /**
-     * Creates an index buffer, which contains typed indices in GPU-controlled memory.
-     * <br /><br />
-     * An index buffer can be attached to a vertex array to select vertices for rendering.
-     * <code>Context.draw</code> can render using the entire index buffer or a subset
-     * of the index buffer defined by an offset and count.
-     *
-     * @param {ArrayBufferView|Number} typedArrayOrSizeInBytes A typed array containing the data to copy to the buffer, or a <code>Number</code> defining the size of the buffer in bytes.
-     * @param {BufferUsage} usage Specifies the expected usage pattern of the buffer.  On some GL implementations, this can significantly affect performance.  See {@link BufferUsage}.
-     * @param {IndexDatatype} indexDatatype The datatype of indices in the buffer.
-     * @returns {IndexBuffer} The index buffer, ready to be attached to a vertex array.
-     *
-     * @exception {DeveloperError} IndexDatatype.UNSIGNED_INT requires OES_element_index_uint, which is not supported on this system.    Check context.elementIndexUint.
-     * @exception {DeveloperError} The size in bytes must be greater than zero.
-     * @exception {DeveloperError} Invalid <code>usage</code>.
-     * @exception {DeveloperError} Invalid <code>indexDatatype</code>.
-     *
-     * @see Context#createVertexBuffer
-     * @see Context#draw
-     * @see {@link https://www.khronos.org/opengles/sdk/docs/man/xhtml/glGenBuffer.xml|glGenBuffer}
-     * @see {@link https://www.khronos.org/opengles/sdk/docs/man/xhtml/glBindBuffer.xml|glBindBuffer} with <code>ELEMENT_ARRAY_BUFFER</code>
-     * @see {@link https://www.khronos.org/opengles/sdk/docs/man/xhtml/glBufferData.xml|glBufferData} with <code>ELEMENT_ARRAY_BUFFER</code>
-     *
-     * @example
-     * // Example 1. Create a stream index buffer of unsigned shorts that is
-     * // 16 bytes in size.
-     * var buffer = context.createIndexBuffer(16, BufferUsage.STREAM_DRAW,
-     *     IndexDatatype.UNSIGNED_SHORT);
-     *
-     * @example
-     * // Example 2. Create a static index buffer containing three unsigned shorts.
-     * var buffer = context.createIndexBuffer(new Uint16Array([0, 1, 2]),
-     *     BufferUsage.STATIC_DRAW, IndexDatatype.UNSIGNED_SHORT)
-     */
-    Context.prototype.createIndexBuffer = function(typedArrayOrSizeInBytes, usage, indexDatatype) {
-        //>>includeStart('debug', pragmas.debug);
-        if (!IndexDatatype.validate(indexDatatype)) {
-            throw new DeveloperError('Invalid indexDatatype.');
-        }
-        //>>includeEnd('debug');
-
-        if ((indexDatatype === IndexDatatype.UNSIGNED_INT) && !this.elementIndexUint) {
-            throw new DeveloperError('IndexDatatype.UNSIGNED_INT requires OES_element_index_uint, which is not supported on this system.  Check context.elementIndexUint.');
-        }
-
-        var bytesPerIndex = IndexDatatype.getSizeInBytes(indexDatatype);
-
-        var gl = this._gl;
-        var buffer = createBuffer(gl, gl.ELEMENT_ARRAY_BUFFER, typedArrayOrSizeInBytes, usage);
-        var numberOfIndices = buffer.sizeInBytes / bytesPerIndex;
-
-        defineProperties(buffer, {
-            indexDatatype: {
-                get : function() {
-                    return indexDatatype;
-                }
-            },
-            bytesPerIndex : {
-                get : function() {
-                    return bytesPerIndex;
-                }
-            },
-            numberOfIndices : {
-                get : function() {
-                    return numberOfIndices;
-                }
-            }
-        });
-
-        return buffer;
-    };
 
     function validateFramebuffer(context, framebuffer) {
         if (context.validateFramebuffer) {

--- a/Source/Renderer/VertexArray.js
+++ b/Source/Renderer/VertexArray.js
@@ -151,7 +151,11 @@ define([
      * @example
      * // Example 1. Create a vertex array with vertices made up of three floating point
      * // values, e.g., a position, from a single vertex buffer.  No index buffer is used.
-     * var positionBuffer = Buffer.createVertexBuffer(context, 12, BufferUsage.STATIC_DRAW);
+     * var positionBuffer = Buffer.createVertexBuffer({
+     *     context : context,
+     *     sizeInBytes : 12,
+     *     usage : BufferUsage.STATIC_DRAW
+     * });
      * var attributes = [
      *     {
      *         index                  : 0,
@@ -172,9 +176,16 @@ define([
      * @example
      * // Example 2. Create a vertex array with vertices from two different vertex buffers.
      * // Each vertex has a three-component position and three-component normal.
-     * var positionBuffer = Buffer.createVertexBuffer(context, 12, BufferUsage.STATIC_DRAW);
-     * var normalBuffer = Buffer.createVertexBuffer(context, 12, BufferUsage.STATIC_DRAW);
-     * var attributes = [
+     * var positionBuffer = Buffer.createVertexBuffer({
+     *     context : context,
+     *     sizeInBytes : 12,
+     *     usage : BufferUsage.STATIC_DRAW
+     * });
+     * var normalBuffer = Buffer.createVertexBuffer({
+     *     context : context,
+     *     sizeInBytes : 12,
+     *     usage : BufferUsage.STATIC_DRAW
+     * });     * var attributes = [
      *     {
      *         index                  : 0,
      *         vertexBuffer           : positionBuffer,
@@ -196,7 +207,11 @@ define([
      * @example
      * // Example 3. Creates the same vertex layout as Example 2 using a single
      * // vertex buffer, instead of two.
-     * var buffer = Buffer.createVertexBuffer(context, 24, BufferUsage.STATIC_DRAW);
+     * var buffer = Buffer.createVertexBuffer({
+     *     context : context,
+     *     sizeInBytes : 24,
+     *     usage : BufferUsage.STATIC_DRAW
+     * });
      * var attributes = [
      *     {
      *         vertexBuffer           : buffer,
@@ -495,7 +510,11 @@ define([
             // Use a single vertex buffer with interleaved vertices.
             var interleavedAttributes = interleaveAttributes(attributes);
             if (defined(interleavedAttributes)) {
-                vertexBuffer = Buffer.createVertexBuffer(context, interleavedAttributes.buffer, bufferUsage);
+                vertexBuffer = Buffer.createVertexBuffer({
+                    context : context,
+                    typedArray : interleavedAttributes.buffer,
+                    usage : bufferUsage
+                });
                 var offsetsInBytes = interleavedAttributes.offsetsInBytes;
                 var strideInBytes = interleavedAttributes.vertexSizeInBytes;
 
@@ -539,7 +558,11 @@ define([
 
                     vertexBuffer = undefined;
                     if (defined(attribute.values)) {
-                        vertexBuffer = Buffer.createVertexBuffer(context, ComponentDatatype.createTypedArray(componentDatatype, attribute.values), bufferUsage);
+                        vertexBuffer = Buffer.createVertexBuffer({
+                            context : context,
+                            typedArray : ComponentDatatype.createTypedArray(componentDatatype, attribute.values),
+                            usage : bufferUsage
+                        });
                     }
 
                     vaAttributes.push({
@@ -558,9 +581,19 @@ define([
         var indices = geometry.indices;
         if (defined(indices)) {
             if ((Geometry.computeNumberOfVertices(geometry) > CesiumMath.SIXTY_FOUR_KILOBYTES) && context.elementIndexUint) {
-                indexBuffer = Buffer.createIndexBuffer(context, new Uint32Array(indices), bufferUsage, IndexDatatype.UNSIGNED_INT);
+                indexBuffer = Buffer.createIndexBuffer({
+                    context : context,
+                    typedArray : new Uint32Array(indices),
+                    usage : bufferUsage,
+                    indexDatatype : IndexDatatype.UNSIGNED_INT
+                });
             } else{
-                indexBuffer = Buffer.createIndexBuffer(context, new Uint16Array(indices), bufferUsage, IndexDatatype.UNSIGNED_SHORT);
+                indexBuffer = Buffer.createIndexBuffer({
+                    context : context,
+                    typedArray : new Uint16Array(indices),
+                    usage : bufferUsage,
+                    indexDatatype : IndexDatatype.UNSIGNED_SHORT
+                });
             }
         }
 

--- a/Source/Renderer/VertexArray.js
+++ b/Source/Renderer/VertexArray.js
@@ -10,6 +10,7 @@ define([
         '../Core/IndexDatatype',
         '../Core/Math',
         '../Core/RuntimeError',
+        './Buffer',
         './BufferUsage'
     ], function(
         ComponentDatatype,
@@ -22,6 +23,7 @@ define([
         IndexDatatype,
         CesiumMath,
         RuntimeError,
+        Buffer,
         BufferUsage) {
     "use strict";
 
@@ -142,14 +144,14 @@ define([
      * @exception {DeveloperError} Attribute must have a <code>strideInBytes</code> less than or equal to 255 or not specify it.
      * @exception {DeveloperError} Index n is used by more than one attribute.
      *
-     * @see Context#createVertexBuffer
-     * @see Context#createIndexBuffer
+     * @see Buffer#createVertexBuffer
+     * @see Buffer#createIndexBuffer
      * @see Context#draw
      *
      * @example
      * // Example 1. Create a vertex array with vertices made up of three floating point
      * // values, e.g., a position, from a single vertex buffer.  No index buffer is used.
-     * var positionBuffer = context.createVertexBuffer(12, BufferUsage.STATIC_DRAW);
+     * var positionBuffer = Buffer.createVertexBuffer(context, 12, BufferUsage.STATIC_DRAW);
      * var attributes = [
      *     {
      *         index                  : 0,
@@ -170,8 +172,8 @@ define([
      * @example
      * // Example 2. Create a vertex array with vertices from two different vertex buffers.
      * // Each vertex has a three-component position and three-component normal.
-     * var positionBuffer = context.createVertexBuffer(12, BufferUsage.STATIC_DRAW);
-     * var normalBuffer = context.createVertexBuffer(12, BufferUsage.STATIC_DRAW);
+     * var positionBuffer = Buffer.createVertexBuffer(context, 12, BufferUsage.STATIC_DRAW);
+     * var normalBuffer = Buffer.createVertexBuffer(context, 12, BufferUsage.STATIC_DRAW);
      * var attributes = [
      *     {
      *         index                  : 0,
@@ -194,7 +196,7 @@ define([
      * @example
      * // Example 3. Creates the same vertex layout as Example 2 using a single
      * // vertex buffer, instead of two.
-     * var buffer = context.createVertexBuffer(24, BufferUsage.STATIC_DRAW);
+     * var buffer = Buffer.createVertexBuffer(context, 24, BufferUsage.STATIC_DRAW);
      * var attributes = [
      *     {
      *         vertexBuffer           : buffer,
@@ -433,8 +435,8 @@ define([
      * @exception {DeveloperError} The geometry must have zero or one index lists.
      * @exception {DeveloperError} Index n is used by more than one attribute.
      *
-     * @see Context#createVertexBuffer
-     * @see Context#createIndexBuffer
+     * @see Buffer#createVertexBuffer
+     * @see Buffer#createIndexBuffer
      * @see GeometryPipeline.createAttributeLocations
      * @see ShaderProgram
      *
@@ -493,7 +495,7 @@ define([
             // Use a single vertex buffer with interleaved vertices.
             var interleavedAttributes = interleaveAttributes(attributes);
             if (defined(interleavedAttributes)) {
-                vertexBuffer = context.createVertexBuffer(interleavedAttributes.buffer, bufferUsage);
+                vertexBuffer = Buffer.createVertexBuffer(context, interleavedAttributes.buffer, bufferUsage);
                 var offsetsInBytes = interleavedAttributes.offsetsInBytes;
                 var strideInBytes = interleavedAttributes.vertexSizeInBytes;
 
@@ -537,7 +539,7 @@ define([
 
                     vertexBuffer = undefined;
                     if (defined(attribute.values)) {
-                        vertexBuffer = context.createVertexBuffer(ComponentDatatype.createTypedArray(componentDatatype, attribute.values), bufferUsage);
+                        vertexBuffer = Buffer.createVertexBuffer(context, ComponentDatatype.createTypedArray(componentDatatype, attribute.values), bufferUsage);
                     }
 
                     vaAttributes.push({
@@ -556,9 +558,9 @@ define([
         var indices = geometry.indices;
         if (defined(indices)) {
             if ((Geometry.computeNumberOfVertices(geometry) > CesiumMath.SIXTY_FOUR_KILOBYTES) && context.elementIndexUint) {
-                indexBuffer = context.createIndexBuffer(new Uint32Array(indices), bufferUsage, IndexDatatype.UNSIGNED_INT);
+                indexBuffer = Buffer.createIndexBuffer(context, new Uint32Array(indices), bufferUsage, IndexDatatype.UNSIGNED_INT);
             } else{
-                indexBuffer = context.createIndexBuffer(new Uint16Array(indices), bufferUsage, IndexDatatype.UNSIGNED_SHORT);
+                indexBuffer = Buffer.createIndexBuffer(context, new Uint16Array(indices), bufferUsage, IndexDatatype.UNSIGNED_SHORT);
             }
         }
 

--- a/Source/Renderer/VertexArrayFacade.js
+++ b/Source/Renderer/VertexArrayFacade.js
@@ -365,7 +365,11 @@ define([
                 if (vertexBufferDefined) {
                     vertexBuffer.destroy();
                 }
-                buffer.vertexBuffer = Buffer.createVertexBuffer(vertexArrayFacade._context, buffer.arrayBuffer, buffer.usage);
+                buffer.vertexBuffer = Buffer.createVertexBuffer({
+                    context : vertexArrayFacade._context,
+                    typedArray : buffer.arrayBuffer,
+                    usage : buffer.usage
+                });
                 buffer.vertexBuffer.vertexArrayDestroyable = false;
 
                 return true; // Created new vertex buffer

--- a/Source/Renderer/VertexArrayFacade.js
+++ b/Source/Renderer/VertexArrayFacade.js
@@ -6,6 +6,7 @@ define([
         '../Core/destroyObject',
         '../Core/DeveloperError',
         '../Core/Math',
+        './Buffer',
         './BufferUsage',
         './VertexArray'
     ], function(
@@ -15,6 +16,7 @@ define([
         destroyObject,
         DeveloperError,
         CesiumMath,
+        Buffer,
         BufferUsage,
         VertexArray) {
     "use strict";
@@ -363,7 +365,7 @@ define([
                 if (vertexBufferDefined) {
                     vertexBuffer.destroy();
                 }
-                buffer.vertexBuffer = vertexArrayFacade._context.createVertexBuffer(buffer.arrayBuffer, buffer.usage);
+                buffer.vertexBuffer = Buffer.createVertexBuffer(vertexArrayFacade._context, buffer.arrayBuffer, buffer.usage);
                 buffer.vertexBuffer.vertexArrayDestroyable = false;
 
                 return true; // Created new vertex buffer

--- a/Source/Scene/BillboardCollection.js
+++ b/Source/Scene/BillboardCollection.js
@@ -549,7 +549,12 @@ define([
 
         // PERFORMANCE_IDEA:  Should we reference count billboard collections, and eventually delete this?
         // Is this too much memory to allocate up front?  Should we dynamically grow it?
-        indexBuffer = Buffer.createIndexBuffer(context, indices, BufferUsage.STATIC_DRAW, IndexDatatype.UNSIGNED_SHORT);
+        indexBuffer = Buffer.createIndexBuffer({
+            context : context,
+            typedArray : indices,
+            usage : BufferUsage.STATIC_DRAW,
+            indexDatatype : IndexDatatype.UNSIGNED_SHORT
+        });
         indexBuffer.vertexArrayDestroyable = false;
         context.cache.billboardCollection_indexBuffer = indexBuffer;
         return indexBuffer;

--- a/Source/Scene/BillboardCollection.js
+++ b/Source/Scene/BillboardCollection.js
@@ -15,6 +15,7 @@ define([
         '../Core/IndexDatatype',
         '../Core/Math',
         '../Core/Matrix4',
+        '../Renderer/Buffer',
         '../Renderer/BufferUsage',
         '../Renderer/DrawCommand',
         '../Renderer/RenderState',
@@ -45,6 +46,7 @@ define([
         IndexDatatype,
         CesiumMath,
         Matrix4,
+        Buffer,
         BufferUsage,
         DrawCommand,
         RenderState,
@@ -547,7 +549,7 @@ define([
 
         // PERFORMANCE_IDEA:  Should we reference count billboard collections, and eventually delete this?
         // Is this too much memory to allocate up front?  Should we dynamically grow it?
-        indexBuffer = context.createIndexBuffer(indices, BufferUsage.STATIC_DRAW, IndexDatatype.UNSIGNED_SHORT);
+        indexBuffer = Buffer.createIndexBuffer(context, indices, BufferUsage.STATIC_DRAW, IndexDatatype.UNSIGNED_SHORT);
         indexBuffer.vertexArrayDestroyable = false;
         context.cache.billboardCollection_indexBuffer = indexBuffer;
         return indexBuffer;

--- a/Source/Scene/GlobeSurfaceTileProvider.js
+++ b/Source/Scene/GlobeSurfaceTileProvider.js
@@ -25,6 +25,7 @@ define([
         '../Core/SphereOutlineGeometry',
         '../Core/Visibility',
         '../Core/WebMercatorProjection',
+        '../Renderer/Buffer',
         '../Renderer/BufferUsage',
         '../Renderer/ContextLimits',
         '../Renderer/DrawCommand',
@@ -67,6 +68,7 @@ define([
         SphereOutlineGeometry,
         Visibility,
         WebMercatorProjection,
+        Buffer,
         BufferUsage,
         ContextLimits,
         DrawCommand,
@@ -845,7 +847,7 @@ define([
         GeometryPipeline.toWireframe(geometry);
 
         var wireframeIndices = geometry.indices;
-        var wireframeIndexBuffer = context.createIndexBuffer(wireframeIndices, BufferUsage.STATIC_DRAW, IndexDatatype.UNSIGNED_SHORT);
+        var wireframeIndexBuffer = Buffer.createIndexBuffer(context, wireframeIndices, BufferUsage.STATIC_DRAW, IndexDatatype.UNSIGNED_SHORT);
         return new VertexArray({
             context : context,
             attributes : vertexArray._attributes,

--- a/Source/Scene/GlobeSurfaceTileProvider.js
+++ b/Source/Scene/GlobeSurfaceTileProvider.js
@@ -847,7 +847,12 @@ define([
         GeometryPipeline.toWireframe(geometry);
 
         var wireframeIndices = geometry.indices;
-        var wireframeIndexBuffer = Buffer.createIndexBuffer(context, wireframeIndices, BufferUsage.STATIC_DRAW, IndexDatatype.UNSIGNED_SHORT);
+        var wireframeIndexBuffer = Buffer.createIndexBuffer({
+            context : context,
+            typedArray : wireframeIndices,
+            usage : BufferUsage.STATIC_DRAW,
+            indexDatatype : IndexDatatype.UNSIGNED_SHORT
+        });
         return new VertexArray({
             context : context,
             attributes : vertexArray._attributes,

--- a/Source/Scene/ImageryLayer.js
+++ b/Source/Scene/ImageryLayer.js
@@ -846,17 +846,30 @@ define([
             };
 
             var indices = TerrainProvider.getRegularGridIndices(2, 64);
-            var indexBuffer = Buffer.createIndexBuffer(context, indices, BufferUsage.STATIC_DRAW, IndexDatatype.UNSIGNED_SHORT);
+            var indexBuffer = Buffer.createIndexBuffer({
+                context : context,
+                typedArray : indices,
+                usage : BufferUsage.STATIC_DRAW,
+                indexDatatype : IndexDatatype.UNSIGNED_SHORT
+            });
 
             reproject.vertexArray = new VertexArray({
                 context : context,
                 attributes : [{
                     index : reprojectAttributeIndices.position,
-                    vertexBuffer : Buffer.createVertexBuffer(context, positions, BufferUsage.STATIC_DRAW),
+                    vertexBuffer : Buffer.createVertexBuffer({
+                        context : context,
+                        typedArray : positions,
+                        usage : BufferUsage.STATIC_DRAW
+                    }),
                     componentsPerAttribute : 2
                 },{
                     index : reprojectAttributeIndices.webMercatorT,
-                    vertexBuffer : Buffer.createVertexBuffer(context, 64 * 2 * 4, BufferUsage.STREAM_DRAW),
+                    vertexBuffer : Buffer.createVertexBuffer({
+                        context : context,
+                        sizeInBytes : 64 * 2 * 4,
+                        usage : BufferUsage.STREAM_DRAW
+                    }),
                     componentsPerAttribute : 1
                 }],
                 indexBuffer : indexBuffer

--- a/Source/Scene/ImageryLayer.js
+++ b/Source/Scene/ImageryLayer.js
@@ -18,6 +18,7 @@ define([
         '../Core/Rectangle',
         '../Core/TerrainProvider',
         '../Core/TileProviderError',
+        '../Renderer/Buffer',
         '../Renderer/BufferUsage',
         '../Renderer/ClearCommand',
         '../Renderer/ContextLimits',
@@ -58,6 +59,7 @@ define([
         Rectangle,
         TerrainProvider,
         TileProviderError,
+        Buffer,
         BufferUsage,
         ClearCommand,
         ContextLimits,
@@ -844,17 +846,17 @@ define([
             };
 
             var indices = TerrainProvider.getRegularGridIndices(2, 64);
-            var indexBuffer = context.createIndexBuffer(indices, BufferUsage.STATIC_DRAW, IndexDatatype.UNSIGNED_SHORT);
+            var indexBuffer = Buffer.createIndexBuffer(context, indices, BufferUsage.STATIC_DRAW, IndexDatatype.UNSIGNED_SHORT);
 
             reproject.vertexArray = new VertexArray({
                 context : context,
                 attributes : [{
                     index : reprojectAttributeIndices.position,
-                    vertexBuffer : context.createVertexBuffer(positions, BufferUsage.STATIC_DRAW),
+                    vertexBuffer : Buffer.createVertexBuffer(context, positions, BufferUsage.STATIC_DRAW),
                     componentsPerAttribute : 2
                 },{
                     index : reprojectAttributeIndices.webMercatorT,
-                    vertexBuffer : context.createVertexBuffer(64 * 2 * 4, BufferUsage.STREAM_DRAW),
+                    vertexBuffer : Buffer.createVertexBuffer(context, 64 * 2 * 4, BufferUsage.STREAM_DRAW),
                     componentsPerAttribute : 1
                 }],
                 indexBuffer : indexBuffer

--- a/Source/Scene/Model.js
+++ b/Source/Scene/Model.js
@@ -27,6 +27,7 @@ define([
         '../Core/Quaternion',
         '../Core/Queue',
         '../Core/RuntimeError',
+        '../Renderer/Buffer',
         '../Renderer/BufferUsage',
         '../Renderer/DrawCommand',
         '../Renderer/RenderState',
@@ -76,6 +77,7 @@ define([
         Quaternion,
         Queue,
         RuntimeError,
+        Buffer,
         BufferUsage,
         DrawCommand,
         RenderState,
@@ -1293,7 +1295,7 @@ define([
             bufferView = bufferViews[bufferViewName];
 
             // Only ARRAY_BUFFER here.  ELEMENT_ARRAY_BUFFER created below.
-            var vertexBuffer = context.createVertexBuffer(loadResources.getBuffer(bufferView), BufferUsage.STATIC_DRAW);
+            var vertexBuffer = Buffer.createVertexBuffer(context, loadResources.getBuffer(bufferView), BufferUsage.STATIC_DRAW);
             vertexBuffer.vertexArrayDestroyable = false;
             rendererBuffers[bufferViewName] = vertexBuffer;
         }
@@ -1308,7 +1310,7 @@ define([
                 bufferView = bufferViews[accessor.bufferView];
 
                 if ((bufferView.target === WebGLRenderingContext.ELEMENT_ARRAY_BUFFER) && !defined(rendererBuffers[accessor.bufferView])) {
-                    var indexBuffer = context.createIndexBuffer(loadResources.getBuffer(bufferView), BufferUsage.STATIC_DRAW, accessor.componentType);
+                    var indexBuffer = Buffer.createIndexBuffer(context, loadResources.getBuffer(bufferView), BufferUsage.STATIC_DRAW, accessor.componentType);
                     indexBuffer.vertexArrayDestroyable = false;
                     rendererBuffers[accessor.bufferView] = indexBuffer;
                     // In theory, several glTF accessors with different componentTypes could

--- a/Source/Scene/Model.js
+++ b/Source/Scene/Model.js
@@ -1295,7 +1295,11 @@ define([
             bufferView = bufferViews[bufferViewName];
 
             // Only ARRAY_BUFFER here.  ELEMENT_ARRAY_BUFFER created below.
-            var vertexBuffer = Buffer.createVertexBuffer(context, loadResources.getBuffer(bufferView), BufferUsage.STATIC_DRAW);
+            var vertexBuffer = Buffer.createVertexBuffer({
+                context : context,
+                typedArray : loadResources.getBuffer(bufferView),
+                usage : BufferUsage.STATIC_DRAW
+            });
             vertexBuffer.vertexArrayDestroyable = false;
             rendererBuffers[bufferViewName] = vertexBuffer;
         }
@@ -1310,7 +1314,12 @@ define([
                 bufferView = bufferViews[accessor.bufferView];
 
                 if ((bufferView.target === WebGLRenderingContext.ELEMENT_ARRAY_BUFFER) && !defined(rendererBuffers[accessor.bufferView])) {
-                    var indexBuffer = Buffer.createIndexBuffer(context, loadResources.getBuffer(bufferView), BufferUsage.STATIC_DRAW, accessor.componentType);
+                    var indexBuffer = Buffer.createIndexBuffer({
+                        context : context,
+                        typedArray : loadResources.getBuffer(bufferView),
+                        usage : BufferUsage.STATIC_DRAW,
+                        indexDatatype : accessor.componentType
+                    });
                     indexBuffer.vertexArrayDestroyable = false;
                     rendererBuffers[accessor.bufferView] = indexBuffer;
                     // In theory, several glTF accessors with different componentTypes could

--- a/Source/Scene/PolylineCollection.js
+++ b/Source/Scene/PolylineCollection.js
@@ -17,6 +17,7 @@ define([
         '../Core/Math',
         '../Core/Matrix4',
         '../Core/Plane',
+        '../Renderer/Buffer',
         '../Renderer/BufferUsage',
         '../Renderer/DrawCommand',
         '../Renderer/RenderState',
@@ -49,6 +50,7 @@ define([
         CesiumMath,
         Matrix4,
         Plane,
+        Buffer,
         BufferUsage,
         DrawCommand,
         RenderState,
@@ -741,13 +743,13 @@ define([
             var widthBufferUsage = collection._buffersUsage[WIDTH_INDEX].bufferUsage;
             var texCoordExpandWidthAndShowBufferUsage = (showBufferUsage === BufferUsage.STREAM_DRAW || widthBufferUsage === BufferUsage.STREAM_DRAW) ? BufferUsage.STREAM_DRAW : BufferUsage.STATIC_DRAW;
 
-            collection._positionBuffer = context.createVertexBuffer(positionArray, positionBufferUsage);
+            collection._positionBuffer = Buffer.createVertexBuffer(context, positionArray, positionBufferUsage);
             var position3DBuffer;
             if (defined(position3DArray)) {
-                position3DBuffer = context.createVertexBuffer(position3DArray, positionBufferUsage);
+                position3DBuffer = Buffer.createVertexBuffer(context, position3DArray, positionBufferUsage);
             }
-            collection._pickColorBuffer = context.createVertexBuffer(pickColorArray, BufferUsage.STATIC_DRAW);
-            collection._texCoordExpandWidthAndShowBuffer = context.createVertexBuffer(texCoordExpandWidthAndShowArray, texCoordExpandWidthAndShowBufferUsage);
+            collection._pickColorBuffer = Buffer.createVertexBuffer(context, pickColorArray, BufferUsage.STATIC_DRAW);
+            collection._texCoordExpandWidthAndShowBuffer = Buffer.createVertexBuffer(context, texCoordExpandWidthAndShowArray, texCoordExpandWidthAndShowBufferUsage);
 
             var pickColorSizeInBytes = 4 * Uint8Array.BYTES_PER_ELEMENT;
             var positionSizeInBytes = 3 * Float32Array.BYTES_PER_ELEMENT;
@@ -760,7 +762,7 @@ define([
 
                 if (indices.length > 0) {
                     var indicesArray = new Uint16Array(indices);
-                    var indexBuffer = context.createIndexBuffer(indicesArray, BufferUsage.STATIC_DRAW, IndexDatatype.UNSIGNED_SHORT);
+                    var indexBuffer = Buffer.createIndexBuffer(context, indicesArray, BufferUsage.STATIC_DRAW, IndexDatatype.UNSIGNED_SHORT);
 
                     vbo += vertexBufferOffset[k];
 

--- a/Source/Scene/PolylineCollection.js
+++ b/Source/Scene/PolylineCollection.js
@@ -743,13 +743,29 @@ define([
             var widthBufferUsage = collection._buffersUsage[WIDTH_INDEX].bufferUsage;
             var texCoordExpandWidthAndShowBufferUsage = (showBufferUsage === BufferUsage.STREAM_DRAW || widthBufferUsage === BufferUsage.STREAM_DRAW) ? BufferUsage.STREAM_DRAW : BufferUsage.STATIC_DRAW;
 
-            collection._positionBuffer = Buffer.createVertexBuffer(context, positionArray, positionBufferUsage);
+            collection._positionBuffer = Buffer.createVertexBuffer({
+                context : context,
+                typedArray : positionArray,
+                usage : positionBufferUsage
+            });
             var position3DBuffer;
             if (defined(position3DArray)) {
-                position3DBuffer = Buffer.createVertexBuffer(context, position3DArray, positionBufferUsage);
+                position3DBuffer = Buffer.createVertexBuffer({
+                    context : context,
+                    typedArray : position3DArray,
+                    usage : positionBufferUsage
+                });
             }
-            collection._pickColorBuffer = Buffer.createVertexBuffer(context, pickColorArray, BufferUsage.STATIC_DRAW);
-            collection._texCoordExpandWidthAndShowBuffer = Buffer.createVertexBuffer(context, texCoordExpandWidthAndShowArray, texCoordExpandWidthAndShowBufferUsage);
+            collection._pickColorBuffer = Buffer.createVertexBuffer({
+                context : context,
+                typedArray : pickColorArray,
+                usage : BufferUsage.STATIC_DRAW
+            });
+            collection._texCoordExpandWidthAndShowBuffer = Buffer.createVertexBuffer({
+                context : context,
+                typedArray : texCoordExpandWidthAndShowArray,
+                usage : texCoordExpandWidthAndShowBufferUsage
+            });
 
             var pickColorSizeInBytes = 4 * Uint8Array.BYTES_PER_ELEMENT;
             var positionSizeInBytes = 3 * Float32Array.BYTES_PER_ELEMENT;
@@ -762,7 +778,12 @@ define([
 
                 if (indices.length > 0) {
                     var indicesArray = new Uint16Array(indices);
-                    var indexBuffer = Buffer.createIndexBuffer(context, indicesArray, BufferUsage.STATIC_DRAW, IndexDatatype.UNSIGNED_SHORT);
+                    var indexBuffer = Buffer.createIndexBuffer({
+                        context : context,
+                        typedArray : indicesArray,
+                        usage : BufferUsage.STATIC_DRAW,
+                        indexDatatype : IndexDatatype.UNSIGNED_SHORT
+                    });
 
                     vbo += vertexBufferOffset[k];
 

--- a/Source/Scene/Primitive.js
+++ b/Source/Scene/Primitive.js
@@ -943,7 +943,10 @@ define([
             var vaLength = attributes.length;
             for (var j = 0; j < vaLength; ++j) {
                 var attribute = attributes[j];
-                attribute.vertexBuffer = Buffer.createVertexBuffer(context, attribute.values, BufferUsage.DYNAMIC_DRAW);
+                attribute.vertexBuffer = Buffer.createVertexBuffer({
+                    context : context,
+                    typedArray : attribute.values,
+                    usage : BufferUsage.DYNAMIC_DRAW});
                 delete attribute.values;
             }
 

--- a/Source/Scene/Primitive.js
+++ b/Source/Scene/Primitive.js
@@ -19,6 +19,7 @@ define([
         '../Core/Matrix4',
         '../Core/subdivideArray',
         '../Core/TaskProcessor',
+        '../Renderer/Buffer',
         '../Renderer/BufferUsage',
         '../Renderer/DrawCommand',
         '../Renderer/RenderState',
@@ -51,6 +52,7 @@ define([
         Matrix4,
         subdivideArray,
         TaskProcessor,
+        Buffer,
         BufferUsage,
         DrawCommand,
         RenderState,
@@ -941,7 +943,7 @@ define([
             var vaLength = attributes.length;
             for (var j = 0; j < vaLength; ++j) {
                 var attribute = attributes[j];
-                attribute.vertexBuffer = context.createVertexBuffer(attribute.values, BufferUsage.DYNAMIC_DRAW);
+                attribute.vertexBuffer = Buffer.createVertexBuffer(context, attribute.values, BufferUsage.DYNAMIC_DRAW);
                 delete attribute.values;
             }
 

--- a/Source/Scene/Sun.js
+++ b/Source/Scene/Sun.js
@@ -15,6 +15,7 @@ define([
         '../Core/Matrix4',
         '../Core/PixelFormat',
         '../Core/PrimitiveType',
+        '../Renderer/Buffer',
         '../Renderer/BufferUsage',
         '../Renderer/ClearCommand',
         '../Renderer/DrawCommand',
@@ -45,6 +46,7 @@ define([
         Matrix4,
         PixelFormat,
         PrimitiveType,
+        Buffer,
         BufferUsage,
         ClearCommand,
         DrawCommand,
@@ -239,7 +241,7 @@ define([
             directions[6] = 0.0;
             directions[7] = 255;
 
-            var vertexBuffer = context.createVertexBuffer(directions, BufferUsage.STATIC_DRAW);
+            var vertexBuffer = Buffer.createVertexBuffer(context, directions, BufferUsage.STATIC_DRAW);
             var attributes = [{
                 index : attributeLocations.direction,
                 vertexBuffer : vertexBuffer,
@@ -248,7 +250,7 @@ define([
                 componentDatatype : ComponentDatatype.UNSIGNED_BYTE
             }];
             // Workaround Internet Explorer 11.0.8 lack of TRIANGLE_FAN
-            var indexBuffer = context.createIndexBuffer(new Uint16Array([0, 1, 2, 0, 2, 3]), BufferUsage.STATIC_DRAW, IndexDatatype.UNSIGNED_SHORT);
+            var indexBuffer = Buffer.createIndexBuffer(context, new Uint16Array([0, 1, 2, 0, 2, 3]), BufferUsage.STATIC_DRAW, IndexDatatype.UNSIGNED_SHORT);
             command.vertexArray = new VertexArray({
                 context : context,
                 attributes : attributes,

--- a/Source/Scene/Sun.js
+++ b/Source/Scene/Sun.js
@@ -241,7 +241,11 @@ define([
             directions[6] = 0.0;
             directions[7] = 255;
 
-            var vertexBuffer = Buffer.createVertexBuffer(context, directions, BufferUsage.STATIC_DRAW);
+            var vertexBuffer = Buffer.createVertexBuffer({
+                context : context,
+                typedArray : directions,
+                usage : BufferUsage.STATIC_DRAW
+            });
             var attributes = [{
                 index : attributeLocations.direction,
                 vertexBuffer : vertexBuffer,
@@ -250,7 +254,12 @@ define([
                 componentDatatype : ComponentDatatype.UNSIGNED_BYTE
             }];
             // Workaround Internet Explorer 11.0.8 lack of TRIANGLE_FAN
-            var indexBuffer = Buffer.createIndexBuffer(context, new Uint16Array([0, 1, 2, 0, 2, 3]), BufferUsage.STATIC_DRAW, IndexDatatype.UNSIGNED_SHORT);
+            var indexBuffer = Buffer.createIndexBuffer({
+                context : context,
+                typedArray : new Uint16Array([0, 1, 2, 0, 2, 3]),
+                usage : BufferUsage.STATIC_DRAW,
+                indexDatatype : IndexDatatype.UNSIGNED_SHORT
+            });
             command.vertexArray = new VertexArray({
                 context : context,
                 attributes : attributes,

--- a/Source/Scene/TileTerrain.js
+++ b/Source/Scene/TileTerrain.js
@@ -8,6 +8,7 @@ define([
         '../Core/IndexDatatype',
         '../Core/OrientedBoundingBox',
         '../Core/TileProviderError',
+        '../Renderer/Buffer',
         '../Renderer/BufferUsage',
         '../Renderer/VertexArray',
         '../ThirdParty/when',
@@ -22,6 +23,7 @@ define([
         IndexDatatype,
         OrientedBoundingBox,
         TileProviderError,
+        Buffer,
         BufferUsage,
         VertexArray,
         when,
@@ -215,7 +217,7 @@ define([
         var stride;
         var numTexCoordComponents;
         var typedArray = tileTerrain.mesh.vertices;
-        var buffer = context.createVertexBuffer(typedArray, BufferUsage.STATIC_DRAW);
+        var buffer = Buffer.createVertexBuffer(context, typedArray, BufferUsage.STATIC_DRAW);
         if (terrainProvider.hasVertexNormals) {
             stride = 7 * ComponentDatatype.getSizeInBytes(datatype);
             numTexCoordComponents = 3;
@@ -247,7 +249,7 @@ define([
         if (!defined(indexBuffer) || indexBuffer.isDestroyed()) {
             var indices = tileTerrain.mesh.indices;
             var indexDatatype = (indices.BYTES_PER_ELEMENT === 2) ?  IndexDatatype.UNSIGNED_SHORT : IndexDatatype.UNSIGNED_INT;
-            indexBuffer = context.createIndexBuffer(indices, BufferUsage.STATIC_DRAW, indexDatatype);
+            indexBuffer = Buffer.createIndexBuffer(context, indices, BufferUsage.STATIC_DRAW, indexDatatype);
             indexBuffer.vertexArrayDestroyable = false;
             indexBuffer.referenceCount = 1;
             indexBuffers[context.id] = indexBuffer;

--- a/Source/Scene/TileTerrain.js
+++ b/Source/Scene/TileTerrain.js
@@ -217,7 +217,11 @@ define([
         var stride;
         var numTexCoordComponents;
         var typedArray = tileTerrain.mesh.vertices;
-        var buffer = Buffer.createVertexBuffer(context, typedArray, BufferUsage.STATIC_DRAW);
+        var buffer = Buffer.createVertexBuffer({
+            context : context,
+            typedArray : typedArray,
+            usage : BufferUsage.STATIC_DRAW
+        });
         if (terrainProvider.hasVertexNormals) {
             stride = 7 * ComponentDatatype.getSizeInBytes(datatype);
             numTexCoordComponents = 3;
@@ -249,7 +253,12 @@ define([
         if (!defined(indexBuffer) || indexBuffer.isDestroyed()) {
             var indices = tileTerrain.mesh.indices;
             var indexDatatype = (indices.BYTES_PER_ELEMENT === 2) ?  IndexDatatype.UNSIGNED_SHORT : IndexDatatype.UNSIGNED_INT;
-            indexBuffer = Buffer.createIndexBuffer(context, indices, BufferUsage.STATIC_DRAW, indexDatatype);
+            indexBuffer = Buffer.createIndexBuffer({
+                context : context,
+                typedArray : indices,
+                usage : BufferUsage.STATIC_DRAW,
+                indexDatatype : indexDatatype
+            });
             indexBuffer.vertexArrayDestroyable = false;
             indexBuffer.referenceCount = 1;
             indexBuffers[context.id] = indexBuffer;

--- a/Specs/Renderer/BufferSpec.js
+++ b/Specs/Renderer/BufferSpec.js
@@ -1,10 +1,12 @@
 /*global defineSuite*/
 defineSuite([
         'Core/IndexDatatype',
+        'Renderer/Buffer',
         'Renderer/BufferUsage',
         'Specs/createContext'
     ], 'Renderer/Buffer', function(
         IndexDatatype,
+        Buffer,
         BufferUsage,
         createContext) {
     "use strict";
@@ -28,7 +30,7 @@ defineSuite([
     });
 
     it('creates vertex buffer', function() {
-        buffer = context.createVertexBuffer(16, BufferUsage.STATIC_DRAW);
+        buffer = Buffer.createVertexBuffer(context, 16, BufferUsage.STATIC_DRAW);
 
         expect(buffer.sizeInBytes).toEqual(16);
         expect(buffer.usage).toEqual(BufferUsage.STATIC_DRAW);
@@ -42,7 +44,7 @@ defineSuite([
         positions[1] = 2.0;
         positions[2] = 3.0;
 
-        buffer = context.createVertexBuffer(sizeInBytes, BufferUsage.STATIC_DRAW);
+        buffer = Buffer.createVertexBuffer(context, sizeInBytes, BufferUsage.STATIC_DRAW);
         buffer.copyFromArrayView(vertices);
     });
 
@@ -52,19 +54,19 @@ defineSuite([
         typedArray[1] = 2.0;
         typedArray[2] = 3.0;
 
-        buffer = context.createVertexBuffer(typedArray, BufferUsage.STATIC_DRAW);
+        buffer = Buffer.createVertexBuffer(context, typedArray, BufferUsage.STATIC_DRAW);
         expect(buffer.sizeInBytes).toEqual(typedArray.byteLength);
         expect(buffer.usage).toEqual(BufferUsage.STATIC_DRAW);
     });
 
     it('only allows typed array or size when creating a vertex buffer', function() {
         expect(function() {
-            buffer = context.createVertexBuffer({}, BufferUsage.STATIC_DRAW);
+            buffer = Buffer.createVertexBuffer(context, {}, BufferUsage.STATIC_DRAW);
         }).toThrowDeveloperError();
     });
 
     it('creates index buffer', function() {
-        buffer = context.createIndexBuffer(6, BufferUsage.STREAM_DRAW, IndexDatatype.UNSIGNED_SHORT);
+        buffer = Buffer.createIndexBuffer(context, 6, BufferUsage.STREAM_DRAW, IndexDatatype.UNSIGNED_SHORT);
 
         expect(buffer.sizeInBytes).toEqual(6);
         expect(buffer.usage).toEqual(BufferUsage.STREAM_DRAW);
@@ -82,7 +84,7 @@ defineSuite([
         indices[1] = 2;
         indices[2] = 3;
 
-        buffer = context.createIndexBuffer(sizeInBytes, BufferUsage.STATIC_DRAW, IndexDatatype.UNSIGNED_SHORT);
+        buffer = Buffer.createIndexBuffer(context, sizeInBytes, BufferUsage.STATIC_DRAW, IndexDatatype.UNSIGNED_SHORT);
         buffer.copyFromArrayView(elements);
     });
 
@@ -92,7 +94,7 @@ defineSuite([
         typedArray[1] = 2;
         typedArray[2] = 3;
 
-        buffer = context.createIndexBuffer(typedArray, BufferUsage.STATIC_DRAW, IndexDatatype.UNSIGNED_SHORT);
+        buffer = Buffer.createIndexBuffer(context, typedArray, BufferUsage.STATIC_DRAW, IndexDatatype.UNSIGNED_SHORT);
         expect(buffer.sizeInBytes).toEqual(typedArray.byteLength);
         expect(buffer.usage).toEqual(BufferUsage.STATIC_DRAW);
         expect(buffer.indexDatatype).toEqual(IndexDatatype.UNSIGNED_SHORT);
@@ -100,12 +102,12 @@ defineSuite([
 
     it('only allows typed array or size when creating a vertex buffer', function() {
         expect(function() {
-            buffer = context.createIndexBuffer({}, BufferUsage.STATIC_DRAW, IndexDatatype.UNSIGNED_SHORT);
+            buffer = Buffer.createIndexBuffer(context, {}, BufferUsage.STATIC_DRAW, IndexDatatype.UNSIGNED_SHORT);
         }).toThrowDeveloperError();
     });
 
     it('destroys', function() {
-        var b = context.createIndexBuffer(3, BufferUsage.STATIC_DRAW, IndexDatatype.UNSIGNED_BYTE);
+        var b = Buffer.createIndexBuffer(context, 3, BufferUsage.STATIC_DRAW, IndexDatatype.UNSIGNED_BYTE);
         expect(b.isDestroyed()).toEqual(false);
         b.destroy();
         expect(b.isDestroyed()).toEqual(true);
@@ -113,25 +115,25 @@ defineSuite([
 
     it('fails to create', function() {
         expect(function() {
-            buffer = context.createVertexBuffer(0, BufferUsage.STATIC_DRAW);
+            buffer = Buffer.createVertexBuffer(context, 0, BufferUsage.STATIC_DRAW);
         }).toThrowDeveloperError();
     });
 
     it('fails to create again', function() {
         expect(function() {
-            buffer = context.createVertexBuffer(4, 0);
+            buffer = Buffer.createVertexBuffer(context, 4, 0);
         }).toThrowDeveloperError();
     });
 
     it('fails to provide an array view', function() {
-        buffer = context.createVertexBuffer(3, BufferUsage.STATIC_DRAW);
+        buffer = Buffer.createVertexBuffer(context, 3, BufferUsage.STATIC_DRAW);
         expect(function() {
             buffer.copyFromArrayView();
         }).toThrowDeveloperError();
     });
 
     it('fails to copy a large array view', function() {
-        buffer = context.createVertexBuffer(3, BufferUsage.STATIC_DRAW);
+        buffer = Buffer.createVertexBuffer(context, 3, BufferUsage.STATIC_DRAW);
         var elements = new ArrayBuffer(3);
 
         expect(function() {
@@ -140,7 +142,7 @@ defineSuite([
     });
 
     it('fails to destroy', function() {
-        var b = context.createIndexBuffer(3, BufferUsage.STATIC_DRAW, IndexDatatype.UNSIGNED_BYTE);
+        var b = Buffer.createIndexBuffer(context, 3, BufferUsage.STATIC_DRAW, IndexDatatype.UNSIGNED_BYTE);
         b.destroy();
 
         expect(function() {

--- a/Specs/Renderer/BufferSpec.js
+++ b/Specs/Renderer/BufferSpec.js
@@ -29,8 +29,71 @@ defineSuite([
         }
     });
 
+    it('throws when creating a vertex buffer with no context', function() {
+        expect(function() {
+            buffer = Buffer.createVertexBuffer({
+                sizeInBytes : 4,
+                usage : BufferUsage.STATIC_DRAW
+            });
+        }).toThrowDeveloperError();
+    });
+
+    it('throws when creating a vertex buffer with an invalid typed array', function() {
+        expect(function() {
+            buffer = Buffer.createVertexBuffer({
+                context : context,
+                typedArray : {},
+                usage : BufferUsage.STATIC_DRAW
+            });
+        }).toThrowDeveloperError();
+    });
+
+    it('throws when creating a vertex buffer with both a typed array and size in bytes', function() {
+        expect(function() {
+            buffer = Buffer.createVertexBuffer({
+                context : context,
+                typedArray : new Float32Array([0, 0, 0, 1]),
+                sizeInBytes : 16,
+                usage : BufferUsage.STATIC_DRAW
+            });
+        }).toThrowDeveloperError();
+    });
+
+    it('throws when creating a vertex buffer without a typed array or size in bytes', function() {
+        expect(function() {
+            buffer = Buffer.createVertexBuffer({
+                context : context,
+                usage : BufferUsage.STATIC_DRAW
+            });
+        }).toThrowDeveloperError();
+    });
+
+    it('throws when creating a vertex buffer with invalid usage', function() {
+        expect(function() {
+            buffer = Buffer.createVertexBuffer({
+                context : context,
+                sizeInBytes : 16,
+                usage : 0
+            });
+        }).toThrowDeveloperError();
+    });
+
+    it('throws when creating a vertex buffer with size of zero', function() {
+        expect(function() {
+            buffer = Buffer.createVertexBuffer({
+                context : context,
+                sizeInBytes : 0,
+                usage : BufferUsage.STATIC_DRAW
+            });
+        }).toThrowDeveloperError();
+    });
+
     it('creates vertex buffer', function() {
-        buffer = Buffer.createVertexBuffer(context, 16, BufferUsage.STATIC_DRAW);
+        buffer = Buffer.createVertexBuffer({
+            context : context,
+            sizeInBytes : 16,
+            usage : BufferUsage.STATIC_DRAW
+        });
 
         expect(buffer.sizeInBytes).toEqual(16);
         expect(buffer.usage).toEqual(BufferUsage.STATIC_DRAW);
@@ -44,7 +107,11 @@ defineSuite([
         positions[1] = 2.0;
         positions[2] = 3.0;
 
-        buffer = Buffer.createVertexBuffer(context, sizeInBytes, BufferUsage.STATIC_DRAW);
+        buffer = Buffer.createVertexBuffer({
+            context : context,
+            sizeInBytes : sizeInBytes,
+            usage : BufferUsage.STATIC_DRAW
+        });
         buffer.copyFromArrayView(vertices);
     });
 
@@ -54,19 +121,108 @@ defineSuite([
         typedArray[1] = 2.0;
         typedArray[2] = 3.0;
 
-        buffer = Buffer.createVertexBuffer(context, typedArray, BufferUsage.STATIC_DRAW);
+        buffer = Buffer.createVertexBuffer({
+            context : context,
+            typedArray : typedArray,
+            usage : BufferUsage.STATIC_DRAW
+        });
         expect(buffer.sizeInBytes).toEqual(typedArray.byteLength);
         expect(buffer.usage).toEqual(BufferUsage.STATIC_DRAW);
     });
 
-    it('only allows typed array or size when creating a vertex buffer', function() {
+    it('can create a vertex buffer from a size in bytes', function() {
+        buffer = Buffer.createVertexBuffer({
+            context : context,
+            sizeInBytes : 4,
+            usage : BufferUsage.STATIC_DRAW
+        });
+        expect(buffer.sizeInBytes).toEqual(4);
+        expect(buffer.usage).toEqual(BufferUsage.STATIC_DRAW);
+    });
+
+    it('throws when creating an index buffer with no context', function() {
         expect(function() {
-            buffer = Buffer.createVertexBuffer(context, {}, BufferUsage.STATIC_DRAW);
+            buffer = Buffer.createIndexBuffer({
+                sizeInBytes : 4,
+                usage : BufferUsage.STATIC_DRAW,
+                indexDatatype : IndexDatatype.UNSIGNED_SHORT
+            });
+        }).toThrowDeveloperError();
+    });
+
+    it('throws when creating an index buffer with an invalid typed array', function() {
+        expect(function() {
+            buffer = Buffer.createIndexBuffer({
+                context : context,
+                typedArray : {},
+                usage : BufferUsage.STATIC_DRAW,
+                indexDatatype : IndexDatatype.UNSIGNED_SHORT
+            });
+        }).toThrowDeveloperError();
+    });
+
+    it('throws when creating an index buffer with both a typed array and size in bytes', function() {
+        expect(function() {
+            buffer = Buffer.createIndexBuffer({
+                context : context,
+                typedArray : new Uint16Array([0, 1, 2, 0, 2, 3]),
+                sizeInBytes : 12,
+                usage : BufferUsage.STATIC_DRAW,
+                indexDatatype : IndexDatatype.UNSIGNED_SHORT
+            });
+        }).toThrowDeveloperError();
+    });
+
+    it('throws when creating an index buffer without a typed array or size in bytes', function() {
+        expect(function() {
+            buffer = Buffer.createIndexBuffer({
+                context : context,
+                usage : BufferUsage.STATIC_DRAW,
+                indexDatatype : IndexDatatype.UNSIGNED_SHORT
+            });
+        }).toThrowDeveloperError();
+    });
+
+    it('throws when creating an index buffer with invalid usage', function() {
+        expect(function() {
+            buffer = Buffer.createIndexBuffer({
+                context : context,
+                sizeInBytes : 16,
+                usage : "invalid",
+                indexDatatype : IndexDatatype.UNSIGNED_SHORT
+            });
+        }).toThrowDeveloperError();
+    });
+
+    it('throws when creating an index buffer with invalid index data type', function() {
+        expect(function() {
+            buffer = Buffer.createIndexBuffer({
+                context : context,
+                sizeInBytes : 16,
+                usage : BufferUsage.STATIC_DRAW,
+                indexDatatype : 'invalid'
+            });
+        }).toThrowDeveloperError();
+    });
+
+    it('throws when creating an index buffer with size of zero', function() {
+        expect(function() {
+            buffer = Buffer.createIndexBuffer({
+                context : context,
+                sizeInBytes : 0,
+                usage : BufferUsage.STATIC_DRAW,
+                indexDatatype : IndexDatatype.UNSIGNED_SHORT
+            });
         }).toThrowDeveloperError();
     });
 
     it('creates index buffer', function() {
-        buffer = Buffer.createIndexBuffer(context, 6, BufferUsage.STREAM_DRAW, IndexDatatype.UNSIGNED_SHORT);
+        buffer = Buffer.createIndexBuffer({
+            context : context,
+            sizeInBytes : 6,
+            usage : BufferUsage.STREAM_DRAW,
+            indexDatatype : IndexDatatype.UNSIGNED_SHORT
+        });
 
         expect(buffer.sizeInBytes).toEqual(6);
         expect(buffer.usage).toEqual(BufferUsage.STREAM_DRAW);
@@ -84,7 +240,12 @@ defineSuite([
         indices[1] = 2;
         indices[2] = 3;
 
-        buffer = Buffer.createIndexBuffer(context, sizeInBytes, BufferUsage.STATIC_DRAW, IndexDatatype.UNSIGNED_SHORT);
+        buffer = Buffer.createIndexBuffer({
+            context : context,
+            sizeInBytes : sizeInBytes,
+            usage : BufferUsage.STATIC_DRAW,
+            indexDatatype : IndexDatatype.UNSIGNED_SHORT
+        });
         buffer.copyFromArrayView(elements);
     });
 
@@ -94,46 +255,58 @@ defineSuite([
         typedArray[1] = 2;
         typedArray[2] = 3;
 
-        buffer = Buffer.createIndexBuffer(context, typedArray, BufferUsage.STATIC_DRAW, IndexDatatype.UNSIGNED_SHORT);
+        buffer = Buffer.createIndexBuffer({
+            context : context,
+            typedArray : typedArray,
+            usage : BufferUsage.STATIC_DRAW,
+            indexDatatype : IndexDatatype.UNSIGNED_SHORT
+        });
         expect(buffer.sizeInBytes).toEqual(typedArray.byteLength);
         expect(buffer.usage).toEqual(BufferUsage.STATIC_DRAW);
         expect(buffer.indexDatatype).toEqual(IndexDatatype.UNSIGNED_SHORT);
     });
 
-    it('only allows typed array or size when creating a vertex buffer', function() {
-        expect(function() {
-            buffer = Buffer.createIndexBuffer(context, {}, BufferUsage.STATIC_DRAW, IndexDatatype.UNSIGNED_SHORT);
-        }).toThrowDeveloperError();
+    it('can create an index buffer from a size in bytes', function() {
+        buffer = Buffer.createIndexBuffer({
+            context : context,
+            sizeInBytes : 6,
+            usage : BufferUsage.STATIC_DRAW,
+            indexDatatype : IndexDatatype.UNSIGNED_SHORT
+        });
+        expect(buffer.sizeInBytes).toEqual(6);
+        expect(buffer.usage).toEqual(BufferUsage.STATIC_DRAW);
+        expect(buffer.indexDatatype).toEqual(IndexDatatype.UNSIGNED_SHORT);
     });
 
     it('destroys', function() {
-        var b = Buffer.createIndexBuffer(context, 3, BufferUsage.STATIC_DRAW, IndexDatatype.UNSIGNED_BYTE);
+        var b = Buffer.createIndexBuffer({
+            context : context,
+            sizeInBytes : 3,
+            usage : BufferUsage.STATIC_DRAW,
+            indexDatatype : IndexDatatype.UNSIGNED_BYTE
+        });
         expect(b.isDestroyed()).toEqual(false);
         b.destroy();
         expect(b.isDestroyed()).toEqual(true);
     });
 
-    it('fails to create', function() {
-        expect(function() {
-            buffer = Buffer.createVertexBuffer(context, 0, BufferUsage.STATIC_DRAW);
-        }).toThrowDeveloperError();
-    });
-
-    it('fails to create again', function() {
-        expect(function() {
-            buffer = Buffer.createVertexBuffer(context, 4, 0);
-        }).toThrowDeveloperError();
-    });
-
     it('fails to provide an array view', function() {
-        buffer = Buffer.createVertexBuffer(context, 3, BufferUsage.STATIC_DRAW);
+        buffer = Buffer.createVertexBuffer({
+            context : context,
+            sizeInBytes : 3,
+            usage : BufferUsage.STATIC_DRAW
+        });
         expect(function() {
             buffer.copyFromArrayView();
         }).toThrowDeveloperError();
     });
 
     it('fails to copy a large array view', function() {
-        buffer = Buffer.createVertexBuffer(context, 3, BufferUsage.STATIC_DRAW);
+        buffer = Buffer.createVertexBuffer({
+            context : context,
+            sizeInBytes : 3,
+            usage : BufferUsage.STATIC_DRAW
+        });
         var elements = new ArrayBuffer(3);
 
         expect(function() {
@@ -142,7 +315,12 @@ defineSuite([
     });
 
     it('fails to destroy', function() {
-        var b = Buffer.createIndexBuffer(context, 3, BufferUsage.STATIC_DRAW, IndexDatatype.UNSIGNED_BYTE);
+        var b = Buffer.createIndexBuffer({
+            context : context,
+            sizeInBytes : 3,
+            usage : BufferUsage.STATIC_DRAW,
+            indexDatatype : IndexDatatype.UNSIGNED_BYTE
+        });
         b.destroy();
 
         expect(function() {

--- a/Specs/Renderer/ContextSpec.js
+++ b/Specs/Renderer/ContextSpec.js
@@ -3,6 +3,7 @@ defineSuite([
         'Renderer/Context',
         'Core/Color',
         'Core/IndexDatatype',
+        'Renderer/Buffer',
         'Renderer/BufferUsage',
         'Renderer/ContextLimits',
         'Specs/createContext',
@@ -11,6 +12,7 @@ defineSuite([
         Context,
         Color,
         IndexDatatype,
+        Buffer,
         BufferUsage,
         ContextLimits,
         createContext,
@@ -178,12 +180,12 @@ defineSuite([
 
     it('gets the element index uint extension', function() {
         if (context.elementIndexUint) {
-            var buffer = context.createIndexBuffer(6, BufferUsage.STREAM_DRAW, IndexDatatype.UNSIGNED_INT);
+            var buffer = Buffer.createIndexBuffer(context, 6, BufferUsage.STREAM_DRAW, IndexDatatype.UNSIGNED_INT);
             expect(buffer).toBeDefined();
             buffer.destroy();
         } else {
             expect(function() {
-                context.createIndexBuffer(6, BufferUsage.STREAM_DRAW, IndexDatatype.UNSIGNED_INT);
+                Buffer.createIndexBuffer(context, 6, BufferUsage.STREAM_DRAW, IndexDatatype.UNSIGNED_INT);
             }).toThrowDeveloperError();
         }
     });

--- a/Specs/Renderer/ContextSpec.js
+++ b/Specs/Renderer/ContextSpec.js
@@ -180,12 +180,22 @@ defineSuite([
 
     it('gets the element index uint extension', function() {
         if (context.elementIndexUint) {
-            var buffer = Buffer.createIndexBuffer(context, 6, BufferUsage.STREAM_DRAW, IndexDatatype.UNSIGNED_INT);
+            var buffer = Buffer.createIndexBuffer({
+                context : context,
+                sizeInBytes : 6,
+                usage : BufferUsage.STREAM_DRAW,
+                indexDatatype : IndexDatatype.UNSIGNED_INT
+            });
             expect(buffer).toBeDefined();
             buffer.destroy();
         } else {
             expect(function() {
-                Buffer.createIndexBuffer(context, 6, BufferUsage.STREAM_DRAW, IndexDatatype.UNSIGNED_INT);
+                Buffer.createIndexBuffer({
+                    context : context,
+                    sizeInBytes : 6,
+                    usage : BufferUsage.STREAM_DRAW,
+                    indexDatatype : IndexDatatype.UNSIGNED_INT
+                });
             }).toThrowDeveloperError();
         }
     });

--- a/Specs/Renderer/CubeMapSpec.js
+++ b/Specs/Renderer/CubeMapSpec.js
@@ -195,7 +195,11 @@ defineSuite([
         va = new VertexArray({
             context : context,
             attributes : [{
-                vertexBuffer : Buffer.createVertexBuffer(context, new Float32Array([0, 0, 0, 1]), BufferUsage.STATIC_DRAW),
+                vertexBuffer : Buffer.createVertexBuffer({
+                    context : context,
+                    typedArray : new Float32Array([0, 0, 0, 1]),
+                    usage : BufferUsage.STATIC_DRAW
+                }),
                 componentsPerAttribute : 4
             }]
         });
@@ -272,7 +276,11 @@ defineSuite([
         va = new VertexArray({
             context : context,
             attributes : [{
-                vertexBuffer : Buffer.createVertexBuffer(context, new Float32Array([0, 0, 0, 1]), BufferUsage.STATIC_DRAW),
+                vertexBuffer : Buffer.createVertexBuffer({
+                    context : context,
+                    typedArray : new Float32Array([0, 0, 0, 1]),
+                    usage : BufferUsage.STATIC_DRAW
+                }),
                 componentsPerAttribute : 4
             }]
         });
@@ -335,7 +343,11 @@ defineSuite([
         va = new VertexArray({
             context : context,
             attributes : [{
-                vertexBuffer : Buffer.createVertexBuffer(context, new Float32Array([0, 0, 0, 1]), BufferUsage.STATIC_DRAW),
+                vertexBuffer : Buffer.createVertexBuffer({
+                    context : context,
+                    typedArray : new Float32Array([0, 0, 0, 1]),
+                    usage : BufferUsage.STATIC_DRAW
+                }),
                 componentsPerAttribute : 4
             }]
         });
@@ -428,7 +440,11 @@ defineSuite([
         va = new VertexArray({
             context : context,
             attributes : [{
-                vertexBuffer : Buffer.createVertexBuffer(context, new Float32Array([0, 0, 0, 1]), BufferUsage.STATIC_DRAW),
+                vertexBuffer : Buffer.createVertexBuffer({
+                    context : context,
+                    typedArray : new Float32Array([0, 0, 0, 1]),
+                    usage : BufferUsage.STATIC_DRAW
+                }),
                 componentsPerAttribute : 4
             }]
         });
@@ -530,7 +546,11 @@ defineSuite([
             va = new VertexArray({
                 context : context,
                 attributes : [{
-                    vertexBuffer : Buffer.createVertexBuffer(context, new Float32Array([0, 0, 0, 1]), BufferUsage.STATIC_DRAW),
+                    vertexBuffer : Buffer.createVertexBuffer({
+                        context : context,
+                        typedArray : new Float32Array([0, 0, 0, 1]),
+                        usage : BufferUsage.STATIC_DRAW
+                    }),
                     componentsPerAttribute : 4
                 }]
             });
@@ -616,7 +636,11 @@ defineSuite([
         va = new VertexArray({
             context : context,
             attributes : [{
-                vertexBuffer : Buffer.createVertexBuffer(context, new Float32Array([0, 0, 0, 1]), BufferUsage.STATIC_DRAW),
+                vertexBuffer : Buffer.createVertexBuffer({
+                    context : context,
+                    typedArray : new Float32Array([0, 0, 0, 1]),
+                    usage : BufferUsage.STATIC_DRAW
+                }),
                 componentsPerAttribute : 4
             }]
         });
@@ -685,7 +709,11 @@ defineSuite([
         va = new VertexArray({
             context : context,
             attributes : [{
-                vertexBuffer : Buffer.createVertexBuffer(context, new Float32Array([0, 0, 0, 1]), BufferUsage.STATIC_DRAW),
+                vertexBuffer : Buffer.createVertexBuffer({
+                    context : context,
+                    typedArray : new Float32Array([0, 0, 0, 1]),
+                    usage : BufferUsage.STATIC_DRAW
+                }),
                 componentsPerAttribute : 4
             }]
         });
@@ -784,7 +812,11 @@ defineSuite([
         va = new VertexArray({
             context : context,
             attributes : [{
-                vertexBuffer : Buffer.createVertexBuffer(context, new Float32Array([0, 0, 0, 1]), BufferUsage.STATIC_DRAW),
+                vertexBuffer : Buffer.createVertexBuffer({
+                    context : context,
+                    typedArray : new Float32Array([0, 0, 0, 1]),
+                    usage : BufferUsage.STATIC_DRAW
+                }),
                 componentsPerAttribute : 4
             }]
         });
@@ -847,7 +879,11 @@ defineSuite([
         va = new VertexArray({
             context : context,
             attributes : [{
-                vertexBuffer : Buffer.createVertexBuffer(context, new Float32Array([0, 0, 0, 1]), BufferUsage.STATIC_DRAW),
+                vertexBuffer : Buffer.createVertexBuffer({
+                    context : context,
+                    typedArray : new Float32Array([0, 0, 0, 1]),
+                    usage : BufferUsage.STATIC_DRAW
+                }),
                 componentsPerAttribute : 4
             }]
         });
@@ -918,7 +954,11 @@ defineSuite([
         va = new VertexArray({
             context : context,
             attributes : [{
-                vertexBuffer : Buffer.createVertexBuffer(context, new Float32Array([0, 0, 0, 1]), BufferUsage.STATIC_DRAW),
+                vertexBuffer : Buffer.createVertexBuffer({
+                    context : context,
+                    typedArray : new Float32Array([0, 0, 0, 1]),
+                    usage : BufferUsage.STATIC_DRAW
+                }),
                 componentsPerAttribute : 4
             }]
         });
@@ -971,7 +1011,11 @@ defineSuite([
         va = new VertexArray({
             context : context,
             attributes : [{
-                vertexBuffer : Buffer.createVertexBuffer(context, new Float32Array([0, 0, 0, 1]), BufferUsage.STATIC_DRAW),
+                vertexBuffer : Buffer.createVertexBuffer({
+                    context : context,
+                    typedArray : new Float32Array([0, 0, 0, 1]),
+                    usage : BufferUsage.STATIC_DRAW
+                }),
                 componentsPerAttribute : 4
             }]
         });

--- a/Specs/Renderer/CubeMapSpec.js
+++ b/Specs/Renderer/CubeMapSpec.js
@@ -5,6 +5,7 @@ defineSuite([
         'Core/loadImage',
         'Core/PixelFormat',
         'Core/PrimitiveType',
+        'Renderer/Buffer',
         'Renderer/BufferUsage',
         'Renderer/ClearCommand',
         'Renderer/ContextLimits',
@@ -26,6 +27,7 @@ defineSuite([
         loadImage,
         PixelFormat,
         PrimitiveType,
+        Buffer,
         BufferUsage,
         ClearCommand,
         ContextLimits,
@@ -193,7 +195,7 @@ defineSuite([
         va = new VertexArray({
             context : context,
             attributes : [{
-                vertexBuffer : context.createVertexBuffer(new Float32Array([0, 0, 0, 1]), BufferUsage.STATIC_DRAW),
+                vertexBuffer : Buffer.createVertexBuffer(context, new Float32Array([0, 0, 0, 1]), BufferUsage.STATIC_DRAW),
                 componentsPerAttribute : 4
             }]
         });
@@ -270,7 +272,7 @@ defineSuite([
         va = new VertexArray({
             context : context,
             attributes : [{
-                vertexBuffer : context.createVertexBuffer(new Float32Array([0, 0, 0, 1]), BufferUsage.STATIC_DRAW),
+                vertexBuffer : Buffer.createVertexBuffer(context, new Float32Array([0, 0, 0, 1]), BufferUsage.STATIC_DRAW),
                 componentsPerAttribute : 4
             }]
         });
@@ -333,7 +335,7 @@ defineSuite([
         va = new VertexArray({
             context : context,
             attributes : [{
-                vertexBuffer : context.createVertexBuffer(new Float32Array([0, 0, 0, 1]), BufferUsage.STATIC_DRAW),
+                vertexBuffer : Buffer.createVertexBuffer(context, new Float32Array([0, 0, 0, 1]), BufferUsage.STATIC_DRAW),
                 componentsPerAttribute : 4
             }]
         });
@@ -426,7 +428,7 @@ defineSuite([
         va = new VertexArray({
             context : context,
             attributes : [{
-                vertexBuffer : context.createVertexBuffer(new Float32Array([0, 0, 0, 1]), BufferUsage.STATIC_DRAW),
+                vertexBuffer : Buffer.createVertexBuffer(context, new Float32Array([0, 0, 0, 1]), BufferUsage.STATIC_DRAW),
                 componentsPerAttribute : 4
             }]
         });
@@ -528,7 +530,7 @@ defineSuite([
             va = new VertexArray({
                 context : context,
                 attributes : [{
-                    vertexBuffer : context.createVertexBuffer(new Float32Array([0, 0, 0, 1]), BufferUsage.STATIC_DRAW),
+                    vertexBuffer : Buffer.createVertexBuffer(context, new Float32Array([0, 0, 0, 1]), BufferUsage.STATIC_DRAW),
                     componentsPerAttribute : 4
                 }]
             });
@@ -614,7 +616,7 @@ defineSuite([
         va = new VertexArray({
             context : context,
             attributes : [{
-                vertexBuffer : context.createVertexBuffer(new Float32Array([0, 0, 0, 1]), BufferUsage.STATIC_DRAW),
+                vertexBuffer : Buffer.createVertexBuffer(context, new Float32Array([0, 0, 0, 1]), BufferUsage.STATIC_DRAW),
                 componentsPerAttribute : 4
             }]
         });
@@ -683,7 +685,7 @@ defineSuite([
         va = new VertexArray({
             context : context,
             attributes : [{
-                vertexBuffer : context.createVertexBuffer(new Float32Array([0, 0, 0, 1]), BufferUsage.STATIC_DRAW),
+                vertexBuffer : Buffer.createVertexBuffer(context, new Float32Array([0, 0, 0, 1]), BufferUsage.STATIC_DRAW),
                 componentsPerAttribute : 4
             }]
         });
@@ -782,7 +784,7 @@ defineSuite([
         va = new VertexArray({
             context : context,
             attributes : [{
-                vertexBuffer : context.createVertexBuffer(new Float32Array([0, 0, 0, 1]), BufferUsage.STATIC_DRAW),
+                vertexBuffer : Buffer.createVertexBuffer(context, new Float32Array([0, 0, 0, 1]), BufferUsage.STATIC_DRAW),
                 componentsPerAttribute : 4
             }]
         });
@@ -845,7 +847,7 @@ defineSuite([
         va = new VertexArray({
             context : context,
             attributes : [{
-                vertexBuffer : context.createVertexBuffer(new Float32Array([0, 0, 0, 1]), BufferUsage.STATIC_DRAW),
+                vertexBuffer : Buffer.createVertexBuffer(context, new Float32Array([0, 0, 0, 1]), BufferUsage.STATIC_DRAW),
                 componentsPerAttribute : 4
             }]
         });
@@ -916,7 +918,7 @@ defineSuite([
         va = new VertexArray({
             context : context,
             attributes : [{
-                vertexBuffer : context.createVertexBuffer(new Float32Array([0, 0, 0, 1]), BufferUsage.STATIC_DRAW),
+                vertexBuffer : Buffer.createVertexBuffer(context, new Float32Array([0, 0, 0, 1]), BufferUsage.STATIC_DRAW),
                 componentsPerAttribute : 4
             }]
         });
@@ -969,7 +971,7 @@ defineSuite([
         va = new VertexArray({
             context : context,
             attributes : [{
-                vertexBuffer : context.createVertexBuffer(new Float32Array([0, 0, 0, 1]), BufferUsage.STATIC_DRAW),
+                vertexBuffer : Buffer.createVertexBuffer(context, new Float32Array([0, 0, 0, 1]), BufferUsage.STATIC_DRAW),
                 componentsPerAttribute : 4
             }]
         });

--- a/Specs/Renderer/DrawSpec.js
+++ b/Specs/Renderer/DrawSpec.js
@@ -67,7 +67,11 @@ defineSuite([
             context : context,
             attributes : [{
                 index : sp.vertexAttributes.position.index,
-                vertexBuffer : Buffer.createVertexBuffer(context, new Float32Array([0, 0, 0, 1]), BufferUsage.STATIC_DRAW),
+                vertexBuffer : Buffer.createVertexBuffer({
+                    context : context,
+                    typedArray : new Float32Array([0, 0, 0, 1]),
+                    usage : BufferUsage.STATIC_DRAW
+                }),
                 componentsPerAttribute : 4
             }]
         });
@@ -98,13 +102,22 @@ defineSuite([
 
         // Two indices instead of one is a workaround for NVIDIA:
         //   http://www.khronos.org/message_boards/viewtopic.php?f=44&t=3719
-        var indexBuffer = Buffer.createIndexBuffer(context, new Uint16Array([0, 0]), BufferUsage.STATIC_DRAW, IndexDatatype.UNSIGNED_SHORT);
+        var indexBuffer = Buffer.createIndexBuffer({
+            context : context,
+            typedArray : new Uint16Array([0, 0]),
+            usage : BufferUsage.STATIC_DRAW,
+            indexDatatype : IndexDatatype.UNSIGNED_SHORT
+        });
 
         va = new VertexArray({
             context : context,
             attributes : [{
                 index : sp.vertexAttributes.position.index,
-                vertexBuffer : Buffer.createVertexBuffer(context, new Float32Array([0, 0, 0, 1]), BufferUsage.STATIC_DRAW),
+                vertexBuffer : Buffer.createVertexBuffer({
+                    context : context,
+                    typedArray : new Float32Array([0, 0, 0, 1]),
+                    usage : BufferUsage.STATIC_DRAW
+                }),
                 componentsPerAttribute : 4
             }],
             indexBuffer : indexBuffer
@@ -147,11 +160,19 @@ defineSuite([
             context : context,
             attributes : [{
                 index : sp.vertexAttributes.position.index,
-                vertexBuffer : Buffer.createVertexBuffer(context, new Float32Array([0, 0, 0, 1]), BufferUsage.STATIC_DRAW),
+                vertexBuffer : Buffer.createVertexBuffer({
+                    context : context,
+                    typedArray : new Float32Array([0, 0, 0, 1]),
+                    usage : BufferUsage.STATIC_DRAW
+                }),
                 componentsPerAttribute : 4
             }, {
                 index : sp.vertexAttributes.intensity.index,
-                vertexBuffer : Buffer.createVertexBuffer(context, new Float32Array([1]), BufferUsage.STATIC_DRAW),
+                vertexBuffer : Buffer.createVertexBuffer({
+                    context : context,
+                    typedArray : new Float32Array([1]),
+                    usage : BufferUsage.STATIC_DRAW
+                }),
                 componentsPerAttribute : 1
             }]
         });
@@ -186,7 +207,11 @@ defineSuite([
         });
 
         var stride = 5 * Float32Array.BYTES_PER_ELEMENT;
-        var vertexBuffer = Buffer.createVertexBuffer(context, new Float32Array([0, 0, 0, 1, 1]), BufferUsage.STATIC_DRAW);
+        var vertexBuffer = Buffer.createVertexBuffer({
+            context : context,
+            typedArray : new Float32Array([0, 0, 0, 1, 1]),
+            usage : BufferUsage.STATIC_DRAW
+        });
 
         va = new VertexArray({
             context : context,
@@ -230,7 +255,11 @@ defineSuite([
             context : context,
             attributes : [{
                 index : sp.vertexAttributes.position.index,
-                vertexBuffer : Buffer.createVertexBuffer(context, new Float32Array([0, 0, 0, 1]), BufferUsage.STATIC_DRAW),
+                vertexBuffer : Buffer.createVertexBuffer({
+                    context : context,
+                    typedArray : new Float32Array([0, 0, 0, 1]),
+                    usage : BufferUsage.STATIC_DRAW
+                }),
                 componentsPerAttribute : 4
             }]
         });
@@ -283,7 +312,11 @@ defineSuite([
             context : context,
             attributes : [{
                 index : sp.vertexAttributes.position.index,
-                vertexBuffer : Buffer.createVertexBuffer(context, new Float32Array([0, 0, 0, 1]), BufferUsage.STATIC_DRAW),
+                vertexBuffer : Buffer.createVertexBuffer({
+                    context : context,
+                    typedArray : new Float32Array([0, 0, 0, 1]),
+                    usage : BufferUsage.STATIC_DRAW
+                }),
                 componentsPerAttribute : 4
             }]
         });
@@ -340,7 +373,11 @@ defineSuite([
             context : context,
             attributes : [{
                 index : sp.vertexAttributes.position.index,
-                vertexBuffer : Buffer.createVertexBuffer(context, new Float32Array([0, 0, 0, 1]), BufferUsage.STATIC_DRAW),
+                vertexBuffer : Buffer.createVertexBuffer({
+                    context : context,
+                    typedArray : new Float32Array([0, 0, 0, 1]),
+                    usage : BufferUsage.STATIC_DRAW
+                }),
                 componentsPerAttribute : 4
             }]
         });
@@ -388,7 +425,11 @@ defineSuite([
             context : context,
             attributes : [{
                 index : sp.vertexAttributes.position.index,
-                vertexBuffer : Buffer.createVertexBuffer(context, new Float32Array([0, 0, 0, 1]), BufferUsage.STATIC_DRAW),
+                vertexBuffer : Buffer.createVertexBuffer({
+                    context : context,
+                    typedArray : new Float32Array([0, 0, 0, 1]),
+                    usage : BufferUsage.STATIC_DRAW
+                }),
                 componentsPerAttribute : 4
             }]
         });
@@ -436,7 +477,11 @@ defineSuite([
             context : context,
             attributes : [{
                 index : sp.vertexAttributes.position.index,
-                vertexBuffer : Buffer.createVertexBuffer(context, new Float32Array([0, 0, 0, 1]), BufferUsage.STATIC_DRAW),
+                vertexBuffer : Buffer.createVertexBuffer({
+                    context : context,
+                    typedArray : new Float32Array([0, 0, 0, 1]),
+                    usage : BufferUsage.STATIC_DRAW
+                }),
                 componentsPerAttribute : 4
             }]
         });
@@ -486,7 +531,11 @@ defineSuite([
             context : context,
             attributes : [{
                 index : sp.vertexAttributes.position.index,
-                vertexBuffer : Buffer.createVertexBuffer(context, new Float32Array([-1000, -1000, 0, 1, 1000, -1000, 0, 1, -1000, 1000, 0, 1, 1000, 1000, 0, 1]), BufferUsage.STATIC_DRAW),
+                vertexBuffer : Buffer.createVertexBuffer({
+                    context : context,
+                    typedArray : new Float32Array([-1000, -1000, 0, 1, 1000, -1000, 0, 1, -1000, 1000, 0, 1, 1000, 1000, 0, 1]),
+                    usage : BufferUsage.STATIC_DRAW
+                }),
                 componentsPerAttribute : 4
             }]
         });
@@ -539,7 +588,11 @@ defineSuite([
             context : context,
             attributes : [{
                 index : sp.vertexAttributes.position.index,
-                vertexBuffer : Buffer.createVertexBuffer(context, new Float32Array([-1000, -1000, 0, 1, 1000, -1000, 0, 1, -1000, 1000, 0, 1, 1000, 1000, 0, 1]), BufferUsage.STATIC_DRAW),
+                vertexBuffer : Buffer.createVertexBuffer({
+                    context : context,
+                    typedArray : new Float32Array([-1000, -1000, 0, 1, 1000, -1000, 0, 1, -1000, 1000, 0, 1, 1000, 1000, 0, 1]),
+                    usage : BufferUsage.STATIC_DRAW
+                }),
                 componentsPerAttribute : 4
             }]
         });
@@ -594,7 +647,11 @@ defineSuite([
             context : context,
             attributes : [{
                 index : sp.vertexAttributes.position.index,
-                vertexBuffer : Buffer.createVertexBuffer(context, new Float32Array([-1000, -1000, 0, 1, 1000, -1000, 0, 1, -1000, 1000, 0, 1, 1000, 1000, 0, 1]), BufferUsage.STATIC_DRAW),
+                vertexBuffer : Buffer.createVertexBuffer({
+                    context : context,
+                    typedArray : new Float32Array([-1000, -1000, 0, 1, 1000, -1000, 0, 1, -1000, 1000, 0, 1, 1000, 1000, 0, 1]),
+                    usage : BufferUsage.STATIC_DRAW
+                }),
                 componentsPerAttribute : 4
             }]
         });
@@ -647,7 +704,11 @@ defineSuite([
             context : context,
             attributes : [{
                 index : sp.vertexAttributes.position.index,
-                vertexBuffer : Buffer.createVertexBuffer(context, new Float32Array([0, 0, 0, 1]), BufferUsage.STATIC_DRAW),
+                vertexBuffer : Buffer.createVertexBuffer({
+                    context : context,
+                    typedArray : new Float32Array([0, 0, 0, 1]),
+                    usage : BufferUsage.STATIC_DRAW
+                }),
                 componentsPerAttribute : 4
             }]
         });
@@ -683,7 +744,11 @@ defineSuite([
             context : context,
             attributes : [{
                 index : sp.vertexAttributes.position.index,
-                vertexBuffer : Buffer.createVertexBuffer(context, new Float32Array([-1000, -1000, 0, 1, 1000, 1000, 0, 1]), BufferUsage.STATIC_DRAW),
+                vertexBuffer : Buffer.createVertexBuffer({
+                    context : context,
+                    typedArray : new Float32Array([-1000, -1000, 0, 1, 1000, 1000, 0, 1]),
+                    usage : BufferUsage.STATIC_DRAW
+                }),
                 componentsPerAttribute : 4
             }]
         });
@@ -721,7 +786,11 @@ defineSuite([
             context : context,
             attributes : [{
                 index : sp.vertexAttributes.position.index,
-                vertexBuffer : Buffer.createVertexBuffer(context, new Float32Array([0, 0, 0, 1]), BufferUsage.STATIC_DRAW),
+                vertexBuffer : Buffer.createVertexBuffer({
+                    context : context,
+                    typedArray : new Float32Array([0, 0, 0, 1]),
+                    usage : BufferUsage.STATIC_DRAW
+                }),
                 componentsPerAttribute : 4
             }]
         });
@@ -763,7 +832,11 @@ defineSuite([
             context : context,
             attributes : [{
                 index : sp.vertexAttributes.position.index,
-                vertexBuffer : Buffer.createVertexBuffer(context, new Float32Array([0, 0, 0, 1]), BufferUsage.STATIC_DRAW),
+                vertexBuffer : Buffer.createVertexBuffer({
+                    context : context,
+                    typedArray : new Float32Array([0, 0, 0, 1]),
+                    usage : BufferUsage.STATIC_DRAW
+                }),
                 componentsPerAttribute : 4
             }]
         });
@@ -817,7 +890,11 @@ defineSuite([
             context : context,
             attributes : [{
                 index : sp.vertexAttributes.position.index,
-                vertexBuffer : Buffer.createVertexBuffer(context, new Float32Array([-1000, -1000, 0, 1, 1000, -1000, 0, 1, -1000, 1000, 0, 1, 1000, 1000, 0, 1]), BufferUsage.STATIC_DRAW),
+                vertexBuffer : Buffer.createVertexBuffer({
+                    context : context,
+                    typedArray : new Float32Array([-1000, -1000, 0, 1, 1000, -1000, 0, 1, -1000, 1000, 0, 1, 1000, 1000, 0, 1]),
+                    usage : BufferUsage.STATIC_DRAW
+                }),
                 componentsPerAttribute : 4
             }]
         });
@@ -896,7 +973,11 @@ defineSuite([
             context : context,
             attributes : [{
                 index : sp.vertexAttributes.position.index,
-                vertexBuffer : Buffer.createVertexBuffer(context, new Float32Array([-1000, -1000, 0, 1, 1000, -1000, 0, 1, -1000, 1000, 0, 1, 1000, 1000, 0, 1]), BufferUsage.STATIC_DRAW),
+                vertexBuffer : Buffer.createVertexBuffer({
+                    context : context,
+                    typedArray : new Float32Array([-1000, -1000, 0, 1, 1000, -1000, 0, 1, -1000, 1000, 0, 1, 1000, 1000, 0, 1]),
+                    usage : BufferUsage.STATIC_DRAW
+                }),
                 componentsPerAttribute : 4
             }]
         });
@@ -972,7 +1053,11 @@ defineSuite([
             context : context,
             attributes : [{
                 index : sp.vertexAttributes.position.index,
-                vertexBuffer : Buffer.createVertexBuffer(context, new Float32Array([0, 0, 0, -1, 0, 0, 0, 1]), BufferUsage.STATIC_DRAW),
+                vertexBuffer : Buffer.createVertexBuffer({
+                    context : context,
+                    typedArray : new Float32Array([0, 0, 0, -1, 0, 0, 0, 1]),
+                    usage : BufferUsage.STATIC_DRAW
+                }),
                 componentsPerAttribute : 4
             }]
         });

--- a/Specs/Renderer/DrawSpec.js
+++ b/Specs/Renderer/DrawSpec.js
@@ -5,6 +5,7 @@ defineSuite([
         'Core/IndexDatatype',
         'Core/PrimitiveType',
         'Core/WindingOrder',
+        'Renderer/Buffer',
         'Renderer/BufferUsage',
         'Renderer/ClearCommand',
         'Renderer/ContextLimits',
@@ -19,6 +20,7 @@ defineSuite([
         IndexDatatype,
         PrimitiveType,
         WindingOrder,
+        Buffer,
         BufferUsage,
         ClearCommand,
         ContextLimits,
@@ -65,7 +67,7 @@ defineSuite([
             context : context,
             attributes : [{
                 index : sp.vertexAttributes.position.index,
-                vertexBuffer : context.createVertexBuffer(new Float32Array([0, 0, 0, 1]), BufferUsage.STATIC_DRAW),
+                vertexBuffer : Buffer.createVertexBuffer(context, new Float32Array([0, 0, 0, 1]), BufferUsage.STATIC_DRAW),
                 componentsPerAttribute : 4
             }]
         });
@@ -96,13 +98,13 @@ defineSuite([
 
         // Two indices instead of one is a workaround for NVIDIA:
         //   http://www.khronos.org/message_boards/viewtopic.php?f=44&t=3719
-        var indexBuffer = context.createIndexBuffer(new Uint16Array([0, 0]), BufferUsage.STATIC_DRAW, IndexDatatype.UNSIGNED_SHORT);
+        var indexBuffer = Buffer.createIndexBuffer(context, new Uint16Array([0, 0]), BufferUsage.STATIC_DRAW, IndexDatatype.UNSIGNED_SHORT);
 
         va = new VertexArray({
             context : context,
             attributes : [{
                 index : sp.vertexAttributes.position.index,
-                vertexBuffer : context.createVertexBuffer(new Float32Array([0, 0, 0, 1]), BufferUsage.STATIC_DRAW),
+                vertexBuffer : Buffer.createVertexBuffer(context, new Float32Array([0, 0, 0, 1]), BufferUsage.STATIC_DRAW),
                 componentsPerAttribute : 4
             }],
             indexBuffer : indexBuffer
@@ -145,11 +147,11 @@ defineSuite([
             context : context,
             attributes : [{
                 index : sp.vertexAttributes.position.index,
-                vertexBuffer : context.createVertexBuffer(new Float32Array([0, 0, 0, 1]), BufferUsage.STATIC_DRAW),
+                vertexBuffer : Buffer.createVertexBuffer(context, new Float32Array([0, 0, 0, 1]), BufferUsage.STATIC_DRAW),
                 componentsPerAttribute : 4
             }, {
                 index : sp.vertexAttributes.intensity.index,
-                vertexBuffer : context.createVertexBuffer(new Float32Array([1]), BufferUsage.STATIC_DRAW),
+                vertexBuffer : Buffer.createVertexBuffer(context, new Float32Array([1]), BufferUsage.STATIC_DRAW),
                 componentsPerAttribute : 1
             }]
         });
@@ -184,7 +186,7 @@ defineSuite([
         });
 
         var stride = 5 * Float32Array.BYTES_PER_ELEMENT;
-        var vertexBuffer = context.createVertexBuffer(new Float32Array([0, 0, 0, 1, 1]), BufferUsage.STATIC_DRAW);
+        var vertexBuffer = Buffer.createVertexBuffer(context, new Float32Array([0, 0, 0, 1, 1]), BufferUsage.STATIC_DRAW);
 
         va = new VertexArray({
             context : context,
@@ -228,7 +230,7 @@ defineSuite([
             context : context,
             attributes : [{
                 index : sp.vertexAttributes.position.index,
-                vertexBuffer : context.createVertexBuffer(new Float32Array([0, 0, 0, 1]), BufferUsage.STATIC_DRAW),
+                vertexBuffer : Buffer.createVertexBuffer(context, new Float32Array([0, 0, 0, 1]), BufferUsage.STATIC_DRAW),
                 componentsPerAttribute : 4
             }]
         });
@@ -281,7 +283,7 @@ defineSuite([
             context : context,
             attributes : [{
                 index : sp.vertexAttributes.position.index,
-                vertexBuffer : context.createVertexBuffer(new Float32Array([0, 0, 0, 1]), BufferUsage.STATIC_DRAW),
+                vertexBuffer : Buffer.createVertexBuffer(context, new Float32Array([0, 0, 0, 1]), BufferUsage.STATIC_DRAW),
                 componentsPerAttribute : 4
             }]
         });
@@ -338,7 +340,7 @@ defineSuite([
             context : context,
             attributes : [{
                 index : sp.vertexAttributes.position.index,
-                vertexBuffer : context.createVertexBuffer(new Float32Array([0, 0, 0, 1]), BufferUsage.STATIC_DRAW),
+                vertexBuffer : Buffer.createVertexBuffer(context, new Float32Array([0, 0, 0, 1]), BufferUsage.STATIC_DRAW),
                 componentsPerAttribute : 4
             }]
         });
@@ -386,7 +388,7 @@ defineSuite([
             context : context,
             attributes : [{
                 index : sp.vertexAttributes.position.index,
-                vertexBuffer : context.createVertexBuffer(new Float32Array([0, 0, 0, 1]), BufferUsage.STATIC_DRAW),
+                vertexBuffer : Buffer.createVertexBuffer(context, new Float32Array([0, 0, 0, 1]), BufferUsage.STATIC_DRAW),
                 componentsPerAttribute : 4
             }]
         });
@@ -434,7 +436,7 @@ defineSuite([
             context : context,
             attributes : [{
                 index : sp.vertexAttributes.position.index,
-                vertexBuffer : context.createVertexBuffer(new Float32Array([0, 0, 0, 1]), BufferUsage.STATIC_DRAW),
+                vertexBuffer : Buffer.createVertexBuffer(context, new Float32Array([0, 0, 0, 1]), BufferUsage.STATIC_DRAW),
                 componentsPerAttribute : 4
             }]
         });
@@ -484,7 +486,7 @@ defineSuite([
             context : context,
             attributes : [{
                 index : sp.vertexAttributes.position.index,
-                vertexBuffer : context.createVertexBuffer(new Float32Array([-1000, -1000, 0, 1, 1000, -1000, 0, 1, -1000, 1000, 0, 1, 1000, 1000, 0, 1]), BufferUsage.STATIC_DRAW),
+                vertexBuffer : Buffer.createVertexBuffer(context, new Float32Array([-1000, -1000, 0, 1, 1000, -1000, 0, 1, -1000, 1000, 0, 1, 1000, 1000, 0, 1]), BufferUsage.STATIC_DRAW),
                 componentsPerAttribute : 4
             }]
         });
@@ -537,7 +539,7 @@ defineSuite([
             context : context,
             attributes : [{
                 index : sp.vertexAttributes.position.index,
-                vertexBuffer : context.createVertexBuffer(new Float32Array([-1000, -1000, 0, 1, 1000, -1000, 0, 1, -1000, 1000, 0, 1, 1000, 1000, 0, 1]), BufferUsage.STATIC_DRAW),
+                vertexBuffer : Buffer.createVertexBuffer(context, new Float32Array([-1000, -1000, 0, 1, 1000, -1000, 0, 1, -1000, 1000, 0, 1, 1000, 1000, 0, 1]), BufferUsage.STATIC_DRAW),
                 componentsPerAttribute : 4
             }]
         });
@@ -592,7 +594,7 @@ defineSuite([
             context : context,
             attributes : [{
                 index : sp.vertexAttributes.position.index,
-                vertexBuffer : context.createVertexBuffer(new Float32Array([-1000, -1000, 0, 1, 1000, -1000, 0, 1, -1000, 1000, 0, 1, 1000, 1000, 0, 1]), BufferUsage.STATIC_DRAW),
+                vertexBuffer : Buffer.createVertexBuffer(context, new Float32Array([-1000, -1000, 0, 1, 1000, -1000, 0, 1, -1000, 1000, 0, 1, 1000, 1000, 0, 1]), BufferUsage.STATIC_DRAW),
                 componentsPerAttribute : 4
             }]
         });
@@ -645,7 +647,7 @@ defineSuite([
             context : context,
             attributes : [{
                 index : sp.vertexAttributes.position.index,
-                vertexBuffer : context.createVertexBuffer(new Float32Array([0, 0, 0, 1]), BufferUsage.STATIC_DRAW),
+                vertexBuffer : Buffer.createVertexBuffer(context, new Float32Array([0, 0, 0, 1]), BufferUsage.STATIC_DRAW),
                 componentsPerAttribute : 4
             }]
         });
@@ -681,7 +683,7 @@ defineSuite([
             context : context,
             attributes : [{
                 index : sp.vertexAttributes.position.index,
-                vertexBuffer : context.createVertexBuffer(new Float32Array([-1000, -1000, 0, 1, 1000, 1000, 0, 1]), BufferUsage.STATIC_DRAW),
+                vertexBuffer : Buffer.createVertexBuffer(context, new Float32Array([-1000, -1000, 0, 1, 1000, 1000, 0, 1]), BufferUsage.STATIC_DRAW),
                 componentsPerAttribute : 4
             }]
         });
@@ -719,7 +721,7 @@ defineSuite([
             context : context,
             attributes : [{
                 index : sp.vertexAttributes.position.index,
-                vertexBuffer : context.createVertexBuffer(new Float32Array([0, 0, 0, 1]), BufferUsage.STATIC_DRAW),
+                vertexBuffer : Buffer.createVertexBuffer(context, new Float32Array([0, 0, 0, 1]), BufferUsage.STATIC_DRAW),
                 componentsPerAttribute : 4
             }]
         });
@@ -761,7 +763,7 @@ defineSuite([
             context : context,
             attributes : [{
                 index : sp.vertexAttributes.position.index,
-                vertexBuffer : context.createVertexBuffer(new Float32Array([0, 0, 0, 1]), BufferUsage.STATIC_DRAW),
+                vertexBuffer : Buffer.createVertexBuffer(context, new Float32Array([0, 0, 0, 1]), BufferUsage.STATIC_DRAW),
                 componentsPerAttribute : 4
             }]
         });
@@ -815,7 +817,7 @@ defineSuite([
             context : context,
             attributes : [{
                 index : sp.vertexAttributes.position.index,
-                vertexBuffer : context.createVertexBuffer(new Float32Array([-1000, -1000, 0, 1, 1000, -1000, 0, 1, -1000, 1000, 0, 1, 1000, 1000, 0, 1]), BufferUsage.STATIC_DRAW),
+                vertexBuffer : Buffer.createVertexBuffer(context, new Float32Array([-1000, -1000, 0, 1, 1000, -1000, 0, 1, -1000, 1000, 0, 1, 1000, 1000, 0, 1]), BufferUsage.STATIC_DRAW),
                 componentsPerAttribute : 4
             }]
         });
@@ -894,7 +896,7 @@ defineSuite([
             context : context,
             attributes : [{
                 index : sp.vertexAttributes.position.index,
-                vertexBuffer : context.createVertexBuffer(new Float32Array([-1000, -1000, 0, 1, 1000, -1000, 0, 1, -1000, 1000, 0, 1, 1000, 1000, 0, 1]), BufferUsage.STATIC_DRAW),
+                vertexBuffer : Buffer.createVertexBuffer(context, new Float32Array([-1000, -1000, 0, 1, 1000, -1000, 0, 1, -1000, 1000, 0, 1, 1000, 1000, 0, 1]), BufferUsage.STATIC_DRAW),
                 componentsPerAttribute : 4
             }]
         });
@@ -970,7 +972,7 @@ defineSuite([
             context : context,
             attributes : [{
                 index : sp.vertexAttributes.position.index,
-                vertexBuffer : context.createVertexBuffer(new Float32Array([0, 0, 0, -1, 0, 0, 0, 1]), BufferUsage.STATIC_DRAW),
+                vertexBuffer : Buffer.createVertexBuffer(context, new Float32Array([0, 0, 0, -1, 0, 0, 0, 1]), BufferUsage.STATIC_DRAW),
                 componentsPerAttribute : 4
             }]
         });

--- a/Specs/Renderer/FramebufferSpec.js
+++ b/Specs/Renderer/FramebufferSpec.js
@@ -3,6 +3,7 @@ defineSuite([
         'Core/Color',
         'Core/PixelFormat',
         'Core/PrimitiveType',
+        'Renderer/Buffer',
         'Renderer/BufferUsage',
         'Renderer/ClearCommand',
         'Renderer/ContextLimits',
@@ -21,6 +22,7 @@ defineSuite([
         Color,
         PixelFormat,
         PrimitiveType,
+        Buffer,
         BufferUsage,
         ClearCommand,
         ContextLimits,
@@ -204,7 +206,7 @@ defineSuite([
             context : context,
             attributes : [{
                 index : sp.vertexAttributes.position.index,
-                vertexBuffer : context.createVertexBuffer(new Float32Array([0, 0, 0, 1]), BufferUsage.STATIC_DRAW),
+                vertexBuffer : Buffer.createVertexBuffer(context, new Float32Array([0, 0, 0, 1]), BufferUsage.STATIC_DRAW),
                 componentsPerAttribute : 4
             }]
         });
@@ -262,7 +264,7 @@ defineSuite([
             context : context,
             attributes : [{
                 index : sp.vertexAttributes.position.index,
-                vertexBuffer : context.createVertexBuffer(new Float32Array([0, 0, 0, 1]), BufferUsage.STATIC_DRAW),
+                vertexBuffer : Buffer.createVertexBuffer(context, new Float32Array([0, 0, 0, 1]), BufferUsage.STATIC_DRAW),
                 componentsPerAttribute : 4
             }]
         });
@@ -306,7 +308,7 @@ defineSuite([
             context : context,
             attributes : [{
                 index : sp.vertexAttributes.position.index,
-                vertexBuffer : context.createVertexBuffer(new Float32Array([0, 0, 0, 1]), BufferUsage.STATIC_DRAW),
+                vertexBuffer : Buffer.createVertexBuffer(context, new Float32Array([0, 0, 0, 1]), BufferUsage.STATIC_DRAW),
                 componentsPerAttribute : 4
             }]
         });
@@ -362,7 +364,7 @@ defineSuite([
             context : context,
             attributes : [{
                 index : sp.vertexAttributes.position.index,
-                vertexBuffer : context.createVertexBuffer(new Float32Array([0, 0, 0, 1]), BufferUsage.STATIC_DRAW),
+                vertexBuffer : Buffer.createVertexBuffer(context, new Float32Array([0, 0, 0, 1]), BufferUsage.STATIC_DRAW),
                 componentsPerAttribute : 4
             }]
         });
@@ -484,7 +486,7 @@ defineSuite([
             context : context,
             attributes : [{
                 index : sp.vertexAttributes.position.index,
-                vertexBuffer : context.createVertexBuffer(new Float32Array([0, 0, 0, 1]), BufferUsage.STATIC_DRAW),
+                vertexBuffer : Buffer.createVertexBuffer(context, new Float32Array([0, 0, 0, 1]), BufferUsage.STATIC_DRAW),
                 componentsPerAttribute : 4
             }]
         });
@@ -571,7 +573,7 @@ defineSuite([
                 context : context,
                 attributes : [{
                     index : sp.vertexAttributes.position.index,
-                    vertexBuffer : context.createVertexBuffer(new Float32Array([0, 0, 0, 1]), BufferUsage.STATIC_DRAW),
+                    vertexBuffer : Buffer.createVertexBuffer(context, new Float32Array([0, 0, 0, 1]), BufferUsage.STATIC_DRAW),
                     componentsPerAttribute : 4
                 }]
             });
@@ -799,7 +801,7 @@ defineSuite([
             context : context,
             attributes : [{
                 index : sp.vertexAttributes.position.index,
-                vertexBuffer : context.createVertexBuffer(new Float32Array([0, 0, 0, 1]), BufferUsage.STATIC_DRAW),
+                vertexBuffer : Buffer.createVertexBuffer(context, new Float32Array([0, 0, 0, 1]), BufferUsage.STATIC_DRAW),
                 componentsPerAttribute : 4
             }]
         });

--- a/Specs/Renderer/FramebufferSpec.js
+++ b/Specs/Renderer/FramebufferSpec.js
@@ -206,7 +206,11 @@ defineSuite([
             context : context,
             attributes : [{
                 index : sp.vertexAttributes.position.index,
-                vertexBuffer : Buffer.createVertexBuffer(context, new Float32Array([0, 0, 0, 1]), BufferUsage.STATIC_DRAW),
+                vertexBuffer : Buffer.createVertexBuffer({
+                    context : context,
+                    typedArray : new Float32Array([0, 0, 0, 1]),
+                    usage : BufferUsage.STATIC_DRAW
+                }),
                 componentsPerAttribute : 4
             }]
         });
@@ -264,7 +268,11 @@ defineSuite([
             context : context,
             attributes : [{
                 index : sp.vertexAttributes.position.index,
-                vertexBuffer : Buffer.createVertexBuffer(context, new Float32Array([0, 0, 0, 1]), BufferUsage.STATIC_DRAW),
+                vertexBuffer : Buffer.createVertexBuffer({
+                    context : context,
+                    typedArray : new Float32Array([0, 0, 0, 1]),
+                    usage : BufferUsage.STATIC_DRAW
+                }),
                 componentsPerAttribute : 4
             }]
         });
@@ -308,7 +316,11 @@ defineSuite([
             context : context,
             attributes : [{
                 index : sp.vertexAttributes.position.index,
-                vertexBuffer : Buffer.createVertexBuffer(context, new Float32Array([0, 0, 0, 1]), BufferUsage.STATIC_DRAW),
+                vertexBuffer : Buffer.createVertexBuffer({
+                    context : context,
+                    typedArray : new Float32Array([0, 0, 0, 1]),
+                    usage : BufferUsage.STATIC_DRAW
+                }),
                 componentsPerAttribute : 4
             }]
         });
@@ -364,7 +376,11 @@ defineSuite([
             context : context,
             attributes : [{
                 index : sp.vertexAttributes.position.index,
-                vertexBuffer : Buffer.createVertexBuffer(context, new Float32Array([0, 0, 0, 1]), BufferUsage.STATIC_DRAW),
+                vertexBuffer : Buffer.createVertexBuffer({
+                    context : context,
+                    typedArray : new Float32Array([0, 0, 0, 1]),
+                    usage : BufferUsage.STATIC_DRAW
+                }),
                 componentsPerAttribute : 4
             }]
         });
@@ -486,7 +502,11 @@ defineSuite([
             context : context,
             attributes : [{
                 index : sp.vertexAttributes.position.index,
-                vertexBuffer : Buffer.createVertexBuffer(context, new Float32Array([0, 0, 0, 1]), BufferUsage.STATIC_DRAW),
+                vertexBuffer : Buffer.createVertexBuffer({
+                    context : context,
+                    typedArray : new Float32Array([0, 0, 0, 1]),
+                    usage : BufferUsage.STATIC_DRAW
+                }),
                 componentsPerAttribute : 4
             }]
         });
@@ -573,7 +593,11 @@ defineSuite([
                 context : context,
                 attributes : [{
                     index : sp.vertexAttributes.position.index,
-                    vertexBuffer : Buffer.createVertexBuffer(context, new Float32Array([0, 0, 0, 1]), BufferUsage.STATIC_DRAW),
+                    vertexBuffer : Buffer.createVertexBuffer({
+                        context : context,
+                        typedArray : new Float32Array([0, 0, 0, 1]),
+                        usage : BufferUsage.STATIC_DRAW
+                    }),
                     componentsPerAttribute : 4
                 }]
             });
@@ -801,7 +825,11 @@ defineSuite([
             context : context,
             attributes : [{
                 index : sp.vertexAttributes.position.index,
-                vertexBuffer : Buffer.createVertexBuffer(context, new Float32Array([0, 0, 0, 1]), BufferUsage.STATIC_DRAW),
+                vertexBuffer : Buffer.createVertexBuffer({
+                    context : context,
+                    typedArray : new Float32Array([0, 0, 0, 1]),
+                    usage : BufferUsage.STATIC_DRAW
+                }),
                 componentsPerAttribute : 4
             }]
         });

--- a/Specs/Renderer/ShaderProgramSpec.js
+++ b/Specs/Renderer/ShaderProgramSpec.js
@@ -82,7 +82,11 @@ defineSuite([
             context : context,
             attributes : [{
                 index : sp.vertexAttributes.position.index,
-                vertexBuffer : Buffer.createVertexBuffer(context, new Float32Array([0, 0, 0, 1]), BufferUsage.STATIC_DRAW),
+                vertexBuffer : Buffer.createVertexBuffer({
+                    context : context,
+                    typedArray : new Float32Array([0, 0, 0, 1]),
+                    usage : BufferUsage.STATIC_DRAW
+                }),
                 componentsPerAttribute : 4
             }]
         });

--- a/Specs/Renderer/ShaderProgramSpec.js
+++ b/Specs/Renderer/ShaderProgramSpec.js
@@ -8,6 +8,7 @@ defineSuite([
         'Core/Matrix3',
         'Core/Matrix4',
         'Core/PrimitiveType',
+        'Renderer/Buffer',
         'Renderer/BufferUsage',
         'Renderer/ClearCommand',
         'Renderer/DrawCommand',
@@ -24,6 +25,7 @@ defineSuite([
         Matrix3,
         Matrix4,
         PrimitiveType,
+        Buffer,
         BufferUsage,
         ClearCommand,
         DrawCommand,
@@ -80,7 +82,7 @@ defineSuite([
             context : context,
             attributes : [{
                 index : sp.vertexAttributes.position.index,
-                vertexBuffer : context.createVertexBuffer(new Float32Array([0, 0, 0, 1]), BufferUsage.STATIC_DRAW),
+                vertexBuffer : Buffer.createVertexBuffer(context, new Float32Array([0, 0, 0, 1]), BufferUsage.STATIC_DRAW),
                 componentsPerAttribute : 4
             }]
         });

--- a/Specs/Renderer/TextureSpec.js
+++ b/Specs/Renderer/TextureSpec.js
@@ -106,7 +106,11 @@ defineSuite([
         va = new VertexArray({
             context : context,
             attributes : [{
-                vertexBuffer : Buffer.createVertexBuffer(context, new Float32Array([0, 0, 0, 1]), BufferUsage.STATIC_DRAW),
+                vertexBuffer : Buffer.createVertexBuffer({
+                    context : context,
+                    typedArray : new Float32Array([0, 0, 0, 1]),
+                    usage : BufferUsage.STATIC_DRAW
+                }),
                 componentsPerAttribute : 4
             }]
         });
@@ -250,7 +254,11 @@ defineSuite([
         va = new VertexArray({
             context : context,
             attributes : [{
-                vertexBuffer : Buffer.createVertexBuffer(context, new Float32Array([0, 0, 0, 1]), BufferUsage.STATIC_DRAW),
+                vertexBuffer : Buffer.createVertexBuffer({
+                    context : context,
+                    typedArray : new Float32Array([0, 0, 0, 1]),
+                    usage : BufferUsage.STATIC_DRAW
+                }),
                 componentsPerAttribute : 4
             }]
         });
@@ -337,7 +345,11 @@ defineSuite([
         va = new VertexArray({
             context : context,
             attributes : [{
-                vertexBuffer : Buffer.createVertexBuffer(context, new Float32Array([0, 0, 0, 1]), BufferUsage.STATIC_DRAW),
+                vertexBuffer : Buffer.createVertexBuffer({
+                    context : context,
+                    typedArray : new Float32Array([0, 0, 0, 1]),
+                    usage : BufferUsage.STATIC_DRAW
+                }),
                 componentsPerAttribute : 4
             }]
         });

--- a/Specs/Renderer/TextureSpec.js
+++ b/Specs/Renderer/TextureSpec.js
@@ -5,6 +5,7 @@ defineSuite([
         'Core/loadImage',
         'Core/PixelFormat',
         'Core/PrimitiveType',
+        'Renderer/Buffer',
         'Renderer/BufferUsage',
         'Renderer/ClearCommand',
         'Renderer/ContextLimits',
@@ -25,6 +26,7 @@ defineSuite([
         loadImage,
         PixelFormat,
         PrimitiveType,
+        Buffer,
         BufferUsage,
         ClearCommand,
         ContextLimits,
@@ -104,7 +106,7 @@ defineSuite([
         va = new VertexArray({
             context : context,
             attributes : [{
-                vertexBuffer : context.createVertexBuffer(new Float32Array([0, 0, 0, 1]), BufferUsage.STATIC_DRAW),
+                vertexBuffer : Buffer.createVertexBuffer(context, new Float32Array([0, 0, 0, 1]), BufferUsage.STATIC_DRAW),
                 componentsPerAttribute : 4
             }]
         });
@@ -248,7 +250,7 @@ defineSuite([
         va = new VertexArray({
             context : context,
             attributes : [{
-                vertexBuffer : context.createVertexBuffer(new Float32Array([0, 0, 0, 1]), BufferUsage.STATIC_DRAW),
+                vertexBuffer : Buffer.createVertexBuffer(context, new Float32Array([0, 0, 0, 1]), BufferUsage.STATIC_DRAW),
                 componentsPerAttribute : 4
             }]
         });
@@ -335,7 +337,7 @@ defineSuite([
         va = new VertexArray({
             context : context,
             attributes : [{
-                vertexBuffer : context.createVertexBuffer(new Float32Array([0, 0, 0, 1]), BufferUsage.STATIC_DRAW),
+                vertexBuffer : Buffer.createVertexBuffer(context, new Float32Array([0, 0, 0, 1]), BufferUsage.STATIC_DRAW),
                 componentsPerAttribute : 4
             }]
         });

--- a/Specs/Renderer/VertexArraySpec.js
+++ b/Specs/Renderer/VertexArraySpec.js
@@ -31,7 +31,11 @@ defineSuite([
     });
 
     it('binds', function() {
-        var positionBuffer = Buffer.createVertexBuffer(context, 3, BufferUsage.STATIC_DRAW);
+        var positionBuffer = Buffer.createVertexBuffer({
+            context : context,
+            sizeInBytes : 3,
+            usage : BufferUsage.STATIC_DRAW
+        });
 
         var attributes = [{
             index : 0,
@@ -55,7 +59,11 @@ defineSuite([
     });
 
     it('binds with default values', function() {
-        var positionBuffer = Buffer.createVertexBuffer(context, 3, BufferUsage.STATIC_DRAW);
+        var positionBuffer = Buffer.createVertexBuffer({
+            context : context,
+            sizeInBytes : 3,
+            usage : BufferUsage.STATIC_DRAW
+        });
 
         var attributes = [{
             vertexBuffer : positionBuffer,
@@ -84,8 +92,16 @@ defineSuite([
 
     it('binds with multiple buffers', function() {
         var attributeSize = 3 * Float32Array.BYTES_PER_ELEMENT;
-        var positionBuffer = Buffer.createVertexBuffer(context, attributeSize, BufferUsage.STATIC_DRAW);
-        var normalBuffer = Buffer.createVertexBuffer(context, attributeSize, BufferUsage.STATIC_DRAW);
+        var positionBuffer = Buffer.createVertexBuffer({
+            context : context,
+            sizeInBytes : attributeSize,
+            usage : BufferUsage.STATIC_DRAW
+        });
+        var normalBuffer = Buffer.createVertexBuffer({
+            context : context,
+            sizeInBytes : attributeSize,
+            usage : BufferUsage.STATIC_DRAW
+        });
 
         var attributes = [{
             index : 0,
@@ -112,7 +128,11 @@ defineSuite([
 
     it('binds with interleaved buffer', function() {
         var attributeSize = 3 * Float32Array.BYTES_PER_ELEMENT;
-        var buffer = Buffer.createVertexBuffer(context, attributeSize, BufferUsage.STATIC_DRAW);
+        var buffer = Buffer.createVertexBuffer({
+            context : context,
+            sizeInBytes : attributeSize,
+            usage : BufferUsage.STATIC_DRAW
+        });
 
         var attributes = [{
             vertexBuffer : buffer,
@@ -141,7 +161,11 @@ defineSuite([
     });
 
     it('adds attributes', function() {
-        var positionBuffer = Buffer.createVertexBuffer(context, 3, BufferUsage.STATIC_DRAW);
+        var positionBuffer = Buffer.createVertexBuffer({
+            context : context,
+            sizeInBytes : 3,
+            usage : BufferUsage.STATIC_DRAW
+        });
 
         var va = new VertexArray({
             context : context,
@@ -165,7 +189,11 @@ defineSuite([
     });
 
     it('modifies attributes', function() {
-        var buffer = Buffer.createVertexBuffer(context, 6, BufferUsage.STATIC_DRAW);
+        var buffer = Buffer.createVertexBuffer({
+            context : context,
+            sizeInBytes : 6,
+            usage : BufferUsage.STATIC_DRAW
+        });
 
         var attributes = [{
             vertexBuffer : buffer,
@@ -221,7 +249,11 @@ defineSuite([
         var va = new VertexArray({
             context : context,
             attributes : [{
-                vertexBuffer : Buffer.createVertexBuffer(context, Float32Array.BYTES_PER_ELEMENT, BufferUsage.STATIC_DRAW),
+                vertexBuffer : Buffer.createVertexBuffer({
+                    context : context,
+                    sizeInBytes : Float32Array.BYTES_PER_ELEMENT,
+                    usage : BufferUsage.STATIC_DRAW
+                }),
                 componentsPerAttribute : 1
             }, {
                 value : [0.5]
@@ -268,7 +300,11 @@ defineSuite([
         var va = new VertexArray({
             context : context,
             attributes : [{
-                vertexBuffer : Buffer.createVertexBuffer(context, Float32Array.BYTES_PER_ELEMENT, BufferUsage.STATIC_DRAW),
+                vertexBuffer : Buffer.createVertexBuffer({
+                    context : context,
+                    sizeInBytes : Float32Array.BYTES_PER_ELEMENT,
+                    usage : BufferUsage.STATIC_DRAW
+                }),
                 componentsPerAttribute : 1
             }, {
                 value : [0.25, 0.75]
@@ -315,7 +351,11 @@ defineSuite([
         var va = new VertexArray({
             context : context,
             attributes : [{
-                vertexBuffer : Buffer.createVertexBuffer(context, Float32Array.BYTES_PER_ELEMENT, BufferUsage.STATIC_DRAW),
+                vertexBuffer : Buffer.createVertexBuffer({
+                    context : context,
+                    sizeInBytes : Float32Array.BYTES_PER_ELEMENT,
+                    usage : BufferUsage.STATIC_DRAW
+                }),
                 componentsPerAttribute : 1
             }, {
                 value : [0.25, 0.5, 0.75]
@@ -362,7 +402,11 @@ defineSuite([
         var va = new VertexArray({
             context : context,
             attributes : [{
-                vertexBuffer : Buffer.createVertexBuffer(context, Float32Array.BYTES_PER_ELEMENT, BufferUsage.STATIC_DRAW),
+                vertexBuffer : Buffer.createVertexBuffer({
+                    context : context,
+                    sizeInBytes : Float32Array.BYTES_PER_ELEMENT,
+                    usage : BufferUsage.STATIC_DRAW
+                }),
                 componentsPerAttribute : 1
             }, {
                 value : [0.2, 0.4, 0.6, 0.8]
@@ -387,7 +431,11 @@ defineSuite([
         var va = new VertexArray({
             context : context,
             attributes : [{
-                vertexBuffer : Buffer.createVertexBuffer(context, new Float32Array([0, 0, 0, 1]), BufferUsage.STATIC_DRAW),
+                vertexBuffer : Buffer.createVertexBuffer({
+                    context : context,
+                    sizeInBytes : new Float32Array([0, 0, 0, 1]),
+                    usage : BufferUsage.STATIC_DRAW
+                }),
                 componentsPerAttribute : 4
             }]
         });
@@ -411,7 +459,11 @@ defineSuite([
     });
 
     it('fails to create (provides both vertexBuffer and value)', function() {
-        var buffer = Buffer.createVertexBuffer(context, 3, BufferUsage.STATIC_DRAW);
+        var buffer = Buffer.createVertexBuffer({
+            context : context,
+            sizeInBytes : 3,
+            usage : BufferUsage.STATIC_DRAW
+        });
 
         var attributes = [{
             vertexBuffer : buffer,
@@ -428,7 +480,11 @@ defineSuite([
     });
 
     it('fails to create with duplicate indices', function() {
-        var buffer = Buffer.createVertexBuffer(context, 1, BufferUsage.STATIC_DRAW);
+        var buffer = Buffer.createVertexBuffer({
+            context : context,
+            sizeInBytes : 1,
+            usage : BufferUsage.STATIC_DRAW
+        });
 
         var attributes = [{
             index : 1,
@@ -449,7 +505,11 @@ defineSuite([
     });
 
     it('fails to create (componentsPerAttribute missing)', function() {
-        var buffer = Buffer.createVertexBuffer(context, 3, BufferUsage.STATIC_DRAW);
+        var buffer = Buffer.createVertexBuffer({
+            context : context,
+            sizeInBytes : 3,
+            usage : BufferUsage.STATIC_DRAW
+        });
 
         var attributes = [{
             vertexBuffer : buffer
@@ -516,7 +576,11 @@ defineSuite([
     });
 
     it('fails to create (componentDatatype)', function() {
-        var buffer = Buffer.createVertexBuffer(context, 3, BufferUsage.STATIC_DRAW);
+        var buffer = Buffer.createVertexBuffer({
+            context : context,
+            sizeInBytes : 3,
+            usage : BufferUsage.STATIC_DRAW
+        });
 
         var attributes = [{
             vertexBuffer : buffer,
@@ -533,7 +597,11 @@ defineSuite([
     });
 
     it('fails to create (strideInBytes)', function() {
-        var buffer = Buffer.createVertexBuffer(context, 3, BufferUsage.STATIC_DRAW);
+        var buffer = Buffer.createVertexBuffer({
+            context : context,
+            sizeInBytes : 3,
+            usage : BufferUsage.STATIC_DRAW
+        });
 
         var attributes = [{
             vertexBuffer : buffer,

--- a/Specs/Renderer/VertexArraySpec.js
+++ b/Specs/Renderer/VertexArraySpec.js
@@ -2,6 +2,7 @@
 defineSuite([
         'Core/ComponentDatatype',
         'Core/PrimitiveType',
+        'Renderer/Buffer',
         'Renderer/BufferUsage',
         'Renderer/DrawCommand',
         'Renderer/ShaderProgram',
@@ -10,6 +11,7 @@ defineSuite([
     ], 'Renderer/VertexArray', function(
         ComponentDatatype,
         PrimitiveType,
+        Buffer,
         BufferUsage,
         DrawCommand,
         ShaderProgram,
@@ -29,7 +31,7 @@ defineSuite([
     });
 
     it('binds', function() {
-        var positionBuffer = context.createVertexBuffer(3, BufferUsage.STATIC_DRAW);
+        var positionBuffer = Buffer.createVertexBuffer(context, 3, BufferUsage.STATIC_DRAW);
 
         var attributes = [{
             index : 0,
@@ -53,7 +55,7 @@ defineSuite([
     });
 
     it('binds with default values', function() {
-        var positionBuffer = context.createVertexBuffer(3, BufferUsage.STATIC_DRAW);
+        var positionBuffer = Buffer.createVertexBuffer(context, 3, BufferUsage.STATIC_DRAW);
 
         var attributes = [{
             vertexBuffer : positionBuffer,
@@ -82,8 +84,8 @@ defineSuite([
 
     it('binds with multiple buffers', function() {
         var attributeSize = 3 * Float32Array.BYTES_PER_ELEMENT;
-        var positionBuffer = context.createVertexBuffer(attributeSize, BufferUsage.STATIC_DRAW);
-        var normalBuffer = context.createVertexBuffer(attributeSize, BufferUsage.STATIC_DRAW);
+        var positionBuffer = Buffer.createVertexBuffer(context, attributeSize, BufferUsage.STATIC_DRAW);
+        var normalBuffer = Buffer.createVertexBuffer(context, attributeSize, BufferUsage.STATIC_DRAW);
 
         var attributes = [{
             index : 0,
@@ -110,7 +112,7 @@ defineSuite([
 
     it('binds with interleaved buffer', function() {
         var attributeSize = 3 * Float32Array.BYTES_PER_ELEMENT;
-        var buffer = context.createVertexBuffer(attributeSize, BufferUsage.STATIC_DRAW);
+        var buffer = Buffer.createVertexBuffer(context, attributeSize, BufferUsage.STATIC_DRAW);
 
         var attributes = [{
             vertexBuffer : buffer,
@@ -139,7 +141,7 @@ defineSuite([
     });
 
     it('adds attributes', function() {
-        var positionBuffer = context.createVertexBuffer(3, BufferUsage.STATIC_DRAW);
+        var positionBuffer = Buffer.createVertexBuffer(context, 3, BufferUsage.STATIC_DRAW);
 
         var va = new VertexArray({
             context : context,
@@ -163,7 +165,7 @@ defineSuite([
     });
 
     it('modifies attributes', function() {
-        var buffer = context.createVertexBuffer(6, BufferUsage.STATIC_DRAW);
+        var buffer = Buffer.createVertexBuffer(context, 6, BufferUsage.STATIC_DRAW);
 
         var attributes = [{
             vertexBuffer : buffer,
@@ -219,7 +221,7 @@ defineSuite([
         var va = new VertexArray({
             context : context,
             attributes : [{
-                vertexBuffer : context.createVertexBuffer(Float32Array.BYTES_PER_ELEMENT, BufferUsage.STATIC_DRAW),
+                vertexBuffer : Buffer.createVertexBuffer(context, Float32Array.BYTES_PER_ELEMENT, BufferUsage.STATIC_DRAW),
                 componentsPerAttribute : 1
             }, {
                 value : [0.5]
@@ -266,7 +268,7 @@ defineSuite([
         var va = new VertexArray({
             context : context,
             attributes : [{
-                vertexBuffer : context.createVertexBuffer(Float32Array.BYTES_PER_ELEMENT, BufferUsage.STATIC_DRAW),
+                vertexBuffer : Buffer.createVertexBuffer(context, Float32Array.BYTES_PER_ELEMENT, BufferUsage.STATIC_DRAW),
                 componentsPerAttribute : 1
             }, {
                 value : [0.25, 0.75]
@@ -313,7 +315,7 @@ defineSuite([
         var va = new VertexArray({
             context : context,
             attributes : [{
-                vertexBuffer : context.createVertexBuffer(Float32Array.BYTES_PER_ELEMENT, BufferUsage.STATIC_DRAW),
+                vertexBuffer : Buffer.createVertexBuffer(context, Float32Array.BYTES_PER_ELEMENT, BufferUsage.STATIC_DRAW),
                 componentsPerAttribute : 1
             }, {
                 value : [0.25, 0.5, 0.75]
@@ -360,7 +362,7 @@ defineSuite([
         var va = new VertexArray({
             context : context,
             attributes : [{
-                vertexBuffer : context.createVertexBuffer(Float32Array.BYTES_PER_ELEMENT, BufferUsage.STATIC_DRAW),
+                vertexBuffer : Buffer.createVertexBuffer(context, Float32Array.BYTES_PER_ELEMENT, BufferUsage.STATIC_DRAW),
                 componentsPerAttribute : 1
             }, {
                 value : [0.2, 0.4, 0.6, 0.8]
@@ -385,7 +387,7 @@ defineSuite([
         var va = new VertexArray({
             context : context,
             attributes : [{
-                vertexBuffer : context.createVertexBuffer(new Float32Array([0, 0, 0, 1]), BufferUsage.STATIC_DRAW),
+                vertexBuffer : Buffer.createVertexBuffer(context, new Float32Array([0, 0, 0, 1]), BufferUsage.STATIC_DRAW),
                 componentsPerAttribute : 4
             }]
         });
@@ -409,7 +411,7 @@ defineSuite([
     });
 
     it('fails to create (provides both vertexBuffer and value)', function() {
-        var buffer = context.createVertexBuffer(3, BufferUsage.STATIC_DRAW);
+        var buffer = Buffer.createVertexBuffer(context, 3, BufferUsage.STATIC_DRAW);
 
         var attributes = [{
             vertexBuffer : buffer,
@@ -426,7 +428,7 @@ defineSuite([
     });
 
     it('fails to create with duplicate indices', function() {
-        var buffer = context.createVertexBuffer(1, BufferUsage.STATIC_DRAW);
+        var buffer = Buffer.createVertexBuffer(context, 1, BufferUsage.STATIC_DRAW);
 
         var attributes = [{
             index : 1,
@@ -447,7 +449,7 @@ defineSuite([
     });
 
     it('fails to create (componentsPerAttribute missing)', function() {
-        var buffer = context.createVertexBuffer(3, BufferUsage.STATIC_DRAW);
+        var buffer = Buffer.createVertexBuffer(context, 3, BufferUsage.STATIC_DRAW);
 
         var attributes = [{
             vertexBuffer : buffer
@@ -514,7 +516,7 @@ defineSuite([
     });
 
     it('fails to create (componentDatatype)', function() {
-        var buffer = context.createVertexBuffer(3, BufferUsage.STATIC_DRAW);
+        var buffer = Buffer.createVertexBuffer(context, 3, BufferUsage.STATIC_DRAW);
 
         var attributes = [{
             vertexBuffer : buffer,
@@ -531,7 +533,7 @@ defineSuite([
     });
 
     it('fails to create (strideInBytes)', function() {
-        var buffer = context.createVertexBuffer(3, BufferUsage.STATIC_DRAW);
+        var buffer = Buffer.createVertexBuffer(context, 3, BufferUsage.STATIC_DRAW);
 
         var attributes = [{
             vertexBuffer : buffer,

--- a/Specs/Renderer/loadCubeMapSpec.js
+++ b/Specs/Renderer/loadCubeMapSpec.js
@@ -4,6 +4,7 @@ defineSuite([
         'Core/Cartesian3',
         'Core/defined',
         'Core/PrimitiveType',
+        'Renderer/Buffer',
         'Renderer/BufferUsage',
         'Renderer/DrawCommand',
         'Renderer/ShaderProgram',
@@ -15,6 +16,7 @@ defineSuite([
         Cartesian3,
         defined,
         PrimitiveType,
+        Buffer,
         BufferUsage,
         DrawCommand,
         ShaderProgram,
@@ -64,7 +66,7 @@ defineSuite([
             var va = new VertexArray({
                 context : context,
                 attributes : [{
-                    vertexBuffer : context.createVertexBuffer(new Float32Array([0, 0, 0, 1]), BufferUsage.STATIC_DRAW),
+                    vertexBuffer : Buffer.createVertexBuffer(context, new Float32Array([0, 0, 0, 1]), BufferUsage.STATIC_DRAW),
                     componentsPerAttribute : 4
                 }]
             });

--- a/Specs/Renderer/loadCubeMapSpec.js
+++ b/Specs/Renderer/loadCubeMapSpec.js
@@ -66,7 +66,11 @@ defineSuite([
             var va = new VertexArray({
                 context : context,
                 attributes : [{
-                    vertexBuffer : Buffer.createVertexBuffer(context, new Float32Array([0, 0, 0, 1]), BufferUsage.STATIC_DRAW),
+                    vertexBuffer : Buffer.createVertexBuffer({
+                        context : context,
+                        typedArray : new Float32Array([0, 0, 0, 1]),
+                        usage : BufferUsage.STATIC_DRAW
+                    }),
                     componentsPerAttribute : 4
                 }]
             });

--- a/Specs/Scene/TextureAtlasSpec.js
+++ b/Specs/Scene/TextureAtlasSpec.js
@@ -7,6 +7,7 @@ defineSuite([
         'Core/Math',
         'Core/PixelFormat',
         'Core/PrimitiveType',
+        'Renderer/Buffer',
         'Renderer/BufferUsage',
         'Renderer/ClearCommand',
         'Renderer/DrawCommand',
@@ -22,6 +23,7 @@ defineSuite([
         CesiumMath,
         PixelFormat,
         PrimitiveType,
+        Buffer,
         BufferUsage,
         ClearCommand,
         DrawCommand,
@@ -105,7 +107,7 @@ void main() {\n\
             context : context,
             attributes : [{
                 index : sp.vertexAttributes.position.index,
-                vertexBuffer : context.createVertexBuffer(new Float32Array([0, 0, 0, 1]), BufferUsage.STATIC_DRAW),
+                vertexBuffer : Buffer.createVertexBuffer(context, new Float32Array([0, 0, 0, 1]), BufferUsage.STATIC_DRAW),
                 componentsPerAttribute : 4
             }]
         });

--- a/Specs/Scene/TextureAtlasSpec.js
+++ b/Specs/Scene/TextureAtlasSpec.js
@@ -107,7 +107,11 @@ void main() {\n\
             context : context,
             attributes : [{
                 index : sp.vertexAttributes.position.index,
-                vertexBuffer : Buffer.createVertexBuffer(context, new Float32Array([0, 0, 0, 1]), BufferUsage.STATIC_DRAW),
+                vertexBuffer : Buffer.createVertexBuffer({
+                    context : context,
+                    typedArray : new Float32Array([0, 0, 0, 1]),
+                    usage : BufferUsage.STATIC_DRAW
+                }),
                 componentsPerAttribute : 4
             }]
         });

--- a/Specs/createContext.js
+++ b/Specs/createContext.js
@@ -5,6 +5,7 @@ define([
         'Core/defined',
         'Core/PrimitiveType',
         'Core/queryToObject',
+        'Renderer/Buffer',
         'Renderer/BufferUsage',
         'Renderer/ClearCommand',
         'Renderer/Context',
@@ -20,6 +21,7 @@ define([
         defined,
         PrimitiveType,
         queryToObject,
+        Buffer,
         BufferUsage,
         ClearCommand,
         Context,
@@ -74,7 +76,7 @@ define([
                 context : context,
                 attributes : [{
                     index : sp.vertexAttributes.position.index,
-                    vertexBuffer : context.createVertexBuffer(new Float32Array([0, 0, 0, 1]), BufferUsage.STATIC_DRAW),
+                    vertexBuffer : Buffer.createVertexBuffer(context, new Float32Array([0, 0, 0, 1]), BufferUsage.STATIC_DRAW),
                     componentsPerAttribute : 4
                 }]
             });

--- a/Specs/createContext.js
+++ b/Specs/createContext.js
@@ -76,7 +76,11 @@ define([
                 context : context,
                 attributes : [{
                     index : sp.vertexAttributes.position.index,
-                    vertexBuffer : Buffer.createVertexBuffer(context, new Float32Array([0, 0, 0, 1]), BufferUsage.STATIC_DRAW),
+                    vertexBuffer : Buffer.createVertexBuffer({
+                        context : context,
+                        typedArray : new Float32Array([0, 0, 0, 1]),
+                        usage : BufferUsage.STATIC_DRAW
+                    }),
                     componentsPerAttribute : 4
                 }]
             });

--- a/Specs/renderFragment.js
+++ b/Specs/renderFragment.js
@@ -2,6 +2,7 @@
 define([
         'Core/defaultValue',
         'Core/PrimitiveType',
+        'Renderer/Buffer',
         'Renderer/BufferUsage',
         'Renderer/ClearCommand',
         'Renderer/DrawCommand',
@@ -11,6 +12,7 @@ define([
     ], function(
         defaultValue,
         PrimitiveType,
+        Buffer,
         BufferUsage,
         ClearCommand,
         DrawCommand,
@@ -34,7 +36,7 @@ define([
             context : context,
             attributes : [{
                 index : sp.vertexAttributes.position.index,
-                vertexBuffer : context.createVertexBuffer(new Float32Array([0.0, 0.0, depth, 1.0]), BufferUsage.STATIC_DRAW),
+                vertexBuffer : Buffer.createVertexBuffer(context, new Float32Array([0.0, 0.0, depth, 1.0]), BufferUsage.STATIC_DRAW),
                 componentsPerAttribute : 4
             }]
         });

--- a/Specs/renderFragment.js
+++ b/Specs/renderFragment.js
@@ -36,7 +36,11 @@ define([
             context : context,
             attributes : [{
                 index : sp.vertexAttributes.position.index,
-                vertexBuffer : Buffer.createVertexBuffer(context, new Float32Array([0.0, 0.0, depth, 1.0]), BufferUsage.STATIC_DRAW),
+                vertexBuffer : Buffer.createVertexBuffer({
+                    context : context,
+                    typedArray : new Float32Array([0.0, 0.0, depth, 1.0]),
+                    usage : BufferUsage.STATIC_DRAW
+                }),
                 componentsPerAttribute : 4
             }]
         });


### PR DESCRIPTION
For #640 

I kept this pretty simple. I made `createVertexBuffer` and `createIndexBuffer` static methods of Buffer instead of creating new classes. I also didn't wrap the arguments in an options object, but that can change.

I think we should wait to make more significant changes to Buffer once Uniform Buffers are out.