### PR TITLE
Adds maximum scale property to models

### DIFF
--- a/Apps/Sandcastle/gallery/3D Models.html
+++ b/Apps/Sandcastle/gallery/3D Models.html
@@ -47,7 +47,8 @@ function createModel(url, height) {
         orientation : orientation,
         model : {
             uri : url,
-            minimumPixelSize : 128
+            minimumPixelSize : 128,
+            maximumScale : 20000
         }
     });
     viewer.trackedEntity = entity;

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ Change Log
 * Fixed an issue where the sun texture is not generated correctly on some mobile devices. [#3141](https://github.com/AnalyticalGraphicsInc/cesium/issues/3141)
 * Fixed a bug in the deprecated `jsonp` that prevented it from returning a promise.  Its replacement, `loadJsonp`, was unaffected.
 * Fixed glTF implementation to read the version as a string as per the specification and to correctly handle backwards compatibility for axis-angle rotations in glTF 0.8 models.
+* Added a maximumScale property to models, giving an upper limit for minimumPixelSize.
 
 ### 1.15 - 2015-11-02
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,7 +6,7 @@ Change Log
 * Fixed an issue where the sun texture is not generated correctly on some mobile devices. [#3141](https://github.com/AnalyticalGraphicsInc/cesium/issues/3141)
 * Fixed a bug in the deprecated `jsonp` that prevented it from returning a promise.  Its replacement, `loadJsonp`, was unaffected.
 * Fixed glTF implementation to read the version as a string as per the specification and to correctly handle backwards compatibility for axis-angle rotations in glTF 0.8 models.
-* Added a maximumScale property to models, giving an upper limit for minimumPixelSize.
+* Added `Model.maximumScale` and `ModelGraphics.maximumScale` properties, giving an upper limit for minimumPixelSize.
 
 ### 1.15 - 2015-11-02
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -73,5 +73,6 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to Cesiu
 * [Cole Murphy](https://github.com/fantasticole)
 * [Keat Tang](https://github.com/keattang)
 * [Denver Pierce](https://github.com/denverpierce)
+* [Tucker Tibbetts](https://github.com/cttibbetts)
 
 Also see [our contributors page](http://cesiumjs.org/contributors.html) for more information.

--- a/Source/DataSources/ModelGraphics.js
+++ b/Source/DataSources/ModelGraphics.js
@@ -97,7 +97,9 @@ define([
         /**
          * Gets or sets the numeric Property specifying the maximum scale
          * size of a model. This property is used as an upper limit for 
-         * minimumPixelSize.
+         * {@link ModelGraphics#minimumPixelSize}.
+         * @memberof ModelGraphics.prototype
+         * @type {Property}
          */
         maximumScale : createPropertyDescriptor('maximumScale'),
 

--- a/Source/DataSources/ModelGraphics.js
+++ b/Source/DataSources/ModelGraphics.js
@@ -31,6 +31,7 @@ define([
      * @param {Property} [options.show=true] A boolean Property specifying the visibility of the model.
      * @param {Property} [options.scale=1.0] A numeric Property specifying a uniform linear scale.
      * @param {Property} [options.minimumPixelSize=0.0] A numeric Property specifying the approximate minimum pixel size of the model regardless of zoom.
+     * @param {Property} [options.maximumScale] The maximum scale size of a model. An upper limit for minimumPixelSize.
      *
      * @see {@link http://cesiumjs.org/2014/03/03/Cesium-3D-Models-Tutorial/|3D Models Tutorial}
      * @demo {@link http://cesiumjs.org/Cesium/Apps/Sandcastle/index.html?src=3D%20Models.html|Cesium Sandcastle 3D Models Demo}
@@ -42,6 +43,8 @@ define([
         this._scaleSubscription = undefined;
         this._minimumPixelSize = undefined;
         this._minimumPixelSizeSubscription = undefined;
+        this._maximumScale = undefined;
+        this._maximumScaleSubscription = undefined;
         this._uri = undefined;
         this._uriSubscription = undefined;
         this._definitionChanged = new Event();
@@ -92,6 +95,13 @@ define([
         minimumPixelSize : createPropertyDescriptor('minimumPixelSize'),
 
         /**
+         * Gets or sets the numeric Property specifying the maximum scale
+         * size of a model. This property is used as an upper limit for 
+         * minimumPixelSize.
+         */
+        maximumScale : createPropertyDescriptor('maximumScale'),
+
+        /**
          * Gets or sets the string Property specifying the URI of the glTF asset.
          * @memberof ModelGraphics.prototype
          * @type {Property}
@@ -112,6 +122,7 @@ define([
         result.show = this.show;
         result.scale = this.scale;
         result.minimumPixelSize = this.minimumPixelSize;
+        result.maximumScale = this.maximumScale;
         result.uri = this.uri;
         return result;
     };
@@ -132,6 +143,7 @@ define([
         this.show = defaultValue(this.show, source.show);
         this.scale = defaultValue(this.scale, source.scale);
         this.minimumPixelSize = defaultValue(this.minimumPixelSize, source.minimumPixelSize);
+        this.maximumScale = defaultValue(this.maximumScale, source.maximumScale);
         this.uri = defaultValue(this.uri, source.uri);
     };
 

--- a/Source/DataSources/ModelVisualizer.js
+++ b/Source/DataSources/ModelVisualizer.js
@@ -125,7 +125,7 @@ define([
             model.show = true;
             model.scale = Property.getValueOrDefault(modelGraphics._scale, time, defaultScale);
             model.minimumPixelSize = Property.getValueOrDefault(modelGraphics._minimumPixelSize, time, defaultMinimumPixelSize);
-            model.maximumScale = Property.getValueOrDefault(modelGraphics._maximumScale, time, null);
+            model.maximumScale = Property.getValueOrUndefined(modelGraphics._maximumScale, time);
             model.modelMatrix = Matrix4.clone(modelMatrix, model.modelMatrix);
         }
         return true;

--- a/Source/DataSources/ModelVisualizer.js
+++ b/Source/DataSources/ModelVisualizer.js
@@ -125,6 +125,7 @@ define([
             model.show = true;
             model.scale = Property.getValueOrDefault(modelGraphics._scale, time, defaultScale);
             model.minimumPixelSize = Property.getValueOrDefault(modelGraphics._minimumPixelSize, time, defaultMinimumPixelSize);
+            model.maximumScale = Property.getValueOrDefault(modelGraphics._maximumScale, time, null);
             model.modelMatrix = Matrix4.clone(modelMatrix, model.modelMatrix);
         }
         return true;

--- a/Source/Scene/Model.js
+++ b/Source/Scene/Model.js
@@ -418,13 +418,12 @@ define([
 
         /**
          * The maximum scale size for a model. This can be used to give 
-         * an upper limit to the minimumPixelSize, ensuring that the model
+         * an upper limit to the {@link Model#minimumPixelSize}, ensuring that the model
          * is never an unreasonable scale.
-
          * 
          * @type {Number}
          */
-        this.maximumScale = defaultValue(options.maximumScale, null);
+        this.maximumScale = options.maximumScale;
         this._maximumScale = this.maximumScale;
 
         /**
@@ -2880,7 +2879,7 @@ define([
             }
         }
 
-        return (model.maximumScale && model.maximumScale < scale) ? model.maximumScale : scale;
+        return defined(model.maximumScale) ? Math.min(model.maximumScale, scale) : scale;
     }
 
     function releaseCachedGltf(model) {

--- a/Source/Scene/Model.js
+++ b/Source/Scene/Model.js
@@ -291,6 +291,7 @@ define([
      * @param {Matrix4} [options.modelMatrix=Matrix4.IDENTITY] The 4x4 transformation matrix that transforms the model from model to world coordinates.
      * @param {Number} [options.scale=1.0] A uniform scale applied to this model.
      * @param {Number} [options.minimumPixelSize=0.0] The approximate minimum pixel size of the model regardless of zoom.
+     * @param {Number} [options.maximumScale] The maximum scale size of a model. An upper limit for minimumPixelSize.
      * @param {Object} [options.id] A user-defined object to return when the model is picked with {@link Scene#pick}.
      * @param {Boolean} [options.allowPicking=true] When <code>true</code>, each glTF mesh and primitive is pickable with {@link Scene#pick}.
      * @param {Boolean} [options.asynchronous=true] Determines if model WebGL resource creation will be spread out over several frames or block until completion once all glTF files are loaded.
@@ -414,6 +415,17 @@ define([
          */
         this.minimumPixelSize = defaultValue(options.minimumPixelSize, 0.0);
         this._minimumPixelSize = this.minimumPixelSize;
+
+        /**
+         * The maximum scale size for a model. This can be used to give 
+         * an upper limit to the minimumPixelSize, ensuring that the model
+         * is never an unreasonable scale.
+
+         * 
+         * @type {Number}
+         */
+        this.maximumScale = defaultValue(options.maximumScale, null);
+        this._maximumScale = this.maximumScale;
 
         /**
          * User-defined object returned when the model is picked.
@@ -823,6 +835,7 @@ define([
      * @param {Matrix4} [options.modelMatrix=Matrix4.IDENTITY] The 4x4 transformation matrix that transforms the model from model to world coordinates.
      * @param {Number} [options.scale=1.0] A uniform scale applied to this model.
      * @param {Number} [options.minimumPixelSize=0.0] The approximate minimum pixel size of the model regardless of zoom.
+     * @param {Number} [options.maxiumumScale] The maximum scale for the model.
      * @param {Boolean} [options.allowPicking=true] When <code>true</code>, each glTF mesh and primitive is pickable with {@link Scene#pick}.
      * @param {Boolean} [options.asynchronous=true] Determines if model WebGL resource creation will be spread out over several frames or block until completion once all glTF files are loaded.
      * @param {Boolean} [options.debugShowBoundingVolume=false] For debugging only. Draws the bounding sphere for each {@link DrawCommand} in the model.
@@ -849,6 +862,7 @@ define([
      *   modelMatrix : modelMatrix,
      *   scale : 2.0,                     // double size
      *   minimumPixelSize : 128,          // never smaller than 128 pixels
+     *   maximumScale: 20000,             // never larger than 20000 * model size (overrides minimumPixelSize)
      *   allowPicking : false,            // not pickable
      *   debugShowBoundingVolume : false, // default
      *   debugWireframe : false
@@ -2866,7 +2880,7 @@ define([
             }
         }
 
-        return scale;
+        return (model.maximumScale && model.maximumScale < scale) ? model.maximumScale : scale;
     }
 
     function releaseCachedGltf(model) {

--- a/Specs/DataSources/ModelGraphicsSpec.js
+++ b/Specs/DataSources/ModelGraphicsSpec.js
@@ -13,7 +13,8 @@ defineSuite([
             uri : '0',
             scale : 1,
             show : false,
-            minimumPixelSize : 2
+            minimumPixelSize : 2,
+            maximumScale: 200
         };
 
         var model = new ModelGraphics(options);
@@ -21,11 +22,13 @@ defineSuite([
         expect(model.scale).toBeInstanceOf(ConstantProperty);
         expect(model.show).toBeInstanceOf(ConstantProperty);
         expect(model.minimumPixelSize).toBeInstanceOf(ConstantProperty);
+        expect(model.maximumScale).toBeInstanceOf(ConstantProperty);
 
         expect(model.uri.getValue()).toEqual(options.uri);
         expect(model.scale.getValue()).toEqual(options.scale);
         expect(model.show.getValue()).toEqual(options.show);
         expect(model.minimumPixelSize.getValue()).toEqual(options.minimumPixelSize);
+        expect(model.maximumScale.getValue()).toEqual(options.maximumScale);
     });
 
     it('merge assigns unassigned properties', function() {
@@ -34,6 +37,7 @@ defineSuite([
         source.show = new ConstantProperty(true);
         source.scale = new ConstantProperty(1.0);
         source.minimumPixelSize = new ConstantProperty(2.0);
+        source.maximumScale = new ConstantProperty(200.0);
 
         var target = new ModelGraphics();
         target.merge(source);
@@ -42,6 +46,7 @@ defineSuite([
         expect(target.show).toBe(source.show);
         expect(target.scale).toBe(source.scale);
         expect(target.minimumPixelSize).toBe(source.minimumPixelSize);
+        expect(target.maximumScale).toBe(source.maximumScale);
     });
 
     it('merge does not assign assigned properties', function() {
@@ -50,17 +55,20 @@ defineSuite([
         source.show = new ConstantProperty(true);
         source.scale = new ConstantProperty(1.0);
         source.minimumPixelSize = new ConstantProperty(2.0);
+        source.maximumScale = new ConstantProperty(200.0);
 
         var uri = new ConstantProperty('');
         var show = new ConstantProperty(true);
         var scale = new ConstantProperty(1.0);
         var minimumPixelSize = new ConstantProperty(2.0);
+        var maximumScale = new ConstantProperty(200.0);
 
         var target = new ModelGraphics();
         target.uri = uri;
         target.show = show;
         target.scale = scale;
         target.minimumPixelSize = minimumPixelSize;
+        target.maximumScale = maximumScale;
 
         target.merge(source);
 
@@ -68,6 +76,7 @@ defineSuite([
         expect(target.show).toBe(show);
         expect(target.scale).toBe(scale);
         expect(target.minimumPixelSize).toBe(minimumPixelSize);
+        expect(target.maximumScale).toBe(maximumScale);
     });
 
     it('clone works', function() {
@@ -76,12 +85,14 @@ defineSuite([
         source.show = new ConstantProperty(true);
         source.scale = new ConstantProperty(1.0);
         source.minimumPixelSize = new ConstantProperty(2.0);
+        source.maximumScale = new ConstantProperty(200.0);
 
         var result = source.clone();
         expect(result.uri).toBe(source.uri);
         expect(result.show).toBe(source.show);
         expect(result.scale).toBe(source.scale);
         expect(result.minimumPixelSize).toBe(source.minimumPixelSize);
+        expect(result.maximumScale).toBe(source.maximumScale);
     });
 
     it('merge throws if source undefined', function() {

--- a/Specs/Scene/ModelSpec.js
+++ b/Specs/Scene/ModelSpec.js
@@ -88,6 +88,7 @@ defineSuite([
         }));
         modelPromises.push(loadModel(cesiumAirUrl, {
             minimumPixelSize : 1,
+            maximumScale : 200,
             asynchronous : false
         }).then(function(model) {
             cesiumAirModel = model;
@@ -126,6 +127,7 @@ defineSuite([
             show : false,
             scale : options.scale,
             minimumPixelSize : options.minimumPixelSize,
+            maximumScale : options.maximumScale,
             id : url,        // for picking tests
             asynchronous : options.asynchronous,
             releaseGltfJson : options.releaseGltfJson,
@@ -172,6 +174,7 @@ defineSuite([
        expect(texturedBoxModel.modelMatrix).toEqual(modelMatrix);
        expect(texturedBoxModel.scale).toEqual(1.0);
        expect(texturedBoxModel.minimumPixelSize).toEqual(0.0);
+       expect(texturedBoxModel.maximumScale).toBeUndefined();
        expect(texturedBoxModel.id).toEqual(texturedBoxUrl);
        expect(texturedBoxModel.allowPicking).toEqual(true);
        expect(texturedBoxModel.activeAnimations).toBeDefined();
@@ -672,6 +675,7 @@ defineSuite([
 
     it('loads cesiumAir', function() {
         expect(cesiumAirModel.minimumPixelSize).toEqual(1);
+        expect(cesiumAirModel.maximumScale).toEqual(200);
         expect(cesiumAirModel.asynchronous).toEqual(false);
     });
 


### PR DESCRIPTION
Adding a maximum scale property to models allows them to scale up (using minimumPixelSize) to a certain point, then stop growing. This allows models that are useful at many zoom levels. 

Before, when fully zoomed out, it was possible to have models that covered continents or even the whole world, which is not particularly useful. 