### PR TITLE
Fixed include ordering in Specs

### DIFF
--- a/Specs/Renderer/BufferSpec.js
+++ b/Specs/Renderer/BufferSpec.js
@@ -1,12 +1,12 @@
 /*global defineSuite*/
 defineSuite([
-        'Core/IndexDatatype',
         'Renderer/Buffer',
+        'Core/IndexDatatype',
         'Renderer/BufferUsage',
         'Specs/createContext'
-    ], 'Renderer/Buffer', function(
-        IndexDatatype,
+    ], function(
         Buffer,
+        IndexDatatype,
         BufferUsage,
         createContext) {
     "use strict";

--- a/Specs/Renderer/CubeMapSpec.js
+++ b/Specs/Renderer/CubeMapSpec.js
@@ -1,5 +1,6 @@
 /*global defineSuite*/
 defineSuite([
+        'Renderer/CubeMap',
         'Core/Cartesian3',
         'Core/Color',
         'Core/loadImage',
@@ -9,7 +10,6 @@ defineSuite([
         'Renderer/BufferUsage',
         'Renderer/ClearCommand',
         'Renderer/ContextLimits',
-        'Renderer/CubeMap',
         'Renderer/DrawCommand',
         'Renderer/PixelDatatype',
         'Renderer/Sampler',
@@ -21,7 +21,8 @@ defineSuite([
         'Renderer/VertexArray',
         'Specs/createContext',
         'ThirdParty/when'
-    ], 'Renderer/CubeMap', function(
+    ], function(
+        CubeMap,
         Cartesian3,
         Color,
         loadImage,
@@ -31,7 +32,6 @@ defineSuite([
         BufferUsage,
         ClearCommand,
         ContextLimits,
-        CubeMap,
         DrawCommand,
         PixelDatatype,
         Sampler,

--- a/Specs/Renderer/FramebufferSpec.js
+++ b/Specs/Renderer/FramebufferSpec.js
@@ -1,5 +1,6 @@
 /*global defineSuite*/
 defineSuite([
+        'Renderer/Framebuffer',
         'Core/Color',
         'Core/PixelFormat',
         'Core/PrimitiveType',
@@ -9,7 +10,6 @@ defineSuite([
         'Renderer/ContextLimits',
         'Renderer/CubeMap',
         'Renderer/DrawCommand',
-        'Renderer/Framebuffer',
         'Renderer/PixelDatatype',
         'Renderer/Renderbuffer',
         'Renderer/RenderbufferFormat',
@@ -18,7 +18,8 @@ defineSuite([
         'Renderer/Texture',
         'Renderer/VertexArray',
         'Specs/createContext'
-    ], 'Renderer/Framebuffer', function(
+    ], function(
+        Framebuffer,
         Color,
         PixelFormat,
         PrimitiveType,
@@ -28,7 +29,6 @@ defineSuite([
         ContextLimits,
         CubeMap,
         DrawCommand,
-        Framebuffer,
         PixelDatatype,
         Renderbuffer,
         RenderbufferFormat,

--- a/Specs/Renderer/RenderStateSpec.js
+++ b/Specs/Renderer/RenderStateSpec.js
@@ -1,13 +1,13 @@
 /*global defineSuite*/
 defineSuite([
+        'Renderer/RenderState',
         'Core/WindingOrder',
         'Renderer/ContextLimits',
-        'Renderer/RenderState',
         'Specs/createContext'
     ], function(
+        RenderState,
         WindingOrder,
         ContextLimits,
-        RenderState,
         createContext) {
     "use strict";
     /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn*/

--- a/Specs/Renderer/RenderbufferSpec.js
+++ b/Specs/Renderer/RenderbufferSpec.js
@@ -1,12 +1,12 @@
 /*global defineSuite*/
 defineSuite([
-        'Renderer/ContextLimits',
         'Renderer/Renderbuffer',
+        'Renderer/ContextLimits',
         'Renderer/RenderbufferFormat',
         'Specs/createContext'
-    ], 'Renderer/Renderbuffer', function(
-        ContextLimits,
+    ], function(
         Renderbuffer,
+        ContextLimits,
         RenderbufferFormat,
         createContext) {
     "use strict";

--- a/Specs/Renderer/SamplerSpec.js
+++ b/Specs/Renderer/SamplerSpec.js
@@ -5,7 +5,7 @@ defineSuite([
         'Renderer/TextureMinificationFilter',
         'Renderer/TextureWrap',
         'Specs/createContext'
-    ], 'Renderer/Sampler', function(
+    ], function(
         Sampler,
         TextureMagnificationFilter,
         TextureMinificationFilter,

--- a/Specs/Renderer/ShaderProgramSpec.js
+++ b/Specs/Renderer/ShaderProgramSpec.js
@@ -1,5 +1,6 @@
 /*global defineSuite*/
 defineSuite([
+        'Renderer/ShaderProgram',
         'Core/Cartesian2',
         'Core/Cartesian3',
         'Core/Cartesian4',
@@ -12,11 +13,11 @@ defineSuite([
         'Renderer/BufferUsage',
         'Renderer/ClearCommand',
         'Renderer/DrawCommand',
-        'Renderer/ShaderProgram',
         'Renderer/ShaderSource',
         'Renderer/VertexArray',
         'Specs/createContext'
     ], function(
+        ShaderProgram,
         Cartesian2,
         Cartesian3,
         Cartesian4,
@@ -29,7 +30,6 @@ defineSuite([
         BufferUsage,
         ClearCommand,
         DrawCommand,
-        ShaderProgram,
         ShaderSource,
         VertexArray,
         createContext) {

--- a/Specs/Renderer/TextureSpec.js
+++ b/Specs/Renderer/TextureSpec.js
@@ -1,5 +1,6 @@
 /*global defineSuite*/
 defineSuite([
+        'Renderer/Texture',
         'Core/Cartesian2',
         'Core/Color',
         'Core/loadImage',
@@ -13,7 +14,6 @@ defineSuite([
         'Renderer/PixelDatatype',
         'Renderer/Sampler',
         'Renderer/ShaderProgram',
-        'Renderer/Texture',
         'Renderer/TextureMagnificationFilter',
         'Renderer/TextureMinificationFilter',
         'Renderer/TextureWrap',
@@ -21,6 +21,7 @@ defineSuite([
         'Specs/createContext',
         'ThirdParty/when'
     ], function(
+        Texture,
         Cartesian2,
         Color,
         loadImage,
@@ -34,7 +35,6 @@ defineSuite([
         PixelDatatype,
         Sampler,
         ShaderProgram,
-        Texture,
         TextureMagnificationFilter,
         TextureMinificationFilter,
         TextureWrap,

--- a/Specs/Renderer/VertexArraySpec.js
+++ b/Specs/Renderer/VertexArraySpec.js
@@ -1,21 +1,21 @@
 /*global defineSuite*/
 defineSuite([
+        'Renderer/VertexArray',
         'Core/ComponentDatatype',
         'Core/PrimitiveType',
         'Renderer/Buffer',
         'Renderer/BufferUsage',
         'Renderer/DrawCommand',
         'Renderer/ShaderProgram',
-        'Renderer/VertexArray',
         'Specs/createContext'
-    ], 'Renderer/VertexArray', function(
+    ], function(
+        VertexArray,
         ComponentDatatype,
         PrimitiveType,
         Buffer,
         BufferUsage,
         DrawCommand,
         ShaderProgram,
-        VertexArray,
         createContext) {
     "use strict";
     /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn*/


### PR DESCRIPTION
In my recent refactoring changes I imported files in the wrong order for some of the Renderer specs. This was causing specs to be placed in the wrong categories. I fixes those changes and did clean up for others where the `name` property was now redundant.