### PR TITLE
Fixed divisor issue

### DIFF
--- a/Source/Renderer/VertexArray.js
+++ b/Source/Renderer/VertexArray.js
@@ -93,10 +93,18 @@ define([
                 gl.bindBuffer(gl.ARRAY_BUFFER, this.vertexBuffer._getBuffer());
                 gl.vertexAttribPointer(index, this.componentsPerAttribute, this.componentDatatype, this.normalize, this.strideInBytes, this.offsetInBytes);
                 gl.enableVertexAttribArray(index);
+                if (this.instanceDivisor > 0) {
+                    context.glVertexAttribDivisor(index, this.instanceDivisor);
+                    context._vertexAttribDivisors[index] = this.instanceDivisor;
+                    context._previousDrawInstanced = true;
+                }
             };
 
             attr.disableVertexAttribArray = function(gl) {
                 gl.disableVertexAttribArray(this.index);
+                if (this.instanceDivisor > 0) {
+                    context.glVertexAttribDivisor(index, 0);
+                }
             };
         } else {
             // Less common case: value array for the same data for each vertex
@@ -707,12 +715,11 @@ define([
     VertexArray.prototype._bind = function() {
         if (defined(this._vao)) {
             this._context.glBindVertexArray(this._vao);
+            if (this._context.instancedArrays) {
+                setVertexAttribDivisor(this);
+            }
         } else {
             bind(this._gl, this._attributes, this._indexBuffer);
-        }
-
-        if (this._context.instancedArrays) {
-            setVertexAttribDivisor(this);
         }
     };
 


### PR DESCRIPTION
For #3116 

This is another attempt to fix the divisor problems. The specs pass and the Sandcastle demos work. It basically reverts what I did in #3113 and adds lines 98 and 99 to set the divisor cache when a VAO is created. 

I'm not completely sure what the Chrome bug is that I'm working against. The title for the Chromium commit is "Fixed issue with vertex attrib divisors of 0 not tracking correctly". So the VAO actually does store the divisor state, except has a problem when the divisors are 0. I was able to test a simpler version of `setVertexAttribDivisor` for this, but it won't work on Firefox because they still seem to store the divisors as global state. Basically two implementations are needed to fix two different browser bugs. The solution here works all around, but on Chrome there will be some excess glVertexAttribDivisor calls when the divisor is > 1. At least Canary now works as expected.