### PR TITLE
Webgl errors

### DIFF
--- a/Source/Renderer/Context.js
+++ b/Source/Renderer/Context.js
@@ -281,7 +281,7 @@ define([
         this._debugShaders = getExtension(gl, ['WEBGL_debug_shaders']);
 
         var textureFilterAnisotropic = options.allowTextureFilterAnisotropic ? getExtension(gl, ['EXT_texture_filter_anisotropic', 'WEBKIT_EXT_texture_filter_anisotropic']) : undefined;
-        this._textureFilterAnisotropic = !!textureFilterAnisotropic;
+        this._textureFilterAnisotropic = textureFilterAnisotropic;
         ContextLimits._maximumTextureFilterAnisotropy = defined(textureFilterAnisotropic) ? gl.getParameter(textureFilterAnisotropic.MAX_TEXTURE_MAX_ANISOTROPY_EXT) : 1.0;
 
         var glCreateVertexArray;
@@ -584,7 +584,7 @@ define([
 
         textureFilterAnisotropic : {
             get : function() {
-                return this._textureFilterAnisotropic;
+                return !!this._textureFilterAnisotropic;
             }
         },
 

--- a/Source/Scene/BillboardCollection.js
+++ b/Source/Scene/BillboardCollection.js
@@ -1256,6 +1256,9 @@ define([
 
                 if (properties[IMAGE_INDEX_INDEX] || properties[PIXEL_OFFSET_INDEX] || properties[HORIZONTAL_ORIGIN_INDEX] || properties[VERTICAL_ORIGIN_INDEX] || properties[SHOW_INDEX]) {
                     writers.push(writeCompressedAttrib0);
+                    if (this._instanced) {
+                        writers.push(writeEyeOffset);
+                    }
                 }
 
                 if (properties[IMAGE_INDEX_INDEX] || properties[ALIGNED_AXIS_INDEX] || properties[TRANSLUCENCY_BY_DISTANCE_INDEX]) {


### PR DESCRIPTION
Fixes #3105.The WebGL errors are not generated. The problem with labels was with instancing. The texture coordinates were not being properly updated. I'm still seeing an issue with the textures on the globe, but I don't think it is related.