### PR TITLE
Refactored ViewportQuadSpec

### DIFF
--- a/Specs/Scene/ViewportQuadSpec.js
+++ b/Specs/Scene/ViewportQuadSpec.js
@@ -7,11 +7,8 @@ defineSuite([
         'Renderer/ClearCommand',
         'Renderer/Texture',
         'Scene/Material',
-        'Specs/createCamera',
-        'Specs/createContext',
-        'Specs/createFrameState',
-        'Specs/pollToPromise',
-        'Specs/render'
+        'Specs/createScene',
+        'Specs/pollToPromise'
     ], function(
         ViewportQuad,
         BoundingRectangle,
@@ -20,44 +17,34 @@ defineSuite([
         ClearCommand,
         Texture,
         Material,
-        createCamera,
-        createContext,
-        createFrameState,
-        pollToPromise,
-        render) {
+        createScene,
+        pollToPromise) {
     "use strict";
     /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn*/
 
-    var context;
-    var frameState;
+    var scene;
     var viewportQuad;
-    var us;
     var testImage;
 
     beforeAll(function() {
-        context = createContext();
-        frameState = createFrameState();
-
+        scene = createScene();
         return loadImage('./Data/Images/Red16x16.png').then(function(image) {
             testImage = image;
         });
     });
 
     afterAll(function() {
-        context.destroyForSpecs();
+        scene.destroyForSpecs();
     });
 
     beforeEach(function() {
         viewportQuad = new ViewportQuad();
         viewportQuad.rectangle = new BoundingRectangle(0, 0, 2, 2);
-
-        us = context.uniformState;
-        us.update(context, createFrameState(createCamera()));
+        scene.primitives.add(viewportQuad);
     });
 
     afterEach(function() {
-        viewportQuad = viewportQuad && viewportQuad.destroy();
-        us = undefined;
+        scene.primitives.removeAll();
     });
 
     it('constructs with a rectangle', function() {
@@ -77,42 +64,39 @@ defineSuite([
             new Color(1.0, 1.0, 1.0, 1.0));
     });
 
-    it('throws when rendered with without a rectangle', function() {
+    it('throws when rendered without a rectangle', function() {
         viewportQuad.rectangle = undefined;
 
         expect(function() {
-            render(context, frameState, viewportQuad);
+            scene.renderForSpecs();
         }).toThrowDeveloperError();
     });
 
-    it('throws when rendered with without a material', function() {
+    it('throws when rendered without a material', function() {
         viewportQuad.material = undefined;
 
         expect(function() {
-            render(context, frameState, viewportQuad);
+            scene.renderForSpecs();
         }).toThrowDeveloperError();
     });
 
     it('does not render when show is false', function() {
-        ClearCommand.ALL.execute(context);
-        expect(context.readPixels()).toEqual([0, 0, 0, 0]);
+        ClearCommand.ALL.execute(scene.context);
+        expect(scene.context.readPixels()).toEqual([0, 0, 0, 255]);
 
         viewportQuad.show = false;
-        render(context, frameState, viewportQuad);
-        expect(context.readPixels()).toEqual([0, 0, 0, 0]);
+        expect(scene.renderForSpecs()).toEqual([0, 0, 0, 255]);
     });
 
     it('renders material', function() {
-        ClearCommand.ALL.execute(context);
-        expect(context.readPixels()).toEqual([0, 0, 0, 0]);
-
-        render(context, frameState, viewportQuad);
-        expect(context.readPixels()).not.toEqual([0, 0, 0, 0]);
+        ClearCommand.ALL.execute(scene.context);
+        expect(scene.context.readPixels()).toEqual([0, 0, 0, 255]);
+        expect(scene.renderForSpecs()).not.toEqual([0, 0, 0, 255]);
     });
 
     it('renders user created texture', function() {
         var texture = new Texture({
-            context : context,
+            context : scene.context,
             source : testImage
         });
 
@@ -122,11 +106,8 @@ defineSuite([
         pollToPromise(function() {
             return viewportQuad.material._loadedImages.length !== 0;
         }).then(function() {
-            ClearCommand.ALL.execute(context);
-            expect(context.readPixels()).toEqual([0, 0, 0, 0]);
-
-            render(context, frameState, viewportQuad);
-            expect(context.readPixels()).toEqual([255, 0, 0, 255]);
+            expect(scene.context.readPixels()).toEqual([0, 0, 0, 0]);
+            expect(scene.renderForSpecs()).toEqual([255, 0, 0, 255]);
         });
     });
 

--- a/Specs/Scene/ViewportQuadSpec.js
+++ b/Specs/Scene/ViewportQuadSpec.js
@@ -40,7 +40,6 @@ defineSuite([
     beforeEach(function() {
         viewportQuad = new ViewportQuad();
         viewportQuad.rectangle = new BoundingRectangle(0, 0, 2, 2);
-        scene.primitives.add(viewportQuad);
     });
 
     afterEach(function() {
@@ -68,6 +67,7 @@ defineSuite([
         viewportQuad.rectangle = undefined;
 
         expect(function() {
+            scene.primitives.add(viewportQuad);
             scene.renderForSpecs();
         }).toThrowDeveloperError();
     });
@@ -76,21 +76,21 @@ defineSuite([
         viewportQuad.material = undefined;
 
         expect(function() {
+            scene.primitives.add(viewportQuad);
             scene.renderForSpecs();
         }).toThrowDeveloperError();
     });
 
     it('does not render when show is false', function() {
-        ClearCommand.ALL.execute(scene.context);
-        expect(scene.context.readPixels()).toEqual([0, 0, 0, 255]);
-
         viewportQuad.show = false;
+        expect(scene.renderForSpecs()).toEqual([0, 0, 0, 255]);
+        scene.primitives.add(viewportQuad);
         expect(scene.renderForSpecs()).toEqual([0, 0, 0, 255]);
     });
 
     it('renders material', function() {
-        ClearCommand.ALL.execute(scene.context);
-        expect(scene.context.readPixels()).toEqual([0, 0, 0, 255]);
+        expect(scene.renderForSpecs()).toEqual([0, 0, 0, 255]);
+        scene.primitives.add(viewportQuad);
         expect(scene.renderForSpecs()).not.toEqual([0, 0, 0, 255]);
     });
 
@@ -106,8 +106,8 @@ defineSuite([
         pollToPromise(function() {
             return viewportQuad.material._loadedImages.length !== 0;
         }).then(function() {
-            ClearCommand.ALL.execute(scene.context);
-            expect(scene.context.readPixels()).toEqual([0, 0, 0, 255]);
+            expect(scene.renderForSpecs()).toEqual([0, 0, 0, 255]);
+            scene.primitives.add(viewportQuad);
             expect(scene.renderForSpecs()).toEqual([255, 0, 0, 255]);
         });
     });

--- a/Specs/Scene/ViewportQuadSpec.js
+++ b/Specs/Scene/ViewportQuadSpec.js
@@ -106,7 +106,8 @@ defineSuite([
         pollToPromise(function() {
             return viewportQuad.material._loadedImages.length !== 0;
         }).then(function() {
-            expect(scene.context.readPixels()).toEqual([0, 0, 0, 0]);
+            ClearCommand.ALL.execute(scene.context);
+            expect(scene.context.readPixels()).toEqual([0, 0, 0, 255]);
             expect(scene.renderForSpecs()).toEqual([255, 0, 0, 255]);
         });
     });

--- a/Specs/Scene/ViewportQuadSpec.js
+++ b/Specs/Scene/ViewportQuadSpec.js
@@ -65,18 +65,18 @@ defineSuite([
 
     it('throws when rendered without a rectangle', function() {
         viewportQuad.rectangle = undefined;
+        scene.primitives.add(viewportQuad);
 
         expect(function() {
-            scene.primitives.add(viewportQuad);
             scene.renderForSpecs();
         }).toThrowDeveloperError();
     });
 
     it('throws when rendered without a material', function() {
         viewportQuad.material = undefined;
+        scene.primitives.add(viewportQuad);
 
         expect(function() {
-            scene.primitives.add(viewportQuad);
             scene.renderForSpecs();
         }).toThrowDeveloperError();
     });


### PR DESCRIPTION
For #1259 

There's an issue where `ClearCommand.ALL.execute(context)` doesn't seem to do anything, and instead the clear color ends up being the scene's background color (0,0,0,255).  I noticed other specs account for this, like [TextureAtlasSpec](https://github.com/AnalyticalGraphicsInc/cesium/blob/9159c4c5a5d2340d2b6fbdc34504bdc01ea213e2/Specs/Scene/TextureAtlasSpec.js#L119-L120).

I'm going to look into this more, but decided to start the pull request anyways.