### PR TITLE
Deprecate EllipsoidPrimitive, RectanglePrimitive, and Polygon

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,9 +5,10 @@ Change Log
 
 * Breaking changes
   * Deleted old `<subfolder>/package.json` and `*.profile.js` files, not used since we moved away from a Dojo-based build years ago.  This should allow future compatibility with newer systems like Browserify and Webpack.
-  * ...
 * Deprecated
-  * ...
+  * Made `EllipsoidPrimitive` private, use `EllipsoidGeometry` or `Entity.ellipsoid` instead.
+  * Deprecated `RectanglePrimitive`, use `RectangleGeometry` or `Entity.rectangle` instead. It will be removed in 1.17.
+  * Deprecated `EllipsoidPrimitive`, use `EllipsoidGeometry` or `Entity.ellipsoid` instead. It will be removed in 1.17.
 * Decreased GPU memory usage in `BillboardCollection` and `LabelCollection` by using the WebGL ANGLE_instanced_arrays extension.
 * Added CZML examples to Sandcastle.  See the new CZML tab.
 * Fixed token issue in `ArcGisMapServerImageryProvider`.

--- a/Source/Scene/EllipsoidPrimitive.js
+++ b/Source/Scene/EllipsoidPrimitive.js
@@ -71,22 +71,7 @@ define([
      * @param {Object} [options.id] A user-defined object to return when the instance is picked with {@link Scene#pick}
      * @param {Boolean} [options.debugShowBoundingVolume=false] For debugging only. Determines if this primitive's commands' bounding spheres are shown.
      *
-     * @demo {@link http://cesiumjs.org/Cesium/Apps/Sandcastle/index.html?src=Volumes.html|Cesium Sandcastle Volumes Demo}
-     *
-     * @example
-     * // 1. Create a sphere using the ellipsoid primitive
-     * primitives.add(new Cesium.EllipsoidPrimitive({
-     *   center : Cesium.Cartesian3.fromDegrees(-75.0, 40.0, 500000.0),
-     *   radii : new Cesium.Cartesian3(500000.0, 500000.0, 500000.0)
-     * }));
-     *
-     * @example
-     * // 2. Create a tall ellipsoid in an east-north-up reference frame
-     * var e = new Cesium.EllipsoidPrimitive();
-     * e.modelMatrix = Cesium.Transforms.eastNorthUpToFixedFrame(
-     *   Cesium.Cartesian3.fromDegrees(-95.0, 40.0, 200000.0));
-     * e.radii = new Cesium.Cartesian3(100000.0, 100000.0, 200000.0);
-     * primitives.add(e);
+     * @private
      */
     var EllipsoidPrimitive = function(options) {
         options = defaultValue(options, defaultValue.EMPTY_OBJECT);

--- a/Source/Scene/Polygon.js
+++ b/Source/Scene/Polygon.js
@@ -4,6 +4,7 @@ define([
         '../Core/defaultValue',
         '../Core/defined',
         '../Core/defineProperties',
+        '../Core/deprecationWarning',
         '../Core/destroyObject',
         '../Core/DeveloperError',
         '../Core/Ellipsoid',
@@ -18,6 +19,7 @@ define([
         defaultValue,
         defined,
         defineProperties,
+        deprecationWarning,
         destroyObject,
         DeveloperError,
         Ellipsoid,
@@ -77,8 +79,13 @@ define([
      *     10.0, 0.0,
      *     0.0, 10.0
      * ]);
+     *
+     * @deprecated
+     * @private
      */
     var Polygon = function(options) {
+        deprecationWarning('Polygon', 'Polygon has been deprecated.  Use PolygonGeometry or Entity.polygon instead.');
+
         options = defaultValue(options, defaultValue.EMPTY_OBJECT);
 
         /**

--- a/Source/Scene/RectanglePrimitive.js
+++ b/Source/Scene/RectanglePrimitive.js
@@ -3,6 +3,7 @@ define([
         '../Core/Color',
         '../Core/defaultValue',
         '../Core/defined',
+        '../Core/deprecationWarning',
         '../Core/destroyObject',
         '../Core/DeveloperError',
         '../Core/Ellipsoid',
@@ -17,6 +18,7 @@ define([
         Color,
         defaultValue,
         defined,
+        deprecationWarning,
         destroyObject,
         DeveloperError,
         Ellipsoid,
@@ -53,8 +55,13 @@ define([
      *   rectangle : Cesium.Rectangle.fromDegrees(0.0, 20.0, 10.0, 30.0)
      * });
      * primitives.add(rectanglePrimitive);
+     *
+     * @deprecated
+     * @private
      */
     var RectanglePrimitive = function(options) {
+        deprecationWarning('RectanglePrimitive', 'RectanglePrimitive has been deprecated.  Use RectangleGeometry or Entity.rectangle instead.');
+
         options = defaultValue(options, defaultValue.EMPTY_OBJECT);
 
         /**

--- a/Specs/Scene/MaterialSpec.js
+++ b/Specs/Scene/MaterialSpec.js
@@ -4,10 +4,13 @@ defineSuite([
         'Core/Cartesian3',
         'Core/Color',
         'Core/Ellipsoid',
+        'Core/GeometryInstance',
         'Core/Math',
+        'Core/PolygonGeometry',
         'Renderer/ClearCommand',
-        'Scene/Polygon',
+        'Scene/EllipsoidSurfaceAppearance',
         'Scene/PolylineCollection',
+        'Scene/Primitive',
         'Specs/createCamera',
         'Specs/createContext',
         'Specs/createFrameState',
@@ -18,10 +21,13 @@ defineSuite([
         Cartesian3,
         Color,
         Ellipsoid,
+        GeometryInstance,
         CesiumMath,
+        PolygonGeometry,
         ClearCommand,
-        Polygon,
+        EllipsoidSurfaceAppearance,
         PolylineCollection,
+        Primitive,
         createCamera,
         createContext,
         createFrameState,
@@ -53,16 +59,26 @@ defineSuite([
         })));
 
         var ellipsoid = Ellipsoid.UNIT_SPHERE;
-        polygon = new Polygon();
-        polygon.ellipsoid = ellipsoid;
-        polygon.granularity = CesiumMath.toRadians(20.0);
-        polygon.positions = Cartesian3.fromDegreesArray([
-            -50.0, -50.0,
-            50.0, -50.0,
-            50.0, 50.0,
-            -50.0, 50.0
-        ], ellipsoid);
-        polygon.asynchronous = false;
+
+        polygon = new Primitive({
+            geometryInstances: new GeometryInstance({
+                geometry: PolygonGeometry.fromPositions({
+                    positions: Cartesian3.fromDegreesArray([
+                        -50.0, -50.0,
+                        50.0, -50.0,
+                        50.0, 50.0,
+                        -50.0, 50.0
+                    ], ellipsoid),
+                    vertexFormat: EllipsoidSurfaceAppearance.VERTEX_FORMAT,
+                    ellipsoid: ellipsoid,
+                    granularity: CesiumMath.toRadians(20.0)
+                })
+            }),
+            appearance: new EllipsoidSurfaceAppearance({
+                aboveGround: false
+            }),
+            asynchronous: false
+        });
 
         polylines = new PolylineCollection();
         polyline = polylines.add({
@@ -81,7 +97,7 @@ defineSuite([
     });
 
     function renderMaterial(material) {
-        polygon.material = material;
+        polygon.appearance.material = material;
 
         ClearCommand.ALL.execute(context);
         expect(context.readPixels()).toEqual([0, 0, 0, 0]);

--- a/Specs/Scene/PickSpec.js
+++ b/Specs/Scene/PickSpec.js
@@ -14,7 +14,6 @@ defineSuite([
         'Scene/OrthographicFrustum',
         'Scene/PerspectiveFrustum',
         'Scene/Primitive',
-        'Scene/RectanglePrimitive',
         'Scene/SceneMode',
         'Specs/createScene'
     ], 'Scene/Pick', function(
@@ -32,7 +31,6 @@ defineSuite([
         OrthographicFrustum,
         PerspectiveFrustum,
         Primitive,
-        RectanglePrimitive,
         SceneMode,
         createScene) {
     "use strict";
@@ -76,11 +74,19 @@ defineSuite([
     function createRectangle() {
         var ellipsoid = Ellipsoid.UNIT_SPHERE;
 
-        var e = new RectanglePrimitive({
-            ellipsoid : ellipsoid,
-            granularity : CesiumMath.toRadians(20.0),
-            rectangle : Rectangle.fromDegrees(-50.0, -50.0, 50.0, 50.0),
-            asynchronous : false
+        var e = new Primitive({
+            geometryInstances: new GeometryInstance({
+                geometry: new RectangleGeometry({
+                    rectangle: Rectangle.fromDegrees(-50.0, -50.0, 50.0, 50.0),
+                    vertexFormat: EllipsoidSurfaceAppearance.VERTEX_FORMAT,
+                    ellipsoid: ellipsoid,
+                    granularity: CesiumMath.toRadians(20.0)
+                })
+            }),
+            appearance: new EllipsoidSurfaceAppearance({
+                aboveGround: false
+            }),
+            asynchronous: false
         });
 
         primitives.add(e);
@@ -115,7 +121,7 @@ defineSuite([
 
     it('does not pick primitives when alpha is zero', function() {
         var rectangle = createRectangle();
-        rectangle.material.uniforms.color.alpha = 0.0;
+        rectangle.appearance.material.uniforms.color.alpha = 0.0;
 
         var pickedObject = scene.pick(new Cartesian2(0, 0));
         expect(pickedObject).not.toBeDefined();
@@ -162,7 +168,7 @@ defineSuite([
         var rectangle1 = createRectangle();
         var rectangle2 = createRectangle();
         rectangle2.height = 0.01;
-        rectangle2.material.uniforms.color.alpha = 0.0;
+        rectangle2.appearance.material.uniforms.color.alpha = 0.0;
 
         var pickedObjects = scene.drillPick(new Cartesian2(0, 0));
         expect(pickedObjects.length).toEqual(1);

--- a/Specs/Scene/PrimitiveCullingSpec.js
+++ b/Specs/Scene/PrimitiveCullingSpec.js
@@ -5,19 +5,22 @@ defineSuite([
         'Core/Cartesian3',
         'Core/defaultValue',
         'Core/Ellipsoid',
+        'Core/GeometryInstance',
         'Core/loadImage',
         'Core/Math',
         'Core/Occluder',
+        'Core/PolygonGeometry',
         'Renderer/Sampler',
         'Renderer/TextureMagnificationFilter',
         'Renderer/TextureMinificationFilter',
         'Scene/BillboardCollection',
+        'Scene/EllipsoidSurfaceAppearance',
         'Scene/HorizontalOrigin',
         'Scene/LabelCollection',
         'Scene/Material',
         'Scene/OrthographicFrustum',
-        'Scene/Polygon',
         'Scene/PolylineCollection',
+        'Scene/Primitive',
         'Scene/PrimitiveCollection',
         'Scene/SceneMode',
         'Scene/TextureAtlas',
@@ -32,19 +35,22 @@ defineSuite([
         Cartesian3,
         defaultValue,
         Ellipsoid,
+        GeometryInstance,
         loadImage,
         CesiumMath,
         Occluder,
+        PolygonGeometry,
         Sampler,
         TextureMagnificationFilter,
         TextureMinificationFilter,
         BillboardCollection,
+        EllipsoidSurfaceAppearance,
         HorizontalOrigin,
         LabelCollection,
         Material,
         OrthographicFrustum,
-        Polygon,
         PolylineCollection,
+        Primitive,
         PrimitiveCollection,
         SceneMode,
         TextureAtlas,
@@ -276,18 +282,27 @@ defineSuite([
 
     function createPolygon(degree, ellipsoid) {
         degree = defaultValue(degree, 50.0);
-        ellipsoid = defaultValue(ellipsoid, Ellipsoid.UNIT_SPHERE);
-        var polygon = new Polygon();
-        polygon.ellipsoid = ellipsoid;
-        polygon.granularity = CesiumMath.toRadians(20.0);
-        polygon.positions = Cartesian3.fromDegreesArray([
-            -degree, -degree,
-            degree, -degree,
-            degree,  degree,
-            -degree,  degree
-        ]);
-        polygon.asynchronous = false;
-        polygon.material.translucent = false;
+        var polygon = new Primitive({
+            geometryInstances: new GeometryInstance({
+                geometry: PolygonGeometry.fromPositions({
+                    positions: Cartesian3.fromDegreesArray([
+                        -degree, -degree,
+                        degree, -degree,
+                        degree, degree,
+                        -degree, degree
+                    ]),
+                    vertexFormat: EllipsoidSurfaceAppearance.VERTEX_FORMAT,
+                    ellipsoid: ellipsoid,
+                    granularity: CesiumMath.toRadians(20.0)
+                })
+            }),
+            appearance: new EllipsoidSurfaceAppearance({
+                aboveGround: false
+            }),
+            asynchronous: false
+        });
+        polygon.appearance.material.translucent = false;
+
         return polygon;
     }
 

--- a/Specs/Scene/SceneSpec.js
+++ b/Specs/Scene/SceneSpec.js
@@ -7,8 +7,10 @@ defineSuite([
         'Core/defined',
         'Core/Ellipsoid',
         'Core/GeographicProjection',
+        'Core/GeometryInstance',
         'Core/PixelFormat',
         'Core/Rectangle',
+        'Core/RectangleGeometry',
         'Core/RuntimeError',
         'Core/WebMercatorProjection',
         'Renderer/DrawCommand',
@@ -18,11 +20,12 @@ defineSuite([
         'Renderer/Texture',
         'Renderer/WebGLConstants',
         'Scene/Camera',
+        'Scene/EllipsoidSurfaceAppearance',
         'Scene/FrameState',
         'Scene/Globe',
         'Scene/Pass',
         'Scene/PrimitiveCollection',
-        'Scene/RectanglePrimitive',
+        'Scene/Primitive',
         'Scene/Scene',
         'Scene/ScreenSpaceCameraController',
         'Scene/TweenCollection',
@@ -38,8 +41,10 @@ defineSuite([
         defined,
         Ellipsoid,
         GeographicProjection,
+        GeometryInstance,
         PixelFormat,
         Rectangle,
+        RectangleGeometry,
         RuntimeError,
         WebMercatorProjection,
         DrawCommand,
@@ -49,11 +54,12 @@ defineSuite([
         Texture,
         WebGLConstants,
         Camera,
+        EllipsoidSurfaceAppearance,
         FrameState,
         Globe,
         Pass,
         PrimitiveCollection,
-        RectanglePrimitive,
+        Primitive,
         Scene,
         ScreenSpaceCameraController,
         TweenCollection,
@@ -80,6 +86,22 @@ defineSuite([
     afterAll(function() {
         scene.destroyForSpecs();
     });
+
+    function createRectangle(rectangle, height) {
+        return new Primitive({
+            geometryInstances: new GeometryInstance({
+                geometry: new RectangleGeometry({
+                    rectangle: rectangle,
+                    vertexFormat: EllipsoidSurfaceAppearance.VERTEX_FORMAT,
+                    height: height
+                })
+            }),
+            appearance: new EllipsoidSurfaceAppearance({
+                aboveGround: false
+            }),
+            asynchronous: false
+        });
+    }
 
     it('constructor has expected defaults', function() {
         expect(scene.canvas).toBeInstanceOf(HTMLCanvasElement);
@@ -253,11 +275,8 @@ defineSuite([
         var rectangle = Rectangle.fromDegrees(-100.0, 30.0, -90.0, 40.0);
         scene.camera.viewRectangle(rectangle);
 
-        var rectanglePrimitive = new RectanglePrimitive({
-            rectangle : rectangle,
-            asynchronous : false
-        });
-        rectanglePrimitive.material.uniforms.color = new Color(1.0, 0.0, 0.0, 1.0);
+        var rectanglePrimitive = createRectangle(rectangle);
+        rectanglePrimitive.appearance.material.uniforms.color = new Color(1.0, 0.0, 0.0, 1.0);
 
         scene.primitives.add(rectanglePrimitive);
 
@@ -270,18 +289,11 @@ defineSuite([
     it('opaque/translucent render order (1)', function() {
         var rectangle = Rectangle.fromDegrees(-100.0, 30.0, -90.0, 40.0);
 
-        var rectanglePrimitive1 = new RectanglePrimitive({
-            rectangle : rectangle,
-            asynchronous : false
-        });
-        rectanglePrimitive1.material.uniforms.color = new Color(1.0, 0.0, 0.0, 1.0);
+        var rectanglePrimitive1 = createRectangle(rectangle);
+        rectanglePrimitive1.appearance.material.uniforms.color = new Color(1.0, 0.0, 0.0, 1.0);
 
-        var rectanglePrimitive2 = new RectanglePrimitive({
-            rectangle : rectangle,
-            height : 1000.0,
-            asynchronous : false
-        });
-        rectanglePrimitive2.material.uniforms.color = new Color(0.0, 1.0, 0.0, 0.5);
+        var rectanglePrimitive2 = createRectangle(rectangle, 1000.0);
+        rectanglePrimitive2.appearance.material.uniforms.color = new Color(0.0, 1.0, 0.0, 0.5);
 
         var primitives = scene.primitives;
         primitives.add(rectanglePrimitive1);
@@ -305,18 +317,11 @@ defineSuite([
     it('opaque/translucent render order (2)', function() {
         var rectangle = Rectangle.fromDegrees(-100.0, 30.0, -90.0, 40.0);
 
-        var rectanglePrimitive1 = new RectanglePrimitive({
-            rectangle : rectangle,
-            height : 1000.0,
-            asynchronous : false
-        });
-        rectanglePrimitive1.material.uniforms.color = new Color(1.0, 0.0, 0.0, 1.0);
+        var rectanglePrimitive1 = createRectangle(rectangle, 1000.0);
+        rectanglePrimitive1.appearance.material.uniforms.color = new Color(1.0, 0.0, 0.0, 1.0);
 
-        var rectanglePrimitive2 = new RectanglePrimitive({
-            rectangle : rectangle,
-            asynchronous : false
-        });
-        rectanglePrimitive2.material.uniforms.color = new Color(0.0, 1.0, 0.0, 0.5);
+        var rectanglePrimitive2 = createRectangle(rectangle);
+        rectanglePrimitive2.appearance.material.uniforms.color = new Color(0.0, 1.0, 0.0, 0.5);
 
         var primitives = scene.primitives;
         primitives.add(rectanglePrimitive1);
@@ -340,12 +345,8 @@ defineSuite([
     it('renders fast path with no translucent primitives', function() {
         var rectangle = Rectangle.fromDegrees(-100.0, 30.0, -90.0, 40.0);
 
-        var rectanglePrimitive = new RectanglePrimitive({
-            rectangle : rectangle,
-            height : 1000.0,
-            asynchronous : false
-        });
-        rectanglePrimitive.material.uniforms.color = new Color(1.0, 0.0, 0.0, 1.0);
+        var rectanglePrimitive = createRectangle(rectangle, 1000.0);
+        rectanglePrimitive.appearance.material.uniforms.color = new Color(1.0, 0.0, 0.0, 1.0);
 
         var primitives = scene.primitives;
         primitives.add(rectanglePrimitive);
@@ -361,12 +362,8 @@ defineSuite([
     it('renders with OIT and without FXAA', function() {
         var rectangle = Rectangle.fromDegrees(-100.0, 30.0, -90.0, 40.0);
 
-        var rectanglePrimitive = new RectanglePrimitive({
-            rectangle : rectangle,
-            height : 1000.0,
-            asynchronous : false
-        });
-        rectanglePrimitive.material.uniforms.color = new Color(1.0, 0.0, 0.0, 0.5);
+        var rectanglePrimitive = createRectangle(rectangle, 1000.0);
+        rectanglePrimitive.appearance.material.uniforms.color = new Color(1.0, 0.0, 0.0, 0.5);
 
         var primitives = scene.primitives;
         primitives.add(rectanglePrimitive);
@@ -424,12 +421,8 @@ defineSuite([
 
         var rectangle = Rectangle.fromDegrees(-100.0, 30.0, -90.0, 40.0);
 
-        var rectanglePrimitive = new RectanglePrimitive({
-            rectangle : rectangle,
-            height : 1000.0,
-            asynchronous : false
-        });
-        rectanglePrimitive.material.uniforms.color = new Color(1.0, 0.0, 0.0, 1.0);
+        var rectanglePrimitive = createRectangle(rectangle, 1000.0);
+        rectanglePrimitive.appearance.material.uniforms.color = new Color(1.0, 0.0, 0.0, 1.0);
 
         var primitives = s.primitives;
         primitives.add(rectanglePrimitive);
@@ -493,12 +486,8 @@ defineSuite([
 
                 var rectangle = Rectangle.fromDegrees(-100.0, 30.0, -90.0, 40.0);
 
-                var rectanglePrimitive = new RectanglePrimitive({
-                    rectangle : rectangle,
-                    height : 1000.0,
-                    asynchronous : false
-                });
-                rectanglePrimitive.material.uniforms.color = new Color(1.0, 0.0, 0.0, 0.5);
+                var rectanglePrimitive = createRectangle(rectangle, 1000.0);
+                rectanglePrimitive.appearance.material.uniforms.color = new Color(1.0, 0.0, 0.0, 0.5);
 
                 var primitives = s.primitives;
                 primitives.add(rectanglePrimitive);
@@ -526,12 +515,8 @@ defineSuite([
 
             var rectangle = Rectangle.fromDegrees(-100.0, 30.0, -90.0, 40.0);
 
-            var rectanglePrimitive = new RectanglePrimitive({
-                rectangle : rectangle,
-                height : 1000.0,
-                asynchronous : false
-            });
-            rectanglePrimitive.material.uniforms.color = new Color(1.0, 0.0, 0.0, 0.5);
+            var rectanglePrimitive = createRectangle(rectangle, 1000.0);
+            rectanglePrimitive.appearance.material.uniforms.color = new Color(1.0, 0.0, 0.0, 0.5);
 
             var primitives = s.primitives;
             primitives.add(rectanglePrimitive);
@@ -551,12 +536,8 @@ defineSuite([
         if (defined(scene._globeDepth)) {
             var rectangle = Rectangle.fromDegrees(-100.0, 30.0, -90.0, 40.0);
 
-            var rectanglePrimitive = new RectanglePrimitive({
-                rectangle : rectangle,
-                height : 1000.0,
-                asynchronous : false
-            });
-            rectanglePrimitive.material.uniforms.color = new Color(1.0, 0.0, 0.0, 0.5);
+            var rectanglePrimitive = createRectangle(rectangle, 1000.0);
+            rectanglePrimitive.appearance.material.uniforms.color = new Color(1.0, 0.0, 0.0, 0.5);
 
             var primitives = scene.primitives;
             primitives.add(rectanglePrimitive);
@@ -592,11 +573,8 @@ defineSuite([
         var position = scene.pickPosition(windowPosition);
         expect(position).not.toBeDefined();
 
-        var rectanglePrimitive = new RectanglePrimitive({
-            rectangle : rectangle,
-            asynchronous : false
-        });
-        rectanglePrimitive.material.uniforms.color = new Color(1.0, 0.0, 0.0, 1.0);
+        var rectanglePrimitive = createRectangle(rectangle);
+        rectanglePrimitive.appearance.material.uniforms.color = new Color(1.0, 0.0, 0.0, 1.0);
 
         var primitives = scene.primitives;
         primitives.add(rectanglePrimitive);

--- a/Specs/Widgets/CesiumInspector/CesiumInspectorViewModelSpec.js
+++ b/Specs/Widgets/CesiumInspector/CesiumInspectorViewModelSpec.js
@@ -2,32 +2,53 @@
 defineSuite([
         'Widgets/CesiumInspector/CesiumInspectorViewModel',
         'Core/defined',
+        'Core/GeometryInstance',
         'Core/Math',
         'Core/Rectangle',
+        'Core/RectangleGeometry',
         'Core/WebMercatorTilingScheme',
+        'Scene/EllipsoidSurfaceAppearance',
         'Scene/Globe',
         'Scene/GlobeSurfaceTile',
         'Scene/Material',
+        'Scene/Primitive',
         'Scene/QuadtreeTile',
-        'Scene/RectanglePrimitive',
         'Specs/createScene'
     ], function(
         CesiumInspectorViewModel,
         defined,
+        GeometryInstance,
         CesiumMath,
         Rectangle,
+        RectangleGeometry,
         WebMercatorTilingScheme,
+        EllipsoidSurfaceAppearance,
         Globe,
         GlobeSurfaceTile,
         Material,
+        Primitive,
         QuadtreeTile,
-        RectanglePrimitive,
         createScene) {
     "use strict";
     /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn*/
 
     var scene;
     var performanceContainer;
+
+    function createRectangle(rectangle, rotation) {
+        return new Primitive({
+            geometryInstances: new GeometryInstance({
+                geometry: new RectangleGeometry({
+                    rectangle: rectangle,
+                    vertexFormat: EllipsoidSurfaceAppearance.VERTEX_FORMAT,
+                    rotation: rotation
+                })
+            }),
+            appearance: new EllipsoidSurfaceAppearance({
+                aboveGround: false
+            })
+        });
+    }
 
     beforeAll(function() {
         scene = createScene();
@@ -94,16 +115,12 @@ defineSuite([
     });
 
     it ('primitive bounding sphere', function() {
-        var p = scene.primitives.add(new RectanglePrimitive({
-            rectangle : new Rectangle(
+        var p = scene.primitives.add(createRectangle(new Rectangle(
                     CesiumMath.toRadians(-110.0),
                     CesiumMath.toRadians(0.0),
                     CesiumMath.toRadians(-90.0),
                     CesiumMath.toRadians(20.0)),
-                rotation : CesiumMath.toRadians(45),
-                material : Material.fromType(Material.ColorType)
-            })
-        );
+                    CesiumMath.toRadians(45)));
         var viewModel = new CesiumInspectorViewModel(scene, performanceContainer);
         scene.render();
         viewModel.primitive = p;
@@ -118,26 +135,18 @@ defineSuite([
     });
 
     it ('primitive filter', function() {
-        var p = scene.primitives.add(new RectanglePrimitive({
-            rectangle : new Rectangle(
-                    CesiumMath.toRadians(-110.0),
-                    CesiumMath.toRadians(0.0),
-                    CesiumMath.toRadians(-90.0),
-                    CesiumMath.toRadians(20.0)),
-                rotation : CesiumMath.toRadians(45),
-                material : Material.fromType(Material.ColorType)
-            })
-        );
+        var p = scene.primitives.add(createRectangle(new Rectangle(
+                CesiumMath.toRadians(-110.0),
+                CesiumMath.toRadians(0.0),
+                CesiumMath.toRadians(-90.0),
+                CesiumMath.toRadians(20.0)),
+                CesiumMath.toRadians(45)));
 
-        var q = scene.primitives.add(new RectanglePrimitive({
-            rectangle : new Rectangle(
-                    CesiumMath.toRadians(-10.0),
-                    CesiumMath.toRadians(0.0),
-                    CesiumMath.toRadians(-9.0),
-                    CesiumMath.toRadians(20.0)),
-                material : Material.fromType(Material.ColorType)
-            })
-        );
+        var q = scene.primitives.add(createRectangle(new Rectangle(
+                CesiumMath.toRadians(-10.0),
+                CesiumMath.toRadians(0.0),
+                CesiumMath.toRadians(-9.0),
+                CesiumMath.toRadians(20.0))));
 
         var viewModel = new CesiumInspectorViewModel(scene, performanceContainer);
         scene.render();
@@ -154,16 +163,13 @@ defineSuite([
     });
 
     it ('primitive reference frame', function() {
-        var p = scene.primitives.add(new RectanglePrimitive({
-            rectangle : new Rectangle(
-                    CesiumMath.toRadians(-110.0),
-                    CesiumMath.toRadians(0.0),
-                    CesiumMath.toRadians(-90.0),
-                    CesiumMath.toRadians(20.0)),
-                rotation : CesiumMath.toRadians(45),
-                material : Material.fromType(Material.ColorType)
-            })
-        );
+        var p = scene.primitives.add(createRectangle(new Rectangle(
+                CesiumMath.toRadians(-110.0),
+                CesiumMath.toRadians(0.0),
+                CesiumMath.toRadians(-90.0),
+                CesiumMath.toRadians(20.0)),
+                CesiumMath.toRadians(45)));
+
         var viewModel = new CesiumInspectorViewModel(scene, performanceContainer);
         scene.render();
         viewModel.primitive = p;


### PR DESCRIPTION
As discussed in #3083, these primitives are no longer needed and add confusion to the public API. I also replaced usage of them in any tests with the equivalent G&A code.

Fixes #3083 