### PR TITLE
Fix incorrect zoomFactor.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,7 +11,7 @@ Change Log
 * `ImageMaterialProperty.image` now accepts an `HTMLVideoElement`. You can also assign a video element directly to an Entity `material` property.
 * `Material` image uniforms now accept and `HTMLVideoElement` anywhere it could previously take a `Canvas` element.
 * Added `VideoSynchronizer` helper object for keeping an `HTMLVideoElement` in sync with a scene's clock.
-* Cesium now honors `window.devicePixelRatio` by default, which greatly improving performance on mobile devices and high DPI displays by rendering at the browser-recommended resolution. This also reduces bandwidth usage in these cases.  To use the previous behavior, set `Viewer.resolutionScale` to `window.devicePixelRatio`.
+* Cesium now honors `window.devicePixelRatio` by default, greatly improving performance on mobile devices and high DPI displays by rendering at the browser-recommended resolution. This also reduces bandwidth usage in these cases.  To use the previous behavior, set `Viewer.resolutionScale` to `window.devicePixelRatio`.
 * Fixed an issue with loading skeletons for skinned glTF models. [#3224](https://github.com/AnalyticalGraphicsInc/cesium/pull/3224)
 * Fixed an issue with tile selection when below the surface of the ellipsoid. [#3170](https://github.com/AnalyticalGraphicsInc/cesium/issues/3170)
 * Added `Cartographic.fromCartesian` function.

--- a/Source/Widgets/CesiumWidget/CesiumWidget.js
+++ b/Source/Widgets/CesiumWidget/CesiumWidget.js
@@ -98,7 +98,7 @@ define([
         var canvas = widget._canvas;
         var width = canvas.clientWidth;
         var height = canvas.clientHeight;
-        var zoomFactor = (1.0 / defaultValue(window.devicePixelRatio, 1.0)) * widget._resolutionScale;
+        var zoomFactor = widget._resolutionScale;
 
         widget._canvasWidth = width;
         widget._canvasHeight = height;


### PR DESCRIPTION
As @kring pointed out in #3249, my code in #3233 was actually wrong and caused increased resolution loss when `window.devicePixelRatio` was greater than 1.  We should just be ignoring `window.devicePixelRatio` completely because the browser takes care of it by default.

@pjcozzi can you give this branch a try.  It was rendering at quarter resolution on your machine, since you have a devicePixelRatio of 2.  Now it will render at half but that should look much better.