### PR TITLE
Default failIfMajorPerformanceCaveat to false

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,7 @@ Change Log
 * Fixed token issue in `ArcGisMapServerImageryProvider`.
 * `ImageryLayerFeatureInfo` now has an `imageryLayer` property, indicating the layer that contains the feature.
 * Added `BoxOutlineGeometry.fromAxisAlignedBoundingBox` and `BoxGeometry.fromAxisAlignedBoundingBox` functions.
+* The WebGL setting of `failIfMajorPerformanceCaveat` now defaults to `false`, which is the official WebGL default. This improves compatibility with out-of-date drivers and remote desktop sessions. Cesium will run slower in these cases instead of simply failing to load. 
 
 ### 1.14 - 2015-10-01
 

--- a/Source/Renderer/Context.js
+++ b/Source/Renderer/Context.js
@@ -201,17 +201,6 @@ define([
 
         // Override select WebGL defaults
         webglOptions.alpha = defaultValue(webglOptions.alpha, false); // WebGL default is true
-        webglOptions.failIfMajorPerformanceCaveat = defaultValue(webglOptions.failIfMajorPerformanceCaveat, true); // WebGL default is false
-
-        // Firefox 35 with ANGLE has a regression that causes alpha : false to affect all framebuffers
-        // Since we can't detect for ANGLE without a context, we just detect for Windows.
-        // https://github.com/AnalyticalGraphicsInc/cesium/issues/2431
-        if (FeatureDetection.isFirefox() && FeatureDetection.isWindows()) {
-            var firefoxVersion = FeatureDetection.firefoxVersion();
-            if (firefoxVersion[0] === 35) {
-                webglOptions.alpha = true;
-            }
-        }
 
         var defaultToWebgl2 = false;
         var webgl2Supported = (typeof WebGL2RenderingContext !== 'undefined');
@@ -294,32 +283,32 @@ define([
         var textureFilterAnisotropic = options.allowTextureFilterAnisotropic ? getExtension(gl, ['EXT_texture_filter_anisotropic', 'WEBKIT_EXT_texture_filter_anisotropic']) : undefined;
         this._textureFilterAnisotropic = !!textureFilterAnisotropic;
         ContextLimits._maximumTextureFilterAnisotropy = defined(textureFilterAnisotropic) ? gl.getParameter(textureFilterAnisotropic.MAX_TEXTURE_MAX_ANISOTROPY_EXT) : 1.0;
-        
+
         var glCreateVertexArray;
         var glBindVertexArray;
         var glDeleteVertexArray;
-        
+
         var glDrawElementsInstanced;
         var glDrawArraysInstanced;
         var glVertexAttribDivisor;
-        
+
         var glDrawBuffers;
-        
+
         var vertexArrayObject;
         var instancedArrays;
         var drawBuffers;
-        
+
         if (webgl2) {
             var that = this;
-            
+
             glCreateVertexArray = function () { return that._gl.createVertexArray(); };
             glBindVertexArray = function(vao) { that._gl.bindVertexArray(vao); };
             glDeleteVertexArray = function(vao) { that._gl.deleteVertexArray(vao); };
-            
+
             glDrawElementsInstanced = function(mode, count, type, offset, instanceCount) { gl.drawElementsInstanced(mode, count, type, offset, instanceCount); };
             glDrawArraysInstanced = function(mode, first, count, instanceCount) { gl.drawArraysInstanced(mode, first, count, instanceCount); };
             glVertexAttribDivisor = function(index, divisor) { gl.vertexAttribDivisor(index, divisor); };
-            
+
             glDrawBuffers = function(buffers) { gl.drawBuffers(buffers); };
         } else {
             vertexArrayObject = getExtension(gl, ['OES_vertex_array_object']);
@@ -328,30 +317,30 @@ define([
                 glBindVertexArray = function(vertexArray) { vertexArrayObject.bindVertexArrayOES(vertexArray); };
                 glDeleteVertexArray = function(vertexArray) { vertexArrayObject.deleteVertexArrayOES(vertexArray); };
             }
-            
+
             instancedArrays = getExtension(gl, ['ANGLE_instanced_arrays']);
             if (defined(instancedArrays)) {
                 glDrawElementsInstanced = function(mode, count, type, offset, instanceCount) { instancedArrays.drawElementsInstancedANGLE(mode, count, type, offset, instanceCount); };
                 glDrawArraysInstanced = function(mode, first, count, instanceCount) { instancedArrays.drawArraysInstancedANGLE(mode, first, count, instanceCount); };
                 glVertexAttribDivisor = function(index, divisor) { instancedArrays.vertexAttribDivisorANGLE(index, divisor); };
             }
-            
+
             drawBuffers = getExtension(gl, ['WEBGL_draw_buffers']);
             if (defined(drawBuffers)) {
                 glDrawBuffers = function(buffers) { drawBuffers.drawBuffersWEBGL(buffers); };
             }
         }
-        
+
         this.glCreateVertexArray = glCreateVertexArray;
         this.glBindVertexArray = glBindVertexArray;
         this.glDeleteVertexArray = glDeleteVertexArray;
-        
+
         this.glDrawElementsInstanced = glDrawElementsInstanced;
         this.glDrawArraysInstanced = glDrawArraysInstanced;
         this.glVertexAttribDivisor = glVertexAttribDivisor;
-        
+
         this.glDrawBuffers = glDrawBuffers;
-        
+
         this._vertexArrayObject = !!vertexArrayObject;
         this._instancedArrays = !!instancedArrays;
         this._drawBuffers = !!drawBuffers;

--- a/Source/Scene/Scene.js
+++ b/Source/Scene/Scene.js
@@ -136,7 +136,7 @@ define([
      *     antialias : true,
      *     premultipliedAlpha : true,
      *     preserveDrawingBuffer : false,
-     *     failIfMajorPerformanceCaveat : true
+     *     failIfMajorPerformanceCaveat : false
      *   },
      *   allowTextureFilterAnisotropic : true
      * }
@@ -150,11 +150,6 @@ define([
      * <code>webgl.alpha</code> defaults to false, which can improve performance compared to the standard WebGL default
      * of true.  If an application needs to composite Cesium above other HTML elements using alpha-blending, set
      * <code>webgl.alpha</code> to true.
-     * </p>
-     * <p>
-     * <code>webgl.failIfMajorPerformanceCaveat</code> defaults to true, which ensures a context is not successfully created
-     * if the system has a major performance issue such as only supporting software rendering.  The standard WebGL default is false,
-     * which is not appropriate for almost any Cesium app.
      * </p>
      * <p>
      * The other <code>webgl</code> properties match the WebGL defaults for {@link http://www.khronos.org/registry/webgl/specs/latest/#5.2|WebGLContextAttributes}.

--- a/Specs/Widgets/CesiumWidget/CesiumWidgetSpec.js
+++ b/Specs/Widgets/CesiumWidget/CesiumWidgetSpec.js
@@ -55,7 +55,6 @@ defineSuite([
         options = defaultValue(options, {});
         options.contextOptions = defaultValue(options.contextOptions, {});
         options.contextOptions.webgl = defaultValue(options.contextOptions.webgl, {});
-        options.contextOptions.webgl.failIfMajorPerformanceCaveat = false;
 
         return new CesiumWidget(container, options);
     }

--- a/Specs/createContext.js
+++ b/Specs/createContext.js
@@ -40,7 +40,6 @@ define([
         options.webgl = clone(defaultValue(options.webgl, {}));
         options.webgl.alpha = defaultValue(options.webgl.alpha, true);
         options.webgl.antialias = defaultValue(options.webgl.antialias, false);
-        options.webgl.failIfMajorPerformanceCaveat = false;
 
 
         var canvas = createCanvas(canvasWidth, canvasHeight);

--- a/Specs/createScene.js
+++ b/Specs/createScene.js
@@ -34,7 +34,6 @@ define([
         var contextOptions = options.contextOptions;
         contextOptions.webgl = defaultValue(contextOptions.webgl, {});
         contextOptions.webgl.antialias = defaultValue(contextOptions.webgl.antialias, false);
-        contextOptions.webgl.failIfMajorPerformanceCaveat = false;
 
         var scene = new Scene(options);
 

--- a/Specs/createViewer.js
+++ b/Specs/createViewer.js
@@ -11,7 +11,6 @@ define([
         options = defaultValue(options, {});
         options.contextOptions = defaultValue(options.contextOptions, {});
         options.contextOptions.webgl = defaultValue(options.contextOptions.webgl, {});
-        options.contextOptions.webgl.failIfMajorPerformanceCaveat = false;
 
         return new Viewer(container, options);
     }


### PR DESCRIPTION
In order to avoid users' first impression of Cesium being a failed to load screen, this changes `failIfMajorPerformanceCaveat` back to the official WebGL default of `false`. While I agree that many Cesium apps will perform poorly under these conditions, there are several use cases where it makes sense, such as RDP sessions.  I also think it's better to provide maximum compatibility out of the box since almost no user will know about or ever use this setting.

I also removed an old Firefox workaround for Firefox 35.  Since 35 was not an ESR release, there's no reason for the workaround to still be there.

P.S. Context.js apparently had some lines with nothing but whitespace that the Eclipse formatter cleaned up, which is why those extra blank changes are there.