### PR TITLE
Fixed token issue in ArcGisMapServerImageryProvider

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,10 @@
 Change Log
 ==========
 
+### 1.15 - 2015-11-02
+
+* Fixed token issue in ArcGisMapServerImageryProvider
+
 ### 1.14 - 2015-10-01
 
 * Breaking changes

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -67,5 +67,6 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to Cesiu
 * [Adam Cole](https://github.com/adamdavidcole)
 * [Tiffany Lu](https://github.com/tiffanylu)
 * [Olivier Terral](https://github.com/oterral)
+* [Piero Toffanin](https://github.com/pierotofy)
 
 Also see [our contributors page](http://cesiumjs.org/contributors.html) for more information.

--- a/Source/Scene/ArcGisMapServerImageryProvider.js
+++ b/Source/Scene/ArcGisMapServerImageryProvider.js
@@ -257,6 +257,9 @@ define([
             if (url.indexOf('?') === -1) {
                 url += '?';
             }
+            if (url[url.length - 1] !== '?'){
+                url += '&';
+            }
             url += 'token=' + token;
         }
 

--- a/Specs/Scene/ArcGisMapServerImageryProviderSpec.js
+++ b/Specs/Scene/ArcGisMapServerImageryProviderSpec.js
@@ -309,14 +309,16 @@ defineSuite([
 
     it('supports non-tiled servers with various constructor parameters', function() {
         var baseUrl = '//tiledArcGisMapServer.invalid';
+        var token = '5e(u|2!7Y';
 
         stubJSONPCall(baseUrl, {
             "currentVersion" : 10.01,
             "copyrightText" : "Test copyright text"
-        });
+        }, undefined, token);
 
         var provider = new ArcGisMapServerImageryProvider({
             url : baseUrl,
+            token: token,
             tileWidth: 128,
             tileHeight: 512,
             tilingScheme: new WebMercatorTilingScheme(),
@@ -357,6 +359,7 @@ defineSuite([
                 expect(params.transparent).toEqual('true');
                 expect(params.size).toEqual('128,512');
                 expect(params.layers).toEqual('show:foo,bar');
+                expect(params.token).toEqual(token);
 
                 // Just return any old image.
                 loadImage.defaultCreateImage('Data/Images/Red16x16.png', crossOrigin, deferred);


### PR DESCRIPTION
When creating an instance of ArcGisMapServerImageryProvider and usePreCachedTilesIfAvailable is false (or _useTiles ends up being false because no pre-cached tiles are available), the token parameter is appended to the layer URL without adding the ampersand character. This results in the generation of an erroneous URL, which then causes errors.

The proposed fix modifies how the token parameter is appended to the URL, by adding the missing "&" character when appropriate.