### PR TITLE
Fix when.defer() usage

### DIFF
--- a/Source/DataSources/KmlDataSource.js
+++ b/Source/DataSources/KmlDataSource.js
@@ -203,7 +203,7 @@ define([
             deferred.reject(reader.error);
         });
         reader.readAsArrayBuffer(magicBlob);
-        return deferred;
+        return deferred.promise;
     }
 
     function readBlobAsText(blob) {
@@ -216,7 +216,7 @@ define([
             deferred.reject(reader.error);
         });
         reader.readAsText(blob);
-        return deferred;
+        return deferred.promise;
     }
 
     function loadXmlFromZip(reader, entry, uriResolver, deferred) {
@@ -1644,7 +1644,7 @@ define([
             deferred.reject(e);
         });
 
-        return deferred;
+        return deferred.promise;
     }
 
     /**

--- a/Source/Scene/GroundPrimitive.js
+++ b/Source/Scene/GroundPrimitive.js
@@ -302,7 +302,7 @@ define([
          */
         readyPromise : {
             get : function() {
-                return this._readyPromise;
+                return this._readyPromise.promise;
             }
         }
     });

--- a/Source/Scene/Model.js
+++ b/Source/Scene/Model.js
@@ -686,7 +686,7 @@ define([
          */
         readyPromise : {
             get : function() {
-                return this._readyPromise;
+                return this._readyPromise.promise;
             }
         },
 
@@ -3103,7 +3103,7 @@ define([
             var model = this;
             frameState.afterRender.push(function() {
                 model._ready = true;
-                model.readyPromise.resolve(model);
+                model._readyPromise.resolve(model);
             });
             return;
         }

--- a/Source/Scene/Primitive.js
+++ b/Source/Scene/Primitive.js
@@ -433,7 +433,7 @@ define([
          */
         readyPromise : {
             get : function() {
-                return this._readyPromise;
+                return this._readyPromise.promise;
             }
         }
     });

--- a/Source/Widgets/Viewer/Viewer.js
+++ b/Source/Widgets/Viewer/Viewer.js
@@ -1557,7 +1557,7 @@ Either specify options.terrainProvider instead or set options.baseLayerPicker to
             }
         });
 
-        return zoomPromise;
+        return zoomPromise.promise;
     }
 
     function clearZoom(viewer) {


### PR DESCRIPTION
It turns out that there are a bunch of places in our code where we use `when.defer()` and return the deferred instance instead of its `promise` property.  This works in most cases because when's deferred
promises are thenable, however they don't have all of when's API, like `always`.  This change makes sure we correctly return `deferred.promise` everywhere.

It's probably a quirk of the version of when we are using that defers aren't always-able and always isn't part of the A+ spec, so there's no reason to add additional tests for these.