### PR TITLE
Fixed PolygonOutlineGeometry example

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -26,6 +26,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to Cesiu
    * [Kai Ninomiya](https://github.com/kainino0x)
    * [Sean Lilley](https://github.com/lilleyse)
    * [Katherina Lim](https://github.com/klim705)
+   * [Gabrielle Getz](https://github.com/ggetz)
 * [NICTA](http://www.nicta.com.au/)
    * [Chris Cooper](https://github.com/chris-cooper)
    * [Kevin Ring](https://github.com/kring)

--- a/Source/Core/PolygonOutlineGeometry.js
+++ b/Source/Core/PolygonOutlineGeometry.js
@@ -276,9 +276,9 @@ define([
      *       -75.0, 30.0,
      *       -70.0, 30.0,
      *       -68.0, 40.0
-     *     ]),
-     *     extrudedHeight: 300000
-     *   }
+     *     ])
+     *   },
+     *   extrudedHeight: 300000
      * });
      * var geometry = Cesium.PolygonOutlineGeometry.createGeometry(extrudedPolygon);
      */


### PR DESCRIPTION
This fixes #3031 

Fixed example in PolygonOutlineGeometry documentation.

The `extrudedHeight` option now goes to root options.