### PR TITLE
Remove console.log from Scene/GlobeSurfaceTileProvider renders in 3D (2)

### DIFF
--- a/Specs/Scene/GlobeSurfaceTileProviderSpec.js
+++ b/Specs/Scene/GlobeSurfaceTileProviderSpec.js
@@ -400,7 +400,6 @@ defineSuite([
 
         return pollToPromise(function() {
             globe.update(frameState);
-            console.log(globe._surface._debug.maxDepth);
             return globe._surface.tileProvider.ready && !defined(globe._surface._tileLoadQueue.head) && globe._surface._debug.tilesWaitingForChildren === 0 && globe._surface._debug.maxDepth >= 11;
         }).then(function() {
             expect(render(frameState, globe)).toBeGreaterThan(0);


### PR DESCRIPTION
This test had a console.log inside its polling function, causing it to spit out a ton of console messages.

This test itself still fails on my machine, but I don't know why: CC #3289