### PR TITLE
Add readyPromise to ImageryProviders

### DIFF
--- a/Source/Core/ArcGisImageServerTerrainProvider.js
+++ b/Source/Core/ArcGisImageServerTerrainProvider.js
@@ -152,6 +152,18 @@ define([
         },
 
         /**
+         * Gets a promise that resolves to true when the provider is ready for use.
+         * @memberof ArcGisImageServerTerrainProvider.prototype
+         * @type {Promise.<Boolean>}
+         * @readonly
+         */
+        readyPromise : {
+            get : function() {
+                return when.resolve(true);
+            }
+        },
+
+        /**
          * Gets a value indicating whether or not the provider includes a water mask.  The water mask
          * indicates which areas of the globe are water rather than land, so they can be rendered
          * as a reflective surface with animated waves.  This function should not be

--- a/Source/Core/ArcGisImageServerTerrainProvider.js
+++ b/Source/Core/ArcGisImageServerTerrainProvider.js
@@ -100,6 +100,7 @@ define([
             credit = new Credit(credit);
         }
         this._credit = credit;
+        this._readyPromise = when.resolve(true);
     };
 
     defineProperties(ArcGisImageServerTerrainProvider.prototype, {
@@ -159,7 +160,7 @@ define([
          */
         readyPromise : {
             get : function() {
-                return when.resolve(true);
+                return this._readyPromise;
             }
         },
 

--- a/Source/Core/CesiumTerrainProvider.js
+++ b/Source/Core/CesiumTerrainProvider.js
@@ -610,7 +610,7 @@ define([
          */
         readyPromise : {
             get : function() {
-                return this._readyPromise;
+                return this._readyPromise.promise;
             }
         },
 

--- a/Source/Core/CesiumTerrainProvider.js
+++ b/Source/Core/CesiumTerrainProvider.js
@@ -147,6 +147,7 @@ define([
         this._credit = credit;
 
         this._ready = false;
+        this._readyPromise = when.defer();
 
         var metadataUrl = joinUrls(this._url, 'layer.json');
         if (defined(this._proxy)) {
@@ -222,6 +223,7 @@ define([
             }
 
             that._ready = true;
+            that._readyPromise.resolve(true);
         }
 
         function metadataFailure(data) {
@@ -597,6 +599,18 @@ define([
         ready : {
             get : function() {
                 return this._ready;
+            }
+        },
+
+        /**
+         * Gets a promise that resolves to true when the provider is ready for use.
+         * @memberof CesiumTerrainProvider.prototype
+         * @type {Promise.<Boolean>}
+         * @readonly
+         */
+        readyPromise : {
+            get : function() {
+                return this._readyPromise;
             }
         },
 

--- a/Source/Core/EllipsoidTerrainProvider.js
+++ b/Source/Core/EllipsoidTerrainProvider.js
@@ -1,5 +1,6 @@
 /*global define*/
 define([
+        '../ThirdParty/when',
         './defaultValue',
         './defined',
         './defineProperties',
@@ -9,6 +10,7 @@ define([
         './HeightmapTerrainData',
         './TerrainProvider'
     ], function(
+        when,
         defaultValue,
         defined,
         defineProperties,
@@ -107,6 +109,18 @@ define([
         ready : {
             get : function() {
                 return true;
+            }
+        },
+
+        /**
+         * Gets a promise that resolves to true when the provider is ready for use.
+         * @memberof EllipsoidTerrainProvider.prototype
+         * @type {Promise.<Boolean>}
+         * @readonly
+         */
+        readyPromise : {
+            get : function() {
+                return when.resolve(true);
             }
         },
 

--- a/Source/Core/EllipsoidTerrainProvider.js
+++ b/Source/Core/EllipsoidTerrainProvider.js
@@ -61,6 +61,7 @@ define([
         });
 
         this._errorEvent = new Event();
+        this._readyPromise = when.resolve(true);
     };
 
     defineProperties(EllipsoidTerrainProvider.prototype, {
@@ -120,7 +121,7 @@ define([
          */
         readyPromise : {
             get : function() {
-                return when.resolve(true);
+                return this._readyPromise;
             }
         },
 

--- a/Source/Core/TerrainProvider.js
+++ b/Source/Core/TerrainProvider.js
@@ -1,12 +1,10 @@
 /*global define*/
 define([
-        '../ThirdParty/when',
         './defined',
         './defineProperties',
         './DeveloperError',
         './Math'
     ], function(
-        when,
         defined,
         defineProperties,
         DeveloperError,

--- a/Source/Core/TerrainProvider.js
+++ b/Source/Core/TerrainProvider.js
@@ -1,10 +1,12 @@
 /*global define*/
 define([
+        '../ThirdParty/when',
         './defined',
         './defineProperties',
         './DeveloperError',
         './Math'
     ], function(
+        when,
         defined,
         defineProperties,
         DeveloperError,
@@ -66,6 +68,16 @@ define([
          * @type {Boolean}
          */
         ready : {
+            get : DeveloperError.throwInstantiationError
+        },
+
+        /**
+         * Gets a promise that resolves to true when the provider is ready for use.
+         * @memberof TerrainProvider.prototype
+         * @type {Promise.<Boolean>}
+         * @readonly
+         */
+        readyPromise : {
             get : DeveloperError.throwInstantiationError
         },
 

--- a/Source/Core/VRTheWorldTerrainProvider.js
+++ b/Source/Core/VRTheWorldTerrainProvider.js
@@ -210,7 +210,7 @@ define([
          */
         readyPromise : {
             get : function() {
-                return this._readyPromise;
+                return this._readyPromise.promise;
             }
         },
 

--- a/Source/Core/VRTheWorldTerrainProvider.js
+++ b/Source/Core/VRTheWorldTerrainProvider.js
@@ -79,6 +79,7 @@ define([
 
         this._errorEvent = new Event();
         this._ready = false;
+        this._readyPromise = when.defer();
 
         this._proxy = options.proxy;
 
@@ -133,6 +134,7 @@ define([
             }
 
             that._ready = true;
+            that._readyPromise.resolve(true);
         }
 
         function metadataFailure(e) {
@@ -197,6 +199,18 @@ define([
         ready : {
             get : function() {
                 return this._ready;
+            }
+        },
+
+        /**
+         * Gets a promise that resolves to true when the provider is ready for use.
+         * @memberof VRTheWorldTerrainProvider.prototype
+         * @type {Promise.<Boolean>}
+         * @readonly
+         */
+        readyPromise : {
+            get : function() {
+                return this._readyPromise;
             }
         },
 

--- a/Source/Scene/ArcGisMapServerImageryProvider.js
+++ b/Source/Scene/ArcGisMapServerImageryProvider.js
@@ -15,6 +15,7 @@ define([
         '../Core/loadJsonp',
         '../Core/Math',
         '../Core/Rectangle',
+        '../Core/RuntimeError',
         '../Core/TileProviderError',
         '../Core/WebMercatorProjection',
         '../Core/WebMercatorTilingScheme',
@@ -38,6 +39,7 @@ define([
         loadJsonp,
         CesiumMath,
         Rectangle,
+        RuntimeError,
         TileProviderError,
         WebMercatorProjection,
         WebMercatorTilingScheme,
@@ -206,6 +208,7 @@ define([
         function metadataFailure(e) {
             var message = 'An error occurred while accessing ' + that._url + '.';
             metadataError = TileProviderError.handleError(metadataError, that, that._errorEvent, message, undefined, undefined, undefined, requestMetadata);
+            that._readyPromise.reject(new RuntimeError(message));
         }
 
         function requestMetadata() {
@@ -480,7 +483,7 @@ define([
          */
         readyPromise : {
             get : function() {
-                return this._readyPromise;
+                return this._readyPromise.promise;
             }
         },
 

--- a/Source/Scene/ArcGisMapServerImageryProvider.js
+++ b/Source/Scene/ArcGisMapServerImageryProvider.js
@@ -135,6 +135,7 @@ define([
         this._errorEvent = new Event();
 
         this._ready = false;
+        this._readyPromise = when.defer();
 
         // Grab the details of this MapServer.
         var that = this;
@@ -198,6 +199,7 @@ define([
             }
 
             that._ready = true;
+            that._readyPromise.resolve(true);
             TileProviderError.handleSuccess(metadataError);
         }
 
@@ -226,6 +228,7 @@ define([
             requestMetadata();
         } else {
             this._ready = true;
+            this._readyPromise.resolve(true);
         }
     };
 
@@ -466,6 +469,18 @@ define([
         ready : {
             get : function() {
                 return this._ready;
+            }
+        },
+
+        /**
+         * Gets a promise that resolves to true when the provider is ready for use.
+         * @memberof ArcGisMapServerImageryProvider.prototype
+         * @type {Promise.<Boolean>}
+         * @readonly
+         */
+        readyPromise : {
+            get : function() {
+                return this._readyPromise;
             }
         },
 

--- a/Source/Scene/BingMapsImageryProvider.js
+++ b/Source/Scene/BingMapsImageryProvider.js
@@ -140,6 +140,7 @@ define([
         this._errorEvent = new Event();
 
         this._ready = false;
+        this._readyPromise = when.defer();
 
         var metadataUrl = this._url + '/REST/v1/Imagery/Metadata/' + this._mapStyle + '?incl=ImageryProviders&key=' + this._key;
         var that = this;
@@ -196,6 +197,7 @@ define([
             }
 
             that._ready = true;
+            that._readyPromise.resolve(true);
             TileProviderError.handleSuccess(metadataError);
         }
 
@@ -438,6 +440,18 @@ define([
         ready : {
             get : function() {
                 return this._ready;
+            }
+        },
+
+        /**
+         * Gets a promise that resolves to true when the provider is ready for use.
+         * @memberof BingMapsImageryProvider.prototype
+         * @type {Promise.<Boolean>}
+         * @readonly
+         */
+        readyPromise : {
+            get : function() {
+                return this._readyPromise;
             }
         },
 

--- a/Source/Scene/BingMapsImageryProvider.js
+++ b/Source/Scene/BingMapsImageryProvider.js
@@ -11,6 +11,7 @@ define([
         '../Core/loadJsonp',
         '../Core/Math',
         '../Core/Rectangle',
+        '../Core/RuntimeError',
         '../Core/TileProviderError',
         '../Core/WebMercatorTilingScheme',
         '../ThirdParty/when',
@@ -29,6 +30,7 @@ define([
         loadJsonp,
         CesiumMath,
         Rectangle,
+        RuntimeError,
         TileProviderError,
         WebMercatorTilingScheme,
         when,
@@ -204,6 +206,7 @@ define([
         function metadataFailure(e) {
             var message = 'An error occurred while accessing ' + metadataUrl + '.';
             metadataError = TileProviderError.handleError(metadataError, that, that._errorEvent, message, undefined, undefined, undefined, requestMetadata);
+            that._readyPromise.reject(new RuntimeError(message));
         }
 
         function requestMetadata() {
@@ -451,7 +454,7 @@ define([
          */
         readyPromise : {
             get : function() {
-                return this._readyPromise;
+                return this._readyPromise.promise;
             }
         },
 

--- a/Source/Scene/GoogleEarthImageryProvider.js
+++ b/Source/Scene/GoogleEarthImageryProvider.js
@@ -140,6 +140,7 @@ define([
         this._errorEvent = new Event();
 
         this._ready = false;
+        this._readyPromise = when.defer();
 
         var metadataUrl = this._url + this._path + '/query?request=Json&vars=geeServerDefs&is2d=t';
         var that = this;
@@ -204,6 +205,7 @@ define([
               .replace('{channel}', that._channel).replace('{version}', that._version);
 
             that._ready = true;
+            that._readyPromise.resolve(true);
             TileProviderError.handleSuccess(metadataError);
         }
 
@@ -467,6 +469,18 @@ define([
         ready : {
             get : function() {
                 return this._ready;
+            }
+        },
+
+        /**
+         * Gets a promise that resolves to true when the provider is ready for use.
+         * @memberof GoogleEarthImageryProvider.prototype
+         * @type {Promise.<Boolean>}
+         * @readonly
+         */
+        readyPromise : {
+            get : function() {
+                return this._readyPromise;
             }
         },
 

--- a/Source/Scene/GoogleEarthImageryProvider.js
+++ b/Source/Scene/GoogleEarthImageryProvider.js
@@ -212,6 +212,7 @@ define([
         function metadataFailure(e) {
             var message = 'An error occurred while accessing ' + metadataUrl + '.';
             metadataError = TileProviderError.handleError(metadataError, that, that._errorEvent, message, undefined, undefined, undefined, requestMetadata);
+            that._readyPromise.reject(new RuntimeError(message));
         }
 
         function requestMetadata() {
@@ -480,7 +481,7 @@ define([
          */
         readyPromise : {
             get : function() {
-                return this._readyPromise;
+                return this._readyPromise.promise;
             }
         },
 

--- a/Source/Scene/GridImageryProvider.js
+++ b/Source/Scene/GridImageryProvider.js
@@ -62,6 +62,8 @@ define([
 
         // We only need a single canvas since all tiles will be the same
         this._canvas = this._createGridCanvas();
+
+        this._readyPromise = when.resolve(true);
     };
 
     defineProperties(GridImageryProvider.prototype, {
@@ -204,7 +206,7 @@ define([
          */
         readyPromise : {
             get : function() {
-                return when.resolve(true);
+                return this._readyPromise;
             }
         },
 

--- a/Source/Scene/GridImageryProvider.js
+++ b/Source/Scene/GridImageryProvider.js
@@ -5,14 +5,16 @@ define([
         '../Core/defined',
         '../Core/defineProperties',
         '../Core/Event',
-        '../Core/GeographicTilingScheme'
+        '../Core/GeographicTilingScheme',
+        '../ThirdParty/when'
     ], function(
         Color,
         defaultValue,
         defined,
         defineProperties,
         Event,
-        GeographicTilingScheme) {
+        GeographicTilingScheme,
+        when) {
     "use strict";
 
     var defaultColor = new Color(1.0, 1.0, 1.0, 0.4);
@@ -191,6 +193,18 @@ define([
         ready : {
             get : function() {
                 return true;
+            }
+        },
+
+        /**
+         * Gets a promise that resolves to true when the provider is ready for use.
+         * @memberof GridImageryProvider.prototype
+         * @type {Promise.<Boolean>}
+         * @readonly
+         */
+        readyPromise : {
+            get : function() {
+                return when.resolve(true);
             }
         },
 

--- a/Source/Scene/ImageryProvider.js
+++ b/Source/Scene/ImageryProvider.js
@@ -102,6 +102,16 @@ define([
         },
 
         /**
+         * Gets a promise that resolves to true when the provider is ready for use.
+         * @memberof ImageryProvider.prototype
+         * @type {Promise.<Boolean>}
+         * @readonly
+         */
+        readyPromise : {
+            get : DeveloperError.throwInstantiationError
+        },
+
+        /**
          * Gets the rectangle, in radians, of the imagery provided by the instance.  This function should
          * not be called before {@link ImageryProvider#ready} returns true.
          * @memberof ImageryProvider.prototype

--- a/Source/Scene/MapboxImageryProvider.js
+++ b/Source/Scene/MapboxImageryProvider.js
@@ -122,6 +122,18 @@ define([
         },
 
         /**
+         * Gets a promise that resolves to true when the provider is ready for use.
+         * @memberof MapboxImageryProvider.prototype
+         * @type {Promise.<Boolean>}
+         * @readonly
+         */
+        readyPromise : {
+            get : function() {
+                return this._imageryProvider.readyPromise;
+            }
+        },
+
+        /**
          * Gets the rectangle, in radians, of the imagery provided by the instance.  This function should
          * not be called before {@link MapboxImageryProvider#ready} returns true.
          * @memberof MapboxImageryProvider.prototype

--- a/Source/Scene/Model.js
+++ b/Source/Scene/Model.js
@@ -417,10 +417,10 @@ define([
         this._minimumPixelSize = this.minimumPixelSize;
 
         /**
-         * The maximum scale size for a model. This can be used to give 
+         * The maximum scale size for a model. This can be used to give
          * an upper limit to the {@link Model#minimumPixelSize}, ensuring that the model
          * is never an unreasonable scale.
-         * 
+         *
          * @type {Number}
          */
         this.maximumScale = options.maximumScale;

--- a/Source/Scene/OpenStreetMapImageryProvider.js
+++ b/Source/Scene/OpenStreetMapImageryProvider.js
@@ -8,6 +8,7 @@ define([
         '../Core/Event',
         '../Core/Rectangle',
         '../Core/WebMercatorTilingScheme',
+        '../ThirdParty/when',
         './ImageryProvider'
     ], function(
         Credit,
@@ -18,6 +19,7 @@ define([
         Event,
         Rectangle,
         WebMercatorTilingScheme,
+        when,
         ImageryProvider) {
     "use strict";
 
@@ -98,6 +100,7 @@ define([
         this._errorEvent = new Event();
 
         this._ready = true;
+        this._readyPromise = when.resolve(true);
 
         var credit = defaultValue(options.credit, defaultCredit);
         if (typeof credit === 'string') {
@@ -300,6 +303,18 @@ define([
         ready : {
             get : function() {
                 return this._ready;
+            }
+        },
+
+        /**
+         * Gets a promise that resolves to true when the provider is ready for use.
+         * @memberof OpenStreetMapImageryProvider.prototype
+         * @type {Boolean}
+         * @readonly
+         */
+        readyPromise : {
+            get : function() {
+                return this._readyPromise;
             }
         },
 

--- a/Source/Scene/SingleTileImageryProvider.js
+++ b/Source/Scene/SingleTileImageryProvider.js
@@ -80,6 +80,7 @@ define([
         this._errorEvent = new Event();
 
         this._ready = false;
+        this._readyPromise = when.defer();
 
         var imageUrl = url;
         if (defined(proxy)) {
@@ -100,6 +101,7 @@ define([
             that._tileWidth = image.width;
             that._tileHeight = image.height;
             that._ready = true;
+            that._readyPromise.resolve(true);
             TileProviderError.handleSuccess(that._errorEvent);
         }
 
@@ -300,6 +302,18 @@ define([
         ready : {
             get : function() {
                 return this._ready;
+            }
+        },
+
+        /**
+         * Gets a promise that resolves to true when the provider is ready for use.
+         * @memberof SingleTileImageryProvider.prototype
+         * @type {Promise.<Boolean>}
+         * @readonly
+         */
+        readyPromise : {
+            get : function() {
+                return this._readyPromise;
             }
         },
 

--- a/Source/Scene/SingleTileImageryProvider.js
+++ b/Source/Scene/SingleTileImageryProvider.js
@@ -9,6 +9,7 @@ define([
         '../Core/GeographicTilingScheme',
         '../Core/loadImage',
         '../Core/Rectangle',
+        '../Core/RuntimeError',
         '../Core/TileProviderError',
         '../ThirdParty/when'
     ], function(
@@ -21,6 +22,7 @@ define([
         GeographicTilingScheme,
         loadImage,
         Rectangle,
+        RuntimeError,
         TileProviderError,
         when) {
     "use strict";
@@ -115,6 +117,7 @@ define([
                     0, 0, 0,
                     doRequest,
                     e);
+            that._readyPromise.reject(new RuntimeError(message));
         }
 
         function doRequest() {
@@ -313,7 +316,7 @@ define([
          */
         readyPromise : {
             get : function() {
-                return this._readyPromise;
+                return this._readyPromise.promise;
             }
         },
 

--- a/Source/Scene/TileCoordinatesImageryProvider.js
+++ b/Source/Scene/TileCoordinatesImageryProvider.js
@@ -5,14 +5,16 @@ define([
         '../Core/defined',
         '../Core/defineProperties',
         '../Core/Event',
-        '../Core/GeographicTilingScheme'
+        '../Core/GeographicTilingScheme',
+        '../ThirdParty/when'
     ], function(
         Color,
         defaultValue,
         defined,
         defineProperties,
         Event,
-        GeographicTilingScheme) {
+        GeographicTilingScheme,
+        when) {
     "use strict";
 
     /**
@@ -171,6 +173,18 @@ define([
         ready : {
             get : function() {
                 return true;
+            }
+        },
+
+        /**
+         * Gets a promise that resolves to true when the provider is ready for use.
+         * @memberof TileCoordinatesImageryProvider.prototype
+         * @type {Promise.<Boolean>}
+         * @readonly
+         */
+        readyPromise : {
+            get : function() {
+                return when.resolve(true);
             }
         },
 

--- a/Source/Scene/TileCoordinatesImageryProvider.js
+++ b/Source/Scene/TileCoordinatesImageryProvider.js
@@ -42,6 +42,7 @@ define([
         this._errorEvent = new Event();
         this._tileWidth = defaultValue(options.tileWidth, 256);
         this._tileHeight = defaultValue(options.tileHeight, 256);
+        this._readyPromise = when.resolve(true);
     };
 
     defineProperties(TileCoordinatesImageryProvider.prototype, {
@@ -184,7 +185,7 @@ define([
          */
         readyPromise : {
             get : function() {
-                return when.resolve(true);
+                return this._readyPromise;
             }
         },
 

--- a/Source/Scene/TileMapServiceImageryProvider.js
+++ b/Source/Scene/TileMapServiceImageryProvider.js
@@ -99,6 +99,7 @@ define([
 
         this._url = url;
         this._ready = false;
+        this._readyPromise = when.defer();
         this._proxy = options.proxy;
         this._tileDiscardPolicy = options.tileDiscardPolicy;
         this._errorEvent = new Event();
@@ -241,6 +242,7 @@ define([
 
             that._tilingScheme = tilingScheme;
             that._ready = true;
+            that._readyPromise.resolve(true);
         }
 
         function metadataFailure(error) {
@@ -253,6 +255,7 @@ define([
             that._tilingScheme = defined(options.tilingScheme) ? options.tilingScheme : new WebMercatorTilingScheme({ ellipsoid : options.ellipsoid });
             that._rectangle = defaultValue(options.rectangle, that._tilingScheme.rectangle);
             that._ready = true;
+            that._readyPromise.resolve(true);
         }
 
         function requestMetadata() {
@@ -464,6 +467,18 @@ define([
         ready : {
             get : function() {
                 return this._ready;
+            }
+        },
+
+        /**
+         * Gets a promise that resolves to true when the provider is ready for use.
+         * @memberof TileMapServiceImageryProvider.prototype
+         * @type {Promise.<Boolean>}
+         * @readonly
+         */
+        readyPromise : {
+            get : function() {
+                return this._readyPromise;
             }
         },
 

--- a/Source/Scene/TileMapServiceImageryProvider.js
+++ b/Source/Scene/TileMapServiceImageryProvider.js
@@ -12,6 +12,7 @@ define([
         '../Core/joinUrls',
         '../Core/loadXML',
         '../Core/Rectangle',
+        '../Core/RuntimeError',
         '../Core/TileProviderError',
         '../Core/WebMercatorTilingScheme',
         '../ThirdParty/when',
@@ -29,6 +30,7 @@ define([
         joinUrls,
         loadXML,
         Rectangle,
+        RuntimeError,
         TileProviderError,
         WebMercatorTilingScheme,
         when,
@@ -178,6 +180,7 @@ define([
                 } else {
                     var message = joinUrls(url, 'tilemapresource.xml') + 'specifies an unsupported profile attribute, ' + tilingSchemeName + '.';
                     metadataError = TileProviderError.handleError(metadataError, that, that._errorEvent, message, undefined, undefined, undefined, requestMetadata);
+                    that._readyPromise.reject(new RuntimeError(message));
                     return;
                 }
             }
@@ -478,7 +481,7 @@ define([
          */
         readyPromise : {
             get : function() {
-                return this._readyPromise;
+                return this._readyPromise.promise;
             }
         },
 

--- a/Source/Scene/UrlTemplateImageryProvider.js
+++ b/Source/Scene/UrlTemplateImageryProvider.js
@@ -161,9 +161,9 @@ define([
         this._proxy = options.proxy;
         this._tileDiscardPolicy = options.tileDiscardPolicy;
         this._getFeatureInfoFormats = options.getFeatureInfoFormats;
-        
+
         this._errorEvent = new Event();
-        
+
         this._subdomains = options.subdomains;
         if (Array.isArray(this._subdomains)) {
             this._subdomains = this._subdomains.slice();
@@ -385,6 +385,18 @@ define([
         ready : {
             get : function() {
                 return true;
+            }
+        },
+
+        /**
+         * Gets a promise that resolves to true when the provider is ready for use.
+         * @memberof UrlTemplateImageryProvider.prototype
+         * @type {Promise.<Boolean>}
+         * @readonly
+         */
+        readyPromise : {
+            get : function() {
+                return when.resolve(true);
             }
         },
 

--- a/Source/Scene/UrlTemplateImageryProvider.js
+++ b/Source/Scene/UrlTemplateImageryProvider.js
@@ -190,6 +190,8 @@ define([
 
         this._urlParts = urlTemplateToParts(this._url, tags);
         this._pickFeaturesUrlParts = urlTemplateToParts(this._pickFeaturesUrl, pickFeaturesTags);
+
+        this._readyPromise = when.resolve(true);
     };
 
     defineProperties(UrlTemplateImageryProvider.prototype, {
@@ -396,7 +398,7 @@ define([
          */
         readyPromise : {
             get : function() {
-                return when.resolve(true);
+                return this._readyPromise;
             }
         },
 

--- a/Source/Scene/WebMapServiceImageryProvider.js
+++ b/Source/Scene/WebMapServiceImageryProvider.js
@@ -12,6 +12,7 @@ define([
         '../Core/queryToObject',
         '../Core/WebMercatorTilingScheme',
         '../ThirdParty/Uri',
+        '../ThirdParty/when',
         './GetFeatureInfoFormat',
         './UrlTemplateImageryProvider'
     ], function(
@@ -27,6 +28,7 @@ define([
         queryToObject,
         WebMercatorTilingScheme,
         Uri,
+        when,
         GetFeatureInfoFormat,
         UrlTemplateImageryProvider) {
     "use strict";
@@ -337,6 +339,18 @@ define([
         ready : {
             get : function() {
                 return this._tileProvider.ready;
+            }
+        },
+
+        /**
+         * Gets a promise that resolves to true when the provider is ready for use.
+         * @memberof WebMapServiceImageryProvider.prototype
+         * @type {Promise.<Boolean>}
+         * @readonly
+         */
+        readyPromise : {
+            get : function() {
+                return this._tileProvider.readyPromise;
             }
         },
 

--- a/Source/Scene/WebMapServiceImageryProvider.js
+++ b/Source/Scene/WebMapServiceImageryProvider.js
@@ -12,7 +12,6 @@ define([
         '../Core/queryToObject',
         '../Core/WebMercatorTilingScheme',
         '../ThirdParty/Uri',
-        '../ThirdParty/when',
         './GetFeatureInfoFormat',
         './UrlTemplateImageryProvider'
     ], function(
@@ -28,7 +27,6 @@ define([
         queryToObject,
         WebMercatorTilingScheme,
         Uri,
-        when,
         GetFeatureInfoFormat,
         UrlTemplateImageryProvider) {
     "use strict";

--- a/Source/Scene/WebMapTileServiceImageryProvider.js
+++ b/Source/Scene/WebMapTileServiceImageryProvider.js
@@ -13,6 +13,7 @@ define([
         '../Core/Rectangle',
         '../Core/WebMercatorTilingScheme',
         '../ThirdParty/Uri',
+        '../ThirdParty/when',
         './ImageryProvider'
     ], function(
         combine,
@@ -28,6 +29,7 @@ define([
         Rectangle,
         WebMercatorTilingScheme,
         Uri,
+        when,
         ImageryProvider) {
     "use strict";
 
@@ -356,6 +358,18 @@ define([
          */
         ready : {
             value: true
+        },
+
+        /**
+         * Gets a promise that resolves to true when the provider is ready for use.
+         * @memberof WebMapTileServiceImageryProvider.prototype
+         * @type {Promise.<Boolean>}
+         * @readonly
+         */
+        readyPromise : {
+            get : function() {
+                return when.resolve(true);
+            }
         },
 
         /**

--- a/Source/Scene/WebMapTileServiceImageryProvider.js
+++ b/Source/Scene/WebMapTileServiceImageryProvider.js
@@ -130,6 +130,8 @@ define([
 
         this._rectangle = defaultValue(options.rectangle, this._tilingScheme.rectangle);
 
+        this._readyPromise = when.resolve(true);
+
         // Check the number of tiles at the minimum level.  If it's more than four,
         // throw an exception, because starting at the higher minimum
         // level will cause too many tiles to be downloaded and rendered.
@@ -368,7 +370,7 @@ define([
          */
         readyPromise : {
             get : function() {
-                return when.resolve(true);
+                return this._readyPromise;
             }
         },
 

--- a/Specs/Core/ArcGisImageServerTerrainProviderSpec.js
+++ b/Specs/Core/ArcGisImageServerTerrainProviderSpec.js
@@ -44,6 +44,17 @@ defineSuite([
         }).toThrowDeveloperError();
     });
 
+    it('resolves readyPromise', function() {
+        var provider = new ArcGisImageServerTerrainProvider({
+            url : 'made/up/url'
+        });
+
+        return provider.readyPromise.then(function (result) {
+            expect(result).toBe(true);
+            expect(provider.ready).toBe(true);
+        });
+    });
+
     it('uses geographic tiling scheme by default', function() {
         var provider = new ArcGisImageServerTerrainProvider({
             url : 'made/up/url'

--- a/Specs/Core/CesiumTerrainProviderSpec.js
+++ b/Specs/Core/CesiumTerrainProviderSpec.js
@@ -110,6 +110,17 @@ defineSuite([
         }).toThrowDeveloperError();
     });
 
+    it('resolves readyPromise', function() {
+        var provider = new CesiumTerrainProvider({
+            url : 'made/up/url'
+        });
+
+        return provider.readyPromise.then(function (result) {
+            expect(result).toBe(true);
+            expect(provider.ready).toBe(true);
+        });
+    });
+
     it('uses geographic tiling scheme by default', function() {
         returnHeightmapTileJson();
 

--- a/Specs/Core/EllipsoidTerrainProviderSpec.js
+++ b/Specs/Core/EllipsoidTerrainProviderSpec.js
@@ -24,6 +24,15 @@ defineSuite([
         expect(EllipsoidTerrainProvider).toConformToInterface(TerrainProvider);
     });
 
+    it('resolves readyPromise', function() {
+        var provider = new EllipsoidTerrainProvider();
+
+        return provider.readyPromise.then(function (result) {
+            expect(result).toBe(true);
+            expect(provider.ready).toBe(true);
+        });
+    });
+
     it('requestTileGeometry creates terrain data.', function() {
         var terrain = new EllipsoidTerrainProvider();
         var terrainData = terrain.requestTileGeometry(0, 0, 0);

--- a/Specs/Core/VRTheWorldTerrainProviderSpec.js
+++ b/Specs/Core/VRTheWorldTerrainProviderSpec.js
@@ -76,6 +76,17 @@ defineSuite([
         }).toThrowDeveloperError();
     });
 
+    it('resolves readyPromise', function() {
+        var provider = new VRTheWorldTerrainProvider({
+            url : 'made/up/url'
+        });
+
+        return provider.readyPromise.then(function (result) {
+            expect(result).toBe(true);
+            expect(provider.ready).toBe(true);
+        });
+    });
+
     it('has error event', function() {
         var provider = new VRTheWorldTerrainProvider({
             url : 'made/up/url'

--- a/Specs/Scene/ArcGisMapServerImageryProviderSpec.js
+++ b/Specs/Scene/ArcGisMapServerImageryProviderSpec.js
@@ -128,6 +128,21 @@ defineSuite([
         }
     };
 
+    it('resolves readyPromise', function() {
+        var baseUrl = '//tiledArcGisMapServer.invalid';
+
+        stubJSONPCall(baseUrl, webMercatorResult);
+
+        var provider = new ArcGisMapServerImageryProvider({
+            url : baseUrl
+        });
+
+        return provider.readyPromise.then(function(result) {
+            expect(result).toBe(true);
+            expect(provider.ready).toBe(true);
+        });
+    });
+
     it('supports tiled servers in web mercator projection', function() {
         var baseUrl = '//tiledArcGisMapServer.invalid';
 

--- a/Specs/Scene/ArcGisMapServerImageryProviderSpec.js
+++ b/Specs/Scene/ArcGisMapServerImageryProviderSpec.js
@@ -143,6 +143,21 @@ defineSuite([
         });
     });
 
+    it('rejects readyPromise on error', function() {
+        var baseUrl = '//tiledArcGisMapServer.invalid';
+
+        var provider = new ArcGisMapServerImageryProvider({
+            url : baseUrl
+        });
+
+        return provider.readyPromise.then(function () {
+            fail('should not resolve');
+        }).otherwise(function (e) {
+            expect(e.message).toContain(baseUrl);
+            expect(provider.ready).toBe(false);
+        });
+    });
+
     it('supports tiled servers in web mercator projection', function() {
         var baseUrl = '//tiledArcGisMapServer.invalid';
 

--- a/Specs/Scene/BingMapsImageryProviderSpec.js
+++ b/Specs/Scene/BingMapsImageryProviderSpec.js
@@ -181,6 +181,24 @@ defineSuite([
         };
     }
 
+    it('resolves readyPromise', function() {
+        var url = 'http://fake.fake.invalid';
+        var mapStyle = BingMapsStyle.ROAD;
+
+        installFakeMetadataRequest(url, mapStyle);
+        installFakeImageRequest();
+
+        var provider = new BingMapsImageryProvider({
+            url : url,
+            mapStyle : mapStyle
+        });
+
+        return provider.readyPromise.then(function(result) {
+            expect(result).toBe(true);
+            expect(provider.ready).toBe(true);
+        });
+    });
+
     it('returns valid value for hasAlphaChannel', function() {
         var url = 'http://fake.fake.invalid';
         var mapStyle = BingMapsStyle.AERIAL;

--- a/Specs/Scene/BingMapsImageryProviderSpec.js
+++ b/Specs/Scene/BingMapsImageryProviderSpec.js
@@ -30,7 +30,7 @@ defineSuite([
         ImageryState,
         pollToPromise) {
     "use strict";
-    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,fail*/
 
     afterEach(function() {
         loadJsonp.loadAndExecuteScript = loadJsonp.defaultLoadAndExecuteScript;
@@ -196,6 +196,20 @@ defineSuite([
         return provider.readyPromise.then(function(result) {
             expect(result).toBe(true);
             expect(provider.ready).toBe(true);
+        });
+    });
+
+    it('rejects readyPromise on error', function() {
+        var url = 'host.invalid';
+        var provider = new BingMapsImageryProvider({
+            url : url
+        });
+
+        return provider.readyPromise.then(function () {
+            fail('should not resolve');
+        }).otherwise(function (e) {
+            expect(provider.ready).toBe(false);
+            expect(e.message).toContain(url);
         });
     });
 

--- a/Specs/Scene/GoogleEarthImageryProviderSpec.js
+++ b/Specs/Scene/GoogleEarthImageryProviderSpec.js
@@ -28,7 +28,7 @@ defineSuite([
         ImageryState,
         pollToPromise) {
     "use strict";
-    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,fail*/
 
     afterEach(function() {
         loadImage.createImage = loadImage.defaultCreateImage;
@@ -76,6 +76,21 @@ defineSuite([
         return provider.readyPromise.then(function (result) {
             expect(result).toBe(true);
             expect(provider.ready).toBe(true);
+        });
+    });
+
+    it('rejects readyPromise on error', function() {
+        var url = 'invalid.localhost';
+        var provider = new GoogleEarthImageryProvider({
+            url : url,
+            channel : 1234
+        });
+
+        return provider.readyPromise.then(function () {
+            fail('should not resolve');
+        }).otherwise(function (e) {
+            expect(provider.ready).toBe(false);
+            expect(e.message).toContain(url);
         });
     });
 

--- a/Specs/Scene/GoogleEarthImageryProviderSpec.js
+++ b/Specs/Scene/GoogleEarthImageryProviderSpec.js
@@ -57,6 +57,28 @@ defineSuite([
         expect(constructWithoutChannel).toThrowDeveloperError();
     });
 
+    it('resolves readyPromise', function() {
+        var path = '';
+        var url = 'http://example.invalid';
+        var channel = 1234;
+        var version = 1;
+
+        loadWithXhr.load = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
+            loadWithXhr.defaultLoad('Data/GoogleEarthImageryProvider/good.json', responseType, method, data, headers, deferred);
+        };
+
+        var provider = new GoogleEarthImageryProvider({
+            url : url,
+            channel : channel,
+            path : path
+        });
+
+        return provider.readyPromise.then(function (result) {
+            expect(result).toBe(true);
+            expect(provider.ready).toBe(true);
+        });
+    });
+
     it('returns valid value for hasAlphaChannel', function() {
         var path = '';
         var url = 'http://example.invalid';

--- a/Specs/Scene/GridImageryProviderSpec.js
+++ b/Specs/Scene/GridImageryProviderSpec.js
@@ -22,6 +22,15 @@ defineSuite([
         expect(GridImageryProvider).toConformToInterface(ImageryProvider);
     });
 
+    it('resolves readyPromise', function() {
+        var provider = new GridImageryProvider();
+
+        return provider.readyPromise.then(function (result) {
+            expect(result).toBe(true);
+            expect(provider.ready).toBe(true);
+        });
+    });
+
     it('returns valid value for hasAlphaChannel', function() {
         var provider = new GridImageryProvider();
 

--- a/Specs/Scene/MapboxImageryProviderSpec.js
+++ b/Specs/Scene/MapboxImageryProviderSpec.js
@@ -40,6 +40,18 @@ defineSuite([
         }).toThrowDeveloperError();
     });
 
+    it('resolves readyPromise', function() {
+        var provider = new MapboxImageryProvider({
+            url : 'made/up/mapbox/server/',
+            mapId: 'test-id'
+        });
+
+        return provider.readyPromise.then(function (result) {
+            expect(result).toBe(true);
+            expect(provider.ready).toBe(true);
+        });
+    });
+
     it('returns valid value for hasAlphaChannel', function() {
         var provider = new MapboxImageryProvider({
             url : 'made/up/mapbox/server/',

--- a/Specs/Scene/OpenStreetMapImageryProviderSpec.js
+++ b/Specs/Scene/OpenStreetMapImageryProviderSpec.js
@@ -36,6 +36,17 @@ defineSuite([
         return new OpenStreetMapImageryProvider();
     });
 
+    it('resolves readyPromise', function() {
+        var provider = new OpenStreetMapImageryProvider({
+            url : 'made/up/osm/server/'
+        });
+
+        return provider.readyPromise.then(function(result) {
+            expect(result).toBe(true);
+            expect(provider.ready).toBe(true);
+        });
+    });
+
     it('returns valid value for hasAlphaChannel', function() {
         var provider = new OpenStreetMapImageryProvider({
             url : 'made/up/osm/server/'

--- a/Specs/Scene/SingleTileImageryProviderSpec.js
+++ b/Specs/Scene/SingleTileImageryProviderSpec.js
@@ -36,6 +36,17 @@ defineSuite([
         expect(SingleTileImageryProvider).toConformToInterface(ImageryProvider);
     });
 
+    it('resolves readyPromise', function() {
+        var provider = new SingleTileImageryProvider({
+            url : 'Data/Images/Red16x16.png'
+        });
+
+        return provider.readyPromise.then(function(result) {
+            expect(result).toBe(true);
+            expect(provider.ready).toBe(true);
+        });
+    });
+
     it('returns valid value for hasAlphaChannel', function() {
         var provider = new SingleTileImageryProvider({
             url : 'Data/Images/Red16x16.png'

--- a/Specs/Scene/SingleTileImageryProviderSpec.js
+++ b/Specs/Scene/SingleTileImageryProviderSpec.js
@@ -26,7 +26,7 @@ defineSuite([
         pollToPromise,
         when) {
     "use strict";
-    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn*/
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn,fail*/
 
     afterEach(function() {
         loadImage.createImage = loadImage.defaultCreateImage;
@@ -44,6 +44,19 @@ defineSuite([
         return provider.readyPromise.then(function(result) {
             expect(result).toBe(true);
             expect(provider.ready).toBe(true);
+        });
+    });
+
+    it('rejects readyPromise on error', function() {
+        var provider = new SingleTileImageryProvider({
+            url : 'invalid.image.url'
+        });
+
+        return provider.readyPromise.then(function() {
+            fail('should not resolve');
+        }).otherwise(function (e) {
+            expect(provider.ready).toBe(false);
+            expect(e.message).toContain(provider.url);
         });
     });
 

--- a/Specs/Scene/TileCoordinatesImageryProviderSpec.js
+++ b/Specs/Scene/TileCoordinatesImageryProviderSpec.js
@@ -24,6 +24,15 @@ defineSuite([
         expect(TileCoordinatesImageryProvider).toConformToInterface(ImageryProvider);
     });
 
+    it('resolves readyPromise', function() {
+        var provider = new TileCoordinatesImageryProvider();
+
+        return provider.readyPromise.then(function(result) {
+            expect(result).toBe(true);
+            expect(provider.ready).toBe(true);
+        });
+    });
+
     it('returns valid value for hasAlphaChannel', function() {
         var provider = new TileCoordinatesImageryProvider();
 

--- a/Specs/Scene/TileMapServiceImageryProviderSpec.js
+++ b/Specs/Scene/TileMapServiceImageryProviderSpec.js
@@ -51,6 +51,17 @@ defineSuite([
         expect(TileMapServiceImageryProvider).toConformToInterface(ImageryProvider);
     });
 
+    it('resolves readyPromise', function() {
+        var provider = new TileMapServiceImageryProvider({
+            url : 'made/up/tms/server/'
+        });
+
+        return provider.readyPromise.then(function(result) {
+            expect(result).toBe(true);
+            expect(provider.ready).toBe(true);
+        });
+    });
+
     it('requires the url to be specified', function() {
         function createWithoutUrl() {
             return new TileMapServiceImageryProvider({});

--- a/Specs/Scene/UrlTemplateImageryProviderSpec.js
+++ b/Specs/Scene/UrlTemplateImageryProviderSpec.js
@@ -49,6 +49,17 @@ defineSuite([
         expect(createWithoutUrl).toThrowDeveloperError();
     });
 
+    it('resolves readyPromise', function() {
+        var provider = new UrlTemplateImageryProvider({
+            url: 'made/up/tms/server/'
+        });
+
+        return provider.readyPromise.then(function(result) {
+            expect(result).toBe(true);
+            expect(provider.ready).toBe(true);
+        });
+    });
+
     it('returns valid value for hasAlphaChannel', function() {
         var provider = new UrlTemplateImageryProvider({
             url: 'made/up/tms/server/'

--- a/Specs/Scene/WebMapServiceImageryProviderSpec.js
+++ b/Specs/Scene/WebMapServiceImageryProviderSpec.js
@@ -73,6 +73,18 @@ defineSuite([
         expect(createWithoutUrl).toThrowDeveloperError();
     });
 
+    it('resolves readyPromise', function() {
+        var provider = new WebMapServiceImageryProvider({
+            url : 'made/up/wms/server',
+            layers : 'someLayer'
+        });
+
+        return provider.readyPromise.then(function(result) {
+            expect(result).toBe(true);
+            expect(provider.ready).toBe(true);
+        });
+    });
+
     it('returns valid value for hasAlphaChannel', function() {
         var provider = new WebMapServiceImageryProvider({
             url : 'made/up/wms/server',

--- a/Specs/Scene/WebMapTileServiceImageryProviderSpec.js
+++ b/Specs/Scene/WebMapTileServiceImageryProviderSpec.js
@@ -199,6 +199,20 @@ defineSuite([
         expect(createWithoutTMS).toThrowDeveloperError();
     });
 
+    it('resolves readyPromise', function() {
+        var provider = new WebMapTileServiceImageryProvider({
+            layer : 'someLayer',
+            style : 'someStyle',
+            url : 'http://wmts.invalid',
+            tileMatrixSetID : 'someTMS'
+        });
+
+        return provider.readyPromise.then(function(result) {
+            expect(result).toBe(true);
+            expect(provider.ready).toBe(true);
+        });
+    });
+
     // default parameters values
     it('uses default values for undefined parameters', function() {
         var provider = new WebMapTileServiceImageryProvider({


### PR DESCRIPTION
Added promise property (similar to `Model` and `Primitive`'s `readyPromise`) to each imagery provider that resolves to true when the provider is ready for use.