### PR TITLE
replace tabs with spaces in GLSL files

### DIFF
--- a/Source/Shaders/Appearances/AllMaterialAppearanceFS.glsl
+++ b/Source/Shaders/Appearances/AllMaterialAppearanceFS.glsl
@@ -9,7 +9,7 @@ void main()
     vec3 positionToEyeEC = -v_positionEC; 
     mat3 tangentToEyeMatrix = czm_tangentToEyeSpaceMatrix(v_normalEC, v_tangentEC, v_binormalEC);
 
-	vec3 normalEC = normalize(v_normalEC);
+    vec3 normalEC = normalize(v_normalEC);
 #ifdef FACE_FORWARD
     normalEC = faceforward(normalEC, vec3(0.0, 0.0, 1.0), -normalEC);
 #endif

--- a/Source/Shaders/Appearances/BasicMaterialAppearanceFS.glsl
+++ b/Source/Shaders/Appearances/BasicMaterialAppearanceFS.glsl
@@ -5,7 +5,7 @@ void main()
 {
     vec3 positionToEyeEC = -v_positionEC; 
 
-	vec3 normalEC = normalize(v_normalEC);
+    vec3 normalEC = normalize(v_normalEC);
 #ifdef FACE_FORWARD
     normalEC = faceforward(normalEC, vec3(0.0, 0.0, 1.0), -normalEC);
 #endif

--- a/Source/Shaders/Appearances/EllipsoidSurfaceAppearanceFS.glsl
+++ b/Source/Shaders/Appearances/EllipsoidSurfaceAppearanceFS.glsl
@@ -6,7 +6,7 @@ void main()
 {
     czm_materialInput materialInput;
     
-	vec3 normalEC = normalize(czm_normal3D * czm_geodeticSurfaceNormal(v_positionMC, vec3(0.0), vec3(1.0)));
+    vec3 normalEC = normalize(czm_normal3D * czm_geodeticSurfaceNormal(v_positionMC, vec3(0.0), vec3(1.0)));
 #ifdef FACE_FORWARD
     normalEC = faceforward(normalEC, vec3(0.0, 0.0, 1.0), -normalEC);
 #endif

--- a/Source/Shaders/Appearances/PerInstanceColorAppearanceFS.glsl
+++ b/Source/Shaders/Appearances/PerInstanceColorAppearanceFS.glsl
@@ -6,7 +6,7 @@ void main()
 {
     vec3 positionToEyeEC = -v_positionEC;
     
-	vec3 normalEC = normalize(v_normalEC);
+    vec3 normalEC = normalize(v_normalEC);
 #ifdef FACE_FORWARD
     normalEC = faceforward(normalEC, vec3(0.0, 0.0, 1.0), -normalEC);
 #endif

--- a/Source/Shaders/Appearances/TexturedMaterialAppearanceFS.glsl
+++ b/Source/Shaders/Appearances/TexturedMaterialAppearanceFS.glsl
@@ -6,7 +6,7 @@ void main()
 {
     vec3 positionToEyeEC = -v_positionEC; 
 
-	vec3 normalEC = normalize(v_normalEC);;
+    vec3 normalEC = normalize(v_normalEC);;
 #ifdef FACE_FORWARD
     normalEC = faceforward(normalEC, vec3(0.0, 0.0, 1.0), -normalEC);
 #endif

--- a/Source/Shaders/Builtin/Functions/alphaWeight.glsl
+++ b/Source/Shaders/Builtin/Functions/alphaWeight.glsl
@@ -7,11 +7,11 @@ float czm_alphaWeight(float a)
     if (czm_sceneMode != czm_sceneMode2D)
     {
         float x = 2.0 * (gl_FragCoord.x - czm_viewport.x) / czm_viewport.z - 1.0;
-	    float y = 2.0 * (gl_FragCoord.y - czm_viewport.y) / czm_viewport.w - 1.0;
-	    z = (gl_FragCoord.z - czm_viewportTransformation[3][2]) / czm_viewportTransformation[2][2];
-	    vec4 q = vec4(x, y, z, 0.0);
-	    q /= gl_FragCoord.w;
-	    z = (czm_inverseProjectionOIT * q).z;
+        float y = 2.0 * (gl_FragCoord.y - czm_viewport.y) / czm_viewport.w - 1.0;
+        z = (gl_FragCoord.z - czm_viewportTransformation[3][2]) / czm_viewportTransformation[2][2];
+        vec4 q = vec4(x, y, z, 0.0);
+        q /= gl_FragCoord.w;
+        z = (czm_inverseProjectionOIT * q).z;
     }
     else
     {

--- a/Source/Shaders/GlobeFS.glsl
+++ b/Source/Shaders/GlobeFS.glsl
@@ -225,8 +225,8 @@ vec4 computeWaterColor(vec3 positionEyeCoordinates, vec2 textureCoordinates, mat
     float highAltitudeFade = linearFade(0.0, 60000.0, positionToEyeECLength);
     float lowAltitudeFade = 1.0 - linearFade(20000.0, 60000.0, positionToEyeECLength);
     vec3 normalTangentSpace = 
-    	(highAltitudeFade * normalTangentSpaceHighAltitude) + 
-    	(lowAltitudeFade * normalTangentSpaceLowAltitude);
+        (highAltitudeFade * normalTangentSpaceHighAltitude) + 
+        (lowAltitudeFade * normalTangentSpaceLowAltitude);
     normalTangentSpace = normalize(normalTangentSpace);
     
     // fade out the normal perturbation as we move farther from the water surface

--- a/Source/Shaders/GlobeFSPole.glsl
+++ b/Source/Shaders/GlobeFSPole.glsl
@@ -14,12 +14,12 @@ void main()
     {
         vec3 positionEC = czm_pointAlongRay(ray, intersection.start);
         vec3 positionMC = (czm_inverseModelView * vec4(positionEC, 1.0)).xyz;
-	    
-	    vec3 normalMC = normalize(czm_geodeticSurfaceNormal(positionMC, vec3(0.0), vec3(1.0)));
-	    vec3 normalEC = normalize(czm_normal * normalMC);
-	    
+        
+        vec3 normalMC = normalize(czm_geodeticSurfaceNormal(positionMC, vec3(0.0), vec3(1.0)));
+        vec3 normalEC = normalize(czm_normal * normalMC);
+        
         vec3 startDayColor = u_color;
-		
+        
         gl_FragColor = vec4(startDayColor, 1.0);
     }
     else


### PR DESCRIPTION
done with:

    find . -iname '*.glsl' -exec sed -i -r 's/\t/    /g' {} \;

There are also trailing spaces, but I don't see that they are forbidden in the [Coding Conventions](https://github.com/AnalyticalGraphicsInc/cesium/wiki/JavaScript-Coding-Conventions).