### PR TITLE
Billboard size in meters

### DIFF
--- a/Apps/Sandcastle/gallery/Billboards.html
+++ b/Apps/Sandcastle/gallery/Billboards.html
@@ -77,6 +77,20 @@ function changeBillboardProperties() {
     billboard.color = Cesium.Color.WHITE.withAlpha(0.25);
 }
 
+function sizeBillboardInMeters() {
+    Sandcastle.declare(sizeBillboardInMeters);
+    
+    var entity = viewer.entities.add({
+        position : Cesium.Cartesian3.fromDegrees(-75.59777, 40.03883),
+        billboard : {
+            image : '../images/Cesium_Logo_overlay.png',
+            sizeInMeters : true
+        }
+    });
+    
+    viewer.zoomTo(entity);
+}
+
 function addMultipleBillboards() {
     Sandcastle.declare(addMultipleBillboards);
 
@@ -224,6 +238,12 @@ Sandcastle.addToolbarMenu([{
     onselect : function() {
         changeBillboardProperties();
         Sandcastle.highlight(changeBillboardProperties);
+    }
+}, {
+    text : 'Size billboard in meters',
+    onselect : function() {
+        sizeBillboardInMeters();
+        Sandcastle.highlight(sizeBillboardInMeters);
     }
 }, {
     text : 'Add multiple billboards',

--- a/Apps/Sandcastle/gallery/development/Billboards.html
+++ b/Apps/Sandcastle/gallery/development/Billboards.html
@@ -57,7 +57,8 @@ function setBillboardProperties() {
         rotation : Cesium.Math.PI_OVER_FOUR, // default: 0.0
         alignedAxis : Cesium.Cartesian3.ZERO, // default
         width : 100, // default: undefined
-        height : 25 // default: undefined
+        height : 25, // default: undefined
+        sizeInMeters : false // default
     });
 }
 
@@ -75,6 +76,23 @@ function changeBillboardProperties() {
     b.position = Cesium.Cartesian3.fromDegrees(-75.59777, 40.03883, 300000.0);
     b.scale = 3.0;
     b.color = new Cesium.Color(1.0, 1.0, 1.0, 0.25);
+}
+
+function sizeBillboardInMeters() {
+    Sandcastle.declare(sizeBillboardInMeters);
+    
+    var center = Cesium.Cartesian3.fromDegrees(-75.59777, 40.03883);
+    var heading = Cesium.Math.toRadians(50.0);
+    var pitch = Cesium.Math.toRadians(-20.0);
+    var range = 100.0;
+    viewer.camera.lookAt(center, new Cesium.HeadingPitchRange(heading, pitch, range));
+    
+    var billboards = scene.primitives.add(new Cesium.BillboardCollection());
+    billboards.add({
+        image : '../images/Cesium_Logo_overlay.png',
+        sizeInMeters : true,
+        position : Cesium.Cartesian3.fromDegrees(-75.59777, 40.03883)
+    });
 }
 
 function addMultipleBillboards() {
@@ -280,6 +298,12 @@ Sandcastle.addToolbarMenu([{
     onselect : function() {
         changeBillboardProperties();
         Sandcastle.highlight(changeBillboardProperties);
+    }
+}, {
+    text : 'Size billboard in meters',
+    onselect : function() {
+        sizeBillboardInMeters();
+        Sandcastle.highlight(sizeBillboardInMeters);
     }
 }, {
     text : 'Add multiple billboards',

--- a/Apps/Sandcastle/gallery/development/Billboards.html
+++ b/Apps/Sandcastle/gallery/development/Billboards.html
@@ -91,7 +91,7 @@ function sizeBillboardInMeters() {
     billboards.add({
         image : '../images/Cesium_Logo_overlay.png',
         sizeInMeters : true,
-        position : Cesium.Cartesian3.fromDegrees(-75.59777, 40.03883)
+        position : center
     });
 }
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,7 @@ Change Log
 * Fixed issues causing the terrain and sky to disappear when the camera is near the surface. [#2415](https://github.com/AnalyticalGraphicsInc/cesium/issues/2415) and [#2271](https://github.com/AnalyticalGraphicsInc/cesium/issues/2271)
 * Changed the `ScreenSpaceCameraController.minimumZoomDistance` default from `20.0` to `1.0`.
 * Used all the template urls defined in the CesiumTerrain provider.[#3038](https://github.com/AnalyticalGraphicsInc/cesium/pull/3038)
+* Added `Billboard.sizeInMeters`. `true` sets the billboard size to be measured in meters; otherwise, the size of the billboard is measured in pixels.
 
 ### 1.13 - 2015-09-01
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,7 +19,7 @@ Change Log
 * Fixed issues causing the terrain and sky to disappear when the camera is near the surface. [#2415](https://github.com/AnalyticalGraphicsInc/cesium/issues/2415) and [#2271](https://github.com/AnalyticalGraphicsInc/cesium/issues/2271)
 * Changed the `ScreenSpaceCameraController.minimumZoomDistance` default from `20.0` to `1.0`.
 * Used all the template urls defined in the CesiumTerrain provider.[#3038](https://github.com/AnalyticalGraphicsInc/cesium/pull/3038)
-* Added `Billboard.sizeInMeters`. `true` sets the billboard size to be measured in meters; otherwise, the size of the billboard is measured in pixels.
+* Added `Billboard.sizeInMeters`. `true` sets the billboard size to be measured in meters; otherwise, the size of the billboard is measured in pixels. Also added support for billboard `sizeInMeters` to entities and CZML.
 
 ### 1.13 - 2015-09-01
 

--- a/Source/DataSources/BillboardGraphics.js
+++ b/Source/DataSources/BillboardGraphics.js
@@ -44,6 +44,7 @@ define([
      * @param {Property} [options.translucencyByDistance] A {@link NearFarScalar} Property used to set translucency based on distance from the camera.
      * @param {Property} [options.pixelOffsetScaleByDistance] A {@link NearFarScalar} Property used to set pixelOffset based on distance from the camera.
      * @param {Property} [options.imageSubRegion] A Property specifying a {@link BoundingRectangle} that defines a sub-region of the image to use for the billboard, rather than the entire image.
+     * @param {Property} [options.sizeInMeters] A boolean Property specifying whether this billboard's size should be measured in meters.
      *
      * @demo {@link http://cesiumjs.org/Cesium/Apps/Sandcastle/index.html?src=Billboards.html|Cesium Sandcastle Billboard Demo}
      */
@@ -80,6 +81,8 @@ define([
         this._translucencyByDistanceSubscription = undefined;
         this._pixelOffsetScaleByDistance = undefined;
         this._pixelOffsetScaleByDistanceSubscription = undefined;
+        this._sizeInMeters = undefined;
+        this._sizeInMetersSubscription = undefined;
         this._definitionChanged = new Event();
 
         this.merge(defaultValue(options, defaultValue.EMPTY_OBJECT));
@@ -283,7 +286,15 @@ define([
          * @memberof BillboardGraphics.prototype
          * @type {Property}
          */
-        pixelOffsetScaleByDistance : createPropertyDescriptor('pixelOffsetScaleByDistance')
+        pixelOffsetScaleByDistance : createPropertyDescriptor('pixelOffsetScaleByDistance'),
+
+        /**
+         * Gets or sets the boolean Property specifying if this billboard's size will be measured in meters.
+         * @memberof BillboardGraphics.prototype
+         * @type {Property}
+         * @default false
+         */
+        sizeInMeters : createPropertyDescriptor('sizeInMeters')
     });
 
     /**
@@ -312,6 +323,7 @@ define([
         result.scaleByDistance = this._scaleByDistance;
         result.translucencyByDistance = this._translucencyByDistance;
         result.pixelOffsetScaleByDistance = this._pixelOffsetScaleByDistance;
+        result.sizeInMeters = this._sizeInMeters;
         return result;
     };
 
@@ -344,6 +356,7 @@ define([
         this.scaleByDistance = defaultValue(this._scaleByDistance, source.scaleByDistance);
         this.translucencyByDistance = defaultValue(this._translucencyByDistance, source.translucencyByDistance);
         this.pixelOffsetScaleByDistance = defaultValue(this._pixelOffsetScaleByDistance, source.pixelOffsetScaleByDistance);
+        this.sizeInMeters = defaultValue(this._sizeInMeters, source.sizeInMeters);
     };
 
     return BillboardGraphics;

--- a/Source/DataSources/BillboardVisualizer.js
+++ b/Source/DataSources/BillboardVisualizer.js
@@ -39,6 +39,7 @@ define([
     var defaultAlignedAxis = Cartesian3.ZERO;
     var defaultHorizontalOrigin = HorizontalOrigin.CENTER;
     var defaultVerticalOrigin = VerticalOrigin.CENTER;
+    var defaultSizeInMeters = false;
 
     var position = new Cartesian3();
     var color = new Color();
@@ -158,6 +159,7 @@ define([
             billboard.scaleByDistance = Property.getValueOrUndefined(billboardGraphics._scaleByDistance, time, scaleByDistance);
             billboard.translucencyByDistance = Property.getValueOrUndefined(billboardGraphics._translucencyByDistance, time, translucencyByDistance);
             billboard.pixelOffsetScaleByDistance = Property.getValueOrUndefined(billboardGraphics._pixelOffsetScaleByDistance, time, pixelOffsetScaleByDistance);
+            billboard.sizeInMeters = Property.getValueOrDefault(billboardGraphics._sizeInMeters, defaultSizeInMeters);
 
             var subRegion = Property.getValueOrUndefined(billboardGraphics._imageSubRegion, time, boundingRectangle);
             if (defined(subRegion)) {

--- a/Source/DataSources/CzmlDataSource.js
+++ b/Source/DataSources/CzmlDataSource.js
@@ -1015,6 +1015,7 @@ define([
         processPacketData(Cartesian3, billboard, 'alignedAxis', billboardData.alignedAxis, interval, sourceUri, entityCollection);
         processPacketData(Boolean, billboard, 'show', billboardData.show, interval, sourceUri, entityCollection);
         processPacketData(VerticalOrigin, billboard, 'verticalOrigin', billboardData.verticalOrigin, interval, sourceUri, entityCollection);
+        processPacketData(Boolean, billboard, 'sizeInMeters', billboardData.sizeInMeters, interval, sourceUri, entityCollection);
     }
 
     function processDocument(packet, dataSource) {

--- a/Source/Renderer/AutomaticUniforms.js
+++ b/Source/Renderer/AutomaticUniforms.js
@@ -1087,6 +1087,12 @@ define([
             }
         }),
 
+        /**
+         * Defines the top clipping plane.
+         *
+         * @alias czm_frustumTop
+         * @glslUniform
+         */
         czm_frustumTop : new AutomaticUniform({
             size : 1,
             datatype : WebGLConstants.FLOAT,
@@ -1095,6 +1101,12 @@ define([
             }
         }),
 
+        /**
+         * Defines the bottom clipping plane.
+         *
+         * @alias czm_frustumBottom
+         * @glslUniform
+         */
         czm_frustumBottom : new AutomaticUniform({
             size : 1,
             datatype : WebGLConstants.FLOAT,
@@ -1103,6 +1115,12 @@ define([
             }
         }),
 
+        /**
+         * Defines the right clipping plane.
+         *
+         * @alias czm_frustumRight
+         * @glslUniform
+         */
         czm_frustumRight : new AutomaticUniform({
             size : 1,
             datatype : WebGLConstants.FLOAT,
@@ -1111,6 +1129,12 @@ define([
             }
         }),
 
+        /**
+         * Defines the left clipping plane.
+         *
+         * @alias czm_frustumLeft
+         * @glslUniform
+         */
         czm_frustumLeft : new AutomaticUniform({
             size : 1,
             datatype : WebGLConstants.FLOAT,

--- a/Source/Renderer/AutomaticUniforms.js
+++ b/Source/Renderer/AutomaticUniforms.js
@@ -1087,6 +1087,38 @@ define([
             }
         }),
 
+        czm_frustumTop : new AutomaticUniform({
+            size : 1,
+            datatype : WebGLConstants.FLOAT,
+            getValue : function(uniformState) {
+                return uniformState.frustumTop;
+            }
+        }),
+
+        czm_frustumBottom : new AutomaticUniform({
+            size : 1,
+            datatype : WebGLConstants.FLOAT,
+            getValue : function(uniformState) {
+                return uniformState.frustumBottom;
+            }
+        }),
+
+        czm_frustumRight : new AutomaticUniform({
+            size : 1,
+            datatype : WebGLConstants.FLOAT,
+            getValue : function(uniformState) {
+                return uniformState.frustumRight;
+            }
+        }),
+
+        czm_frustumLeft : new AutomaticUniform({
+            size : 1,
+            datatype : WebGLConstants.FLOAT,
+            getValue : function(uniformState) {
+                return uniformState.frustumLeft;
+            }
+        }),
+
         /**
          * An automatic GLSL uniform representing the sun position in world coordinates.
          *

--- a/Source/Renderer/AutomaticUniforms.js
+++ b/Source/Renderer/AutomaticUniforms.js
@@ -1088,58 +1088,17 @@ define([
         }),
 
         /**
-         * Defines the top clipping plane.
+         * The distances to the frustum planes. The top, bottom, left and right distances are
+         * the x, y, z, and w components, respectively.
          *
-         * @alias czm_frustumTop
+         * @alias czm_frustumPlanes
          * @glslUniform
          */
-        czm_frustumTop : new AutomaticUniform({
+        czm_frustumPlanes : new AutomaticUniform({
             size : 1,
-            datatype : WebGLConstants.FLOAT,
+            datatype : WebGLConstants.FLOAT_VEC4,
             getValue : function(uniformState) {
-                return uniformState.frustumTop;
-            }
-        }),
-
-        /**
-         * Defines the bottom clipping plane.
-         *
-         * @alias czm_frustumBottom
-         * @glslUniform
-         */
-        czm_frustumBottom : new AutomaticUniform({
-            size : 1,
-            datatype : WebGLConstants.FLOAT,
-            getValue : function(uniformState) {
-                return uniformState.frustumBottom;
-            }
-        }),
-
-        /**
-         * Defines the right clipping plane.
-         *
-         * @alias czm_frustumRight
-         * @glslUniform
-         */
-        czm_frustumRight : new AutomaticUniform({
-            size : 1,
-            datatype : WebGLConstants.FLOAT,
-            getValue : function(uniformState) {
-                return uniformState.frustumRight;
-            }
-        }),
-
-        /**
-         * Defines the left clipping plane.
-         *
-         * @alias czm_frustumLeft
-         * @glslUniform
-         */
-        czm_frustumLeft : new AutomaticUniform({
-            size : 1,
-            datatype : WebGLConstants.FLOAT,
-            getValue : function(uniformState) {
-                return uniformState.frustumLeft;
+                return uniformState.frustumPlanes;
             }
         }),
 

--- a/Source/Renderer/UniformState.js
+++ b/Source/Renderer/UniformState.js
@@ -53,10 +53,7 @@ define([
         this._infiniteProjection = Matrix4.clone(Matrix4.IDENTITY);
         this._entireFrustum = new Cartesian2();
         this._currentFrustum = new Cartesian2();
-        this._frustumTop = undefined;
-        this._frustumBottom = undefined;
-        this._frustumRight = undefined;
-        this._frustumLeft = undefined;
+        this._frustumPlanes = new Cartesian4();
 
         this._frameState = undefined;
         this._temeToPseudoFixed = Matrix3.clone(Matrix4.IDENTITY);
@@ -637,42 +634,14 @@ define([
         },
 
         /**
+         * The distances to the frustum planes. The top, bottom, left and right distances are
+         * the x, y, z, and w components, respectively.
          * @memberof UniformState.prototype
-         * @type {Number}
+         * @type {Cartesian4}
          */
-        frustumTop : {
+        frustumPlanes : {
             get : function() {
-                return this._frustumTop;
-            }
-        },
-
-        /**
-         * @memberof UniformState.prototype
-         * @type {Number}
-         */
-        frustumBottom : {
-            get : function() {
-                return this._frustumBottom;
-            }
-        },
-
-        /**
-         * @memberof UniformState.prototype
-         * @type {Number}
-         */
-        frustumRight : {
-            get : function() {
-                return this._frustumRight;
-            }
-        },
-
-        /**
-         * @memberof UniformState.prototype
-         * @type {Number}
-         */
-        frustumLeft : {
-            get : function() {
-                return this._frustumLeft;
+                return this._frustumPlanes;
             }
         },
 
@@ -893,10 +862,10 @@ define([
             frustum = frustum._offCenterFrustum;
         }
 
-        this._frustumTop = frustum.top;
-        this._frustumBottom = frustum.bottom;
-        this._frustumRight = frustum.right;
-        this._frustumLeft = frustum.left;
+        this._frustumPlanes.x = frustum.top;
+        this._frustumPlanes.y = frustum.bottom;
+        this._frustumPlanes.z = frustum.left;
+        this._frustumPlanes.w = frustum.right;
     };
 
     /**

--- a/Source/Renderer/UniformState.js
+++ b/Source/Renderer/UniformState.js
@@ -636,24 +636,40 @@ define([
             }
         },
 
+        /**
+         * @memberof UniformState.prototype
+         * @type {Number}
+         */
         frustumTop : {
             get : function() {
                 return this._frustumTop;
             }
         },
 
+        /**
+         * @memberof UniformState.prototype
+         * @type {Number}
+         */
         frustumBottom : {
             get : function() {
                 return this._frustumBottom;
             }
         },
 
+        /**
+         * @memberof UniformState.prototype
+         * @type {Number}
+         */
         frustumRight : {
             get : function() {
                 return this._frustumRight;
             }
         },
 
+        /**
+         * @memberof UniformState.prototype
+         * @type {Number}
+         */
         frustumLeft : {
             get : function() {
                 return this._frustumLeft;

--- a/Source/Renderer/UniformState.js
+++ b/Source/Renderer/UniformState.js
@@ -53,6 +53,10 @@ define([
         this._infiniteProjection = Matrix4.clone(Matrix4.IDENTITY);
         this._entireFrustum = new Cartesian2();
         this._currentFrustum = new Cartesian2();
+        this._frustumTop = undefined;
+        this._frustumBottom = undefined;
+        this._frustumRight = undefined;
+        this._frustumLeft = undefined;
 
         this._frameState = undefined;
         this._temeToPseudoFixed = Matrix3.clone(Matrix4.IDENTITY);
@@ -632,6 +636,30 @@ define([
             }
         },
 
+        frustumTop : {
+            get : function() {
+                return this._frustumTop;
+            }
+        },
+
+        frustumBottom : {
+            get : function() {
+                return this._frustumBottom;
+            }
+        },
+
+        frustumRight : {
+            get : function() {
+                return this._frustumRight;
+            }
+        },
+
+        frustumLeft : {
+            get : function() {
+                return this._frustumLeft;
+            }
+        },
+
         /**
          * The the height (<code>x</code>) and the height squared (<code>y</code>)
          * in meters of the camera above the 2D world plane. This uniform is only valid
@@ -844,6 +872,15 @@ define([
         }
         this._currentFrustum.x = frustum.near;
         this._currentFrustum.y = frustum.far;
+
+        if (!defined(frustum.top)) {
+            frustum = frustum._offCenterFrustum;
+        }
+
+        this._frustumTop = frustum.top;
+        this._frustumBottom = frustum.bottom;
+        this._frustumRight = frustum.right;
+        this._frustumLeft = frustum.left;
     };
 
     /**

--- a/Source/Scene/Billboard.js
+++ b/Source/Scene/Billboard.js
@@ -695,6 +695,13 @@ define([
             }
         },
 
+        /**
+         * Gets or sets if the billboard size is in meters or pixels. <code>true</code> to size the billboard in meters;
+         * otherwise, the size is in pixels.
+         * @memberof Billboard.prototype
+         * @type {Boolean}
+         * @default false
+         */
         sizeInMeters : {
             get : function() {
                 return this._sizeInMeters;

--- a/Source/Scene/Billboard.js
+++ b/Source/Scene/Billboard.js
@@ -103,6 +103,7 @@ define([
         this._translucencyByDistance = options.translucencyByDistance;
         this._pixelOffsetScaleByDistance = options.pixelOffsetScaleByDistance;
         this._heightReference = defaultValue(options.heightReference, HeightReference.NONE);
+        this._sizeInMeters = defaultValue(options.sizeInMeters, false);
         this._id = options.id;
         this._collection = defaultValue(options.collection, billboardCollection);
 
@@ -690,6 +691,18 @@ define([
                 if (this._height !== value) {
                     this._height = value;
                     makeDirty(this, IMAGE_INDEX_INDEX);
+                }
+            }
+        },
+
+        sizeInMeters : {
+            get : function() {
+                return this._sizeInMeters;
+            },
+            set : function(value) {
+                if (this._sizeInMeters !== value) {
+                    this._sizeInMeters = value;
+                    makeDirty(this, COLOR_INDEX);
                 }
             }
         },

--- a/Source/Scene/BillboardCollection.js
+++ b/Source/Scene/BillboardCollection.js
@@ -84,7 +84,7 @@ define([
         positionLowAndRotation : 1,
         compressedAttribute0 : 2,        // pixel offset, translate, horizontal origin, vertical origin, show, texture coordinates, direction
         compressedAttribute1 : 3,        // aligned axis, translucency by distance, image width
-        compressedAttribute2 : 4,        // image height, color, pick color, 2 bytes free
+        compressedAttribute2 : 4,        // image height, color, pick color, 15 bits free
         eyeOffset : 5,
         scaleByDistance : 6,
         pixelOffsetScaleByDistance : 7
@@ -832,6 +832,7 @@ define([
 
         var color = billboard.color;
         var pickColor = billboard.getPickId(context).color;
+        var sizeInMeters = billboard.sizeInMeters ? 1.0 : 0.0;
 
         var height = 0;
         var index = billboard._imageIndex;
@@ -861,7 +862,7 @@ define([
         blue = Color.floatToByte(pickColor.blue);
         var compressed1 = red * LEFT_SHIFT16 + green * LEFT_SHIFT8 + blue;
 
-        var compressed2 = Color.floatToByte(color.alpha) * LEFT_SHIFT8 + Color.floatToByte(pickColor.alpha);
+        var compressed2 = Color.floatToByte(color.alpha) * LEFT_SHIFT16 + Color.floatToByte(pickColor.alpha) * LEFT_SHIFT8 + sizeInMeters;
 
         var writer = vafWriters[attributeLocations.compressedAttribute2];
         writer(i + 0, compressed0, compressed1, compressed2, imageHeight);

--- a/Source/Scene/BillboardCollection.js
+++ b/Source/Scene/BillboardCollection.js
@@ -183,6 +183,7 @@ define([
         this._maxPixelOffset = 0.0;
         this._allHorizontalCenter = true;
         this._allVerticalCenter = true;
+        this._allSizedInMeters = true;
 
         this._baseVolume = new BoundingSphere();
         this._baseVolumeWC = new BoundingSphere();
@@ -834,6 +835,8 @@ define([
         var pickColor = billboard.getPickId(context).color;
         var sizeInMeters = billboard.sizeInMeters ? 1.0 : 0.0;
 
+        billboardCollection._allSizedInMeters = billboardCollection._allSizedInMeters && sizeInMeters === 1.0;
+
         var height = 0;
         var index = billboard._imageIndex;
         if (index !== -1) {
@@ -1009,17 +1012,20 @@ define([
     var scratchToCenter = new Cartesian3();
     var scratchProj = new Cartesian3();
     function updateBoundingVolume(collection, context, frameState, boundingVolume) {
-        var camera = frameState.camera;
-        var frustum = camera.frustum;
+        var pixelScale = 1.0;
+        if (!collection._allSizedInMeters || collection._maxPixelOffset !== 0.0) {
+            var camera = frameState.camera;
+            var frustum = camera.frustum;
 
-        var toCenter = Cartesian3.subtract(camera.positionWC, boundingVolume.center, scratchToCenter);
-        var proj = Cartesian3.multiplyByScalar(camera.directionWC, Cartesian3.dot(toCenter, camera.directionWC), scratchProj);
-        var distance = Math.max(0.0, Cartesian3.magnitude(proj) - boundingVolume.radius);
+            var toCenter = Cartesian3.subtract(camera.positionWC, boundingVolume.center, scratchToCenter);
+            var proj = Cartesian3.multiplyByScalar(camera.directionWC, Cartesian3.dot(toCenter, camera.directionWC), scratchProj);
+            var distance = Math.max(0.0, Cartesian3.magnitude(proj) - boundingVolume.radius);
 
-        scratchDrawingBufferDimensions.x = context.drawingBufferWidth;
-        scratchDrawingBufferDimensions.y = context.drawingBufferHeight;
-        var pixelSize = frustum.getPixelSize(scratchDrawingBufferDimensions, distance);
-        var pixelScale = Math.max(pixelSize.x, pixelSize.y);
+            scratchDrawingBufferDimensions.x = context.drawingBufferWidth;
+            scratchDrawingBufferDimensions.y = context.drawingBufferHeight;
+            var pixelSize = frustum.getPixelSize(scratchDrawingBufferDimensions, distance);
+            pixelScale = Math.max(pixelSize.x, pixelSize.y);
+        }
 
         var size = pixelScale * collection._maxScale * collection._maxSize * 2.0;
         if (collection._allHorizontalCenter && collection._allVerticalCenter ) {

--- a/Source/Shaders/BillboardCollectionVS.glsl
+++ b/Source/Shaders/BillboardCollectionVS.glsl
@@ -2,7 +2,7 @@ attribute vec4 positionHighAndScale;
 attribute vec4 positionLowAndRotation;   
 attribute vec4 compressedAttribute0;        // pixel offset, translate, horizontal origin, vertical origin, show, texture coordinates, direction
 attribute vec4 compressedAttribute1;        // aligned axis, translucency by distance, image width
-attribute vec4 compressedAttribute2;        // image height, color, pick color, 2 bytes free
+attribute vec4 compressedAttribute2;        // image height, color, pick color, 15 bits free
 attribute vec3 eyeOffset;                   // eye offset in meters
 attribute vec4 scaleByDistance;             // near, nearScale, far, farScale
 attribute vec4 pixelOffsetScaleByDistance;  // near, nearScale, far, farScale
@@ -32,13 +32,17 @@ const float SHIFT_RIGHT3 = 1.0 / 8.0;
 const float SHIFT_RIGHT2 = 1.0 / 4.0;
 const float SHIFT_RIGHT1 = 1.0 / 2.0;
 
-vec4 computePositionWindowCoordinates(vec4 positionEC, vec2 imageSize, float scale, vec2 direction, vec2 origin, vec2 translate, vec2 pixelOffset, vec3 alignedAxis, float rotation)
+vec4 computePositionWindowCoordinates(vec4 positionEC, vec2 imageSize, float scale, vec2 direction, vec2 origin, vec2 translate, vec2 pixelOffset, vec3 alignedAxis, float rotation, bool sizeInMeters)
 {
-    vec4 positionWC = czm_eyeToWindowCoordinates(positionEC);
-    
     vec2 halfSize = imageSize * scale * czm_resolutionScale;
     halfSize *= ((direction * 2.0) - 1.0);
     
+    if (sizeInMeters)
+    {
+        positionEC.xy += halfSize;
+    }
+    
+    vec4 positionWC = czm_eyeToWindowCoordinates(positionEC);
     positionWC.xy += (origin * abs(halfSize));
     
 #if defined(ROTATION) || defined(ALIGNED_AXIS)
@@ -61,7 +65,11 @@ vec4 computePositionWindowCoordinates(vec4 positionEC, vec2 imageSize, float sca
     }
 #endif
     
-    positionWC.xy += halfSize;
+    if (!sizeInMeters)
+    {
+        positionWC.xy += halfSize;
+    }
+    
     positionWC.xy += translate;
     positionWC.xy += (pixelOffset * czm_resolutionScale);
     
@@ -155,6 +163,8 @@ void main()
     color.r = floor(temp);
     
     temp = compressedAttribute2.z * SHIFT_RIGHT8;
+    bool sizeInMeters = (temp - floor(temp)) * SHIFT_LEFT8 > 0.0;
+    temp = floor(temp) * SHIFT_RIGHT8;
     
 #ifdef RENDER_FOR_PICK
     color.a = (temp - floor(temp)) * SHIFT_LEFT8;
@@ -219,7 +229,7 @@ void main()
     origin.y = 1.0;
 #endif
 
-    vec4 positionWC = computePositionWindowCoordinates(positionEC, imageSize, scale, direction, origin, translate, pixelOffset, alignedAxis, rotation);
+    vec4 positionWC = computePositionWindowCoordinates(positionEC, imageSize, scale, direction, origin, translate, pixelOffset, alignedAxis, rotation, sizeInMeters);
     gl_Position = czm_viewportOrthographic * vec4(positionWC.xy, -positionWC.z, 1.0);
     v_textureCoordinates = textureCoordinates;
 

--- a/Source/Shaders/BillboardCollectionVS.glsl
+++ b/Source/Shaders/BillboardCollectionVS.glsl
@@ -43,7 +43,15 @@ vec4 computePositionWindowCoordinates(vec4 positionEC, vec2 imageSize, float sca
     }
     
     vec4 positionWC = czm_eyeToWindowCoordinates(positionEC);
-    positionWC.xy += (origin * abs(halfSize));
+    
+    if (sizeInMeters)
+    {
+        positionWC.xy += (origin * abs(halfSize)) / czm_metersPerPixel(positionEC);
+    }
+    else
+    {
+        positionWC.xy += (origin * abs(halfSize));
+    }
     
 #if defined(ROTATION) || defined(ALIGNED_AXIS)
     if (!all(equal(alignedAxis, vec3(0.0))) || rotation != 0.0)

--- a/Source/Shaders/Builtin/Functions/metersPerPixel.glsl
+++ b/Source/Shaders/Builtin/Functions/metersPerPixel.glsl
@@ -12,23 +12,24 @@ float czm_metersPerPixel(vec4 positionEC)
 {
     float width = czm_viewport.z;
     float height = czm_viewport.w;
-    float pixelWidth, pixelHeight;
+    float pixelWidth;
+    float pixelHeight;
     
     if (czm_sceneMode == czm_sceneMode2D)
     {
-	    float frustumWidth = czm_frustumRight - czm_frustumLeft;
-	    float frustumHeight = czm_frustumTop - czm_frustumBottom;
-	    pixelWidth = frustumWidth / width;
-	    pixelHeight = frustumHeight / height;
+        float frustumWidth = czm_frustumRight - czm_frustumLeft;
+        float frustumHeight = czm_frustumTop - czm_frustumBottom;
+        pixelWidth = frustumWidth / width;
+        pixelHeight = frustumHeight / height;
     }
     else
     {
         float distanceToPixel = -positionEC.z;
-	    float inverseNear = 1.0 / czm_currentFrustum.x;
-	    float tanTheta = czm_frustumTop * inverseNear;
-	    pixelHeight = 2.0 * distanceToPixel * tanTheta / height;
-	    tanTheta = czm_frustumRight * inverseNear;
-	    pixelWidth = 2.0 * distanceToPixel * tanTheta / width;
+        float inverseNear = 1.0 / czm_currentFrustum.x;
+        float tanTheta = czm_frustumTop * inverseNear;
+        pixelHeight = 2.0 * distanceToPixel * tanTheta / height;
+        tanTheta = czm_frustumRight * inverseNear;
+        pixelWidth = 2.0 * distanceToPixel * tanTheta / width;
     }
 
     return max(pixelWidth, pixelHeight);

--- a/Source/Shaders/Builtin/Functions/metersPerPixel.glsl
+++ b/Source/Shaders/Builtin/Functions/metersPerPixel.glsl
@@ -1,0 +1,34 @@
+/**
+ * @name czm_metersPerPixel
+ * @glslFunction
+ *
+ * @param {vec3} positionEC The position to get the meters per pixel in eye coordinates.
+ *
+ * @returns {float} The meters per pixel at positionEC.
+ */
+float czm_metersPerPixel(vec4 positionEC)
+{
+    float width = czm_viewport.z;
+    float height = czm_viewport.w;
+    float pixelWidth, pixelHeight;
+    
+    if (czm_sceneMode == czm_sceneMode2D)
+    {
+	    float frustumWidth = czm_frustumRight - czm_frustumLeft;
+	    float frustumHeight = czm_frustumTop - czm_frustumBottom;
+	    pixelWidth = frustumWidth / width;
+	    pixelHeight = frustumHeight / height;
+    }
+    else
+    {
+        float distanceToPixel = -positionEC.z;
+	    float inverseNear = 1.0 / czm_currentFrustum.x;
+	    float tanTheta = czm_frustumTop * inverseNear;
+	    pixelHeight = 2.0 * distanceToPixel * tanTheta / height;
+	    tanTheta = czm_frustumRight * inverseNear;
+	    pixelWidth = 2.0 * distanceToPixel * tanTheta / width;
+    }
+
+    float pixelSize = max(pixelWidth, pixelHeight);
+    return pixelSize;
+}

--- a/Source/Shaders/Builtin/Functions/metersPerPixel.glsl
+++ b/Source/Shaders/Builtin/Functions/metersPerPixel.glsl
@@ -15,10 +15,15 @@ float czm_metersPerPixel(vec4 positionEC)
     float pixelWidth;
     float pixelHeight;
     
+    float top = czm_frustumPlanes.x;
+    float bottom = czm_frustumPlanes.y;
+    float left = czm_frustumPlanes.z;
+    float right = czm_frustumPlanes.w;
+    
     if (czm_sceneMode == czm_sceneMode2D)
     {
-        float frustumWidth = czm_frustumRight - czm_frustumLeft;
-        float frustumHeight = czm_frustumTop - czm_frustumBottom;
+        float frustumWidth = right - left;
+        float frustumHeight = top - bottom;
         pixelWidth = frustumWidth / width;
         pixelHeight = frustumHeight / height;
     }
@@ -26,9 +31,9 @@ float czm_metersPerPixel(vec4 positionEC)
     {
         float distanceToPixel = -positionEC.z;
         float inverseNear = 1.0 / czm_currentFrustum.x;
-        float tanTheta = czm_frustumTop * inverseNear;
+        float tanTheta = top * inverseNear;
         pixelHeight = 2.0 * distanceToPixel * tanTheta / height;
-        tanTheta = czm_frustumRight * inverseNear;
+        tanTheta = right * inverseNear;
         pixelWidth = 2.0 * distanceToPixel * tanTheta / width;
     }
 

--- a/Source/Shaders/Builtin/Functions/metersPerPixel.glsl
+++ b/Source/Shaders/Builtin/Functions/metersPerPixel.glsl
@@ -1,4 +1,6 @@
 /**
+ * Computes the size of a pixel in meters at a distance from the eye.
+ 
  * @name czm_metersPerPixel
  * @glslFunction
  *
@@ -29,6 +31,5 @@ float czm_metersPerPixel(vec4 positionEC)
 	    pixelWidth = 2.0 * distanceToPixel * tanTheta / width;
     }
 
-    float pixelSize = max(pixelWidth, pixelHeight);
-    return pixelSize;
+    return max(pixelWidth, pixelHeight);
 }

--- a/Specs/DataSources/BillboardGraphicsSpec.js
+++ b/Specs/DataSources/BillboardGraphicsSpec.js
@@ -36,7 +36,8 @@ defineSuite([
             height : 12,
             scaleByDistance : new NearFarScalar(13, 14, 15, 16),
             translucencyByDistance : new NearFarScalar(17, 18, 19, 20),
-            pixelOffsetScaleByDistance : new NearFarScalar(21, 22, 23, 24)
+            pixelOffsetScaleByDistance : new NearFarScalar(21, 22, 23, 24),
+            sizeInMeters : true
         };
 
         var billboard = new BillboardGraphics(options);
@@ -54,6 +55,7 @@ defineSuite([
         expect(billboard.scaleByDistance).toBeInstanceOf(ConstantProperty);
         expect(billboard.translucencyByDistance).toBeInstanceOf(ConstantProperty);
         expect(billboard.pixelOffsetScaleByDistance).toBeInstanceOf(ConstantProperty);
+        expect(billboard.sizeInMeters).toBeInstanceOf(ConstantProperty);
 
         expect(billboard.image.getValue()).toEqual(options.image);
         expect(billboard.rotation.getValue()).toEqual(options.rotation);
@@ -69,6 +71,7 @@ defineSuite([
         expect(billboard.scaleByDistance.getValue()).toEqual(options.scaleByDistance);
         expect(billboard.translucencyByDistance.getValue()).toEqual(options.translucencyByDistance);
         expect(billboard.pixelOffsetScaleByDistance.getValue()).toEqual(options.pixelOffsetScaleByDistance);
+        expect(billboard.sizeInMeters.getValue()).toEqual(options.sizeInMeters);
     });
 
     it('merge assigns unassigned properties', function() {
@@ -89,6 +92,7 @@ defineSuite([
         source.scaleByDistance = new ConstantProperty(new NearFarScalar());
         source.translucencyByDistance = new ConstantProperty(new NearFarScalar());
         source.pixelOffsetScaleByDistance = new ConstantProperty(new NearFarScalar(1.0, 0.0, 3.0e9, 0.0));
+        source.sizeInMeters = new ConstantProperty(true);
 
         var target = new BillboardGraphics();
         target.merge(source);
@@ -109,6 +113,7 @@ defineSuite([
         expect(target.scaleByDistance).toBe(source.scaleByDistance);
         expect(target.translucencyByDistance).toBe(source.translucencyByDistance);
         expect(target.pixelOffsetScaleByDistance).toBe(source.pixelOffsetScaleByDistance);
+        expect(target.sizeInMeters).toBe(source.sizeInMeters);
     });
 
     it('merge does not assign assigned properties', function() {
@@ -129,6 +134,7 @@ defineSuite([
         source.scaleByDistance = new ConstantProperty(new NearFarScalar());
         source.translucencyByDistance = new ConstantProperty(new NearFarScalar());
         source.pixelOffsetScaleByDistance = new ConstantProperty(new NearFarScalar(1.0, 0.0, 3.0e9, 0.0));
+        source.sizeInMeters = new ConstantProperty(true);
 
         var image = new ConstantProperty('');
         var imageSubRegion = new ConstantProperty();
@@ -146,6 +152,7 @@ defineSuite([
         var scaleByDistance = new ConstantProperty(new NearFarScalar());
         var translucencyByDistance = new ConstantProperty(new NearFarScalar());
         var pixelOffsetScaleByDistance = new ConstantProperty(new NearFarScalar());
+        var sizeInMeters = new ConstantProperty(true);
 
         var target = new BillboardGraphics();
         target.image = image;
@@ -164,6 +171,7 @@ defineSuite([
         target.scaleByDistance = scaleByDistance;
         target.translucencyByDistance = translucencyByDistance;
         target.pixelOffsetScaleByDistance = pixelOffsetScaleByDistance;
+        target.sizeInMeters = sizeInMeters;
 
         target.merge(source);
 
@@ -183,6 +191,7 @@ defineSuite([
         expect(target.scaleByDistance).toBe(scaleByDistance);
         expect(target.translucencyByDistance).toBe(translucencyByDistance);
         expect(target.pixelOffsetScaleByDistance).toBe(pixelOffsetScaleByDistance);
+        expect(target.sizeInMeters).toBe(sizeInMeters);
     });
 
     it('clone works', function() {
@@ -203,6 +212,7 @@ defineSuite([
         source.scaleByDistance = new ConstantProperty(new NearFarScalar());
         source.translucencyByDistance = new ConstantProperty(new NearFarScalar());
         source.pixelOffsetScaleByDistance = new ConstantProperty(new NearFarScalar(1.0, 0.0, 3.0e9, 0.0));
+        source.sizeInMeters = new ConstantProperty(true);
 
         var result = source.clone();
         expect(result.image).toBe(source.image);
@@ -221,6 +231,7 @@ defineSuite([
         expect(result.scaleByDistance).toBe(source.scaleByDistance);
         expect(result.translucencyByDistance).toBe(source.translucencyByDistance);
         expect(result.pixelOffsetScaleByDistance).toBe(source.pixelOffsetScaleByDistance);
+        expect(result.sizeInMeters).toBe(source.sizeInMeters);
     });
 
     it('merge throws if source undefined', function() {

--- a/Specs/DataSources/BillboardVisualizerSpec.js
+++ b/Specs/DataSources/BillboardVisualizerSpec.js
@@ -147,6 +147,7 @@ defineSuite([
         billboard.scaleByDistance = new ConstantProperty(new NearFarScalar());
         billboard.translucencyByDistance = new ConstantProperty(new NearFarScalar());
         billboard.pixelOffsetScaleByDistance = new ConstantProperty(new NearFarScalar(1.0, 0.0, 3.0e9, 0.0));
+        billboard.sizeInMeters = new ConstantProperty(true);
 
         visualizer.update(time);
 
@@ -172,6 +173,7 @@ defineSuite([
             expect(bb.scaleByDistance).toEqual(testObject.billboard.scaleByDistance.getValue(time));
             expect(bb.translucencyByDistance).toEqual(testObject.billboard.translucencyByDistance.getValue(time));
             expect(bb.pixelOffsetScaleByDistance).toEqual(testObject.billboard.pixelOffsetScaleByDistance.getValue(time));
+            expect(bb.sizeInMeters).toEqual(testObject.billboard.sizeInMeters.getValue(time));
             expect(bb._imageSubRegion).toEqual(testObject.billboard.imageSubRegion.getValue(time));
 
             billboard.show = new ConstantProperty(false);

--- a/Specs/Renderer/AutomaticUniformSpec.js
+++ b/Specs/Renderer/AutomaticUniformSpec.js
@@ -41,6 +41,10 @@ defineSuite([
             frustum : {
                 near : 1.0,
                 far : 1000.0,
+                top : 2.0,
+                bottom : -2.0,
+                left : -1.0,
+                right : 1.0,
                 projectionMatrix : defaultValue(projection, Matrix4.clone(Matrix4.IDENTITY)),
                 infiniteProjectionMatrix : defaultValue(infiniteProjection, Matrix4.clone(Matrix4.IDENTITY)),
                 computeCullingVolume : function() {
@@ -761,6 +765,38 @@ defineSuite([
         us.update(context, createFrameState(createMockCamera()));
 
         var fs = 'void main() { gl_FragColor = vec4((czm_entireFrustum.x == 1.0) && (czm_entireFrustum.y == 1000.0)); }';
+        context.verifyDrawForSpecs(fs);
+    });
+
+    it('has czm_frustumTop', function() {
+        var us = context.uniformState;
+        us.update(context, createFrameState(createMockCamera()));
+
+        var fs = 'void main() { gl_FragColor = vec4(czm_frustumTop == 2.0); }';
+        context.verifyDrawForSpecs(fs);
+    });
+
+    it('has czm_frustumBottom', function() {
+        var us = context.uniformState;
+        us.update(context, createFrameState(createMockCamera()));
+
+        var fs = 'void main() { gl_FragColor = vec4(czm_frustumBottom == -2.0); }';
+        context.verifyDrawForSpecs(fs);
+    });
+
+    it('has czm_frustumRight', function() {
+        var us = context.uniformState;
+        us.update(context, createFrameState(createMockCamera()));
+
+        var fs = 'void main() { gl_FragColor = vec4(czm_frustumRight == 1.0); }';
+        context.verifyDrawForSpecs(fs);
+    });
+
+    it('has czm_frustumLeft', function() {
+        var us = context.uniformState;
+        us.update(context, createFrameState(createMockCamera()));
+
+        var fs = 'void main() { gl_FragColor = vec4(czm_frustumLeft == -1.0); }';
         context.verifyDrawForSpecs(fs);
     });
 

--- a/Specs/Renderer/AutomaticUniformSpec.js
+++ b/Specs/Renderer/AutomaticUniformSpec.js
@@ -768,35 +768,11 @@ defineSuite([
         context.verifyDrawForSpecs(fs);
     });
 
-    it('has czm_frustumTop', function() {
+    it('has czm_frustumPlanes', function() {
         var us = context.uniformState;
         us.update(context, createFrameState(createMockCamera()));
 
-        var fs = 'void main() { gl_FragColor = vec4(czm_frustumTop == 2.0); }';
-        context.verifyDrawForSpecs(fs);
-    });
-
-    it('has czm_frustumBottom', function() {
-        var us = context.uniformState;
-        us.update(context, createFrameState(createMockCamera()));
-
-        var fs = 'void main() { gl_FragColor = vec4(czm_frustumBottom == -2.0); }';
-        context.verifyDrawForSpecs(fs);
-    });
-
-    it('has czm_frustumRight', function() {
-        var us = context.uniformState;
-        us.update(context, createFrameState(createMockCamera()));
-
-        var fs = 'void main() { gl_FragColor = vec4(czm_frustumRight == 1.0); }';
-        context.verifyDrawForSpecs(fs);
-    });
-
-    it('has czm_frustumLeft', function() {
-        var us = context.uniformState;
-        us.update(context, createFrameState(createMockCamera()));
-
-        var fs = 'void main() { gl_FragColor = vec4(czm_frustumLeft == -1.0); }';
+        var fs = 'void main() { gl_FragColor = vec4(equal(czm_frustumPlanes, vec4(2.0, -2.0, -1.0, 1.0))); }';
         context.verifyDrawForSpecs(fs);
     });
 

--- a/Specs/Renderer/BuiltinFunctionsSpec.js
+++ b/Specs/Renderer/BuiltinFunctionsSpec.js
@@ -293,8 +293,4 @@ defineSuite([
             '}';
         context.verifyDrawForSpecs(fs);
     });
-
-    it('has czm_metersPerPixel', function() {
-
-    });
 }, 'WebGL');

--- a/Specs/Renderer/BuiltinFunctionsSpec.js
+++ b/Specs/Renderer/BuiltinFunctionsSpec.js
@@ -293,4 +293,8 @@ defineSuite([
             '}';
         context.verifyDrawForSpecs(fs);
     });
+
+    it('has czm_metersPerPixel', function() {
+
+    });
 }, 'WebGL');

--- a/Specs/Scene/BillboardCollectionSpec.js
+++ b/Specs/Scene/BillboardCollectionSpec.js
@@ -126,6 +126,7 @@ defineSuite([
         expect(b.height).not.toBeDefined();
         expect(b.id).not.toBeDefined();
         expect(b.heightReference).toEqual(HeightReference.NONE);
+        expect(b.sizeInMeters).toEqual(false);
     });
 
     it('can add and remove before first update.', function() {
@@ -157,6 +158,7 @@ defineSuite([
             pixelOffsetScaleByDistance : new NearFarScalar(1.0, 1.0, 1.0e6, 0.0),
             width : 300.0,
             height : 200.0,
+            sizeInMeters : true,
             id : 'id'
         });
 
@@ -179,6 +181,7 @@ defineSuite([
         expect(b.pixelOffsetScaleByDistance).toEqual(new NearFarScalar(1.0, 1.0, 1.0e6, 0.0));
         expect(b.width).toEqual(300.0);
         expect(b.height).toEqual(200.0);
+        expect(b.sizeInMeters).toEqual(true);
         expect(b.id).toEqual('id');
     });
 
@@ -200,6 +203,7 @@ defineSuite([
         b.scaleByDistance = new NearFarScalar(1.0e6, 3.0, 1.0e8, 0.0);
         b.translucencyByDistance = new NearFarScalar(1.0e6, 1.0, 1.0e8, 0.0);
         b.pixelOffsetScaleByDistance = new NearFarScalar(1.0e6, 3.0, 1.0e8, 0.0);
+        b.sizeInMeters = true;
 
         expect(b.show).toEqual(false);
         expect(b.position).toEqual(new Cartesian3(1.0, 2.0, 3.0));
@@ -220,10 +224,27 @@ defineSuite([
         expect(b.pixelOffsetScaleByDistance).toEqual(new NearFarScalar(1.0e6, 3.0, 1.0e8, 0.0));
         expect(b.width).toEqual(300.0);
         expect(b.height).toEqual(200.0);
+        expect(b.sizeInMeters).toEqual(true);
     });
 
     it('is not destroyed', function() {
         expect(billboards.isDestroyed()).toEqual(false);
+    });
+
+    it('renders billboard with sizeInMeters', function() {
+        billboards.add({
+            position : Cartesian3.ZERO,
+            image : greenImage,
+            width : 2.0,
+            height : 2.0,
+            sizeInMeters : true
+        });
+
+        camera.position = new Cartesian3(2.0, 0.0, 0.0);
+        expect(scene.renderForSpecs()).toEqual([0, 255, 0, 255]);
+
+        camera.position = new Cartesian3(1e6, 0.0, 0.0);
+        expect(scene.renderForSpecs()).toEqual([0, 0, 0, 255]);
     });
 
     it('disables billboard scaleByDistance', function() {


### PR DESCRIPTION
Adds `Billboard.sizeInMeters`. It uses the image size by default bute should be used in conjunction with the `width` and `height` properties.