### PR TITLE
removed unneccisary subtraction, combined high and low parameters

### DIFF
--- a/Source/Scene/GlobeSurfaceTileProvider.js
+++ b/Source/Scene/GlobeSurfaceTileProvider.js
@@ -990,9 +990,8 @@ define([
                 northLatitude = tile.rectangle.north;
 
                 southMercatorY = WebMercatorProjection.geodeticLatitudeToMercatorAngle(southLatitude);
-                var northMercatorY = WebMercatorProjection.geodeticLatitudeToMercatorAngle(northLatitude);
 
-                oneOverMercatorHeight = 1.0 / (northMercatorY - southMercatorY);
+                oneOverMercatorHeight = 1.0 / (WebMercatorProjection.geodeticLatitudeToMercatorAngle(northLatitude) - southMercatorY);
 
                 useWebMercatorProjection = true;
             }

--- a/Source/Scene/GlobeSurfaceTileProvider.js
+++ b/Source/Scene/GlobeSurfaceTileProvider.js
@@ -760,8 +760,8 @@ define([
             u_southAndNorthLatitude : function() {
                 return this.southAndNorthLatitude;
             },
-            u_southMercatorYLowAndHighAndOneOverHeight : function() {
-                return this.southMercatorYLowAndHighAndOneOverHeight;
+            u_southMercatorYAndOneOverHeight : function() {
+                return this.southMercatorYAndOneOverHeight;
             },
             u_waterMask : function() {
                 return this.waterMask;
@@ -791,7 +791,7 @@ define([
             dayIntensity : 0.0,
 
             southAndNorthLatitude : new Cartesian2(),
-            southMercatorYLowAndHighAndOneOverHeight : new Cartesian3(),
+            southMercatorYAndOneOverHeight : new Cartesian2(),
 
             waterMask : undefined,
             waterMaskTranslationAndScale : new Cartesian4()
@@ -958,8 +958,7 @@ define([
         // Only used for Mercator projections.
         var southLatitude = 0.0;
         var northLatitude = 0.0;
-        var southMercatorYHigh = 0.0;
-        var southMercatorYLow = 0.0;
+        var southMercatorY = 0.0;
         var oneOverMercatorHeight = 0.0;
 
         var useWebMercatorProjection = false;
@@ -990,12 +989,8 @@ define([
                 southLatitude = tile.rectangle.south;
                 northLatitude = tile.rectangle.north;
 
-                var southMercatorY = WebMercatorProjection.geodeticLatitudeToMercatorAngle(southLatitude);
+                southMercatorY = WebMercatorProjection.geodeticLatitudeToMercatorAngle(southLatitude);
                 var northMercatorY = WebMercatorProjection.geodeticLatitudeToMercatorAngle(northLatitude);
-
-                float32ArrayScratch[0] = southMercatorY;
-                southMercatorYHigh = float32ArrayScratch[0];
-                southMercatorYLow = southMercatorY - float32ArrayScratch[0];
 
                 oneOverMercatorHeight = 1.0 / (northMercatorY - southMercatorY);
 
@@ -1068,9 +1063,8 @@ define([
             Cartesian4.clone(tileRectangle, uniformMap.tileRectangle);
             uniformMap.southAndNorthLatitude.x = southLatitude;
             uniformMap.southAndNorthLatitude.y = northLatitude;
-            uniformMap.southMercatorYLowAndHighAndOneOverHeight.x = southMercatorYLow;
-            uniformMap.southMercatorYLowAndHighAndOneOverHeight.y = southMercatorYHigh;
-            uniformMap.southMercatorYLowAndHighAndOneOverHeight.z = oneOverMercatorHeight;
+            uniformMap.southMercatorYAndOneOverHeight.x = southMercatorY;
+            uniformMap.southMercatorYAndOneOverHeight.y = oneOverMercatorHeight;
             Matrix4.clone(modifiedModelViewScratch, uniformMap.modifiedModelView);
 
             var applyBrightness = false;

--- a/Source/Shaders/Builtin/Functions/latitudeToWebMercatorFraction.glsl
+++ b/Source/Shaders/Builtin/Functions/latitudeToWebMercatorFraction.glsl
@@ -5,25 +5,17 @@
  * @glslFunction
  *
  * @param {float} latitude The geodetic latitude, in radians.
- * @param {float} southMercatorYLow The low portion of the Web Mercator coordinate of the southern boundary of the rectangle.
- * @param {float} southMercatorYHigh The high portion of the Web Mercator coordinate of the southern boundary of the rectangle.
+ * @param {float} southMercatorY The Web Mercator coordinate of the southern boundary of the rectangle.
  * @param {float} oneOverMercatorHeight The total height of the rectangle in Web Mercator coordinates.
  *
  * @returns {float} The fraction of the rectangle at which the latitude occurs.  If the latitude is the southern
  *          boundary of the rectangle, the return value will be zero.  If it is the northern boundary, the return
  *          value will be 1.0.  Latitudes in between are mapped according to the Web Mercator projection.
  */ 
-float czm_latitudeToWebMercatorFraction(float latitude, float southMercatorYLow, float southMercatorYHigh, float oneOverMercatorHeight)
+float czm_latitudeToWebMercatorFraction(float latitude, float southMercatorY, float oneOverMercatorHeight)
 {
     float sinLatitude = sin(latitude);
     float mercatorY = 0.5 * log((1.0 + sinLatitude) / (1.0 - sinLatitude));
     
-    // mercatorY - southMercatorY in simulated double precision.
-    float t1 = 0.0 - southMercatorYLow;
-    float e = t1 - 0.0;
-    float t2 = ((-southMercatorYLow - e) + (0.0 - (t1 - e))) + mercatorY - southMercatorYHigh;
-    float highDifference = t1 + t2;
-    float lowDifference = t2 - (highDifference - t1);
-    
-    return highDifference * oneOverMercatorHeight + lowDifference * oneOverMercatorHeight;
+    return (mercatorY - southMercatorY) * oneOverMercatorHeight;
 }

--- a/Source/Shaders/GlobeVS.glsl
+++ b/Source/Shaders/GlobeVS.glsl
@@ -7,7 +7,7 @@ uniform vec4 u_tileRectangle;
 
 // Uniforms for 2D Mercator projection
 uniform vec2 u_southAndNorthLatitude;
-uniform vec3 u_southMercatorYLowAndHighAndOneOverHeight;
+uniform vec2 u_southMercatorYAndOneOverHeight;
 
 varying vec3 v_positionMC;
 varying vec3 v_positionEC;
@@ -38,8 +38,8 @@ float get2DMercatorYPositionFraction()
     float northLatitude = u_southAndNorthLatitude.y;
     if (northLatitude - southLatitude > maxTileWidth)
     {
-        float southMercatorY = u_southMercatorYLowAndHighAndOneOverHeight.y;
-        float oneOverMercatorHeight = u_southMercatorYLowAndHighAndOneOverHeight.z;
+        float southMercatorY = u_southMercatorYAndOneOverHeight.x;
+        float oneOverMercatorHeight = u_southMercatorYAndOneOverHeight.y;
 
         float currentLatitude = mix(southLatitude, northLatitude, textureCoordAndEncodedNormals.y);
         currentLatitude = clamp(currentLatitude, -czm_webMercatorMaxLatitude, czm_webMercatorMaxLatitude);

--- a/Source/Shaders/GlobeVS.glsl
+++ b/Source/Shaders/GlobeVS.glsl
@@ -38,13 +38,12 @@ float get2DMercatorYPositionFraction()
     float northLatitude = u_southAndNorthLatitude.y;
     if (northLatitude - southLatitude > maxTileWidth)
     {
-        float southMercatorYLow = u_southMercatorYLowAndHighAndOneOverHeight.x;
-        float southMercatorYHigh = u_southMercatorYLowAndHighAndOneOverHeight.y;
+        float southMercatorY = u_southMercatorYLowAndHighAndOneOverHeight.y;
         float oneOverMercatorHeight = u_southMercatorYLowAndHighAndOneOverHeight.z;
 
         float currentLatitude = mix(southLatitude, northLatitude, textureCoordAndEncodedNormals.y);
         currentLatitude = clamp(currentLatitude, -czm_webMercatorMaxLatitude, czm_webMercatorMaxLatitude);
-        positionFraction = czm_latitudeToWebMercatorFraction(currentLatitude, southMercatorYLow, southMercatorYHigh, oneOverMercatorHeight);
+        positionFraction = czm_latitudeToWebMercatorFraction(currentLatitude, southMercatorY, oneOverMercatorHeight);
     }    
     return positionFraction;
 }


### PR DESCRIPTION
Closes #965.

Removed simulated double precision subtraction from `latitudeToWebMercatorFraction.glsl` and combined `high` and `low` parameters into one `southMercatorY`. Changed occurrence of the function call to match the new parameters.