### PR TITLE
Honor windows.devicePixelRatio by default

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -33,6 +33,7 @@ Change Log
 * Added `createOpenStreetMapImageryProvider` function to replace the `OpenStreetMapImageryProvider` class. This function returns a constructed `UrlTemplateImageryProvider`.
 * Fixed an issue with tile selection when below the surface of the ellipsoid. [#3170](https://github.com/AnalyticalGraphicsInc/cesium/issues/3170)
 * Fixed an issue with loading skeletons for skinned glTF models. [#3224](https://github.com/AnalyticalGraphicsInc/cesium/pull/3224)
+* Cesium now honors `window.devicePixelRatio` by default, which greatly improving performance on mobile devices and high DPI displays by rendering at the browser-recommended resolution. To use the previous behavior, set `Viewer.resolutionScale` to `window.devicePixelRatio`.
 
 ### 1.15 - 2015-11-02
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -33,7 +33,7 @@ Change Log
 * Added `createOpenStreetMapImageryProvider` function to replace the `OpenStreetMapImageryProvider` class. This function returns a constructed `UrlTemplateImageryProvider`.
 * Fixed an issue with tile selection when below the surface of the ellipsoid. [#3170](https://github.com/AnalyticalGraphicsInc/cesium/issues/3170)
 * Fixed an issue with loading skeletons for skinned glTF models. [#3224](https://github.com/AnalyticalGraphicsInc/cesium/pull/3224)
-* Cesium now honors `window.devicePixelRatio` by default, which greatly improving performance on mobile devices and high DPI displays by rendering at the browser-recommended resolution. To use the previous behavior, set `Viewer.resolutionScale` to `window.devicePixelRatio`.
+* Cesium now honors `window.devicePixelRatio` by default, which greatly improving performance on mobile devices and high DPI displays by rendering at the browser-recommended resolution. This also reduces bandwidth usage in these cases.  To use the previous behavior, set `Viewer.resolutionScale` to `window.devicePixelRatio`.
 
 ### 1.15 - 2015-11-02
 

--- a/Source/Widgets/CesiumWidget/CesiumWidget.js
+++ b/Source/Widgets/CesiumWidget/CesiumWidget.js
@@ -98,7 +98,7 @@ define([
         var canvas = widget._canvas;
         var width = canvas.clientWidth;
         var height = canvas.clientHeight;
-        var zoomFactor = defaultValue(window.devicePixelRatio, 1.0) * widget._resolutionScale;
+        var zoomFactor = (1.0 / defaultValue(window.devicePixelRatio, 1.0)) * widget._resolutionScale;
 
         widget._canvasWidth = width;
         widget._canvasHeight = height;


### PR DESCRIPTION
Honor windows.devicePixelRatio by default

Way back in #1162 (over two years ago), we put in changes to let Cesium render at native screen resolution, ignoring `window.devicePixelRatio`.  This made sense at the time because

1. A lot of mobile devices would end up rendering at 320x240 and look horrible.
2. 4K screens were would render at 1920x1080 instead of 4K (and 4K was rare and everyone that had one had powerful hardware to go along with it.

The above reasons no longer make sense

1. Mobile screens have crazy resolutions now (for example my phone is 2560 x 1440), but many don't have the GPU to render WebGL at that resolution.  When we honor the DPI setting, we are still rendering at a high resolution (in this case 1280 x 720) and there's no noticeable difference in visual quality because of the small screen size.  On my phone this brings a blank Viewer from 15fps to 60fps.

2. 4K and high DPI displays are everywhere (especially on Mac) but a lot of those machines can't render WebGL anywhere near 60fps at 4k.  Similar performance gains will happen for these devices.

Finally, this also greatly reduces bandwidth when devicePixelRatio > 1 because we are sucking down way less terrain and imagery tiles.  This is another huge improvement for mobile.