### PR TITLE
Geocoder flies to rectangle crossing IDL

### DIFF
--- a/Source/Scene/Camera.js
+++ b/Source/Scene/Camera.js
@@ -2019,6 +2019,10 @@ define([
         //>>includeEnd('debug');
 
         ellipsoid = defaultValue(ellipsoid, Ellipsoid.WGS84);
+        if (this._mode !== SceneMode.SCENE3D && rectangle.west > rectangle.east) {
+            rectangle = Rectangle.MAX_VALUE;
+        }
+
         if (this._mode === SceneMode.SCENE3D) {
             rectangleCameraPosition3D(this, rectangle, ellipsoid, this.position);
         } else if (this._mode === SceneMode.COLUMBUS_VIEW) {


### PR DESCRIPTION
Fixes #2079

The Geocoder uses `flyTo` with a rectangle destination.
For duration=0, I had to copy the `flyTo` logic to use for `setView` because our camera API is wildly inconsistent.