### PR TITLE
Fix Travis jsHint checking.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -214,7 +214,8 @@ gulp.task('jsHint', ['build'], function() {
     return gulp.src(jsHintFiles)
         .pipe(jshint.extract('auto'))
         .pipe(jshint())
-        .pipe(jshint.reporter('jshint-stylish'));
+        .pipe(jshint.reporter('jshint-stylish'))
+        .pipe(jshint.reporter('fail'));
 });
 
 gulp.task('jsHint-watch', function() {


### PR DESCRIPTION
`gulp-jshint` does not return 1 on jsHint failure by default, instead it prints the jsHint errors to the screen and cleanly exists with 0. This adds their built-in "fail" reporter to return 1 and therefore allow travis to fail as well.

I also submitted a jsHint to this branch to verify it now fails.  Once we see the failure, I'll undo the change and force push so we can merge.

One downside of this change is that running `npm run jsHint` will now spew the npm error log when it fails (because of the 1 return code).  However, devs can run `npm run jsHint -s` to avoid this.  Since most of us will run `jsHint-watch` or via WebStorm or Eclipse (neither of which will have this problem), I don't think it's a big deal.  If it is, we can always work around it with alternate build targets or command line parameters.