### PR TITLE
Model error handling

### DIFF
--- a/Source/Scene/Model.js
+++ b/Source/Scene/Model.js
@@ -347,7 +347,9 @@ define([
         this._releaseGltfJson = defaultValue(options.releaseGltfJson, false);
         this._animationIds = undefined;
 
-        this._readyPromise = when.defer();
+        // Use optional readyPromise if provided
+        this._readyPromise = defined(options.readyPromise) ? options.readyPromise : when.defer();
+        this._ready = false;
 
         var cachedGltf;
         if (defined(cacheKey) && defined(gltfCache[cacheKey]) && gltfCache[cacheKey].ready) {
@@ -491,8 +493,6 @@ define([
         this.pickPrimitive = options.pickPrimitive;
 
         this._allowPicking = defaultValue(options.allowPicking, true);
-
-        this._ready = false;
 
         /**
          * The currently playing glTF animations.

--- a/Source/Scene/ModelInstanceCollection.js
+++ b/Source/Scene/ModelInstanceCollection.js
@@ -156,7 +156,7 @@ define([
         },
         readyPromise : {
             get : function() {
-                return this._readyPromise;
+                return this._readyPromise.promise;
             }
         }
     });
@@ -790,7 +790,7 @@ define([
             var that = this;
             when(this._model.readyPromise).otherwise(function(error) {
                 that._state = LoadState.FAILED;
-                that.readyPromise.reject(error);
+                that._readyPromise.reject(error);
             });
         }
 
@@ -810,7 +810,7 @@ define([
             createCommands(this, modelCommands.draw, modelCommands.pick);
             updateCommands(this);
 
-            this.readyPromise.resolve(this);
+            this._readyPromise.resolve(this);
             return;
         }
 

--- a/Specs/Scene/Instanced3DModel3DTileContentProviderSpec.js
+++ b/Specs/Scene/Instanced3DModel3DTileContentProviderSpec.js
@@ -181,14 +181,14 @@ defineSuite([
     });
 
     it('rejects readyPromise on error', function() {
-        // Try loading a tile with an empty url.
+        // Try loading a tile with an invalid url.
         // Expect promise to be rejected in Model, then in ModelInstanceCollection, and
         // finally in Instanced3DModel3DTileContentProvider.
         var arrayBuffer = generateTileBuffer({
             gltfFormat : 0
         });
 
-        var tileset = {};
+        var tileset = {url : ''};
         var tile = {};
         var url = '';
         var instancedTile = new Instanced3DModel3DTileContentProvider(tileset, tile, url);

--- a/Specs/Scene/ModelSpec.js
+++ b/Specs/Scene/ModelSpec.js
@@ -495,6 +495,12 @@ defineSuite([
                 gltf : gltf
             }));
 
+            model.readyPromise.then(function(model) {
+                fail('should not resolve');
+            }).otherwise(function(error) {
+                expect(model.ready).toEqual(false);
+            });
+
             expect(function() {
                 scene.renderForSpecs();
             }).toThrowRuntimeError();

--- a/Specs/Scene/ModelSpec.js
+++ b/Specs/Scene/ModelSpec.js
@@ -217,6 +217,23 @@ defineSuite([
         });
     });
 
+    it('rejects readyPromise on error', function() {
+        var promise = when.defer();
+        promise.promise.then(function(model) {
+            fail('should not resolve');
+        }).otherwise(function(error) {
+            expect(error).toBeDefined();
+        });
+
+        var arrayBuffer = new ArrayBuffer(16);
+        expect(function() {
+            return new Model({
+                gltf : arrayBuffer,
+                readyPromise : promise
+            });
+        }).toThrowDeveloperError();
+    });
+
     it('renders from glTF', function() {
         // Simulate using procedural glTF as opposed to loading it from a file
         return loadModelJson(texturedBoxModel.gltf).then(function(model) {


### PR DESCRIPTION
For #3177 
Related to comments in #3239 

Tests for:
* `throw new RuntimeError('Unsupported glTF Extension: ' + extension);`
* `throw new DeveloperError('bgltf is not a valid Binary glTF file.');`
* `throw new DeveloperError('Only Binary glTF version 1 is supported.  Version ' + version + ' is not.');`

I added a ready promise reject test for the invalid extension spec, but the other ones throw errors in the constructor which makes it hard to reject the ready promise.