### PR TITLE
HeadingPitchRange from Scene to Core

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,7 @@ Change Log
   * Deprecated `OrthographicFrustum.getPixelSize`, use `OrthographicFrustum.getPixelDimensions` instead. It will be removed in 1.17.
   * Deprecated `PerspectiveFrustum.getPixelSize`, use `PerspectiveFrustum.getPixelDimensions` instead. It will be removed in 1.17.
   * Deprecated `PerspectiveOffCenterFrustum.getPixelSize`, use `PerspectiveOffCenterFrustum.getPixelDimensions` instead. It will be removed in 1.17.
+  * Deprecated `Scene\HeadingPitchRange`, use `Core\HeadingPitchRange` instead. It will be removed in 1.17.
 * Decreased GPU memory usage in `BillboardCollection` and `LabelCollection` by using the WebGL ANGLE_instanced_arrays extension.
 * Added CZML examples to Sandcastle.  See the new CZML tab.
 * Fixed token issue in `ArcGisMapServerImageryProvider`.

--- a/Source/Core/HeadingPitchRange.js
+++ b/Source/Core/HeadingPitchRange.js
@@ -1,10 +1,10 @@
 /*global define*/
 define([
-        '../Core/HeadingPitchRange',
-        '../Core/deprecationWarning'
+        './defaultValue',
+        './defined'
     ], function(
-        CoreHeadingPitchRange,
-        deprecationWarning) {
+        defaultValue,
+        defined) {
     "use strict";
 
     /**
@@ -18,12 +18,26 @@ define([
      * @param {Number} [heading=0.0] The heading angle in radians.
      * @param {Number} [pitch=0.0] The pitch angle in radians.
      * @param {Number} [range=0.0] The distance from the center in meters.
-     *
-     * @depricated
      */
     var HeadingPitchRange = function(heading, pitch, range) {
-        deprecationWarning('HeadingPitchRange', 'Scene/HeadingPitchRange is deprecated. Use Core/HeadingPitchRange instead.');
-        return new CoreHeadingPitchRange(heading, pitch, range);
+        /**
+         * Heading is the rotation from the local north direction where a positive angle is increasing eastward.
+         * @type {Number}
+         */
+        this.heading = defaultValue(heading, 0.0);
+
+        /**
+         * Pitch is the rotation from the local xy-plane. Positive pitch angles
+         * are above the plane. Negative pitch angles are below the plane.
+         * @type {Number}
+         */
+        this.pitch = defaultValue(pitch, 0.0);
+
+        /**
+         * Range is the distance from the center of the local frame.
+         * @type {Number}
+         */
+        this.range = defaultValue(range, 0.0);
     };
 
     /**
@@ -34,7 +48,17 @@ define([
      * @returns {HeadingPitchRange} The modified result parameter or a new HeadingPitchRange instance if one was not provided. (Returns undefined if hpr is undefined)
      */
     HeadingPitchRange.clone = function(hpr, result) {
-        return CoreHeadingPitchRange.clone(hpr, result);
+        if (!defined(hpr)) {
+            return undefined;
+        }
+        if (!defined(result)) {
+            result = new HeadingPitchRange();
+        }
+
+        result.heading = hpr.heading;
+        result.pitch = hpr.pitch;
+        result.range = hpr.range;
+        return result;
     };
 
     return HeadingPitchRange;

--- a/Source/DataSources/EntityView.js
+++ b/Source/DataSources/EntityView.js
@@ -13,7 +13,7 @@ define([
         '../Core/Matrix3',
         '../Core/Matrix4',
         '../Core/Transforms',
-        '../Scene/HeadingPitchRange',
+        '../Core/HeadingPitchRange',
         '../Scene/SceneMode'
     ], function(
         BoundingSphere,

--- a/Source/Scene/Camera.js
+++ b/Source/Scene/Camera.js
@@ -21,7 +21,7 @@ define([
         '../Core/Rectangle',
         '../Core/Transforms',
         './CameraFlightPath',
-        './HeadingPitchRange',
+        '../Core/HeadingPitchRange',
         './PerspectiveFrustum',
         './SceneMode'
     ], function(

--- a/Source/Scene/HeadingPitchRange.js
+++ b/Source/Scene/HeadingPitchRange.js
@@ -19,7 +19,7 @@ define([
      * @param {Number} [pitch=0.0] The pitch angle in radians.
      * @param {Number} [range=0.0] The distance from the center in meters.
      *
-     * @depricated
+     * @deprecated
      */
     var HeadingPitchRange = function(heading, pitch, range) {
         deprecationWarning('HeadingPitchRange', 'Scene/HeadingPitchRange is deprecated. Use Core/HeadingPitchRange instead.');

--- a/Specs/Core/HeadingPitchRangeSpec.js
+++ b/Specs/Core/HeadingPitchRangeSpec.js
@@ -1,0 +1,38 @@
+/*global defineSuite*/
+defineSuite([
+    'Core/HeadingPitchRange'
+], function(
+    HeadingPitchRange) {
+    "use strict";
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn*/
+
+    it('construct with default values', function() {
+        var hpr = new HeadingPitchRange();
+        expect(hpr.heading).toEqual(0.0);
+        expect(hpr.pitch).toEqual(0.0);
+        expect(hpr.range).toEqual(0.0);
+    });
+
+    it('construct with all values', function() {
+        var hpr = new HeadingPitchRange(1.0, 2.0, 3.0);
+        expect(hpr.heading).toEqual(1.0);
+        expect(hpr.pitch).toEqual(2.0);
+        expect(hpr.range).toEqual(3.0);
+    });
+
+    it('clone with a result parameter', function() {
+        var hpr = new HeadingPitchRange(1.0, 2.0, 3.0);
+        var result = new HeadingPitchRange();
+        var returnedResult = HeadingPitchRange.clone(hpr, result);
+        expect(hpr).not.toBe(result);
+        expect(result).toBe(returnedResult);
+        expect(hpr).toEqual(result);
+    });
+
+    it('clone works with a result parameter that is an input parameter', function() {
+        var hpr = new HeadingPitchRange(1.0, 2.0, 3.0);
+        var returnedResult = HeadingPitchRange.clone(hpr, hpr);
+        expect(hpr).toBe(returnedResult);
+    });
+
+});

--- a/Specs/Scene/CameraSpec.js
+++ b/Specs/Scene/CameraSpec.js
@@ -16,7 +16,7 @@ defineSuite([
         'Core/Transforms',
         'Core/WebMercatorProjection',
         'Scene/CameraFlightPath',
-        'Scene/HeadingPitchRange',
+        'Core/HeadingPitchRange',
         'Scene/OrthographicFrustum',
         'Scene/PerspectiveFrustum',
         'Scene/SceneMode',

--- a/Specs/Scene/ModelSpec.js
+++ b/Specs/Scene/ModelSpec.js
@@ -14,7 +14,7 @@ defineSuite([
         'Core/Transforms',
         'Renderer/RenderState',
         'Renderer/WebGLConstants',
-        'Scene/HeadingPitchRange',
+        'Core/HeadingPitchRange',
         'Scene/ModelAnimationLoop',
         'Specs/createScene',
         'Specs/pollToPromise',


### PR DESCRIPTION
Closes #2738

Deprecated `Scene/HeadingPitchRange` and added `Core/HeadingPitchRange`.

Added unit tests for `Core/HeadingPitchRange` and changes occurrences of `Scene/HeadingPitchRange` to `Core/HeadingPitchRange`.