### PR TITLE
Event for tile load queue change on QuadtreePrimitive

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,7 @@ Change Log
 * `CorridorGeometry` and `PolylineVolumeGeometry` render short segments [#3293](https://github.com/AnalyticalGraphicsInc/cesium/issues/3293)
 * `Rectangle.fromCartographicArray` finds the smallest rectangle regardess of whether or not it crosses the international date line. [#3227](https://github.com/AnalyticalGraphicsInc/cesium/issues/3227)
 * Bug fix for `CorridorGeometry` with nearly colinear points [#3320](https://github.com/AnalyticalGraphicsInc/cesium/issues/3320)
+* Added `QuadtreePrimitive#tileLoadProgressEvent` and `Globe#tileLoadProgressEvent` - these raise an event when the length of the tile load queue changes, enabling incremental loading indicators.
 
 ### 1.16 - 2015-12-01
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -35,6 +35,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to Cesiu
    * [Keith Grochow](https://github.com/kgrochow)
    * [Chloe Chen](https://github.com/chloeleichen)
    * [Arthur Street](https://github.com/RacingTadpole)
+   * [Alex Gilleran](https://github.com/AlexGilleran)
 * [EU Edge](http://euedge.com/)
    * [Ákos Maróy](https://github.com/akosmaroy)
 * [Raytheon Intelligence and Information Systems](http://www.raytheon.com/)

--- a/Source/Scene/Globe.js
+++ b/Source/Scene/Globe.js
@@ -225,6 +225,18 @@ define([
             set : function(value) {
                 this._surface.tileProvider.baseColor = value;
             }
+        },
+        /**
+         * Gets an event that's fired when a tile is loaded, or when a new tile to be loaded is added to the queue. The
+         * event passes the new length of the tile load queue.
+         *
+         * @memberof Globe.prototype
+         * @type {Event}
+         */
+        tileLoadProgressEvent : {
+            get: function() {
+                return this._surface.tileLoadProgressEvent;
+            }
         }
     });
 

--- a/Source/Scene/QuadtreePrimitive.js
+++ b/Source/Scene/QuadtreePrimitive.js
@@ -131,6 +131,9 @@ define([
         this._occluders = new QuadtreeOccluders({
             ellipsoid : ellipsoid
         });
+
+        this._tileLoadProgressEvent = new Event();
+        this._lastTileLoadQueueLength = 0;
     };
 
     defineProperties(QuadtreePrimitive.prototype, {
@@ -142,6 +145,18 @@ define([
         tileProvider : {
             get : function() {
                 return this._tileProvider;
+            }
+        },
+        /**
+         * Gets an event that's fired when a tile is loaded, or when a new tile to be loaded is added to this quadtree's
+         * load queue. The event passes the new length of the tile load queue.
+         *
+         * @memberof QuadtreePrimitive.prototype
+         * @type {Event}
+         */
+        tileLoadProgressEvent : {
+            get : function() {
+                return this._tileLoadProgressEvent;
             }
         }
     });
@@ -415,6 +430,8 @@ define([
             }
         }
 
+        raiseTileLoadProgressEvent(primitive);
+
         if (debug.enableDebugOutput) {
             if (debug.tilesVisited !== debug.lastTilesVisited ||
                 debug.tilesRendered !== debug.lastTilesRendered ||
@@ -430,6 +447,19 @@ define([
                 debug.lastMaxDepth = debug.maxDepth;
                 debug.lastTilesWaitingForChildren = debug.tilesWaitingForChildren;
             }
+        }
+    }
+
+    /**
+     * Checks if the load queue length has changed since the last time we raised a queue change event - if so, raises
+     * a new one.
+     */
+    function raiseTileLoadProgressEvent(primitive) {
+        var currentLoadQueueLength = primitive._tileLoadQueue.length;
+
+        if (currentLoadQueueLength !== primitive._lastTileLoadQueueLength) {
+            primitive._tileLoadProgressEvent.raiseEvent(currentLoadQueueLength);
+            primitive._lastTileLoadQueueLength = currentLoadQueueLength;
         }
     }
 

--- a/Specs/Scene/QuadtreePrimitiveSpec.js
+++ b/Specs/Scene/QuadtreePrimitiveSpec.js
@@ -24,7 +24,7 @@ defineSuite([
         EventHelper,
         QuadtreeTile) {
     "use strict";
-    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn*/
+    /*global jasmine,it,expect,beforeEach,afterEach,beforeAll,afterAll*/
 
     var context;
     var frameState;

--- a/Specs/Scene/QuadtreePrimitiveSpec.js
+++ b/Specs/Scene/QuadtreePrimitiveSpec.js
@@ -8,8 +8,10 @@ defineSuite([
         'Core/Visibility',
         'Scene/QuadtreeTileLoadState',
         'Specs/createContext',
-        'Specs/createFrameState'
-    ], function(
+        'Specs/createFrameState',
+        'Core/EventHelper',
+        'Scene/QuadtreeTile'
+], function(
         QuadtreePrimitive,
         Cartesian3,
         Cartographic,
@@ -18,8 +20,11 @@ defineSuite([
         Visibility,
         QuadtreeTileLoadState,
         createContext,
-        createFrameState) {
+        createFrameState,
+        EventHelper,
+        QuadtreeTile) {
     "use strict";
+    /*global jasmine,describe,xdescribe,it,xit,expect,beforeEach,afterEach,beforeAll,afterAll,spyOn*/
 
     var context;
     var frameState;
@@ -132,6 +137,47 @@ defineSuite([
         expect(calls).toBe(2);
     });
 
+    it('tileLoadProgressEvent is raised when tile loaded and when new children discovered', function() {
+        var eventHelper = new EventHelper();
+
+        var tileProvider = createSpyTileProvider();
+        tileProvider.getReady.and.returnValue(true);
+        tileProvider.computeTileVisibility.and.returnValue(Visibility.FULL);
+
+        var quadtree = new QuadtreePrimitive({
+            tileProvider : tileProvider
+        });
+
+        var progressEventSpy = jasmine.createSpy('progressEventSpy');
+        eventHelper.add(quadtree.tileLoadProgressEvent, progressEventSpy);
+
+        // Initial update to get the zero-level tiles set up.
+        quadtree.update(frameState);
+
+        // There will now be two zero-level tiles in the load queue.
+        expect(progressEventSpy.calls.mostRecent().args[0]).toEqual(2);
+
+        // Change one to loaded and update again
+        quadtree._levelZeroTiles[0].state = QuadtreeTileLoadState.DONE;
+        quadtree._levelZeroTiles[1].state = QuadtreeTileLoadState.LOADING;
+        quadtree.update(frameState);
+
+        // Now there should only be one left in the update queue
+        expect(progressEventSpy.calls.mostRecent().args[0]).toEqual(1);
+
+        // Simulate the second zero-level child having loaded with two children.
+        quadtree._levelZeroTiles[1]._children = [
+            buildEmptyQuadtreeTile(tileProvider),
+            buildEmptyQuadtreeTile(tileProvider)
+        ];
+        quadtree._levelZeroTiles[1].state = QuadtreeTileLoadState.DONE;
+        quadtree._levelZeroTiles[1].renderable = true;
+        quadtree.update(frameState);
+
+        // Now this should be back to 2.
+        expect(progressEventSpy.calls.mostRecent().args[0]).toEqual(2);
+    });
+
     it('forEachLoadedTile does not enumerate tiles in the START state', function() {
         var tileProvider = createSpyTileProvider();
         tileProvider.getReady.and.returnValue(true);
@@ -178,12 +224,13 @@ defineSuite([
             tileProvider : tileProvider
         });
 
-        var removeFunc = quadtree.updateHeight(Cartographic.fromDegrees(-72.0, 40.0), function(position) {});
+        var removeFunc = quadtree.updateHeight(Cartographic.fromDegrees(-72.0, 40.0), function(position) {
+        });
 
         quadtree.update(frameState);
 
         var addedCallback = false;
-        quadtree.forEachLoadedTile(function (tile) {
+        quadtree.forEachLoadedTile(function(tile) {
             addedCallback = addedCallback || tile.customData.length > 0;
         });
 
@@ -193,7 +240,7 @@ defineSuite([
         quadtree.update(frameState);
 
         var removedCallback = true;
-        quadtree.forEachLoadedTile(function (tile) {
+        quadtree.forEachLoadedTile(function(tile) {
             removedCallback = removedCallback && tile.customData.length === 0;
         });
 
@@ -232,7 +279,7 @@ defineSuite([
         quadtree.update(frameState);
         expect(position).toEqual(Cartesian3.ZERO);
 
-        quadtree.forEachLoadedTile(function (tile) {
+        quadtree.forEachLoadedTile(function(tile) {
             tile.data = {
                 pick : function() {
                     return updatedPosition;
@@ -244,4 +291,13 @@ defineSuite([
 
         expect(position).toEqual(updatedPosition);
     });
+
+    function buildEmptyQuadtreeTile(tileProvider) {
+        return new QuadtreeTile({
+            x : 0,
+            y : 0,
+            level : 0,
+            tilingScheme : tileProvider.tilingScheme
+        });
+    }
 }, 'WebGL');


### PR DESCRIPTION
This adds a property `tileLoadProgressEvent` on `QuadtreePrimitive` (and proxied through `Globe`) that allows client code to subscribe to changes in the length of the tile load queue. This enables the creation of incremental loading indicators such as the one proposed here:

https://github.com/TerriaJS/terriajs/issues/539