### PR TITLE
Make scene.mode setter actually work.

### DIFF
--- a/Source/Scene/Scene.js
+++ b/Source/Scene/Scene.js
@@ -889,13 +889,21 @@ define([
             },
             set : function(value) {
                 //>>includeStart('debug', pragmas.debug);
-                if (!defined(value)) {
-                    throw new DeveloperError('value is required.');
-                }
                 if (this.scene3DOnly && value !== SceneMode.SCENE3D) {
                     throw new DeveloperError('Only SceneMode.SCENE3D is valid when scene3DOnly is true.');
                 }
                 //>>includeEnd('debug');
+                if (value === SceneMode.SCENE2D) {
+                    this.morphTo2D(0);
+                } else if (value === SceneMode.SCENE3D) {
+                    this.morphTo3D(0);
+                } else if (value === SceneMode.COLUMBUS_VIEW) {
+                    this.morphToColumbusView(0);
+                    //>>includeStart('debug', pragmas.debug);
+                } else {
+                    throw new DeveloperError('value must be a valid SceneMode enumeration.')
+                    //>>includeEnd('debug');
+                }
                 this._mode = value;
             }
         },

--- a/Source/Scene/SceneTransitioner.js
+++ b/Source/Scene/SceneTransitioner.js
@@ -144,7 +144,7 @@ define([
         this._scene.morphStart.raiseEvent(this, this._previousMode, SceneMode.SCENE2D, true);
 
         updateFrustums(this);
-        scene.mode = SceneMode.MORPHING;
+        scene._mode = SceneMode.MORPHING;
         createMorphHandler(this, complete2DCallback);
 
         if (this._previousMode === SceneMode.COLUMBUS_VIEW) {
@@ -172,7 +172,7 @@ define([
         this._scene.morphStart.raiseEvent(this, this._previousMode, SceneMode.COLUMBUS_VIEW, true);
 
         updateFrustums(this);
-        scene.mode = SceneMode.MORPHING;
+        scene._mode = SceneMode.MORPHING;
         createMorphHandler(this, completeColumbusViewCallback);
 
         if (this._previousMode === SceneMode.SCENE2D) {
@@ -200,7 +200,7 @@ define([
         this._scene.morphStart.raiseEvent(this, this._previousMode, SceneMode.SCENE3D, true);
 
         updateFrustums(this);
-        scene.mode = SceneMode.MORPHING;
+        scene._mode = SceneMode.MORPHING;
         createMorphHandler(this, complete3DCallback);
 
         if (this._previousMode === SceneMode.SCENE2D) {
@@ -636,7 +636,7 @@ define([
 
     function complete3DCallback(transitioner) {
         var scene = transitioner._scene;
-        scene.mode = SceneMode.SCENE3D;
+        scene._mode = SceneMode.SCENE3D;
         scene.morphTime = SceneMode.getMorphTime(SceneMode.SCENE3D);
 
         destroyMorphHandler(transitioner);
@@ -663,7 +663,7 @@ define([
     function complete2DCallback(transitioner) {
         var scene = transitioner._scene;
 
-        scene.mode = SceneMode.SCENE2D;
+        scene._mode = SceneMode.SCENE2D;
         scene.morphTime = SceneMode.getMorphTime(SceneMode.SCENE2D);
 
         destroyMorphHandler(transitioner);
@@ -685,7 +685,7 @@ define([
 
     function completeColumbusViewCallback(transitioner) {
         var scene = transitioner._scene;
-        scene.mode = SceneMode.COLUMBUS_VIEW;
+        scene._mode = SceneMode.COLUMBUS_VIEW;
         scene.morphTime = SceneMode.getMorphTime(SceneMode.COLUMBUS_VIEW);
 
         destroyMorphHandler(transitioner);

--- a/Specs/Scene/CameraFlightPathSpec.js
+++ b/Specs/Scene/CameraFlightPathSpec.js
@@ -119,7 +119,7 @@ defineSuite([
     });
 
     it('creates an animation in Columbus view', function() {
-        scene.mode = SceneMode.COLUMBUS_VIEW;
+        scene._mode = SceneMode.COLUMBUS_VIEW;
         var camera = scene.camera;
 
         camera.position = new Cartesian3(0.0, 0.0, 1000.0);
@@ -147,7 +147,7 @@ defineSuite([
     });
 
     it('creates an animation in 2D', function() {
-        scene.mode = SceneMode.SCENE2D;
+        scene._mode = SceneMode.SCENE2D;
         var camera = scene.camera;
 
         camera.position = new Cartesian3(0.0, 0.0, 1000.0);
@@ -246,7 +246,7 @@ defineSuite([
     });
 
     it('duration is 0 when destination is the same as camera position in 2D', function() {
-        scene.mode = SceneMode.SCENE2D;
+        scene._mode = SceneMode.SCENE2D;
         var camera = scene.camera;
 
         camera.position = new Cartesian3(0.0, 0.0, 1000.0);
@@ -269,7 +269,7 @@ defineSuite([
     });
 
     it('duration is 0 when destination is the same as camera position in 3D', function() {
-        scene.mode = SceneMode.SCENE3D;
+        scene._mode = SceneMode.SCENE3D;
         var camera = scene.camera;
 
         camera.position = new Cartesian3(0.0, 0.0, 1000.0);
@@ -286,7 +286,7 @@ defineSuite([
     });
 
     it('duration is 0 when destination is the same as camera position in CV', function() {
-        scene.mode = SceneMode.COLUMBUS_VIEW;
+        scene._mode = SceneMode.COLUMBUS_VIEW;
         var camera = scene.camera;
 
         camera.position = new Cartesian3(0.0, 0.0, 1000.0);
@@ -305,7 +305,7 @@ defineSuite([
     });
 
     it('creates an animation in 2D 0 duration', function() {
-        scene.mode = SceneMode.SCENE2D;
+        scene._mode = SceneMode.SCENE2D;
         var camera = scene.camera;
 
         camera.position = new Cartesian3(0.0, 0.0, 1000.0);
@@ -336,7 +336,7 @@ defineSuite([
     });
 
     it('creates an animation in Columbus view 0 duration', function() {
-        scene.mode = SceneMode.COLUMBUS_VIEW;
+        scene._mode = SceneMode.COLUMBUS_VIEW;
         var camera = scene.camera;
 
         camera.position = new Cartesian3(0.0, 0.0, 1000.0);


### PR DESCRIPTION
Scene.mode has always been documented as set/get, but setting was used more like a private property and in most cases using it caused a crash. This makes it actually work as intended.

Fixes #2869