### PR TITLE
Rework external tiles.json

### DIFF
--- a/Source/Scene/Cesium3DTile.js
+++ b/Source/Scene/Cesium3DTile.js
@@ -146,10 +146,10 @@ define([
             var contentFactory = Cesium3DTileContentProviderFactory[type];
 
             if (type === 'json') {
-                // TODO : should this be in the factory class?
                 this.hasTilesetContent = true;
-                content = new Tileset3DTileContentProvider(tileset, this, url);
-            } else if (defined(contentFactory)) {
+            }
+
+            if (defined(contentFactory)) {
                 content = contentFactory(tileset, this, url);
             } else {
                 throw new DeveloperError('Unknown tile content type, ' + type + ', for ' + url);

--- a/Source/Scene/Cesium3DTile.js
+++ b/Source/Scene/Cesium3DTile.js
@@ -146,8 +146,9 @@ define([
             var contentFactory = Cesium3DTileContentProviderFactory[type];
 
             if (type === 'json') {
+                // TODO : should this be in the factory class?
                 this.hasTilesetContent = true;
-                content = new Tileset3DTileContentProvider();
+                content = new Tileset3DTileContentProvider(tileset, this, url);
             } else if (defined(contentFactory)) {
                 content = contentFactory(tileset, this, url);
             } else {

--- a/Source/Scene/Cesium3DTile.js
+++ b/Source/Scene/Cesium3DTile.js
@@ -121,12 +121,7 @@ define([
          */
         this.numberOfChildrenWithoutContent = defined(header.children) ? header.children.length : 0;
 
-        /**
-         * DOC_TBA
-         *
-         * @readonly
-         */
-        this.numberOfUnrefinableChildren = this.numberOfChildrenWithoutContent;
+        this._numberOfUnrefinableChildren = this.numberOfChildrenWithoutContent;
 
         /**
          * DOC_TBA
@@ -152,7 +147,7 @@ define([
 
             if (type === 'json') {
                 this.hasTilesetContent = true;
-                this.numberOfUnrefinableChildren = 1;
+                this._numberOfUnrefinableChildren = 1;
             }
 
             if (defined(contentFactory)) {
@@ -261,7 +256,7 @@ define([
      * DOC_TBA
      */
     Cesium3DTile.prototype.isRefinable = function() {
-        return this.numberOfUnrefinableChildren === 0;
+        return this._numberOfUnrefinableChildren === 0;
     };
 
     /**

--- a/Source/Scene/Cesium3DTileContentProviderFactory.js
+++ b/Source/Scene/Cesium3DTileContentProviderFactory.js
@@ -4,13 +4,15 @@ define([
         './Composite3DTileContentProvider',
         './Empty3DTileContentProvider',
         './Instanced3DModel3DTileContentProvider',
-        './Points3DTileContentProvider'
+        './Points3DTileContentProvider',
+        './Tileset3DTileContentProvider'
     ], function(
         Batched3DModel3DTileContentProvider,
         Composite3DTileContentProvider,
         Empty3DTileContentProvider,
         Instanced3DModel3DTileContentProvider,
-        Points3DTileContentProvider) {
+        Points3DTileContentProvider,
+        Tileset3DTileContentProvider) {
     "use strict";
 
     /**
@@ -29,6 +31,9 @@ define([
         cmpt : function(tileset, tile, url) {
             // Send in the factory in order to avoid a cyclical dependency
             return new Composite3DTileContentProvider(tileset, tile, url, Cesium3DTileContentProviderFactory);
+        },
+        json : function(tileset, tile, url) {
+            return new Tileset3DTileContentProvider(tileset, tile, url);
         }
     };
 

--- a/Source/Scene/Cesium3DTileset.js
+++ b/Source/Scene/Cesium3DTileset.js
@@ -405,6 +405,12 @@ define([
                 // and geometric error are equal to its parent.
                 if (t.isReady()) {
                     child = t.children[0];
+                    // If the child is not yet ready, select t's parent so that
+                    // that something can be rendered. This avoids the appearance of
+                    // removing a tile and showing nothing in its place
+                    if (!child.isReady() && defined(t.parent) && t.parent.isReady()) {
+                        selectTile(selectedTiles, t.parent, fullyVisible, frameState);
+                    }
                     if (child.isContentUnloaded()) {
                         requestContent(tiles3D, child, outOfCore);
                     } else {

--- a/Source/Scene/Cesium3DTileset.js
+++ b/Source/Scene/Cesium3DTileset.js
@@ -325,7 +325,6 @@ define([
         addLoadProgressEvent(tiles3D);
 
         tile.requestContent();
-
         var removeFunction = removeFromProcessingQueue(tiles3D, tile);
         when(tile.processingPromise).then(addToProcessingQueue(tiles3D, tile)).otherwise(endRequest(tiles3D, tile));
         when(tile.readyPromise).then(removeFunction).otherwise(removeFunction);
@@ -396,7 +395,6 @@ define([
             var k;
             var additiveRefinment = (t.refine === Cesium3DTileRefine.ADD);
 
-
             if (t.hasTilesetContent && t.isReady()) {
                 // If tile has tileset content, skip it and process its child instead (the tileset root)
                 child = t.children[0];
@@ -465,7 +463,6 @@ define([
                     // or slots are available to request them.  If we are just rendering the
                     // tile (and can't make child requests because no slots are available)
                     // then the children do not need to be sorted.
-
                     var allChildrenLoaded = t.numberOfChildrenWithoutContent === 0;
                     if (allChildrenLoaded || requestScheduler.hasAvailableRequests()) {
                         // Distance is used for sorting now and for computing SSE when the tile comes off the stack.

--- a/Source/Scene/Cesium3DTileset.js
+++ b/Source/Scene/Cesium3DTileset.js
@@ -398,8 +398,10 @@ define([
             if (t.hasTilesetContent && t.isReady()) {
                 // If tile has tileset content, skip it and process its child instead (the tileset root)
                 child = t.children[0];
-                if (child.isContentUnloaded() && outOfCore) {
-                    requestContent(tiles3D, child);
+                if (child.isContentUnloaded()) {
+                    if (outOfCore) {
+                        requestContent(tiles3D, child);
+                    }
                 } else {
                     stack.push(child);
                 }
@@ -436,8 +438,10 @@ define([
 
                             // Use parent's geometric error with child's box to see if we already meet the SSE
                             if (getScreenSpaceError(t.geometricError, child, frameState) > maximumScreenSpaceError) {
-                                if (child.isContentUnloaded() && (child.visibility(cullingVolume) !== CullingVolume.MASK_OUTSIDE) && outOfCore) {
-                                    requestContent(tiles3D, child);
+                                if (child.isContentUnloaded()) {
+                                    if ((child.visibility(cullingVolume) !== CullingVolume.MASK_OUTSIDE) && outOfCore) {
+                                        requestContent(tiles3D, child);
+                                    }
                                 } else {
                                     stack.push(child);
                                 }

--- a/Source/Scene/Cesium3DTileset.js
+++ b/Source/Scene/Cesium3DTileset.js
@@ -393,7 +393,7 @@ define([
             var childrenLength = children.length;
             var child;
             var k;
-            var additiveRefinment = (t.refine === Cesium3DTileRefine.ADD);
+            var additiveRefinement = (t.refine === Cesium3DTileRefine.ADD);
 
             if (t.hasTilesetContent && t.isReady()) {
                 // If tile has tileset content, skip it and process its child instead (the tileset root)
@@ -406,7 +406,7 @@ define([
                 continue;
             }
 
-            if (additiveRefinment) {
+            if (additiveRefinement) {
                 // With additive refinement, the tile is rendered
                 // regardless of if its SSE is sufficient.
                 selectTile(selectedTiles, t, fullyVisible, frameState);

--- a/Source/Scene/Tileset3DTileContentProvider.js
+++ b/Source/Scene/Tileset3DTileContentProvider.js
@@ -12,11 +12,41 @@ define([
     /**
      * @private
      */
-    var Tileset3DTileContentProvider = function() {
+    var Tileset3DTileContentProvider = function(tileset, tile, url) {
+        this._tileset = tileset;
+        this._tile = tile;
+        this._url = url;
+
+        /**
+         * @readonly
+         */
         this.state = Cesium3DTileContentState.UNLOADED;
+
+        /**
+         * @type {Promise}
+         */
+        this.processingPromise = when.defer();
+
+        /**
+         * @type {Promise}
+         */
+        this.readyPromise = when.defer();
     };
 
     Tileset3DTileContentProvider.prototype.request = function() {
+        var that = this;
+
+        this.state = Cesium3DTileContentState.LOADING;
+
+        this._tileset.loadTilesJson(this._url, this._tile).then(function() {
+            that.state = Cesium3DTileContentState.PROCESSING;
+            that.processingPromise.resolve(that);
+            that.state = Cesium3DTileContentState.READY;
+            that.readyPromise.resolve(that);
+        }).otherwise(function(error) {
+            that.state = Cesium3DTileContentState.FAILED;
+            that.readyPromise.reject(error);
+        });
     };
 
     Tileset3DTileContentProvider.prototype.update = function(owner, frameState) {


### PR DESCRIPTION
Continuation of #3237

I tried experimenting with different approaches to loading external `tiles.json` that makes use of `Tileset3DTileContentProvider`. I was able to clean it up a good amount, so now `selectTiles` looks a lot more like the original code, with this addition:
https://github.com/AnalyticalGraphicsInc/cesium/blob/bd97bc4f9fb2733536c3b810084fcff6510a700e/Source/Scene/Cesium3DTileset.js#L400-L409

I'm not handling the case where replacement refinement should select its parent if the subtree isn't  ready, but I don't think it's hard to add.

@pjcozzi and @e-andersson: Can you look at this and make sure I'm not forgetting something?