### PR TITLE
Add subdomains support to WMS and WMTS

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@ Change Log
   * ...
 * Deprecated
   * ...
+* Added `subdomains` option to `WebMapTileServiceImageryProvider`.
 * Added `subdomains` option to `WebMapServiceImageryProvider`.
 * Fix zooming in 2D when tracking an object. The zoom was based on location rather than the tracked object. [#2991](https://github.com/AnalyticalGraphicsInc/cesium/issues/2991)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@ Change Log
   * ...
 * Deprecated
   * ...
+* Added `subdomains` option to `WebMapServiceImageryProvider`.
 * Fix zooming in 2D when tracking an object. The zoom was based on location rather than the tracked object. [#2991](https://github.com/AnalyticalGraphicsInc/cesium/issues/2991)
 
 ### 1.13 - 2015-09-01

--- a/Source/Scene/WebMapServiceImageryProvider.js
+++ b/Source/Scene/WebMapServiceImageryProvider.js
@@ -38,7 +38,7 @@ define([
      * @constructor
      *
      * @param {Object} options Object with the following properties:
-     * @param {String} options.url The URL of the WMS service.
+     * @param {String} options.url The URL of the WMS service. The URL has the same keywords as the UrlTemplateImageryProvider.
      * @param {String} options.layers The layers to include, separated by commas.
      * @param {Object} [options.parameters=WebMapServiceImageryProvider.DefaultParameters] Additional parameters
      *        to pass to the WMS server in the GetMap URL.
@@ -66,6 +66,9 @@ define([
      * @param {Credit|String} [options.credit] A credit for the data source, which is displayed on the canvas.
      * @param {Object} [options.proxy] A proxy to use for requests. This object is
      *        expected to have a getURL function which returns the proxied URL, if needed.
+     * @param {String|String[]} [options.subdomains='abc'] The subdomains to use for the <code>{s}</code> placeholder in the URL template.
+     *                          If this parameter is a single string, each character in the string is a subdomain.  If it is
+     *                          an array, each element in the array is a subdomain.
      *
      * @see ArcGisMapServerImageryProvider
      * @see BingMapsImageryProvider
@@ -174,6 +177,7 @@ define([
             minimumLevel : options.minimumLevel,
             maximumLevel : options.maximumLevel,
             proxy : options.proxy,
+            subdomains: options.subdomains,
             tileDiscardPolicy : options.tileDiscardPolicy,
             credit : options.credit,
             getFeatureInfoFormats : getFeatureInfoFormats

--- a/Source/Scene/WebMapTileServiceImageryProvider.js
+++ b/Source/Scene/WebMapTileServiceImageryProvider.js
@@ -39,7 +39,7 @@ define([
      * @constructor
      *
      * @param {Object} options Object with the following properties:
-     * @param {String} options.url The base URL for the WMTS GetTile operation (for KVP-encoded requests) or the tile-URL template (for RESTful requests). The tile-URL template should contain the following variables: &#123;style&#125;, &#123;TileMatrixSet&#125;, &#123;TileMatrix&#125;, &#123;TileRow&#125;, &#123;TileCol&#125;. The first two are optional if actual values are hardcoded or not required by the server.
+     * @param {String} options.url The base URL for the WMTS GetTile operation (for KVP-encoded requests) or the tile-URL template (for RESTful requests). The tile-URL template should contain the following variables: &#123;style&#125;, &#123;TileMatrixSet&#125;, &#123;TileMatrix&#125;, &#123;TileRow&#125;, &#123;TileCol&#125;. The first two are optional if actual values are hardcoded or not required by the server. The `{s}` keyword may be used to specify subdomains.
      * @param {String} [options.format='image/jpeg'] The MIME type for images to retrieve from the server.
      * @param {String} options.layer The layer name for WMTS requests.
      * @param {String} options.style The style name for WMTS requests.
@@ -54,6 +54,9 @@ define([
      * @param {Number} [options.maximumLevel] The maximum level-of-detail supported by the imagery provider, or undefined if there is no limit.
      * @param {Ellipsoid} [options.ellipsoid] The ellipsoid.  If not specified, the WGS84 ellipsoid is used.
      * @param {Credit|String} [options.credit] A credit for the data source, which is displayed on the canvas.
+     * @param {String|String[]} [options.subdomains='abc'] The subdomains to use for the <code>{s}</code> placeholder in the URL template.
+     *                          If this parameter is a single string, each character in the string is a subdomain.  If it is
+     *                          an array, each element in the array is a subdomain.
      *
      * @see ArcGisMapServerImageryProvider
      * @see BingMapsImageryProvider
@@ -139,6 +142,15 @@ define([
 
         var credit = options.credit;
         this._credit = typeof credit === 'string' ? new Credit(credit) : credit;
+
+        this._subdomains = options.subdomains;
+        if (Array.isArray(this._subdomains)) {
+            this._subdomains = this._subdomains.slice();
+        } else if (defined(this._subdomains) && this._subdomains.length > 0) {
+            this._subdomains = this._subdomains.split('');
+        } else {
+            this._subdomains = ['a', 'b', 'c'];
+        }
     };
 
     var defaultParameters = freezeObject({
@@ -150,6 +162,7 @@ define([
     function buildImageUrl(imageryProvider, col, row, level) {
         var labels = imageryProvider._tileMatrixLabels;
         var tileMatrix = defined(labels) ? labels[level] : level.toString();
+        var subdomains = imageryProvider._subdomains;
         var url;
 
         if (imageryProvider._url.indexOf('{') >= 0) {
@@ -160,7 +173,8 @@ define([
                 .replace('{TileMatrixSet}', imageryProvider._tileMatrixSetID)
                 .replace('{TileMatrix}', tileMatrix)
                 .replace('{TileRow}', row.toString())
-                .replace('{TileCol}', col.toString());
+                .replace('{TileCol}', col.toString())
+                .replace('{s}', subdomains[(col + row + level) % subdomains.length]);
         }
         else {
             // build KVP request

--- a/Specs/Scene/WebMapServiceImageryProviderSpec.js
+++ b/Specs/Scene/WebMapServiceImageryProviderSpec.js
@@ -127,6 +127,32 @@ defineSuite([
         });
     });
 
+    it('supports subdomains string in URL', function() {
+        var provider = new WebMapServiceImageryProvider({
+            url : '{s}',
+            subdomains: '123',
+            layers : ''
+        });
+
+        var loadImageSpy = spyOn(ImageryProvider, 'loadImage');
+        provider.requestImage(0, 0, 0);
+        var url = ImageryProvider.loadImage.calls.mostRecent().args[1];
+        expect('123'.indexOf(url.substring(0, 1))).toBeGreaterThanOrEqualTo(0);
+    });
+
+    it('supports subdomains array in URL', function() {
+        var provider = new WebMapServiceImageryProvider({
+            url : '{s}',
+            subdomains: ['foo', 'bar'],
+            layers : ''
+        });
+
+        var loadImageSpy = spyOn(ImageryProvider, 'loadImage');
+        provider.requestImage(0, 0, 0);
+        var url = ImageryProvider.loadImage.calls.mostRecent().args[1];
+        expect(['foo', 'bar'].indexOf(url.substring(0, 3))).toBeGreaterThanOrEqualTo(0);
+    });
+
     it('supports a question mark at the end of the URL', function() {
         var provider = new WebMapServiceImageryProvider({
             url : 'made/up/wms/server?',

--- a/Specs/Scene/WebMapTileServiceImageryProviderSpec.js
+++ b/Specs/Scene/WebMapTileServiceImageryProviderSpec.js
@@ -91,6 +91,48 @@ defineSuite([
         expect(parseInt(queryObject.tilerow, 10)).toEqual(tilerow);
     });
 
+    it('supports subdomains string urls', function() {
+        var options = {
+            url : '{s}',
+            layer : '',
+            style : '',
+            subdomains : '123',
+            tileMatrixSetID : ''
+        };
+
+        var provider = new WebMapTileServiceImageryProvider(options);
+
+        var loadImageSpy = spyOn(ImageryProvider, 'loadImage');
+
+        var tilecol = 1;
+        var tilerow = 1;
+        var level = 1;
+        provider.requestImage(tilecol, tilerow, level);
+        var url = ImageryProvider.loadImage.calls.mostRecent().args[1];
+        expect('123'.indexOf(url)).toBeGreaterThanOrEqualTo(0);
+    });
+
+    it('supports subdomains array urls', function() {
+        var options = {
+            url : '{s}',
+            layer : '',
+            style : '',
+            subdomains : ['foo', 'bar'],
+            tileMatrixSetID : ''
+        };
+
+        var provider = new WebMapTileServiceImageryProvider(options);
+
+        var loadImageSpy = spyOn(ImageryProvider, 'loadImage');
+
+        var tilecol = 1;
+        var tilerow = 1;
+        var level = 1;
+        provider.requestImage(tilecol, tilerow, level);
+        var url = ImageryProvider.loadImage.calls.mostRecent().args[1];
+        expect(['foo', 'bar'].indexOf(url)).toBeGreaterThanOrEqualTo(0);
+    });
+
     it('generates expected tile urls from template', function() {
         var options = {
             url : 'http://wmts.invalid/{style}/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.png',


### PR DESCRIPTION
Allows to specify `subdomains` to overcome browser limits on the number of simultaneous requests per host.

See https://cesiumjs.org/forum.html#!topic/cesium-dev/tCCooBxpZFU/discussion.