### PR TITLE
MapboxImageryProvider credit option

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@ Change Log
 * Deprecated
   * ...
 * Fix zooming in 2D when tracking an object. The zoom was based on location rather than the tracked object. [#2991](https://github.com/AnalyticalGraphicsInc/cesium/issues/2991)
+* Added `options.credit` parameter to `MapboxImageryProvider`.
 
 ### 1.13 - 2015-09-01
 

--- a/Source/Scene/MapboxImageryProvider.js
+++ b/Source/Scene/MapboxImageryProvider.js
@@ -56,7 +56,7 @@ define([
         var mapId = options.mapId;
         //>>includeStart('debug', pragmas.debug);
         if (!defined(mapId)) {
-            throw new DeveloperError('options.url is required.');
+            throw new DeveloperError('options.mapId is required.');
         }
         //>>includeEnd('debug');
 

--- a/Source/Scene/MapboxImageryProvider.js
+++ b/Source/Scene/MapboxImageryProvider.js
@@ -81,7 +81,8 @@ define([
             if (typeof credit === 'string') {
                 credit = new Credit(credit);
             }
-            defaultCredit2.push(credit);
+            defaultCredit1 = credit;
+            defaultCredit2.length = 0;
         }
 
         this._imageryProvider = new UrlTemplateImageryProvider({

--- a/Source/Scene/MapboxImageryProvider.js
+++ b/Source/Scene/MapboxImageryProvider.js
@@ -19,7 +19,7 @@ define([
 
     var trailingSlashRegex = /\/$/;
     var defaultCredit1 = new Credit('© Mapbox © OpenStreetMap', undefined, 'https://www.mapbox.com/about/maps/');
-    var defaultCredit2 = new Credit('Improve this map', undefined, 'https://www.mapbox.com/map-feedback/');
+    var defaultCredit2 = [new Credit('Improve this map', undefined, 'https://www.mapbox.com/map-feedback/')];
 
     /**
      * Provides tiled imagery hosted by Mapbox.
@@ -39,7 +39,7 @@ define([
      *                 to result in rendering problems.
      * @param {Number} [options.maximumLevel] The maximum level-of-detail supported by the imagery provider, or undefined if there is no limit.
      * @param {Rectangle} [options.rectangle=Rectangle.MAX_VALUE] The rectangle, in radians, covered by the image.
-
+     * @param {Credit|String} [options.credit] A credit for the data source, which is displayed on the canvas.
      *
      * @see {@link https://www.mapbox.com/developers/api/maps/#tiles}
      * @see {@link https://www.mapbox.com/developers/api/#access-tokens}
@@ -74,6 +74,14 @@ define([
         templateUrl += mapId + '/{z}/{x}/{y}.' + this._format;
         if (defined(this._accessToken)) {
             templateUrl += '?access_token=' + this._accessToken;
+        }
+
+        if (defined(options.credit)) {
+            var credit = options.credit;
+            if (typeof credit === 'string') {
+                credit = new Credit(credit);
+            }
+            defaultCredit2.push(credit);
         }
 
         this._imageryProvider = new UrlTemplateImageryProvider({
@@ -277,7 +285,7 @@ define([
      * @exception {DeveloperError} <code>getTileCredits</code> must not be called before the imagery provider is ready.
      */
     MapboxImageryProvider.prototype.getTileCredits = function(x, y, level) {
-        return [defaultCredit2];
+        return defaultCredit2;
     };
 
     /**

--- a/Specs/Scene/MapboxImageryProviderSpec.js
+++ b/Specs/Scene/MapboxImageryProviderSpec.js
@@ -205,6 +205,25 @@ defineSuite([
         expect(provider.minimumLevel).toEqual(1);
     });
 
+
+    it('when no credit is supplied, the provider adds a default credit', function() {
+        var provider = new MapboxImageryProvider({
+            url : 'made/up/mapbox/server/',
+            mapId: 'test-id'
+        });
+        expect(provider.credit.text).toEqual('© Mapbox © OpenStreetMap');
+    });
+
+    it('turns the supplied credit into a logo', function() {
+        var creditText = 'Thanks to our awesome made up source of this imagery!';
+        var providerWithCredit = new MapboxImageryProvider({
+            url : 'made/up/mapbox/server/',
+            mapId: 'test-id',
+            credit: creditText
+        });
+        expect(providerWithCredit.credit.text).toEqual(creditText);
+    });
+
     it('raises error event when image cannot be loaded', function() {
         var provider = new MapboxImageryProvider({
             url : 'made/up/mapbox/server/',


### PR DESCRIPTION
Fixes #3009

If a credit is passed in, I add it after the other two credits that Mapbox requires to use their imagery.  Should I replace the default credits instead?