### PR TITLE
Clear tracked entity on scene.morphStart

### DIFF
--- a/Source/Widgets/Viewer/Viewer.js
+++ b/Source/Widgets/Viewer/Viewer.js
@@ -370,6 +370,7 @@ Either specify options.terrainProvider instead or set options.baseLayerPicker to
         var eventHelper = new EventHelper();
 
         eventHelper.add(clock.onTick, Viewer.prototype._onTick, this);
+        eventHelper.add(cesiumWidget.scene.morphStart, Viewer.prototype._clearTrackedObject, this);
 
         // Selection Indicator
         var selectionIndicator;
@@ -438,7 +439,6 @@ Either specify options.terrainProvider instead or set options.baseLayerPicker to
 
         var sceneModePicker;
         if (!scene3DOnly && (!defined(options.sceneModePicker) || options.sceneModePicker !== false)) {
-            eventHelper.add(cesiumWidget.scene.morphStart, Viewer.prototype._clearTrackedObject, this);
             sceneModePicker = new SceneModePicker(toolbar, cesiumWidget.scene);
         }
 

--- a/Source/Widgets/Viewer/Viewer.js
+++ b/Source/Widgets/Viewer/Viewer.js
@@ -438,6 +438,7 @@ Either specify options.terrainProvider instead or set options.baseLayerPicker to
 
         var sceneModePicker;
         if (!scene3DOnly && (!defined(options.sceneModePicker) || options.sceneModePicker !== false)) {
+            eventHelper.add(cesiumWidget.scene.morphStart, Viewer.prototype._clearTrackedObject, this);
             sceneModePicker = new SceneModePicker(toolbar, cesiumWidget.scene);
         }
 


### PR DESCRIPTION
Inspired by #3215

It's confusing to the user that the camera is still locked on the entity after scene mode change because the camera doesn't zoom back in on the `trackedEntity`.  I figured clearing the tracked entity is the best solution until we tackle resetting the camera after the scene transition (#2647)