### PR TITLE
Feature/selectable entity

### DIFF
--- a/Source/DataSources/CzmlDataSource.js
+++ b/Source/DataSources/CzmlDataSource.js
@@ -856,6 +856,10 @@ define([
     function processName(entity, packet, entityCollection, sourceUri) {
         entity.name = defaultValue(packet.name, entity.name);
     }
+    
+    function processSelectble(entity, packet, entityCollection, sourceUri) {
+        entity.selectable = devaultValue(packet.selectable, true);    
+    }
 
     function processDescription(entity, packet, entityCollection, sourceUri) {
         var descriptionData = packet.description;
@@ -1633,6 +1637,7 @@ define([
     processLabel, //
     processModel, //
     processName, //
+    processSelectable,
     processDescription, //
     processPath, //
     processPoint, //

--- a/Source/DataSources/CzmlDataSource.js
+++ b/Source/DataSources/CzmlDataSource.js
@@ -857,8 +857,8 @@ define([
         entity.name = defaultValue(packet.name, entity.name);
     }
     
-    function processSelectble(entity, packet, entityCollection, sourceUri) {
-        entity.selectable = devaultValue(packet.selectable, true);    
+    function processSelectable(entity, packet, entityCollection, sourceUri) {
+        entity.selectable = defaultValue(packet.selectable, true);    
     }
 
     function processDescription(entity, packet, entityCollection, sourceUri) {

--- a/Source/DataSources/Entity.js
+++ b/Source/DataSources/Entity.js
@@ -277,7 +277,19 @@ define([
          * @memberof Entity.prototype
          * @type {Boolean}
          */
-        selectable: createPropertyDescriptor('selectable'),
+        selectable: {
+            get: function() {
+                return this._selectable;
+            },
+            set: function(value) {
+                if (!defined(value))
+                    throw new DeveloperError('value is required');
+                
+                
+                if (value === this._selectable) return;
+                this._selectable = value;
+            }
+        },
         
         /**
          * Gets whether this entity is being displayed, taking into account

--- a/Source/DataSources/Entity.js
+++ b/Source/DataSources/Entity.js
@@ -282,11 +282,13 @@ define([
                 return this._selectable;
             },
             set: function(value) {
-                if (!defined(value))
+                if (!defined(value)) {
                     throw new DeveloperError('value is required');
+                }
                 
-                
-                if (value === this._selectable) return;
+                if (value === this._selectable) {
+                    return;
+                }
                 this._selectable = value;
             }
         },

--- a/Source/DataSources/Entity.js
+++ b/Source/DataSources/Entity.js
@@ -92,6 +92,7 @@ define([
      * @param {String} [options.name] A human readable name to display to users. It does not have to be unique.
      * @param {TimeIntervalCollection} [options.availability] The availability, if any, associated with this object.
      * @param {Boolean} [options.show] A boolean value indicating if the entity and its children are displayed.
+     * @param {Boolean} [options.selectable] A boolean value indicating whether the entity is selectable. Default true.
      * @param {Property} [options.description] A string Property specifying an HTML description for this entity.
      * @param {PositionProperty} [options.position] A Property specifying the entity position.
      * @param {Property} [options.orientation] A Property specifying the entity orientation.
@@ -128,6 +129,7 @@ define([
         this._definitionChanged = new Event();
         this._name = options.name;
         this._show = defaultValue(options.show, true);
+        this._selectable = defaultValue(options.selectable, true);
         this._parent = undefined;
         this._propertyNames = ['billboard', 'box', 'corridor', 'cylinder', 'description', 'ellipse', //
                                'ellipsoid', 'label', 'model', 'orientation', 'path', 'point', 'polygon', //
@@ -269,6 +271,14 @@ define([
                 this._definitionChanged.raiseEvent(this, 'show', value, !value);
             }
         },
+        
+        /**
+         * Gets or sets whether this entity is selectabled or not
+         * @memberof Entity.prototype
+         * @type {Boolean}
+         */
+        selectable: createPropertyDescriptor('selectable'),
+        
         /**
          * Gets whether this entity is being displayed, taking into account
          * the visibility of any ancestor entities.

--- a/Source/Renderer/Context.js
+++ b/Source/Renderer/Context.js
@@ -1112,7 +1112,7 @@ define([
         }
         //>>includeEnd('debug');
 
-        return ((pickColor = this._pickObjects[pickColor.toRgba()]) && pickColor.id.selectable) ? pickColor : undefined;
+        return this._pickObjects[pickColor.toRgba()];
     };
 
     function PickId(pickObjects, key, color) {

--- a/Source/Renderer/Context.js
+++ b/Source/Renderer/Context.js
@@ -1112,7 +1112,7 @@ define([
         }
         //>>includeEnd('debug');
 
-        return this._pickObjects[pickColor.toRgba()];
+        return ((pickColor = this._pickObjects[pickColor.toRgba()]) && pickColor.id.selectable) ? pickColor : undefined;
     };
 
     function PickId(pickObjects, key, color) {

--- a/Source/Renderer/PickFramebuffer.js
+++ b/Source/Renderer/PickFramebuffer.js
@@ -114,6 +114,9 @@ define([
 
                 var object = context.getObjectByPickColor(colorScratch);
                 if (defined(object)) {
+                    if (object.id && (typeof object.id === 'object')) {
+                        return (object.id.selectable) ? object : undefined;
+                    }
                     return object;
                 }
             }

--- a/Specs/DataSources/CzmlDataSourceSpec.js
+++ b/Specs/DataSources/CzmlDataSourceSpec.js
@@ -2091,4 +2091,18 @@ defineSuite([
             expect(error.message).toContain('CZML version information invalid.  It is expected to be a property on the document object in the <Major>.<Minor> version format.');
         });
     });
+    
+    it('sets selectable according to the CZML field', function() {
+        var packet = {
+            position : {
+                cartesian : [1.0, 2.0, 3.0]
+            },
+            selectable : false
+        };
+        
+        var dataSource = new CzmlDataSource();
+        dataSource.load(makePacket(packet));
+        var entity = dataSource.entities.values[0];
+        expect(entity.selectable).toBe(false);
+    });
 });

--- a/Specs/DataSources/EntitySpec.js
+++ b/Specs/DataSources/EntitySpec.js
@@ -80,11 +80,13 @@ defineSuite([
         expect(entity.viewFrom).toBeUndefined();
         expect(entity.wall).toBeUndefined();
         expect(entity.entityCollection).toBeUndefined();
+        expect(entity.selectable).toBe(true);
 
         var options = {
             id : 'someId',
             name : 'bob',
             show : false,
+            selectable: false,
             availability : new TimeIntervalCollection(),
             parent : new Entity(),
             customProperty : {},
@@ -113,6 +115,7 @@ defineSuite([
         expect(entity.id).toEqual(options.id);
         expect(entity.name).toEqual(options.name);
         expect(entity.show).toBe(options.show);
+        expect(entity.selectable).toBe(options.selectable);
         expect(entity.availability).toBe(options.availability);
         expect(entity.parent).toBe(options.parent);
         expect(entity.customProperty).toBe(options.customProperty);

--- a/Specs/Widgets/Viewer/ViewerSpec.js
+++ b/Specs/Widgets/Viewer/ViewerSpec.js
@@ -907,7 +907,7 @@ defineSuite([
     it('cannot select an entity when selectable is false', function() {
         var viewer = createViewer(container);
         
-        var entity = viewer.entities.add({
+        viewer.entities.add({
             rectangle: {
                 coordinates: Rectangle.fromDegrees(-50.0, -50.0, 50.0, 50.0)
             },
@@ -918,7 +918,7 @@ defineSuite([
         expect(pickedObject).toBeUndefined();
         
         viewer.destroy();
-    })
+    });
 
     it('does not crash when tracking an object with a position property whose value is undefined.', function() {
         viewer = createViewer(container);

--- a/Specs/Widgets/Viewer/ViewerSpec.js
+++ b/Specs/Widgets/Viewer/ViewerSpec.js
@@ -2,12 +2,14 @@
 defineSuite([
         'Widgets/Viewer/Viewer',
         'Core/Cartesian3',
+        'Core/Cartesian2',
         'Core/ClockRange',
         'Core/ClockStep',
         'Core/EllipsoidTerrainProvider',
         'Core/JulianDate',
         'Core/Matrix4',
         'Core/WebMercatorProjection',
+        'Core/Rectangle',
         'DataSources/ConstantPositionProperty',
         'DataSources/ConstantProperty',
         'DataSources/DataSourceClock',
@@ -36,12 +38,14 @@ defineSuite([
     ], function(
         Viewer,
         Cartesian3,
+        Cartesian2,
         ClockRange,
         ClockStep,
         EllipsoidTerrainProvider,
         JulianDate,
         Matrix4,
         WebMercatorProjection,
+        Rectangle,
         ConstantPositionProperty,
         ConstantProperty,
         DataSourceClock,
@@ -899,6 +903,22 @@ defineSuite([
             });
         });
     });
+    
+    it('cannot select an entity when selectable is false', function() {
+        var viewer = createViewer(container);
+        
+        var entity = viewer.entities.add({
+            rectangle: {
+                coordinates: Rectangle.fromDegrees(-50.0, -50.0, 50.0, 50.0)
+            },
+            selectable: false
+        });
+        
+        var pickedObject = viewer.scene.pick(new Cartesian2(0, 0));
+        expect(pickedObject).toBeUndefined();
+        
+        viewer.destroy();
+    })
 
     it('does not crash when tracking an object with a position property whose value is undefined.', function() {
         viewer = createViewer(container);


### PR DESCRIPTION
Hello friends,

I happened across a use case similar to [this issue here](https://github.com/AnalyticalGraphicsInc/cesium/issues/1592), although emackey speaks of an enum for picking priority, whereas my use case was I suppose more similar to [this guys question on the forum](https://groups.google.com/forum/#!topic/cesium-dev/agtOrHYEhUo) who only wanted to be able to toggle on/off selectability of individual Entities.
I created a 'selectable' member for the Entity which will govern whether a user can select an Entity.  The selectable defaults to true and can be set in the 'options' object parameter of the Entity constructor, or by setting the 'selectable' value in a loaded CZML object.
TODO:
 Write some unit tests.  Im kind of a noob so unfamiliar with Jasmine, I will have to read into it this weekend, but I wanted to get feedback if this is functionality is something you want.
