### PR TITLE
Removed "defined" workaround for Chrome 25-28

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,7 @@ Change Log
 * Fixed token issue in `ArcGisMapServerImageryProvider`.
 * `ImageryLayerFeatureInfo` now has an `imageryLayer` property, indicating the layer that contains the feature.
 * Added `BoxOutlineGeometry.fromAxisAlignedBoundingBox` and `BoxGeometry.fromAxisAlignedBoundingBox` functions.
+* Removed a workaround for Chrome 25-28
 
 ### 1.14 - 2015-10-01
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -32,6 +32,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to Cesiu
    * [Kevin Ring](https://github.com/kring)
    * [Keith Grochow](https://github.com/kgrochow)
    * [Chloe Chen](https://github.com/chloeleichen)
+   * [Arthur Street](https://github.com/racingtadpole)
 * [EU Edge](http://euedge.com/)
    * [Ákos Maróy](https://github.com/akosmaroy)
 * [Raytheon Intelligence and Information Systems](http://www.raytheon.com/)

--- a/Source/Core/defaultValue.js
+++ b/Source/Core/defaultValue.js
@@ -19,7 +19,7 @@ define([
      * param = Cesium.defaultValue(param, 'default');
      */
     var defaultValue = function(a, b) {
-        if (a !== undefined) {
+        if (typeof a !== 'undefined') {
             return a;
         }
         return b;

--- a/Source/Core/defined.js
+++ b/Source/Core/defined.js
@@ -16,7 +16,7 @@ define(function() {
      * }
      */
     var defined = function(value) {
-        return value !== undefined;
+        return typeof value !== 'undefined';
     };
 
     return defined;


### PR DESCRIPTION
I'm undoing commit https://github.com/AnalyticalGraphicsInc/cesium/commit/5af834f3c73f1dc1abb67d12fe0b65c83c8f126e , which has the comment: 

"This horrible violation of Cesium coding standards is a workaround for:
https://code.google.com/p/chromium/issues/detail?id=167394 
It can be deleted once Chrome 29 (or maybe 28?) becomes stable."