### PR TITLE
Add npm-debug.log to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ Thumbs.db
 /Specs/SpecList.js
 
 /node_modules
+npm-debug.log
 
 # WebStorm user-specific
 .idea/workspace.xml


### PR DESCRIPTION
Surprised we've gone this long without it being in there.