### PR TITLE
Added compute pass

### DIFF
--- a/Source/Renderer/ComputeCommand.js
+++ b/Source/Renderer/ComputeCommand.js
@@ -59,22 +59,22 @@ define([
         this.outputTexture = options.outputTexture;
 
         /**
-         * Function that is called after the ComputeCommand is executed. Takes the output
-         * texture as its single argument.
-         *
-         * @type {Function}
-         * @default undefined
-         */
-        this.callback = options.callback;
-
-        /**
          * Function that is called immediately before the ComputeCommand is executed. Used to
          * update any renderer resources. Takes the ComputeCommand as its single argument.
          *
          * @type {Function}
          * @default undefined
          */
-        this.preExecutionCallback = options.preExecutionCallback;
+        this.preExecute = options.preExecute;
+
+        /**
+         * Function that is called after the ComputeCommand is executed. Takes the output
+         * texture as its single argument.
+         *
+         * @type {Function}
+         * @default undefined
+         */
+        this.postExecute = options.postExecute;
 
         /**
          * Whether the renderer resources will persist beyond this call. If not, they

--- a/Source/Renderer/ComputeCommand.js
+++ b/Source/Renderer/ComputeCommand.js
@@ -59,8 +59,8 @@ define([
         this.outputTexture = options.outputTexture;
 
         /**
-         * Whether this command will persist beyond this call.
-         * If not, resources will be destroyed after completion.
+         * Whether the renderer resources will persist beyond this call. If not, they
+         * will be destroyed after completion.
          *
          * @type {Boolean}
          * @default false
@@ -94,8 +94,8 @@ define([
      *
      * @param {Context} context The context that processes the compute command.
      */
-    ComputeCommand.prototype.execute = function(context) {
-        context.computeEngine.execute(this);
+    ComputeCommand.prototype.execute = function(computeEngine) {
+        computeEngine.execute(this);
     };
 
     return ComputeCommand;

--- a/Source/Renderer/ComputeCommand.js
+++ b/Source/Renderer/ComputeCommand.js
@@ -59,6 +59,24 @@ define([
         this.outputTexture = options.outputTexture;
 
         /**
+         * Function that is called after the ComputeCommand is executed. Takes the output
+         * texture as its single argument.
+         *
+         * @type {Function}
+         * @default undefined
+         */
+        this.callback = options.callback;
+
+        /**
+         * Function that is called immediately before the ComputeCommand is executed. Used to
+         * update any renderer resources. Takes the ComputeCommand as its single argument.
+         *
+         * @type {Function}
+         * @default undefined
+         */
+        this.preExecutionCallback = options.preExecutionCallback;
+
+        /**
          * Whether the renderer resources will persist beyond this call. If not, they
          * will be destroyed after completion.
          *

--- a/Source/Renderer/ComputeCommand.js
+++ b/Source/Renderer/ComputeCommand.js
@@ -10,7 +10,7 @@ define([
     "use strict";
 
     /**
-     * Represents a command to the renderer for compute.
+     * Represents a command to the renderer for GPU Compute (using old-school GPGPU).
      *
      * @private
      */

--- a/Source/Renderer/ComputeCommand.js
+++ b/Source/Renderer/ComputeCommand.js
@@ -1,0 +1,102 @@
+/*global define*/
+define([
+        '../Core/defaultValue',
+        '../Core/PrimitiveType',
+        '../Scene/Pass'
+    ], function(
+        defaultValue,
+        PrimitiveType,
+        Pass) {
+    "use strict";
+
+    /**
+     * Represents a command to the renderer for compute.
+     *
+     * @private
+     */
+    var ComputeCommand = function(options) {
+        options = defaultValue(options, defaultValue.EMPTY_OBJECT);
+
+        /**
+         * The vertex array. If none is provided, a viewport quad will be used.
+         *
+         * @type {VertexArray}
+         * @default undefined
+         */
+        this.vertexArray = options.vertexArray;
+
+        /**
+         * The fragment shader source. The default vertex shader is ViewportQuadVS.
+         *
+         * @type {ShaderSource}
+         * @default undefined
+         */
+        this.fragmentShaderSource = options.fragmentShaderSource;
+
+        /**
+         * The shader program to apply.
+         *
+         * @type {ShaderProgram}
+         * @default undefined
+         */
+        this.shaderProgram = options.shaderProgram;
+
+        /**
+         * An object with functions whose names match the uniforms in the shader program
+         * and return values to set those uniforms.
+         *
+         * @type {Object}
+         * @default undefined
+         */
+        this.uniformMap = options.uniformMap;
+
+        /**
+         * Texture to use for offscreen rendering.
+         *
+         * @type {Texture}
+         * @default undefined
+         */
+        this.outputTexture = options.outputTexture;
+
+        /**
+         * Whether this command will persist beyond this call.
+         * If not, resources will be destroyed after completion.
+         *
+         * @type {Boolean}
+         * @default false
+         */
+        this.persists = defaultValue(options.persists, false);
+
+        /**
+         * The pass when to render. Always compute pass.
+         *
+         * @type {Pass}
+         * @default Pass.COMPUTE;
+         */
+        this.pass = Pass.COMPUTE;
+
+        /**
+         * The object who created this command.  This is useful for debugging command
+         * execution; it allows us to see who created a command when we only have a
+         * reference to the command, and can be used to selectively execute commands
+         * with {@link Scene#debugCommandFilter}.
+         *
+         * @type {Object}
+         * @default undefined
+         *
+         * @see Scene#debugCommandFilter
+         */
+        this.owner = options.owner;
+    };
+
+    /**
+     * Executes the compute command.
+     *
+     * @param {Context} context The context that processes the compute command.
+     */
+    ComputeCommand.prototype.execute = function(context) {
+        context.computeEngine.execute(this);
+    };
+
+    return ComputeCommand;
+});

--- a/Source/Renderer/ComputeEngine.js
+++ b/Source/Renderer/ComputeEngine.js
@@ -53,7 +53,6 @@ define([
         position : 0,
         textureCoordinates : 1
     };
-
     var renderStateScratch;
     var drawCommandScratch = new DrawCommand({
         primitiveType : PrimitiveType.TRIANGLES
@@ -147,12 +146,18 @@ define([
         if (!defined(computeCommand)) {
             throw new DeveloperError('computeCommand is required.');
         }
+        //>>includeEnd('debug');
 
+        if (defined(computeCommand.preExecutionCallback)) {
+            computeCommand.preExecutionCallback(computeCommand);
+        }
+
+        //>>includeStart('debug', pragmas.debug);
         if (!defined(computeCommand.fragmentShaderSource) && !defined(computeCommand.shaderProgram)) {
             throw new DeveloperError('computeCommand.fragmentShaderSource or computeCommand.shaderProgram is required.');
         }
 
-        if(!defined(computeCommand.outputTexture)) {
+        if (!defined(computeCommand.outputTexture)) {
             throw new DeveloperError('computeCommand.outputTexture is required.');
         }
         //>>includeEnd('debug');
@@ -185,6 +190,13 @@ define([
 
         if (!computeCommand.persists) {
             shaderProgram.destroy();
+            if (defined(computeCommand.vertexArray)) {
+                vertexArray.destroy();
+            }
+        }
+
+        if (defined(computeCommand.callback)) {
+            computeCommand.callback(texture);
         }
     };
 

--- a/Source/Renderer/ComputeEngine.js
+++ b/Source/Renderer/ComputeEngine.js
@@ -1,0 +1,194 @@
+/*global define*/
+define([
+        '../Core/BoundingRectangle',
+        '../Core/Color',
+        '../Core/ComponentDatatype',
+        '../Core/defaultValue',
+        '../Core/defined',
+        '../Core/defineProperties',
+        '../Core/destroyObject',
+        '../Core/DeveloperError',
+        '../Core/Geometry',
+        '../Core/GeometryAttribute',
+        '../Core/PrimitiveType',
+        '../Shaders/ViewportQuadVS',
+        './BufferUsage',
+        './ClearCommand',
+        './DrawCommand',
+        './Framebuffer',
+        './RenderState',
+        './ShaderProgram',
+        './VertexArray'
+    ], function(
+        BoundingRectangle,
+        Color,
+        ComponentDatatype,
+        defaultValue,
+        defined,
+        defineProperties,
+        destroyObject,
+        DeveloperError,
+        Geometry,
+        GeometryAttribute,
+        PrimitiveType,
+        ViewportQuadVS,
+        BufferUsage,
+        ClearCommand,
+        DrawCommand,
+        Framebuffer,
+        RenderState,
+        ShaderProgram,
+        VertexArray) {
+    "use strict";
+
+    /**
+     * @private
+     */
+    var ComputeEngine = function(context) {
+        this._context = context;
+        this._viewportQuadVertexArray = undefined;
+    };
+
+    function createViewportQuadVertexArray(computeEngine) {
+        var vertexArray = computeEngine._viewportQuadVertexArray;
+
+        if (!defined(vertexArray)) {
+            var geometry = new Geometry({
+                attributes : {
+                    position : new GeometryAttribute({
+                        componentDatatype : ComponentDatatype.FLOAT,
+                        componentsPerAttribute : 2,
+                        values : [
+                            -1.0, -1.0,
+                            1.0, -1.0,
+                            1.0,  1.0,
+                            -1.0,  1.0
+                        ]
+                    }),
+
+                    textureCoordinates : new GeometryAttribute({
+                        componentDatatype : ComponentDatatype.FLOAT,
+                        componentsPerAttribute : 2,
+                        values : [
+                            0.0, 0.0,
+                            1.0, 0.0,
+                            1.0, 1.0,
+                            0.0, 1.0
+                        ]
+                    })
+                },
+                // Workaround Internet Explorer 11.0.8 lack of TRIANGLE_FAN
+                indices : new Uint16Array([0, 1, 2, 0, 2, 3]),
+                primitiveType : PrimitiveType.TRIANGLES
+            });
+
+            vertexArray = VertexArray.fromGeometry({
+                context : computeEngine._context,
+                geometry : geometry,
+                attributeLocations : {
+                    position : 0,
+                    textureCoordinates : 1
+                },
+                bufferUsage : BufferUsage.STATIC_DRAW,
+                interleave : true
+            });
+
+            computeEngine._viewportQuadVertexArray = vertexArray;
+        }
+
+        return vertexArray;
+    }
+
+    var viewportQuadAttributeLocations = {
+        position : 0,
+        textureCoordinates : 1
+    };
+
+    function createFramebuffer(context, texture) {
+        var fbo = new Framebuffer({
+            context : context,
+            colorTextures : [texture]
+        });
+        fbo.destroyAttachments = false;
+        return fbo;
+    }
+
+    function createViewportQuadShader(context, fragmentShaderSource) {
+        return ShaderProgram.fromCache({
+            context : context,
+            vertexShaderSource : ViewportQuadVS,
+            fragmentShaderSource : fragmentShaderSource,
+            attributeLocations : viewportQuadAttributeLocations
+        });
+    }
+
+    function createRenderState(width, height)
+    {
+        return RenderState.fromCache({
+            viewport : new BoundingRectangle(0.0, 0.0, width, height)
+        });
+    }
+
+    ComputeEngine.prototype.execute = function(computeCommand) {
+        //>>includeStart('debug', pragmas.debug);
+        if (!defined(computeCommand)) {
+            throw new DeveloperError('computeCommand is required.');
+        }
+
+        if (!defined(computeCommand.fragmentShaderSource) && !defined(computeCommand.shaderProgram)) {
+            throw new DeveloperError('computeCommand.fragmentShaderSource or computeCommand.shaderProgram is required.');
+        }
+
+        if(!defined(computeCommand.outputTexture)) {
+            throw new DeveloperError('computeCommand.outputTexture is required.');
+        }
+        //>>includeEnd('debug');
+
+        var texture = computeCommand.outputTexture;
+        var width = texture.width;
+        var height = texture.height;
+
+        var context = this._context;
+        var vertexArray = computeCommand.vertexArray || createViewportQuadVertexArray(this);
+        var shaderProgram = computeCommand.shaderProgram || createViewportQuadShader(context, computeCommand.fragmentShaderSource);
+        var framebuffer = createFramebuffer(context, texture);
+        var renderState = createRenderState(width, height);
+        var uniformMap = defaultValue(computeCommand.uniformMap, defaultValue.EMPTY_OBJECT);
+
+        var clearCommand = new ClearCommand({
+            color : new Color(0.0, 0.0, 0.0, 0.0),
+            framebuffer : framebuffer,
+            renderState : renderState
+        });
+
+        var drawCommand = new DrawCommand({
+            vertexArray : vertexArray,
+            primitiveType : PrimitiveType.TRIANGLES,
+            renderState : renderState,
+            shaderProgram : shaderProgram,
+            uniformMap : uniformMap,
+            framebuffer : framebuffer,
+            owner : computeCommand.owner
+        });
+
+        clearCommand.execute(context);
+        drawCommand.execute(context);
+        framebuffer.destroy();
+
+        if (!computeCommand.persists) {
+            shaderProgram.destroy();
+        }
+
+    };
+
+    ComputeEngine.prototype.isDestroyed = function() {
+        return false;
+    };
+
+    ComputeEngine.prototype.destroy = function() {
+        this._viewportQuadVertexArray = this._viewportQuadVertexArray && this._viewportQuadVertexArray.destroy();
+        return destroyObject(this);
+    };
+
+    return ComputeEngine;
+});

--- a/Source/Renderer/Context.js
+++ b/Source/Renderer/Context.js
@@ -918,7 +918,7 @@ define([
         textureCoordinates : 1
     };
 
-    Context.prototype.createViewportQuadCommand = function(fragmentShaderSource, overrides) {
+    Context.prototype.getViewportQuadVertexArray = function() {
         // Per-context cache for viewport quads
         var vertexArray = this.cache.viewportQuad_vertexArray;
 
@@ -955,10 +955,7 @@ define([
             vertexArray = VertexArray.fromGeometry({
                 context : this,
                 geometry : geometry,
-                attributeLocations : {
-                    position : 0,
-                    textureCoordinates : 1
-                },
+                attributeLocations : viewportQuadAttributeLocations,
                 bufferUsage : BufferUsage.STATIC_DRAW,
                 interleave : true
             });
@@ -966,10 +963,14 @@ define([
             this.cache.viewportQuad_vertexArray = vertexArray;
         }
 
+        return vertexArray;
+    };
+
+    Context.prototype.createViewportQuadCommand = function(fragmentShaderSource, overrides) {
         overrides = defaultValue(overrides, defaultValue.EMPTY_OBJECT);
 
         return new DrawCommand({
-            vertexArray : vertexArray,
+            vertexArray : this.getViewportQuadVertexArray(),
             primitiveType : PrimitiveType.TRIANGLES,
             renderState : overrides.renderState,
             shaderProgram : ShaderProgram.fromCache({

--- a/Source/Renderer/Context.js
+++ b/Source/Renderer/Context.js
@@ -19,7 +19,6 @@ define([
         '../Shaders/ViewportQuadVS',
         './BufferUsage',
         './ClearCommand',
-        './ComputeEngine',
         './ContextLimits',
         './CubeMap',
         './DrawCommand',
@@ -53,7 +52,6 @@ define([
         ViewportQuadVS,
         BufferUsage,
         ClearCommand,
-        ComputeEngine,
         ContextLimits,
         CubeMap,
         DrawCommand,
@@ -301,7 +299,6 @@ define([
         this._defaultTexture = undefined;
         this._defaultCubeMap = undefined;
 
-        this._computeEngine = new ComputeEngine(this);
         this._us = us;
         this._currentRenderState = rs;
         this._currentPassState = ps;
@@ -668,16 +665,6 @@ define([
         defaultFramebuffer : {
             get : function() {
                 return defaultFramebufferMarker;
-            }
-        },
-
-        /**
-         * @memberof Context.prototype
-         * @type {ComputeEngine}
-         */
-        computeEngine : {
-            get : function() {
-                return this._computeEngine;
             }
         }
     });
@@ -1101,7 +1088,6 @@ define([
         this._shaderCache = this._shaderCache.destroy();
         this._defaultTexture = this._defaultTexture && this._defaultTexture.destroy();
         this._defaultCubeMap = this._defaultCubeMap && this._defaultCubeMap.destroy();
-        this._computeEngine = this._computeEngine && this._computeEngine.destroy();
 
         return destroyObject(this);
     };

--- a/Source/Renderer/Context.js
+++ b/Source/Renderer/Context.js
@@ -19,6 +19,7 @@ define([
         '../Shaders/ViewportQuadVS',
         './BufferUsage',
         './ClearCommand',
+        './ComputeEngine',
         './ContextLimits',
         './CubeMap',
         './DrawCommand',
@@ -52,6 +53,7 @@ define([
         ViewportQuadVS,
         BufferUsage,
         ClearCommand,
+        ComputeEngine,
         ContextLimits,
         CubeMap,
         DrawCommand,
@@ -299,6 +301,7 @@ define([
         this._defaultTexture = undefined;
         this._defaultCubeMap = undefined;
 
+        this._computeEngine = new ComputeEngine(this);
         this._us = us;
         this._currentRenderState = rs;
         this._currentPassState = ps;
@@ -665,6 +668,16 @@ define([
         defaultFramebuffer : {
             get : function() {
                 return defaultFramebufferMarker;
+            }
+        },
+
+        /**
+         * @memberof Context.prototype
+         * @type {ComputeEngine}
+         */
+        computeEngine : {
+            get : function() {
+                return this._computeEngine;
             }
         }
     });
@@ -1088,6 +1101,7 @@ define([
         this._shaderCache = this._shaderCache.destroy();
         this._defaultTexture = this._defaultTexture && this._defaultTexture.destroy();
         this._defaultCubeMap = this._defaultCubeMap && this._defaultCubeMap.destroy();
+        this._computeEngine = this._computeEngine && this._computeEngine.destroy();
 
         return destroyObject(this);
     };

--- a/Source/Renderer/VertexArray.js
+++ b/Source/Renderer/VertexArray.js
@@ -185,7 +185,8 @@ define([
      *     context : context,
      *     sizeInBytes : 12,
      *     usage : BufferUsage.STATIC_DRAW
-     * });     * var attributes = [
+     * });
+     * var attributes = [
      *     {
      *         index                  : 0,
      *         vertexBuffer           : positionBuffer,

--- a/Source/Scene/Camera.js
+++ b/Source/Scene/Camera.js
@@ -1953,7 +1953,7 @@ define([
     };
 
     /**
-     * View an rectangle on an ellipsoid or map.
+     * View a rectangle on an ellipsoid or map.
      *
      * @param {Rectangle} rectangle The rectangle to view.
      * @param {Ellipsoid} [ellipsoid=Ellipsoid.WGS84] The ellipsoid to view.

--- a/Source/Scene/GlobeSurfaceTile.js
+++ b/Source/Scene/GlobeSurfaceTile.js
@@ -295,7 +295,7 @@ define([
         }
     };
 
-    GlobeSurfaceTile.processStateMachine = function(tile, context, terrainProvider, imageryLayerCollection) {
+    GlobeSurfaceTile.processStateMachine = function(tile, context, commandList, terrainProvider, imageryLayerCollection) {
         var surfaceTile = tile.data;
         if (!defined(surfaceTile)) {
             surfaceTile = tile.data = new GlobeSurfaceTile();
@@ -345,7 +345,7 @@ define([
                 }
             }
 
-            var thisTileDoneLoading = tileImagery.processStateMachine(tile, context);
+            var thisTileDoneLoading = tileImagery.processStateMachine(tile, context, commandList);
             isDoneLoading = isDoneLoading && thisTileDoneLoading;
 
             // The imagery is renderable as soon as we have any renderable imagery for this region.

--- a/Source/Scene/GlobeSurfaceTileProvider.js
+++ b/Source/Scene/GlobeSurfaceTileProvider.js
@@ -430,8 +430,8 @@ define([
      *
      * @exception {DeveloperError} <code>loadTile</code> must not be called before the tile provider is ready.
      */
-    GlobeSurfaceTileProvider.prototype.loadTile = function(context, frameState, tile) {
-        GlobeSurfaceTile.processStateMachine(tile, context, this._terrainProvider, this._imageryLayers);
+    GlobeSurfaceTileProvider.prototype.loadTile = function(context, frameState, commandList, tile) {
+        GlobeSurfaceTile.processStateMachine(tile, context, commandList, this._terrainProvider, this._imageryLayers);
     };
 
     var boundingSphereScratch = new BoundingSphere();

--- a/Source/Scene/Imagery.js
+++ b/Source/Scene/Imagery.js
@@ -80,7 +80,7 @@ define([
         return this.referenceCount;
     };
 
-    Imagery.prototype.processStateMachine = function(context) {
+    Imagery.prototype.processStateMachine = function(context, commandList) {
         if (this.state === ImageryState.UNLOADED) {
             this.state = ImageryState.TRANSITIONING;
             this.imageryLayer._requestImagery(this);
@@ -93,7 +93,7 @@ define([
 
         if (this.state === ImageryState.TEXTURE_LOADED) {
             this.state = ImageryState.TRANSITIONING;
-            this.imageryLayer._reprojectTexture(context, this);
+            this.imageryLayer._reprojectTexture(context, commandList, this);
         }
     };
 

--- a/Source/Scene/ImageryLayer.js
+++ b/Source/Scene/ImageryLayer.js
@@ -954,7 +954,7 @@ define([
             owner : imageryLayer
         });
 
-        computeCommand.execute(context);
+        computeCommand.execute(context.computeEngine);
 
         return outputTexture;
     }

--- a/Source/Scene/ImageryLayer.js
+++ b/Source/Scene/ImageryLayer.js
@@ -724,7 +724,6 @@ define([
      * @param {Context} context The rendered context to use.
      * @param {Imagery} imagery The imagery instance to reproject.
      */
-
     ImageryLayer.prototype._reprojectTexture = function(context, commandList, imagery) {
         var texture = imagery.texture;
         var rectangle = imagery.rectangle;
@@ -741,10 +740,10 @@ define([
                     owner : this,
                     // Update render resources right before execution instead of now.
                     // This allows different ImageryLayers to share the same vao and buffers.
-                    preExecutionCallback : function(command) {
+                    preExecute : function(command) {
                         reprojectToGeographic(command, context, texture, imagery.rectangle);
                     },
-                    callback : function(outputTexture) {
+                    postExecute : function(outputTexture) {
                         texture.destroy();
                         imagery.texture = outputTexture;
                         finalizeReprojectTexture(that, context, imagery, outputTexture);

--- a/Source/Scene/Pass.js
+++ b/Source/Scene/Pass.js
@@ -11,15 +11,17 @@ define([
      * @private
      */
     var Pass = {
-        GLOBE : 0,
-        GROUND : 1,
-        OPAQUE : 2,
         // Commands are executed in order by pass up to the translucent pass.
-        // Translucent geometry needs special handling (sorting/OIT). Overlays
-        // are also special (they're executed last, they're not sorted by frustum).
-        TRANSLUCENT : 3,
-        OVERLAY : 4,
-        NUMBER_OF_PASSES : 5
+        // Translucent geometry needs special handling (sorting/OIT). The compute pass
+        // is executed first and the overlay pass is executed last. Both are not sorted
+        // by frustum.
+        COMPUTE : 0,
+        GLOBE : 1,
+        GROUND : 2,
+        OPAQUE : 3,
+        TRANSLUCENT : 4,
+        OVERLAY : 5,
+        NUMBER_OF_PASSES : 6
     };
 
     return freezeObject(Pass);

--- a/Source/Scene/QuadtreePrimitive.js
+++ b/Source/Scene/QuadtreePrimitive.js
@@ -249,7 +249,7 @@ define([
             this._tileProvider.beginUpdate(context, frameState, commandList);
 
             selectTilesForRendering(this, context, frameState);
-            processTileLoadQueue(this, context, frameState);
+            processTileLoadQueue(this, context, frameState, commandList);
             createRenderCommandsForSelectedTiles(this, context, frameState, commandList);
 
             this._tileProvider.endUpdate(context, frameState, commandList);
@@ -499,7 +499,7 @@ define([
         primitive._tileLoadQueue.push(tile);
     }
 
-    function processTileLoadQueue(primitive, context, frameState) {
+    function processTileLoadQueue(primitive, context, frameState, commandList) {
         var tileLoadQueue = primitive._tileLoadQueue;
         var tileProvider = primitive._tileProvider;
 
@@ -518,7 +518,7 @@ define([
         for (var len = tileLoadQueue.length - 1, i = len; i >= 0; --i) {
             var tile = tileLoadQueue[i];
             primitive._tileReplacementQueue.markTileRendered(tile);
-            tileProvider.loadTile(context, frameState, tile);
+            tileProvider.loadTile(context, frameState, commandList, tile);
             if (getTimestamp() >= endTime) {
                 break;
             }

--- a/Source/Scene/Scene.js
+++ b/Source/Scene/Scene.js
@@ -1482,11 +1482,10 @@ define([
             executeCommand(skyAtmosphereCommand, scene, context, passState);
         }
 
-        if (defined(sunComputeCommand)) {
-            sunComputeCommand.execute(scene._computeEngine);
-        }
-
         if (sunVisible) {
+            if (defined(sunComputeCommand)) {
+                sunComputeCommand.execute(scene._computeEngine);
+            }
             sunDrawCommand.execute(context, passState);
             if (scene.sunBloom) {
                 var framebuffer;

--- a/Source/Scene/Scene.js
+++ b/Source/Scene/Scene.js
@@ -230,10 +230,10 @@ define([
 
         this._sunPostProcess = undefined;
 
+        this._computeCommandList = [];
         this._commandList = [];
         this._frustumCommandsList = [];
         this._overlayCommandList = [];
-        this._computeCommandList = [];
 
         this._pickFramebuffer = undefined;
 
@@ -815,17 +815,6 @@ define([
             }
         },
 
-
-        /**
-         * @memberof Scene.prototype
-         * @type {ComputeEngine}
-         */
-        computeEngine : {
-            get : function() {
-                return this._computeEngine;
-            }
-        },
-
         /**
          * This property is for debugging only; it is not for production use.
          * <p>
@@ -1044,9 +1033,9 @@ define([
     var distances = new Interval();
 
     function createPotentiallyVisibleSet(scene) {
+        var computeList = scene._computeCommandList;
         var commandList = scene._commandList;
         var overlayList = scene._overlayCommandList;
-        var computeList = scene._computeCommandList;
 
         var cullingVolume = scene._frameState.cullingVolume;
         var camera = scene._camera;
@@ -1069,8 +1058,9 @@ define([
                 frustumCommandsList[n].indices[p] = 0;
             }
         }
-        overlayList.length = 0;
+
         computeList.length = 0;
+        overlayList.length = 0;
 
         var near = Number.MAX_VALUE;
         var far = Number.MIN_VALUE;
@@ -1493,7 +1483,7 @@ define([
         }
 
         if (defined(sunComputeCommand)) {
-            sunComputeCommand.execute(scene.computeEngine);
+            sunComputeCommand.execute(scene._computeEngine);
         }
 
         if (sunVisible) {
@@ -1641,11 +1631,10 @@ define([
     }
 
     function executeComputeCommands(scene) {
-        var context = scene.context;
         var commandList = scene._computeCommandList;
         var length = commandList.length;
         for (var i = 0; i < length; ++i) {
-            commandList[i].execute(scene.computeEngine);
+            commandList[i].execute(scene._computeEngine);
         }
     }
 
@@ -1727,9 +1716,9 @@ define([
         var context = scene.context;
         us.update(context, frameState);
 
+        scene._computeCommandList.length = 0;
         scene._commandList.length = 0;
         scene._overlayCommandList.length = 0;
-        scene._computeCommandList.length = 0;
 
         updatePrimitives(scene);
         createPotentiallyVisibleSet(scene);

--- a/Source/Scene/Scene.js
+++ b/Source/Scene/Scene.js
@@ -219,7 +219,7 @@ define([
         this._passState = new PassState(context);
         this._canvas = canvas;
         this._context = context;
-        this._computeEngine = context.computeEngine;
+        this._computeEngine = new ComputeEngine(context);
         this._globe = undefined;
         this._primitives = new PrimitiveCollection();
         this._groundPrimitives = new PrimitiveCollection();
@@ -1492,10 +1492,11 @@ define([
             executeCommand(skyAtmosphereCommand, scene, context, passState);
         }
 
+        if (defined(sunComputeCommand)) {
+            sunComputeCommand.execute(scene.computeEngine);
+        }
+
         if (sunVisible) {
-            if (defined(sunComputeCommand)) {
-                sunComputeCommand.execute(scene.computeEngine);
-            }
             sunDrawCommand.execute(context, passState);
             if (scene.sunBloom) {
                 var framebuffer;
@@ -2178,7 +2179,7 @@ define([
      */
     Scene.prototype.destroy = function() {
         this._tweens.removeAll();
-        //this._computeEngine = this._computeEngine && this._computeEngine.destroy();
+        this._computeEngine = this._computeEngine && this._computeEngine.destroy();
         this._screenSpaceCameraController = this._screenSpaceCameraController && this._screenSpaceCameraController.destroy();
         this._pickFramebuffer = this._pickFramebuffer && this._pickFramebuffer.destroy();
         this._primitives = this._primitives && this._primitives.destroy();

--- a/Source/Scene/Sun.js
+++ b/Source/Scene/Sun.js
@@ -18,6 +18,7 @@ define([
         '../Renderer/Buffer',
         '../Renderer/BufferUsage',
         '../Renderer/ClearCommand',
+        '../Renderer/ComputeCommand',
         '../Renderer/DrawCommand',
         '../Renderer/Framebuffer',
         '../Renderer/RenderState',
@@ -49,6 +50,7 @@ define([
         Buffer,
         BufferUsage,
         ClearCommand,
+        ComputeCommand,
         DrawCommand,
         Framebuffer,
         RenderState,
@@ -179,21 +181,6 @@ define([
                 pixelFormat : PixelFormat.RGBA
             });
 
-            var fbo = new Framebuffer({
-                context : context,
-                colorTextures : [this._texture]
-            });
-            fbo.destroyAttachments = false;
-
-            var clearCommand = new ClearCommand({
-                color : new Color(0.0, 0.0, 0.0, 0.0),
-                framebuffer : fbo
-            });
-
-            var rs = RenderState.fromCache({
-                viewport : new BoundingRectangle(0.0, 0.0, size, size)
-            });
-
             this._glowLengthTS = this._glowFactor * 5.0;
             this._radiusTS = (1.0 / (1.0 + 2.0 * this._glowLengthTS)) * 0.5;
 
@@ -207,18 +194,14 @@ define([
                 }
             };
 
-            var drawCommand = context.createViewportQuadCommand(SunTextureFS, {
-                renderState : rs,
+            var computeCommand = new ComputeCommand({
+                fragmentShaderSource : SunTextureFS,
+                outputTexture : this._texture,
                 uniformMap : uniformMap,
-                framebuffer : fbo,
                 owner : this
             });
 
-            clearCommand.execute(context);
-            drawCommand.execute(context);
-
-            drawCommand.shaderProgram.destroy();
-            fbo.destroy();
+            computeCommand.execute(context);
         }
 
         var command = this._command;

--- a/Source/Scene/Sun.js
+++ b/Source/Scene/Sun.js
@@ -161,6 +161,7 @@ define([
 
         var drawingBufferWidth = scene.drawingBufferWidth;
         var drawingBufferHeight = scene.drawingBufferHeight;
+        var computeCommand;
 
         if (!defined(this._texture) ||
                 drawingBufferWidth !== this._drawingBufferWidth ||
@@ -194,14 +195,12 @@ define([
                 }
             };
 
-            var computeCommand = new ComputeCommand({
+            computeCommand = new ComputeCommand({
                 fragmentShaderSource : SunTextureFS,
                 outputTexture : this._texture,
                 uniformMap : uniformMap,
                 owner : this
             });
-
-            computeCommand.execute(context);
         }
 
         var command = this._command;
@@ -303,7 +302,10 @@ define([
         this._size = Math.ceil(Cartesian2.magnitude(Cartesian2.subtract(limbWC, positionWC, scratchCartesian4)));
         this._size = 2.0 * this._size * (1.0 + 2.0 * this._glowLengthTS);
 
-        return command;
+        return {
+            computeCommand : computeCommand,
+            drawCommand : command
+        };
     };
 
     /**

--- a/Source/Scene/Sun.js
+++ b/Source/Scene/Sun.js
@@ -91,12 +91,8 @@ define([
             boundingVolume : new BoundingSphere(),
             owner : this
         });
-        this._computeCommand = new ComputeCommand({
-            persists : false,
-            owner : this
-        });
         this._commands = {
-            drawCommand : undefined,
+            drawCommand : this._drawCommand,
             computeCommand : undefined
         };
         this._boundingVolume = new BoundingSphere();
@@ -169,7 +165,6 @@ define([
 
         var drawingBufferWidth = scene.drawingBufferWidth;
         var drawingBufferHeight = scene.drawingBufferHeight;
-        var computeCommand;
 
         if (!defined(this._texture) ||
                 drawingBufferWidth !== this._drawingBufferWidth ||
@@ -203,10 +198,15 @@ define([
                 }
             };
 
-            computeCommand = this._computeCommand;
-            computeCommand.fragmentShaderSource = SunTextureFS;
-            computeCommand.outputTexture = this._texture;
-            computeCommand.uniformMap = uniformMap;
+            this._commands.computeCommand = new ComputeCommand({
+                fragmentShaderSource : SunTextureFS,
+                outputTexture  : this._texture,
+                persists : false,
+                owner : this,
+                postExecute : function() {
+                    that._commands.computeCommand = undefined;
+                }
+            });
         }
 
         var drawCommand = this._drawCommand;
@@ -308,8 +308,6 @@ define([
         this._size = Math.ceil(Cartesian2.magnitude(Cartesian2.subtract(limbWC, positionWC, scratchCartesian4)));
         this._size = 2.0 * this._size * (1.0 + 2.0 * this._glowLengthTS);
 
-        this._commands.drawCommand = drawCommand;
-        this._commands.computeCommand = computeCommand;
         return this._commands;
     };
 

--- a/Source/Scene/TileImagery.js
+++ b/Source/Scene/TileImagery.js
@@ -44,11 +44,11 @@ define([
      * @param {Context} context The context.
      * @returns {Boolean} True if this instance is done loading; otherwise, false.
      */
-    TileImagery.prototype.processStateMachine = function(tile, context) {
+    TileImagery.prototype.processStateMachine = function(tile, context, commandList) {
         var loadingImagery = this.loadingImagery;
         var imageryLayer = loadingImagery.imageryLayer;
 
-        loadingImagery.processStateMachine(context);
+        loadingImagery.processStateMachine(context, commandList);
 
         if (loadingImagery.state === ImageryState.READY) {
             if (defined(this.readyImagery)) {
@@ -90,7 +90,7 @@ define([
                 // Push the ancestor's load process along a bit.  This is necessary because some ancestor imagery
                 // tiles may not be attached directly to a terrain tile.  Such tiles will never load if
                 // we don't do it here.
-                closestAncestorThatNeedsLoading.processStateMachine(context);
+                closestAncestorThatNeedsLoading.processStateMachine(context, commandList);
                 return false; // not done loading
             } else {
                 // This imagery tile is failed or invalid, and we have the "best available" substitute.

--- a/Specs/Renderer/ComputeCommandSpec.js
+++ b/Specs/Renderer/ComputeCommandSpec.js
@@ -1,0 +1,162 @@
+/*global defineSuite*/
+defineSuite([
+        'Renderer/ComputeCommand',
+        'Core/BoundingRectangle',
+        'Core/PixelFormat',
+        'Renderer/Buffer',
+        'Renderer/BufferUsage',
+        'Renderer/ShaderProgram',
+        'Renderer/Texture',
+        'Renderer/VertexArray',
+        'Scene/Material',
+        'Scene/ViewportQuad',
+        'Specs/createScene'
+    ], function(
+        ComputeCommand,
+        BoundingRectangle,
+        PixelFormat,
+        Buffer,
+        BufferUsage,
+        ShaderProgram,
+        Texture,
+        VertexArray,
+        Material,
+        ViewportQuad,
+        createScene) {
+    "use strict";
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn*/
+
+    var scene;
+    var context;
+
+    beforeAll(function() {
+        scene = createScene();
+        context = scene._context;
+    });
+
+    afterAll(function() {
+        scene.destroyForSpecs();
+    });
+
+    afterEach(function() {
+       scene.primitives.removeAll();
+    });
+
+    function CommandMockPrimitive(command) {
+        this.update = function(context, frameState, commandList) {
+            commandList.push(command);
+        };
+        this.destroy = function() {
+        };
+    }
+
+    it('throws if no shader is provided', function() {
+        var outputTexture = new Texture({
+            context : context,
+            width : 1,
+            height : 1,
+            pixelFormat : PixelFormat.RGBA
+        });
+        var computeCommand = new ComputeCommand({
+            outputTexture : outputTexture
+        });
+        scene.primitives.add(new CommandMockPrimitive(computeCommand));
+
+        expect(function() {
+            scene.renderForSpecs();
+        }).toThrowDeveloperError();
+    });
+
+    it('throws if no output texture is provided', function() {
+        var computeCommand = new ComputeCommand({
+            fragmentShaderSource : 'void main() { gl_FragColor = vec4(1.0); }'
+        });
+        scene.primitives.add(new CommandMockPrimitive(computeCommand));
+
+        expect(function() {
+            scene.renderForSpecs();
+        }).toThrowDeveloperError();
+    });
+
+    it('renderer resources are destroyed if persists is set to false', function() {
+        var vertexShader = 'attribute vec4 position; void main() { gl_PointSize = 1.0; gl_Position = position; }';
+        var fragmentShader = 'void main() { gl_FragColor = vec4(1.0); }';
+        var shaderProgram = ShaderProgram.fromCache({
+            context : context,
+            vertexShaderSource : vertexShader,
+            fragmentShaderSource : fragmentShader
+        });
+
+        var vertexArray = new VertexArray({
+            context : context,
+            attributes : [{
+                index : shaderProgram.vertexAttributes.position.index,
+                vertexBuffer : Buffer.createVertexBuffer({
+                    context : context,
+                    typedArray : new Float32Array([0, 0, 0, 1]),
+                    usage : BufferUsage.STATIC_DRAW
+                }),
+                componentsPerAttribute : 4
+            }]
+        });
+
+        var outputTexture = new Texture({
+            context : context,
+            width : 1,
+            height : 1,
+            pixelFormat : PixelFormat.RGBA
+        });
+
+        var computeCommand = new ComputeCommand({
+            vertexArray : vertexArray,
+            shaderProgram : shaderProgram,
+            outputTexture : outputTexture
+        });
+
+        // check that resources are not destroyed when persists is true
+        computeCommand.persists = true;
+        scene.primitives.add(new CommandMockPrimitive(computeCommand));
+        scene.renderForSpecs();
+        context.shaderCache.destroyReleasedShaderPrograms();
+        scene.primitives.removeAll();
+
+        expect(shaderProgram.isDestroyed()).toEqual(false);
+        expect(vertexArray.isDestroyed()).toEqual(false);
+        expect(outputTexture.isDestroyed()).toEqual(false);
+
+        // check that resources are destroyed when persists is false
+        // except outputTexture which is not destroyed by the compute command
+        computeCommand.persists = false;
+        scene.primitives.add(new CommandMockPrimitive(computeCommand));
+        scene.renderForSpecs();
+        context.shaderCache.destroyReleasedShaderPrograms();
+        scene.primitives.removeAll();
+
+        expect(shaderProgram.isDestroyed()).toEqual(true);
+        expect(vertexArray.isDestroyed()).toEqual(true);
+        expect(outputTexture.isDestroyed()).toEqual(false);
+    });
+
+    it('renders to a texture and draws that texture to the screen', function() {
+        var outputTexture = new Texture({
+            context : context,
+            width : 1,
+            height : 1,
+            pixelFormat : PixelFormat.RGBA
+        });
+        var computeCommand = new ComputeCommand({
+            fragmentShaderSource : 'void main() { gl_FragColor = vec4(1.0); }',
+            outputTexture : outputTexture
+        });
+
+        var viewportQuad = new ViewportQuad();
+        viewportQuad.rectangle = new BoundingRectangle(0, 0, 1, 1);
+        viewportQuad.material = Material.fromType(Material.ImageType);
+        viewportQuad.material.uniforms.image = outputTexture;
+
+        expect(scene.renderForSpecs()).toEqual([0, 0, 0, 255]);
+        scene.primitives.add(new CommandMockPrimitive(computeCommand));
+        scene.primitives.add(viewportQuad);
+        expect(scene.renderForSpecs()).not.toEqual([0, 0, 0, 255]);
+    });
+}, 'WebGL');

--- a/Specs/Renderer/ComputeCommandSpec.js
+++ b/Specs/Renderer/ComputeCommandSpec.js
@@ -31,7 +31,7 @@ defineSuite([
 
     beforeAll(function() {
         scene = createScene();
-        context = scene._context;
+        context = scene.context;
     });
 
     afterAll(function() {

--- a/Specs/Renderer/ComputeCommandSpec.js
+++ b/Specs/Renderer/ComputeCommandSpec.js
@@ -78,7 +78,7 @@ defineSuite([
         }).toThrowDeveloperError();
     });
 
-    it('renderer resources are destroyed if persists is set to false', function() {
+    it('renderer resources are preserved or destroyed based on the persists flag', function() {
         var vertexShader = 'attribute vec4 position; void main() { gl_PointSize = 1.0; gl_Position = position; }';
         var fragmentShader = 'void main() { gl_FragColor = vec4(1.0); }';
         var shaderProgram = ShaderProgram.fromCache({
@@ -113,7 +113,7 @@ defineSuite([
             outputTexture : outputTexture
         });
 
-        // check that resources are not destroyed when persists is true
+        // check that resources are preserved when persists is true
         computeCommand.persists = true;
         scene.primitives.add(new CommandMockPrimitive(computeCommand));
         scene.renderForSpecs();
@@ -124,8 +124,8 @@ defineSuite([
         expect(vertexArray.isDestroyed()).toEqual(false);
         expect(outputTexture.isDestroyed()).toEqual(false);
 
-        // check that resources are destroyed when persists is false
-        // except outputTexture which is not destroyed by the compute command
+        // check that resources are destroyed when persists is false, except
+        // outputTexture which is always preserved
         computeCommand.persists = false;
         scene.primitives.add(new CommandMockPrimitive(computeCommand));
         scene.renderForSpecs();

--- a/Specs/Renderer/FramebufferSpec.js
+++ b/Specs/Renderer/FramebufferSpec.js
@@ -238,9 +238,9 @@ defineSuite([
         // 2 of 4.  Clear framebuffer color attachment to green.
         framebuffer = new Framebuffer({
             context : context,
-            colorTextures : [cubeMap.positiveX]
+            colorTextures : [cubeMap.positiveX],
+            destroyAttachments : false
         });
-        framebuffer.destroyAttachments = false;
 
         var clearCommand = new ClearCommand({
             color : new Color (0.0, 1.0, 0.0, 1.0),

--- a/Specs/Scene/GlobeSpec.js
+++ b/Specs/Scene/GlobeSpec.js
@@ -83,9 +83,9 @@ defineSuite([
         scene.camera.viewRectangle(new Rectangle(0.0001, 0.0001, 0.0025, 0.0025), Ellipsoid.WGS84);
 
         return updateUntilDone(globe).then(function() {
-            scene._globe = undefined;
+            scene.globe.show = false;
             expect(scene.renderForSpecs()).toEqual([0, 0, 0, 255]);
-            scene._globe = globe;
+            scene.globe.show = true;
             expect(scene.renderForSpecs()).not.toEqual([0, 0, 0, 255]);
         });
     });
@@ -100,9 +100,9 @@ defineSuite([
         scene.camera.viewRectangle(new Rectangle(0.0001, 0.0001, 0.0025, 0.0025), Ellipsoid.WGS84);
 
         return updateUntilDone(globe).then(function() {
-            scene._globe = undefined;
+            scene.globe.show = false;
             expect(scene.renderForSpecs()).toEqual([0, 0, 0, 255]);
-            scene._globe = globe;
+            scene.globe.show = true;
             expect(scene.renderForSpecs()).not.toEqual([0, 0, 0, 255]);
         });
     });
@@ -133,9 +133,9 @@ defineSuite([
             scene.camera.viewRectangle(new Rectangle(0.0001, 0.0001, 0.0025, 0.0025), Ellipsoid.WGS84);
 
             return updateUntilDone(globe).then(function() {
-                scene._globe = undefined;
+                scene.globe.show = false;
                 expect(scene.renderForSpecs()).toEqual([0, 0, 0, 255]);
-                scene._globe = globe;
+                scene.globe.show = true;
                 expect(scene.renderForSpecs()).not.toEqual([0, 0, 0, 255]);
             });
         });

--- a/Specs/Scene/GlobeSpec.js
+++ b/Specs/Scene/GlobeSpec.js
@@ -8,10 +8,8 @@ defineSuite([
         'Core/Rectangle',
         'Renderer/ClearCommand',
         'Scene/SingleTileImageryProvider',
-        'Specs/createContext',
-        'Specs/createFrameState',
-        'Specs/pollToPromise',
-        'Specs/render'
+        'Specs/createScene',
+        'Specs/pollToPromise'
     ], function(
         Globe,
         CesiumTerrainProvider,
@@ -21,32 +19,29 @@ defineSuite([
         Rectangle,
         ClearCommand,
         SingleTileImageryProvider,
-        createContext,
-        createFrameState,
-        pollToPromise,
-        render) {
+        createScene,
+        pollToPromise) {
     "use strict";
     /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn*/
 
-    var context;
-    var frameState;
+    var scene;
     var globe;
 
     beforeAll(function() {
-        context = createContext();
+        scene = createScene();
     });
 
     afterAll(function() {
-        context.destroyForSpecs();
+        scene.destroyForSpecs();
     });
 
     beforeEach(function() {
-        frameState = createFrameState();
         globe = new Globe();
+        scene.globe = globe;
     });
 
     afterEach(function() {
-        globe.destroy();
+        scene.globe = undefined;
         loadWithXhr.load = loadWithXhr.defaultLoad;
     });
 
@@ -66,15 +61,14 @@ defineSuite([
     }
 
     /**
-     * Repeatedly calls update until the load queue is empty.  Returns a promise that resolves
+     * Repeatedly calls render until the load queue is empty. Returns a promise that resolves
      * when the load queue is empty.
      */
     function updateUntilDone(globe) {
         // update until the load queue is empty.
         return pollToPromise(function() {
             globe._surface._debug.enableDebugOutput = true;
-            var commandList = [];
-            globe.update(context, frameState, commandList);
+            scene.render();
             return globe._surface.tileProvider.ready && !defined(globe._surface._tileLoadQueue.head) && globe._surface._debug.tilesWaitingForChildren === 0;
         });
     }
@@ -86,14 +80,13 @@ defineSuite([
         layerCollection.removeAll();
         layerCollection.addImageryProvider(new SingleTileImageryProvider({url : 'Data/Images/Red16x16.png'}));
 
-        frameState.camera.viewRectangle(new Rectangle(0.0001, 0.0001, 0.0025, 0.0025), Ellipsoid.WGS84);
+        scene.camera.viewRectangle(new Rectangle(0.0001, 0.0001, 0.0025, 0.0025), Ellipsoid.WGS84);
 
         return updateUntilDone(globe).then(function() {
-            ClearCommand.ALL.execute(context);
-            expect(context.readPixels()).toEqual([0, 0, 0, 0]);
-
-            render(context, frameState, globe);
-            expect(context.readPixels()).not.toEqual([0, 0, 0, 0]);
+            scene._globe = undefined;
+            expect(scene.renderForSpecs()).toEqual([0, 0, 0, 255]);
+            scene._globe = globe;
+            expect(scene.renderForSpecs()).not.toEqual([0, 0, 0, 255]);
         });
     });
 
@@ -104,14 +97,13 @@ defineSuite([
         layerCollection.removeAll();
         layerCollection.addImageryProvider(new SingleTileImageryProvider({url : 'Data/Images/Red16x16.png'}));
 
-        frameState.camera.viewRectangle(new Rectangle(0.0001, 0.0001, 0.0025, 0.0025), Ellipsoid.WGS84);
+        scene.camera.viewRectangle(new Rectangle(0.0001, 0.0001, 0.0025, 0.0025), Ellipsoid.WGS84);
 
         return updateUntilDone(globe).then(function() {
-            ClearCommand.ALL.execute(context);
-            expect(context.readPixels()).toEqual([0, 0, 0, 0]);
-
-            render(context, frameState, globe);
-            expect(context.readPixels()).not.toEqual([0, 0, 0, 0]);
+            scene._globe = undefined;
+            expect(scene.renderForSpecs()).toEqual([0, 0, 0, 255]);
+            scene._globe = globe;
+            expect(scene.renderForSpecs()).not.toEqual([0, 0, 0, 255]);
         });
     });
 
@@ -138,14 +130,13 @@ defineSuite([
         return pollToPromise(function() {
             return terrainProvider.ready;
         }).then(function() {
-            frameState.camera.viewRectangle(new Rectangle(0.0001, 0.0001, 0.0025, 0.0025), Ellipsoid.WGS84);
+            scene.camera.viewRectangle(new Rectangle(0.0001, 0.0001, 0.0025, 0.0025), Ellipsoid.WGS84);
 
             return updateUntilDone(globe).then(function() {
-                ClearCommand.ALL.execute(context);
-                expect(context.readPixels()).toEqual([0, 0, 0, 0]);
-
-                render(context, frameState, globe);
-                expect(context.readPixels()).not.toEqual([0, 0, 0, 0]);
+                scene._globe = undefined;
+                expect(scene.renderForSpecs()).toEqual([0, 0, 0, 255]);
+                scene._globe = globe;
+                expect(scene.renderForSpecs()).not.toEqual([0, 0, 0, 255]);
             });
         });
     });

--- a/Specs/Scene/GlobeSurfaceTileSpec.js
+++ b/Specs/Scene/GlobeSurfaceTileSpec.js
@@ -48,6 +48,7 @@ defineSuite([
 
     describe('processStateMachine', function() {
         var context;
+        var commandList = [];
         var alwaysDeferTerrainProvider;
         var alwaysFailTerrainProvider;
         var realTerrainProvider;
@@ -124,12 +125,12 @@ defineSuite([
         });
 
         it('transitions to the LOADING state immediately', function() {
-            GlobeSurfaceTile.processStateMachine(rootTile, context, alwaysDeferTerrainProvider, imageryLayerCollection);
+            GlobeSurfaceTile.processStateMachine(rootTile, context, commandList, alwaysDeferTerrainProvider, imageryLayerCollection);
             expect(rootTile.state).toBe(QuadtreeTileLoadState.LOADING);
         });
 
         it('creates loadedTerrain but not upsampledTerrain for root tiles', function() {
-            GlobeSurfaceTile.processStateMachine(rootTile, context, alwaysDeferTerrainProvider, imageryLayerCollection);
+            GlobeSurfaceTile.processStateMachine(rootTile, context, commandList, alwaysDeferTerrainProvider, imageryLayerCollection);
             expect(rootTile.data.loadedTerrain).toBeDefined();
             expect(rootTile.data.upsampledTerrain).toBeUndefined();
         });
@@ -137,7 +138,7 @@ defineSuite([
         it('non-root tiles get neither loadedTerrain nor upsampledTerrain when their parent is not loaded nor upsampled', function() {
             var children = rootTile.children;
             for (var i = 0; i < children.length; ++i) {
-                GlobeSurfaceTile.processStateMachine(children[i], context, alwaysDeferTerrainProvider, imageryLayerCollection);
+                GlobeSurfaceTile.processStateMachine(children[i], context, commandList, alwaysDeferTerrainProvider, imageryLayerCollection);
                 expect(children[i].data.loadedTerrain).toBeUndefined();
                 expect(children[i].data.upsampledTerrain).toBeUndefined();
             }
@@ -145,12 +146,12 @@ defineSuite([
 
         it('once a root tile is loaded, its children get both loadedTerrain and upsampledTerrain', function() {
             return pollToPromise(function() {
-                GlobeSurfaceTile.processStateMachine(rootTile, context, realTerrainProvider, imageryLayerCollection);
+                GlobeSurfaceTile.processStateMachine(rootTile, context, commandList, realTerrainProvider, imageryLayerCollection);
                 return rootTile.state === QuadtreeTileLoadState.DONE;
             }).then(function() {
                 var children = rootTile.children;
                 for (var i = 0; i < children.length; ++i) {
-                    GlobeSurfaceTile.processStateMachine(children[i], context, alwaysDeferTerrainProvider, imageryLayerCollection);
+                    GlobeSurfaceTile.processStateMachine(children[i], context, commandList, alwaysDeferTerrainProvider, imageryLayerCollection);
                     expect(children[i].data.loadedTerrain).toBeDefined();
                     expect(children[i].data.upsampledTerrain).toBeDefined();
                 }
@@ -159,7 +160,7 @@ defineSuite([
 
         it('loaded terrainData is copied to the tile once it is available', function() {
             return pollToPromise(function() {
-                GlobeSurfaceTile.processStateMachine(rootTile, context, realTerrainProvider, imageryLayerCollection);
+                GlobeSurfaceTile.processStateMachine(rootTile, context, commandList, realTerrainProvider, imageryLayerCollection);
                 return rootTile.data.loadedTerrain.state >= TerrainState.RECEIVED;
             }).then(function() {
                 expect(rootTile.data.terrainData).toBeDefined();
@@ -168,12 +169,12 @@ defineSuite([
 
         it('upsampled terrainData is copied to the tile once it is available', function() {
             return pollToPromise(function() {
-                GlobeSurfaceTile.processStateMachine(rootTile, context, realTerrainProvider, imageryLayerCollection);
+                GlobeSurfaceTile.processStateMachine(rootTile, context, commandList, realTerrainProvider, imageryLayerCollection);
                 return rootTile.data.loadedTerrain.state >= TerrainState.RECEIVED;
             }).then(function() {
                 return pollToPromise(function() {
                     var childTile = rootTile.children[0];
-                    GlobeSurfaceTile.processStateMachine(childTile, context, alwaysDeferTerrainProvider, imageryLayerCollection);
+                    GlobeSurfaceTile.processStateMachine(childTile, context, commandList, alwaysDeferTerrainProvider, imageryLayerCollection);
                     return childTile.data.upsampledTerrain.state >= TerrainState.RECEIVED;
                 }).then(function() {
                     expect(rootTile.children[0].data.terrainData).toBeDefined();
@@ -185,20 +186,20 @@ defineSuite([
             var childTile = rootTile.children[0];
 
             return pollToPromise(function() {
-                GlobeSurfaceTile.processStateMachine(rootTile, context, realTerrainProvider, imageryLayerCollection);
+                GlobeSurfaceTile.processStateMachine(rootTile, context, commandList, realTerrainProvider, imageryLayerCollection);
                 return rootTile.data.loadedTerrain.state >= TerrainState.RECEIVED;
             }).then(function() {
                 var upsampledTerrainData;
 
                 return pollToPromise(function() {
-                    GlobeSurfaceTile.processStateMachine(childTile, context, alwaysDeferTerrainProvider, imageryLayerCollection);
+                    GlobeSurfaceTile.processStateMachine(childTile, context, commandList, alwaysDeferTerrainProvider, imageryLayerCollection);
                     return childTile.data.upsampledTerrain.state >= TerrainState.RECEIVED;
                 }).then(function() {
                     upsampledTerrainData = childTile.data.terrainData;
                     expect(upsampledTerrainData).toBeDefined();
 
                     return pollToPromise(function() {
-                        GlobeSurfaceTile.processStateMachine(childTile, context, realTerrainProvider, imageryLayerCollection);
+                        GlobeSurfaceTile.processStateMachine(childTile, context, commandList, realTerrainProvider, imageryLayerCollection);
                         return childTile.data.loadedTerrain.state >= TerrainState.RECEIVED;
                     }).then(function() {
                         expect(childTile.data.terrainData).not.toBe(upsampledTerrainData);
@@ -212,9 +213,9 @@ defineSuite([
             var grandchildTile = childTile.children[0];
 
             return pollToPromise(function() {
-                GlobeSurfaceTile.processStateMachine(rootTile, context, realTerrainProvider, imageryLayerCollection);
-                GlobeSurfaceTile.processStateMachine(childTile, context, alwaysDeferTerrainProvider, imageryLayerCollection);
-                GlobeSurfaceTile.processStateMachine(grandchildTile, context, alwaysDeferTerrainProvider, imageryLayerCollection);
+                GlobeSurfaceTile.processStateMachine(rootTile, context, commandList, realTerrainProvider, imageryLayerCollection);
+                GlobeSurfaceTile.processStateMachine(childTile, context, commandList, alwaysDeferTerrainProvider, imageryLayerCollection);
+                GlobeSurfaceTile.processStateMachine(grandchildTile, context, commandList, alwaysDeferTerrainProvider, imageryLayerCollection);
                 return rootTile.data.loadedTerrain.state >= TerrainState.RECEIVED &&
                        childTile.data.upsampledTerrain.state >= TerrainState.RECEIVED &&
                        grandchildTile.data.upsampledTerrain.state >= TerrainState.RECEIVED;
@@ -223,7 +224,7 @@ defineSuite([
                 expect(grandchildTile.data.loadedTerrain).toBeUndefined();
 
                 return pollToPromise(function() {
-                    GlobeSurfaceTile.processStateMachine(childTile, context, realTerrainProvider, imageryLayerCollection);
+                    GlobeSurfaceTile.processStateMachine(childTile, context, commandList, realTerrainProvider, imageryLayerCollection);
                     return childTile.data.loadedTerrain.state >= TerrainState.RECEIVED;
                 }).then(function() {
                     expect(grandchildTile.data.upsampledTerrain).not.toBe(grandchildUpsampledTerrain);
@@ -238,10 +239,10 @@ defineSuite([
             var greatGrandchildTile = grandchildTile.children[0];
 
             return pollToPromise(function() {
-                GlobeSurfaceTile.processStateMachine(rootTile, context, realTerrainProvider, imageryLayerCollection);
-                GlobeSurfaceTile.processStateMachine(childTile, context, alwaysDeferTerrainProvider, imageryLayerCollection);
-                GlobeSurfaceTile.processStateMachine(grandchildTile, context, alwaysDeferTerrainProvider, imageryLayerCollection);
-                GlobeSurfaceTile.processStateMachine(greatGrandchildTile, context, alwaysDeferTerrainProvider, imageryLayerCollection);
+                GlobeSurfaceTile.processStateMachine(rootTile, context, commandList, realTerrainProvider, imageryLayerCollection);
+                GlobeSurfaceTile.processStateMachine(childTile, context, commandList, alwaysDeferTerrainProvider, imageryLayerCollection);
+                GlobeSurfaceTile.processStateMachine(grandchildTile, context, commandList, alwaysDeferTerrainProvider, imageryLayerCollection);
+                GlobeSurfaceTile.processStateMachine(greatGrandchildTile, context, commandList, alwaysDeferTerrainProvider, imageryLayerCollection);
                 return rootTile.data.loadedTerrain.state >= TerrainState.RECEIVED &&
                        childTile.data.upsampledTerrain.state >= TerrainState.RECEIVED &&
                        grandchildTile.data.upsampledTerrain.state >= TerrainState.RECEIVED &&
@@ -250,8 +251,8 @@ defineSuite([
                 var greatGrandchildUpsampledTerrain = grandchildTile.data.upsampledTerrain;
 
                 return pollToPromise(function() {
-                    GlobeSurfaceTile.processStateMachine(childTile, context, realTerrainProvider, imageryLayerCollection);
-                    GlobeSurfaceTile.processStateMachine(grandchildTile, context, alwaysDeferTerrainProvider, imageryLayerCollection);
+                    GlobeSurfaceTile.processStateMachine(childTile, context, commandList, realTerrainProvider, imageryLayerCollection);
+                    GlobeSurfaceTile.processStateMachine(grandchildTile, context, commandList, alwaysDeferTerrainProvider, imageryLayerCollection);
                     return childTile.data.loadedTerrain.state >= TerrainState.RECEIVED &&
                            grandchildTile.data.upsampledTerrain.state >= TerrainState.RECEIVED;
                 }).then(function() {
@@ -265,8 +266,8 @@ defineSuite([
             var childTile = rootTile.children[0];
 
             return pollToPromise(function() {
-                GlobeSurfaceTile.processStateMachine(rootTile, context, realTerrainProvider, imageryLayerCollection);
-                GlobeSurfaceTile.processStateMachine(childTile, context, alwaysDeferTerrainProvider, imageryLayerCollection);
+                GlobeSurfaceTile.processStateMachine(rootTile, context, commandList, realTerrainProvider, imageryLayerCollection);
+                GlobeSurfaceTile.processStateMachine(childTile, context, commandList, alwaysDeferTerrainProvider, imageryLayerCollection);
                 return rootTile.renderable && childTile.renderable;
             }).then(function() {
                 expect(childTile.data.waterMaskTexture).toBeDefined();
@@ -274,7 +275,7 @@ defineSuite([
                 var referenceCount = childWaterMaskTexture.referenceCount;
 
                 return pollToPromise(function() {
-                    GlobeSurfaceTile.processStateMachine(childTile, context, realTerrainProvider, imageryLayerCollection);
+                    GlobeSurfaceTile.processStateMachine(childTile, context, commandList, realTerrainProvider, imageryLayerCollection);
                     return childTile.state === QuadtreeTileLoadState.DONE;
                 }).then(function() {
                     expect(childTile.data.waterMaskTexture).toBeDefined();
@@ -288,8 +289,8 @@ defineSuite([
             var childTile = rootTile.children[0];
 
             return pollToPromise(function() {
-                GlobeSurfaceTile.processStateMachine(rootTile, context, realTerrainProvider, imageryLayerCollection);
-                GlobeSurfaceTile.processStateMachine(childTile, context, alwaysFailTerrainProvider, imageryLayerCollection);
+                GlobeSurfaceTile.processStateMachine(rootTile, context, commandList, realTerrainProvider, imageryLayerCollection);
+                GlobeSurfaceTile.processStateMachine(childTile, context, commandList, alwaysFailTerrainProvider, imageryLayerCollection);
                 return rootTile.renderable && childTile.renderable;
             }).then(function() {
                 expect(childTile.data.loadedTerrain).toBeUndefined();
@@ -302,8 +303,8 @@ defineSuite([
             var grandchildTile = childTile.children[0];
 
             return pollToPromise(function() {
-                GlobeSurfaceTile.processStateMachine(rootTile, context, realTerrainProvider, imageryLayerCollection);
-                GlobeSurfaceTile.processStateMachine(childTile, context, alwaysDeferTerrainProvider, imageryLayerCollection);
+                GlobeSurfaceTile.processStateMachine(rootTile, context, commandList, realTerrainProvider, imageryLayerCollection);
+                GlobeSurfaceTile.processStateMachine(childTile, context, commandList, alwaysDeferTerrainProvider, imageryLayerCollection);
                 return rootTile.data.loadedTerrain.state >= TerrainState.RECEIVED &&
                        childTile.data.upsampledTerrain.state >= TerrainState.RECEIVED;
             }).then(function() {
@@ -311,14 +312,14 @@ defineSuite([
                 childTile.data.terrainData._childTileMask = 15;
 
                 return pollToPromise(function() {
-                    GlobeSurfaceTile.processStateMachine(grandchildTile, context, realTerrainProvider, imageryLayerCollection);
+                    GlobeSurfaceTile.processStateMachine(grandchildTile, context, commandList, realTerrainProvider, imageryLayerCollection);
                     return grandchildTile.state === QuadtreeTileLoadState.DONE;
                 }).then(function() {
                     expect(grandchildTile.data.loadedTerrain).toBeUndefined();
                     expect(grandchildTile.data.upsampledTerrain).toBeUndefined();
 
                     return pollToPromise(function() {
-                        GlobeSurfaceTile.processStateMachine(childTile, context, realTerrainProvider, imageryLayerCollection);
+                        GlobeSurfaceTile.processStateMachine(childTile, context, commandList, realTerrainProvider, imageryLayerCollection);
                         return childTile.state === QuadtreeTileLoadState.DONE;
                     }).then(function() {
                         expect(grandchildTile.state).toBe(QuadtreeTileLoadState.DONE);
@@ -335,9 +336,9 @@ defineSuite([
             var greatGrandchildTile = grandchildTile.children[0];
 
             return pollToPromise(function() {
-                GlobeSurfaceTile.processStateMachine(rootTile, context, realTerrainProvider, imageryLayerCollection);
-                GlobeSurfaceTile.processStateMachine(childTile, context, alwaysDeferTerrainProvider, imageryLayerCollection);
-                GlobeSurfaceTile.processStateMachine(grandchildTile, context, alwaysDeferTerrainProvider, imageryLayerCollection);
+                GlobeSurfaceTile.processStateMachine(rootTile, context, commandList, realTerrainProvider, imageryLayerCollection);
+                GlobeSurfaceTile.processStateMachine(childTile, context, commandList, alwaysDeferTerrainProvider, imageryLayerCollection);
+                GlobeSurfaceTile.processStateMachine(grandchildTile, context, commandList, alwaysDeferTerrainProvider, imageryLayerCollection);
                 return rootTile.data.loadedTerrain.state >= TerrainState.RECEIVED &&
                        childTile.data.upsampledTerrain.state >= TerrainState.RECEIVED &&
                        grandchildTile.data.upsampledTerrain.state >= TerrainState.RECEIVED;
@@ -346,15 +347,15 @@ defineSuite([
                 grandchildTile.data.terrainData._childTileMask = 15;
 
                 return pollToPromise(function() {
-                    GlobeSurfaceTile.processStateMachine(greatGrandchildTile, context, realTerrainProvider, imageryLayerCollection);
+                    GlobeSurfaceTile.processStateMachine(greatGrandchildTile, context, commandList, realTerrainProvider, imageryLayerCollection);
                     return greatGrandchildTile.state === QuadtreeTileLoadState.DONE;
                 }).then(function() {
                     expect(greatGrandchildTile.data.loadedTerrain).toBeUndefined();
                     expect(greatGrandchildTile.data.upsampledTerrain).toBeUndefined();
 
                     return pollToPromise(function() {
-                        GlobeSurfaceTile.processStateMachine(childTile, context, realTerrainProvider, imageryLayerCollection);
-                        GlobeSurfaceTile.processStateMachine(grandchildTile, context, alwaysDeferTerrainProvider, imageryLayerCollection);
+                        GlobeSurfaceTile.processStateMachine(childTile, context, commandList, realTerrainProvider, imageryLayerCollection);
+                        GlobeSurfaceTile.processStateMachine(grandchildTile, context, commandList, alwaysDeferTerrainProvider, imageryLayerCollection);
                         return childTile.state === QuadtreeTileLoadState.DONE &&
                                !defined(grandchildTile.data.upsampledTerrain);
                     }).then(function() {
@@ -370,8 +371,8 @@ defineSuite([
             var childTile = rootTile.children[0];
 
             return pollToPromise(function() {
-                GlobeSurfaceTile.processStateMachine(rootTile, context, realTerrainProvider, imageryLayerCollection);
-                GlobeSurfaceTile.processStateMachine(childTile, context, alwaysFailTerrainProvider, imageryLayerCollection);
+                GlobeSurfaceTile.processStateMachine(rootTile, context, commandList, realTerrainProvider, imageryLayerCollection);
+                GlobeSurfaceTile.processStateMachine(childTile, context, commandList, alwaysFailTerrainProvider, imageryLayerCollection);
                 return rootTile.state >= QuadtreeTileLoadState.DONE &&
                        childTile.state >= QuadtreeTileLoadState.DONE;
             }).then(function() {
@@ -406,10 +407,10 @@ defineSuite([
 
             return pollToPromise(function() {
                 if (rootTile.state !== QuadtreeTileLoadState.DONE) {
-                    GlobeSurfaceTile.processStateMachine(rootTile, context, allWaterTerrainProvider, imageryLayerCollection);
+                    GlobeSurfaceTile.processStateMachine(rootTile, context, commandList, allWaterTerrainProvider, imageryLayerCollection);
                     return false;
                 } else {
-                    GlobeSurfaceTile.processStateMachine(childTile, context, allWaterTerrainProvider, imageryLayerCollection);
+                    GlobeSurfaceTile.processStateMachine(childTile, context, commandList, allWaterTerrainProvider, imageryLayerCollection);
                     return childTile.state === QuadtreeTileLoadState.DONE;
                 }
             }).then(function() {
@@ -444,10 +445,10 @@ defineSuite([
 
             return pollToPromise(function() {
                 if (rootTile.state !== QuadtreeTileLoadState.DONE) {
-                    GlobeSurfaceTile.processStateMachine(rootTile, context, allLandTerrainProvider, imageryLayerCollection);
+                    GlobeSurfaceTile.processStateMachine(rootTile, context, commandList, allLandTerrainProvider, imageryLayerCollection);
                     return false;
                 } else {
-                    GlobeSurfaceTile.processStateMachine(childTile, context, allLandTerrainProvider, imageryLayerCollection);
+                    GlobeSurfaceTile.processStateMachine(childTile, context, commandList, allLandTerrainProvider, imageryLayerCollection);
                     return childTile.state === QuadtreeTileLoadState.DONE;
                 }
             }).then(function() {
@@ -465,7 +466,7 @@ defineSuite([
 
             var imageryLayerCollection = new ImageryLayerCollection();
 
-            GlobeSurfaceTile.processStateMachine(tile, context, alwaysDeferTerrainProvider, imageryLayerCollection);
+            GlobeSurfaceTile.processStateMachine(tile, context, commandList, alwaysDeferTerrainProvider, imageryLayerCollection);
 
             var layer = new ImageryLayer({
                 requestImage : function() {
@@ -478,7 +479,7 @@ defineSuite([
             expect(imagery.parent.state).toBe(ImageryState.UNLOADED);
 
             return pollToPromise(function() {
-                GlobeSurfaceTile.processStateMachine(tile, context, alwaysDeferTerrainProvider, imageryLayerCollection);
+                GlobeSurfaceTile.processStateMachine(tile, context, commandList, alwaysDeferTerrainProvider, imageryLayerCollection);
                 return imagery.parent.state !== ImageryState.UNLOADED;
             });
         });
@@ -486,6 +487,7 @@ defineSuite([
 
     describe('pick', function() {
         var context;
+        var commandList = [];
 
         beforeAll(function() {
             context = createContext();
@@ -515,7 +517,7 @@ defineSuite([
                     return false;
                 }
 
-                GlobeSurfaceTile.processStateMachine(tile, context, terrainProvider, imageryLayerCollection);
+                GlobeSurfaceTile.processStateMachine(tile, context, commandList, terrainProvider, imageryLayerCollection);
                 return tile.state === QuadtreeTileLoadState.DONE;
             }).then(function() {
                 var ray = new Ray(

--- a/Specs/Scene/ImageryLayerCollectionSpec.js
+++ b/Specs/Scene/ImageryLayerCollectionSpec.js
@@ -304,8 +304,7 @@ defineSuite([
             // update until the load queue is empty.
             return pollToPromise(function() {
                 globe._surface._debug.enableDebugOutput = true;
-                var commandList = [];
-                globe.update(scene.context, scene.frameState, commandList);
+                scene.render();
                 return globe._surface.tileProvider.ready && globe._surface._tileLoadQueue.length === 0 && globe._surface._debug.tilesWaitingForChildren === 0;
             });
         }

--- a/Specs/Scene/ImageryLayerSpec.js
+++ b/Specs/Scene/ImageryLayerSpec.js
@@ -6,8 +6,10 @@ defineSuite([
         'Core/loadImage',
         'Core/loadWithXhr',
         'Core/Rectangle',
+        'Renderer/ComputeEngine',
         'Scene/ArcGisMapServerImageryProvider',
         'Scene/BingMapsImageryProvider',
+        'Scene/Globe',
         'Scene/GlobeSurfaceTile',
         'Scene/Imagery',
         'Scene/ImageryLayerCollection',
@@ -26,8 +28,10 @@ defineSuite([
         loadImage,
         loadWithXhr,
         Rectangle,
+        ComputeEngine,
         ArcGisMapServerImageryProvider,
         BingMapsImageryProvider,
+        Globe,
         GlobeSurfaceTile,
         Imagery,
         ImageryLayerCollection,
@@ -43,13 +47,16 @@ defineSuite([
     /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn*/
 
     var context;
+    var computeEngine;
 
     beforeAll(function() {
         context = createContext();
+        computeEngine = new ComputeEngine(context);
     });
 
     afterAll(function() {
         context.destroyForSpecs();
+        computeEngine.destroy();
     });
 
     afterEach(function() {
@@ -165,7 +172,9 @@ defineSuite([
                     return imagery.state === ImageryState.TEXTURE_LOADED;
                 }).then(function() {
                     var textureBeforeReprojection = imagery.texture;
-                    layer._reprojectTexture(context, imagery);
+                    var commandList = [];
+                    layer._reprojectTexture(context, commandList, imagery);
+                    commandList[0].execute(computeEngine);
 
                     return pollToPromise(function() {
                         return imagery.state === ImageryState.READY;

--- a/Specs/Scene/QuadtreePrimitiveSpec.js
+++ b/Specs/Scene/QuadtreePrimitiveSpec.js
@@ -97,7 +97,7 @@ defineSuite([
         var tileProvider = createSpyTileProvider();
         tileProvider.getReady.and.returnValue(true);
         tileProvider.computeTileVisibility.and.returnValue(Visibility.FULL);
-        tileProvider.loadTile.and.callFake(function(context, frameState, tile) {
+        tileProvider.loadTile.and.callFake(function(context, frameState, commandList, tile) {
             tile.renderable = true;
         });
 
@@ -117,7 +117,7 @@ defineSuite([
         tileProvider.computeTileVisibility.and.returnValue(Visibility.FULL);
 
         var calls = 0;
-        tileProvider.loadTile.and.callFake(function(context, frameState, tile) {
+        tileProvider.loadTile.and.callFake(function(context, frameState, commandList, tile) {
             ++calls;
             tile.state = QuadtreeTileLoadState.DONE;
         });
@@ -140,7 +140,7 @@ defineSuite([
         tileProvider.computeDistanceToTile.and.returnValue(1e-15);
 
         // Load the root tiles.
-        tileProvider.loadTile.and.callFake(function(context, frameState, tile) {
+        tileProvider.loadTile.and.callFake(function(context, frameState, commandList, tile) {
             tile.state = QuadtreeTileLoadState.DONE;
             tile.renderable = true;
         });
@@ -152,7 +152,7 @@ defineSuite([
         quadtree.update(context, frameState, []);
 
         // Don't load further tiles.
-        tileProvider.loadTile.and.callFake(function(context, frameState, tile) {
+        tileProvider.loadTile.and.callFake(function(context, frameState, commandList, tile) {
             tile.state = QuadtreeTileLoadState.START;
         });
 
@@ -170,7 +170,7 @@ defineSuite([
         tileProvider.computeDistanceToTile.and.returnValue(1e-15);
 
         // Load the root tiles.
-        tileProvider.loadTile.and.callFake(function(context, frameState, tile) {
+        tileProvider.loadTile.and.callFake(function(context, frameState, commandList, tile) {
             tile.state = QuadtreeTileLoadState.DONE;
             tile.renderable = true;
         });
@@ -214,7 +214,7 @@ defineSuite([
         };
 
         // Load the root tiles.
-        tileProvider.loadTile.and.callFake(function(context, frameState, tile) {
+        tileProvider.loadTile.and.callFake(function(context, frameState, commandList, tile) {
             tile.state = QuadtreeTileLoadState.DONE;
             tile.renderable = true;
         });


### PR DESCRIPTION
For #751 

Still a work in progress.

Some thoughts:
* I decided to allow the `ComputeCommand` to accept a custom vao instead of supporting subdivisions. Having a custom vao, especially the one in ImageryLayer, seems like a special case, and it might be annoying to generalize that.
* I pass in a `Texture` object instead of creating it fresh inside `ComputeEngine`. The object that called the compute command will need that texture back anyway.
* I create and destroy FBO's for every compute command, I think there should be a more efficient solution.
* Sun and ImageryLayers are both special cases, and don't act like primitives. So the code that actually handles`ComputeCommand` in `Scene` isn't doing anything right now.
* `ComputeEngine` is inside `Context` but maybe should go in `Scene` instead. I did this for now because ImageryLayer only has a reference to the context.
