### PR TITLE
Set shuttle ring to max angle when multiplier is too large.

### DIFF
--- a/Source/Widgets/Animation/AnimationViewModel.js
+++ b/Source/Widgets/Animation/AnimationViewModel.js
@@ -81,6 +81,13 @@ define([
             return multiplier * realtimeShuttleRingAngle;
         }
 
+        var fastedMultipler = shuttleRingTicks[shuttleRingTicks.length - 1];
+        if(multiplier > fastedMultipler){
+            multiplier = fastedMultipler;
+        } else if(multiplier < -fastedMultipler){
+            multiplier = -fastedMultipler;
+        }
+
         var minp = realtimeShuttleRingAngle;
         var maxp = maxShuttleRingAngle;
         var maxv;
@@ -88,7 +95,7 @@ define([
         var scale;
 
         if (multiplier > 0) {
-            maxv = Math.log(shuttleRingTicks[shuttleRingTicks.length - 1]);
+            maxv = Math.log(fastedMultipler);
             scale = (maxv - minv) / (maxp - minp);
             return (Math.log(multiplier) - minv) / scale + minp;
         }


### PR DESCRIPTION
Previously, when the clock had a multiplier larger than the largest shuttle ring tick mark, the dial marker would end up going offscreen making it impossible to adjust the multiplier through the UI.  Ancient code tried to account for this by expanding the list of valid ticks to include the new multiplier.  Unfortunately, that approach isn't ideal because it would change user settings out from under them.  Instead, this approach simply sets the dial to it's max value when the muliplier is larger and the first click to slow things down will snap to the largest actual tick.

Fixes #1072

You can use the attached kml file to play with the behavior in Viewer.
[us_states.kml.txt](https://github.com/AnalyticalGraphicsInc/cesium/files/13594/us_states.kml.txt)
