### PR TITLE
Gulp: prevent copy unminified

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -31,7 +31,6 @@ if (/\.0$/.test(version)) {
 //per-task variables.  We use the command line argument here to detect which task is being run.
 var taskName = process.argv[2];
 var noDevelopmentGallery = taskName === 'release' || taskName === 'makeZipFile';
-var copyUnminified = taskName === 'combine' || taskName === 'default' || taskName === undefined;
 var minifyShaders = taskName === 'minify' || taskName === 'minifyRelease' || taskName === 'release' || taskName === 'makeZipFile' || taskName === 'buildApps';
 
 var sourceFiles = ['Source/**/*.js',
@@ -152,11 +151,6 @@ gulp.task('combine', ['generateStubs'], function() {
         removePragmas : false,
         optimizer : 'none',
         outputDirectory : outputDirectory
-    }).then(function() {
-        if (!copyUnminified) {
-            return;
-        }
-        return streamToPromise(gulp.src(outputDirectory + '/**').pipe(gulp.dest(path.join('Build', 'Cesium'))));
     });
 });
 
@@ -166,11 +160,6 @@ gulp.task('combineRelease', ['generateStubs'], function() {
         removePragmas : true,
         optimizer : 'none',
         outputDirectory : outputDirectory
-    }).then(function() {
-        if (!copyUnminified) {
-            return;
-        }
-        return streamToPromise(gulp.src(outputDirectory + '/**').pipe(gulp.dest(path.join('Build', 'Cesium'))));
     });
 });
 


### PR DESCRIPTION
`gulp combine` output used to be copied to Build/Cesium, effectively overwritting any minified version previously outputted there. With this PR, no more copy is done by gulp.

```
-- original description
By default, the unminified Cesium build will be copied in `Build/Cesium`
in addition to `Build/CesiumUnminified`. This will overwrite any existing
 `Build/Cesium` directory so it may be inappropriate.

This PR allows disabling this behaviour by passing an environment variable:
- copy (default): `gulp combine`;
- no copy: `NO_COPY_UNMINIFIED=1 gulp combine`.

It also add support for `combineRelease`, which seems to have been forgotten.
```