### PR TITLE
Fix deprecation warning when tests are loaded

### DIFF
--- a/Specs/Core/BoxGeometrySpec.js
+++ b/Specs/Core/BoxGeometrySpec.js
@@ -100,8 +100,8 @@ defineSuite([
     });
 
     createPackableSpecs(BoxGeometry, new BoxGeometry({
-        minimumCorner : new Cartesian3(1.0, 2.0, 3.0),
-        maximumCorner : new Cartesian3(4.0, 5.0, 6.0),
+        minimum : new Cartesian3(1.0, 2.0, 3.0),
+        maximum : new Cartesian3(4.0, 5.0, 6.0),
         vertexFormat : VertexFormat.POSITION_AND_NORMAL
     }), [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 1.0, 1.0, 0.0, 0.0, 0.0, 0.0]);
 });

--- a/Specs/Core/BoxOutlineGeometrySpec.js
+++ b/Specs/Core/BoxOutlineGeometrySpec.js
@@ -75,7 +75,7 @@ defineSuite([
     });
 
     createPackableSpecs(BoxOutlineGeometry, new BoxOutlineGeometry({
-        minimumCorner : new Cartesian3(1.0, 2.0, 3.0),
-        maximumCorner : new Cartesian3(4.0, 5.0, 6.0)
+        minimum : new Cartesian3(1.0, 2.0, 3.0),
+        maximum : new Cartesian3(4.0, 5.0, 6.0)
     }), [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
 });

--- a/Specs/Core/GeometryPipelineSpec.js
+++ b/Specs/Core/GeometryPipelineSpec.js
@@ -1639,8 +1639,8 @@ defineSuite([
                 normal : true,
                 st : true
             }),
-            maximumCorner : new Cartesian3(250000.0, 250000.0, 250000.0),
-            minimumCorner : new Cartesian3(-250000.0, -250000.0, -250000.0)
+            maximum : new Cartesian3(250000.0, 250000.0, 250000.0),
+            minimum : new Cartesian3(-250000.0, -250000.0, -250000.0)
         }));
         geometry = GeometryPipeline.computeBinormalAndTangent(geometry);
         var actualTangents = geometry.attributes.tangent.values;
@@ -1648,8 +1648,8 @@ defineSuite([
 
         var expectedGeometry = BoxGeometry.createGeometry(new BoxGeometry({
             vertexFormat: VertexFormat.ALL,
-            maximumCorner : new Cartesian3(250000.0, 250000.0, 250000.0),
-            minimumCorner : new Cartesian3(-250000.0, -250000.0, -250000.0)
+            maximum : new Cartesian3(250000.0, 250000.0, 250000.0),
+            minimum : new Cartesian3(-250000.0, -250000.0, -250000.0)
         }));
         var expectedTangents = expectedGeometry.attributes.tangent.values;
         var expectedBinormals = expectedGeometry.attributes.binormal.values;
@@ -1679,8 +1679,8 @@ defineSuite([
             vertexFormat : new VertexFormat({
                 position : true
             }),
-            maximumCorner : new Cartesian3(250000.0, 250000.0, 250000.0),
-            minimumCorner : new Cartesian3(-250000.0, -250000.0, -250000.0)
+            maximum : new Cartesian3(250000.0, 250000.0, 250000.0),
+            minimum : new Cartesian3(-250000.0, -250000.0, -250000.0)
         }));
         expect(geometry.attributes.normal).not.toBeDefined();
         geometry = GeometryPipeline.compressVertices(geometry);
@@ -1693,8 +1693,8 @@ defineSuite([
                 position : true,
                 normal : true
             }),
-            maximumCorner : new Cartesian3(250000.0, 250000.0, 250000.0),
-            minimumCorner : new Cartesian3(-250000.0, -250000.0, -250000.0)
+            maximum : new Cartesian3(250000.0, 250000.0, 250000.0),
+            minimum : new Cartesian3(-250000.0, -250000.0, -250000.0)
         }));
         expect(geometry.attributes.normal).toBeDefined();
         var originalNormals = Array.prototype.slice.call(geometry.attributes.normal.values);
@@ -1717,8 +1717,8 @@ defineSuite([
                 position : true,
                 st : true
             }),
-            maximumCorner : new Cartesian3(250000.0, 250000.0, 250000.0),
-            minimumCorner : new Cartesian3(-250000.0, -250000.0, -250000.0)
+            maximum : new Cartesian3(250000.0, 250000.0, 250000.0),
+            minimum : new Cartesian3(-250000.0, -250000.0, -250000.0)
         }));
         expect(geometry.attributes.st).toBeDefined();
         var originalST = Array.prototype.slice.call(geometry.attributes.st.values);
@@ -1747,8 +1747,8 @@ defineSuite([
                 normal : true,
                 st : true
             }),
-            maximumCorner : new Cartesian3(250000.0, 250000.0, 250000.0),
-            minimumCorner : new Cartesian3(-250000.0, -250000.0, -250000.0)
+            maximum : new Cartesian3(250000.0, 250000.0, 250000.0),
+            minimum : new Cartesian3(-250000.0, -250000.0, -250000.0)
         }));
         expect(geometry.attributes.normal).toBeDefined();
         expect(geometry.attributes.st).toBeDefined();
@@ -1778,8 +1778,8 @@ defineSuite([
                 tangent : true,
                 binormal : true
             }),
-            maximumCorner : new Cartesian3(250000.0, 250000.0, 250000.0),
-            minimumCorner : new Cartesian3(-250000.0, -250000.0, -250000.0)
+            maximum : new Cartesian3(250000.0, 250000.0, 250000.0),
+            minimum : new Cartesian3(-250000.0, -250000.0, -250000.0)
         }));
         expect(geometry.attributes.normal).toBeDefined();
         expect(geometry.attributes.tangent).toBeDefined();

--- a/Specs/Scene/MultifrustumSpec.js
+++ b/Specs/Scene/MultifrustumSpec.js
@@ -249,7 +249,7 @@ defineSuite([
 
                 var dimensions = new Cartesian3(500000.0, 500000.0, 500000.0);
                 var maximum = Cartesian3.multiplyByScalar(dimensions, 0.5, new Cartesian3());
-                var minimum = Cartesian3.negate(maximumCorner, new Cartesian3());
+                var minimum = Cartesian3.negate(maximum, new Cartesian3());
                 var geometry = BoxGeometry.createGeometry(new BoxGeometry({
                     minimum : minimum,
                     maximum : maximum

--- a/Specs/Scene/MultifrustumSpec.js
+++ b/Specs/Scene/MultifrustumSpec.js
@@ -248,11 +248,11 @@ defineSuite([
                 fs += '}';
 
                 var dimensions = new Cartesian3(500000.0, 500000.0, 500000.0);
-                var maximumCorner = Cartesian3.multiplyByScalar(dimensions, 0.5, new Cartesian3());
-                var minimumCorner = Cartesian3.negate(maximumCorner, new Cartesian3());
+                var maximum = Cartesian3.multiplyByScalar(dimensions, 0.5, new Cartesian3());
+                var minimum = Cartesian3.negate(maximumCorner, new Cartesian3());
                 var geometry = BoxGeometry.createGeometry(new BoxGeometry({
-                    minimumCorner: minimumCorner,
-                    maximumCorner: maximumCorner
+                    minimum : minimum,
+                    maximum : maximum
                 }));
                 var attributeLocations = GeometryPipeline.createAttributeLocations(geometry);
                 this._va = VertexArray.fromGeometry({


### PR DESCRIPTION
Opening http://localhost:8080/Specs/SpecRunner.html?category=none would output deprecation warnings about `minimumCorner` and `maximumCorner`.

I left a few uses of these elsewhere in the tests so they are still tested until #3090.