### PR TITLE
Polyline entity updates with correct ellipsoid

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@ Change Log
 * Entities have a reference to their entity collection.
 * Entity collections have a reference to their owner (usually a data source, but can be a `CompositeEntityCollection`).
 * `GeoJsonDataSource.load` now takes an optional `describeProperty` function for generating feature description properties. [#3140](https://github.com/AnalyticalGraphicsInc/cesium/pull/3140)
+* Fixed a bug which caused `Entity` polyline graphics to be incorrect when a scene's ellipsoid was not WGS84. [#3174](https://github.com/AnalyticalGraphicsInc/cesium/pull/3174)
 
 ### 1.15 - 2015-11-02
 

--- a/Source/DataSources/PolylineGeometryUpdater.js
+++ b/Source/DataSources/PolylineGeometryUpdater.js
@@ -427,6 +427,13 @@ define([
     /**
      * @private
      */
+    var generateCartesianArcOptions = {
+        positions : undefined,
+        granularity : undefined,
+        height : undefined,
+        ellipsoid : undefined
+    };
+
     var DynamicGeometryUpdater = function(primitives, geometryUpdater) {
         var sceneId = geometryUpdater._scene.id;
 
@@ -446,12 +453,8 @@ define([
         this._primitives = primitives;
         this._geometryUpdater = geometryUpdater;
         this._positions = [];
-    };
 
-    var generateCartesianArcOptions = {
-        positions : undefined,
-        granularity : undefined,
-        height : undefined
+        generateCartesianArcOptions.ellipsoid = geometryUpdater._scene.globe.ellipsoid;
     };
 
     DynamicGeometryUpdater.prototype.update = function(time) {


### PR DESCRIPTION
Reported on the forum: https://groups.google.com/forum/?hl=en#!topic/cesium-dev/Zkt3n4_4lI8

The ellipsoid wasn't being sent to `PolylinePipeline.generateCartesianArc` in the polyline's `DynamicGeometryUpdater` so it was using WGS84 instead.