### PR TITLE
Video demo tweak

### DIFF
--- a/Apps/Sandcastle/gallery/Video.html
+++ b/Apps/Sandcastle/gallery/Video.html
@@ -33,7 +33,7 @@
 <div id="loadingOverlay"><h1>Loading...</h1></div>
 <div id="toolbar"></div>
 
-<video id="trailer" autoplay loop crossorigin controls>
+<video id="trailer" style="display: none;" autoplay loop crossorigin controls>
     <source src="http://cesiumjs.org/videos/Sandcastle/big-buck-bunny_trailer.webm" type="video/webm">
     <source src="http://cesiumjs.org/videos/Sandcastle/big-buck-bunny_trailer.mp4" type="video/mp4">
     <source src="http://cesiumjs.org/videos/Sandcastle/big-buck-bunny_trailer.mov" type="video/quicktime">


### PR DESCRIPTION
On iPhone and potentially other mobile devices, showing the video overlay by default causes problems because they force things to be full screen. On @shunter's recommendation, I'm hiding it by default.