### PR TITLE
Fix Sandcastle jsHint

### DIFF
--- a/Apps/Sandcastle/.jshintrc
+++ b/Apps/Sandcastle/.jshintrc
@@ -1,6 +1,5 @@
 {
   "extends": "../.jshintrc",
-  "jasmine": false,
   "unused": false,
   "predef": [
     "JSON",

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -772,10 +772,16 @@ var gallery_demos = [' + demos.join(', ') + '];';
 }
 
 function createJsHintOptions() {
-    var contents = fs.readFileSync(path.join('Apps', 'Sandcastle', '.jshintrc'), 'utf8');
-    contents = '\
+    var primary = JSON.parse(fs.readFileSync('.jshintrc', 'utf8'));
+    var gallery = JSON.parse(fs.readFileSync(path.join('Apps', 'Sandcastle', '.jshintrc'), 'utf8'));
+    primary.jasmine = false;
+    primary.predef = gallery.predef;
+    primary.unused = gallery.unused;
+
+    var contents = '\
 // This file is automatically rebuilt by the Cesium build process.\n\
-var sandcastleJsHintOptions = ' + contents + ';';
+var sandcastleJsHintOptions = ' + JSON.stringify(primary, null, 4) + ';';
+
     fs.writeFileSync(path.join('Apps', 'Sandcastle', 'jsHintOptions.js'), contents);
 }
 


### PR DESCRIPTION
We were writing out jsHintOptions with the `extends` attribute, which wasn't working when loaded into the browser.  Now the build process loads the primary jshint file and modifies is to match the gallery in order to write out a complete jsHintOptions object.

This could probably be a little more robust (since not all changes to Apps/Sandcastle/.jshintrc get reflected automatically jsHintOptions, but I doubt that will be an issue given that these files will rarely change.

Fixes #3267