### PR TITLE
Fix BoxGeometry deprecation.

### DIFF
--- a/Source/Core/BoxGeometry.js
+++ b/Source/Core/BoxGeometry.js
@@ -60,24 +60,21 @@ define([
         var min = options.minimum;
         var max = options.maximum;
 
+        if (!defined(min) && defined(options.minimumCorner)) {
+            min = options.minimumCorner;
+            deprecationWarning('BoxGeometry', 'options.minimumCorner is deprecated. Use options.minimum instead.');
+        }
+        if (!defined(max) && defined(options.maximumCorner)) {
+            max = options.maximumCorner;
+            deprecationWarning('BoxGeometry', 'options.maximumCorner is deprecated. Use options.maximum instead.');
+        }
+
         //>>includeStart('debug', pragmas.debug);
         if (!defined(min)) {
-            if (defined(options.minimumCorner)) {
-                min = options.minimumCorner;
-                deprecationWarning('BoxGeometry', 'options.minimumCorner is deprecated. Use options.minimum instead.');
-            }
-            else {
-                throw new DeveloperError('options.minimum is required.');
-            }
+            throw new DeveloperError('options.minimum is required.');
         }
         if (!defined(max)) {
-            if (defined(options.maximumCorner)) {
-                max = options.maximumCorner;
-                deprecationWarning('BoxGeometry', 'options.maximumCorner is deprecated. Use options.maximum instead.');
-            }
-            else {
-                throw new DeveloperError('options.maximum is required');
-            }
+            throw new DeveloperError('options.maximum is required');
         }
         //>>includeEnd('debug');
 

--- a/Source/Core/BoxOutlineGeometry.js
+++ b/Source/Core/BoxOutlineGeometry.js
@@ -56,24 +56,21 @@ define([
         var min = options.minimum;
         var max = options.maximum;
 
+        if (!defined(min) && defined(options.minimumCorner)) {
+            min = options.minimumCorner;
+            deprecationWarning('BoxOutlineGeometry', 'options.minimumCorner is deprecated. Use options.minimum instead.');
+        }
+        if (!defined(max) && defined(options.maximumCorner)) {
+            max = options.maximumCorner;
+            deprecationWarning('BoxOutlineGeometry', 'options.maximumCorner is deprecated. Use options.maximum instead.');
+        }
+
         //>>includeStart('debug', pragmas.debug);
         if (!defined(min)) {
-            if (defined(options.minimumCorner)) {
-                min = options.minimumCorner;
-                deprecationWarning('BoxOutlineGeometry', 'options.minimumCorner is deprecated. Use options.minimum instead.');
-            }
-            else {
-                throw new DeveloperError('options.minimum is required.');
-            }
+            throw new DeveloperError('options.minimum is required.');
         }
         if (!defined(max)) {
-            if (defined(options.maximumCorner)) {
-                max = options.maximumCorner;
-                deprecationWarning('BoxOutlineGeometry', 'options.maximumCorner is deprecated. Use options.maximum instead.');
-            }
-            else {
-                throw new DeveloperError('options.maximum is required');
-            }
+            throw new DeveloperError('options.maximum is required');
         }
         //>>includeEnd('debug');
 

--- a/Source/Core/ShowGeometryInstanceAttribute.js
+++ b/Source/Core/ShowGeometryInstanceAttribute.js
@@ -29,8 +29,8 @@ define([
      *   geometry : new Cesium.BoxGeometry({
      *     vertexFormat : Cesium.VertexFormat.POSITION_AND_NORMAL,
      *     dimensions : new Cesium.Cartesian3(1000000.0, 1000000.0, 500000.0),
-     *     minimumCorner : new Cesium.Cartesian3(-250000.0, -250000.0, -250000.0),
-     *     maximumCorner : new Cesium.Cartesian3(250000.0, 250000.0, 250000.0)
+     *     minimum : new Cesium.Cartesian3(-250000.0, -250000.0, -250000.0),
+     *     maximum : new Cesium.Cartesian3(250000.0, 250000.0, 250000.0)
      *   }),
      *   modelMatrix : Cesium.Matrix4.multiplyByTranslation(Cesium.Transforms.eastNorthUpToFixedFrame(
      *     Cesium.Cartesian3.fromDegrees(-75.59777, 40.03883)), new Cesium.Cartesian3(0.0, 0.0, 1000000.0), new Cesium.Matrix4()),


### PR DESCRIPTION
#3073 introduced a bug where the deprecated behavior did not work in release mode.  Any code that handles deprecated behavior must be outside of pragma statements or else it won't be part of the minified release.

This can be tested by running `ant minify` and then running [Run all tests against combined file with debug code removed](http://localhost:8080/Specs/SpecRunner.html?built=true&release=true)