### PR TITLE
Don't include documentation in NPM package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -9,6 +9,7 @@
 /Apps
 /Build/minifyShaders.state
 /Build/Stubs
+/Build/Documentation
 /Cesium-*.zip
 /Documentation
 /favicon.ico


### PR DESCRIPTION
I accidentally forgot to exclude the built documentation in #3243.

To test this run `npm run release` followed by `npm pack`.  This will produce `cesium-1.16.0.tgz`, which you can unpack and inspect to make sure Build/Documentation does not exist.