### PR TITLE
Handle static entity geometry color changing when show is time-dynamic

### DIFF
--- a/Source/DataSources/StaticGeometryColorBatch.js
+++ b/Source/DataSources/StaticGeometryColorBatch.js
@@ -25,6 +25,7 @@ define([
         this.closed = closed;
         this.primitives = primitives;
         this.createPrimitive = false;
+        this.waitingOnCreate = false;
         this.primitive = undefined;
         this.oldPrimitive = undefined;
         this.geometry = new AssociativeArray();
@@ -126,6 +127,7 @@ define([
             this.attributes.removeAll();
             this.primitive = primitive;
             this.createPrimitive = false;
+            this.waitingOnCreate = true;
         } else if (defined(primitive) && primitive.ready) {
             if (defined(this.oldPrimitive)) {
                 primitives.remove(this.oldPrimitive);
@@ -133,6 +135,7 @@ define([
             }
             var updatersWithAttributes = this.updatersWithAttributes.values;
             var length = updatersWithAttributes.length;
+            var waitingOnCreate = this.waitingOnCreate;
             for (i = 0; i < length; i++) {
                 var updater = updatersWithAttributes[i];
                 var instance = this.geometry.get(updater.entity.id);
@@ -143,7 +146,7 @@ define([
                     this.attributes.set(instance.id.id, attributes);
                 }
 
-                if (!updater.fillMaterialProperty.isConstant) {
+                if (!updater.fillMaterialProperty.isConstant || waitingOnCreate) {
                     var colorProperty = updater.fillMaterialProperty.color;
                     colorProperty.getValue(time, colorScratch);
                     if (!Color.equals(attributes._lastColor, colorScratch)) {
@@ -163,6 +166,7 @@ define([
             }
 
             this.updateShows(primitive);
+            this.waitingOnCreate = false;
         } else if (defined(primitive) && !primitive.ready) {
             isUpdated = false;
         }

--- a/Source/DataSources/StaticOutlineGeometryBatch.js
+++ b/Source/DataSources/StaticOutlineGeometryBatch.js
@@ -23,6 +23,7 @@ define([
         this.translucent = translucent;
         this.primitives = primitives;
         this.createPrimitive = false;
+        this.waitingOnCreate = false;
         this.primitive = undefined;
         this.oldPrimitive = undefined;
         this.geometry = new AssociativeArray();
@@ -130,6 +131,7 @@ define([
             this.attributes.removeAll();
             this.primitive = primitive;
             this.createPrimitive = false;
+            this.waitingOnCreate = true;
         } else if (defined(primitive) && primitive.ready) {
             if (defined(this.oldPrimitive)) {
                 primitives.remove(this.oldPrimitive);
@@ -138,6 +140,7 @@ define([
 
             var updatersWithAttributes = this.updatersWithAttributes.values;
             var length = updatersWithAttributes.length;
+            var waitingOnCreate = this.waitingOnCreate;
             for (i = 0; i < length; i++) {
                 var updater = updatersWithAttributes[i];
                 var instance = this.geometry.get(updater.entity.id);
@@ -148,7 +151,7 @@ define([
                     this.attributes.set(instance.id.id, attributes);
                 }
 
-                if (!updater.outlineColorProperty.isConstant) {
+                if (!updater.outlineColorProperty.isConstant || waitingOnCreate) {
                     var outlineColorProperty = updater.outlineColorProperty;
                     outlineColorProperty.getValue(time, colorScratch);
                     if (!Color.equals(attributes._lastColor, colorScratch)) {
@@ -168,6 +171,7 @@ define([
             }
 
             this.updateShows(primitive);
+            this.waitingOnCreate = false;
         } else if (defined(primitive) && !primitive.ready) {
             isUpdated = false;
         }

--- a/Specs/DataSources/GeometryVisualizerSpec.js
+++ b/Specs/DataSources/GeometryVisualizerSpec.js
@@ -8,6 +8,7 @@ defineSuite([
         'Core/JulianDate',
         'Core/ShowGeometryInstanceAttribute',
         'DataSources/BoundingSphereState',
+        'DataSources/CallbackProperty',
         'DataSources/ColorMaterialProperty',
         'DataSources/ConstantPositionProperty',
         'DataSources/ConstantProperty',
@@ -17,7 +18,9 @@ defineSuite([
         'DataSources/EntityCollection',
         'DataSources/GridMaterialProperty',
         'DataSources/SampledProperty',
+        'DataSources/StaticGeometryColorBatch',
         'DataSources/StaticGeometryPerMaterialBatch',
+        'DataSources/StaticOutlineGeometryBatch',
         'Specs/createDynamicProperty',
         'Specs/createScene',
         'Specs/pollToPromise'
@@ -30,6 +33,7 @@ defineSuite([
         JulianDate,
         ShowGeometryInstanceAttribute,
         BoundingSphereState,
+        CallbackProperty,
         ColorMaterialProperty,
         ConstantPositionProperty,
         ConstantProperty,
@@ -39,7 +43,9 @@ defineSuite([
         EntityCollection,
         GridMaterialProperty,
         SampledProperty,
+        StaticGeometryColorBatch,
         StaticGeometryPerMaterialBatch,
+        StaticOutlineGeometryBatch,
         createDynamicProperty,
         createScene,
         pollToPromise) {
@@ -472,6 +478,101 @@ defineSuite([
                 return isUpdated;
             }).then(function() {
                 expect(scene.primitives.length).toEqual(2);
+                batch.removeAllPrimitives();
+            });
+        });
+    });
+
+    it('StaticGeometryColorBatch updates color attribute after rebuilding primitive', function() {
+        var batch = new StaticGeometryColorBatch(scene.primitives, EllipseGeometryUpdater.materialAppearanceType, false);
+
+        var entity = new Entity({
+            position : new Cartesian3(1234, 5678, 9101112),
+            ellipse : {
+                semiMajorAxis : 2,
+                semiMinorAxis : 1,
+                show : new CallbackProperty(function() {
+                    return true;
+                }, false),
+                material : Color.RED
+            }
+        });
+
+        var updater = new EllipseGeometryUpdater(entity, scene);
+        batch.add(time, updater);
+
+        return pollToPromise(function() {
+            scene.initializeFrame();
+            var isUpdated = batch.update(time);
+            scene.render(time);
+            return isUpdated;
+        }).then(function() {
+            expect(scene.primitives.length).toEqual(1);
+            var primitive = scene.primitives.get(0);
+            var attributes = primitive.getGeometryInstanceAttributes(entity);
+            expect(attributes.color).toEqual([255, 0, 0, 255]);
+
+            entity.ellipse.material = Color.GREEN;
+            batch.remove(updater);
+            batch.add(time, updater);
+            return pollToPromise(function() {
+                scene.initializeFrame();
+                var isUpdated = batch.update(time);
+                scene.render(time);
+                return isUpdated;
+            }).then(function() {
+                expect(scene.primitives.length).toEqual(1);
+                var primitive = scene.primitives.get(0);
+                var attributes = primitive.getGeometryInstanceAttributes(entity);
+                expect(attributes.color).toEqual([0, 128, 0, 255]);
+                batch.removeAllPrimitives();
+            });
+        });
+    });
+
+    it('StaticOutlineGeometryBatch updates color attribute after rebuilding primitive', function() {
+        var batch = new StaticOutlineGeometryBatch(scene.primitives, scene, false);
+
+        var entity = new Entity({
+            position : new Cartesian3(1234, 5678, 9101112),
+            ellipse : {
+                semiMajorAxis : 2,
+                semiMinorAxis : 1,
+                show : new CallbackProperty(function() {
+                    return true;
+                }, false),
+                outline : true,
+                outlineColor : Color.RED
+            }
+        });
+
+        var updater = new EllipseGeometryUpdater(entity, scene);
+        batch.add(time, updater);
+
+        return pollToPromise(function() {
+            scene.initializeFrame();
+            var isUpdated = batch.update(time);
+            scene.render(time);
+            return isUpdated;
+        }).then(function() {
+            expect(scene.primitives.length).toEqual(1);
+            var primitive = scene.primitives.get(0);
+            var attributes = primitive.getGeometryInstanceAttributes(entity);
+            expect(attributes.color).toEqual([255, 0, 0, 255]);
+
+            entity.ellipse.outlineColor = Color.GREEN;
+            batch.remove(updater);
+            batch.add(time, updater);
+            return pollToPromise(function() {
+                scene.initializeFrame();
+                var isUpdated = batch.update(time);
+                scene.render(time);
+                return isUpdated;
+            }).then(function() {
+                expect(scene.primitives.length).toEqual(1);
+                var primitive = scene.primitives.get(0);
+                var attributes = primitive.getGeometryInstanceAttributes(entity);
+                expect(attributes.color).toEqual([0, 128, 0, 255]);
                 batch.removeAllPrimitives();
             });
         });


### PR DESCRIPTION
For performance reasons, we don't evaluate attribute values every frame and instead check if it's constant and cache the value.  However, we were never updating the cache if a static color value was reassigned to a geometry with a time dynamic show attribute.

Fixes #3336

I added new tests, but this area of the code has grown incredibly over-complicated in its bookkeeping.  I have some ideas on greatly cleaning up GeometryVisualizer long term, we just need to find the time to implement them.