### PR TITLE
Improved Model coverage

### DIFF
--- a/Specs/Data/Models/Box-Textured-Custom/CesiumTexturedBoxTest.gltf
+++ b/Specs/Data/Models/Box-Textured-Custom/CesiumTexturedBoxTest.gltf
@@ -354,6 +354,71 @@
                     "semantic": "VIEWPORT",
                     "type": 35666
                 },
+                "nodeModelMatrix": {
+                    "semantic": "MODEL",
+                    "type": 35676,
+                    "node" : "node_3"
+                },
+                "nodeViewMatrix": {
+                    "semantic": "VIEW",
+                    "type": 35676,
+                    "node" : "node_3"
+                },
+                "nodeProjectionMatrix": {
+                    "semantic": "PROJECTION",
+                    "type": 35676,
+                    "node" : "node_3"
+                },
+                "nodeModelViewMatrix": {
+                    "semantic": "MODELVIEW",
+                    "type": 35676,
+                    "node" : "node_3"
+                },
+                "nodeModelViewProjectionMatrix": {
+                    "semantic": "MODELVIEWPROJECTION",
+                    "type": 35676,
+                    "node" : "node_3"
+                },
+                "nodeModelInverseMatrix": {
+                    "semantic": "MODELINVERSE",
+                    "type": 35676,
+                    "node" : "node_3"
+                },
+                "nodeViewInverseMatrix": {
+                    "semantic": "VIEWINVERSE",
+                    "type": 35676,
+                    "node" : "node_3"
+                },
+                "nodeModelViewInverseMatrix": {
+                    "semantic": "MODELVIEWINVERSE",
+                    "type": 35676,
+                    "node" : "node_3"
+                },
+                "nodeProjectionInverseMatrix" : {
+                    "semantic": "PROJECTIONINVERSE",
+                    "type": 35676,
+                    "node" : "node_3"
+                },
+                "nodeModelViewProjectionInverseMatrix": {
+                    "semantic": "MODELVIEWPROJECTIONINVERSE",
+                    "type": 35676,
+                    "node" : "node_3"
+                },
+                "nodeModelInverseTransposeMatrix": {
+                    "semantic": "MODELINVERSETRANSPOSE",
+                    "type": 35676,
+                    "node" : "node_3"
+                },
+                "nodeModelViewInverseTransposeMatrix": {
+                    "semantic": "MODELVIEWINVERSETRANSPOSE",
+                    "type": 35676,
+                    "node" : "node_3"
+                },
+                "nodeViewportMatrix": {
+                    "semantic": "VIEWPORT",
+                    "type": 35666,
+                    "node" : "node_3"
+                },
                 "vec2": {
                     "type": 35664
                 },
@@ -392,6 +457,19 @@
                 "u_projectionInverseMatrix": "projectionInverseMatrix",
                 "u_modelInverseTransposeMatrix": "modelInverseTransposeMatrix",
                 "u_viewport": "viewportMatrix",
+                "u_nodeModelMatrix": "nodeModelMatrix",
+                "u_nodeViewMatrix": "nodeViewMatrix",
+                "u_nodeProjectionMatrix": "nodeProjectionMatrix",
+                "u_nodeModelViewMatrix": "nodeModelViewMatrix",
+                "u_nodeModelViewProjectionMatrix": "nodeModelViewProjectionMatrix",
+                "u_nodeModelInverseMatrix": "nodeModelInverseMatrix",
+                "u_nodeViewInverseMatrix": "nodeViewInverseMatrix",
+                "u_nodeModelViewInverseMatrix": "nodeModelViewInverseMatrix",
+                "u_nodeModelViewProjectionInverseMatrix": "nodeModelViewProjectionInverseMatrix",
+                "u_nodeProjectionInverseMatrix": "nodeProjectionInverseMatrix",
+                "u_nodeModelInverseTransposeMatrix": "nodeModelInverseTransposeMatrix",
+                "u_nodeModelViewInverseTransposeMatrix": "nodeModelViewInverseTransposeMatrix",
+                "u_nodeViewport": "nodeViewportMatrix",
                 "u_vec2": "vec2",
                 "u_mat2": "mat2",
                 "u_mat3": "mat3",

--- a/Specs/Data/Models/Box-Textured-Custom/CesiumTexturedBoxTest0FS.glsl
+++ b/Specs/Data/Models/Box-Textured-Custom/CesiumTexturedBoxTest0FS.glsl
@@ -17,6 +17,20 @@ uniform mat4 u_modelViewProjectionInverseMatrix;
 uniform mat4 u_modelInverseTransposeMatrix;
 uniform vec4 u_viewport;
 
+uniform mat4 u_nodeModelMatrix;
+uniform mat4 u_nodeViewMatrix;
+uniform mat4 u_nodeProjectionMatrix;
+uniform mat4 u_nodeModelViewMatrix;
+uniform mat4 u_nodeModelViewProjectionMatrix;
+uniform mat4 u_nodeModelInverseMatrix;
+uniform mat4 u_nodeViewInverseMatrix;
+uniform mat4 u_nodeProjectionInverseMatrix;
+uniform mat4 u_nodeModelViewInverseMatrix;
+uniform mat4 u_nodeModelViewProjectionInverseMatrix;
+uniform mat4 u_nodeModelInverseTransposeMatrix;
+uniform mat4 u_nodeModelViewInverseTransposeMatrix;
+uniform vec4 u_nodeViewport;
+
 uniform vec2 u_vec2;
 uniform mat2 u_mat2;
 uniform mat3 u_mat3;
@@ -46,6 +60,19 @@ color.r =
     u_modelViewProjectionInverseMatrix[0][0] + 
     u_modelInverseTransposeMatrix[0][0] + 
     u_viewport.x + 
+    u_nodeModelMatrix[0][0] +
+    u_nodeViewMatrix[0][0] +
+    u_nodeProjectionMatrix[0][0] +
+    u_nodeModelViewMatrix[0][0] +
+    u_nodeModelViewProjectionMatrix[0][0] +
+    u_nodeModelInverseMatrix[0][0] +
+    u_nodeViewInverseMatrix[0][0] +
+    u_nodeProjectionInverseMatrix[0][0] +
+    u_nodeModelViewInverseMatrix[0][0] +
+    u_nodeModelViewProjectionInverseMatrix[0][0] +
+    u_nodeModelInverseTransposeMatrix[0][0] +
+    u_nodeModelViewInverseTransposeMatrix[0][0] +
+    u_nodeViewport.x +
     u_vec2.x +
     u_mat2[0][0] +
     u_mat3[0][0] +


### PR DESCRIPTION
For #3245 

Amended the `textureBoxCustom` model to use node semantics for better code coverage. Only one that's missing is `CESIUM_RTC_MODELVIEW`.