### PR TITLE
Standardize object declarations.

### DIFF
--- a/Apps/Sandcastle/gallery/Custom DataSource.html
+++ b/Apps/Sandcastle/gallery/Custom DataSource.html
@@ -41,7 +41,7 @@ function startup(Cesium) {
  * dataSource.loadUrl('sample.json');
  * viewer.dataSources.add(dataSource);
  */
-var WebGLGlobeDataSource = function(name) {
+function WebGLGlobeDataSource(name) {
     //All public configuration is defined as ES5 properties
     //These are just the "private" variables and their defaults.
     this._name = name;
@@ -53,7 +53,7 @@ var WebGLGlobeDataSource = function(name) {
     this._seriesNames = [];
     this._seriesToDisplay = undefined;
     this._heightScale = 10000000;
-};
+}
 
 Object.defineProperties(WebGLGlobeDataSource.prototype, {
     //The below properties must be implemented by all DataSource instances

--- a/Apps/Sandcastle/gallery/development/QuadtreePrimitive.html
+++ b/Apps/Sandcastle/gallery/development/QuadtreePrimitive.html
@@ -27,12 +27,12 @@
 function startup(Cesium) {
     "use strict";
 //Sandcastle_Begin
-var DemoTileProvider = function() {
+function DemoTileProvider() {
     this._quadtree = undefined;
     this._tilingScheme = new Cesium.GeographicTilingScheme();
     this._errorEvent = new Cesium.Event();
     this._levelZeroMaximumError = Cesium.QuadtreeTileProvider.computeDefaultLevelZeroMaximumGeometricError(this._tilingScheme);
-};
+}
 
 Object.defineProperties(DemoTileProvider.prototype, {
     quadtree : {

--- a/Source/Core/ArcGisImageServerTerrainProvider.js
+++ b/Source/Core/ArcGisImageServerTerrainProvider.js
@@ -62,7 +62,7 @@ define([
      * });
      * viewer.terrainProvider = terrainProvider;
      */
-    var ArcGisImageServerTerrainProvider = function ArcGisImageServerTerrainProvider(options) {
+    function ArcGisImageServerTerrainProvider(options) {
         //>>includeStart('debug', pragmas.debug);
         if (!defined(options) || !defined(options.url)) {
             throw new DeveloperError('options.url is required.');
@@ -101,7 +101,7 @@ define([
         }
         this._credit = credit;
         this._readyPromise = when.resolve(true);
-    };
+    }
 
     defineProperties(ArcGisImageServerTerrainProvider.prototype, {
         /**

--- a/Source/Core/AssociativeArray.js
+++ b/Source/Core/AssociativeArray.js
@@ -15,10 +15,10 @@ define([
      * @alias AssociativeArray
      * @constructor
      */
-    var AssociativeArray = function() {
+    function AssociativeArray() {
         this._array = [];
         this._hash = {};
-    };
+    }
 
     defineProperties(AssociativeArray.prototype, {
         /**

--- a/Source/Core/AxisAlignedBoundingBox.js
+++ b/Source/Core/AxisAlignedBoundingBox.js
@@ -25,7 +25,7 @@ define([
      * @see BoundingSphere
      * @see BoundingRectangle
      */
-    var AxisAlignedBoundingBox = function(minimum, maximum, center) {
+    function AxisAlignedBoundingBox(minimum, maximum, center) {
         /**
          * The minimum point defining the bounding box.
          * @type {Cartesian3}
@@ -53,7 +53,7 @@ define([
          * @type {Cartesian3}
          */
         this.center = center;
-    };
+    }
 
     /**
      * Computes an instance of an AxisAlignedBoundingBox. The box is determined by

--- a/Source/Core/BoundingRectangle.js
+++ b/Source/Core/BoundingRectangle.js
@@ -31,7 +31,7 @@ define([
      *
      * @see BoundingSphere
      */
-    var BoundingRectangle = function(x, y, width, height) {
+    function BoundingRectangle(x, y, width, height) {
         /**
          * The x coordinate of the rectangle.
          * @type {Number}
@@ -59,7 +59,7 @@ define([
          * @default 0.0
          */
         this.height = defaultValue(height, 0.0);
-    };
+    }
 
     /**
      * Computes a bounding rectangle enclosing the list of 2D points.

--- a/Source/Core/BoundingSphere.js
+++ b/Source/Core/BoundingSphere.js
@@ -41,7 +41,7 @@ define([
      * @see BoundingRectangle
      * @see Packable
      */
-    var BoundingSphere = function(center, radius) {
+    function BoundingSphere(center, radius) {
         /**
          * The center point of the sphere.
          * @type {Cartesian3}
@@ -55,7 +55,7 @@ define([
          * @default 0.0
          */
         this.radius = defaultValue(radius, 0.0);
-    };
+    }
 
     var fromPointsXMin = new Cartesian3();
     var fromPointsYMin = new Cartesian3();
@@ -973,6 +973,7 @@ define([
     for (var n = 0; n < 8; ++n) {
         projectTo2DPositionsScratch[n] = new Cartesian3();
     }
+
     var projectTo2DProjection = new GeographicProjection();
     /**
      * Creates a bounding sphere in 2D from a bounding sphere in 3D world coordinates.

--- a/Source/Core/BoxGeometry.js
+++ b/Source/Core/BoxGeometry.js
@@ -52,7 +52,7 @@ define([
      * });
      * var geometry = Cesium.BoxGeometry.createGeometry(box);
      */
-    var BoxGeometry = function(options) {
+    function BoxGeometry(options) {
         options = defaultValue(options, defaultValue.EMPTY_OBJECT);
 
         var min = options.minimum;
@@ -73,7 +73,7 @@ define([
         this._maximum = Cartesian3.clone(max);
         this._vertexFormat = vertexFormat;
         this._workerName = 'createBoxGeometry';
-    };
+    }
 
     /**
      * Creates a cube centered at the origin given its dimensions.

--- a/Source/Core/BoxOutlineGeometry.js
+++ b/Source/Core/BoxOutlineGeometry.js
@@ -48,7 +48,7 @@ define([
      * });
      * var geometry = Cesium.BoxOutlineGeometry.createGeometry(box);
      */
-    var BoxOutlineGeometry = function(options) {
+    function BoxOutlineGeometry(options) {
         options = defaultValue(options, defaultValue.EMPTY_OBJECT);
 
         var min = options.minimum;
@@ -66,7 +66,7 @@ define([
         this._min = Cartesian3.clone(min);
         this._max = Cartesian3.clone(max);
         this._workerName = 'createBoxOutlineGeometry';
-    };
+    }
 
     /**
      * Creates an outline of a cube centered at the origin given its dimensions.

--- a/Source/Core/Cartesian2.js
+++ b/Source/Core/Cartesian2.js
@@ -25,7 +25,7 @@ define([
      * @see Cartesian4
      * @see Packable
      */
-    var Cartesian2 = function(x, y) {
+    function Cartesian2(x, y) {
         /**
          * The X component.
          * @type {Number}
@@ -39,7 +39,7 @@ define([
          * @default 0.0
          */
         this.y = defaultValue(y, 0.0);
-    };
+    }
 
     /**
      * Creates a Cartesian2 instance from x and y coordinates.

--- a/Source/Core/Cartesian3.js
+++ b/Source/Core/Cartesian3.js
@@ -26,7 +26,7 @@ define([
      * @see Cartesian4
      * @see Packable
      */
-    var Cartesian3 = function(x, y, z) {
+    function Cartesian3(x, y, z) {
         /**
          * The X component.
          * @type {Number}
@@ -47,7 +47,7 @@ define([
          * @default 0.0
          */
         this.z = defaultValue(z, 0.0);
-    };
+    }
 
     /**
      * Converts the provided Spherical into Cartesian3 coordinates.

--- a/Source/Core/Cartesian4.js
+++ b/Source/Core/Cartesian4.js
@@ -27,7 +27,7 @@ define([
      * @see Cartesian3
      * @see Packable
      */
-    var Cartesian4 = function(x, y, z, w) {
+    function Cartesian4(x, y, z, w) {
         /**
          * The X component.
          * @type {Number}
@@ -55,7 +55,7 @@ define([
          * @default 0.0
          */
         this.w = defaultValue(w, 0.0);
-    };
+    }
 
     /**
      * Creates a Cartesian4 instance from x, y, z and w coordinates.

--- a/Source/Core/Cartographic.js
+++ b/Source/Core/Cartographic.js
@@ -28,7 +28,7 @@ define([
      *
      * @see Ellipsoid
      */
-    var Cartographic = function(longitude, latitude, height) {
+    function Cartographic(longitude, latitude, height) {
         /**
          * The longitude, in radians.
          * @type {Number}
@@ -49,7 +49,7 @@ define([
          * @default 0.0
          */
         this.height = defaultValue(height, 0.0);
-    };
+    }
 
     /**
      * Creates a new Cartographic instance from longitude and latitude

--- a/Source/Core/CatmullRomSpline.js
+++ b/Source/Core/CatmullRomSpline.js
@@ -142,7 +142,7 @@ define([
      * var p0 = spline.evaluate(times[i]);         // equal to positions[i]
      * var p1 = spline.evaluate(times[i] + delta); // interpolated value when delta < times[i + 1] - times[i]
      */
-    var CatmullRomSpline = function(options) {
+    function CatmullRomSpline(options) {
         options = defaultValue(options, defaultValue.EMPTY_OBJECT);
 
         var points = options.points;
@@ -188,7 +188,7 @@ define([
 
         this._evaluateFunction = createEvaluateFunction(this);
         this._lastTimeIndex = 0;
-    };
+    }
 
     defineProperties(CatmullRomSpline.prototype, {
         /**

--- a/Source/Core/CesiumTerrainProvider.js
+++ b/Source/Core/CesiumTerrainProvider.js
@@ -93,7 +93,7 @@ define([
      * // The globe must enable lighting to make use of the terrain's vertex normals
      * viewer.scene.globe.enableLighting = true;
      */
-    var CesiumTerrainProvider = function CesiumTerrainProvider(options) {
+    function CesiumTerrainProvider(options) {
         //>>includeStart('debug', pragmas.debug)
         if (!defined(options) || !defined(options.url)) {
             throw new DeveloperError('options.url is required.');
@@ -250,7 +250,7 @@ define([
         }
 
         requestMetadata();
-    };
+    }
 
     /**
      * When using the Quantized-Mesh format, a tile may be returned that includes additional extensions, such as PerVertexNormals, watermask, etc.
@@ -517,10 +517,9 @@ define([
             extensionList.push("watermask");
         }
 
-        var tileLoader = function(tileUrl) {
+        function tileLoader(tileUrl) {
             return loadArrayBuffer(tileUrl, getRequestHeader(extensionList));
-        };
-
+        }
         throttleRequests = defaultValue(throttleRequests, true);
         if (throttleRequests) {
             promise = throttleRequestByServer(url, tileLoader);

--- a/Source/Core/CircleGeometry.js
+++ b/Source/Core/CircleGeometry.js
@@ -51,7 +51,7 @@ define([
      * });
      * var geometry = Cesium.CircleGeometry.createGeometry(circle);
      */
-    var CircleGeometry = function(options) {
+    function CircleGeometry(options) {
         options = defaultValue(options, defaultValue.EMPTY_OBJECT);
         var radius = options.radius;
 
@@ -77,7 +77,7 @@ define([
         };
         this._ellipseGeometry = new EllipseGeometry(ellipseGeometryOptions);
         this._workerName = 'createCircleGeometry';
-    };
+    }
 
     /**
      * The number of elements used to pack the object into an array.

--- a/Source/Core/CircleOutlineGeometry.js
+++ b/Source/Core/CircleOutlineGeometry.js
@@ -46,7 +46,7 @@ define([
      * });
      * var geometry = Cesium.CircleOutlineGeometry.createGeometry(circle);
      */
-    var CircleOutlineGeometry = function(options) {
+    function CircleOutlineGeometry(options) {
         options = defaultValue(options, defaultValue.EMPTY_OBJECT);
         var radius = options.radius;
 
@@ -71,7 +71,7 @@ define([
         };
         this._ellipseGeometry = new EllipseOutlineGeometry(ellipseGeometryOptions);
         this._workerName = 'createCircleOutlineGeometry';
-    };
+    }
 
     /**
      * The number of elements used to pack the object into an array.

--- a/Source/Core/Clock.js
+++ b/Source/Core/Clock.js
@@ -51,7 +51,7 @@ define([
      *    clockStep : Cesium.ClockStep.SYSTEM_CLOCK_MULTIPLIER
      * });
      */
-    var Clock = function(options) {
+    function Clock(options) {
         options = defaultValue(options, defaultValue.EMPTY_OBJECT);
 
         var startTime = options.startTime;
@@ -155,7 +155,7 @@ define([
         this.onTick = new Event();
 
         this._lastSystemTime = getTimestamp();
-    };
+    }
 
     /**
      * Advances the clock from the currentTime based on the current configuration options.

--- a/Source/Core/Color.js
+++ b/Source/Core/Color.js
@@ -47,7 +47,7 @@ define([
      *
      * @see Packable
      */
-    var Color = function(red, green, blue, alpha) {
+    function Color(red, green, blue, alpha) {
         /**
          * The red component.
          * @type {Number}
@@ -72,7 +72,7 @@ define([
          * @default 1.0
          */
         this.alpha = defaultValue(alpha, 1.0);
-    };
+    }
 
     /**
      * Creates a Color instance from a {@link Cartesian4}. <code>x</code>, <code>y</code>, <code>z</code>,

--- a/Source/Core/ColorGeometryInstanceAttribute.js
+++ b/Source/Core/ColorGeometryInstanceAttribute.js
@@ -42,7 +42,7 @@ define([
      *   }
      * });
      */
-    var ColorGeometryInstanceAttribute = function(red, green, blue, alpha) {
+    function ColorGeometryInstanceAttribute(red, green, blue, alpha) {
         red = defaultValue(red, 1.0);
         green = defaultValue(green, 1.0);
         blue = defaultValue(blue, 1.0);
@@ -61,7 +61,7 @@ define([
             Color.floatToByte(blue),
             Color.floatToByte(alpha)
         ]);
-    };
+    }
 
     defineProperties(ColorGeometryInstanceAttribute.prototype, {
         /**

--- a/Source/Core/CorridorGeometry.js
+++ b/Source/Core/CorridorGeometry.js
@@ -648,7 +648,7 @@ define([
      *   width : 100000
      * });
      */
-    var CorridorGeometry = function(options) {
+    function CorridorGeometry(options) {
         options = defaultValue(options, defaultValue.EMPTY_OBJECT);
         var positions = options.positions;
         var width = options.width;
@@ -677,7 +677,7 @@ define([
          * @type {Number}
          */
         this.packedLength = 1 + positions.length * Cartesian3.packedLength + Ellipsoid.packedLength + VertexFormat.packedLength + 5;
-    };
+    }
 
     /**
      * Stores the provided instance into the provided array.

--- a/Source/Core/CorridorOutlineGeometry.js
+++ b/Source/Core/CorridorOutlineGeometry.js
@@ -325,7 +325,7 @@ define([
      *   width : 100000
      * });
      */
-    var CorridorOutlineGeometry = function(options) {
+    function CorridorOutlineGeometry(options) {
         options = defaultValue(options, defaultValue.EMPTY_OBJECT);
         var positions = options.positions;
         var width = options.width;
@@ -353,7 +353,7 @@ define([
          * @type {Number}
          */
         this.packedLength = 1 + positions.length * Cartesian3.packedLength + Ellipsoid.packedLength + 5;
-    };
+    }
 
     /**
      * Stores the provided instance into the provided array.

--- a/Source/Core/Credit.js
+++ b/Source/Core/Credit.js
@@ -26,7 +26,7 @@ define([
      * //Create a credit with a tooltip, image and link
      * var credit = new Cesium.Credit('Cesium', '/images/cesium_logo.png', 'http://cesiumjs.org/');
      */
-    var Credit = function(text, imageUrl, link) {
+    function Credit(text, imageUrl, link) {
         var hasLink = (defined(link));
         var hasImage = (defined(imageUrl));
         var hasText = (defined(text));
@@ -59,7 +59,7 @@ define([
         }
 
         this._id = id;
-    };
+    }
 
     defineProperties(Credit.prototype, {
         /**

--- a/Source/Core/CylinderGeometry.js
+++ b/Source/Core/CylinderGeometry.js
@@ -72,7 +72,7 @@ define([
      * });
      * var geometry = Cesium.CylinderGeometry.createGeometry(cylinder);
      */
-    var CylinderGeometry = function(options) {
+    function CylinderGeometry(options) {
         options = defaultValue(options, defaultValue.EMPTY_OBJECT);
 
         var length = options.length;
@@ -105,7 +105,7 @@ define([
         this._vertexFormat = VertexFormat.clone(vertexFormat);
         this._slices = slices;
         this._workerName = 'createCylinderGeometry';
-    };
+    }
 
     /**
      * The number of elements used to pack the object into an array.

--- a/Source/Core/CylinderOutlineGeometry.js
+++ b/Source/Core/CylinderOutlineGeometry.js
@@ -63,7 +63,7 @@ define([
      * });
      * var geometry = Cesium.CylinderOutlineGeometry.createGeometry(cylinder);
      */
-    var CylinderOutlineGeometry = function(options) {
+    function CylinderOutlineGeometry(options) {
         options = defaultValue(options, defaultValue.EMPTY_OBJECT);
 
         var length = options.length;
@@ -96,7 +96,7 @@ define([
         this._slices = slices;
         this._numberOfVerticalLines = numberOfVerticalLines;
         this._workerName = 'createCylinderOutlineGeometry';
-    };
+    }
 
     /**
      * The number of elements used to pack the object into an array.

--- a/Source/Core/DefaultProxy.js
+++ b/Source/Core/DefaultProxy.js
@@ -11,9 +11,9 @@ define(function() {
      *
      * @param {String} proxy The proxy URL that will be used to requests all resources.
      */
-    var DefaultProxy = function(proxy) {
+    function DefaultProxy(proxy) {
         this.proxy = proxy;
-    };
+    }
 
     /**
      * Get the final URL to use to request a given resource.

--- a/Source/Core/DeveloperError.js
+++ b/Source/Core/DeveloperError.js
@@ -22,7 +22,7 @@ define([
      *
      * @see RuntimeError
      */
-    var DeveloperError = function(message) {
+    function DeveloperError(message) {
         /**
          * 'DeveloperError' indicating that this exception was thrown due to a developer error.
          * @type {String}
@@ -51,7 +51,7 @@ define([
          * @readonly
          */
         this.stack = stack;
-    };
+    }
 
     DeveloperError.prototype.toString = function() {
         var str = this.name + ': ' + this.message;

--- a/Source/Core/EarthOrientationParameters.js
+++ b/Source/Core/EarthOrientationParameters.js
@@ -68,7 +68,7 @@ define([
      *
      * @private
      */
-    var EarthOrientationParameters = function EarthOrientationParameters(options) {
+    function EarthOrientationParameters(options) {
         options = defaultValue(options, defaultValue.EMPTY_OBJECT);
 
         this._dates = undefined;
@@ -108,7 +108,7 @@ define([
                 'samples' : []
             });
         }
-    };
+    }
 
     /**
      * A default {@link EarthOrientationParameters} instance that returns zero for all EOP values.

--- a/Source/Core/EarthOrientationParametersSample.js
+++ b/Source/Core/EarthOrientationParametersSample.js
@@ -16,7 +16,7 @@ define(function() {
      *
      * @private
      */
-    var EarthOrientationParametersSample = function EarthOrientationParametersSample(xPoleWander, yPoleWander, xPoleOffset, yPoleOffset, ut1MinusUtc) {
+    function EarthOrientationParametersSample(xPoleWander, yPoleWander, xPoleOffset, yPoleOffset, ut1MinusUtc) {
         /**
          * The pole wander about the X axis, in radians.
          * @type {Number}
@@ -46,7 +46,7 @@ define(function() {
          * @type {Number}
          */
         this.ut1MinusUtc = ut1MinusUtc;
-    };
+    }
 
     return EarthOrientationParametersSample;
 });

--- a/Source/Core/EllipseGeometry.js
+++ b/Source/Core/EllipseGeometry.js
@@ -621,7 +621,7 @@ define([
      * });
      * var geometry = Cesium.EllipseGeometry.createGeometry(ellipse);
      */
-    var EllipseGeometry = function(options) {
+    function EllipseGeometry(options) {
         options = defaultValue(options, defaultValue.EMPTY_OBJECT);
 
         var center = options.center;
@@ -667,7 +667,7 @@ define([
         this._extrudedHeight = defaultValue(extrudedHeight, height);
         this._extrude = extrude;
         this._workerName = 'createEllipseGeometry';
-    };
+    }
 
     /**
      * The number of elements used to pack the object into an array.

--- a/Source/Core/EllipseOutlineGeometry.js
+++ b/Source/Core/EllipseOutlineGeometry.js
@@ -161,7 +161,7 @@ define([
      * });
      * var geometry = Cesium.EllipseOutlineGeometry.createGeometry(ellipse);
      */
-    var EllipseOutlineGeometry = function(options) {
+    function EllipseOutlineGeometry(options) {
         options = defaultValue(options, defaultValue.EMPTY_OBJECT);
 
         var center = options.center;
@@ -205,7 +205,7 @@ define([
         this._extrude = extrude;
         this._numberOfVerticalLines = Math.max(defaultValue(options.numberOfVerticalLines, 16), 0);
         this._workerName = 'createEllipseOutlineGeometry';
-    };
+    }
 
     /**
      * The number of elements used to pack the object into an array.

--- a/Source/Core/Ellipsoid.js
+++ b/Source/Core/Ellipsoid.js
@@ -77,7 +77,7 @@ define([
      * @see Ellipsoid.WGS84
      * @see Ellipsoid.UNIT_SPHERE
      */
-    var Ellipsoid = function(x, y, z) {
+    function Ellipsoid(x, y, z) {
         this._radii = undefined;
         this._radiiSquared = undefined;
         this._radiiToTheFourth = undefined;
@@ -88,7 +88,7 @@ define([
         this._centerToleranceSquared = undefined;
 
         initialize(this, x, y, z);
-    };
+    }
 
     defineProperties(Ellipsoid.prototype, {
         /**

--- a/Source/Core/EllipsoidGeodesic.js
+++ b/Source/Core/EllipsoidGeodesic.js
@@ -205,7 +205,7 @@ define([
      * @param {Cartographic} [end] The final planetodetic point on the path.
      * @param {Ellipsoid} [ellipsoid=Ellipsoid.WGS84] The ellipsoid on which the geodesic lies.
      */
-    var EllipsoidGeodesic = function(start, end, ellipsoid) {
+    function EllipsoidGeodesic(start, end, ellipsoid) {
         var e = defaultValue(ellipsoid, Ellipsoid.WGS84);
         this._ellipsoid = e;
         this._start = new Cartographic();
@@ -220,7 +220,7 @@ define([
         if (defined(start) && defined(end)) {
             computeProperties(this, start, end, e);
         }
-    };
+    }
 
     defineProperties(EllipsoidGeodesic.prototype, {
         /**

--- a/Source/Core/EllipsoidGeometry.js
+++ b/Source/Core/EllipsoidGeometry.js
@@ -69,7 +69,7 @@ define([
      * });
      * var geometry = Cesium.EllipsoidGeometry.createGeometry(ellipsoid);
      */
-    var EllipsoidGeometry = function(options) {
+    function EllipsoidGeometry(options) {
         options = defaultValue(options, defaultValue.EMPTY_OBJECT);
 
         var radii = defaultValue(options.radii, defaultRadii);
@@ -91,7 +91,7 @@ define([
         this._slicePartitions = slicePartitions;
         this._vertexFormat = VertexFormat.clone(vertexFormat);
         this._workerName = 'createEllipsoidGeometry';
-    };
+    }
 
     /**
      * The number of elements used to pack the object into an array.

--- a/Source/Core/EllipsoidOutlineGeometry.js
+++ b/Source/Core/EllipsoidOutlineGeometry.js
@@ -59,7 +59,7 @@ define([
      * });
      * var geometry = Cesium.EllipsoidOutlineGeometry.createGeometry(ellipsoid);
      */
-    var EllipsoidOutlineGeometry = function(options) {
+    function EllipsoidOutlineGeometry(options) {
         options = defaultValue(options, defaultValue.EMPTY_OBJECT);
 
         var radii = defaultValue(options.radii, defaultRadii);
@@ -84,7 +84,7 @@ define([
         this._slicePartitions = slicePartitions;
         this._subdivisions = subdivisions;
         this._workerName = 'createEllipsoidOutlineGeometry';
-    };
+    }
 
     /**
      * The number of elements used to pack the object into an array.

--- a/Source/Core/EllipsoidTangentPlane.js
+++ b/Source/Core/EllipsoidTangentPlane.js
@@ -46,7 +46,7 @@ define([
      *
      * @exception {DeveloperError} origin must not be at the center of the ellipsoid.
      */
-    var EllipsoidTangentPlane = function(origin, ellipsoid) {
+    function EllipsoidTangentPlane(origin, ellipsoid) {
         //>>includeStart('debug', pragmas.debug);
         if (!defined(origin)) {
             throw new DeveloperError('origin is required.');
@@ -70,7 +70,7 @@ define([
 
         var normal = Cartesian3.fromCartesian4(Matrix4.getColumn(eastNorthUp, 2, scratchCart4));
         this._plane = Plane.fromPointNormal(origin, normal);
-    };
+    }
 
     defineProperties(EllipsoidTangentPlane.prototype, {
         /**

--- a/Source/Core/EllipsoidTerrainProvider.js
+++ b/Source/Core/EllipsoidTerrainProvider.js
@@ -38,7 +38,7 @@ define([
      *
      * @see TerrainProvider
      */
-    var EllipsoidTerrainProvider = function EllipsoidTerrainProvider(options) {
+    function EllipsoidTerrainProvider(options) {
         options = defaultValue(options, {});
 
         this._tilingScheme = options.tilingScheme;
@@ -62,7 +62,7 @@ define([
 
         this._errorEvent = new Event();
         this._readyPromise = when.resolve(true);
-    };
+    }
 
     defineProperties(EllipsoidTerrainProvider.prototype, {
         /**

--- a/Source/Core/EllipsoidalOccluder.js
+++ b/Source/Core/EllipsoidalOccluder.js
@@ -40,7 +40,7 @@ define([
      *
      * @private
      */
-    var EllipsoidalOccluder = function(ellipsoid, cameraPosition) {
+    function EllipsoidalOccluder(ellipsoid, cameraPosition) {
         //>>includeStart('debug', pragmas.debug);
         if (!defined(ellipsoid)) {
             throw new DeveloperError('ellipsoid is required.');
@@ -56,7 +56,7 @@ define([
         if (defined(cameraPosition)) {
             this.cameraPosition = cameraPosition;
         }
-    };
+    }
 
     defineProperties(EllipsoidalOccluder.prototype, {
         /**

--- a/Source/Core/EncodedCartesian3.js
+++ b/Source/Core/EncodedCartesian3.js
@@ -22,7 +22,7 @@ define([
      *
      * @private
      */
-    var EncodedCartesian3 = function() {
+    function EncodedCartesian3() {
         /**
          * The high bits for each component.  Bits 0 to 22 store the whole value.  Bits 23 to 31 are not used.
          *
@@ -38,7 +38,7 @@ define([
          * @default {@link Cartesian3.ZERO}
          */
         this.low = Cartesian3.clone(Cartesian3.ZERO);
-    };
+    }
 
     /**
      * Encodes a 64-bit floating-point value as two floating-point values that, when converted to

--- a/Source/Core/Event.js
+++ b/Source/Core/Event.js
@@ -29,12 +29,12 @@ define([
      * evt.raiseEvent('1', '2');
      * evt.removeEventListener(MyObject.prototype.myListener);
      */
-    var Event = function() {
+    function Event() {
         this._listeners = [];
         this._scopes = [];
         this._toRemove = [];
         this._insideRaiseEvent = false;
-    };
+    }
 
     defineProperties(Event.prototype, {
         /**

--- a/Source/Core/EventHelper.js
+++ b/Source/Core/EventHelper.js
@@ -26,9 +26,9 @@ define([
      * // later...
      * helper.removeAll();
      */
-    var EventHelper = function() {
+    function EventHelper() {
         this._removalFunctions = [];
-    };
+    }
 
     /**
      * Adds a listener to an event, and records the registration to be cleaned up later.

--- a/Source/Core/GeographicProjection.js
+++ b/Source/Core/GeographicProjection.js
@@ -30,11 +30,11 @@ define([
      *
      * @see WebMercatorProjection
      */
-    var GeographicProjection = function(ellipsoid) {
+    function GeographicProjection(ellipsoid) {
         this._ellipsoid = defaultValue(ellipsoid, Ellipsoid.WGS84);
         this._semimajorAxis = this._ellipsoid.maximumRadius;
         this._oneOverSemimajorAxis = 1.0 / this._semimajorAxis;
-    };
+    }
 
     defineProperties(GeographicProjection.prototype, {
         /**

--- a/Source/Core/GeographicTilingScheme.js
+++ b/Source/Core/GeographicTilingScheme.js
@@ -38,7 +38,7 @@ define([
      * @param {Number} [options.numberOfLevelZeroTilesY=1] The number of tiles in the Y direction at level zero of
      * the tile tree.
      */
-    var GeographicTilingScheme = function GeographicTilingScheme(options) {
+    function GeographicTilingScheme(options) {
         options = defaultValue(options, {});
 
         this._ellipsoid = defaultValue(options.ellipsoid, Ellipsoid.WGS84);
@@ -46,8 +46,7 @@ define([
         this._projection = new GeographicProjection(this._ellipsoid);
         this._numberOfLevelZeroTilesX = defaultValue(options.numberOfLevelZeroTilesX, 2);
         this._numberOfLevelZeroTilesY = defaultValue(options.numberOfLevelZeroTilesY, 1);
-    };
-
+    }
 
     defineProperties(GeographicTilingScheme.prototype, {
         /**

--- a/Source/Core/Geometry.js
+++ b/Source/Core/Geometry.js
@@ -63,7 +63,7 @@ define([
      *   boundingSphere : Cesium.BoundingSphere.fromVertices(positions)
      * });
      */
-    var Geometry = function(options) {
+    function Geometry(options) {
         options = defaultValue(options, defaultValue.EMPTY_OBJECT);
 
         //>>includeStart('debug', pragmas.debug);
@@ -158,7 +158,7 @@ define([
          * @private
          */
         this.boundingSphereCV = undefined;
-    };
+    }
 
     /**
      * Computes the number of vertices in a geometry.  The runtime is linear with

--- a/Source/Core/GeometryAttribute.js
+++ b/Source/Core/GeometryAttribute.js
@@ -43,7 +43,7 @@ define([
      *   primitiveType : Cesium.PrimitiveType.LINE_LOOP
      * });
      */
-    var GeometryAttribute = function(options) {
+    function GeometryAttribute(options) {
         options = defaultValue(options, defaultValue.EMPTY_OBJECT);
 
         //>>includeStart('debug', pragmas.debug);
@@ -135,7 +135,7 @@ define([
          * ]);
          */
         this.values = options.values;
-    };
+    }
 
     return GeometryAttribute;
 });

--- a/Source/Core/GeometryAttributes.js
+++ b/Source/Core/GeometryAttributes.js
@@ -15,7 +15,7 @@ define([
      * @alias GeometryAttributes
      * @constructor
      */
-    var GeometryAttributes = function(options) {
+    function GeometryAttributes(options) {
         options = defaultValue(options, defaultValue.EMPTY_OBJECT);
 
         /**
@@ -89,7 +89,7 @@ define([
          * @default undefined
          */
         this.color = options.color;
-    };
+    }
 
     return GeometryAttributes;
 });

--- a/Source/Core/GeometryInstance.js
+++ b/Source/Core/GeometryInstance.js
@@ -55,7 +55,7 @@ define([
      *   id : 'top'
      * });
      */
-    var GeometryInstance = function(options) {
+    function GeometryInstance(options) {
         options = defaultValue(options, defaultValue.EMPTY_OBJECT);
 
         //>>includeStart('debug', pragmas.debug);
@@ -122,7 +122,7 @@ define([
          * @private
          */
         this.eastHemisphereGeometry = undefined;
-    };
+    }
 
     return GeometryInstance;
 });

--- a/Source/Core/GeometryInstanceAttribute.js
+++ b/Source/Core/GeometryInstanceAttribute.js
@@ -44,7 +44,7 @@ define([
      *   }
      * });
      */
-    var GeometryInstanceAttribute = function(options) {
+    function GeometryInstanceAttribute(options) {
         options = defaultValue(options, defaultValue.EMPTY_OBJECT);
 
         //>>includeStart('debug', pragmas.debug);
@@ -134,7 +134,7 @@ define([
          * })
          */
         this.value = options.value;
-    };
+    }
 
     return GeometryInstanceAttribute;
 });

--- a/Source/Core/GregorianDate.js
+++ b/Source/Core/GregorianDate.js
@@ -10,7 +10,7 @@ define(function() {
      *
      * @see JulianDate#toGregorianDate
      */
-    var GregorianDate = function(year, month, day, hour, minute, second, millisecond, isLeapSecond) {
+    function GregorianDate(year, month, day, hour, minute, second, millisecond, isLeapSecond) {
         /**
          * Gets or sets the year as a whole number.
          * @type {Number}
@@ -51,7 +51,7 @@ define(function() {
          * @type {Boolean}
          */
         this.isLeapSecond = isLeapSecond;
-    };
+    }
 
     return GregorianDate;
 });

--- a/Source/Core/HeadingPitchRange.js
+++ b/Source/Core/HeadingPitchRange.js
@@ -19,7 +19,7 @@ define([
      * @param {Number} [pitch=0.0] The pitch angle in radians.
      * @param {Number} [range=0.0] The distance from the center in meters.
      */
-    var HeadingPitchRange = function(heading, pitch, range) {
+    function HeadingPitchRange(heading, pitch, range) {
         /**
          * Heading is the rotation from the local north direction where a positive angle is increasing eastward.
          * @type {Number}
@@ -38,7 +38,7 @@ define([
          * @type {Number}
          */
         this.range = defaultValue(range, 0.0);
-    };
+    }
 
     /**
      * Duplicates a HeadingPitchRange instance.

--- a/Source/Core/HeightmapTerrainData.js
+++ b/Source/Core/HeightmapTerrainData.js
@@ -94,7 +94,7 @@ define([
      *   waterMask : waterMask
      * });
      */
-    var HeightmapTerrainData = function HeightmapTerrainData(options) {
+    function HeightmapTerrainData(options) {
         //>>includeStart('debug', pragmas.debug);
         if (!defined(options) || !defined(options.buffer)) {
             throw new DeveloperError('options.buffer is required.');
@@ -128,7 +128,7 @@ define([
         this._structure = structure;
         this._createdByUpsampling = defaultValue(options.createdByUpsampling, false);
         this._waterMask = options.waterMask;
-    };
+    }
 
     defineProperties(HeightmapTerrainData.prototype, {
         /**

--- a/Source/Core/HermiteSpline.js
+++ b/Source/Core/HermiteSpline.js
@@ -177,7 +177,7 @@ define([
      *
      * var p0 = spline.evaluate(times[0]);
      */
-    var HermiteSpline = function(options) {
+    function HermiteSpline(options) {
         options = defaultValue(options, defaultValue.EMPTY_OBJECT);
 
         var points = options.points;
@@ -206,7 +206,7 @@ define([
         this._outTangents = outTangents;
 
         this._lastTimeIndex = 0;
-    };
+    }
 
     defineProperties(HermiteSpline.prototype, {
         /**

--- a/Source/Core/Iau2006XysData.js
+++ b/Source/Core/Iau2006XysData.js
@@ -38,7 +38,7 @@ define([
      *
      * @private
      */
-    var Iau2006XysData = function Iau2006XysData(options) {
+    function Iau2006XysData(options) {
         options = defaultValue(options, defaultValue.EMPTY_OBJECT);
 
         this._xysFileUrlTemplate = options.xysFileUrlTemplate;
@@ -75,7 +75,7 @@ define([
         // Allocate scratch arrays for interpolation.
         this._work = new Array(order + 1);
         this._coef = new Array(order + 1);
-    };
+    }
 
     var julianDateScratch = new JulianDate(0, 0.0, TimeStandard.TAI);
 

--- a/Source/Core/Iau2006XysSample.js
+++ b/Source/Core/Iau2006XysSample.js
@@ -14,7 +14,7 @@ define(function() {
      *
      * @private
      */
-    var Iau2006XysSample = function Iau2006XysSample(x, y, s) {
+    function Iau2006XysSample(x, y, s) {
         /**
          * The X value.
          * @type {Number}
@@ -32,7 +32,7 @@ define(function() {
          * @type {Number}
          */
         this.s = s;
-    };
+    }
 
     return Iau2006XysSample;
 });

--- a/Source/Core/IauOrientationAxes.js
+++ b/Source/Core/IauOrientationAxes.js
@@ -29,13 +29,13 @@ define([
      *
      * @private
      */
-    var IauOrientationAxes = function(computeFunction) {
+    function IauOrientationAxes(computeFunction) {
         if (!defined(computeFunction) || typeof computeFunction !== 'function') {
             computeFunction = Iau2000Orientation.ComputeMoon;
         }
 
         this._computeFunction = computeFunction;
-    };
+    }
 
     var xAxisScratch = new Cartesian3();
     var yAxisScratch = new Cartesian3();

--- a/Source/Core/IauOrientationParameters.js
+++ b/Source/Core/IauOrientationParameters.js
@@ -15,7 +15,7 @@ define(function() {
      *
      * @private
      */
-    var IauOrientationParameters = function(rightAscension, declination, rotation, rotationRate) {
+    function IauOrientationParameters(rightAscension, declination, rotation, rotationRate) {
         /**
          * The right ascension of the north pole of the body with respect to
          * the International Celestial Reference Frame, in radians.
@@ -50,7 +50,7 @@ define(function() {
          * @private
          */
         this.rotationRate = rotationRate;
-    };
+    }
 
     return IauOrientationParameters;
 });

--- a/Source/Core/Interval.js
+++ b/Source/Core/Interval.js
@@ -13,7 +13,7 @@ define([
      * @param {Number} [start=0.0] The beginning of the interval.
      * @param {Number} [stop=0.0] The end of the interval.
      */
-    var Interval = function(start, stop) {
+    function Interval(start, stop) {
         /**
          * The beginning of the interval.
          * @type {Number}
@@ -26,7 +26,7 @@ define([
          * @default 0.0
          */
         this.stop = defaultValue(stop, 0.0);
-    };
+    }
 
     return Interval;
 });

--- a/Source/Core/JulianDate.js
+++ b/Source/Core/JulianDate.js
@@ -174,7 +174,7 @@ define([
      * @param {Number} secondsOfDay The number of seconds into the current Julian Day Number.  Fractional seconds, negative seconds and seconds greater than a day will be handled correctly.
      * @param {TimeStandard} [timeStandard=TimeStandard.UTC] The time standard in which the first two parameters are defined.
      */
-    var JulianDate = function(julianDayNumber, secondsOfDay, timeStandard) {
+    function JulianDate(julianDayNumber, secondsOfDay, timeStandard) {
         /**
          * Gets or sets the number of whole days.
          * @type {Number}
@@ -200,7 +200,7 @@ define([
         if (timeStandard === TimeStandard.UTC) {
             convertUtcToTai(this);
         }
-    };
+    }
 
     /**
      * Creates a new instance from a JavaScript Date.

--- a/Source/Core/LeapSecond.js
+++ b/Source/Core/LeapSecond.js
@@ -11,7 +11,7 @@ define(function() {
      * @param {JulianDate} [date] A Julian date representing the time of the leap second.
      * @param {Number} [offset] The cumulative number of seconds that TAI is ahead of UTC at the provided date.
      */
-    var LeapSecond = function(date, offset) {
+    function LeapSecond(date, offset) {
         /**
          * Gets or sets the date at which this leap second occurs.
          * @type {JulianDate}
@@ -24,7 +24,7 @@ define(function() {
          * @type {Number}
          */
         this.offset = offset;
-    };
+    }
 
     return LeapSecond;
 });

--- a/Source/Core/LinearSpline.js
+++ b/Source/Core/LinearSpline.js
@@ -48,7 +48,7 @@ define([
      *
      * var p0 = spline.evaluate(times[0]);
      */
-    var LinearSpline = function(options) {
+    function LinearSpline(options) {
         options = defaultValue(options, defaultValue.EMPTY_OBJECT);
 
         var points = options.points;
@@ -70,7 +70,7 @@ define([
         this._points = points;
 
         this._lastTimeIndex = 0;
-    };
+    }
 
     defineProperties(LinearSpline.prototype, {
         /**

--- a/Source/Core/MapProjection.js
+++ b/Source/Core/MapProjection.js
@@ -17,9 +17,9 @@ define([
      * @see GeographicProjection
      * @see WebMercatorProjection
      */
-    var MapProjection = function() {
+    function MapProjection() {
         DeveloperError.throwInstantiationError();
-    };
+    }
 
     defineProperties(MapProjection.prototype, {
         /**

--- a/Source/Core/Matrix2.js
+++ b/Source/Core/Matrix2.js
@@ -31,12 +31,12 @@ define([
      * @see Matrix3
      * @see Matrix4
      */
-    var Matrix2 = function(column0Row0, column1Row0, column0Row1, column1Row1) {
+    function Matrix2(column0Row0, column1Row0, column0Row1, column1Row1) {
         this[0] = defaultValue(column0Row0, 0.0);
         this[1] = defaultValue(column0Row1, 0.0);
         this[2] = defaultValue(column1Row0, 0.0);
         this[3] = defaultValue(column1Row1, 0.0);
-    };
+    }
 
     /**
      * The number of elements used to pack the object into an array.

--- a/Source/Core/Matrix3.js
+++ b/Source/Core/Matrix3.js
@@ -39,7 +39,7 @@ define([
      * @see Matrix2
      * @see Matrix4
      */
-    var Matrix3 = function(column0Row0, column1Row0, column2Row0,
+    function Matrix3(column0Row0, column1Row0, column2Row0,
                            column0Row1, column1Row1, column2Row1,
                            column0Row2, column1Row2, column2Row2) {
         this[0] = defaultValue(column0Row0, 0.0);
@@ -51,7 +51,7 @@ define([
         this[6] = defaultValue(column2Row0, 0.0);
         this[7] = defaultValue(column2Row1, 0.0);
         this[8] = defaultValue(column2Row2, 0.0);
-    };
+    }
 
     /**
      * The number of elements used to pack the object into an array.

--- a/Source/Core/Matrix4.js
+++ b/Source/Core/Matrix4.js
@@ -61,7 +61,7 @@ define([
      * @see Matrix3
      * @see Packable
      */
-    var Matrix4 = function(column0Row0, column1Row0, column2Row0, column3Row0,
+    function Matrix4(column0Row0, column1Row0, column2Row0, column3Row0,
                            column0Row1, column1Row1, column2Row1, column3Row1,
                            column0Row2, column1Row2, column2Row2, column3Row2,
                            column0Row3, column1Row3, column2Row3, column3Row3) {
@@ -81,7 +81,7 @@ define([
         this[13] = defaultValue(column3Row1, 0.0);
         this[14] = defaultValue(column3Row2, 0.0);
         this[15] = defaultValue(column3Row3, 0.0);
-    };
+    }
 
     /**
      * The number of elements used to pack the object into an array.

--- a/Source/Core/NearFarScalar.js
+++ b/Source/Core/NearFarScalar.js
@@ -21,7 +21,7 @@ define([
      *
      * @see Packable
      */
-    var NearFarScalar = function(near, nearValue, far, farValue) {
+    function NearFarScalar(near, nearValue, far, farValue) {
         /**
          * The lower bound of the camera range.
          * @type {Number}
@@ -46,7 +46,7 @@ define([
          * @default 0.0
          */
         this.farValue = defaultValue(farValue, 0.0);
-    };
+    }
 
     /**
      * Duplicates a NearFarScalar instance.

--- a/Source/Core/Occluder.js
+++ b/Source/Core/Occluder.js
@@ -41,7 +41,7 @@ define([
      * var occluderBoundingSphere = new Cesium.BoundingSphere(new Cesium.Cartesian3(0, 0, -1), 1);
      * var occluder = new Cesium.Occluder(occluderBoundingSphere, cameraPosition);
      */
-    var Occluder = function(occluderBoundingSphere, cameraPosition) {
+    function Occluder(occluderBoundingSphere, cameraPosition) {
         //>>includeStart('debug', pragmas.debug);
         if (!defined(occluderBoundingSphere)) {
             throw new DeveloperError('occluderBoundingSphere is required.');
@@ -61,7 +61,7 @@ define([
 
         // cameraPosition fills in the above values
         this.cameraPosition = cameraPosition;
-    };
+    }
 
     var scratchCartesian3 = new Cartesian3();
 

--- a/Source/Core/OrientedBoundingBox.js
+++ b/Source/Core/OrientedBoundingBox.js
@@ -54,7 +54,7 @@ define([
      *
      * var obb = new Cesium.OrientedBoundingBox(center, halfAxes);
      */
-    var OrientedBoundingBox = function(center, halfAxes) {
+    function OrientedBoundingBox(center, halfAxes) {
         /**
          * The center of the box.
          * @type {Cartesian3}
@@ -67,7 +67,7 @@ define([
          * @default {@link Matrix3.IDENTITY}
          */
         this.halfAxes = Matrix3.clone(defaultValue(halfAxes, Matrix3.ZERO));
-    };
+    }
 
     var scratchCartesian1 = new Cartesian3();
     var scratchCartesian2 = new Cartesian3();
@@ -191,7 +191,7 @@ define([
      * @param {OrientedBoundingBox} [result] The object onto which to store the result.
      * @returns {OrientedBoundingBox} The modified result parameter or a new OrientedBoundingBox instance if one was not provided.
      */
-    var fromTangentPlaneExtents = function(tangentPlane, minimumX, maximumX, minimumY, maximumY, minimumZ, maximumZ, result) {
+    function fromTangentPlaneExtents(tangentPlane, minimumX, maximumX, minimumY, maximumY, minimumZ, maximumZ, result) {
         //>>includeStart('debug', pragmas.debug);
         if (!defined(minimumX) ||
             !defined(maximumX) ||
@@ -228,7 +228,7 @@ define([
         Matrix3.multiplyByScale(halfAxes, scale, halfAxes);
 
         return result;
-    };
+    }
 
     var scratchRectangleCenterCartographic = new Cartographic();
     var scratchRectangleCenter = new Cartesian3();

--- a/Source/Core/PinBuilder.js
+++ b/Source/Core/PinBuilder.js
@@ -28,9 +28,9 @@ define([
      *
      * @demo {@link http://cesiumjs.org/Cesium/Apps/Sandcastle/index.html?src=Map%20Pins.html|Cesium Sandcastle PinBuilder Demo}
      */
-    var PinBuilder = function() {
+    function PinBuilder() {
         this._cache = {};
-    };
+    }
 
     /**
      * Creates an empty pin of the specified color and size.

--- a/Source/Core/Plane.js
+++ b/Source/Core/Plane.js
@@ -34,7 +34,7 @@ define([
      * // The plane x=0
      * var plane = new Cesium.Plane(Cesium.Cartesian3.UNIT_X, 0.0);
      */
-    var Plane = function(normal, distance) {
+    function Plane(normal, distance) {
         //>>includeStart('debug', pragmas.debug);
         if (!defined(normal))  {
             throw new DeveloperError('normal is required.');
@@ -61,7 +61,7 @@ define([
          * @type {Number}
          */
         this.distance = distance;
-    };
+    }
 
     /**
      * Creates a plane from a normal and a point on the plane.

--- a/Source/Core/PointGeometry.js
+++ b/Source/Core/PointGeometry.js
@@ -43,7 +43,7 @@ define([
      *
      * @private
      */
-    var PointGeometry = function(options) {
+    function PointGeometry(options) {
         options = defaultValue(options, defaultValue.EMPTY_OBJECT);
 
         //>>includeStart('debug', pragmas.debug);
@@ -60,7 +60,7 @@ define([
         this._boundingSphere = BoundingSphere.clone(options.boundingSphere);
 
         this._workerName = 'createPointGeometry';
-    };
+    }
 
     /**
      * Computes the geometric representation a point collection, including its vertices and a bounding sphere.

--- a/Source/Core/PolygonGeometry.js
+++ b/Source/Core/PolygonGeometry.js
@@ -446,7 +446,7 @@ define([
      * });
      * var geometry = Cesium.PolygonGeometry.createGeometry(extrudedPolygon);
      */
-    var PolygonGeometry = function(options) {
+    function PolygonGeometry(options) {
         //>>includeStart('debug', pragmas.debug);
         if (!defined(options) || !defined(options.polygonHierarchy)) {
             throw new DeveloperError('options.polygonHierarchy is required.');
@@ -485,7 +485,7 @@ define([
          * @type {Number}
          */
         this.packedLength = PolygonGeometryLibrary.computeHierarchyPackedLength(polygonHierarchy) + Ellipsoid.packedLength + VertexFormat.packedLength + 7;
-    };
+    }
 
     /**
      * A description of a polygon from an array of positions. Polygon geometry can be rendered with both {@link Primitive} and {@link GroundPrimitive}.

--- a/Source/Core/PolygonHierarchy.js
+++ b/Source/Core/PolygonHierarchy.js
@@ -14,7 +14,7 @@ define([
      * @param {Cartesian3[]} [positions] A linear ring defining the outer boundary of the polygon or hole.
      * @param {PolygonHierarchy[]} [holes] An array of polygon hierarchies defining holes in the polygon.
      */
-    var PolygonHierarchy = function(positions, holes) {
+    function PolygonHierarchy(positions, holes) {
         /**
          * A linear ring defining the outer boundary of the polygon or hole.
          * @type {Cartesian3[]}
@@ -26,7 +26,7 @@ define([
          * @type {PolygonHierarchy[]}
          */
         this.holes = defined(holes) ? holes : [];
-    };
+    }
 
     return PolygonHierarchy;
 });

--- a/Source/Core/PolygonOutlineGeometry.js
+++ b/Source/Core/PolygonOutlineGeometry.js
@@ -282,7 +282,7 @@ define([
      * });
      * var geometry = Cesium.PolygonOutlineGeometry.createGeometry(extrudedPolygon);
      */
-    var PolygonOutlineGeometry = function(options) {
+    function PolygonOutlineGeometry(options) {
         //>>includeStart('debug', pragmas.debug);
         if (!defined(options) || !defined(options.polygonHierarchy)) {
             throw new DeveloperError('options.polygonHierarchy is required.');
@@ -317,7 +317,7 @@ define([
          * @type {Number}
          */
         this.packedLength = PolygonGeometryLibrary.computeHierarchyPackedLength(polygonHierarchy) + Ellipsoid.packedLength + 6;
-    };
+    }
 
     /**
      * Stores the provided instance into the provided array.

--- a/Source/Core/PolylineGeometry.js
+++ b/Source/Core/PolylineGeometry.js
@@ -110,7 +110,7 @@ define([
      * });
      * var geometry = Cesium.PolylineGeometry.createGeometry(polyline);
      */
-    var PolylineGeometry = function(options) {
+    function PolylineGeometry(options) {
         options = defaultValue(options, defaultValue.EMPTY_OBJECT);
         var positions = options.positions;
         var colors = options.colors;
@@ -147,7 +147,7 @@ define([
          * @type {Number}
          */
         this.packedLength = numComponents + Ellipsoid.packedLength + VertexFormat.packedLength + 4;
-    };
+    }
 
     /**
      * Stores the provided instance into the provided array.

--- a/Source/Core/PolylineVolumeGeometry.js
+++ b/Source/Core/PolylineVolumeGeometry.js
@@ -215,7 +215,7 @@ define([
      *   shapePositions : computeCircle(100000.0)
      * });
      */
-    var PolylineVolumeGeometry = function(options) {
+    function PolylineVolumeGeometry(options) {
         options = defaultValue(options, defaultValue.EMPTY_OBJECT);
         var positions = options.polylinePositions;
         var shape = options.shapePositions;
@@ -245,7 +245,7 @@ define([
          * @type {Number}
          */
         this.packedLength = numComponents + Ellipsoid.packedLength + VertexFormat.packedLength + 2;
-    };
+    }
 
     /**
      * Stores the provided instance into the provided array.

--- a/Source/Core/PolylineVolumeOutlineGeometry.js
+++ b/Source/Core/PolylineVolumeOutlineGeometry.js
@@ -130,7 +130,7 @@ define([
      *   shapePositions : computeCircle(100000.0)
      * });
      */
-    var PolylineVolumeOutlineGeometry = function(options) {
+    function PolylineVolumeOutlineGeometry(options) {
         options = defaultValue(options, defaultValue.EMPTY_OBJECT);
         var positions = options.polylinePositions;
         var shape = options.shapePositions;
@@ -159,7 +159,7 @@ define([
          * @type {Number}
          */
         this.packedLength = numComponents + Ellipsoid.packedLength + 2;
-    };
+    }
 
     /**
      * Stores the provided instance into the provided array.

--- a/Source/Core/QuantizedMeshTerrainData.js
+++ b/Source/Core/QuantizedMeshTerrainData.js
@@ -105,7 +105,7 @@ define([
      *     northSkirtHeight : 1.0
      * });
      */
-    var QuantizedMeshTerrainData = function QuantizedMeshTerrainData(options) {
+    function QuantizedMeshTerrainData(options) {
         //>>includeStart('debug', pragmas.debug)
         if (!defined(options) || !defined(options.quantizedVertices)) {
             throw new DeveloperError('options.quantizedVertices is required.');
@@ -191,7 +191,7 @@ define([
 
         this._createdByUpsampling = defaultValue(options.createdByUpsampling, false);
         this._waterMask = options.waterMask;
-    };
+    }
 
     defineProperties(QuantizedMeshTerrainData.prototype, {
         /**

--- a/Source/Core/Quaternion.js
+++ b/Source/Core/Quaternion.js
@@ -31,7 +31,7 @@ define([
      *
      * @see PackableForInterpolation
      */
-    var Quaternion = function(x, y, z, w) {
+    function Quaternion(x, y, z, w) {
         /**
          * The X component.
          * @type {Number}
@@ -59,7 +59,7 @@ define([
          * @default 0.0
          */
         this.w = defaultValue(w, 0.0);
-    };
+    }
 
     var fromAxisAngleScratch = new Cartesian3();
 

--- a/Source/Core/QuaternionSpline.js
+++ b/Source/Core/QuaternionSpline.js
@@ -91,7 +91,7 @@ define([
      * @see CatmullRomSpline
      * @see LinearSpline
      */
-    var QuaternionSpline = function(options) {
+    function QuaternionSpline(options) {
         options = defaultValue(options, defaultValue.EMPTY_OBJECT);
 
         var points = options.points;
@@ -119,7 +119,7 @@ define([
 
         this._evaluateFunction = createEvaluateFunction(this);
         this._lastTimeIndex = 0;
-    };
+    }
 
     defineProperties(QuaternionSpline.prototype, {
         /**

--- a/Source/Core/Queue.js
+++ b/Source/Core/Queue.js
@@ -11,11 +11,11 @@ define([
      * @alias Queue
      * @constructor
      */
-    var Queue = function() {
+    function Queue() {
         this._array = [];
         this._offset = 0;
         this._length = 0;
-    };
+    }
 
     defineProperties(Queue.prototype, {
         /**

--- a/Source/Core/Ray.js
+++ b/Source/Core/Ray.js
@@ -19,7 +19,7 @@ define([
      * @param {Cartesian3} [origin=Cartesian3.ZERO] The origin of the ray.
      * @param {Cartesian3} [direction=Cartesian3.ZERO] The direction of the ray.
      */
-    var Ray = function(origin, direction) {
+    function Ray(origin, direction) {
         direction = Cartesian3.clone(defaultValue(direction, Cartesian3.ZERO));
         if (!Cartesian3.equals(direction, Cartesian3.ZERO)) {
             Cartesian3.normalize(direction, direction);
@@ -37,7 +37,7 @@ define([
          * @type {Cartesian3}
          */
         this.direction = direction;
-    };
+    }
 
     /**
      * Computes the point along the ray given by r(t) = o + t*d,

--- a/Source/Core/Rectangle.js
+++ b/Source/Core/Rectangle.js
@@ -32,7 +32,7 @@ define([
      *
      * @see Packable
      */
-    var Rectangle = function(west, south, east, north) {
+    function Rectangle(west, south, east, north) {
         /**
          * The westernmost longitude in radians in the range [-Pi, Pi].
          *
@@ -64,7 +64,7 @@ define([
          * @default 0.0
          */
         this.north = defaultValue(north, 0.0);
-    };
+    }
 
     defineProperties(Rectangle.prototype, {
         /**

--- a/Source/Core/RectangleGeometry.js
+++ b/Source/Core/RectangleGeometry.js
@@ -545,7 +545,7 @@ define([
      * });
      * var geometry = Cesium.RectangleGeometry.createGeometry(rectangle);
      */
-    var RectangleGeometry = function(options) {
+    function RectangleGeometry(options) {
         options = defaultValue(options, defaultValue.EMPTY_OBJECT);
 
         var rectangle = options.rectangle;
@@ -582,7 +582,7 @@ define([
         this._closeTop = closeTop;
         this._closeBottom = closeBottom;
         this._workerName = 'createRectangleGeometry';
-    };
+    }
 
     /**
      * The number of elements used to pack the object into an array.

--- a/Source/Core/RectangleOutlineGeometry.js
+++ b/Source/Core/RectangleOutlineGeometry.js
@@ -193,7 +193,7 @@ define([
      * });
      * var geometry = Cesium.RectangleOutlineGeometry.createGeometry(rectangle);
      */
-    var RectangleOutlineGeometry = function(options) {
+    function RectangleOutlineGeometry(options) {
         options = defaultValue(options, defaultValue.EMPTY_OBJECT);
 
         var rectangle = options.rectangle;
@@ -220,7 +220,7 @@ define([
         this._rotation = rotation;
         this._extrudedHeight = extrudedHeight;
         this._workerName = 'createRectangleOutlineGeometry';
-    };
+    }
 
     /**
      * The number of elements used to pack the object into an array.

--- a/Source/Core/RequestErrorEvent.js
+++ b/Source/Core/RequestErrorEvent.js
@@ -18,7 +18,7 @@ define([
      * @param {String|Object} [responseHeaders] The response headers, represented either as an object literal or as a
      *                        string in the format returned by XMLHttpRequest's getAllResponseHeaders() function.
      */
-    var RequestErrorEvent = function RequestErrorEvent(statusCode, response, responseHeaders) {
+    function RequestErrorEvent(statusCode, response, responseHeaders) {
         /**
          * The HTTP error status code, such as 404.  If the error does not have a particular
          * HTTP code, this property will be undefined.
@@ -46,7 +46,7 @@ define([
         if (typeof this.responseHeaders === 'string') {
             this.responseHeaders = parseResponseHeaders(this.responseHeaders);
         }
-    };
+    }
 
     /**
      * Creates a string representing this RequestErrorEvent.

--- a/Source/Core/RuntimeError.js
+++ b/Source/Core/RuntimeError.js
@@ -21,7 +21,7 @@ define([
      *
      * @see DeveloperError
      */
-    var RuntimeError = function(message) {
+    function RuntimeError(message) {
         /**
          * 'RuntimeError' indicating that this exception was thrown due to a runtime error.
          * @type {String}
@@ -50,8 +50,7 @@ define([
          * @readonly
          */
         this.stack = stack;
-    };
-
+    }
     RuntimeError.prototype.toString = function() {
         var str = this.name + ': ' + this.message;
 

--- a/Source/Core/ScreenSpaceEventHandler.js
+++ b/Source/Core/ScreenSpaceEventHandler.js
@@ -62,10 +62,9 @@ define([
     };
 
     function registerListener(screenSpaceEventHandler, domType, element, callback) {
-        var listener = function(e) {
+        function listener(e) {
             callback(screenSpaceEventHandler, e);
-        };
-
+        }
         element.addEventListener(domType, listener, false);
 
         screenSpaceEventHandler._removalFunctions.push(function() {
@@ -641,7 +640,7 @@ define([
      *
      * @constructor
      */
-    var ScreenSpaceEventHandler = function(element) {
+    function ScreenSpaceEventHandler(element) {
         this._inputEvents = {};
         this._buttonDown = undefined;
         this._isPinching = false;
@@ -663,7 +662,7 @@ define([
         this._element = defaultValue(element, document);
 
         registerListeners(this);
-    };
+    }
 
     /**
      * Set a function to be executed on an input event.

--- a/Source/Core/ShowGeometryInstanceAttribute.js
+++ b/Source/Core/ShowGeometryInstanceAttribute.js
@@ -40,7 +40,7 @@ define([
      *   }
      * });
      */
-    var ShowGeometryInstanceAttribute = function(show) {
+    function ShowGeometryInstanceAttribute(show) {
         show = defaultValue(show, true);
 
         /**
@@ -51,7 +51,7 @@ define([
          * @default [1.0]
          */
         this.value = ShowGeometryInstanceAttribute.toValue(show);
-    };
+    }
 
     defineProperties(ShowGeometryInstanceAttribute.prototype, {
         /**

--- a/Source/Core/SimplePolylineGeometry.js
+++ b/Source/Core/SimplePolylineGeometry.js
@@ -106,7 +106,7 @@ define([
      * });
      * var geometry = Cesium.SimplePolylineGeometry.createGeometry(polyline);
      */
-    var SimplePolylineGeometry = function(options) {
+    function SimplePolylineGeometry(options) {
         options = defaultValue(options, defaultValue.EMPTY_OBJECT);
         var positions = options.positions;
         var colors = options.colors;
@@ -137,7 +137,7 @@ define([
          * @type {Number}
          */
         this.packedLength = numComponents + Ellipsoid.packedLength + 3;
-    };
+    }
 
     /**
      * Stores the provided instance into the provided array.

--- a/Source/Core/SphereGeometry.js
+++ b/Source/Core/SphereGeometry.js
@@ -41,7 +41,7 @@ define([
      * });
      * var geometry = Cesium.SphereGeometry.createGeometry(sphere);
      */
-    var SphereGeometry = function(options) {
+    function SphereGeometry(options) {
         var radius = defaultValue(options.radius, 1.0);
         var radii = new Cartesian3(radius, radius, radius);
         var ellipsoidOptions = {
@@ -53,7 +53,7 @@ define([
 
         this._ellipsoidGeometry = new EllipsoidGeometry(ellipsoidOptions);
         this._workerName = 'createSphereGeometry';
-    };
+    }
 
     /**
      * The number of elements used to pack the object into an array.

--- a/Source/Core/SphereOutlineGeometry.js
+++ b/Source/Core/SphereOutlineGeometry.js
@@ -39,7 +39,7 @@ define([
      * });
      * var geometry = Cesium.SphereOutlineGeometry.createGeometry(sphere);
      */
-    var SphereOutlineGeometry = function(options) {
+    function SphereOutlineGeometry(options) {
         var radius = defaultValue(options.radius, 1.0);
         var radii = new Cartesian3(radius, radius, radius);
         var ellipsoidOptions = {
@@ -51,7 +51,7 @@ define([
 
         this._ellipsoidGeometry = new EllipsoidOutlineGeometry(ellipsoidOptions);
         this._workerName = 'createSphereOutlineGeometry';
-    };
+    }
 
     /**
      * The number of elements used to pack the object into an array.

--- a/Source/Core/Spherical.js
+++ b/Source/Core/Spherical.js
@@ -19,11 +19,11 @@ define([
      * @param {Number} [cone=0.0] The angular coordinate measured from the positive z-axis and toward the negative z-axis.
      * @param {Number} [magnitude=1.0] The linear coordinate measured from the origin.
      */
-    var Spherical = function(clock, cone, magnitude) {
+    function Spherical(clock, cone, magnitude) {
         this.clock = defaultValue(clock, 0.0);
         this.cone = defaultValue(cone, 0.0);
         this.magnitude = defaultValue(magnitude, 1.0);
-    };
+    }
 
     /**
      * Converts the provided Cartesian3 into Spherical coordinates.

--- a/Source/Core/Spline.js
+++ b/Source/Core/Spline.js
@@ -21,7 +21,7 @@ define([
      * @see LinearSpline
      * @see QuaternionSpline
      */
-    var Spline = function() {
+    function Spline() {
         /**
          * An array of times for the control points.
          * @type {Number[]}
@@ -37,7 +37,7 @@ define([
         this.points = undefined;
 
         DeveloperError.throwInstantiationError();
-    };
+    }
 
     /**
      * Evaluates the curve at a given time.

--- a/Source/Core/TaskProcessor.js
+++ b/Source/Core/TaskProcessor.js
@@ -171,13 +171,13 @@ define([
      *                                        scheduleTask will not queue any more tasks, allowing
      *                                        work to be rescheduled in future frames.
      */
-    var TaskProcessor = function(workerName, maximumActiveTasks) {
+    function TaskProcessor(workerName, maximumActiveTasks) {
         this._workerName = workerName;
         this._maximumActiveTasks = defaultValue(maximumActiveTasks, 5);
         this._activeTasks = 0;
         this._deferreds = {};
         this._nextID = 0;
-    };
+    }
 
     var emptyTransferableObjectArray = [];
 

--- a/Source/Core/TerrainData.js
+++ b/Source/Core/TerrainData.js
@@ -17,9 +17,9 @@ define([
      * @see HeightmapTerrainData
      * @see QuantizedMeshTerrainData
      */
-    var TerrainData = function TerrainData() {
+    function TerrainData() {
         DeveloperError.throwInstantiationError();
-    };
+    }
 
     defineProperties(TerrainData.prototype, {
         /**

--- a/Source/Core/TerrainEncoding.js
+++ b/Source/Core/TerrainEncoding.js
@@ -45,7 +45,7 @@ define([
      *
      * @private
      */
-    var TerrainEncoding = function(axisAlignedBoundingBox, minimumHeight, maximumHeight, fromENU, hasVertexNormals) {
+    function TerrainEncoding(axisAlignedBoundingBox, minimumHeight, maximumHeight, fromENU, hasVertexNormals) {
         var quantization;
         var center;
         var toENU;
@@ -138,8 +138,7 @@ define([
          * @type {Boolean}
          */
         this.hasVertexNormals = hasVertexNormals;
-    };
-
+    }
     TerrainEncoding.prototype.encode = function(vertexBuffer, bufferIndex, position, uv, height, normalToPack) {
         var u = uv.x;
         var v = uv.y;

--- a/Source/Core/TerrainMesh.js
+++ b/Source/Core/TerrainMesh.js
@@ -30,7 +30,7 @@ define([
       *
       * @private
       */
-    var TerrainMesh = function TerrainMesh(center, vertices, indices, minimumHeight, maximumHeight, boundingSphere3D, occludeePointInScaledSpace, vertexStride, orientedBoundingBox, encoding) {
+    function TerrainMesh(center, vertices, indices, minimumHeight, maximumHeight, boundingSphere3D, occludeePointInScaledSpace, vertexStride, orientedBoundingBox, encoding) {
         /**
          * The center of the tile.  Vertex positions are specified relative to this center.
          * @type {Cartesian3}
@@ -98,7 +98,7 @@ define([
          * @type {TerrainEncoding}
          */
         this.encoding = encoding;
-    };
+    }
 
     return TerrainMesh;
 });

--- a/Source/Core/TerrainProvider.js
+++ b/Source/Core/TerrainProvider.js
@@ -23,9 +23,9 @@ define([
      * @see CesiumTerrainProvider
      * @see ArcGisImageServerTerrainProvider
      */
-    var TerrainProvider = function() {
+    function TerrainProvider() {
         DeveloperError.throwInstantiationError();
-    };
+    }
 
     defineProperties(TerrainProvider.prototype, {
         /**

--- a/Source/Core/TileProviderError.js
+++ b/Source/Core/TileProviderError.js
@@ -26,7 +26,7 @@ define([
      * @param {Number} [timesRetried=0] The number of times this operation has been retried.
      * @param {Error} [error] The error or exception that occurred, if any.
      */
-    var TileProviderError = function TileProviderError(provider, message, x, y, level, timesRetried, error) {
+    function TileProviderError(provider, message, x, y, level, timesRetried, error) {
         /**
          * The {@link ImageryProvider} or {@link TerrainProvider} that experienced the error.
          * @type {ImageryProvider|TerrainProvider}
@@ -81,7 +81,7 @@ define([
          * @type {Error}
          */
         this.error = error;
-    };
+    }
 
     /**
      * Handles an error in an {@link ImageryProvider} or {@link TerrainProvider} by raising an event if it has any listeners, or by

--- a/Source/Core/TilingScheme.js
+++ b/Source/Core/TilingScheme.js
@@ -20,9 +20,9 @@ define([
      * @see WebMercatorTilingScheme
      * @see GeographicTilingScheme
      */
-    var TilingScheme = function TilingScheme(options) {
+    function TilingScheme(options) {
         throw new DeveloperError('This type should not be instantiated directly.  Instead, use WebMercatorTilingScheme or GeographicTilingScheme.');
-    };
+    }
 
     defineProperties(TilingScheme.prototype, {
         /**

--- a/Source/Core/TimeInterval.js
+++ b/Source/Core/TimeInterval.js
@@ -68,7 +68,7 @@ define([
      * var dateToCheck = Cesium.JulianDate.fromIso8601('1982-09-08T11:30:00Z');
      * var containsDate = Cesium.TimeInterval.contains(timeInterval, dateToCheck);
      */
-    var TimeInterval = function(options) {
+    function TimeInterval(options) {
         options = defaultValue(options, defaultValue.EMPTY_OBJECT);
         /**
          * Gets or sets the start time of this interval.
@@ -101,7 +101,7 @@ define([
          * @default true
          */
         this.isStopIncluded = defaultValue(options.isStopIncluded, true);
-    };
+    }
 
     defineProperties(TimeInterval.prototype, {
         /**

--- a/Source/Core/TimeIntervalCollection.js
+++ b/Source/Core/TimeIntervalCollection.js
@@ -30,7 +30,7 @@ define([
      *
      * @param {TimeInterval[]} [intervals] An array of intervals to add to the collection.
      */
-    var TimeIntervalCollection = function(intervals) {
+    function TimeIntervalCollection(intervals) {
         this._intervals = [];
         this._changedEvent = new Event();
 
@@ -40,7 +40,7 @@ define([
                 this.addInterval(intervals[i]);
             }
         }
-    };
+    }
 
     defineProperties(TimeIntervalCollection.prototype, {
         /**

--- a/Source/Core/VRTheWorldTerrainProvider.js
+++ b/Source/Core/VRTheWorldTerrainProvider.js
@@ -66,7 +66,7 @@ define([
      * });
      * viewer.terrainProvider = terrainProvider;
      */
-    var VRTheWorldTerrainProvider = function VRTheWorldTerrainProvider(options) {
+    function VRTheWorldTerrainProvider(options) {
         options = defaultValue(options, defaultValue.EMPTY_OBJECT);
         if (!defined(options.url)) {
             throw new DeveloperError('options.url is required.');
@@ -147,7 +147,7 @@ define([
         }
 
         requestMetadata();
-    };
+    }
 
     defineProperties(VRTheWorldTerrainProvider.prototype, {
         /**

--- a/Source/Core/VertexFormat.js
+++ b/Source/Core/VertexFormat.js
@@ -31,7 +31,7 @@ define([
      * @see Geometry#attributes
      * @see Packable
      */
-    var VertexFormat = function(options) {
+    function VertexFormat(options) {
         options = defaultValue(options, defaultValue.EMPTY_OBJECT);
 
         /**
@@ -105,7 +105,7 @@ define([
          * @default false
          */
         this.color = defaultValue(options.color, false);
-    };
+    }
 
     /**
      * An immutable vertex format with only a position attribute.

--- a/Source/Core/VideoSynchronizer.js
+++ b/Source/Core/VideoSynchronizer.js
@@ -33,7 +33,7 @@ define([
      *
      * @demo {@link http://cesiumjs.org/Cesium/Apps/Sandcastle/index.html?src=Video.html|Video Material Demo}
      */
-    var VideoSynchronizer = function(options) {
+    function VideoSynchronizer(options) {
         options = defaultValue(options, defaultValue.EMPTY_OBJECT);
 
         this._clock = undefined;
@@ -65,7 +65,7 @@ define([
         this._seeking = false;
         this._seekFunction = undefined;
         this._firstTickAfterSeek = false;
-    };
+    }
 
     defineProperties(VideoSynchronizer.prototype, {
         /**

--- a/Source/Core/WallGeometry.js
+++ b/Source/Core/WallGeometry.js
@@ -81,7 +81,7 @@ define([
      * });
      * var geometry = Cesium.WallGeometry.createGeometry(wall);
      */
-    var WallGeometry = function(options) {
+    function WallGeometry(options) {
         options = defaultValue(options, defaultValue.EMPTY_OBJECT);
 
         var wallPositions = options.positions;
@@ -128,7 +128,7 @@ define([
          * @type {Number}
          */
         this.packedLength = numComponents + Ellipsoid.packedLength + VertexFormat.packedLength + 1;
-    };
+    }
 
     /**
      * Stores the provided instance into the provided array.

--- a/Source/Core/WallOutlineGeometry.js
+++ b/Source/Core/WallOutlineGeometry.js
@@ -72,7 +72,7 @@ define([
      * });
      * var geometry = Cesium.WallOutlineGeometry.createGeometry(wall);
      */
-    var WallOutlineGeometry = function(options) {
+    function WallOutlineGeometry(options) {
         options = defaultValue(options, defaultValue.EMPTY_OBJECT);
 
         var wallPositions = options.positions;
@@ -117,7 +117,7 @@ define([
          * @type {Number}
          */
         this.packedLength = numComponents + Ellipsoid.packedLength + 1;
-    };
+    }
 
     /**
      * Stores the provided instance into the provided array.

--- a/Source/Core/WebMercatorProjection.js
+++ b/Source/Core/WebMercatorProjection.js
@@ -31,11 +31,11 @@ define([
      *
      * @see GeographicProjection
      */
-    var WebMercatorProjection = function(ellipsoid) {
+    function WebMercatorProjection(ellipsoid) {
         this._ellipsoid = defaultValue(ellipsoid, Ellipsoid.WGS84);
         this._semimajorAxis = this._ellipsoid.maximumRadius;
         this._oneOverSemimajorAxis = 1.0 / this._semimajorAxis;
-    };
+    }
 
     defineProperties(WebMercatorProjection.prototype, {
         /**

--- a/Source/Core/WebMercatorTilingScheme.js
+++ b/Source/Core/WebMercatorTilingScheme.js
@@ -40,7 +40,7 @@ define([
      *        globe is covered in the longitude direction and an equal distance is covered in the latitude
      *        direction, resulting in a square projection.
      */
-    var WebMercatorTilingScheme = function WebMercatorTilingScheme(options) {
+    function WebMercatorTilingScheme(options) {
         options = defaultValue(options, {});
 
         this._ellipsoid = defaultValue(options.ellipsoid, Ellipsoid.WGS84);
@@ -63,7 +63,7 @@ define([
         var northeast = this._projection.unproject(this._rectangleNortheastInMeters);
         this._rectangle = new Rectangle(southwest.longitude, southwest.latitude,
                                   northeast.longitude, northeast.latitude);
-    };
+    }
 
     defineProperties(WebMercatorTilingScheme.prototype, {
         /**

--- a/Source/Core/appendForwardSlash.js
+++ b/Source/Core/appendForwardSlash.js
@@ -5,12 +5,12 @@ define(function() {
     /**
      * @private
      */
-    var appendForwardSlash = function(url) {
+    function appendForwardSlash(url) {
         if (url.length === 0 || url[url.length - 1] !== '/') {
             url = url + '/';
         }
         return url;
-    };
+    }
 
     return appendForwardSlash;
 });

--- a/Source/Core/barycentricCoordinates.js
+++ b/Source/Core/barycentricCoordinates.js
@@ -35,7 +35,7 @@ define([
      *   new Cesium.Cartesian3( 1.0, 0.0, 0.0),
      *   new Cesium.Cartesian3( 0.0, 1.0, 1.0));
      */
-    var barycentricCoordinates = function(point, p0, p1, p2, result) {
+    function barycentricCoordinates(point, p0, p1, p2, result) {
         //>>includeStart('debug', pragmas.debug);
         if (!defined(point) || !defined(p0) || !defined(p1) || !defined(p2)) {
             throw new DeveloperError('point, p0, p1, and p2 are required.');
@@ -78,7 +78,7 @@ define([
         result.z = (dot00 * dot12 - dot01 * dot02) * q;
         result.x = 1.0 - result.y - result.z;
         return result;
-    };
+    }
 
     return barycentricCoordinates;
 });

--- a/Source/Core/binarySearch.js
+++ b/Source/Core/binarySearch.js
@@ -23,13 +23,13 @@ define([
      *
      * @example
      * // Create a comparator function to search through an array of numbers.
-     * var comparator = function(a, b) {
+     * function comparator(a, b) {
      *     return a - b;
      * };
      * var numbers = [0, 2, 4, 6, 8];
      * var index = Cesium.binarySearch(numbers, 6, comparator); // 3
      */
-    var binarySearch = function(array, itemToFind, comparator) {
+    function binarySearch(array, itemToFind, comparator) {
         //>>includeStart('debug', pragmas.debug);
         if (!defined(array)) {
             throw new DeveloperError('array is required.');
@@ -61,7 +61,7 @@ define([
             return i;
         }
         return ~(high + 1);
-    };
+    }
 
     /**
      * A function used to compare two items while performing a binary search.

--- a/Source/Core/buildModuleUrl.js
+++ b/Source/Core/buildModuleUrl.js
@@ -66,7 +66,7 @@ define([
      *
      * @private
      */
-    var buildModuleUrl = function(moduleID) {
+    function buildModuleUrl(moduleID) {
         if (!defined(implementation)) {
             //select implementation
             if (defined(require.toUrl)) {
@@ -86,7 +86,7 @@ define([
         a.href = a.href; // IE only absolutizes href on get, not set
 
         return a.href;
-    };
+    }
 
     // exposed for testing
     buildModuleUrl._cesiumScriptRegex = cesiumScriptRegex;

--- a/Source/Core/cancelAnimationFrame.js
+++ b/Source/Core/cancelAnimationFrame.js
@@ -40,12 +40,12 @@ define([
      *
      * @see {@link http://www.w3.org/TR/animation-timing/#the-WindowAnimationTiming-interface|The WindowAnimationTiming interface}
      */
-    var cancelAnimationFrame = function(requestID) {
+    function cancelAnimationFrame(requestID) {
         // we need this extra wrapper function because the native cancelAnimationFrame
         // functions must be invoked on the global scope (window), which is not the case
         // if invoked as Cesium.cancelAnimationFrame(requestID)
         implementation(requestID);
-    };
+    }
 
     return cancelAnimationFrame;
 });

--- a/Source/Core/clone.js
+++ b/Source/Core/clone.js
@@ -14,7 +14,7 @@ define([
      * @param {Boolean} [deep=false] If true, all properties will be deep cloned recursively.
      * @returns {Object} The cloned object.
      */
-    var clone = function(object, deep) {
+    function clone(object, deep) {
         if (object === null || typeof object !== 'object') {
             return object;
         }
@@ -33,7 +33,7 @@ define([
         }
 
         return result;
-    };
+    }
 
     return clone;
 });

--- a/Source/Core/combine.js
+++ b/Source/Core/combine.js
@@ -38,7 +38,7 @@ define([
      *
      * @exports combine
      */
-    var combine = function(object1, object2, deep) {
+    function combine(object1, object2, deep) {
         deep = defaultValue(deep, false);
 
         var result = {};
@@ -74,7 +74,7 @@ define([
             }
         }
         return result;
-    };
+    }
 
     return combine;
 });

--- a/Source/Core/createGuid.js
+++ b/Source/Core/createGuid.js
@@ -14,14 +14,14 @@ define(function() {
      * @example
      * this.guid = Cesium.createGuid();
      */
-    var createGuid = function() {
+    function createGuid() {
         // http://stackoverflow.com/questions/105034/how-to-create-a-guid-uuid-in-javascript
         return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
             var r = Math.random() * 16 | 0;
             var v = c === 'x' ? r : (r & 0x3 | 0x8);
             return v.toString(16);
         });
-    };
+    }
 
     return createGuid;
 });

--- a/Source/Core/defaultValue.js
+++ b/Source/Core/defaultValue.js
@@ -18,12 +18,12 @@ define([
      * @example
      * param = Cesium.defaultValue(param, 'default');
      */
-    var defaultValue = function(a, b) {
+    function defaultValue(a, b) {
         if (a !== undefined) {
             return a;
         }
         return b;
-    };
+    }
 
     /**
      * A frozen empty object that can be used as the default value for options passed as

--- a/Source/Core/defined.js
+++ b/Source/Core/defined.js
@@ -15,9 +15,9 @@ define(function() {
      *      doSomethingElse();
      * }
      */
-    var defined = function(value) {
+    function defined(value) {
         return value !== undefined;
-    };
+    }
 
     return defined;
 });

--- a/Source/Core/definedNotNull.js
+++ b/Source/Core/definedNotNull.js
@@ -15,9 +15,9 @@ define(function() {
      *      doSomethingElse();
      * }
      */
-    var definedNotNull = function(value) {
+    function definedNotNull(value) {
         return value !== undefined && value !== null;
-    };
+    }
 
     return definedNotNull;
 });

--- a/Source/Core/deprecationWarning.js
+++ b/Source/Core/deprecationWarning.js
@@ -21,7 +21,7 @@ define([
      *
      * @example
      * // Deprecated function or class
-     * var Foo = function() {
+     * function Foo() {
      *    deprecationWarning('Foo', 'Foo was deprecated in Cesium 1.01.  It will be removed in 1.03.  Use newFoo instead.');
      *    // ...
      * }
@@ -48,7 +48,7 @@ define([
      *
      * @private
      */
-    var deprecationWarning = function(identifier, message) {
+    function deprecationWarning(identifier, message) {
         //>>includeStart('debug', pragmas.debug);
         if (!defined(identifier) || !defined(message)) {
             throw new DeveloperError('identifier and message are required.');
@@ -59,7 +59,7 @@ define([
             warnings[identifier] = true;
             console.log(message);
         }
-    };
+    }
 
     return deprecationWarning;
 });

--- a/Source/Core/destroyObject.js
+++ b/Source/Core/destroyObject.js
@@ -37,7 +37,7 @@ define([
      *     return Cesium.destroyObject(this);
      * };
      */
-    var destroyObject = function(object, message) {
+    function destroyObject(object, message) {
         message = defaultValue(message, 'This object was destroyed, i.e., destroy() was called.');
 
         function throwOnDestroyed() {
@@ -53,7 +53,7 @@ define([
         object.isDestroyed = returnTrue;
 
         return undefined;
-    };
+    }
 
     return destroyObject;
 });

--- a/Source/Core/formatError.js
+++ b/Source/Core/formatError.js
@@ -14,7 +14,7 @@ define([
      * @param {Object} object The item to find in the array.
      * @returns {String} A string containing the formatted error.
      */
-    var formatError = function(object) {
+    function formatError(object) {
         var result;
 
         var name = object.name;
@@ -31,7 +31,7 @@ define([
         }
 
         return result;
-    };
+    }
 
     return formatError;
 });

--- a/Source/Core/getBaseUri.js
+++ b/Source/Core/getBaseUri.js
@@ -18,7 +18,7 @@ define([
      * // basePath will be "/Gallery/";
      * var basePath = Cesium.getBaseUri('/Gallery/simple.czml?value=true&example=false');
      */
-    var getBaseUri = function(uri) {
+    function getBaseUri(uri) {
         //>>includeStart('debug', pragmas.debug);
         if (!defined(uri)) {
             throw new DeveloperError('uri is required.');
@@ -32,7 +32,7 @@ define([
         }
 
         return basePath;
-    };
+    }
 
     return getBaseUri;
 });

--- a/Source/Core/getFilenameFromUri.js
+++ b/Source/Core/getFilenameFromUri.js
@@ -20,7 +20,7 @@ define([
      * //fileName will be"simple.czml";
      * var fileName = Cesium.getFilenameFromUri('/Gallery/simple.czml?value=true&example=false');
      */
-    var getFilenameFromUri = function(uri) {
+    function getFilenameFromUri(uri) {
         //>>includeStart('debug', pragmas.debug);
         if (!defined(uri)) {
             throw new DeveloperError('uri is required.');
@@ -35,7 +35,7 @@ define([
             path = path.substr(index + 1);
         }
         return path;
-    };
+    }
 
     return getFilenameFromUri;
 });

--- a/Source/Core/getImagePixels.js
+++ b/Source/Core/getImagePixels.js
@@ -16,7 +16,7 @@ define([
      * @param {Image} image The image to extract pixels from.
      * @returns {CanvasPixelArray} The pixels of the image.
      */
-    var getImagePixels = function(image, width, height) {
+    function getImagePixels(image, width, height) {
         if (!defined(width)) {
             width = image.width;
         }
@@ -42,7 +42,7 @@ define([
 
         context2d.drawImage(image, 0, 0, width, height);
         return context2d.getImageData(0, 0, width, height).data;
-    };
+    }
 
     return getImagePixels;
 });

--- a/Source/Core/getMagic.js
+++ b/Source/Core/getMagic.js
@@ -10,10 +10,10 @@ define([
     /**
      * @private
      */
-    var getMagic = function(uint8Array, byteOffset) {
+    function getMagic(uint8Array, byteOffset) {
         byteOffset = defaultValue(byteOffset, 0);
         return getStringFromTypedArray(uint8Array, byteOffset, Math.min(4, uint8Array.length));
-    };
+    }
 
     return getMagic;
 });

--- a/Source/Core/getStringFromTypedArray.js
+++ b/Source/Core/getStringFromTypedArray.js
@@ -13,7 +13,7 @@ define([
     /**
      * @private
      */
-    var getStringFromTypedArray = function(uint8Array, byteOffset, byteLength) {
+    function getStringFromTypedArray(uint8Array, byteOffset, byteLength) {
         //>>includeStart('debug', pragmas.debug);
         if (!defined(uint8Array)) {
             throw new DeveloperError('uint8Array is required.');
@@ -35,7 +35,7 @@ define([
         uint8Array = uint8Array.subarray(byteOffset, byteOffset + byteLength);
 
         return getStringFromTypedArray.decode(uint8Array);
-    };
+    }
 
     // Exposed functions for testing
     getStringFromTypedArray.decodeWithTextDecoder = function(view) {

--- a/Source/Core/isCrossOriginUrl.js
+++ b/Source/Core/isCrossOriginUrl.js
@@ -12,7 +12,7 @@ define([
      *
      * @private
      */
-    var isCrossOriginUrl = function(url) {
+    function isCrossOriginUrl(url) {
         if (!defined(a)) {
             a = document.createElement('a');
         }
@@ -29,7 +29,7 @@ define([
         a.href = a.href; // IE only absolutizes href on get, not set
 
         return protocol !== a.protocol || host !== a.host;
-    };
+    }
 
     return isCrossOriginUrl;
 });

--- a/Source/Core/joinUrls.js
+++ b/Source/Core/joinUrls.js
@@ -22,7 +22,7 @@ define([
      * @param {Boolean} [appendSlash=true] The boolean determining whether there should be a forward slash between first and second.
      * @private
      */
-    var joinUrls = function(first, second, appendSlash) {
+    function joinUrls(first, second, appendSlash) {
         //>>includeStart('debug', pragmas.debug);
         if (!defined(first)) {
             throw new DeveloperError('first is required');
@@ -102,7 +102,7 @@ define([
         }
 
         return url;
-    };
+    }
 
     return joinUrls;
 });

--- a/Source/Core/loadArrayBuffer.js
+++ b/Source/Core/loadArrayBuffer.js
@@ -28,13 +28,13 @@ define([
      *     // an error occurred
      * });
      */
-    var loadArrayBuffer = function(url, headers) {
+    function loadArrayBuffer(url, headers) {
         return loadWithXhr({
             url : url,
             responseType : 'arraybuffer',
             headers : headers
         });
-    };
+    }
 
     return loadArrayBuffer;
 });

--- a/Source/Core/loadBlob.js
+++ b/Source/Core/loadBlob.js
@@ -28,13 +28,13 @@ define([
      *     // an error occurred
      * });
      */
-    var loadBlob = function(url, headers) {
+    function loadBlob(url, headers) {
         return loadWithXhr({
             url : url,
             responseType : 'blob',
             headers : headers
         });
-    };
+    }
 
     return loadBlob;
 });

--- a/Source/Core/loadImage.js
+++ b/Source/Core/loadImage.js
@@ -43,7 +43,7 @@ define([
      *     // images is an array containing all the loaded images
      * });
      */
-    var loadImage = function(url, allowCrossOrigin) {
+    function loadImage(url, allowCrossOrigin) {
         //>>includeStart('debug', pragmas.debug);
         if (!defined(url)) {
             throw new DeveloperError('url is required.');
@@ -68,7 +68,7 @@ define([
 
             return deferred.promise;
         });
-    };
+    }
 
     // This is broken out into a separate function so that it can be mocked for testing purposes.
     loadImage.createImage = function(url, crossOrigin, deferred) {

--- a/Source/Core/loadImageFromTypedArray.js
+++ b/Source/Core/loadImageFromTypedArray.js
@@ -14,7 +14,7 @@ define([
     /**
      * @private
      */
-    var loadImageFromTypedArray = function(uint8Array, format) {
+    function loadImageFromTypedArray(uint8Array, format) {
         //>>includeStart('debug', pragmas.debug);
         if (!defined(uint8Array)) {
             throw new DeveloperError('uint8Array is required.');
@@ -37,7 +37,7 @@ define([
             window.URL.revokeObjectURL(blobUrl);
             return when.reject(error);
         });
-    };
+    }
 
     return loadImageFromTypedArray;
 });

--- a/Source/Core/loadImageViaBlob.js
+++ b/Source/Core/loadImageViaBlob.js
@@ -45,7 +45,7 @@ define([
      *     // images is an array containing all the loaded images
      * });
      */
-    var loadImageViaBlob = function(url) {
+    function loadImageViaBlob(url) {
         if (dataUriRegex.test(url)) {
             return loadImage(url);
         }
@@ -62,7 +62,7 @@ define([
                 return when.reject(error);
             });
         });
-    };
+    }
 
     var xhrBlobSupported = (function() {
         try {

--- a/Source/Core/loadJson.js
+++ b/Source/Core/loadJson.js
@@ -43,7 +43,7 @@ define([
      *     // an error occurred
      * });
      */
-    var loadJson = function loadJson(url, headers) {
+    function loadJson(url, headers) {
         //>>includeStart('debug', pragmas.debug);
         if (!defined(url)) {
             throw new DeveloperError('url is required.');
@@ -61,7 +61,7 @@ define([
         return loadText(url, headers).then(function(value) {
             return JSON.parse(value);
         });
-    };
+    }
 
     return loadJson;
 });

--- a/Source/Core/loadJsonp.js
+++ b/Source/Core/loadJsonp.js
@@ -41,7 +41,7 @@ define([
      *     // an error occurred
      * });
      */
-    var loadJsonp = function(url, options) {
+    function loadJsonp(url, options) {
         //>>includeStart('debug', pragmas.debug);
         if (!defined(url)) {
             throw new DeveloperError('url is required.');
@@ -92,7 +92,7 @@ define([
         loadJsonp.loadAndExecuteScript(url, functionName, deferred);
 
         return deferred.promise;
-    };
+    }
 
     // This is broken out into a separate function so that it can be mocked for testing purposes.
     loadJsonp.loadAndExecuteScript = function(url, functionName, deferred) {

--- a/Source/Core/loadText.js
+++ b/Source/Core/loadText.js
@@ -31,12 +31,12 @@ define([
      *     // an error occurred
      * });
      */
-    var loadText = function(url, headers) {
+    function loadText(url, headers) {
         return loadWithXhr({
             url : url,
             headers : headers
         });
-    };
+    }
 
     return loadText;
 });

--- a/Source/Core/loadWithXhr.js
+++ b/Source/Core/loadWithXhr.js
@@ -50,7 +50,7 @@ define([
      *     // an error occurred
      * });
      */
-    var loadWithXhr = function(options) {
+    function loadWithXhr(options) {
         options = defaultValue(options, defaultValue.EMPTY_OBJECT);
 
         //>>includeStart('debug', pragmas.debug);
@@ -72,7 +72,7 @@ define([
 
             return deferred.promise;
         });
-    };
+    }
 
     var dataUriRegex = /^data:(.*?)(;base64)?,(.*)$/;
 

--- a/Source/Core/loadXML.js
+++ b/Source/Core/loadXML.js
@@ -31,14 +31,14 @@ define([
      *     // an error occurred
      * });
      */
-    var loadXML = function(url, headers) {
+    function loadXML(url, headers) {
         return loadWithXhr({
             url : url,
             responseType : 'document',
             headers : headers,
             overrideMimeType : 'text/xml'
         });
-    };
+    }
 
     return loadXML;
 });

--- a/Source/Core/mergeSort.js
+++ b/Source/Core/mergeSort.js
@@ -71,7 +71,7 @@ define([
      *     return Cesium.BoundingSphere.distanceSquaredTo(b, position) - Cesium.BoundingSphere.distanceSquaredTo(a, position);
      * }, position);
      */
-    var mergeSort = function(array, comparator, userDefinedObject) {
+    function mergeSort(array, comparator, userDefinedObject) {
         //>>includeStart('debug', pragmas.debug);
         if (!defined(array)) {
             throw new DeveloperError('array is required.');
@@ -93,7 +93,7 @@ define([
         // trim scratch arrays
         leftScratchArray.length = 0;
         rightScratchArray.length = 0;
-    };
+    }
 
     /**
      * A function used to compare two items while performing a merge sort.

--- a/Source/Core/objectToQuery.js
+++ b/Source/Core/objectToQuery.js
@@ -29,7 +29,7 @@ define([
      * // str will be:
      * // 'key1=some%20value&key2=a%2Fb&key3=x&key3=y'
      */
-    var objectToQuery = function(obj) {
+    function objectToQuery(obj) {
         //>>includeStart('debug', pragmas.debug);
         if (!defined(obj)) {
             throw new DeveloperError('obj is required.');
@@ -60,7 +60,7 @@ define([
         // https://github.com/AnalyticalGraphicsInc/cesium/issues/2192
 
         return result;
-    };
+    }
 
     return objectToQuery;
 });

--- a/Source/Core/parseResponseHeaders.js
+++ b/Source/Core/parseResponseHeaders.js
@@ -15,7 +15,7 @@ define([], function() {
      * 
      * @private
      */
-    var parseResponseHeaders = function(headerString) {
+    function parseResponseHeaders(headerString) {
         var headers = {};
 
         if (!headerString) {
@@ -37,7 +37,7 @@ define([], function() {
         }
 
         return headers;
-    };
+    }
 
     return parseResponseHeaders;
 });

--- a/Source/Core/pointInsideTriangle.js
+++ b/Source/Core/pointInsideTriangle.js
@@ -28,10 +28,10 @@ define([
      *   new Cesium.Cartesian2(1.0, 0.0),
      *   new Cesium.Cartesian2(0.0, 1.0));
      */
-    var pointInsideTriangle = function(point, p0, p1, p2) {
+    function pointInsideTriangle(point, p0, p1, p2) {
         barycentricCoordinates(point, p0, p1, p2, coords);
         return (coords.x > 0.0) && (coords.y > 0.0) && (coords.z > 0);
-    };
+    }
 
     return pointInsideTriangle;
 });

--- a/Source/Core/queryToObject.js
+++ b/Source/Core/queryToObject.js
@@ -29,7 +29,7 @@ define([
      * //   key3 : ['x', 'y']
      * // }
      */
-    var queryToObject = function(queryString) {
+    function queryToObject(queryString) {
         //>>includeStart('debug', pragmas.debug);
         if (!defined(queryString)) {
             throw new DeveloperError('queryString is required.');
@@ -63,7 +63,7 @@ define([
             }
         }
         return result;
-    };
+    }
 
     return queryToObject;
 });

--- a/Source/Core/requestAnimationFrame.js
+++ b/Source/Core/requestAnimationFrame.js
@@ -64,12 +64,12 @@ define([
      * }
      * tick();
      */
-    var requestAnimationFrame = function(callback) {
+    function requestAnimationFrame(callback) {
         // we need this extra wrapper function because the native requestAnimationFrame
         // functions must be invoked on the global scope (window), which is not the case
         // if invoked as Cesium.requestAnimationFrame(callback)
         return implementation(callback);
-    };
+    }
 
     /**
      * A function that will be called when the next frame should be drawn.

--- a/Source/Core/sampleTerrain.js
+++ b/Source/Core/sampleTerrain.js
@@ -43,7 +43,7 @@ define([
      *     // updatedPositions is just a reference to positions.
      * });
      */
-    var sampleTerrain = function(terrainProvider, level, positions) {
+    function sampleTerrain(terrainProvider, level, positions) {
         //>>includeStart('debug', pragmas.debug);
         if (!defined(terrainProvider)) {
             throw new DeveloperError('terrainProvider is required.');
@@ -71,7 +71,7 @@ define([
         doSamplingWhenReady();
 
         return deferred.promise;
-    };
+    }
 
     function doSampling(terrainProvider, level, positions) {
         var tilingScheme = terrainProvider.tilingScheme;

--- a/Source/Core/scaleToGeodeticSurface.js
+++ b/Source/Core/scaleToGeodeticSurface.js
@@ -30,7 +30,7 @@ define([
      *
      * @private
      */
-    var scaleToGeodeticSurface = function(cartesian, oneOverRadii, oneOverRadiiSquared, centerToleranceSquared, result) {
+    function scaleToGeodeticSurface(cartesian, oneOverRadii, oneOverRadiiSquared, centerToleranceSquared, result) {
         //>>includeStart('debug', pragmas.debug);
         if (!defined(cartesian)) {
             throw new DeveloperError('cartesian is required.');
@@ -130,7 +130,7 @@ define([
         result.y = positionY * yMultiplier;
         result.z = positionZ * zMultiplier;
         return result;
-    };
+    }
 
     return scaleToGeodeticSurface;
 });

--- a/Source/Core/subdivideArray.js
+++ b/Source/Core/subdivideArray.js
@@ -17,7 +17,7 @@ define([
      *
      * @exception {DeveloperError} numberOfArrays must be greater than 0.
      */
-    var subdivideArray = function(array, numberOfArrays) {
+    function subdivideArray(array, numberOfArrays) {
         //>>includeStart('debug', pragmas.debug);
         if (!defined(array)) {
             throw new DeveloperError('array is required.');
@@ -37,7 +37,7 @@ define([
             i += size;
         }
         return result;
-    };
+    }
 
     return subdivideArray;
 });

--- a/Source/Core/throttleRequestByServer.js
+++ b/Source/Core/throttleRequestByServer.js
@@ -41,7 +41,7 @@ define([
      * @example
      * // throttle requests for an image
      * var url = 'http://madeupserver.example.com/myImage.png';
-     * var requestFunction = function(url) {
+     * function requestFunction(url) {
      *   // in this simple example, loadImage could be used directly as requestFunction.
      *   return Cesium.loadImage(url);
      * };
@@ -54,7 +54,7 @@ define([
      *   });
      * }
      */
-    var throttleRequestByServer = function(url, requestFunction) {
+    function throttleRequestByServer(url, requestFunction) {
         var server = getServer(url);
 
         var activeRequestsForServer = defaultValue(activeRequests[server], 0);
@@ -71,7 +71,7 @@ define([
             activeRequests[server]--;
             return when.reject(error);
         });
-    };
+    }
 
     /**
      * Specifies the maximum number of requests that can be simultaneously open to a single server.  If this value is higher than

--- a/Source/Core/wrapFunction.js
+++ b/Source/Core/wrapFunction.js
@@ -12,7 +12,7 @@ define([
      *
      * @private
      */
-    var wrapFunction = function(obj, oldFunction, newFunction) {
+    function wrapFunction(obj, oldFunction, newFunction) {
         //>>includeStart('debug', pragmas.debug);
         if (typeof oldFunction !== 'function') {
             throw new DeveloperError("oldFunction is required to be a function.");
@@ -27,7 +27,7 @@ define([
             newFunction.apply(obj, arguments);
             oldFunction.apply(obj, arguments);
         };
-    };
+    }
 
     return wrapFunction;
 });

--- a/Source/Core/writeTextToCanvas.js
+++ b/Source/Core/writeTextToCanvas.js
@@ -32,7 +32,7 @@ define([
      *                   from measureText will also be added to the returned canvas. If text is
      *                   blank, returns undefined.
      */
-    var writeTextToCanvas = function(text, options) {
+    function writeTextToCanvas(text, options) {
         //>>includeStart('debug', pragmas.debug);
         if (!defined(text)) {
             throw new DeveloperError('text is required.');
@@ -112,7 +112,7 @@ define([
         }
 
         return canvas;
-    };
+    }
 
     return writeTextToCanvas;
 });

--- a/Source/DataSources/BillboardGraphics.js
+++ b/Source/DataSources/BillboardGraphics.js
@@ -48,7 +48,7 @@ define([
      *
      * @demo {@link http://cesiumjs.org/Cesium/Apps/Sandcastle/index.html?src=Billboards.html|Cesium Sandcastle Billboard Demo}
      */
-    var BillboardGraphics = function(options) {
+    function BillboardGraphics(options) {
         this._image = undefined;
         this._imageSubscription = undefined;
         this._imageSubRegion = undefined;
@@ -86,7 +86,7 @@ define([
         this._definitionChanged = new Event();
 
         this.merge(defaultValue(options, defaultValue.EMPTY_OBJECT));
-    };
+    }
 
     defineProperties(BillboardGraphics.prototype, {
         /**

--- a/Source/DataSources/BillboardVisualizer.js
+++ b/Source/DataSources/BillboardVisualizer.js
@@ -50,11 +50,11 @@ define([
     var pixelOffsetScaleByDistance = new NearFarScalar();
     var boundingRectangle = new BoundingRectangle();
 
-    var EntityData = function(entity) {
+    function EntityData(entity) {
         this.entity = entity;
         this.billboard = undefined;
         this.textureValue = undefined;
-    };
+    }
 
     /**
      * A {@link Visualizer} which maps {@link Entity#billboard} to a {@link Billboard}.
@@ -64,7 +64,7 @@ define([
      * @param {Scene} scene The scene the primitives will be rendered in.
      * @param {EntityCollection} entityCollection The entityCollection to visualize.
      */
-    var BillboardVisualizer = function(scene, entityCollection) {
+    function BillboardVisualizer(scene, entityCollection) {
         //>>includeStart('debug', pragmas.debug);
         if (!defined(scene)) {
             throw new DeveloperError('scene is required.');
@@ -82,7 +82,7 @@ define([
         this._entityCollection = entityCollection;
         this._items = new AssociativeArray();
         this._onCollectionChanged(entityCollection, entityCollection.values, [], []);
-    };
+    }
 
     /**
      * Updates the primitives created by this visualizer to match their

--- a/Source/DataSources/BoxGeometryUpdater.js
+++ b/Source/DataSources/BoxGeometryUpdater.js
@@ -52,11 +52,11 @@ define([
     var defaultOutlineColor = new ConstantProperty(Color.BLACK);
     var scratchColor = new Color();
 
-    var GeometryOptions = function(entity) {
+    function GeometryOptions(entity) {
         this.id = entity;
         this.vertexFormat = undefined;
         this.dimensions = undefined;
-    };
+    }
 
     /**
      * A {@link GeometryUpdater} for boxes.
@@ -67,7 +67,7 @@ define([
      * @param {Entity} entity The entity containing the geometry to be visualized.
      * @param {Scene} scene The scene where visualization is taking place.
      */
-    var BoxGeometryUpdater = function(entity, scene) {
+    function BoxGeometryUpdater(entity, scene) {
         //>>includeStart('debug', pragmas.debug);
         if (!defined(entity)) {
             throw new DeveloperError('entity is required');
@@ -92,7 +92,7 @@ define([
         this._outlineWidth = 1.0;
         this._options = new GeometryOptions(entity);
         this._onEntityPropertyChanged(entity, 'box', entity.box, undefined);
-    };
+    }
 
     defineProperties(BoxGeometryUpdater, {
         /**
@@ -485,14 +485,13 @@ define([
     /**
      * @private
      */
-    var DynamicGeometryUpdater = function(primitives, geometryUpdater) {
+    function DynamicGeometryUpdater(primitives, geometryUpdater) {
         this._primitives = primitives;
         this._primitive = undefined;
         this._outlinePrimitive = undefined;
         this._geometryUpdater = geometryUpdater;
         this._options = new GeometryOptions(geometryUpdater._entity);
-    };
-
+    }
     DynamicGeometryUpdater.prototype.update = function(time) {
         //>>includeStart('debug', pragmas.debug);
         if (!defined(time)) {

--- a/Source/DataSources/BoxGraphics.js
+++ b/Source/DataSources/BoxGraphics.js
@@ -34,7 +34,7 @@ define([
      *
      * @demo {@link http://cesiumjs.org/Cesium/Apps/Sandcastle/index.html?src=Box.html|Cesium Sandcastle Box Demo}
      */
-    var BoxGraphics = function(options) {
+    function BoxGraphics(options) {
         this._dimensions = undefined;
         this._dimensionsSubscription = undefined;
         this._show = undefined;
@@ -52,7 +52,7 @@ define([
         this._definitionChanged = new Event();
 
         this.merge(defaultValue(options, defaultValue.EMPTY_OBJECT));
-    };
+    }
 
     defineProperties(BoxGraphics.prototype, {
         /**

--- a/Source/DataSources/CallbackProperty.js
+++ b/Source/DataSources/CallbackProperty.js
@@ -20,12 +20,12 @@ define([
      * @param {CallbackProperty~Callback} callback The function to be called when the property is evaluated.
      * @param {Boolean} isConstant <code>true</code> when the callback function returns the same value every time, <code>false</code> if the value will change.
      */
-    var CallbackProperty = function(callback, isConstant) {
+    function CallbackProperty(callback, isConstant) {
         this._callback = undefined;
         this._isConstant = undefined;
         this._definitionChanged = new Event();
         this.setCallback(callback, isConstant);
-    };
+    }
 
     defineProperties(CallbackProperty.prototype, {
         /**

--- a/Source/DataSources/CheckerboardMaterialProperty.js
+++ b/Source/DataSources/CheckerboardMaterialProperty.js
@@ -33,7 +33,7 @@ define([
      * @param {Property} [options.oddColor=Color.BLACK] A Property specifying the second {@link Color}.
      * @param {Property} [options.repeat=new Cartesian2(2.0, 2.0)] A {@link Cartesian2} Property specifying how many times the tiles repeat in each direction.
      */
-    var CheckerboardMaterialProperty = function(options) {
+    function CheckerboardMaterialProperty(options) {
         options = defaultValue(options, defaultValue.EMPTY_OBJECT);
 
         this._definitionChanged = new Event();
@@ -50,7 +50,7 @@ define([
         this.evenColor = options.evenColor;
         this.oddColor = options.oddColor;
         this.repeat = options.repeat;
-    };
+    }
 
     defineProperties(CheckerboardMaterialProperty.prototype, {
         /**

--- a/Source/DataSources/ColorMaterialProperty.js
+++ b/Source/DataSources/ColorMaterialProperty.js
@@ -27,12 +27,12 @@ define([
      * @alias ColorMaterialProperty
      * @constructor
      */
-    var ColorMaterialProperty = function(color) {
+    function ColorMaterialProperty(color) {
         this._definitionChanged = new Event();
         this._color = undefined;
         this._colorSubscription = undefined;
         this.color = color;
-    };
+    }
 
     defineProperties(ColorMaterialProperty.prototype, {
         /**

--- a/Source/DataSources/CompositeEntityCollection.js
+++ b/Source/DataSources/CompositeEntityCollection.js
@@ -126,7 +126,7 @@ define([
      *
      * @param {EntityCollection[]} [collections] The initial list of EntityCollection instances to merge.
      */
-    var CompositeEntityCollection = function(collections) {
+    function CompositeEntityCollection(collections) {
         this._composite = new EntityCollection(this);
         this._suspendCount = 0;
         this._collections = defined(collections) ? collections.slice() : [];
@@ -135,7 +135,7 @@ define([
         this._eventHash = {};
         recomposite(this);
         this._shouldRecomposite = false;
-    };
+    }
 
     defineProperties(CompositeEntityCollection.prototype, {
         /**

--- a/Source/DataSources/CompositeMaterialProperty.js
+++ b/Source/DataSources/CompositeMaterialProperty.js
@@ -21,11 +21,11 @@ define([
      * @alias CompositeMaterialProperty
      * @constructor
      */
-    var CompositeMaterialProperty = function() {
+    function CompositeMaterialProperty() {
         this._definitionChanged = new Event();
         this._composite = new CompositeProperty();
         this._composite.definitionChanged.addEventListener(CompositeMaterialProperty.prototype._raiseDefinitionChanged, this);
-    };
+    }
 
     defineProperties(CompositeMaterialProperty.prototype, {
         /**

--- a/Source/DataSources/CompositePositionProperty.js
+++ b/Source/DataSources/CompositePositionProperty.js
@@ -25,12 +25,12 @@ define([
      * @alias CompositePositionProperty
      * @constructor
      */
-    var CompositePositionProperty = function(referenceFrame) {
+    function CompositePositionProperty(referenceFrame) {
         this._referenceFrame = defaultValue(referenceFrame, ReferenceFrame.FIXED);
         this._definitionChanged = new Event();
         this._composite = new CompositeProperty();
         this._composite.definitionChanged.addEventListener(CompositePositionProperty.prototype._raiseDefinitionChanged, this);
-    };
+    }
 
     defineProperties(CompositePositionProperty.prototype, {
         /**

--- a/Source/DataSources/CompositeProperty.js
+++ b/Source/DataSources/CompositeProperty.js
@@ -18,10 +18,9 @@ define([
     "use strict";
 
     function subscribeAll(property, eventHelper, definitionChanged, intervals) {
-        var callback = function() {
+        function callback() {
             definitionChanged.raiseEvent(property);
-        };
-
+        }
         var items = [];
         eventHelper.removeAll();
         var length = intervals.length;
@@ -64,12 +63,12 @@ define([
      *     data : sampledProperty
      * }));
      */
-    var CompositeProperty = function() {
+    function CompositeProperty() {
         this._eventHelper = new EventHelper();
         this._definitionChanged = new Event();
         this._intervals = new TimeIntervalCollection();
         this._intervals.changedEvent.addEventListener(CompositeProperty.prototype._intervalsChanged, this);
-    };
+    }
 
     defineProperties(CompositeProperty.prototype, {
         /**

--- a/Source/DataSources/ConstantPositionProperty.js
+++ b/Source/DataSources/ConstantPositionProperty.js
@@ -29,11 +29,11 @@ define([
      * @param {Cartesian3} [value] The property value.
      * @param {ReferenceFrame} [referenceFrame=ReferenceFrame.FIXED] The reference frame in which the position is defined.
      */
-    var ConstantPositionProperty = function(value, referenceFrame) {
+    function ConstantPositionProperty(value, referenceFrame) {
         this._definitionChanged = new Event();
         this._value = Cartesian3.clone(value);
         this._referenceFrame = defaultValue(referenceFrame, ReferenceFrame.FIXED);
-    };
+    }
 
     defineProperties(ConstantPositionProperty.prototype, {
         /**

--- a/Source/DataSources/ConstantProperty.js
+++ b/Source/DataSources/ConstantProperty.js
@@ -26,13 +26,13 @@ define([
      * @exception {DeveloperError} value.clone is a required function.
      * @exception {DeveloperError} value.equals is a required function.
      */
-    var ConstantProperty = function(value) {
+    function ConstantProperty(value) {
         this._value = undefined;
         this._hasClone = false;
         this._hasEquals = false;
         this._definitionChanged = new Event();
         this.setValue(value);
-    };
+    }
 
     defineProperties(ConstantProperty.prototype, {
         /**

--- a/Source/DataSources/CorridorGeometryUpdater.js
+++ b/Source/DataSources/CorridorGeometryUpdater.js
@@ -52,7 +52,7 @@ define([
     var defaultOutlineColor = new ConstantProperty(Color.BLACK);
     var scratchColor = new Color();
 
-    var GeometryOptions = function(entity) {
+    function GeometryOptions(entity) {
         this.id = entity;
         this.vertexFormat = undefined;
         this.positions = undefined;
@@ -61,7 +61,7 @@ define([
         this.height = undefined;
         this.extrudedHeight = undefined;
         this.granularity = undefined;
-    };
+    }
 
     /**
      * A {@link GeometryUpdater} for corridors.
@@ -72,7 +72,7 @@ define([
      * @param {Entity} entity The entity containing the geometry to be visualized.
      * @param {Scene} scene The scene where visualization is taking place.
      */
-    var CorridorGeometryUpdater = function(entity, scene) {
+    function CorridorGeometryUpdater(entity, scene) {
         //>>includeStart('debug', pragmas.debug);
         if (!defined(entity)) {
             throw new DeveloperError('entity is required');
@@ -98,7 +98,7 @@ define([
         this._outlineWidth = 1.0;
         this._options = new GeometryOptions(entity);
         this._onEntityPropertyChanged(entity, 'corridor', entity.corridor, undefined);
-    };
+    }
 
     defineProperties(CorridorGeometryUpdater, {
         /**
@@ -505,14 +505,13 @@ define([
     /**
      * @private
      */
-    var DynamicGeometryUpdater = function(primitives, geometryUpdater) {
+    function DynamicGeometryUpdater(primitives, geometryUpdater) {
         this._primitives = primitives;
         this._primitive = undefined;
         this._outlinePrimitive = undefined;
         this._geometryUpdater = geometryUpdater;
         this._options = new GeometryOptions(geometryUpdater._entity);
-    };
-
+    }
     DynamicGeometryUpdater.prototype.update = function(time) {
         //>>includeStart('debug', pragmas.debug);
         if (!defined(time)) {

--- a/Source/DataSources/CorridorGraphics.js
+++ b/Source/DataSources/CorridorGraphics.js
@@ -42,7 +42,7 @@ define([
      * @see Entity
      * @demo {@link http://cesiumjs.org/Cesium/Apps/Sandcastle/index.html?src=Corridor.html|Cesium Sandcastle Corridor Demo}
      */
-    var CorridorGraphics = function(options) {
+    function CorridorGraphics(options) {
         this._show = undefined;
         this._showSubscription = undefined;
         this._material = undefined;
@@ -70,7 +70,7 @@ define([
         this._definitionChanged = new Event();
 
         this.merge(defaultValue(options, defaultValue.EMPTY_OBJECT));
-    };
+    }
 
     defineProperties(CorridorGraphics.prototype, {
         /**

--- a/Source/DataSources/CustomDataSource.js
+++ b/Source/DataSources/CustomDataSource.js
@@ -31,7 +31,7 @@ define([
      *
      * viewer.dataSources.add(dataSource);
      */
-    var CustomDataSource = function(name) {
+    function CustomDataSource(name) {
         this._name = name;
         this._clock = undefined;
         this._changed = new Event();
@@ -39,7 +39,7 @@ define([
         this._isLoading = false;
         this._loading = new Event();
         this._entityCollection = new EntityCollection(this);
-    };
+    }
 
     defineProperties(CustomDataSource.prototype, {
         /**

--- a/Source/DataSources/CylinderGeometryUpdater.js
+++ b/Source/DataSources/CylinderGeometryUpdater.js
@@ -55,7 +55,7 @@ define([
 
     var scratchColor = new Color();
 
-    var GeometryOptions = function(entity) {
+    function GeometryOptions(entity) {
         this.id = entity;
         this.vertexFormat = undefined;
         this.length = undefined;
@@ -63,7 +63,7 @@ define([
         this.bottomRadius = undefined;
         this.slices = undefined;
         this.numberOfVerticalLines = undefined;
-    };
+    }
 
     /**
      * A {@link GeometryUpdater} for cylinders.
@@ -74,7 +74,7 @@ define([
      * @param {Entity} entity The entity containing the geometry to be visualized.
      * @param {Scene} scene The scene where visualization is taking place.
      */
-    var CylinderGeometryUpdater = function(entity, scene) {
+    function CylinderGeometryUpdater(entity, scene) {
         //>>includeStart('debug', pragmas.debug);
         if (!defined(entity)) {
             throw new DeveloperError('entity is required');
@@ -99,7 +99,7 @@ define([
         this._outlineWidth = 1.0;
         this._options = new GeometryOptions(entity);
         this._onEntityPropertyChanged(entity, 'cylinder', entity.cylinder, undefined);
-    };
+    }
 
     defineProperties(CylinderGeometryUpdater, {
         /**
@@ -505,14 +505,13 @@ define([
     /**
      * @private
      */
-    var DynamicGeometryUpdater = function(primitives, geometryUpdater) {
+    function DynamicGeometryUpdater(primitives, geometryUpdater) {
         this._primitives = primitives;
         this._primitive = undefined;
         this._outlinePrimitive = undefined;
         this._geometryUpdater = geometryUpdater;
         this._options = new GeometryOptions(geometryUpdater._entity);
-    };
-
+    }
     DynamicGeometryUpdater.prototype.update = function(time) {
         //>>includeStart('debug', pragmas.debug);
         if (!defined(time)) {

--- a/Source/DataSources/CylinderGraphics.js
+++ b/Source/DataSources/CylinderGraphics.js
@@ -39,7 +39,7 @@ define([
      *
      * @demo {@link http://cesiumjs.org/Cesium/Apps/Sandcastle/index.html?src=Cylinder.html|Cesium Sandcastle Cylinder Demo}
      */
-    var CylinderGraphics = function(options) {
+    function CylinderGraphics(options) {
         this._length = undefined;
         this._lengthSubscription = undefined;
         this._topRadius = undefined;
@@ -65,7 +65,8 @@ define([
         this._definitionChanged = new Event();
 
         this.merge(defaultValue(options, defaultValue.EMPTY_OBJECT));
-    };
+    }
+
     defineProperties(CylinderGraphics.prototype, {
         /**
          * Gets the event that is raised whenever a property or sub-property is changed or modified.

--- a/Source/DataSources/CzmlDataSource.js
+++ b/Source/DataSources/CzmlDataSource.js
@@ -1499,10 +1499,10 @@ define([
         return dataSource;
     }
 
-    var DocumentPacket = function() {
+    function DocumentPacket() {
         this.name = undefined;
         this.clock = undefined;
-    };
+    }
 
     /**
      * A {@link DataSource} which processes {@link https://github.com/AnalyticalGraphicsInc/cesium/wiki/CZML-Guide|CZML}.
@@ -1513,7 +1513,7 @@ define([
      *
      * @demo {@link http://cesiumjs.org/Cesium/Apps/Sandcastle/index.html?src=CZML.html|Cesium Sandcastle CZML Demo}
      */
-    var CzmlDataSource = function(name) {
+    function CzmlDataSource(name) {
         this._name = name;
         this._changed = new Event();
         this._error = new Event();
@@ -1523,7 +1523,7 @@ define([
         this._documentPacket = new DocumentPacket();
         this._version = undefined;
         this._entityCollection = new EntityCollection(this);
-    };
+    }
 
     /**
      * Creates a Promise to a new instance loaded with the provided CZML data.

--- a/Source/DataSources/DataSource.js
+++ b/Source/DataSources/DataSource.js
@@ -17,9 +17,9 @@ define([
      * @see Entity
      * @see DataSourceDisplay
      */
-    var DataSource = function() {
+    function DataSource() {
         DeveloperError.throwInstantiationError();
-    };
+    }
 
     defineProperties(DataSource.prototype, {
         /**

--- a/Source/DataSources/DataSourceClock.js
+++ b/Source/DataSources/DataSourceClock.js
@@ -25,7 +25,7 @@ define([
      * @alias DataSourceClock
      * @constructor
      */
-    var DataSourceClock = function() {
+    function DataSourceClock() {
         this._startTime = undefined;
         this._stopTime = undefined;
         this._currentTime = undefined;
@@ -33,7 +33,7 @@ define([
         this._clockStep = undefined;
         this._multiplier = undefined;
         this._definitionChanged = new Event();
-    };
+    }
 
     defineProperties(DataSourceClock.prototype, {
         /**

--- a/Source/DataSources/DataSourceCollection.js
+++ b/Source/DataSources/DataSourceCollection.js
@@ -22,11 +22,11 @@ define([
      * @alias DataSourceCollection
      * @constructor
      */
-    var DataSourceCollection = function() {
+    function DataSourceCollection() {
         this._dataSources = [];
         this._dataSourceAdded = new Event();
         this._dataSourceRemoved = new Event();
-    };
+    }
 
     defineProperties(DataSourceCollection.prototype, {
         /**

--- a/Source/DataSources/DataSourceDisplay.js
+++ b/Source/DataSources/DataSourceDisplay.js
@@ -65,7 +65,7 @@ define([
      *        A function which creates an array of visualizers used for visualization.
      *        If undefined, all standard visualizers are used.
      */
-    var DataSourceDisplay = function(options) {
+    function DataSourceDisplay(options) {
         //>>includeStart('debug', pragmas.debug);
         if (!defined(options)) {
             throw new DeveloperError('options is required.');
@@ -96,7 +96,7 @@ define([
         var defaultDataSource = new CustomDataSource();
         this._onDataSourceAdded(undefined, defaultDataSource);
         this._defaultDataSource = defaultDataSource;
-    };
+    }
 
     /**
      * Gets or sets the default function which creates an array of visualizers used for visualization.

--- a/Source/DataSources/DynamicGeometryUpdater.js
+++ b/Source/DataSources/DynamicGeometryUpdater.js
@@ -17,9 +17,9 @@ define([
      * @alias DynamicGeometryUpdater
      * @constructor
      */
-    var DynamicGeometryUpdater = function() {
+    function DynamicGeometryUpdater() {
         DeveloperError.throwInstantiationError();
-    };
+    }
 
     /**
      * Updates the geometry to the specified time.

--- a/Source/DataSources/EllipseGeometryUpdater.js
+++ b/Source/DataSources/EllipseGeometryUpdater.js
@@ -52,7 +52,7 @@ define([
     var defaultOutlineColor = new ConstantProperty(Color.BLACK);
     var scratchColor = new Color();
 
-    var GeometryOptions = function(entity) {
+    function GeometryOptions(entity) {
         this.id = entity;
         this.vertexFormat = undefined;
         this.center = undefined;
@@ -64,7 +64,7 @@ define([
         this.granularity = undefined;
         this.stRotation = undefined;
         this.numberOfVerticalLines = undefined;
-    };
+    }
 
     /**
      * A {@link GeometryUpdater} for ellipses.
@@ -75,7 +75,7 @@ define([
      * @param {Entity} entity The entity containing the geometry to be visualized.
      * @param {Scene} scene The scene where visualization is taking place.
      */
-    var EllipseGeometryUpdater = function(entity, scene) {
+    function EllipseGeometryUpdater(entity, scene) {
         //>>includeStart('debug', pragmas.debug);
         if (!defined(entity)) {
             throw new DeveloperError('entity is required');
@@ -101,7 +101,7 @@ define([
         this._outlineWidth = 1.0;
         this._options = new GeometryOptions(entity);
         this._onEntityPropertyChanged(entity, 'ellipse', entity.ellipse, undefined);
-    };
+    }
 
     defineProperties(EllipseGeometryUpdater, {
         /**
@@ -517,14 +517,13 @@ define([
     /**
      * @private
      */
-    var DynamicGeometryUpdater = function(primitives, geometryUpdater) {
+    function DynamicGeometryUpdater(primitives, geometryUpdater) {
         this._primitives = primitives;
         this._primitive = undefined;
         this._outlinePrimitive = undefined;
         this._geometryUpdater = geometryUpdater;
         this._options = new GeometryOptions(geometryUpdater._entity);
-    };
-
+    }
     DynamicGeometryUpdater.prototype.update = function(time) {
         //>>includeStart('debug', pragmas.debug);
         if (!defined(time)) {

--- a/Source/DataSources/EllipseGraphics.js
+++ b/Source/DataSources/EllipseGraphics.js
@@ -44,7 +44,7 @@ define([
      *
      * @demo {@link http://cesiumjs.org/Cesium/Apps/Sandcastle/index.html?src=Circles and Ellipses.html|Cesium Sandcastle Circles and Ellipses Demo}
      */
-    var EllipseGraphics = function(options) {
+    function EllipseGraphics(options) {
         this._semiMajorAxis = undefined;
         this._semiMajorAxisSubscription = undefined;
         this._semiMinorAxis = undefined;
@@ -76,7 +76,7 @@ define([
         this._definitionChanged = new Event();
 
         this.merge(defaultValue(options, defaultValue.EMPTY_OBJECT));
-    };
+    }
 
     defineProperties(EllipseGraphics.prototype, {
         /**

--- a/Source/DataSources/EllipsoidGeometryUpdater.js
+++ b/Source/DataSources/EllipsoidGeometryUpdater.js
@@ -61,14 +61,14 @@ define([
     var scratchColor = new Color();
     var unitSphere = new Cartesian3(1, 1, 1);
 
-    var GeometryOptions = function(entity) {
+    function GeometryOptions(entity) {
         this.id = entity;
         this.vertexFormat = undefined;
         this.radii = undefined;
         this.stackPartitions = undefined;
         this.slicePartitions = undefined;
         this.subdivisions = undefined;
-    };
+    }
 
     /**
      * A {@link GeometryUpdater} for ellipsoids.
@@ -79,7 +79,7 @@ define([
      * @param {Entity} entity The entity containing the geometry to be visualized.
      * @param {Scene} scene The scene where visualization is taking place.
      */
-    var EllipsoidGeometryUpdater = function(entity, scene) {
+    function EllipsoidGeometryUpdater(entity, scene) {
         //>>includeStart('debug', pragmas.debug);
         if (!defined(entity)) {
             throw new DeveloperError('entity is required');
@@ -104,7 +104,7 @@ define([
         this._outlineWidth = 1.0;
         this._options = new GeometryOptions(entity);
         this._onEntityPropertyChanged(entity, 'ellipsoid', entity.ellipsoid, undefined);
-    };
+    }
 
     defineProperties(EllipsoidGeometryUpdater, {
         /**
@@ -507,7 +507,7 @@ define([
     /**
      * @private
      */
-    var DynamicGeometryUpdater = function(primitives, geometryUpdater) {
+    function DynamicGeometryUpdater(primitives, geometryUpdater) {
         this._entity = geometryUpdater._entity;
         this._scene = geometryUpdater._scene;
         this._primitives = primitives;
@@ -524,8 +524,7 @@ define([
         this._lastOutlineShow = undefined;
         this._lastOutlineWidth = undefined;
         this._lastOutlineColor = undefined;
-    };
-
+    }
     DynamicGeometryUpdater.prototype.update = function(time) {
         //>>includeStart('debug', pragmas.debug);
         if (!defined(time)) {

--- a/Source/DataSources/EllipsoidGraphics.js
+++ b/Source/DataSources/EllipsoidGraphics.js
@@ -37,7 +37,7 @@ define([
      *
      * @demo {@link http://cesiumjs.org/Cesium/Apps/Sandcastle/index.html?src=Spheres%20and%20Ellipsoids.html|Cesium Sandcastle Spheres and Ellipsoids Demo}
      */
-    var EllipsoidGraphics = function(options) {
+    function EllipsoidGraphics(options) {
         this._show = undefined;
         this._showSubscription = undefined;
         this._radii = undefined;
@@ -61,7 +61,7 @@ define([
         this._definitionChanged = new Event();
 
         this.merge(defaultValue(options, defaultValue.EMPTY_OBJECT));
-    };
+    }
 
     defineProperties(EllipsoidGraphics.prototype, {
         /**

--- a/Source/DataSources/Entity.js
+++ b/Source/DataSources/Entity.js
@@ -115,7 +115,7 @@ define([
      *
      * @see {@link http://cesiumjs.org/2015/02/02/Visualizing-Spatial-Data/|Visualizing Spatial Data}
      */
-    var Entity = function(options) {
+    function Entity(options) {
         options = defaultValue(options, defaultValue.EMPTY_OBJECT);
 
         var id = options.id;
@@ -181,7 +181,7 @@ define([
 
         this.parent = options.parent;
         this.merge(options);
-    };
+    }
 
     function updateShow(entity, children, isShowing) {
         var length = children.length;

--- a/Source/DataSources/EntityCollection.js
+++ b/Source/DataSources/EntityCollection.js
@@ -50,7 +50,7 @@ define([
      *
      * @param {DataSource|CompositeEntityCollection} [owner] The data source (or composite entity collection) which created this collection.
      */
-    var EntityCollection = function(owner) {
+    function EntityCollection(owner) {
         this._owner = owner;
         this._entities = new AssociativeArray();
         this._addedEntities = new AssociativeArray();
@@ -59,7 +59,7 @@ define([
         this._suspendCount = 0;
         this._collectionChanged = new Event();
         this._id = createGuid();
-    };
+    }
 
     /**
      * Prevents {@link EntityCollection#collectionChanged} events from being raised

--- a/Source/DataSources/EntityView.js
+++ b/Source/DataSources/EntityView.js
@@ -199,7 +199,7 @@ define([
      * @param {Ellipsoid} [ellipsoid=Ellipsoid.WGS84] The ellipsoid to use for orienting the camera.
      * @param {BoundingSphere} [boundingSphere] An initial bounding sphere for setting the default view.
      */
-    var EntityView = function(entity, scene, ellipsoid, boundingSphere) {
+    function EntityView(entity, scene, ellipsoid, boundingSphere) {
 
         /**
          * The entity to track with the camera.
@@ -235,7 +235,7 @@ define([
         this._defaultOffset3D = undefined;
 
         this._offset3D = new Cartesian3();
-    };
+    }
 
     // STATIC properties defined here, not per-instance.
     defineProperties(EntityView, {

--- a/Source/DataSources/GeoJsonDataSource.js
+++ b/Source/DataSources/GeoJsonDataSource.js
@@ -487,7 +487,7 @@ define([
      *   markerSymbol: '?'
      * }));
      */
-    var GeoJsonDataSource = function(name) {
+    function GeoJsonDataSource(name) {
         this._name = name;
         this._changed = new Event();
         this._error = new Event();
@@ -496,7 +496,7 @@ define([
         this._entityCollection = new EntityCollection(this);
         this._promises = [];
         this._pinBuilder = new PinBuilder();
-    };
+    }
 
     /**
      * Creates a Promise to a new instance loaded with the provided GeoJSON or TopoJSON data.

--- a/Source/DataSources/GeometryUpdater.js
+++ b/Source/DataSources/GeometryUpdater.js
@@ -27,9 +27,9 @@ define([
      * @see RectangleGeometryUpdater
      * @see WallGeometryUpdater
      */
-    var GeometryUpdater = function(entity, scene) {
+    function GeometryUpdater(entity, scene) {
         DeveloperError.throwInstantiationError();
-    };
+    }
 
     defineProperties(GeometryUpdater, {
         /**

--- a/Source/DataSources/GeometryVisualizer.js
+++ b/Source/DataSources/GeometryVisualizer.js
@@ -25,11 +25,10 @@ define([
 
     var emptyArray = [];
 
-    var DynamicGeometryBatch = function(primitives) {
+    function DynamicGeometryBatch(primitives) {
         this._primitives = primitives;
         this._dynamicUpdaters = new AssociativeArray();
-    };
-
+    }
     DynamicGeometryBatch.prototype.add = function(time, updater) {
         this._dynamicUpdaters.set(updater.entity.id, updater.createDynamicUpdater(this._primitives));
     };
@@ -112,7 +111,7 @@ define([
      * @param {Scene} scene The scene the primitives will be rendered in.
      * @param {EntityCollection} entityCollection The entityCollection to visualize.
      */
-    var GeometryVisualizer = function(type, scene, entityCollection) {
+    function GeometryVisualizer(type, scene, entityCollection) {
         //>>includeStart('debug', pragmas.debug);
         if (!defined(type)) {
             throw new DeveloperError('type is required.');
@@ -149,7 +148,7 @@ define([
         this._entityCollection = entityCollection;
         entityCollection.collectionChanged.addEventListener(GeometryVisualizer.prototype._onCollectionChanged, this);
         this._onCollectionChanged(entityCollection, entityCollection.values, emptyArray);
-    };
+    }
 
     /**
      * Updates all of the primitives created by this visualizer to match their

--- a/Source/DataSources/GridMaterialProperty.js
+++ b/Source/DataSources/GridMaterialProperty.js
@@ -38,7 +38,7 @@ define([
      *
      * @constructor
      */
-    var GridMaterialProperty = function(options) {
+    function GridMaterialProperty(options) {
         options = defaultValue(options, defaultValue.EMPTY_OBJECT);
 
         this._definitionChanged = new Event();
@@ -58,7 +58,7 @@ define([
         this.lineCount = options.lineCount;
         this.lineThickness = options.lineThickness;
         this.lineOffset = options.lineOffset;
-    };
+    }
 
     defineProperties(GridMaterialProperty.prototype, {
         /**

--- a/Source/DataSources/ImageMaterialProperty.js
+++ b/Source/DataSources/ImageMaterialProperty.js
@@ -29,7 +29,7 @@ define([
      * @param {Property} [options.image] A Property specifying the Image, URL, Canvas, or Video.
      * @param {Property} [options.repeat=new Cartesian2(1.0, 1.0)] A {@link Cartesian2} Property specifying the number of times the image repeats in each direction.
      */
-    var ImageMaterialProperty = function(options) {
+    function ImageMaterialProperty(options) {
         options = defaultValue(options, defaultValue.EMPTY_OBJECT);
 
         this._definitionChanged = new Event();
@@ -43,7 +43,7 @@ define([
         this.image = options.image;
         this.repeat = options.repeat;
         this.alpha = options.alpha;
-    };
+    }
 
     defineProperties(ImageMaterialProperty.prototype, {
         /**

--- a/Source/DataSources/KmlDataSource.js
+++ b/Source/DataSources/KmlDataSource.js
@@ -1670,7 +1670,7 @@ define([
      * var viewer = new Cesium.Viewer('cesiumContainer');
      * viewer.dataSources.add(Cesium.KmlDataSource.load('../../SampleData/facilities.kmz'));
      */
-    var KmlDataSource = function(proxy) {
+    function KmlDataSource(proxy) {
         this._changed = new Event();
         this._error = new Event();
         this._loading = new Event();
@@ -1681,7 +1681,7 @@ define([
         this._proxy = proxy;
         this._pinBuilder = new PinBuilder();
         this._promises = [];
-    };
+    }
 
     /**
      * Creates a Promise to a new instance loaded with the provided KML data.
@@ -1853,7 +1853,7 @@ define([
      * @alias KmlFeatureData
      * @constructor
      */
-    var KmlFeatureData = function() {
+    function KmlFeatureData() {
         /**
          * Gets the atom syndication format author field.
          * @type Object
@@ -1962,7 +1962,7 @@ define([
          * @type String
          */
         this.extendedData = undefined;
-    };
+    }
 
     return KmlDataSource;
 });

--- a/Source/DataSources/LabelGraphics.js
+++ b/Source/DataSources/LabelGraphics.js
@@ -45,7 +45,7 @@ define([
      *
      * @demo {@link http://cesiumjs.org/Cesium/Apps/Sandcastle/index.html?src=Labels.html|Cesium Sandcastle Labels Demo}
      */
-    var LabelGraphics = function(options) {
+    function LabelGraphics(options) {
         this._text = undefined;
         this._textSubscription = undefined;
         this._font = undefined;
@@ -77,7 +77,7 @@ define([
         this._definitionChanged = new Event();
 
         this.merge(defaultValue(options, defaultValue.EMPTY_OBJECT));
-    };
+    }
 
     defineProperties(LabelGraphics.prototype, {
         /**

--- a/Source/DataSources/LabelVisualizer.js
+++ b/Source/DataSources/LabelVisualizer.js
@@ -50,11 +50,11 @@ define([
     var translucencyByDistance = new NearFarScalar();
     var pixelOffsetScaleByDistance = new NearFarScalar();
 
-    var EntityData = function(entity) {
+    function EntityData(entity) {
         this.entity = entity;
         this.label = undefined;
         this.index = undefined;
-    };
+    }
 
     /**
      * A {@link Visualizer} which maps the {@link LabelGraphics} instance
@@ -65,7 +65,7 @@ define([
      * @param {Scene} scene The scene the primitives will be rendered in.
      * @param {EntityCollection} entityCollection The entityCollection to visualize.
      */
-    var LabelVisualizer = function(scene, entityCollection) {
+    function LabelVisualizer(scene, entityCollection) {
         //>>includeStart('debug', pragmas.debug);
         if (!defined(scene)) {
             throw new DeveloperError('scene is required.');
@@ -84,7 +84,7 @@ define([
         this._items = new AssociativeArray();
 
         this._onCollectionChanged(entityCollection, entityCollection.values, [], []);
-    };
+    }
 
     /**
      * Updates the primitives created by this visualizer to match their

--- a/Source/DataSources/MaterialProperty.js
+++ b/Source/DataSources/MaterialProperty.js
@@ -28,9 +28,9 @@ define([
      * @see PolylineOutlineMaterialProperty
      * @see StripeMaterialProperty
      */
-    var MaterialProperty = function() {
+    function MaterialProperty() {
         DeveloperError.throwInstantiationError();
-    };
+    }
 
     defineProperties(MaterialProperty.prototype, {
         /**

--- a/Source/DataSources/ModelGraphics.js
+++ b/Source/DataSources/ModelGraphics.js
@@ -37,7 +37,7 @@ define([
      * @see {@link http://cesiumjs.org/2014/03/03/Cesium-3D-Models-Tutorial/|3D Models Tutorial}
      * @demo {@link http://cesiumjs.org/Cesium/Apps/Sandcastle/index.html?src=3D%20Models.html|Cesium Sandcastle 3D Models Demo}
      */
-    var ModelGraphics = function(options) {
+    function ModelGraphics(options) {
         this._show = undefined;
         this._showSubscription = undefined;
         this._scale = undefined;
@@ -53,7 +53,7 @@ define([
         this._definitionChanged = new Event();
 
         this.merge(defaultValue(options, defaultValue.EMPTY_OBJECT));
-    };
+    }
 
     defineProperties(ModelGraphics.prototype, {
         /**

--- a/Source/DataSources/ModelVisualizer.js
+++ b/Source/DataSources/ModelVisualizer.js
@@ -39,7 +39,7 @@ define([
      * @param {Scene} scene The scene the primitives will be rendered in.
      * @param {EntityCollection} entityCollection The entityCollection to visualize.
      */
-    var ModelVisualizer = function(scene, entityCollection) {
+    function ModelVisualizer(scene, entityCollection) {
         //>>includeStart('debug', pragmas.debug);
         if (!defined(scene)) {
             throw new DeveloperError('scene is required.');
@@ -57,7 +57,7 @@ define([
         this._modelHash = {};
         this._entitiesToVisualize = new AssociativeArray();
         this._onCollectionChanged(entityCollection, entityCollection.values, [], []);
-    };
+    }
 
     /**
      * Updates models created this visualizer to match their

--- a/Source/DataSources/PathGraphics.js
+++ b/Source/DataSources/PathGraphics.js
@@ -31,7 +31,7 @@ define([
      * @param {MaterialProperty} [options.material=Color.WHITE] A Property specifying the material used to draw the path.
      * @param {Property} [options.resolution=60] A numeric Property specifying the width in pixels.
      */
-    var PathGraphics = function(options) {
+    function PathGraphics(options) {
         this._material = undefined;
         this._materialSubscription = undefined;
         this._show = undefined;
@@ -47,7 +47,7 @@ define([
         this._definitionChanged = new Event();
 
         this.merge(defaultValue(options, defaultValue.EMPTY_OBJECT));
-    };
+    }
 
     defineProperties(PathGraphics.prototype, {
         /**

--- a/Source/DataSources/PathVisualizer.js
+++ b/Source/DataSources/PathVisualizer.js
@@ -52,12 +52,12 @@ define([
     var subSampleCompositePropertyScratch = new TimeInterval();
     var subSampleIntervalPropertyScratch = new TimeInterval();
 
-    var EntityData = function(entity) {
+    function EntityData(entity) {
         this.entity = entity;
         this.polyline = undefined;
         this.index = undefined;
         this.updater = undefined;
-    };
+    }
 
     function subSampleSampledProperty(property, start, stop, times, updateTime, referenceFrame, maximumStep, startingIndex, result) {
         var r = startingIndex;
@@ -266,14 +266,13 @@ define([
     }
 
     var toFixedScratch = new Matrix3();
-    var PolylineUpdater = function(scene, referenceFrame) {
+    function PolylineUpdater(scene, referenceFrame) {
         this._unusedIndexes = [];
         this._polylineCollection = new PolylineCollection();
         this._scene = scene;
         this._referenceFrame = referenceFrame;
         scene.primitives.add(this._polylineCollection);
-    };
-
+    }
     PolylineUpdater.prototype.update = function(time) {
         if (this._referenceFrame === ReferenceFrame.INERTIAL) {
             var toFixed = Transforms.computeIcrfToFixedMatrix(time, toFixedScratch);
@@ -394,7 +393,7 @@ define([
      * @param {Scene} scene The scene the primitives will be rendered in.
      * @param {EntityCollection} entityCollection The entityCollection to visualize.
      */
-    var PathVisualizer = function(scene, entityCollection) {
+    function PathVisualizer(scene, entityCollection) {
         //>>includeStart('debug', pragmas.debug);
         if (!defined(scene)) {
             throw new DeveloperError('scene is required.');
@@ -412,7 +411,7 @@ define([
         this._items = new AssociativeArray();
 
         this._onCollectionChanged(entityCollection, entityCollection.values, [], []);
-    };
+    }
 
     /**
      * Updates all of the primitives created by this visualizer to match their

--- a/Source/DataSources/PointGraphics.js
+++ b/Source/DataSources/PointGraphics.js
@@ -30,7 +30,7 @@ define([
      * @param {Property} [options.scaleByDistance] A {@link NearFarScalar} Property used to scale the point based on distance.
      * @param {Property} [options.translucencyByDistance] A {@link NearFarScalar} Property used to set translucency based on distance from the camera.
      */
-    var PointGraphics = function(options) {
+    function PointGraphics(options) {
         this._color = undefined;
         this._colorSubscription = undefined;
         this._pixelSize = undefined;
@@ -48,7 +48,7 @@ define([
         this._definitionChanged = new Event();
 
         this.merge(defaultValue(options, defaultValue.EMPTY_OBJECT));
-    };
+    }
 
     defineProperties(PointGraphics.prototype, {
         /**

--- a/Source/DataSources/PointVisualizer.js
+++ b/Source/DataSources/PointVisualizer.js
@@ -34,14 +34,14 @@ define([
     var scaleByDistance = new NearFarScalar();
     var translucencyByDistance = new NearFarScalar();
 
-    var EntityData = function(entity) {
+    function EntityData(entity) {
         this.entity = entity;
         this.pointPrimitive = undefined;
         this.color = undefined;
         this.outlineColor = undefined;
         this.pixelSize = undefined;
         this.outlineWidth = undefined;
-    };
+    }
 
     /**
      * A {@link Visualizer} which maps {@link Entity#point} to a {@link PointPrimitive}.
@@ -51,7 +51,7 @@ define([
      * @param {Scene} scene The scene the primitives will be rendered in.
      * @param {EntityCollection} entityCollection The entityCollection to visualize.
      */
-    var PointVisualizer = function(scene, entityCollection) {
+    function PointVisualizer(scene, entityCollection) {
         //>>includeStart('debug', pragmas.debug);
         if (!defined(scene)) {
             throw new DeveloperError('scene is required.');
@@ -69,7 +69,7 @@ define([
         this._pointPrimitiveCollection = undefined;
         this._items = new AssociativeArray();
         this._onCollectionChanged(entityCollection, entityCollection.values, [], []);
-    };
+    }
 
     /**
      * Updates the primitives created by this visualizer to match their

--- a/Source/DataSources/PolygonGeometryUpdater.js
+++ b/Source/DataSources/PolygonGeometryUpdater.js
@@ -56,7 +56,7 @@ define([
     var defaultOutlineColor = new ConstantProperty(Color.BLACK);
     var scratchColor = new Color();
 
-    var GeometryOptions = function(entity) {
+    function GeometryOptions(entity) {
         this.id = entity;
         this.vertexFormat = undefined;
         this.polygonHierarchy = undefined;
@@ -65,7 +65,7 @@ define([
         this.extrudedHeight = undefined;
         this.granularity = undefined;
         this.stRotation = undefined;
-    };
+    }
 
     /**
      * A {@link GeometryUpdater} for polygons.
@@ -76,7 +76,7 @@ define([
      * @param {Entity} entity The entity containing the geometry to be visualized.
      * @param {Scene} scene The scene where visualization is taking place.
      */
-    var PolygonGeometryUpdater = function(entity, scene) {
+    function PolygonGeometryUpdater(entity, scene) {
         //>>includeStart('debug', pragmas.debug);
         if (!defined(entity)) {
             throw new DeveloperError('entity is required');
@@ -102,7 +102,7 @@ define([
         this._outlineWidth = 1.0;
         this._options = new GeometryOptions(entity);
         this._onEntityPropertyChanged(entity, 'polygon', entity.polygon, undefined);
-    };
+    }
 
     defineProperties(PolygonGeometryUpdater, {
         /**
@@ -518,14 +518,13 @@ define([
     /**
      * @private
      */
-    var DynamicGeometryUpdater = function(primitives, geometryUpdater) {
+    function DynamicGeometryUpdater(primitives, geometryUpdater) {
         this._primitives = primitives;
         this._primitive = undefined;
         this._outlinePrimitive = undefined;
         this._geometryUpdater = geometryUpdater;
         this._options = new GeometryOptions(geometryUpdater._entity);
-    };
-
+    }
     DynamicGeometryUpdater.prototype.update = function(time) {
         //>>includeStart('debug', pragmas.debug);
         if (!defined(time)) {

--- a/Source/DataSources/PolygonGraphics.js
+++ b/Source/DataSources/PolygonGraphics.js
@@ -42,7 +42,7 @@ define([
      * @see Entity
      * @demo {@link http://cesiumjs.org/Cesium/Apps/Sandcastle/index.html?src=Polygon.html|Cesium Sandcastle Polygon Demo}
      */
-    var PolygonGraphics = function(options) {
+    function PolygonGraphics(options) {
         this._show = undefined;
         this._showSubscription = undefined;
         this._material = undefined;
@@ -70,7 +70,7 @@ define([
         this._fillSubscription = undefined;
 
         this.merge(defaultValue(options, defaultValue.EMPTY_OBJECT));
-    };
+    }
 
     defineProperties(PolygonGraphics.prototype, {
         /**

--- a/Source/DataSources/PolylineArrowMaterialProperty.js
+++ b/Source/DataSources/PolylineArrowMaterialProperty.js
@@ -27,12 +27,12 @@ define([
      * @alias PolylineArrowMaterialProperty
      * @constructor
      */
-    var PolylineArrowMaterialProperty = function(color) {
+    function PolylineArrowMaterialProperty(color) {
         this._definitionChanged = new Event();
         this._color = undefined;
         this._colorSubscription = undefined;
         this.color = color;
-    };
+    }
 
     defineProperties(PolylineArrowMaterialProperty.prototype, {
         /**

--- a/Source/DataSources/PolylineGeometryUpdater.js
+++ b/Source/DataSources/PolylineGeometryUpdater.js
@@ -55,14 +55,14 @@ define([
     var defaultMaterial = new ColorMaterialProperty(Color.WHITE);
     var defaultShow = new ConstantProperty(true);
 
-    var GeometryOptions = function(entity) {
+    function GeometryOptions(entity) {
         this.id = entity;
         this.vertexFormat = undefined;
         this.positions = undefined;
         this.width = undefined;
         this.followSurface = undefined;
         this.granularity = undefined;
-    };
+    }
 
     /**
      * A {@link GeometryUpdater} for polylines.
@@ -73,7 +73,7 @@ define([
      * @param {Entity} entity The entity containing the geometry to be visualized.
      * @param {Scene} scene The scene where visualization is taking place.
      */
-    var PolylineGeometryUpdater = function(entity, scene) {
+    function PolylineGeometryUpdater(entity, scene) {
         //>>includeStart('debug', pragmas.debug);
         if (!defined(entity)) {
             throw new DeveloperError('entity is required');
@@ -93,7 +93,7 @@ define([
         this._materialProperty = undefined;
         this._options = new GeometryOptions(entity);
         this._onEntityPropertyChanged(entity, 'polyline', entity.polyline, undefined);
-    };
+    }
 
     defineProperties(PolylineGeometryUpdater, {
         /**
@@ -434,7 +434,7 @@ define([
         ellipsoid : undefined
     };
 
-    var DynamicGeometryUpdater = function(primitives, geometryUpdater) {
+    function DynamicGeometryUpdater(primitives, geometryUpdater) {
         var sceneId = geometryUpdater._scene.id;
 
         var polylineCollection = polylineCollections[sceneId];
@@ -455,8 +455,7 @@ define([
         this._positions = [];
 
         generateCartesianArcOptions.ellipsoid = geometryUpdater._scene.globe.ellipsoid;
-    };
-
+    }
     DynamicGeometryUpdater.prototype.update = function(time) {
         var geometryUpdater = this._geometryUpdater;
         var entity = geometryUpdater._entity;

--- a/Source/DataSources/PolylineGlowMaterialProperty.js
+++ b/Source/DataSources/PolylineGlowMaterialProperty.js
@@ -29,7 +29,7 @@ define([
      * @param {Property} [options.color=Color.WHITE] A Property specifying the {@link Color} of the line.
      * @param {Property} [options.glowPower=0.25] A numeric Property specifying the strength of the glow, as a percentage of the total line width.
      */
-    var PolylineGlowMaterialProperty = function(options) {
+    function PolylineGlowMaterialProperty(options) {
         options = defaultValue(options, defaultValue.EMPTY_OBJECT);
 
         this._definitionChanged = new Event();
@@ -40,7 +40,7 @@ define([
 
         this.color = options.color;
         this.glowPower = options.glowPower;
-    };
+    }
 
     defineProperties(PolylineGlowMaterialProperty.prototype, {
         /**

--- a/Source/DataSources/PolylineGraphics.js
+++ b/Source/DataSources/PolylineGraphics.js
@@ -36,7 +36,7 @@ define([
      * @see Entity
      * @demo {@link http://cesiumjs.org/Cesium/Apps/Sandcastle/index.html?src=Polyline.html|Cesium Sandcastle Polyline Demo}
      */
-    var PolylineGraphics = function(options) {
+    function PolylineGraphics(options) {
         this._show = undefined;
         this._showSubscription = undefined;
         this._material = undefined;
@@ -53,7 +53,7 @@ define([
         this._definitionChanged = new Event();
 
         this.merge(defaultValue(options, defaultValue.EMPTY_OBJECT));
-    };
+    }
 
     defineProperties(PolylineGraphics.prototype, {
         /**

--- a/Source/DataSources/PolylineOutlineMaterialProperty.js
+++ b/Source/DataSources/PolylineOutlineMaterialProperty.js
@@ -31,7 +31,7 @@ define([
      * @param {Property} [options.outlineColor=Color.BLACK] A Property specifying the {@link Color} of the outline.
      * @param {Property} [options.outlineWidth=1.0] A numeric Property specifying the width of the outline, in pixels.
      */
-    var PolylineOutlineMaterialProperty = function(options) {
+    function PolylineOutlineMaterialProperty(options) {
         options = defaultValue(options, defaultValue.EMPTY_OBJECT);
 
         this._definitionChanged = new Event();
@@ -45,7 +45,7 @@ define([
         this.color = options.color;
         this.outlineColor = options.outlineColor;
         this.outlineWidth = options.outlineWidth;
-    };
+    }
 
     defineProperties(PolylineOutlineMaterialProperty.prototype, {
         /**

--- a/Source/DataSources/PolylineVolumeGeometryUpdater.js
+++ b/Source/DataSources/PolylineVolumeGeometryUpdater.js
@@ -52,14 +52,14 @@ define([
     var defaultOutlineColor = new ConstantProperty(Color.BLACK);
     var scratchColor = new Color();
 
-    var GeometryOptions = function(entity) {
+    function GeometryOptions(entity) {
         this.id = entity;
         this.vertexFormat = undefined;
         this.polylinePositions = undefined;
         this.shapePositions = undefined;
         this.cornerType = undefined;
         this.granularity = undefined;
-    };
+    }
 
     /**
      * A {@link GeometryUpdater} for polyline volumes.
@@ -70,7 +70,7 @@ define([
      * @param {Entity} entity The entity containing the geometry to be visualized.
      * @param {Scene} scene The scene where visualization is taking place.
      */
-    var PolylineVolumeGeometryUpdater = function(entity, scene) {
+    function PolylineVolumeGeometryUpdater(entity, scene) {
         //>>includeStart('debug', pragmas.debug);
         if (!defined(entity)) {
             throw new DeveloperError('entity is required');
@@ -95,7 +95,7 @@ define([
         this._outlineWidth = 1.0;
         this._options = new GeometryOptions(entity);
         this._onEntityPropertyChanged(entity, 'polylineVolume', entity.polylineVolume, undefined);
-    };
+    }
 
     defineProperties(PolylineVolumeGeometryUpdater, {
         /**
@@ -492,14 +492,13 @@ define([
     /**
      * @private
      */
-    var DynamicGeometryUpdater = function(primitives, geometryUpdater) {
+    function DynamicGeometryUpdater(primitives, geometryUpdater) {
         this._primitives = primitives;
         this._primitive = undefined;
         this._outlinePrimitive = undefined;
         this._geometryUpdater = geometryUpdater;
         this._options = new GeometryOptions(geometryUpdater._entity);
-    };
-
+    }
     DynamicGeometryUpdater.prototype.update = function(time) {
         //>>includeStart('debug', pragmas.debug);
         if (!defined(time)) {

--- a/Source/DataSources/PolylineVolumeGraphics.js
+++ b/Source/DataSources/PolylineVolumeGraphics.js
@@ -39,7 +39,7 @@ define([
      * @see Entity
      * @demo {@link http://cesiumjs.org/Cesium/Apps/Sandcastle/index.html?src=Polyline%20Volume.html|Cesium Sandcastle Polyline Volume Demo}
      */
-    var PolylineVolumeGraphics = function(options) {
+    function PolylineVolumeGraphics(options) {
         this._show = undefined;
         this._showSubscription = undefined;
         this._material = undefined;
@@ -63,7 +63,7 @@ define([
         this._definitionChanged = new Event();
 
         this.merge(defaultValue(options, defaultValue.EMPTY_OBJECT));
-    };
+    }
 
     defineProperties(PolylineVolumeGraphics.prototype, {
         /**

--- a/Source/DataSources/PositionProperty.js
+++ b/Source/DataSources/PositionProperty.js
@@ -30,9 +30,9 @@ define([
      * @see SampledPositionProperty
      * @see TimeIntervalCollectionPositionProperty
      */
-    var PositionProperty = function() {
+    function PositionProperty() {
         DeveloperError.throwInstantiationError();
-    };
+    }
 
     defineProperties(PositionProperty.prototype, {
         /**

--- a/Source/DataSources/PositionPropertyArray.js
+++ b/Source/DataSources/PositionPropertyArray.js
@@ -28,13 +28,13 @@ define([
      *
      * @param {Property[]} [value] An array of Property instances.
      */
-    var PositionPropertyArray = function(value, referenceFrame) {
+    function PositionPropertyArray(value, referenceFrame) {
         this._value = undefined;
         this._definitionChanged = new Event();
         this._eventHelper = new EventHelper();
         this._referenceFrame = defaultValue(referenceFrame, ReferenceFrame.FIXED);
         this.setValue(value);
-    };
+    }
 
     defineProperties(PositionPropertyArray.prototype, {
         /**

--- a/Source/DataSources/Property.js
+++ b/Source/DataSources/Property.js
@@ -28,9 +28,9 @@ define([
      * @see PositionProperty
      * @see ReferenceProperty
      */
-    var Property = function() {
+    function Property() {
         DeveloperError.throwInstantiationError();
-    };
+    }
 
     defineProperties(Property.prototype, {
         /**

--- a/Source/DataSources/PropertyArray.js
+++ b/Source/DataSources/PropertyArray.js
@@ -24,12 +24,12 @@ define([
      *
      * @param {Property[]} [value] An array of Property instances.
      */
-    var PropertyArray = function(value) {
+    function PropertyArray(value) {
         this._value = undefined;
         this._definitionChanged = new Event();
         this._eventHelper = new EventHelper();
         this.setValue(value);
-    };
+    }
 
     defineProperties(PropertyArray.prototype, {
         /**

--- a/Source/DataSources/RectangleGeometryUpdater.js
+++ b/Source/DataSources/RectangleGeometryUpdater.js
@@ -52,7 +52,7 @@ define([
     var defaultOutlineColor = new ConstantProperty(Color.BLACK);
     var scratchColor = new Color();
 
-    var GeometryOptions = function(entity) {
+    function GeometryOptions(entity) {
         this.id = entity;
         this.vertexFormat = undefined;
         this.rectangle = undefined;
@@ -63,7 +63,7 @@ define([
         this.granularity = undefined;
         this.stRotation = undefined;
         this.rotation = undefined;
-    };
+    }
 
     /**
      * A {@link GeometryUpdater} for rectangles.
@@ -74,7 +74,7 @@ define([
      * @param {Entity} entity The entity containing the geometry to be visualized.
      * @param {Scene} scene The scene where visualization is taking place.
      */
-    var RectangleGeometryUpdater = function(entity, scene) {
+    function RectangleGeometryUpdater(entity, scene) {
         //>>includeStart('debug', pragmas.debug);
         if (!defined(entity)) {
             throw new DeveloperError('entity is required');
@@ -100,7 +100,7 @@ define([
         this._outlineWidth = 1.0;
         this._options = new GeometryOptions(entity);
         this._onEntityPropertyChanged(entity, 'rectangle', entity.rectangle, undefined);
-    };
+    }
 
     defineProperties(RectangleGeometryUpdater, {
         /**
@@ -513,14 +513,13 @@ define([
     /**
      * @private
      */
-    var DynamicGeometryUpdater = function(primitives, geometryUpdater) {
+    function DynamicGeometryUpdater(primitives, geometryUpdater) {
         this._primitives = primitives;
         this._primitive = undefined;
         this._outlinePrimitive = undefined;
         this._geometryUpdater = geometryUpdater;
         this._options = new GeometryOptions(geometryUpdater._entity);
-    };
-
+    }
     DynamicGeometryUpdater.prototype.update = function(time) {
         //>>includeStart('debug', pragmas.debug);
         if (!defined(time)) {

--- a/Source/DataSources/RectangleGraphics.js
+++ b/Source/DataSources/RectangleGraphics.js
@@ -44,7 +44,7 @@ define([
      * @see Entity
      * @demo {@link http://cesiumjs.org/Cesium/Apps/Sandcastle/index.html?src=Rectangle.html|Cesium Sandcastle Rectangle Demo}
      */
-    var RectangleGraphics = function(options) {
+    function RectangleGraphics(options) {
         this._show = undefined;
         this._showSubscription = undefined;
         this._material = undefined;
@@ -76,7 +76,7 @@ define([
         this._definitionChanged = new Event();
 
         this.merge(defaultValue(options, defaultValue.EMPTY_OBJECT));
-    };
+    }
 
     defineProperties(RectangleGraphics.prototype, {
         /**

--- a/Source/DataSources/ReferenceProperty.js
+++ b/Source/DataSources/ReferenceProperty.js
@@ -103,7 +103,7 @@ define([
      * object5.billboard.scale = Cesium.ReferenceProperty.fromString(collection, '\\#object\\.4#billboard.scale');
      * collection.add(object5);
      */
-    var ReferenceProperty = function(targetCollection, targetId, targetPropertyNames) {
+    function ReferenceProperty(targetCollection, targetId, targetPropertyNames) {
         //>>includeStart('debug', pragmas.debug);
         if (!defined(targetCollection)) {
             throw new DeveloperError('targetCollection is required.');
@@ -132,7 +132,7 @@ define([
         this._resolveProperty = true;
 
         targetCollection.collectionChanged.addEventListener(ReferenceProperty.prototype._onCollectionChanged, this);
-    };
+    }
 
     defineProperties(ReferenceProperty.prototype, {
         /**

--- a/Source/DataSources/SampledPositionProperty.js
+++ b/Source/DataSources/SampledPositionProperty.js
@@ -32,7 +32,7 @@ define([
      * @param {ReferenceFrame} [referenceFrame=ReferenceFrame.FIXED] The reference frame in which the position is defined.
      * @param {Number} [numberOfDerivatives=0] The number of derivatives that accompany each position; i.e. velocity, acceleration, etc...
      */
-    var SampledPositionProperty = function(referenceFrame, numberOfDerivatives) {
+    function SampledPositionProperty(referenceFrame, numberOfDerivatives) {
         numberOfDerivatives = defaultValue(numberOfDerivatives, 0);
 
         var derivativeTypes;
@@ -51,7 +51,7 @@ define([
         this._property._definitionChanged.addEventListener(function() {
             this._definitionChanged.raiseEvent(this);
         }, this);
-    };
+    }
 
     defineProperties(SampledPositionProperty.prototype, {
         /**

--- a/Source/DataSources/SampledProperty.js
+++ b/Source/DataSources/SampledProperty.js
@@ -67,7 +67,7 @@ define([
     var timesSpliceArgs = [];
     var valuesSpliceArgs = [];
 
-    var mergeNewSamples = function(epoch, times, values, newData, packedLength) {
+    function mergeNewSamples(epoch, times, values, newData, packedLength) {
         var newDataIndex = 0;
         var i;
         var prevItem;
@@ -119,7 +119,7 @@ define([
                 newDataIndex++;
             }
         }
-    };
+    }
 
     /**
      * A {@link Property} whose value is interpolated for a given time from the
@@ -164,7 +164,7 @@ define([
      * //Retrieve an interpolated value
      * var result = property.getValue(Cesium.JulianDate.fromIso8601(`2012-08-01T00:02:34.00Z`));
      */
-    var SampledProperty = function(type, derivativeTypes) {
+    function SampledProperty(type, derivativeTypes) {
         //>>includeStart('debug', pragmas.debug);
         if (!defined(type)) {
             throw new DeveloperError('type is required.');
@@ -217,7 +217,7 @@ define([
         this._forwardExtrapolationDuration = 0;
         this._backwardExtrapolationType = ExtrapolationType.NONE;
         this._backwardExtrapolationDuration = 0;
-    };
+    }
 
     defineProperties(SampledProperty.prototype, {
         /**

--- a/Source/DataSources/ScaledPositionProperty.js
+++ b/Source/DataSources/ScaledPositionProperty.js
@@ -22,12 +22,12 @@ define([
      * It will go away or be refactored to support data with arbitrary height references.
      * @private
      */
-    var ScaledPositionProperty = function(value) {
+    function ScaledPositionProperty(value) {
         this._definitionChanged = new Event();
         this._value = undefined;
         this._removeSubscription = undefined;
         this.setValue(value);
-    };
+    }
 
     defineProperties(ScaledPositionProperty.prototype, {
         isConstant : {

--- a/Source/DataSources/StaticGeometryColorBatch.js
+++ b/Source/DataSources/StaticGeometryColorBatch.js
@@ -19,7 +19,7 @@ define([
 
     var colorScratch = new Color();
 
-    var Batch = function(primitives, translucent, appearanceType, closed) {
+    function Batch(primitives, translucent, appearanceType, closed) {
         this.translucent = translucent;
         this.appearanceType = appearanceType;
         this.closed = closed;
@@ -34,8 +34,7 @@ define([
         this.subscriptions = new AssociativeArray();
         this.showsUpdated = new AssociativeArray();
         this.itemsToRemove = [];
-    };
-
+    }
     Batch.prototype.add = function(updater, instance) {
         var id = updater.entity.id;
         this.createPrimitive = true;
@@ -231,11 +230,10 @@ define([
     /**
      * @private
      */
-    var StaticGeometryColorBatch = function(primitives, appearanceType, closed) {
+    function StaticGeometryColorBatch(primitives, appearanceType, closed) {
         this._solidBatch = new Batch(primitives, false, appearanceType, closed);
         this._translucentBatch = new Batch(primitives, true, appearanceType, closed);
-    };
-
+    }
     StaticGeometryColorBatch.prototype.add = function(time, updater) {
         var instance = updater.createFillGeometryInstance(time);
         if (instance.attributes.color.value[3] === 255) {

--- a/Source/DataSources/StaticGeometryPerMaterialBatch.js
+++ b/Source/DataSources/StaticGeometryPerMaterialBatch.js
@@ -15,7 +15,7 @@ define([
         MaterialProperty) {
     "use strict";
 
-    var Batch = function(primitives, appearanceType, materialProperty, closed) {
+    function Batch(primitives, appearanceType, materialProperty, closed) {
         this.primitives = primitives;
         this.appearanceType = appearanceType;
         this.materialProperty = materialProperty;
@@ -32,8 +32,7 @@ define([
         this.removeMaterialSubscription = materialProperty.definitionChanged.addEventListener(Batch.prototype.onMaterialChanged, this);
         this.subscriptions = new AssociativeArray();
         this.showsUpdated = new AssociativeArray();
-    };
-
+    }
     Batch.prototype.onMaterialChanged = function() {
         this.invalidated = true;
     };
@@ -239,13 +238,12 @@ define([
     /**
      * @private
      */
-    var StaticGeometryPerMaterialBatch = function(primitives, appearanceType, closed) {
+    function StaticGeometryPerMaterialBatch(primitives, appearanceType, closed) {
         this._items = [];
         this._primitives = primitives;
         this._appearanceType = appearanceType;
         this._closed = closed;
-    };
-
+    }
     StaticGeometryPerMaterialBatch.prototype.add = function(time, updater) {
         var items = this._items;
         var length = items.length;

--- a/Source/DataSources/StaticOutlineGeometryBatch.js
+++ b/Source/DataSources/StaticOutlineGeometryBatch.js
@@ -19,7 +19,7 @@ define([
         BoundingSphereState) {
     "use strict";
 
-    var Batch = function(primitives, translucent, width) {
+    function Batch(primitives, translucent, width) {
         this.translucent = translucent;
         this.primitives = primitives;
         this.createPrimitive = false;
@@ -33,8 +33,7 @@ define([
         this.width = width;
         this.subscriptions = new AssociativeArray();
         this.showsUpdated = new AssociativeArray();
-    };
-
+    }
     Batch.prototype.add = function(updater, instance) {
         var id = updater.entity.id;
         this.createPrimitive = true;
@@ -237,13 +236,12 @@ define([
     /**
      * @private
      */
-    var StaticOutlineGeometryBatch = function(primitives, scene) {
+    function StaticOutlineGeometryBatch(primitives, scene) {
         this._primitives = primitives;
         this._scene = scene;
         this._solidBatches = new AssociativeArray();
         this._translucentBatches = new AssociativeArray();
-    };
-
+    }
     StaticOutlineGeometryBatch.prototype.add = function(time, updater) {
         var instance = updater.createOutlineGeometryInstance(time);
         var width = this._scene.clampLineWidth(updater.outlineWidth);

--- a/Source/DataSources/StripeMaterialProperty.js
+++ b/Source/DataSources/StripeMaterialProperty.js
@@ -37,7 +37,7 @@ define([
      * @param {Property} [options.offset=0] A numeric Property specifying how far into the pattern to start the material.
      * @param {Property} [options.orientation=StripeOrientation.HORIZONTAL] A Property specifying the {@link StripeOrientation}.
      */
-    var StripeMaterialProperty = function(options) {
+    function StripeMaterialProperty(options) {
         options = defaultValue(options, defaultValue.EMPTY_OBJECT);
 
         this._definitionChanged = new Event();
@@ -62,7 +62,7 @@ define([
         this.oddColor = options.oddColor;
         this.offset = options.offset;
         this.repeat = options.repeat;
-    };
+    }
 
     defineProperties(StripeMaterialProperty.prototype, {
         /**

--- a/Source/DataSources/TimeIntervalCollectionPositionProperty.js
+++ b/Source/DataSources/TimeIntervalCollectionPositionProperty.js
@@ -29,12 +29,12 @@ define([
      *
      * @param {ReferenceFrame} [referenceFrame=ReferenceFrame.FIXED] The reference frame in which the position is defined.
      */
-    var TimeIntervalCollectionPositionProperty = function(referenceFrame) {
+    function TimeIntervalCollectionPositionProperty(referenceFrame) {
         this._definitionChanged = new Event();
         this._intervals = new TimeIntervalCollection();
         this._intervals.changedEvent.addEventListener(TimeIntervalCollectionPositionProperty.prototype._intervalsChanged, this);
         this._referenceFrame = defaultValue(referenceFrame, ReferenceFrame.FIXED);
-    };
+    }
 
     defineProperties(TimeIntervalCollectionPositionProperty.prototype, {
         /**

--- a/Source/DataSources/TimeIntervalCollectionProperty.js
+++ b/Source/DataSources/TimeIntervalCollectionProperty.js
@@ -51,11 +51,11 @@ define([
      *     data : new Cesium.Cartesian2(85.0, 4.1)
      * }));
      */
-    var TimeIntervalCollectionProperty = function() {
+    function TimeIntervalCollectionProperty() {
         this._definitionChanged = new Event();
         this._intervals = new TimeIntervalCollection();
         this._intervals.changedEvent.addEventListener(TimeIntervalCollectionProperty.prototype._intervalsChanged, this);
-    };
+    }
 
     defineProperties(TimeIntervalCollectionProperty.prototype, {
         /**

--- a/Source/DataSources/VelocityOrientationProperty.js
+++ b/Source/DataSources/VelocityOrientationProperty.js
@@ -46,7 +46,7 @@ define([
      *   orientation : new Cesium.VelocityOrientationProperty(position)
      * }));
      */
-    var VelocityOrientationProperty = function(position, ellipsoid) {
+    function VelocityOrientationProperty(position, ellipsoid) {
         this._position = undefined;
         this._subscription = undefined;
         this._ellipsoid = undefined;
@@ -54,7 +54,7 @@ define([
 
         this.position = position;
         this.ellipsoid = defaultValue(ellipsoid, Ellipsoid.WGS84);
-    };
+    }
 
     defineProperties(VelocityOrientationProperty.prototype, {
         /**

--- a/Source/DataSources/Visualizer.js
+++ b/Source/DataSources/Visualizer.js
@@ -21,9 +21,9 @@ define([
      * @see PointVisualizer
      * @see GeometryVisualizer
      */
-    var Visualizer = function() {
+    function Visualizer() {
         DeveloperError.throwInstantiationError();
-    };
+    }
 
     /**
      * Updates the visualization to the provided time.

--- a/Source/DataSources/WallGeometryUpdater.js
+++ b/Source/DataSources/WallGeometryUpdater.js
@@ -52,14 +52,14 @@ define([
     var defaultOutlineColor = new ConstantProperty(Color.BLACK);
     var scratchColor = new Color();
 
-    var GeometryOptions = function(entity) {
+    function GeometryOptions(entity) {
         this.id = entity;
         this.vertexFormat = undefined;
         this.positions = undefined;
         this.minimumHeights = undefined;
         this.maximumHeights = undefined;
         this.granularity = undefined;
-    };
+    }
 
     /**
      * A {@link GeometryUpdater} for walls.
@@ -70,7 +70,7 @@ define([
      * @param {Entity} entity The entity containing the geometry to be visualized.
      * @param {Scene} scene The scene where visualization is taking place.
      */
-    var WallGeometryUpdater = function(entity, scene) {
+    function WallGeometryUpdater(entity, scene) {
         //>>includeStart('debug', pragmas.debug);
         if (!defined(entity)) {
             throw new DeveloperError('entity is required');
@@ -95,7 +95,7 @@ define([
         this._outlineWidth = 1.0;
         this._options = new GeometryOptions(entity);
         this._onEntityPropertyChanged(entity, 'wall', entity.wall, undefined);
-    };
+    }
 
     defineProperties(WallGeometryUpdater, {
         /**
@@ -495,14 +495,13 @@ define([
     /**
      * @private
      */
-    var DynamicGeometryUpdater = function(primitives, geometryUpdater) {
+    function DynamicGeometryUpdater(primitives, geometryUpdater) {
         this._primitives = primitives;
         this._primitive = undefined;
         this._outlinePrimitive = undefined;
         this._geometryUpdater = geometryUpdater;
         this._options = new GeometryOptions(geometryUpdater._entity);
-    };
-
+    }
     DynamicGeometryUpdater.prototype.update = function(time) {
         //>>includeStart('debug', pragmas.debug);
         if (!defined(time)) {

--- a/Source/DataSources/WallGraphics.js
+++ b/Source/DataSources/WallGraphics.js
@@ -39,7 +39,7 @@ define([
      * @see Entity
      * @demo {@link http://cesiumjs.org/Cesium/Apps/Sandcastle/index.html?src=Wall.html|Cesium Sandcastle Wall Demo}
      */
-    var WallGraphics = function(options) {
+    function WallGraphics(options) {
         this._show = undefined;
         this._showSubscription = undefined;
         this._material = undefined;
@@ -63,7 +63,7 @@ define([
         this._definitionChanged = new Event();
 
         this.merge(defaultValue(options, defaultValue.EMPTY_OBJECT));
-    };
+    }
 
     defineProperties(WallGraphics.prototype, {
         /**

--- a/Source/DataSources/dynamicGeometryGetBoundingSphere.js
+++ b/Source/DataSources/dynamicGeometryGetBoundingSphere.js
@@ -14,7 +14,7 @@ define([
     /**
      * @private
      */
-    var dynamicGeometryGetBoundingSphere = function(entity, primitive, outlinePrimitive, result) {
+    function dynamicGeometryGetBoundingSphere(entity, primitive, outlinePrimitive, result) {
         //>>includeStart('debug', pragmas.debug);
         if (!defined(entity)) {
             throw new DeveloperError('entity is required.');
@@ -48,7 +48,7 @@ define([
         }
 
         return BoundingSphereState.FAILED;
-    };
+    }
 
     return dynamicGeometryGetBoundingSphere;
 });

--- a/Source/Renderer/AutomaticUniforms.js
+++ b/Source/Renderer/AutomaticUniforms.js
@@ -12,11 +12,11 @@ define([
 
     var viewerPositionWCScratch = new Cartesian3();
 
-    var AutomaticUniform = function(options) {
+    function AutomaticUniform(options) {
         this._size = options.size;
         this._datatype = options.datatype;
         this.getValue = options.getValue;
-    };
+    }
 
     // this check must use typeof, not defined, because defined doesn't work with undeclared variables.
     if (typeof WebGLRenderingContext === 'undefined') {

--- a/Source/Renderer/Buffer.js
+++ b/Source/Renderer/Buffer.js
@@ -22,7 +22,7 @@ define([
     /**
      * @private
      */
-    var Buffer = function(options) {
+    function Buffer(options) {
         options = defaultValue(options, defaultValue.EMPTY_OBJECT);
 
         //>>includeStart('debug', pragmas.debug);
@@ -75,7 +75,7 @@ define([
         this._usage = usage;
         this._buffer = buffer;
         this.vertexArrayDestroyable = true;
-    };
+    }
 
     /**
      * Creates a vertex buffer, which contains untyped vertex data in GPU-controlled memory.

--- a/Source/Renderer/ClearCommand.js
+++ b/Source/Renderer/ClearCommand.js
@@ -14,7 +14,7 @@ define([
      *
      * @private
      */
-    var ClearCommand = function(options) {
+    function ClearCommand(options) {
         options = defaultValue(options, defaultValue.EMPTY_OBJECT);
 
         /**
@@ -77,7 +77,7 @@ define([
          * @see Scene#debugCommandFilter
          */
         this.owner = options.owner;
-    };
+    }
 
     /**
      * Clears color to (0.0, 0.0, 0.0, 0.0); depth to 1.0; and stencil to 0.

--- a/Source/Renderer/ComputeCommand.js
+++ b/Source/Renderer/ComputeCommand.js
@@ -14,7 +14,7 @@ define([
      *
      * @private
      */
-    var ComputeCommand = function(options) {
+    function ComputeCommand(options) {
         options = defaultValue(options, defaultValue.EMPTY_OBJECT);
 
         /**
@@ -105,7 +105,7 @@ define([
          * @see Scene#debugCommandFilter
          */
         this.owner = options.owner;
-    };
+    }
 
     /**
      * Executes the compute command.

--- a/Source/Renderer/ComputeEngine.js
+++ b/Source/Renderer/ComputeEngine.js
@@ -42,9 +42,9 @@ define([
     /**
      * @private
      */
-    var ComputeEngine = function(context) {
+    function ComputeEngine(context) {
         this._context = context;
-    };
+    }
 
     var renderStateScratch;
     var drawCommandScratch = new DrawCommand({

--- a/Source/Renderer/Context.js
+++ b/Source/Renderer/Context.js
@@ -180,7 +180,7 @@ define([
     /**
      * @private
      */
-    var Context = function(canvas, options) {
+    function Context(canvas, options) {
         // this check must use typeof, not defined, because defined doesn't work with undeclared variables.
         if (typeof WebGLRenderingContext === 'undefined') {
             throw new RuntimeError('The browser does not support WebGL.  Visit http://get.webgl.org.');
@@ -408,7 +408,7 @@ define([
 
 
         RenderState.apply(gl, rs, ps);
-    };
+    }
 
     var defaultFramebufferMarker = {};
 

--- a/Source/Renderer/CubeMap.js
+++ b/Source/Renderer/CubeMap.js
@@ -33,7 +33,7 @@ define([
         TextureWrap) {
     "use strict";
 
-    var CubeMap = function(options) {
+    function CubeMap(options) {
 
         options = defaultValue(options, defaultValue.EMPTY_OBJECT);
 
@@ -170,7 +170,7 @@ define([
         this._negativeZ = new CubeMapFace(gl, texture, textureTarget, gl.TEXTURE_CUBE_MAP_NEGATIVE_Z, pixelFormat, pixelDatatype, size, preMultiplyAlpha, flipY);
 
         this.sampler = new Sampler();
-    };
+    }
 
     defineProperties(CubeMap.prototype, {
         positiveX : {

--- a/Source/Renderer/CubeMapFace.js
+++ b/Source/Renderer/CubeMapFace.js
@@ -14,7 +14,7 @@ define([
     /**
      * @private
      */
-    var CubeMapFace = function(gl, texture, textureTarget, targetFace, pixelFormat, pixelDatatype, size, preMultiplyAlpha, flipY) {
+    function CubeMapFace(gl, texture, textureTarget, targetFace, pixelFormat, pixelDatatype, size, preMultiplyAlpha, flipY) {
         this._gl = gl;
         this._texture = texture;
         this._textureTarget = textureTarget;
@@ -24,7 +24,7 @@ define([
         this._size = size;
         this._preMultiplyAlpha = preMultiplyAlpha;
         this._flipY = flipY;
-    };
+    }
 
     defineProperties(CubeMapFace.prototype, {
         pixelFormat : {

--- a/Source/Renderer/DrawCommand.js
+++ b/Source/Renderer/DrawCommand.js
@@ -12,7 +12,7 @@ define([
      *
      * @private
      */
-    var DrawCommand = function(options) {
+    function DrawCommand(options) {
         options = defaultValue(options, defaultValue.EMPTY_OBJECT);
 
         /**
@@ -188,7 +188,7 @@ define([
          * @private
          */
         this.oit = undefined;
-    };
+    }
 
     /**
      * Executes the draw command.

--- a/Source/Renderer/Framebuffer.js
+++ b/Source/Renderer/Framebuffer.js
@@ -68,7 +68,7 @@ define([
      *
      * @private
      */
-    var Framebuffer = function(options) {
+    function Framebuffer(options) {
         options = defaultValue(options, defaultValue.EMPTY_OBJECT);
 
         //>>includeStart('debug', pragmas.debug);
@@ -236,7 +236,7 @@ define([
         }
 
         this._unBind();
-    };
+    }
 
     defineProperties(Framebuffer.prototype, {
         /**

--- a/Source/Renderer/PassState.js
+++ b/Source/Renderer/PassState.js
@@ -8,7 +8,7 @@ define(function() {
      *
      * @private
      */
-    var PassState = function(context) {
+    function PassState(context) {
         /**
          * The context used to execute commands for this pass.
          *
@@ -49,7 +49,7 @@ define(function() {
          * @default undefined
          */
         this.scissorTest = undefined;
-    };
+    }
 
     return PassState;
 });

--- a/Source/Renderer/PickFramebuffer.js
+++ b/Source/Renderer/PickFramebuffer.js
@@ -26,7 +26,7 @@ define([
     /**
      * @private
      */
-    var PickFramebuffer = function(context) {
+    function PickFramebuffer(context) {
         // Override per-command states
         var passState = new PassState(context);
         passState.blendingEnabled = false;
@@ -40,8 +40,7 @@ define([
         this._passState = passState;
         this._width = 0;
         this._height = 0;
-    };
-
+    }
     PickFramebuffer.prototype.begin = function(screenSpaceRectangle) {
         var context = this._context;
         var width = context.drawingBufferWidth;

--- a/Source/Renderer/RenderState.js
+++ b/Source/Renderer/RenderState.js
@@ -87,7 +87,7 @@ define([
     /**
      * @private
      */
-    var RenderState = function(renderState) {
+    function RenderState(renderState) {
         var rs = defaultValue(renderState, {});
         var cull = defaultValue(rs.cull, {});
         var polygonOffset = defaultValue(rs.polygonOffset, {});
@@ -273,7 +273,7 @@ define([
 
         this.id = 0;
         this._applyFunctions = [];
-    };
+    }
 
     var nextRenderStateId = 0;
     var renderStateCache = {};
@@ -558,9 +558,9 @@ define([
         gl.stencilMask(renderState.stencilMask);
     }
 
-    var applyBlendingColor = function(gl, color) {
+    function applyBlendingColor(gl, color) {
         gl.blendColor(color.red, color.green, color.blue, color.alpha);
-    };
+    }
 
     function applyBlending(gl, renderState, passState) {
         var blending = renderState.blending;
@@ -610,7 +610,7 @@ define([
         }
     }
 
-    var applySampleCoverage = function(gl, renderState) {
+    function applySampleCoverage(gl, renderState) {
         var sampleCoverage = renderState.sampleCoverage;
         var enabled = sampleCoverage.enabled;
 
@@ -619,7 +619,7 @@ define([
         if (enabled) {
             gl.sampleCoverage(sampleCoverage.value, sampleCoverage.invert);
         }
-    };
+    }
 
     var scratchViewport = new BoundingRectangle();
     function applyViewport(gl, renderState, passState) {

--- a/Source/Renderer/Sampler.js
+++ b/Source/Renderer/Sampler.js
@@ -20,7 +20,7 @@ define([
     /**
      * @private
      */
-    var Sampler = function(options) {
+    function Sampler(options) {
         options = defaultValue(options, defaultValue.EMPTY_OBJECT);
 
         var wrapS = defaultValue(options.wrapS, TextureWrap.CLAMP_TO_EDGE);
@@ -56,7 +56,7 @@ define([
         this._minificationFilter = minificationFilter;
         this._magnificationFilter = magnificationFilter;
         this._maximumAnisotropy = maximumAnisotropy;
-    };
+    }
 
     defineProperties(Sampler.prototype, {
         wrapS : {

--- a/Source/Renderer/ShaderCache.js
+++ b/Source/Renderer/ShaderCache.js
@@ -16,12 +16,12 @@ define([
     /**
      * @private
      */
-    var ShaderCache = function(context) {
+    function ShaderCache(context) {
         this._context = context;
         this._shaders = {};
         this._numberOfShaders = 0;
         this._shadersToRelease = {};
-    };
+    }
 
     defineProperties(ShaderCache.prototype, {
         numberOfShaders : {

--- a/Source/Renderer/ShaderProgram.js
+++ b/Source/Renderer/ShaderProgram.js
@@ -30,7 +30,7 @@ define([
     /**
      * @private
      */
-    var ShaderProgram = function(options) {
+    function ShaderProgram(options) {
         var modifiedFS = handleUniformPrecisionMismatches(options.vertexShaderText, options.fragmentShaderText);
 
         this._gl = options.gl;
@@ -62,8 +62,7 @@ define([
          * @private
          */
         this.id = nextShaderProgramId++;
-    };
-
+    }
     ShaderProgram.fromCache = function(options) {
         options = defaultValue(options, defaultValue.EMPTY_OBJECT);
 

--- a/Source/Renderer/ShaderSource.js
+++ b/Source/Renderer/ShaderSource.js
@@ -260,7 +260,7 @@ define([
      *
      * @private
      */
-    var ShaderSource = function(options) {
+    function ShaderSource(options) {
         options = defaultValue(options, defaultValue.EMPTY_OBJECT);
         var pickColorQualifier = options.pickColorQualifier;
 
@@ -274,8 +274,7 @@ define([
         this.sources = defined(options.sources) ? options.sources.slice(0) : [];
         this.pickColorQualifier = pickColorQualifier;
         this.includeBuiltIns = defaultValue(options.includeBuiltIns, true);
-    };
-
+    }
     ShaderSource.prototype.clone = function() {
         return new ShaderSource({
             sources : this.sources,

--- a/Source/Renderer/Texture.js
+++ b/Source/Renderer/Texture.js
@@ -35,7 +35,7 @@ define([
         WebGLConstants) {
     "use strict";
     
-    var Texture = function(options) {
+    function Texture(options) {
         options = defaultValue(options, defaultValue.EMPTY_OBJECT);
 
         //>>includeStart('debug', pragmas.debug);
@@ -183,7 +183,7 @@ define([
         this._sampler = undefined;
 
         this.sampler = defined(options.sampler) ? options.sampler : new Sampler();
-    };
+    }
 
     /**
      * Creates a texture, and copies a subimage of the framebuffer to it.  When called without arguments,

--- a/Source/Renderer/UniformState.js
+++ b/Source/Renderer/UniformState.js
@@ -34,7 +34,7 @@ define([
     /**
      * @private
      */
-    var UniformState = function() {
+    function UniformState() {
         /**
          * @type {Texture}
          */
@@ -148,7 +148,7 @@ define([
         this._resolutionScale = 1.0;
 
         this._fogDensity = undefined;
-    };
+    }
 
     defineProperties(UniformState.prototype, {
         /**

--- a/Source/Renderer/VertexArray.js
+++ b/Source/Renderer/VertexArray.js
@@ -262,7 +262,7 @@ define([
      *
      * @private
      */
-    var VertexArray = function(options) {
+    function VertexArray(options) {
         options = defaultValue(options, defaultValue.EMPTY_OBJECT);
 
         //>>includeStart('debug', pragmas.debug);
@@ -338,7 +338,7 @@ define([
         this._vao = vao;
         this._attributes = vaAttributes;
         this._indexBuffer = indexBuffer;
-    };
+    }
 
     function computeNumberOfVertices(attribute) {
         return attribute.values.length / attribute.componentsPerAttribute;

--- a/Source/Renderer/VertexArrayFacade.js
+++ b/Source/Renderer/VertexArrayFacade.js
@@ -24,7 +24,7 @@ define([
     /**
      * @private
      */
-    var VertexArrayFacade = function(context, attributes, sizeInVertices, instanced) {
+    function VertexArrayFacade(context, attributes, sizeInVertices, instanced) {
         //>>includeStart('debug', pragmas.debug);
         if (!context) {
             throw new DeveloperError('context is required.');
@@ -102,8 +102,7 @@ define([
         this.va = undefined;
 
         this.resize(sizeInVertices);
-    };
-
+    }
     VertexArrayFacade._verifyAttributes = function(attributes) {
         var attrs = [];
 

--- a/Source/Renderer/createUniform.js
+++ b/Source/Renderer/createUniform.js
@@ -26,7 +26,7 @@ define([
     /**
      * @private
      */
-    var createUniform = function(gl, activeUniform, uniformName, location) {
+    function createUniform(gl, activeUniform, uniformName, location) {
         switch (activeUniform.type) {
             case gl.FLOAT:
                 return new UniformFloat(gl, activeUniform, uniformName, location);
@@ -60,9 +60,7 @@ define([
             default:
                 throw new RuntimeError('Unrecognized uniform type: ' + activeUniform.type + ' for uniform "' + uniformName + '".');
         }
-    };
-
-    ///////////////////////////////////////////////////////////////////////////
+    }
 
     function UniformFloat(gl, activeUniform, uniformName, location) {
         /**

--- a/Source/Renderer/createUniformArray.js
+++ b/Source/Renderer/createUniformArray.js
@@ -28,7 +28,7 @@ define([
     /**
      * @private
      */
-    var createUniformArray = function(gl, activeUniform, uniformName, locations) {
+    function createUniformArray(gl, activeUniform, uniformName, locations) {
         switch (activeUniform.type) {
             case gl.FLOAT:
                 return new UniformArrayFloat(gl, activeUniform, uniformName, locations);
@@ -62,9 +62,7 @@ define([
             default:
                 throw new RuntimeError('Unrecognized uniform type: ' + activeUniform.type + ' for uniform "' + uniformName + '".');
         }
-    };
-
-    ///////////////////////////////////////////////////////////////////////////
+    }
 
     function UniformArrayFloat(gl, activeUniform, uniformName, locations) {
         var length = locations.length;

--- a/Source/Renderer/loadCubeMap.js
+++ b/Source/Renderer/loadCubeMap.js
@@ -48,7 +48,7 @@ define([
      *
      * @private
      */
-    var loadCubeMap = function(context, urls, allowCrossOrigin) {
+    function loadCubeMap(context, urls, allowCrossOrigin) {
         //>>includeStart('debug', pragmas.debug);
         if (!defined(context)) {
             throw new DeveloperError('context is required.');
@@ -92,7 +92,7 @@ define([
                 }
             });
         });
-    };
+    }
 
     return loadCubeMap;
 });

--- a/Source/Scene/Appearance.js
+++ b/Source/Scene/Appearance.js
@@ -42,7 +42,7 @@ define([
      *
      * @demo {@link http://cesiumjs.org/Cesium/Apps/Sandcastle/index.html?src=Geometry%20and%20Appearances.html|Geometry and Appearances Demo}
      */
-    var Appearance = function(options) {
+    function Appearance(options) {
         options = defaultValue(options, defaultValue.EMPTY_OBJECT);
 
         /**
@@ -68,7 +68,7 @@ define([
         this._fragmentShaderSource = options.fragmentShaderSource;
         this._renderState = options.renderState;
         this._closed = defaultValue(options.closed, false);
-    };
+    }
 
     defineProperties(Appearance.prototype, {
         /**

--- a/Source/Scene/ArcGisMapServerImageryProvider.js
+++ b/Source/Scene/ArcGisMapServerImageryProvider.js
@@ -110,7 +110,7 @@ define([
      *     url: '//services.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer'
      * });
      */
-    var ArcGisMapServerImageryProvider = function ArcGisMapServerImageryProvider(options) {
+    function ArcGisMapServerImageryProvider(options) {
         options = defaultValue(options, {});
 
         //>>includeStart('debug', pragmas.debug);
@@ -233,7 +233,7 @@ define([
             this._ready = true;
             this._readyPromise.resolve(true);
         }
-    };
+    }
 
     function buildImageUrl(imageryProvider, x, y, level) {
         var url;

--- a/Source/Scene/Billboard.js
+++ b/Source/Scene/Billboard.js
@@ -70,7 +70,7 @@ define([
      *
      * @demo {@link http://cesiumjs.org/Cesium/Apps/Sandcastle/index.html?src=Billboards.html|Cesium Sandcastle Billboard Demo}
      */
-    var Billboard = function(options, billboardCollection) {
+    function Billboard(options, billboardCollection) {
         options = defaultValue(options, defaultValue.EMPTY_OBJECT);
 
         //>>includeStart('debug', pragmas.debug);
@@ -152,7 +152,7 @@ define([
         this._mode = SceneMode.SCENE3D;
 
         this._updateClamping();
-    };
+    }
 
     var SHOW_INDEX = Billboard.SHOW_INDEX = 0;
     var POSITION_INDEX = Billboard.POSITION_INDEX = 1;
@@ -881,7 +881,7 @@ define([
             owner._removeCallbackFunc();
         }
 
-        var updateFunction = function(clampedPosition) {
+        function updateFunction(clampedPosition) {
             if (owner._heightReference === HeightReference.RELATIVE_TO_GROUND) {
                 if (owner._mode === SceneMode.SCENE3D) {
                     var clampedCart = ellipsoid.cartesianToCartographic(clampedPosition, scratchCartographic);
@@ -892,8 +892,7 @@ define([
                 }
             }
             owner._clampedPosition = Cartesian3.clone(clampedPosition, owner._clampedPosition);
-        };
-
+        }
         owner._removeCallbackFunc = surface.updateHeight(position, updateFunction);
 
         var height = globe.getHeight(position);

--- a/Source/Scene/BillboardCollection.js
+++ b/Source/Scene/BillboardCollection.js
@@ -150,7 +150,7 @@ define([
      *   image : 'url/to/another/image'
      * });
      */
-    var BillboardCollection = function(options) {
+    function BillboardCollection(options) {
         options = defaultValue(options, defaultValue.EMPTY_OBJECT);
 
         this._scene = options.scene;
@@ -280,7 +280,7 @@ define([
                 return that._textureAtlas.texture;
             }
         };
-    };
+    }
 
     defineProperties(BillboardCollection.prototype, {
         /**

--- a/Source/Scene/BingMapsImageryProvider.js
+++ b/Source/Scene/BingMapsImageryProvider.js
@@ -94,7 +94,7 @@ define([
      *     mapStyle : Cesium.BingMapsStyle.AERIAL
      * });
      */
-    var BingMapsImageryProvider = function BingMapsImageryProvider(options) {
+    function BingMapsImageryProvider(options) {
         options = defaultValue(options, {});
 
         //>>includeStart('debug', pragmas.debug);
@@ -218,7 +218,7 @@ define([
         }
 
         requestMetadata();
-    };
+    }
 
     defineProperties(BingMapsImageryProvider.prototype, {
         /**

--- a/Source/Scene/Camera.js
+++ b/Source/Scene/Camera.js
@@ -81,7 +81,7 @@ define([
      * camera.frustum.near = 1.0;
      * camera.frustum.far = 2.0;
      */
-    var Camera = function(scene) {
+    function Camera(scene) {
         //>>includeStart('debug', pragmas.debug);
         if (!defined(scene)) {
             throw new DeveloperError('scene is required.');
@@ -216,7 +216,7 @@ define([
         mag += mag * Camera.DEFAULT_VIEW_FACTOR;
         Cartesian3.normalize(this.position, this.position);
         Cartesian3.multiplyByScalar(this.position, mag, this.position);
-    };
+    }
 
     /**
      * @private
@@ -2314,11 +2314,10 @@ define([
             newPosition.z += -maxY - center.z;
         }
 
-        var updateCV = function(value) {
+        function updateCV(value) {
             var interp = Cartesian3.lerp(position, newPosition, value.time, new Cartesian3());
             camera.worldToCameraCoordinatesPoint(interp, camera.position);
-        };
-
+        }
         return {
             easingFunction : EasingFunction.EXPONENTIAL_OUT,
             startObject : {

--- a/Source/Scene/CameraEventAggregator.js
+++ b/Source/Scene/CameraEventAggregator.js
@@ -254,7 +254,7 @@ define([
      *
      * @see ScreenSpaceEventHandler
      */
-    var CameraEventAggregator = function(canvas) {
+    function CameraEventAggregator(canvas) {
         //>>includeStart('debug', pragmas.debug);
         if (!defined(canvas)) {
             throw new DeveloperError('canvas is required.');
@@ -295,7 +295,7 @@ define([
                 }
             }
         }
-    };
+    }
 
     defineProperties(CameraEventAggregator.prototype, {
         /**

--- a/Source/Scene/CameraFlightPath.js
+++ b/Source/Scene/CameraFlightPath.js
@@ -121,7 +121,7 @@ define([
 
         var heightFunction = createHeightFunction(camera, destination, start.z, destination.z, optionAltitude);
 
-        var update = function(value) {
+        function update(value) {
             var time = value.time / duration;
 
             camera.setView({
@@ -134,8 +134,7 @@ define([
 
             Cartesian2.lerp(start, destination, time, camera.position);
             camera.position.z = heightFunction(time);
-        };
-
+        }
         return update;
     }
 
@@ -169,7 +168,7 @@ define([
 
         var heightFunction = createHeightFunction(camera, destination, startCart.height, destCart.height, optionAltitude);
 
-        var update = function(value) {
+        function update(value) {
             var time = value.time / duration;
 
             var position = Cartesian3.fromRadians(
@@ -186,8 +185,7 @@ define([
                     roll : CesiumMath.lerp(startRoll, roll, time)
                 }
             });
-        };
-
+        }
         return update;
     }
 
@@ -200,7 +198,7 @@ define([
         var startHeight = camera.frustum.right - camera.frustum.left;
         var heightFunction = createHeightFunction(camera, destination, startHeight, destination.z, optionAltitude);
 
-        var update = function(value) {
+        function update(value) {
             var time = value.time / duration;
 
             camera.setView({
@@ -221,8 +219,7 @@ define([
             frustum.left -= incrementAmount;
             frustum.top = ratio * frustum.right;
             frustum.bottom = -frustum.top;
-        };
-
+        }
         return update;
     }
 
@@ -240,13 +237,13 @@ define([
     }
 
     function wrapCallback(controller, cb) {
-        var wrapped = function() {
+        function wrapped() {
             if (typeof cb === 'function') {
                 cb();
             }
 
             controller.enableInputs = true;
-        };
+        }
         return wrapped;
     }
 

--- a/Source/Scene/CreditDisplay.js
+++ b/Source/Scene/CreditDisplay.js
@@ -156,7 +156,7 @@ define([
      * @example
      * var creditDisplay = new Cesium.CreditDisplay(creditContainer);
      */
-    var CreditDisplay = function(container, delimiter) {
+    function CreditDisplay(container, delimiter) {
         //>>includeStart('debug', pragmas.debug);
         if (!defined(container)) {
             throw new DeveloperError('credit container is required');
@@ -185,7 +185,7 @@ define([
             imageCredits : [],
             textCredits : []
         };
-    };
+    }
 
     /**
      * Adds a credit to the list of current credits to be displayed in the credit container

--- a/Source/Scene/CullingVolume.js
+++ b/Source/Scene/CullingVolume.js
@@ -23,7 +23,7 @@ define([
      *
      * @param {Cartesian4[]} planes An array of clipping planes.
      */
-    var CullingVolume = function(planes) {
+    function CullingVolume(planes) {
         /**
          * Each plane is represented by a Cartesian4 object, where the x, y, and z components
          * define the unit vector normal to the plane, and the w component is the distance of the
@@ -32,7 +32,7 @@ define([
          * @default []
          */
         this.planes = defaultValue(planes, []);
-    };
+    }
 
     var scratchPlane = new Plane(new Cartesian3(), 0.0);
     /**

--- a/Source/Scene/DebugAppearance.js
+++ b/Source/Scene/DebugAppearance.js
@@ -41,7 +41,7 @@ define([
      *   })
      * });
      */
-    var DebugAppearance = function(options) {
+    function DebugAppearance(options) {
         options = defaultValue(options, defaultValue.EMPTY_OBJECT);
         var attributeName = options.attributeName;
 
@@ -129,7 +129,7 @@ define([
 
         this._attributeName = attributeName;
         this._glslDatatype = glslDatatype;
-    };
+    }
 
     defineProperties(DebugAppearance.prototype, {
         /**

--- a/Source/Scene/DebugModelMatrixPrimitive.js
+++ b/Source/Scene/DebugModelMatrixPrimitive.js
@@ -51,7 +51,7 @@ define([
      *   width : 10.0
      * }));
      */
-    var DebugModelMatrixPrimitive = function(options) {
+    function DebugModelMatrixPrimitive(options) {
         options = defaultValue(options, defaultValue.EMPTY_OBJECT);
 
         /**
@@ -101,7 +101,7 @@ define([
         this._id = undefined;
 
         this._primitive = undefined;
-    };
+    }
 
     /**
      * @private

--- a/Source/Scene/DepthPlane.js
+++ b/Source/Scene/DepthPlane.js
@@ -42,13 +42,13 @@ define([
     /**
      * @private
      */
-    var DepthPlane = function() {
+    function DepthPlane() {
         this._rs = undefined;
         this._sp = undefined;
         this._va = undefined;
         this._command = undefined;
         this._mode = undefined;
-    };
+    }
 
     var depthQuadScratch = FeatureDetection.supportsTypedArrays() ? new Float32Array(12) : [];
     var scratchCartesian1 = new Cartesian3();

--- a/Source/Scene/DiscardMissingTileImagePolicy.js
+++ b/Source/Scene/DiscardMissingTileImagePolicy.js
@@ -30,7 +30,7 @@ define([
      *                  if all of the pixelsToCheck in the missingImageUrl have an alpha value of 0.  If false, the
      *                  discard check will proceed no matter the values of the pixelsToCheck.
      */
-    var DiscardMissingTileImagePolicy = function(options) {
+    function DiscardMissingTileImagePolicy(options) {
         options = defaultValue(options, defaultValue.EMPTY_OBJECT);
 
         if (!defined(options.missingImageUrl)) {
@@ -87,7 +87,7 @@ define([
         }
 
         when(loadImageViaBlob(options.missingImageUrl), success, failure);
-    };
+    }
 
     /**
      * Determines if the discard policy is ready to process images.

--- a/Source/Scene/EllipsoidPrimitive.js
+++ b/Source/Scene/EllipsoidPrimitive.js
@@ -73,7 +73,7 @@ define([
      *
      * @private
      */
-    var EllipsoidPrimitive = function(options) {
+    function EllipsoidPrimitive(options) {
         options = defaultValue(options, defaultValue.EMPTY_OBJECT);
 
         /**
@@ -224,7 +224,7 @@ define([
                 return that._pickId.color;
             }
         };
-    };
+    }
 
     function getVertexArray(context) {
         var vertexArray = context.cache.ellipsoidPrimitive_vertexArray;

--- a/Source/Scene/EllipsoidSurfaceAppearance.js
+++ b/Source/Scene/EllipsoidSurfaceAppearance.js
@@ -56,7 +56,7 @@ define([
      *   })
      * });
      */
-    var EllipsoidSurfaceAppearance = function(options) {
+    function EllipsoidSurfaceAppearance(options) {
         options = defaultValue(options, defaultValue.EMPTY_OBJECT);
 
         var translucent = defaultValue(options.translucent, true);
@@ -93,7 +93,7 @@ define([
         this._flat = defaultValue(options.flat, false);
         this._faceForward = defaultValue(options.faceForward, aboveGround);
         this._aboveGround = aboveGround;
-    };
+    }
 
     defineProperties(EllipsoidSurfaceAppearance.prototype, {
         /**

--- a/Source/Scene/FXAA.js
+++ b/Source/Scene/FXAA.js
@@ -32,7 +32,7 @@ define([
     /**
      * @private
      */
-    var FXAA = function(context) {
+    function FXAA(context) {
         this._texture = undefined;
         this._depthTexture = undefined;
         this._depthRenderbuffer = undefined;
@@ -45,7 +45,7 @@ define([
             owner : this
         });
         this._clearCommand = clearCommand;
-    };
+    }
 
     function destroyResources(fxaa) {
         fxaa._fbo = fxaa._fbo && fxaa._fbo.destroy();

--- a/Source/Scene/Fog.js
+++ b/Source/Scene/Fog.js
@@ -18,7 +18,7 @@ define([
      * @alias Fog
      * @constructor
      */
-    var Fog = function() {
+    function Fog() {
         /**
          * <code>true</code> if fog is enabled, <code>false</code> otherwise.
          * @type {Boolean}
@@ -45,7 +45,7 @@ define([
          * @default 2.0
          */
         this.screenSpaceErrorFactor = 2.0;
-    };
+    }
 
     // These values were found by sampling the density at certain views and finding at what point culled tiles impacted the view at the horizon.
     var heightsTable = [359.393, 800.749, 1275.6501, 2151.1192, 3141.7763, 4777.5198, 6281.2493, 12364.307, 15900.765, 49889.0549, 78026.8259, 99260.7344, 120036.3873, 151011.0158, 156091.1953, 203849.3112, 274866.9803, 319916.3149, 493552.0528, 628733.5874];

--- a/Source/Scene/FrameRateMonitor.js
+++ b/Source/Scene/FrameRateMonitor.js
@@ -42,7 +42,7 @@ define([
      *        the end of the warmup period.  If the frame rate averages less than this during any samplingWindow after the warmupPeriod, the
      *        lowFrameRate event will be raised and the page will redirect to the redirectOnLowFrameRateUrl, if any.
      */
-    var FrameRateMonitor = function(options) {
+    function FrameRateMonitor(options) {
         //>>includeStart('debug', pragmas.debug);
         if (!defined(options) || !defined(options.scene)) {
             throw new DeveloperError('options.scene is required.');
@@ -125,7 +125,7 @@ define([
                 document.removeEventListener(visibilityChangeEventName, visibilityChangeListener, false);
             };
         }
-    };
+    }
 
     /**
      * The default frame rate monitoring settings.  These settings are used when {@link FrameRateMonitor.fromScene}

--- a/Source/Scene/FrameState.js
+++ b/Source/Scene/FrameState.js
@@ -16,7 +16,7 @@ define([
      *
      * @private
      */
-    var FrameState = function(context, creditDisplay) {
+    function FrameState(context, creditDisplay) {
         /**
          * The rendering context.
          * @type {Context}
@@ -162,7 +162,7 @@ define([
         * @type {Number}
         */
         this.terrainExaggeration = 1.0;
-    };
+    }
 
     /**
      * A function that will be called at the end of the frame.

--- a/Source/Scene/FrustumCommands.js
+++ b/Source/Scene/FrustumCommands.js
@@ -17,7 +17,7 @@ define([
      *
      * @private
      */
-    var FrustumCommands = function(near, far) {
+    function FrustumCommands(near, far) {
         this.near = defaultValue(near, 0.0);
         this.far = defaultValue(far, 0.0);
 
@@ -32,7 +32,7 @@ define([
 
         this.commands = commands;
         this.indices = indices;
-    };
+    }
 
     return FrustumCommands;
 });

--- a/Source/Scene/GetFeatureInfoFormat.js
+++ b/Source/Scene/GetFeatureInfoFormat.js
@@ -32,7 +32,7 @@ define([
      *        in order to produce an array of picked {@link ImageryLayerFeatureInfo} instances.  If this parameter is not specified,
      *        a default function for the type of response is used.
      */
-    var GetFeatureInfoFormat = function(type, format, callback) {
+    function GetFeatureInfoFormat(type, format, callback) {
         //>>includeStart('debug', pragmas.debug);
         if (!defined(type)) {
             throw new DeveloperError('type is required.');
@@ -78,7 +78,7 @@ define([
         }
 
         this.callback = callback;
-    };
+    }
 
     function geoJsonToFeatureInfo(json) {
         var result = [];

--- a/Source/Scene/Globe.js
+++ b/Source/Scene/Globe.js
@@ -67,7 +67,7 @@ define([
      * @param {Ellipsoid} [ellipsoid=Ellipsoid.WGS84] Determines the size and shape of the
      * globe.
      */
-    var Globe = function(ellipsoid) {
+    function Globe(ellipsoid) {
         ellipsoid = defaultValue(ellipsoid, Ellipsoid.WGS84);
         var terrainProvider = new EllipsoidTerrainProvider({
             ellipsoid : ellipsoid
@@ -190,7 +190,7 @@ define([
 
         this._oceanNormalMap = undefined;
         this._zoomedOutOceanSpecularIntensity = 0.5;
-    };
+    }
 
     defineProperties(Globe.prototype, {
         /**

--- a/Source/Scene/GlobeDepth.js
+++ b/Source/Scene/GlobeDepth.js
@@ -28,7 +28,7 @@ define([
     /**
      * @private
      */
-    var GlobeDepth = function() {
+    function GlobeDepth() {
         this._colorTexture = undefined;
         this._depthStencilTexture = undefined;
         this._globeDepthTexture = undefined;
@@ -41,7 +41,7 @@ define([
         this._copyDepthCommand = undefined;
 
         this._debugGlobeDepthViewportCommand = undefined;
-    };
+    }
 
     function executeDebugGlobeDepth(globeDepth, context, passState) {
         if (!defined(globeDepth._debugGlobeDepthViewportCommand)) {

--- a/Source/Scene/GlobeSurfaceTile.js
+++ b/Source/Scene/GlobeSurfaceTile.js
@@ -53,7 +53,7 @@ define([
      * @alias GlobeSurfaceTile
      * @private
      */
-    var GlobeSurfaceTile = function() {
+    function GlobeSurfaceTile() {
         /**
          * The {@link TileImagery} attached to this tile.
          * @type {TileImagery[]}
@@ -138,7 +138,7 @@ define([
         this.pickTerrain = undefined;
 
         this.surfaceShader = undefined;
-    };
+    }
 
     defineProperties(GlobeSurfaceTile.prototype, {
         /**

--- a/Source/Scene/GlobeSurfaceTileProvider.js
+++ b/Source/Scene/GlobeSurfaceTileProvider.js
@@ -102,7 +102,7 @@ define([
      *
      * @private
      */
-    var GlobeSurfaceTileProvider = function GlobeSurfaceTileProvider(options) {
+    function GlobeSurfaceTileProvider(options) {
         //>>includeStart('debug', pragmas.debug);
         if (!defined(options)) {
             throw new DeveloperError('options is required.');
@@ -156,7 +156,7 @@ define([
         this._baseColor = undefined;
         this._firstPassInitialColor = undefined;
         this.baseColor = new Color(0.0, 0.0, 0.5, 1.0);
-    };
+    }
 
     defineProperties(GlobeSurfaceTileProvider.prototype, {
         /**

--- a/Source/Scene/GoogleEarthImageryProvider.js
+++ b/Source/Scene/GoogleEarthImageryProvider.js
@@ -97,7 +97,7 @@ define([
      *     channel : 1008
      * });
      */
-    var GoogleEarthImageryProvider = function GoogleEarthImageryProvider(options) {
+    function GoogleEarthImageryProvider(options) {
         options = defaultValue(options, {});
 
         //>>includeStart('debug', pragmas.debug);
@@ -223,8 +223,7 @@ define([
         }
 
         requestMetadata();
-    };
-
+    }
 
     defineProperties(GoogleEarthImageryProvider.prototype, {
         /**

--- a/Source/Scene/GridImageryProvider.js
+++ b/Source/Scene/GridImageryProvider.js
@@ -42,7 +42,7 @@ define([
      * @param {Number} [options.tileHeight=256] The height of the tile for level-of-detail selection purposes.
      * @param {Number} [options.canvasSize=256] The size of the canvas used for rendering.
      */
-    var GridImageryProvider = function GridImageryProvider(options) {
+    function GridImageryProvider(options) {
         options = defaultValue(options, defaultValue.EMPTY_OBJECT);
 
         this._tilingScheme = defined(options.tilingScheme) ? options.tilingScheme : new GeographicTilingScheme({ ellipsoid : options.ellipsoid });
@@ -64,7 +64,7 @@ define([
         this._canvas = this._createGridCanvas();
 
         this._readyPromise = when.resolve(true);
-    };
+    }
 
     defineProperties(GridImageryProvider.prototype, {
         /**

--- a/Source/Scene/GroundPrimitive.js
+++ b/Source/Scene/GroundPrimitive.js
@@ -109,7 +109,7 @@ define([
      *   geometryInstance : rectangleInstance
      * }));
      */
-    var GroundPrimitive = function(options) {
+    function GroundPrimitive(options) {
         options = defaultValue(options, defaultValue.EMPTY_OBJECT);
 
         /**
@@ -179,7 +179,7 @@ define([
             _createShaderProgramFunction : undefined,
             _createCommandsFunction : undefined
         };
-    };
+    }
 
     defineProperties(GroundPrimitive.prototype, {
         /**

--- a/Source/Scene/Imagery.js
+++ b/Source/Scene/Imagery.js
@@ -15,7 +15,7 @@ define([
      * @alias Imagery
      * @private
      */
-    var Imagery = function(imageryLayer, x, y, level, rectangle) {
+    function Imagery(imageryLayer, x, y, level, rectangle) {
         this.imageryLayer = imageryLayer;
         this.x = x;
         this.y = y;
@@ -41,8 +41,7 @@ define([
         }
 
         this.rectangle = rectangle;
-    };
-
+    }
     Imagery.createPlaceholder = function(imageryLayer) {
         var result = new Imagery(imageryLayer, 0, 0, 0);
         result.addReference();

--- a/Source/Scene/ImageryLayer.js
+++ b/Source/Scene/ImageryLayer.js
@@ -150,7 +150,7 @@ define([
      * @param {Number} [options.maximumTerrainLevel] The maximum terrain level-of-detail at which to show this imagery layer,
      *                 or undefined to show it at all levels.  Level zero is the least-detailed level.
      */
-    var ImageryLayer = function ImageryLayer(imageryProvider, options) {
+    function ImageryLayer(imageryProvider, options) {
         this._imageryProvider = imageryProvider;
 
         options = defaultValue(options, {});
@@ -235,7 +235,7 @@ define([
         this._isBaseLayer = false;
 
         this._requestImageError = undefined;
-    };
+    }
 
     defineProperties(ImageryLayer.prototype, {
 

--- a/Source/Scene/ImageryLayerCollection.js
+++ b/Source/Scene/ImageryLayerCollection.js
@@ -32,7 +32,7 @@ define([
      * @demo {@link http://cesiumjs.org/Cesium/Apps/Sandcastle/index.html?src=Imagery%20Adjustment.html|Cesium Sandcastle Imagery Adjustment Demo}
      * @demo {@link http://cesiumjs.org/Cesium/Apps/Sandcastle/index.html?src=Imagery%20Layers%20Manipulation.html|Cesium Sandcastle Imagery Manipulation Demo}
      */
-    var ImageryLayerCollection = function ImageryLayerCollection() {
+    function ImageryLayerCollection() {
         this._layers = [];
 
         /**
@@ -69,7 +69,7 @@ define([
          * @default Event()
          */
         this.layerShownOrHidden = new Event();
-    };
+    }
 
     defineProperties(ImageryLayerCollection.prototype, {
         /**

--- a/Source/Scene/ImageryLayerFeatureInfo.js
+++ b/Source/Scene/ImageryLayerFeatureInfo.js
@@ -11,7 +11,7 @@ define([
      * @alias ImageryLayerFeatureInfo
      * @constructor
      */
-    var ImageryLayerFeatureInfo = function() {
+    function ImageryLayerFeatureInfo() {
         /**
          * Gets or sets the name of the feature.
          * @type {String}
@@ -44,7 +44,7 @@ define([
          * @type {Object}
          */
         this.imageryLayer = undefined;
-    };
+    }
 
     /**
      * Configures the name of this feature by selecting an appropriate property.  The name will be obtained from

--- a/Source/Scene/ImageryProvider.js
+++ b/Source/Scene/ImageryProvider.js
@@ -34,7 +34,7 @@ define([
      * @demo {@link http://cesiumjs.org/Cesium/Apps/Sandcastle/index.html?src=Imagery%20Layers.html|Cesium Sandcastle Imagery Layers Demo}
      * @demo {@link http://cesiumjs.org/Cesium/Apps/Sandcastle/index.html?src=Imagery%20Layers%20Manipulation.html|Cesium Sandcastle Imagery Manipulation Demo}
      */
-    var ImageryProvider = function ImageryProvider() {
+    function ImageryProvider() {
         /**
          * The default alpha blending value of this provider, with 0.0 representing fully transparent and
          * 1.0 representing fully opaque.
@@ -88,7 +88,7 @@ define([
         this.defaultGamma = undefined;
 
         DeveloperError.throwInstantiationError();
-    };
+    }
 
     defineProperties(ImageryProvider.prototype, {
         /**

--- a/Source/Scene/Label.js
+++ b/Source/Scene/Label.js
@@ -60,7 +60,7 @@ define([
      *
      * @demo {@link http://cesiumjs.org/Cesium/Apps/Sandcastle/index.html?src=Labels.html|Cesium Sandcastle Labels Demo}
      */
-    var Label = function(options, labelCollection) {
+    function Label(options, labelCollection) {
         options = defaultValue(options, defaultValue.EMPTY_OBJECT);
 
         //>>includeStart('debug', pragmas.debug);
@@ -101,7 +101,7 @@ define([
         this._mode = undefined;
 
         this._updateClamping();
-    };
+    }
 
     defineProperties(Label.prototype, {
         /**

--- a/Source/Scene/LabelCollection.js
+++ b/Source/Scene/LabelCollection.js
@@ -320,7 +320,7 @@ define([
      *   text : 'Another label'
      * });
      */
-    var LabelCollection = function(options) {
+    function LabelCollection(options) {
         options = defaultValue(options, defaultValue.EMPTY_OBJECT);
 
         this._scene = options.scene;
@@ -381,7 +381,7 @@ define([
          * @default false
          */
         this.debugShowBoundingVolume = defaultValue(options.debugShowBoundingVolume, false);
-    };
+    }
 
     defineProperties(LabelCollection.prototype, {
         /**

--- a/Source/Scene/MapboxImageryProvider.js
+++ b/Source/Scene/MapboxImageryProvider.js
@@ -51,7 +51,7 @@ define([
      *     accessToken: 'thisIsMyAccessToken'
      * });
      */
-    var MapboxImageryProvider = function MapboxImageryProvider(options) {
+    function MapboxImageryProvider(options) {
         options = defaultValue(options, defaultValue.EMPTY_OBJECT);
         var mapId = options.mapId;
         //>>includeStart('debug', pragmas.debug);
@@ -94,7 +94,7 @@ define([
             maximumLevel: options.maximumLevel,
             rectangle: options.rectangle
         });
-    };
+    }
 
     defineProperties(MapboxImageryProvider.prototype, {
         /**

--- a/Source/Scene/Material.js
+++ b/Source/Scene/Material.js
@@ -258,7 +258,7 @@ define([
      *     }
      * });
      */
-    var Material = function(options) {
+    function Material(options) {
         /**
          * The material type. Can be an existing type or a new type. If no type is specified in fabric, type is a GUID.
          * @type {String}
@@ -321,7 +321,7 @@ define([
         if (!defined(Material._uniformList[this.type])) {
             Material._uniformList[this.type] = Object.keys(this._uniforms);
         }
-    };
+    }
 
     // Cached list of combined uniform names indexed by type.
     // Used to get the list of uniforms in the same order.

--- a/Source/Scene/MaterialAppearance.js
+++ b/Source/Scene/MaterialAppearance.js
@@ -65,7 +65,7 @@ define([
      *
      * });
      */
-    var MaterialAppearance = function(options) {
+    function MaterialAppearance(options) {
         options = defaultValue(options, defaultValue.EMPTY_OBJECT);
 
         var translucent = defaultValue(options.translucent, true);
@@ -104,7 +104,7 @@ define([
         this._vertexFormat = materialSupport.vertexFormat;
         this._flat = defaultValue(options.flat, false);
         this._faceForward = defaultValue(options.faceForward, !closed);
-    };
+    }
 
     defineProperties(MaterialAppearance.prototype, {
         /**

--- a/Source/Scene/Model.js
+++ b/Source/Scene/Model.js
@@ -210,13 +210,13 @@ define([
     //
     // Note that this is a global cache, compared to renderer resources, which
     // are cached per context.
-    var CachedGltf = function(options) {
+    function CachedGltf(options) {
         this._gltf = modelMaterialsCommon(gltfDefaults(options.gltf));
         this._bgltf = options.bgltf;
         this.ready = options.ready;
         this.modelsToLoad = [];
         this.count = 0;
-    };
+    }
 
     defineProperties(CachedGltf.prototype, {
         gltf : {
@@ -315,7 +315,7 @@ define([
      *
      * @demo {@link http://cesiumjs.org/Cesium/Apps/Sandcastle/index.html?src=3D%20Models.html|Cesium Sandcastle Models Demo}
      */
-    var Model = function(options) {
+    function Model(options) {
         options = defaultValue(options, defaultValue.EMPTY_OBJECT);
 
         var cacheKey = options.cacheKey;
@@ -557,7 +557,7 @@ define([
         // CESIUM_RTC extension
         this._rtcCenter = undefined;    // in world coordinates
         this._rtcCenterEye = undefined; // in eye coordinates
-    };
+    }
 
     defineProperties(Model.prototype, {
         /**
@@ -2259,11 +2259,11 @@ define([
 
     ///////////////////////////////////////////////////////////////////////////
 
-    var DelayLoadedTextureUniform = function(value, model) {
+    function DelayLoadedTextureUniform(value, model) {
         this._value = undefined;
         this._textureId = value;
         this._model = model;
-    };
+    }
 
     defineProperties(DelayLoadedTextureUniform.prototype, {
         value : {
@@ -3065,7 +3065,7 @@ define([
 
     ///////////////////////////////////////////////////////////////////////////
 
-    var CachedRendererResources = function(context, cacheKey) {
+    function CachedRendererResources(context, cacheKey) {
         this.buffers = undefined;
         this.vertexArrays = undefined;
         this.programs = undefined;
@@ -3078,7 +3078,7 @@ define([
         this.context = context;
         this.cacheKey = cacheKey;
         this.count = 0;
-    };
+    }
 
     function destroy(property) {
         for (var name in property) {

--- a/Source/Scene/ModelAnimation.js
+++ b/Source/Scene/ModelAnimation.js
@@ -30,7 +30,7 @@ define([
      *
      * @see ModelAnimationCollection#add
      */
-    var ModelAnimation = function(options, model, runtimeAnimation) {
+    function ModelAnimation(options, model, runtimeAnimation) {
         this._name = options.name;
         this._startTime = JulianDate.clone(options.startTime);
         this._delay = defaultValue(options.delay, 0.0); // in seconds
@@ -122,7 +122,7 @@ define([
         this._raiseStopEvent = function() {
             that.stop.raiseEvent(model, that);
         };
-    };
+    }
 
     defineProperties(ModelAnimation.prototype, {
         /**

--- a/Source/Scene/ModelAnimationCache.js
+++ b/Source/Scene/ModelAnimationCache.js
@@ -24,8 +24,8 @@ define([
     /**
      * @private
      */
-    var ModelAnimationCache = function() {
-    };
+    function ModelAnimationCache() {
+    }
 
     function getAccessorKey(model, accessor) {
         var gltf = model.gltf;
@@ -109,10 +109,9 @@ define([
     }
 
  // GLTF_SPEC: https://github.com/KhronosGroup/glTF/issues/185
-    var ConstantSpline = function(value) {
+    function ConstantSpline(value) {
         this._value = value;
-    };
-
+    }
     ConstantSpline.prototype.evaluate = function(time, result) {
         return this._value;
     };

--- a/Source/Scene/ModelAnimationCollection.js
+++ b/Source/Scene/ModelAnimationCollection.js
@@ -33,7 +33,7 @@ define([
      *
      * @see Model#activeAnimations
      */
-    var ModelAnimationCollection = function(model) {
+    function ModelAnimationCollection(model) {
         /**
          * The event fired when an animation is added to the collection.  This can be used, for
          * example, to keep a UI in sync.
@@ -65,7 +65,7 @@ define([
         this._model = model;
         this._scheduledAnimations = [];
         this._previousTime = undefined;
-    };
+    }
 
     defineProperties(ModelAnimationCollection.prototype, {
         /**

--- a/Source/Scene/ModelMaterial.js
+++ b/Source/Scene/ModelMaterial.js
@@ -23,11 +23,11 @@ define([
      *
      * @see Model#getMaterial
      */
-    var ModelMaterial = function(model, material, id) {
+    function ModelMaterial(model, material, id) {
         this._name = material.name;
         this._id = id;
         this._uniformMap = model._uniformMaps[id];
-    };
+    }
 
     defineProperties(ModelMaterial.prototype, {
         /**

--- a/Source/Scene/ModelMesh.js
+++ b/Source/Scene/ModelMesh.js
@@ -16,7 +16,7 @@ define([
      *
      * @see Model#getMesh
      */
-    var ModelMesh = function(mesh, runtimeMaterialsById, id) {
+    function ModelMesh(mesh, runtimeMaterialsById, id) {
         var materials = [];
         var primitives = mesh.primitives;
         var length = primitives.length;
@@ -28,7 +28,7 @@ define([
         this._name = mesh.name;
         this._materials = materials;
         this._id = id;
-    };
+    }
 
     defineProperties(ModelMesh.prototype, {
         /**

--- a/Source/Scene/ModelNode.js
+++ b/Source/Scene/ModelNode.js
@@ -27,7 +27,7 @@ define([
      * var node = model.getNode('LOD3sp');
      * node.matrix = Cesium.Matrix4.fromScale(new Cesium.Cartesian3(5.0, 1.0, 1.0), node.matrix);
      */
-    var ModelNode = function(model, node, runtimeNode, id, matrix) {
+    function ModelNode(model, node, runtimeNode, id, matrix) {
         this._model = model;
         this._runtimeNode = runtimeNode;
         this._name = node.name;
@@ -40,7 +40,7 @@ define([
 
         this._show = true;
         this._matrix = Matrix4.clone(matrix);
-    };
+    }
 
     defineProperties(ModelNode.prototype, {
         /**

--- a/Source/Scene/Moon.js
+++ b/Source/Scene/Moon.js
@@ -47,7 +47,7 @@ define([
      * @example
      * scene.moon = new Cesium.Moon();
      */
-    var Moon = function(options) {
+    function Moon(options) {
         options = defaultValue(options, defaultValue.EMPTY_OBJECT);
 
         var url = options.textureUrl;
@@ -88,7 +88,7 @@ define([
         this._ellipsoidPrimitive.material.translucent = false;
 
         this._axes = new IauOrientationAxes();
-    };
+    }
 
     defineProperties(Moon.prototype, {
         /**

--- a/Source/Scene/NeverTileDiscardPolicy.js
+++ b/Source/Scene/NeverTileDiscardPolicy.js
@@ -10,8 +10,8 @@ define([], function() {
      *
      * @see DiscardMissingTileImagePolicy
      */
-    var NeverTileDiscardPolicy = function(options) {
-    };
+    function NeverTileDiscardPolicy(options) {
+    }
 
     /**
      * Determines if the discard policy is ready to process images.

--- a/Source/Scene/OIT.js
+++ b/Source/Scene/OIT.js
@@ -38,7 +38,7 @@ define([
     /**
      * @private
      */
-    var OIT = function(context) {
+    function OIT(context) {
         // We support multipass for the Chrome D3D9 backend and ES 2.0 on mobile.
         this._translucentMultipassSupport = false;
         this._translucentMRTSupport = false;
@@ -84,7 +84,7 @@ define([
         this._compositeCommand = undefined;
         this._adjustTranslucentCommand = undefined;
         this._adjustAlphaCommand = undefined;
-    };
+    }
 
     function destroyTextures(oit) {
         oit._accumulationTexture = oit._accumulationTexture && !oit._accumulationTexture.isDestroyed() && oit._accumulationTexture.destroy();

--- a/Source/Scene/OpenStreetMapImageryProvider.js
+++ b/Source/Scene/OpenStreetMapImageryProvider.js
@@ -67,7 +67,7 @@ define([
      * 
      * @deprecated
      */
-    var OpenStreetMapImageryProvider = function OpenStreetMapImageryProvider(options) {
+    function OpenStreetMapImageryProvider(options) {
         deprecationWarning('OpenStreetMapImageryProvider', 'OpenStreetMapImageryProvider is deprecated. It will be removed in Cesium 1.18. Use createOpenStreetMapImageryProvider instead.');
         options = defaultValue(options, {});
 
@@ -112,7 +112,7 @@ define([
             credit = new Credit(credit);
         }
         this._credit = credit;
-    };
+    }
 
     function buildImageUrl(imageryProvider, x, y, level) {
         var url = imageryProvider._url + level + '/' + x + '/' + y + '.' + imageryProvider._fileExtension;

--- a/Source/Scene/OrthographicFrustum.js
+++ b/Source/Scene/OrthographicFrustum.js
@@ -39,7 +39,7 @@ define([
      * frustum.near = 0.01 * maxRadii;
      * frustum.far = 50.0 * maxRadii;
      */
-    var OrthographicFrustum = function() {
+    function OrthographicFrustum() {
         /**
          * The left clipping plane.
          * @type {Number}
@@ -90,7 +90,7 @@ define([
 
         this._cullingVolume = new CullingVolume();
         this._orthographicMatrix = new Matrix4();
-    };
+    }
 
     function update(frustum) {
         //>>includeStart('debug', pragmas.debug);

--- a/Source/Scene/PerInstanceColorAppearance.js
+++ b/Source/Scene/PerInstanceColorAppearance.js
@@ -82,7 +82,7 @@ define([
      *   appearance : new Cesium.PerInstanceColorAppearance()
      * });
      */
-    var PerInstanceColorAppearance = function(options) {
+    function PerInstanceColorAppearance(options) {
         options = defaultValue(options, defaultValue.EMPTY_OBJECT);
 
         var translucent = defaultValue(options.translucent, true);
@@ -122,7 +122,7 @@ define([
         this._vertexFormat = vertexFormat;
         this._flat = flat;
         this._faceForward = defaultValue(options.faceForward, !closed);
-    };
+    }
 
     defineProperties(PerInstanceColorAppearance.prototype, {
         /**

--- a/Source/Scene/PerformanceDisplay.js
+++ b/Source/Scene/PerformanceDisplay.js
@@ -20,7 +20,7 @@ define([
     /**
      * @private
      */
-    var PerformanceDisplay = function(options) {
+    function PerformanceDisplay(options) {
         options = defaultValue(options, defaultValue.EMPTY_OBJECT);
 
         var container = getElement(options.container);
@@ -49,7 +49,7 @@ define([
         this._time = undefined;
         this._fps = 0;
         this._frameTime = 0;
-    };
+    }
 
     /**
      * Update the display.  This function should only be called once per frame, because

--- a/Source/Scene/PerspectiveFrustum.js
+++ b/Source/Scene/PerspectiveFrustum.js
@@ -29,7 +29,7 @@ define([
      * frustum.near = 1.0;
      * frustum.far = 2.0;
      */
-    var PerspectiveFrustum = function() {
+    function PerspectiveFrustum() {
         this._offCenterFrustum = new PerspectiveOffCenterFrustum();
 
         /**
@@ -68,7 +68,7 @@ define([
          */
         this.far = 500000000.0;
         this._far = this.far;
-    };
+    }
 
     function update(frustum) {
         //>>includeStart('debug', pragmas.debug);

--- a/Source/Scene/PerspectiveOffCenterFrustum.js
+++ b/Source/Scene/PerspectiveOffCenterFrustum.js
@@ -41,7 +41,7 @@ define([
      * frustum.near = 1.0;
      * frustum.far = 2.0;
      */
-    var PerspectiveOffCenterFrustum = function() {
+    function PerspectiveOffCenterFrustum() {
         /**
          * Defines the left clipping plane.
          * @type {Number}
@@ -93,7 +93,7 @@ define([
         this._cullingVolume = new CullingVolume();
         this._perspectiveMatrix = new Matrix4();
         this._infinitePerspective = new Matrix4();
-    };
+    }
 
     function update(frustum) {
         //>>includeStart('debug', pragmas.debug);

--- a/Source/Scene/PickDepth.js
+++ b/Source/Scene/PickDepth.js
@@ -24,7 +24,7 @@ define([
     /**
      * @private
      */
-    var PickDepth = function() {
+    function PickDepth() {
         this.framebuffer = undefined;
 
         this._depthTexture = undefined;
@@ -32,7 +32,7 @@ define([
         this._copyDepthCommand = undefined;
 
         this._debugPickDepthViewportCommand = undefined;
-    };
+    }
 
     function executeDebugPickDepth(pickDepth, context, passState) {
         if (!defined(pickDepth._debugPickDepthViewportCommand)) {

--- a/Source/Scene/PointAppearance.js
+++ b/Source/Scene/PointAppearance.js
@@ -54,7 +54,7 @@ define([
      *
      * @private
      */
-    var PointAppearance = function(options) {
+    function PointAppearance(options) {
         options = defaultValue(options, defaultValue.EMPTY_OBJECT);
 
         this._vertexShaderSource = defaultValue(options.vertexShaderSource, PointAppearanceVS);
@@ -93,7 +93,7 @@ define([
         // Combine default uniforms and additional uniforms
         var optionsUniforms = options.uniforms;
         this.uniforms = combine(this.uniforms, optionsUniforms, true);
-    };
+    }
 
     defineProperties(PointAppearance.prototype, {
         /**

--- a/Source/Scene/PointPrimitive.js
+++ b/Source/Scene/PointPrimitive.js
@@ -51,7 +51,7 @@ define([
      *
      * @demo {@link http://cesiumjs.org/Cesium/Apps/Sandcastle/index.html?src=Points.html|Cesium Sandcastle Points Demo}
      */
-    var PointPrimitive = function(options, pointPrimitiveCollection) {
+    function PointPrimitive(options, pointPrimitiveCollection) {
         options = defaultValue(options, defaultValue.EMPTY_OBJECT);
 
         //>>includeStart('debug', pragmas.debug);
@@ -79,7 +79,7 @@ define([
         this._pointPrimitiveCollection = pointPrimitiveCollection;
         this._dirty = false;
         this._index = -1; //Used only by PointPrimitiveCollection
-    };
+    }
 
     var SHOW_INDEX = PointPrimitive.SHOW_INDEX = 0;
     var POSITION_INDEX = PointPrimitive.POSITION_INDEX = 1;

--- a/Source/Scene/PointPrimitiveCollection.js
+++ b/Source/Scene/PointPrimitiveCollection.js
@@ -110,7 +110,7 @@ define([
      *   color : Cesium.Color.CYAN
      * });
      */
-    var PointPrimitiveCollection = function(options) {
+    function PointPrimitiveCollection(options) {
         options = defaultValue(options, defaultValue.EMPTY_OBJECT);
 
         this._sp = undefined;
@@ -212,7 +212,7 @@ define([
                 return that._maxTotalPointSize;
             }
         };
-    };
+    }
 
     defineProperties(PointPrimitiveCollection.prototype, {
         /**

--- a/Source/Scene/Polyline.js
+++ b/Source/Scene/Polyline.js
@@ -41,7 +41,7 @@ define([
      *
      * @demo {@link http://cesiumjs.org/Cesium/Apps/Sandcastle/index.html?src=Polylines.html|Cesium Sandcastle Polyline Demo}
      */
-    var Polyline = function(options, polylineCollection) {
+    function Polyline(options, polylineCollection) {
         options = defaultValue(options, defaultValue.EMPTY_OBJECT);
 
         this._show = defaultValue(options.show, true);
@@ -90,7 +90,7 @@ define([
         this._boundingVolume = BoundingSphere.fromPoints(this._actualPositions);
         this._boundingVolumeWC = BoundingSphere.transform(this._boundingVolume, this._modelMatrix);
         this._boundingVolume2D = new BoundingSphere(); // modified in PolylineCollection
-    };
+    }
 
     var SHOW_INDEX = Polyline.SHOW_INDEX = 0;
     var WIDTH_INDEX = Polyline.WIDTH_INDEX = 1;

--- a/Source/Scene/PolylineCollection.js
+++ b/Source/Scene/PolylineCollection.js
@@ -144,7 +144,7 @@ define([
      *   width : 4
      * });
      */
-    var PolylineCollection = function(options) {
+    function PolylineCollection(options) {
         options = defaultValue(options, defaultValue.EMPTY_OBJECT);
 
         /**
@@ -198,7 +198,7 @@ define([
         this._positionBuffer = undefined;
         this._pickColorBuffer = undefined;
         this._texCoordExpandWidthAndShowBuffer = undefined;
-    };
+    }
 
     defineProperties(PolylineCollection.prototype, {
         /**
@@ -1046,7 +1046,7 @@ define([
         this.bucket = bucket;
     }
 
-    var PolylineBucket = function(material, mode, modelMatrix) {
+    function PolylineBucket(material, mode, modelMatrix) {
         this.polylines = [];
         this.lengthOfPositions = 0;
         this.material = material;
@@ -1054,8 +1054,7 @@ define([
         this.pickShaderProgram = undefined;
         this.mode = mode;
         this.modelMatrix = modelMatrix;
-    };
-
+    }
     PolylineBucket.prototype.addPolyline = function(p) {
         var polylines = this.polylines;
         polylines.push(p);

--- a/Source/Scene/PolylineColorAppearance.js
+++ b/Source/Scene/PolylineColorAppearance.js
@@ -57,7 +57,7 @@ define([
      *   })
      * });
      */
-    var PolylineColorAppearance = function(options) {
+    function PolylineColorAppearance(options) {
         options = defaultValue(options, defaultValue.EMPTY_OBJECT);
 
         var translucent = defaultValue(options.translucent, true);
@@ -92,7 +92,7 @@ define([
         // Non-derived members
 
         this._vertexFormat = vertexFormat;
-    };
+    }
 
     defineProperties(PolylineColorAppearance.prototype, {
         /**

--- a/Source/Scene/PolylineMaterialAppearance.js
+++ b/Source/Scene/PolylineMaterialAppearance.js
@@ -57,7 +57,7 @@ define([
      *   })
      * });
      */
-    var PolylineMaterialAppearance = function(options) {
+    function PolylineMaterialAppearance(options) {
         options = defaultValue(options, defaultValue.EMPTY_OBJECT);
 
         var translucent = defaultValue(options.translucent, true);
@@ -94,7 +94,7 @@ define([
         // Non-derived members
 
         this._vertexFormat = vertexFormat;
-    };
+    }
 
     defineProperties(PolylineMaterialAppearance.prototype, {
         /**

--- a/Source/Scene/Primitive.js
+++ b/Source/Scene/Primitive.js
@@ -178,7 +178,7 @@ define([
      *   appearance : new Cesium.PerInstanceColorAppearance()
      * }));
      */
-    var Primitive = function(options) {
+    function Primitive(options) {
         options = defaultValue(options, defaultValue.EMPTY_OBJECT);
 
         /**
@@ -326,7 +326,7 @@ define([
         this._createGeometryResults = undefined;
         this._ready = false;
         this._readyPromise = when.defer();
-    };
+    }
 
     defineProperties(Primitive.prototype, {
         /**

--- a/Source/Scene/PrimitiveCollection.js
+++ b/Source/Scene/PrimitiveCollection.js
@@ -37,7 +37,7 @@ define([
      * scene.primitives.add(collection);  // Add collection
      * scene.primitives.add(labels);      // Add regular primitive
      */
-    var PrimitiveCollection = function(options) {
+    function PrimitiveCollection(options) {
         options = defaultValue(options, defaultValue.EMPTY_OBJECT);
 
         this._primitives = [];
@@ -76,7 +76,7 @@ define([
          * labels = labels.destroy();    // explicitly destroy
          */
         this.destroyPrimitives = defaultValue(options.destroyPrimitives, true);
-    };
+    }
 
     defineProperties(PrimitiveCollection.prototype, {
         /**

--- a/Source/Scene/QuadtreeOccluders.js
+++ b/Source/Scene/QuadtreeOccluders.js
@@ -18,9 +18,9 @@ define([
      *
      * @param {Ellipsoid} [options.ellipsoid=Ellipsoid.WGS84] The ellipsoid that potentially occludes tiles.
      */
-    var QuadtreeOccluders = function(options) {
+    function QuadtreeOccluders(options) {
         this._ellipsoid = new EllipsoidalOccluder(options.ellipsoid, Cartesian3.ZERO);
-    };
+    }
 
     defineProperties(QuadtreeOccluders.prototype, {
         /**

--- a/Source/Scene/QuadtreePrimitive.js
+++ b/Source/Scene/QuadtreePrimitive.js
@@ -60,7 +60,7 @@ define([
      *        frame, so the actual number of resident tiles may be higher.  The value of
      *        this property will not affect visual quality.
      */
-    var QuadtreePrimitive = function QuadtreePrimitive(options) {
+    function QuadtreePrimitive(options) {
         //>>includeStart('debug', pragmas.debug);
         if (!defined(options) || !defined(options.tileProvider)) {
             throw new DeveloperError('options.tileProvider is required.');
@@ -131,7 +131,7 @@ define([
         this._occluders = new QuadtreeOccluders({
             ellipsoid : ellipsoid
         });
-    };
+    }
 
     defineProperties(QuadtreePrimitive.prototype, {
         /**

--- a/Source/Scene/QuadtreeTile.js
+++ b/Source/Scene/QuadtreeTile.js
@@ -26,7 +26,7 @@ define([
      * @param {TilingScheme} options.tilingScheme The tiling scheme in which this tile exists.
      * @param {QuadtreeTile} [options.parent] This tile's parent, or undefined if this is a root tile.
      */
-    var QuadtreeTile = function QuadtreeTile(options) {
+    function QuadtreeTile(options) {
         //>>includeStart('debug', pragmas.debug);
         if (!defined(options)) {
             throw new DeveloperError('options is required.');
@@ -99,7 +99,7 @@ define([
          * @default undefined
          */
         this.data = undefined;
-    };
+    }
 
     /**
      * Creates a rectangular set of tiles for level of detail zero, the coarsest, least detailed level.

--- a/Source/Scene/QuadtreeTileProvider.js
+++ b/Source/Scene/QuadtreeTileProvider.js
@@ -16,9 +16,9 @@ define([
      * @constructor
      * @private
      */
-    var QuadtreeTileProvider = function QuadtreeTileProvider() {
+    function QuadtreeTileProvider() {
         DeveloperError.throwInstantiationError();
-    };
+    }
 
     /**
      * Computes the default geometric error for level zero of the quadtree.

--- a/Source/Scene/Scene.js
+++ b/Source/Scene/Scene.js
@@ -189,7 +189,7 @@ define([
      *   }
      * });
      */
-    var Scene = function(options) {
+    function Scene(options) {
         options = defaultValue(options, defaultValue.EMPTY_OBJECT);
         var canvas = options.canvas;
         var contextOptions = options.contextOptions;
@@ -535,7 +535,7 @@ define([
         // give frameState, camera, and screen space camera controller initial state before rendering
         updateFrameState(this, 0.0, JulianDate.now());
         this.initializeFrame();
-    };
+    }
 
     var OPAQUE_FRUSTUM_NEAR_OFFSET = 0.99;
 

--- a/Source/Scene/SceneTransitioner.js
+++ b/Source/Scene/SceneTransitioner.js
@@ -36,7 +36,7 @@ define([
     /**
      * @private
      */
-    var SceneTransitioner = function(scene, ellipsoid) {
+    function SceneTransitioner(scene, ellipsoid) {
         //>>includeStart('debug', pragmas.debug);
         if (!defined(scene)) {
             throw new DeveloperError('scene is required.');
@@ -122,7 +122,7 @@ define([
         this._morphHandler = undefined;
         this._morphCancelled = false;
         this._completeMorph = undefined;
-    };
+    }
 
     SceneTransitioner.prototype.completeMorph = function() {
         if (defined(this._completeMorph)) {
@@ -249,7 +249,6 @@ define([
                 transitioner._morphCancelled = true;
                 completeMorphFunction(transitioner);
             };
-
             transitioner._completeMorph = completeMorph;
             transitioner._morphHandler.setInputAction(completeMorph, ScreenSpaceEventType.LEFT_DOWN);
             transitioner._morphHandler.setInputAction(completeMorph, ScreenSpaceEventType.MIDDLE_DOWN);
@@ -281,14 +280,13 @@ define([
         var endDir = Cartesian3.clone(transitioner._camera2D.direction);
         var endUp = Cartesian3.clone(transitioner._camera2D.up);
 
-        var update = function(value) {
+        function update(value) {
             camera.position = columbusViewMorph(startPos, endPos, value.time);
             camera.direction = columbusViewMorph(startDir, endDir, value.time);
             camera.up = columbusViewMorph(startUp, endUp, value.time);
             camera.right = Cartesian3.cross(camera.direction, camera.up, camera.right);
             Cartesian3.normalize(camera.right, camera.right);
-        };
-
+        }
         var tween = scene.tweens.add({
             duration : duration,
             easingFunction : EasingFunction.QUARTIC_OUT,
@@ -332,14 +330,13 @@ define([
         var d = Cartesian3.magnitude(startPos) * Math.tan(startFOV * 0.5);
         camera.frustum.far = d / Math.tan(endFOV * 0.5) + 10000000.0;
 
-        var update = function(value) {
+        function update(value) {
             camera.frustum.fov = CesiumMath.lerp(startFOV, endFOV, value.time);
 
             var distance = d / Math.tan(camera.frustum.fov * 0.5);
             var pos = new Cartesian3();
             camera.position = Cartesian3.multiplyByScalar(Cartesian3.normalize(camera.position, pos), distance, pos);
-        };
-
+        }
         var tween = scene.tweens.add({
             duration : duration,
             easingFunction : EasingFunction.QUARTIC_OUT,
@@ -377,14 +374,13 @@ define([
         var endDir = Cartesian3.clone(transitioner._camera2D.direction);
         var endUp = Cartesian3.clone(transitioner._camera2D.up);
 
-        var updateCV = function(value) {
+        function updateCV(value) {
             camera.position = columbusViewMorph(startPos, endPos, value.time);
             camera.direction = columbusViewMorph(startDir, endDir, value.time);
             camera.up = columbusViewMorph(startUp, endUp, value.time);
             camera.right = Cartesian3.cross(camera.direction, camera.up, camera.right);
             Cartesian3.normalize(camera.right, camera.right);
-        };
-
+        }
         duration *= 0.5;
         var tween = scene.tweens.add({
             duration : duration,
@@ -418,9 +414,9 @@ define([
         camera3DTo2D.direction2D = Cartesian3.clone(transitioner._camera2D.direction2D);
         camera3DTo2D.up2D = Cartesian3.clone(transitioner._camera2D.up2D);
 
-        var completeCallback = function() {
+        function completeCallback() {
             morphPerspectiveToOrthographic(transitioner, duration, complete);
-        };
+        }
         morphFrom3DToColumbusView(transitioner, duration, camera3DTo2D, completeCallback);
     }
 
@@ -445,14 +441,13 @@ define([
 
         var startPos = Cartesian3.clone(camera.position);
 
-        var update2D = function(value) {
+        function update2D(value) {
             camera.position = columbusViewMorph(startPos, endPos2D, value.time);
             camera.frustum.top = CesiumMath.lerp(top, frustum2D.top, value.time);
             camera.frustum.bottom = CesiumMath.lerp(bottom, frustum2D.bottom, value.time);
             camera.frustum.right = CesiumMath.lerp(right, frustum2D.right, value.time);
             camera.frustum.left = CesiumMath.lerp(left, frustum2D.left, value.time);
-        };
-
+        }
         var startTime = (right - left) / (2.0 * maxRadii * Math.PI);
         var endTime = 1.0;
         if (startTime > endTime) {
@@ -500,7 +495,7 @@ define([
 
         duration *= 0.5;
 
-        var completeFrustumChange = function() {
+        function completeFrustumChange() {
             var startPos = Cartesian3.clone(camera.position);
             var startDir = Cartesian3.clone(camera.direction);
             var startUp = Cartesian3.clone(camera.up);
@@ -509,14 +504,13 @@ define([
             var endDir = Cartesian3.clone(transitioner._cameraCV.direction);
             var endUp = Cartesian3.clone(transitioner._cameraCV.up);
 
-            var updateCV = function(value) {
+            function updateCV(value) {
                 camera.position = columbusViewMorph(startPos, endPos, value.time);
                 camera.direction = columbusViewMorph(startDir, endDir, value.time);
                 camera.up = columbusViewMorph(startUp, endUp, value.time);
                 camera.right = Cartesian3.cross(camera.direction, camera.up, camera.right);
                 Cartesian3.normalize(camera.right, camera.right);
-            };
-
+            }
             var tween = scene.tweens.add({
                 duration : duration,
                 easingFunction : EasingFunction.QUARTIC_OUT,
@@ -533,8 +527,7 @@ define([
             });
 
             transitioner._currentTweens.push(tween);
-        };
-
+        }
         morphOrthographicToPerspective(transitioner, duration, ellipsoid, completeFrustumChange);
     }
 
@@ -551,14 +544,13 @@ define([
         var endDir = Cartesian3.clone(endCamera.direction2D);
         var endUp = Cartesian3.clone(endCamera.up2D);
 
-        var update = function(value) {
+        function update(value) {
             camera.position = columbusViewMorph(startPos, endPos, value.time);
             camera.direction = columbusViewMorph(startDir, endDir, value.time);
             camera.up = columbusViewMorph(startUp, endUp, value.time);
             camera.right = Cartesian3.cross(camera.direction, camera.up, camera.right);
             Cartesian3.normalize(camera.right, camera.right);
-        };
-
+        }
         var tween = scene.tweens.add({
             duration : duration,
             easingFunction : EasingFunction.QUARTIC_OUT,

--- a/Source/Scene/ScreenSpaceCameraController.js
+++ b/Source/Scene/ScreenSpaceCameraController.js
@@ -58,7 +58,7 @@ define([
      *
      * @param {Scene} scene The scene.
      */
-    var ScreenSpaceCameraController = function(scene) {
+    function ScreenSpaceCameraController(scene) {
         //>>includeStart('debug', pragmas.debug);
         if (!defined(scene)) {
             throw new DeveloperError('scene is required.');
@@ -304,7 +304,7 @@ define([
         this._translateFactor = 1.0;
         this._minimumZoomRate = 20.0;
         this._maximumZoomRate = 5906376272000.0;  // distance from the Sun to Pluto in meters.
-    };
+    }
 
     function decay(time, coefficient) {
         if (time < 0) {

--- a/Source/Scene/SingleTileImageryProvider.js
+++ b/Source/Scene/SingleTileImageryProvider.js
@@ -50,7 +50,7 @@ define([
      * @see WebMapTileServiceImageryProvider
      * @see UrlTemplateImageryProvider
      */
-    var SingleTileImageryProvider = function(options) {
+    function SingleTileImageryProvider(options) {
         options = defaultValue(options, {});
         var url = options.url;
 
@@ -125,8 +125,7 @@ define([
         }
 
         doRequest();
-    };
-
+    }
 
     defineProperties(SingleTileImageryProvider.prototype, {
         /**

--- a/Source/Scene/SkyAtmosphere.js
+++ b/Source/Scene/SkyAtmosphere.js
@@ -61,7 +61,7 @@ define([
      *
      * @see Scene.skyAtmosphere
      */
-    var SkyAtmosphere = function(ellipsoid) {
+    function SkyAtmosphere(ellipsoid) {
         ellipsoid = defaultValue(ellipsoid, Ellipsoid.WGS84);
 
         /**
@@ -113,7 +113,7 @@ define([
                 return (1.0 / (that._outerRadius - innerRadius)) / rayleighScaleDepth;
             }
         };
-    };
+    }
 
     defineProperties(SkyAtmosphere.prototype, {
         /**

--- a/Source/Scene/SkyBox.js
+++ b/Source/Scene/SkyBox.js
@@ -72,7 +72,7 @@ define([
      *   }
      * });
      */
-    var SkyBox = function(options) {
+    function SkyBox(options) {
         /**
          * The sources used to create the cube map faces: an object
          * with <code>positiveX</code>, <code>negativeX</code>, <code>positiveY</code>,
@@ -98,7 +98,7 @@ define([
             owner : this
         });
         this._cubeMap = undefined;
-    };
+    }
 
     /**
      * Called when {@link Viewer} or {@link CesiumWidget} render the scene to

--- a/Source/Scene/Sun.js
+++ b/Source/Scene/Sun.js
@@ -77,7 +77,7 @@ define([
      * @example
      * scene.sun = new Cesium.Sun();
      */
-    var Sun = function() {
+    function Sun() {
         /**
          * Determines if the sun will be shown.
          *
@@ -116,7 +116,7 @@ define([
                 return that._size;
             }
         };
-    };
+    }
 
     defineProperties(Sun.prototype, {
         /**

--- a/Source/Scene/SunPostProcess.js
+++ b/Source/Scene/SunPostProcess.js
@@ -49,7 +49,7 @@ define([
         PassThrough) {
     "use strict";
 
-    var SunPostProcess = function() {
+    function SunPostProcess() {
         this._fbo = undefined;
 
         this._downSampleFBO1 = undefined;
@@ -81,7 +81,7 @@ define([
         this._uRadius = undefined;
 
         this._blurStep = new Cartesian2();
-    };
+    }
 
     SunPostProcess.prototype.clear = function(context, color) {
         var clear = this._clearFBO1Command;

--- a/Source/Scene/TextureAtlas.js
+++ b/Source/Scene/TextureAtlas.js
@@ -65,7 +65,7 @@ define([
      *
      * @private
      */
-    var TextureAtlas = function(options) {
+    function TextureAtlas(options) {
         options = defaultValue(options, defaultValue.EMPTY_OBJECT);
         var borderWidthInPixels = defaultValue(options.borderWidthInPixels, 1.0);
         var initialSize = defaultValue(options.initialSize, defaultInitialSize);
@@ -117,7 +117,7 @@ define([
         this._copyCommand = this._context.createViewportQuadCommand(fs, {
             uniformMap : uniformMap
         });
-    };
+    }
 
     defineProperties(TextureAtlas.prototype, {
         /**

--- a/Source/Scene/TileCoordinatesImageryProvider.js
+++ b/Source/Scene/TileCoordinatesImageryProvider.js
@@ -34,7 +34,7 @@ define([
      * @param {Number} [options.tileWidth=256] The width of the tile for level-of-detail selection purposes.
      * @param {Number} [options.tileHeight=256] The height of the tile for level-of-detail selection purposes.
      */
-    var TileCoordinatesImageryProvider = function TileCoordinatesImageryProvider(options) {
+    function TileCoordinatesImageryProvider(options) {
         options = defaultValue(options, defaultValue.EMPTY_OBJECT);
 
         this._tilingScheme = defined(options.tilingScheme) ? options.tilingScheme : new GeographicTilingScheme({ ellipsoid : options.ellipsoid });
@@ -43,7 +43,7 @@ define([
         this._tileWidth = defaultValue(options.tileWidth, 256);
         this._tileHeight = defaultValue(options.tileHeight, 256);
         this._readyPromise = when.resolve(true);
-    };
+    }
 
     defineProperties(TileCoordinatesImageryProvider.prototype, {
         /**

--- a/Source/Scene/TileDiscardPolicy.js
+++ b/Source/Scene/TileDiscardPolicy.js
@@ -15,9 +15,9 @@ define([
      * @see DiscardMissingTileImagePolicy
      * @see NeverTileDiscardPolicy
      */
-    var TileDiscardPolicy = function(options) {
+    function TileDiscardPolicy(options) {
         DeveloperError.throwInstantiationError();
-    };
+    }
 
     /**
      * Determines if the discard policy is ready to process images.

--- a/Source/Scene/TileImagery.js
+++ b/Source/Scene/TileImagery.js
@@ -17,12 +17,12 @@ define([
      * @param {Cartesian4} textureCoordinateRectangle The texture rectangle of the tile that is covered
      *        by the imagery, where X=west, Y=south, Z=east, W=north.
      */
-    var TileImagery = function(imagery, textureCoordinateRectangle) {
+    function TileImagery(imagery, textureCoordinateRectangle) {
         this.readyImagery = undefined;
         this.loadingImagery = imagery;
         this.textureCoordinateRectangle = textureCoordinateRectangle;
         this.textureTranslationAndScale = undefined;
-    };
+    }
 
     /**
      * Frees the resources held by this instance.

--- a/Source/Scene/TileMapServiceImageryProvider.js
+++ b/Source/Scene/TileMapServiceImageryProvider.js
@@ -88,7 +88,7 @@ define([
      *        Cesium.Math.toRadians(40.0))
      * });
      */
-    var TileMapServiceImageryProvider = function TileMapServiceImageryProvider(options) {
+    function TileMapServiceImageryProvider(options) {
         options = defaultValue(options, {});
 
         //>>includeStart('debug', pragmas.debug);
@@ -272,7 +272,7 @@ define([
         }
 
         requestMetadata();
-    };
+    }
 
     function buildImageUrl(imageryProvider, x, y, level) {
         var yTiles = imageryProvider._tilingScheme.getNumberOfYTilesAtLevel(level);

--- a/Source/Scene/TileReplacementQueue.js
+++ b/Source/Scene/TileReplacementQueue.js
@@ -12,12 +12,12 @@ define([
      * @alias TileReplacementQueue
      * @private
      */
-    var TileReplacementQueue = function TileReplacementQueue() {
+    function TileReplacementQueue() {
         this.head = undefined;
         this.tail = undefined;
         this.count = 0;
         this._lastBeforeStartOfFrame = undefined;
-    };
+    }
 
     /**
      * Marks the start of the render frame.  Tiles before (closer to the head) this tile in the

--- a/Source/Scene/TileTerrain.js
+++ b/Source/Scene/TileTerrain.js
@@ -41,7 +41,7 @@ define([
      * @param {Number} [upsampleDetails.y] The Y coordinate of the tile being upsampled.
      * @param {Number} [upsampleDetails.level] The level coordinate of the tile being upsampled.
      */
-    var TileTerrain = function TileTerrain(upsampleDetails) {
+    function TileTerrain(upsampleDetails) {
         /**
          * The current state of the terrain in the terrain processing pipeline.
          * @type {TerrainState}
@@ -52,7 +52,7 @@ define([
         this.mesh = undefined;
         this.vertexArray = undefined;
         this.upsampleDetails = upsampleDetails;
-    };
+    }
 
     TileTerrain.prototype.freeResources = function() {
         this.state = TerrainState.UNLOADED;

--- a/Source/Scene/TweenCollection.js
+++ b/Source/Scene/TweenCollection.js
@@ -30,7 +30,7 @@ define([
      *
      * @private
      */
-    var Tween = function(tweens, tweenjs, startObject, stopObject, duration, delay, easingFunction, update, complete, cancel) {
+    function Tween(tweens, tweenjs, startObject, stopObject, duration, delay, easingFunction, update, complete, cancel) {
         this._tweens = tweens;
         this._tweenjs = tweenjs;
 
@@ -56,7 +56,7 @@ define([
          * @private
          */
         this.needsStart = true;
-    };
+    }
 
     defineProperties(Tween.prototype, {
         /**
@@ -178,9 +178,9 @@ define([
      *
      * @private
      */
-    var TweenCollection = function() {
+    function TweenCollection() {
         this._tweens = [];
-    };
+    }
 
     defineProperties(TweenCollection.prototype, {
         /**

--- a/Source/Scene/UrlTemplateImageryProvider.js
+++ b/Source/Scene/UrlTemplateImageryProvider.js
@@ -149,7 +149,7 @@ define([
      *    rectangle : Cesium.Rectangle.fromDegrees(96.799393, -43.598214999057824, 153.63925700000001, -9.2159219997013)
      * });
      */
-    var UrlTemplateImageryProvider = function UrlTemplateImageryProvider(options) {
+    function UrlTemplateImageryProvider(options) {
         //>>includeStart('debug', pragmas.debug);
         if (!defined(options) || !defined(options.url)) {
             throw new DeveloperError('options.url is required.');
@@ -192,7 +192,7 @@ define([
         this._pickFeaturesUrlParts = urlTemplateToParts(this._pickFeaturesUrl, pickFeaturesTags);
 
         this._readyPromise = when.resolve(true);
-    };
+    }
 
     defineProperties(UrlTemplateImageryProvider.prototype, {
         /**

--- a/Source/Scene/ViewportQuad.js
+++ b/Source/Scene/ViewportQuad.js
@@ -38,7 +38,7 @@ define([
      * var viewportQuad = new Cesium.ViewportQuad(new Cesium.BoundingRectangle(0, 0, 80, 40));
      * viewportQuad.material.uniforms.color = new Cesium.Color(1.0, 0.0, 0.0, 1.0);
      */
-    var ViewportQuad = function(rectangle, material) {
+    function ViewportQuad(rectangle, material) {
         /**
          * Determines if the viewport quad primitive will be shown.
          *
@@ -90,7 +90,7 @@ define([
 
         this._overlayCommand = undefined;
         this._rs = undefined;
-    };
+    }
 
     /**
      * Called when {@link Viewer} or {@link CesiumWidget} render the scene to

--- a/Source/Scene/WebMapServiceImageryProvider.js
+++ b/Source/Scene/WebMapServiceImageryProvider.js
@@ -89,7 +89,7 @@ define([
      *
      * viewer.imageryLayers.addImageryProvider(provider);
      */
-    var WebMapServiceImageryProvider = function WebMapServiceImageryProvider(options) {
+    function WebMapServiceImageryProvider(options) {
         options = defaultValue(options, defaultValue.EMPTY_OBJECT);
 
         //>>includeStart('debug', pragmas.debug);
@@ -180,7 +180,7 @@ define([
             credit : options.credit,
             getFeatureInfoFormats : getFeatureInfoFormats
         });
-    };
+    }
 
     defineProperties(WebMapServiceImageryProvider.prototype, {
         /**

--- a/Source/Scene/WebMapTileServiceImageryProvider.js
+++ b/Source/Scene/WebMapTileServiceImageryProvider.js
@@ -96,7 +96,7 @@ define([
      * });
      * viewer.imageryLayers.addImageryProvider(shadedRelief2);
      */
-    var WebMapTileServiceImageryProvider = function WebMapTileServiceImageryProvider(options) {
+    function WebMapTileServiceImageryProvider(options) {
         options = defaultValue(options, defaultValue.EMPTY_OBJECT);
 
         if (!defined(options.url)) {
@@ -155,7 +155,7 @@ define([
         } else {
             this._subdomains = ['a', 'b', 'c'];
         }
-    };
+    }
 
     var defaultParameters = freezeObject({
         service : 'WMTS',

--- a/Source/Scene/createOpenStreetMapImageryProvider.js
+++ b/Source/Scene/createOpenStreetMapImageryProvider.js
@@ -56,7 +56,7 @@ define([
      *     url : '//a.tile.openstreetmap.org/'
      * });
      */
-    var createOpenStreetMapImageryProvider = function createOpenStreetMapImageryProvider(options) {
+    function createOpenStreetMapImageryProvider(options) {
         options = defaultValue(options, {});
 
         var url = defaultValue(options.url, '//a.tile.openstreetmap.org/');
@@ -105,7 +105,7 @@ define([
             maximumLevel: maximumLevel,
             rectangle: rectangle
         });
-    };
+    }
 
     return createOpenStreetMapImageryProvider;
 });

--- a/Source/Scene/createTangentSpaceDebugPrimitive.js
+++ b/Source/Scene/createTangentSpaceDebugPrimitive.js
@@ -42,7 +42,7 @@ define([
      *    modelMatrix : instance.modelMatrix
      * }));
      */
-    var createTangentSpaceDebugPrimitive = function(options) {
+    function createTangentSpaceDebugPrimitive(options) {
         options = defaultValue(options, defaultValue.EMPTY_OBJECT);
         var instances = [];
         var geometry = options.geometry;
@@ -105,7 +105,7 @@ define([
         }
 
         return undefined;
-    };
+    }
 
     return createTangentSpaceDebugPrimitive;
 });

--- a/Source/Scene/getModelAccessor.js
+++ b/Source/Scene/getModelAccessor.js
@@ -18,7 +18,7 @@ define([
     /**
      * @private
      */
-    var getModelAccessor = function(accessor) {
+    function getModelAccessor(accessor) {
         var componentDatatype = accessor.componentType;
         var componentsPerAttribute = ComponentsPerAttribute[accessor.type];
 
@@ -28,7 +28,7 @@ define([
                 return ComponentDatatype.createArrayBufferView(componentDatatype, buffer, byteOffset, componentsPerAttribute * length);
             }
         };
-    };
+    }
 
     return getModelAccessor;
 });

--- a/Source/Scene/modelMaterialsCommon.js
+++ b/Source/Scene/modelMaterialsCommon.js
@@ -640,7 +640,7 @@ define([
      *
      * @private
      */
-    var modelMaterialsCommon = function(gltf) {
+    function modelMaterialsCommon(gltf) {
         if (!defined(gltf)) {
             return undefined;
         }
@@ -709,7 +709,7 @@ define([
         }
 
         return gltf;
-    };
+    }
 
     return modelMaterialsCommon;
 });

--- a/Source/ThirdParty/Uri.js
+++ b/Source/ThirdParty/Uri.js
@@ -46,8 +46,7 @@ define(function() {
 			this.query = c[4];
 			this.fragment = c[5];
 		}
-	};
-
+	}
 	// Initial values on the prototype
 	URI.prototype.scheme    = null;
 	URI.prototype.authority = null;

--- a/Source/ThirdParty/sprintf.js
+++ b/Source/ThirdParty/sprintf.js
@@ -158,6 +158,7 @@ function sprintf () {
     if (!chr) {
       chr = ' ';
     }
+
     var padding = (str.length >= len) ? '' : Array(1 + len - str.length >>> 0).join(chr);
     return leftJustify ? str + padding : padding + str;
   };

--- a/Source/ThirdParty/topojson.js
+++ b/Source/ThirdParty/topojson.js
@@ -446,8 +446,7 @@ EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     }
 
     return topology;
-  };
-
+  }
   function cartesianRingArea(ring) {
     var i = -1,
         n = ring.length,

--- a/Source/Widgets/Animation/Animation.js
+++ b/Source/Widgets/Animation/Animation.js
@@ -206,7 +206,7 @@ define([
 
     //This is a private class for treating an SVG element like a button.
     //If we ever need a general purpose SVG button, we can make this generic.
-    var SvgButton = function(svgElement, viewModel) {
+    function SvgButton(svgElement, viewModel) {
         this._viewModel = viewModel;
         this.svgElement = svgElement;
         this._enabled = undefined;
@@ -231,7 +231,7 @@ define([
         subscribeAndEvaluate(viewModel, 'toggled', this.setToggled, this),//
         subscribeAndEvaluate(viewModel, 'tooltip', this.setTooltip, this),//
         subscribeAndEvaluate(viewModel.command, 'canExecute', this.setEnabled, this)];
-    };
+    }
 
     SvgButton.prototype.destroy = function() {
         this.svgElement.removeEventListener('click', this._clickFunction, true);
@@ -330,7 +330,7 @@ define([
      * }
      * Cesium.requestAnimationFrame(tick);
      */
-    var Animation = function(container, viewModel) {
+    function Animation(container, viewModel) {
         //>>includeStart('debug', pragmas.debug);
         if (!defined(container)) {
             throw new DeveloperError('container is required.');
@@ -504,9 +504,9 @@ define([
         container.appendChild(svg);
 
         var that = this;
-        var mouseCallback = function(e) {
+        function mouseCallback(e) {
             setShuttleRingFromMouseOrTouch(that, e);
-        };
+        }
         this._mouseCallback = mouseCallback;
 
         shuttleRingBackPanel.addEventListener('mousedown', mouseCallback, true);
@@ -567,7 +567,7 @@ define([
 
         this.applyThemeChanges();
         this.resize();
-    };
+    }
 
     defineProperties(Animation.prototype, {
         /**

--- a/Source/Widgets/Animation/AnimationViewModel.js
+++ b/Source/Widgets/Animation/AnimationViewModel.js
@@ -114,7 +114,7 @@ define([
      *
      * @see Animation
      */
-    var AnimationViewModel = function(clockViewModel) {
+    function AnimationViewModel(clockViewModel) {
         //>>includeStart('debug', pragmas.debug);
         if (!defined(clockViewModel)) {
             throw new DeveloperError('clockViewModel is required.');
@@ -369,7 +369,7 @@ define([
                 clockViewModel.multiplier = shuttleRingTicks[index];
             }
         });
-    };
+    }
 
     /**
      * Gets or sets the default date formatter used by new instances.

--- a/Source/Widgets/BaseLayerPicker/BaseLayerPicker.js
+++ b/Source/Widgets/BaseLayerPicker/BaseLayerPicker.js
@@ -104,7 +104,7 @@ define([
      *     imageryProviderViewModels : imageryViewModels
      * });
      */
-    var BaseLayerPicker = function(container, options) {
+    function BaseLayerPicker(container, options) {
         //>>includeStart('debug', pragmas.debug);
         if (!defined(container)) {
             throw new DeveloperError('container is required.');
@@ -218,7 +218,7 @@ click: function($data) { $parent.selectedTerrain = $data; }');
             document.addEventListener('mousedown', this._closeDropDown, true);
             document.addEventListener('touchstart', this._closeDropDown, true);
         }
-    };
+    }
 
     defineProperties(BaseLayerPicker.prototype, {
         /**

--- a/Source/Widgets/BaseLayerPicker/BaseLayerPickerViewModel.js
+++ b/Source/Widgets/BaseLayerPicker/BaseLayerPickerViewModel.js
@@ -34,7 +34,7 @@ define([
      * @exception {DeveloperError} imageryProviderViewModels must be an array.
      * @exception {DeveloperError} terrainProviderViewModels must be an array.
      */
-    var BaseLayerPickerViewModel = function(options) {
+    function BaseLayerPickerViewModel(options) {
         options = defaultValue(options, defaultValue.EMPTY_OBJECT);
 
         var globe = options.globe;
@@ -191,7 +191,7 @@ define([
 
         this.selectedImagery = defaultValue(options.selectedImageryProviderViewModel, imageryProviderViewModels[0]);
         this.selectedTerrain = defaultValue(options.selectedTerrainProviderViewModel, terrainProviderViewModels[0]);
-    };
+    }
 
     defineProperties(BaseLayerPickerViewModel.prototype, {
         /**

--- a/Source/Widgets/BaseLayerPicker/ProviderViewModel.js
+++ b/Source/Widgets/BaseLayerPicker/ProviderViewModel.js
@@ -30,7 +30,7 @@ define([
      * @see ImageryProvider
      * @see TerrainProvider
      */
-    var ProviderViewModel = function(options) {
+    function ProviderViewModel(options) {
         //>>includeStart('debug', pragmas.debug);
         if (!defined(options.name)) {
             throw new DeveloperError('options.name is required.');
@@ -72,7 +72,7 @@ define([
         this.iconUrl = options.iconUrl;
 
         knockout.track(this, ['name', 'tooltip', 'iconUrl']);
-    };
+    }
 
     defineProperties(ProviderViewModel.prototype, {
         /**

--- a/Source/Widgets/CesiumInspector/CesiumInspector.js
+++ b/Source/Widgets/CesiumInspector/CesiumInspector.js
@@ -31,7 +31,7 @@ define([
      *
      * @demo {@link http://cesiumjs.org/Cesium/Apps/Sandcastle/index.html?src=Cesium%20Inspector.html|Cesium Sandcastle Cesium Inspector Demo}
      */
-    var CesiumInspector = function(container, scene) {
+    function CesiumInspector(container, scene) {
         if (!defined(container)) {
             throw new DeveloperError('container is required.');
         }
@@ -336,7 +336,7 @@ define([
         tileCoords.appendChild(document.createTextNode('Show tile coordinates'));
 
         knockout.applyBindings(viewModel, this._element);
-    };
+    }
 
     defineProperties(CesiumInspector.prototype, {
         /**

--- a/Source/Widgets/CesiumInspector/CesiumInspectorViewModel.js
+++ b/Source/Widgets/CesiumInspector/CesiumInspectorViewModel.js
@@ -75,7 +75,7 @@ define([
      *
      * @exception {DeveloperError} scene is required.
      */
-    var CesiumInspectorViewModel = function(scene, performanceContainer) {
+    function CesiumInspectorViewModel(scene, performanceContainer) {
         //>>includeStart('debug', pragmas.debug);
         if (!defined(scene)) {
             throw new DeveloperError('scene is required');
@@ -453,7 +453,7 @@ define([
             return true;
         });
 
-        var pickPrimitive = function(e) {
+        function pickPrimitive(e) {
             eventHandler.removeInputAction(ScreenSpaceEventType.LEFT_CLICK);
             that.pickPrimitiveActive = false;
             var newPick = that._scene.pick({
@@ -463,8 +463,7 @@ define([
             if (defined(newPick)) {
                 that.primitive = defined(newPick.collection) ? newPick.collection : newPick.primitive;
             }
-        };
-
+        }
         this._pickPrimitive = createCommand(function() {
             that.pickPrimitiveActive = !that.pickPrimitiveActive;
             if (that.pickPrimitiveActive) {
@@ -474,7 +473,7 @@ define([
             }
         });
 
-        var selectTile = function(e) {
+        function selectTile(e) {
             var selectedTile;
             var ellipsoid = globe.ellipsoid;
             var cartesian = that._scene.camera.pickEllipsoid({
@@ -504,8 +503,7 @@ define([
 
             eventHandler.removeInputAction(ScreenSpaceEventType.LEFT_CLICK);
             that.pickTileActive = false;
-        };
-
+        }
         this._pickTile = createCommand(function() {
             that.pickTileActive = !that.pickTileActive;
 
@@ -515,7 +513,7 @@ define([
                 eventHandler.removeInputAction(ScreenSpaceEventType.LEFT_CLICK);
             }
         });
-    };
+    }
 
     defineProperties(CesiumInspectorViewModel.prototype, {
         /**

--- a/Source/Widgets/CesiumWidget/CesiumWidget.js
+++ b/Source/Widgets/CesiumWidget/CesiumWidget.js
@@ -188,7 +188,7 @@ define([
      *     mapProjection : new Cesium.WebMercatorProjection()
      * });
      */
-    var CesiumWidget = function(container, options) {
+    function CesiumWidget(container, options) {
         //>>includeStart('debug', pragmas.debug);
         if (!defined(container)) {
             throw new DeveloperError('container is required.');
@@ -345,7 +345,7 @@ define([
             }
             throw error;
         }
-    };
+    }
 
     defineProperties(CesiumWidget.prototype, {
         /**
@@ -563,9 +563,9 @@ define([
         var errorPanelScroller = document.createElement('div');
         errorPanelScroller.className = 'cesium-widget-errorPanel-scroll';
         content.appendChild(errorPanelScroller);
-        var resizeCallback = function() {
+        function resizeCallback() {
             errorPanelScroller.style.maxHeight = Math.max(Math.round(element.clientHeight * 0.9 - 100), 30) + 'px';
-        };
+        }
         resizeCallback();
         if (defined(window.addEventListener)) {
             window.addEventListener('resize', resizeCallback, false);

--- a/Source/Widgets/ClockViewModel.js
+++ b/Source/Widgets/ClockViewModel.js
@@ -26,7 +26,7 @@ define([
      *
      * @see Clock
      */
-    var ClockViewModel = function(clock) {
+    function ClockViewModel(clock) {
         if (!defined(clock)) {
             clock = new Clock();
         }
@@ -190,7 +190,7 @@ define([
                 clock.shouldAnimate = value;
             }
         });
-    };
+    }
 
     defineProperties(ClockViewModel.prototype, {
         /**

--- a/Source/Widgets/Command.js
+++ b/Source/Widgets/Command.js
@@ -16,7 +16,7 @@ define([
      * @alias Command
      * @constructor
      */
-    var Command = function() {
+    function Command() {
         /**
          * Gets whether this command can currently be executed.  This property is observable.
          * @type {Boolean}
@@ -43,7 +43,7 @@ define([
         this.afterExecute = undefined;
 
         DeveloperError.throwInstantiationError();
-    };
+    }
 
     return Command;
 });

--- a/Source/Widgets/FullscreenButton/FullscreenButton.js
+++ b/Source/Widgets/FullscreenButton/FullscreenButton.js
@@ -33,7 +33,7 @@ define([
      *
      * @see Fullscreen
      */
-    var FullscreenButton = function(container, fullscreenElement) {
+    function FullscreenButton(container, fullscreenElement) {
         //>>includeStart('debug', pragmas.debug);
         if (!defined(container)) {
             throw new DeveloperError('container is required.');
@@ -64,7 +64,7 @@ cesiumSvgPath: { path: isFullscreen ? _exitFullScreenPath : _enterFullScreenPath
         this._container = container;
         this._viewModel = viewModel;
         this._element = element;
-    };
+    }
 
     defineProperties(FullscreenButton.prototype, {
         /**

--- a/Source/Widgets/FullscreenButton/FullscreenButtonViewModel.js
+++ b/Source/Widgets/FullscreenButton/FullscreenButtonViewModel.js
@@ -26,7 +26,7 @@ define([
      *
      * @param {Element|String} [fullscreenElement=document.body] The element or id to be placed into fullscreen mode.
      */
-    var FullscreenButtonViewModel = function(fullscreenElement) {
+    function FullscreenButtonViewModel(fullscreenElement) {
         var that = this;
 
         var tmpIsFullscreen = knockout.observable(Fullscreen.fullscreen);
@@ -87,7 +87,7 @@ define([
             tmpIsFullscreen(Fullscreen.fullscreen);
         };
         document.addEventListener(Fullscreen.changeEventName, this._callback);
-    };
+    }
 
     defineProperties(FullscreenButtonViewModel.prototype, {
         /**

--- a/Source/Widgets/Geocoder/Geocoder.js
+++ b/Source/Widgets/Geocoder/Geocoder.js
@@ -42,7 +42,7 @@ define([
      *        this widget without creating a separate key for your application.
      * @param {Number} [options.flightDuration=1.5] The duration of the camera flight to an entered location, in seconds.
      */
-    var Geocoder = function(options) {
+    function Geocoder(options) {
         //>>includeStart('debug', pragmas.debug);
         if (!defined(options) || !defined(options.container)) {
             throw new DeveloperError('options.container is required.');
@@ -112,7 +112,7 @@ cesiumSvgPath: { path: isSearchInProgress ? _stopSearchPath : _startSearchPath, 
             document.addEventListener('touchend', this._onInputEnd, true);
         }
 
-    };
+    }
 
     defineProperties(Geocoder.prototype, {
         /**

--- a/Source/Widgets/Geocoder/GeocoderViewModel.js
+++ b/Source/Widgets/Geocoder/GeocoderViewModel.js
@@ -48,7 +48,7 @@ define([
      *        this widget without creating a separate key for your application.
      * @param {Number} [options.flightDuration] The duration of the camera flight to an entered location, in seconds.
      */
-    var GeocoderViewModel = function(options) {
+    function GeocoderViewModel(options) {
         //>>includeStart('debug', pragmas.debug);
         if (!defined(options) || !defined(options.scene)) {
             throw new DeveloperError('options.scene is required.');
@@ -139,7 +139,7 @@ define([
                 this._flightDuration = value;
             }
         });
-    };
+    }
 
     defineProperties(GeocoderViewModel.prototype, {
         /**

--- a/Source/Widgets/HomeButton/HomeButton.js
+++ b/Source/Widgets/HomeButton/HomeButton.js
@@ -27,7 +27,7 @@ define([
      * @param {Scene} scene The Scene instance to use.
      * @param {Number} [duration] The time, in seconds, it takes to complete the camera flight home.
      */
-    var HomeButton = function(container, scene, duration) {
+    function HomeButton(container, scene, duration) {
         //>>includeStart('debug', pragmas.debug);
         if (!defined(container)) {
             throw new DeveloperError('container is required.');
@@ -55,7 +55,7 @@ cesiumSvgPath: { path: _svgPath, width: 28, height: 28 }');
         this._container = container;
         this._viewModel = viewModel;
         this._element = element;
-    };
+    }
 
     defineProperties(HomeButton.prototype, {
         /**

--- a/Source/Widgets/HomeButton/HomeButtonViewModel.js
+++ b/Source/Widgets/HomeButton/HomeButtonViewModel.js
@@ -78,7 +78,7 @@ define([
      * @param {Scene} scene The scene instance to use.
      * @param {Number} [duration] The duration of the camera flight in seconds.
      */
-    var HomeButtonViewModel = function(scene, duration) {
+    function HomeButtonViewModel(scene, duration) {
         //>>includeStart('debug', pragmas.debug);
         if (!defined(scene)) {
             throw new DeveloperError('scene is required.');
@@ -101,7 +101,7 @@ define([
         this.tooltip = 'View Home';
 
         knockout.track(this, ['tooltip']);
-    };
+    }
 
     defineProperties(HomeButtonViewModel.prototype, {
         /**

--- a/Source/Widgets/InfoBox/InfoBox.js
+++ b/Source/Widgets/InfoBox/InfoBox.js
@@ -33,7 +33,7 @@ define([
      *
      * @exception {DeveloperError} Element with id "container" does not exist in the document.
      */
-    var InfoBox = function(container) {
+    function InfoBox(container) {
         //>>includeStart('debug', pragmas.debug);
         if (!defined(container)) {
             throw new DeveloperError('container is required.');
@@ -140,7 +140,7 @@ click: function () { closeClicked.raiseEvent(this); }');
 
         //Chrome does not send the load event unless we explicitly set a src
         frame.setAttribute('src', 'about:blank');
-    };
+    }
 
     defineProperties(InfoBox.prototype, {
         /**

--- a/Source/Widgets/InfoBox/InfoBoxViewModel.js
+++ b/Source/Widgets/InfoBox/InfoBoxViewModel.js
@@ -19,7 +19,7 @@ define([
      * @alias InfoBoxViewModel
      * @constructor
      */
-    var InfoBoxViewModel = function() {
+    function InfoBoxViewModel() {
         this._cameraClicked = new Event();
         this._closeClicked = new Event();
 
@@ -79,7 +79,7 @@ define([
                 return !defined(this.description) || this.description.length === 0;
             }
         });
-    };
+    }
 
     /**
      * Gets the maximum height of sections within the info box, minus an offset, in CSS-ready form.

--- a/Source/Widgets/NavigationHelpButton/NavigationHelpButton.js
+++ b/Source/Widgets/NavigationHelpButton/NavigationHelpButton.js
@@ -44,7 +44,7 @@ define([
      *     container : 'navigationHelpButtonContainer'
      * });
      */
-    var NavigationHelpButton = function(options) {
+    function NavigationHelpButton(options) {
         //>>includeStart('debug', pragmas.debug);
         if (!defined(options) || !defined(options.container)) {
             throw new DeveloperError('options.container is required.');
@@ -192,7 +192,7 @@ cesiumSvgPath: { path: _svgPath, width: 32, height: 32 }');
             document.addEventListener('mousedown', this._closeInstructions, true);
             document.addEventListener('touchstart', this._closeInstructions, true);
         }
-    };
+    }
 
     defineProperties(NavigationHelpButton.prototype, {
         /**

--- a/Source/Widgets/NavigationHelpButton/NavigationHelpButtonViewModel.js
+++ b/Source/Widgets/NavigationHelpButton/NavigationHelpButtonViewModel.js
@@ -14,7 +14,7 @@ define([
      * @alias NavigationHelpButtonViewModel
      * @constructor
      */
-    var NavigationHelpButtonViewModel = function() {
+    function NavigationHelpButtonViewModel() {
         /**
          * Gets or sets whether the instructions are currently shown.  This property is observable.
          * @type {Boolean}
@@ -43,7 +43,7 @@ define([
         this.tooltip = 'Navigation Instructions';
 
         knockout.track(this, ['tooltip', 'showInstructions', '_touch']);
-    };
+    }
 
     defineProperties(NavigationHelpButtonViewModel.prototype, {
         /**

--- a/Source/Widgets/PerformanceWatchdog/PerformanceWatchdog.js
+++ b/Source/Widgets/PerformanceWatchdog/PerformanceWatchdog.js
@@ -30,7 +30,7 @@ define([
      *        message to display when a low frame rate is detected.  The message is interpeted as HTML, so make sure
      *        it comes from a trusted source so that your application is not vulnerable to cross-site scripting attacks.
      */
-    var PerformanceWatchdog = function(options) {
+    function PerformanceWatchdog(options) {
         //>>includeStart('debug', pragmas.debug);
         if (!defined(options) || !defined(options.container)) {
             throw new DeveloperError('options.container is required.');
@@ -67,7 +67,7 @@ define([
         this._container = container;
         this._viewModel = viewModel;
         this._element = element;
-    };
+    }
 
     defineProperties(PerformanceWatchdog.prototype, {
         /**

--- a/Source/Widgets/PerformanceWatchdog/PerformanceWatchdogViewModel.js
+++ b/Source/Widgets/PerformanceWatchdog/PerformanceWatchdogViewModel.js
@@ -31,7 +31,7 @@ define([
      *        message to display when a low frame rate is detected.  The message is interpeted as HTML, so make sure
      *        it comes from a trusted source so that your application is not vulnerable to cross-site scripting attacks.
      */
-    var PerformanceWatchdogViewModel = function(options) {
+    function PerformanceWatchdogViewModel(options) {
         //>>includeStart('debug', pragmas.debug);
         if (!defined(options) || !defined(options.scene)) {
             throw new DeveloperError('options.scene is required.');
@@ -78,7 +78,7 @@ define([
         this._unsubscribeNominalFrameRate = monitor.nominalFrameRate.addEventListener(function() {
             that.showingLowFrameRateMessage = false;
         });
-    };
+    }
 
     defineProperties(PerformanceWatchdogViewModel.prototype, {
         /**

--- a/Source/Widgets/SceneModePicker/SceneModePicker.js
+++ b/Source/Widgets/SceneModePicker/SceneModePicker.js
@@ -52,7 +52,7 @@ define([
      *
      * var sceneModePicker = new Cesium.SceneModePicker('sceneModePickerContainer', scene);
      */
-    var SceneModePicker = function(container, scene, duration) {
+    function SceneModePicker(container, scene, duration) {
         //>>includeStart('debug', pragmas.debug);
         if (!defined(container)) {
             throw new DeveloperError('container is required.');
@@ -143,7 +143,7 @@ cesiumSvgPath: { path: _columbusViewPath, width: 64, height: 64 }');
             document.addEventListener('mousedown', this._closeDropDown, true);
             document.addEventListener('touchstart', this._closeDropDown, true);
         }
-    };
+    }
 
     defineProperties(SceneModePicker.prototype, {
         /**

--- a/Source/Widgets/SceneModePicker/SceneModePickerViewModel.js
+++ b/Source/Widgets/SceneModePicker/SceneModePickerViewModel.js
@@ -29,7 +29,7 @@ define([
      * @param {Scene} scene The Scene to morph
      * @param {Number} [duration=2.0] The duration of scene morph animations, in seconds
      */
-    var SceneModePickerViewModel = function(scene, duration) {
+    function SceneModePickerViewModel(scene, duration) {
         //>>includeStart('debug', pragmas.debug);
         if (!defined(scene)) {
             throw new DeveloperError('scene is required.');
@@ -120,7 +120,7 @@ define([
 
         //Used by knockout
         this._sceneMode = SceneMode;
-    };
+    }
 
     defineProperties(SceneModePickerViewModel.prototype, {
         /**

--- a/Source/Widgets/SelectionIndicator/SelectionIndicator.js
+++ b/Source/Widgets/SelectionIndicator/SelectionIndicator.js
@@ -28,7 +28,7 @@ define([
      *
      * @exception {DeveloperError} Element with id "container" does not exist in the document.
      */
-    var SelectionIndicator = function(container, scene) {
+    function SelectionIndicator(container, scene) {
         //>>includeStart('debug', pragmas.debug);
         if (!defined(container)) {
             throw new DeveloperError('container is required.');
@@ -70,7 +70,7 @@ css: { "cesium-selection-wrapper-visible" : isVisible }');
         this._viewModel = viewModel;
 
         knockout.applyBindings(this._viewModel, this._element);
-    };
+    }
 
     defineProperties(SelectionIndicator.prototype, {
         /**

--- a/Source/Widgets/SelectionIndicator/SelectionIndicatorViewModel.js
+++ b/Source/Widgets/SelectionIndicator/SelectionIndicatorViewModel.js
@@ -31,7 +31,7 @@ define([
      * @param {Element} selectionIndicatorElement The element containing all elements that make up the selection indicator.
      * @param {Element} container The DOM element that contains the widget.
      */
-    var SelectionIndicatorViewModel = function(scene, selectionIndicatorElement, container) {
+    function SelectionIndicatorViewModel(scene, selectionIndicatorElement, container) {
         //>>includeStart('debug', pragmas.debug);
         if (!defined(scene)) {
             throw new DeveloperError('scene is required.');
@@ -101,7 +101,7 @@ define([
         this.computeScreenSpacePosition = function(position, result) {
             return SceneTransforms.wgs84ToWindowCoordinates(scene, position, result);
         };
-    };
+    }
 
     /**
      * Updates the view of the selection indicator to match the position and content properties of the view model.

--- a/Source/Widgets/Timeline/Timeline.js
+++ b/Source/Widgets/Timeline/Timeline.js
@@ -82,7 +82,7 @@ define([
      * @param {Element} container The parent HTML container node for this widget.
      * @param {Clock} clock The clock to use.
      */
-    var Timeline = function(container, clock) {
+    function Timeline(container, clock) {
         //>>includeStart('debug', pragmas.debug);
         if (!defined(container)) {
             throw new DeveloperError('container is required.');
@@ -165,7 +165,7 @@ define([
 
         clock.onTick.addEventListener(this.updateFromClock, this);
         this.updateFromClock();
-    };
+    }
 
     /**
      * @private

--- a/Source/Widgets/ToggleButtonViewModel.js
+++ b/Source/Widgets/ToggleButtonViewModel.js
@@ -23,7 +23,7 @@ define([
      * @param {Boolean} [options.toggled=false] A boolean indicating whether the button should be initially toggled.
      * @param {String} [options.tooltip=''] A string containing the button's tooltip.
      */
-    var ToggleButtonViewModel = function(command, options) {
+    function ToggleButtonViewModel(command, options) {
         //>>includeStart('debug', pragmas.debug);
         if (!defined(command)) {
             throw new DeveloperError('command is required.');
@@ -49,7 +49,7 @@ define([
         this.tooltip = defaultValue(options.tooltip, '');
 
         knockout.track(this, ['toggled', 'tooltip']);
-    };
+    }
 
     defineProperties(ToggleButtonViewModel.prototype, {
         /**

--- a/Source/Widgets/Viewer/Viewer.js
+++ b/Source/Widgets/Viewer/Viewer.js
@@ -277,7 +277,7 @@ define([
      *     window.alert(error);
      * });
      */
-    var Viewer = function(container, options) {
+    function Viewer(container, options) {
         //>>includeStart('debug', pragmas.debug);
         if (!defined(container)) {
             throw new DeveloperError('container is required.');
@@ -613,7 +613,7 @@ Either specify options.terrainProvider instead or set options.baseLayerPicker to
 
         cesiumWidget.screenSpaceEventHandler.setInputAction(pickAndSelectObject, ScreenSpaceEventType.LEFT_CLICK);
         cesiumWidget.screenSpaceEventHandler.setInputAction(pickAndTrackObject, ScreenSpaceEventType.LEFT_DOUBLE_CLICK);
-    };
+    }
 
     defineProperties(Viewer.prototype, {
         /**

--- a/Source/Widgets/Viewer/viewerCesiumInspectorMixin.js
+++ b/Source/Widgets/Viewer/viewerCesiumInspectorMixin.js
@@ -27,7 +27,7 @@ define([
      * var viewer = new Cesium.Viewer('cesiumContainer');
      * viewer.extend(Cesium.viewerCesiumInspectorMixin);
      */
-    var viewerCesiumInspectorMixin = function(viewer) {
+    function viewerCesiumInspectorMixin(viewer) {
         if (!defined(viewer)) {
             throw new DeveloperError('viewer is required.');
         }
@@ -48,7 +48,7 @@ define([
         viewer.scene.postRender.addEventListener(function() {
             viewer.cesiumInspector.viewModel.update();
         });
-    };
+    }
 
     return viewerCesiumInspectorMixin;
 });

--- a/Source/Widgets/Viewer/viewerDragDropMixin.js
+++ b/Source/Widgets/Viewer/viewerDragDropMixin.js
@@ -50,7 +50,7 @@ define([
      *     window.alert('Error processing ' + source + ':' + error);
      * });
      */
-    var viewerDragDropMixin = function(viewer, options) {
+    function viewerDragDropMixin(viewer, options) {
         //>>includeStart('debug', pragmas.debug);
         if (!defined(viewer)) {
             throw new DeveloperError('viewer is required.');
@@ -212,7 +212,7 @@ define([
 
         //Specs need access to handleDrop
         viewer._handleDrop = handleDrop;
-    };
+    }
 
     function stop(event) {
         event.stopPropagation();

--- a/Source/Widgets/Viewer/viewerPerformanceWatchdogMixin.js
+++ b/Source/Widgets/Viewer/viewerPerformanceWatchdogMixin.js
@@ -32,7 +32,7 @@ define([
      *     lowFrameRateMessage : 'Why is this going so <em>slowly</em>?'
      * });
      */
-    var viewerPerformanceWatchdogMixin = function(viewer, options) {
+    function viewerPerformanceWatchdogMixin(viewer, options) {
         if (!defined(viewer)) {
             throw new DeveloperError('viewer is required.');
         }
@@ -52,7 +52,7 @@ define([
                 }
             }
         });
-    };
+    }
 
     return viewerPerformanceWatchdogMixin;
 });

--- a/Source/Widgets/createCommand.js
+++ b/Source/Widgets/createCommand.js
@@ -28,7 +28,7 @@ define([
      * @param {Function} func The function to execute.
      * @param {Boolean} [canExecute=true] A boolean indicating whether the function can currently be executed.
      */
-    var createCommand = function(func, canExecute) {
+    function createCommand(func, canExecute) {
         //>>includeStart('debug', pragmas.debug);
         if (!defined(func)) {
             throw new DeveloperError('func is required.');
@@ -74,7 +74,7 @@ define([
         });
 
         return command;
-    };
+    }
 
     return createCommand;
 });

--- a/Source/Widgets/getElement.js
+++ b/Source/Widgets/getElement.js
@@ -12,7 +12,7 @@ define([
      *
      * @exception {DeveloperError} Element with id "id" does not exist in the document.
      */
-    var getElement = function(element) {
+    function getElement(element) {
         if (typeof element === 'string') {
             var foundElement = document.getElementById(element);
 
@@ -25,7 +25,7 @@ define([
             element = foundElement;
         }
         return element;
-    };
+    }
 
     return getElement;
 });

--- a/Source/Widgets/subscribeAndEvaluate.js
+++ b/Source/Widgets/subscribeAndEvaluate.js
@@ -20,10 +20,10 @@ define([
      * @param {String} [event='change'] The name of the event to receive notification for.
      * @returns The subscription object from Knockout which can be used to dispose the subscription later.
      */
-    var subscribeAndEvaluate = function(owner, observablePropertyName, callback, target, event) {
+    function subscribeAndEvaluate(owner, observablePropertyName, callback, target, event) {
         callback.call(target, owner[observablePropertyName]);
         return knockout.getObservable(owner, observablePropertyName).subscribe(callback, target, event);
-    };
+    }
 
     return subscribeAndEvaluate;
 });

--- a/Source/Workers/createTaskProcessorWorker.js
+++ b/Source/Workers/createTaskProcessorWorker.js
@@ -33,7 +33,7 @@ define([
      * return Cesium.createTaskProcessorWorker(doCalculation);
      * // the resulting function is compatible with TaskProcessor
      */
-    var createTaskProcessorWorker = function(workerFunction) {
+    function createTaskProcessorWorker(workerFunction) {
         var postMessage;
         var transferableObjects = [];
         var responseMessage = {
@@ -84,7 +84,7 @@ define([
                 postMessage(responseMessage);
             }
         };
-    };
+    }
 
     /**
      * A function that performs a calculation in a Web Worker.

--- a/Specs/BadGeometry.js
+++ b/Specs/BadGeometry.js
@@ -7,7 +7,7 @@ define([
         RuntimeError) {
     "use strict";
 
-    var BadGeometry = function() {
+    function BadGeometry() {
         this._workerName = '../../Specs/TestWorkers/createBadGeometry';
 
         // Make this worker loadable when testing against the built version of Cesium.
@@ -17,7 +17,7 @@ define([
                 this._workerName = '../' + this._workerName;
             }
         }
-    };
+    }
 
     BadGeometry.createGeometry = function() {
         //This function is only called when synchronous, see Specs/TestWorks/createBadGeometry for asynchronous.

--- a/Specs/Core/HermiteSplineSpec.js
+++ b/Specs/Core/HermiteSplineSpec.js
@@ -58,7 +58,7 @@ defineSuite([
 
     // returns a function for a hermite curve between points p and q
     // with tangents pT and qT respectively on the interval [0, 1]
-    var createHermiteBasis = function(p, pT, q, qT) {
+    function createHermiteBasis(p, pT, q, qT) {
         return function(u) {
             var a = 2.0 * u * u * u - 3.0 * u * u + 1.0;
             var b = -2.0 * u * u * u + 3.0 * u * u;
@@ -72,7 +72,7 @@ defineSuite([
 
             return Cartesian3.add(Cartesian3.add(Cartesian3.add(p0, p1, p0), p2, p0), p3, p0);
         };
-    };
+    }
 
     it('create spline', function() {
         var hs = new HermiteSpline({

--- a/Specs/Core/sampleTerrainSpec.js
+++ b/Specs/Core/sampleTerrainSpec.js
@@ -32,7 +32,7 @@ defineSuite([
 
     it('queries heights from Small Terrain', function() {
         var terrainProvider = new CesiumTerrainProvider({
-            url : '//s3.amazonaws.com/cesiumjs/smallTerrain'
+            url : '//cesiumjs.org/smallTerrain'
         });
 
         var positions = [

--- a/Specs/DataSources/CompositeEntityCollectionSpec.js
+++ b/Specs/DataSources/CompositeEntityCollectionSpec.js
@@ -25,12 +25,11 @@ defineSuite([
         EntityCollection) {
     "use strict";
 
-    var CollectionListener = function() {
+    function CollectionListener() {
         this.timesCalled = 0;
         this.added = [];
         this.removed = [];
-    };
-
+    }
     CollectionListener.prototype.onCollectionChanged = function(collection, added, removed) {
         this.timesCalled++;
         this.added = added.slice(0);

--- a/Specs/DataSources/DataSourceDisplaySpec.js
+++ b/Specs/DataSources/DataSourceDisplaySpec.js
@@ -39,7 +39,7 @@ defineSuite([
         }
     });
 
-    var MockVisualizer = function(scene, entityCollection) {
+    function MockVisualizer(scene, entityCollection) {
         this.scene = scene;
         this.entityCollection = entityCollection;
         this.updatesCalled = 0;
@@ -48,8 +48,7 @@ defineSuite([
 
         this.getBoundingSphereResult = undefined;
         this.getBoundingSphereState = undefined;
-    };
-
+    }
     MockVisualizer.prototype.update = function(time) {
         this.lastUpdateTime = time;
         this.updatesCalled++;
@@ -68,9 +67,9 @@ defineSuite([
         this.destroyed = true;
     };
 
-    var visualizersCallback = function() {
+    function visualizersCallback() {
         return [new MockVisualizer()];
-    };
+    }
 
     it('constructor sets expected values', function() {
         display = new DataSourceDisplay({

--- a/Specs/DataSources/EntityCollectionSpec.js
+++ b/Specs/DataSources/EntityCollectionSpec.js
@@ -15,13 +15,12 @@ defineSuite([
         Entity) {
     "use strict";
 
-    var CollectionListener = function() {
+    function CollectionListener() {
         this.timesCalled = 0;
         this.added = undefined;
         this.removed = undefined;
         this.changed = undefined;
-    };
-
+    }
     CollectionListener.prototype.onCollectionChanged = function(collection, added, removed, changed) {
         this.timesCalled++;
         this.added = added.slice(0);

--- a/Specs/DataSources/PathVisualizerSpec.js
+++ b/Specs/DataSources/PathVisualizerSpec.js
@@ -491,7 +491,7 @@ defineSuite([
         expect(result).toEqual([new Cartesian3(0, 0, 3)]);
     });
 
-    var CustomPositionProperty = function(innerProperty) {
+    function CustomPositionProperty(innerProperty) {
         this.SampledProperty = innerProperty;
         this.isConstant = innerProperty.isConstant;
         this.definitionChanged = innerProperty.definitionChanged;
@@ -508,7 +508,7 @@ defineSuite([
         this.equals = function(other) {
             return innerProperty.equals(other);
         };
-    };
+    }
 
     it('subSample works for custom properties', function() {
         var t1 = new JulianDate(0, 0);

--- a/Specs/DataSources/SampledPropertySpec.js
+++ b/Specs/DataSources/SampledPropertySpec.js
@@ -113,10 +113,9 @@ defineSuite([
     });
 
     it('works with PackableForInterpolation', function() {
-        var CustomType = function(value) {
+        function CustomType(value) {
             this.x = value;
-        };
-
+        }
         CustomType.packedLength = 1;
 
         CustomType.packedInterpolationLength = 2;

--- a/Specs/DataSources/createMaterialPropertyDescriptorSpec.js
+++ b/Specs/DataSources/createMaterialPropertyDescriptorSpec.js
@@ -13,10 +13,9 @@ defineSuite([
         ImageMaterialProperty) {
     "use strict";
 
-    var MockGraphics = function() {
+    function MockGraphics() {
         this._definitionChanged = new Event();
-    };
-
+    }
     Object.defineProperties(MockGraphics.prototype, {
         materialProperty : createMaterialPropertyDescriptor('materialProperty')
     });

--- a/Specs/MockDataSource.js
+++ b/Specs/MockDataSource.js
@@ -7,7 +7,7 @@ define([
         EntityCollection) {
     "use strict";
 
-    var MockDataSource = function() {
+    function MockDataSource() {
         //Values to be fiddled with by the test
         this.changedEvent = new Event();
         this.errorEvent = new Event();
@@ -18,8 +18,7 @@ define([
         this.isLoading = false;
         this.loadingEvent = new Event();
         this.destroyed = false;
-    };
-
+    }
     MockDataSource.prototype.update = function() {
         return true;
     };

--- a/Specs/Scene/CameraSpec.js
+++ b/Specs/Scene/CameraSpec.js
@@ -58,7 +58,7 @@ defineSuite([
     var rotateAmount = CesiumMath.PI_OVER_TWO;
     var zoomAmount = 1.0;
 
-    var FakeScene = function(projection) {
+    function FakeScene(projection) {
         this.canvas = {
             clientWidth: 512,
             clientHeight: 384
@@ -73,8 +73,7 @@ defineSuite([
             drawingBufferWidth : 1024,
             drawingBufferHeight : 768
         };
-    };
-
+    }
     beforeEach(function() {
         position = Cartesian3.clone(Cartesian3.UNIT_Z);
         up = Cartesian3.clone(Cartesian3.UNIT_Y);

--- a/Specs/Scene/CullingVolumeSpec.js
+++ b/Specs/Scene/CullingVolumeSpec.js
@@ -44,7 +44,7 @@ defineSuite([
         }).toThrowDeveloperError();
     });
 
-    var testWithAndWithoutPlaneMask = function(culling, bound, intersect) {
+    function testWithAndWithoutPlaneMask(culling, bound, intersect) {
         expect(culling.computeVisibility(bound)).toEqual(intersect);
 
         var mask = culling.computeVisibilityWithPlaneMask(bound, CullingVolume.MASK_INDETERMINATE);
@@ -57,8 +57,7 @@ defineSuite([
             expect(mask).not.toEqual(CullingVolume.MASK_OUTSIDE);
         }
         expect(culling.computeVisibilityWithPlaneMask(bound, mask)).toEqual(mask);
-    };
-
+    }
     describe('box intersections', function() {
 
         it('can contain an axis aligned bounding box', function() {

--- a/Specs/Scene/GeometryRenderingSpec.js
+++ b/Specs/Scene/GeometryRenderingSpec.js
@@ -561,23 +561,23 @@ defineSuite([
         });
 
         it('renders bottom', function() {
-            var afterView = function(frameState, primitive) {
+            function afterView(frameState, primitive) {
                 var height = (extrudedHeight - geometryHeight) * 0.5;
                 var transform = Matrix4.multiplyByTranslation(
                         Transforms.eastNorthUpToFixedFrame(primitive._boundingSphereWC[0].center),
                         new Cartesian3(0.0, 0.0, height), new Matrix4());
                 frameState.camera.lookAtTransform(transform, new Cartesian3(0.0, 0.0, primitive._boundingSphereWC[0].radius));
                 frameState.camera.rotateDown(CesiumMath.PI);
-            };
+            }
             render3D(instance, afterView);
         });
 
         it('renders wall', function() {
-            var afterView = function(frameState, primitive) {
+            function afterView(frameState, primitive) {
                 var transform = Transforms.eastNorthUpToFixedFrame(primitive._boundingSphereWC[0].center);
                 frameState.camera.lookAtTransform(transform, new Cartesian3(0.0, 0.0, primitive._boundingSphereWC[0].radius));
                 frameState.camera.rotateDown(CesiumMath.PI_OVER_TWO);
-            };
+            }
             render3D(instance, afterView);
         });
     }, 'WebGL');
@@ -787,47 +787,47 @@ defineSuite([
         });
 
         it('renders bottom', function() {
-            var afterView = function(frameState, primitive) {
+            function afterView(frameState, primitive) {
                 var transform = Transforms.eastNorthUpToFixedFrame(primitive._boundingSphereWC[0].center);
                 frameState.camera.lookAtTransform(transform, new Cartesian3(0.0, 0.0, primitive._boundingSphereWC[0].radius));
                 frameState.camera.rotateDown(CesiumMath.PI);
-            };
+            }
             render3D(instance, afterView);
         });
 
         it('renders north wall', function() {
-            var afterView = function(frameState, primitive) {
+            function afterView(frameState, primitive) {
                 var transform = Transforms.eastNorthUpToFixedFrame(primitive._boundingSphereWC[0].center);
                 frameState.camera.lookAtTransform(transform, new Cartesian3(0.0, 0.0, primitive._boundingSphereWC[0].radius));
                 frameState.camera.rotateDown(-CesiumMath.PI_OVER_TWO);
-            };
+            }
             render3D(instance, afterView);
         });
 
         it('renders south wall', function() {
-            var afterView = function(frameState, primitive) {
+            function afterView(frameState, primitive) {
                 var transform = Transforms.eastNorthUpToFixedFrame(primitive._boundingSphereWC[0].center);
                 frameState.camera.lookAtTransform(transform, new Cartesian3(0.0, 0.0, primitive._boundingSphereWC[0].radius));
                 frameState.camera.rotateDown(CesiumMath.PI_OVER_TWO);
-            };
+            }
             render3D(instance, afterView);
         });
 
         it('renders west wall', function() {
-            var afterView = function(frameState, primitive) {
+            function afterView(frameState, primitive) {
                 var transform = Transforms.eastNorthUpToFixedFrame(primitive._boundingSphereWC[0].center);
                 frameState.camera.lookAtTransform(transform, new Cartesian3(0.0, 0.0, primitive._boundingSphereWC[0].radius));
                 frameState.camera.rotateRight(-CesiumMath.PI_OVER_TWO);
-            };
+            }
             render3D(instance, afterView);
         });
 
         it('renders east wall', function() {
-            var afterView = function(frameState, primitive) {
+            function afterView(frameState, primitive) {
                 var transform = Transforms.eastNorthUpToFixedFrame(primitive._boundingSphereWC[0].center);
                 frameState.camera.lookAtTransform(transform, new Cartesian3(0.0, 0.0, primitive._boundingSphereWC[0].radius));
                 frameState.camera.rotateRight(CesiumMath.PI_OVER_TWO);
-            };
+            }
             render3D(instance, afterView);
         });
     }, 'WebGL');
@@ -983,50 +983,50 @@ defineSuite([
         });
 
         it('renders bottom', function() {
-            var afterView = function(frameState, primitive) {
+            function afterView(frameState, primitive) {
                 var height = (extrudedHeight - geometryHeight) * 0.5;
                 var transform = Matrix4.multiplyByTranslation(
                         Transforms.eastNorthUpToFixedFrame(primitive._boundingSphereWC[0].center),
                         new Cartesian3(0.0, 0.0, height), new Matrix4());
                 frameState.camera.lookAtTransform(transform, new Cartesian3(0.0, 0.0, primitive._boundingSphereWC[0].radius));
                 frameState.camera.rotateDown(CesiumMath.PI);
-            };
+            }
             render3D(instance, afterView);
         });
 
         it('renders wall 1', function() {
-            var afterView = function(frameState, primitive) {
+            function afterView(frameState, primitive) {
                 var transform = Transforms.eastNorthUpToFixedFrame(primitive._boundingSphereWC[0].center);
                 frameState.camera.lookAtTransform(transform, new Cartesian3(0.0, 0.0, primitive._boundingSphereWC[0].radius));
                 frameState.camera.rotateUp(CesiumMath.PI_OVER_TWO);
-            };
+            }
             render3D(instance, afterView);
         });
 
         it('renders wall 2', function() {
-            var afterView = function(frameState, primitive) {
+            function afterView(frameState, primitive) {
                 var transform = Transforms.eastNorthUpToFixedFrame(primitive._boundingSphereWC[0].center);
                 frameState.camera.lookAtTransform(transform, new Cartesian3(0.0, 0.0, primitive._boundingSphereWC[0].radius));
                 frameState.camera.rotateDown(-CesiumMath.PI_OVER_TWO);
-            };
+            }
             render3D(instance, afterView);
         });
 
         it('renders wall 3', function() {
-            var afterView = function(frameState, primitive) {
+            function afterView(frameState, primitive) {
                 var transform = Transforms.eastNorthUpToFixedFrame(primitive._boundingSphereWC[0].center);
                 frameState.camera.lookAtTransform(transform, new Cartesian3(0.0, 0.0, primitive._boundingSphereWC[0].radius));
                 frameState.camera.rotateRight(-CesiumMath.PI_OVER_TWO);
-            };
+            }
             render3D(instance, afterView);
         });
 
         it('renders wall 4', function() {
-            var afterView = function(frameState, primitive) {
+            function afterView(frameState, primitive) {
                 var transform = Transforms.eastNorthUpToFixedFrame(primitive._boundingSphereWC[0].center);
                 frameState.camera.lookAtTransform(transform, new Cartesian3(0.0, 0.0, primitive._boundingSphereWC[0].radius));
                 frameState.camera.rotateRight(CesiumMath.PI_OVER_TWO);
-            };
+            }
             render3D(instance, afterView);
         });
 
@@ -1249,50 +1249,50 @@ defineSuite([
         });
 
         it('renders bottom', function() {
-            var afterView = function(frameState, primitive) {
+            function afterView(frameState, primitive) {
                 var height = (extrudedHeight - geometryHeight) * 0.5;
                 var transform = Matrix4.multiplyByTranslation(
                         Transforms.eastNorthUpToFixedFrame(primitive._boundingSphereWC[0].center),
                         new Cartesian3(0.0, 0.0, height), new Matrix4());
                 frameState.camera.lookAtTransform(transform, new Cartesian3(0.0, 0.0, primitive._boundingSphereWC[0].radius));
                 frameState.camera.rotateDown(CesiumMath.PI);
-            };
+            }
             render3D(instance, afterView);
         });
 
         it('renders north wall', function() {
-            var afterView = function(frameState, primitive) {
+            function afterView(frameState, primitive) {
                 var transform = Transforms.eastNorthUpToFixedFrame(primitive._boundingSphereWC[0].center);
                 frameState.camera.lookAtTransform(transform, new Cartesian3(0.0, 0.0, primitive._boundingSphereWC[0].radius));
                 frameState.camera.rotateDown(-CesiumMath.PI_OVER_TWO);
-            };
+            }
             render3D(instance, afterView);
         });
 
         it('renders south wall', function() {
-            var afterView = function(frameState, primitive) {
+            function afterView(frameState, primitive) {
                 var transform = Transforms.eastNorthUpToFixedFrame(primitive._boundingSphereWC[0].center);
                 frameState.camera.lookAtTransform(transform, new Cartesian3(0.0, 0.0, primitive._boundingSphereWC[0].radius));
                 frameState.camera.rotateDown(CesiumMath.PI_OVER_TWO);
-            };
+            }
             render3D(instance, afterView);
         });
 
         it('renders west wall', function() {
-            var afterView = function(frameState, primitive) {
+            function afterView(frameState, primitive) {
                 var transform = Transforms.eastNorthUpToFixedFrame(primitive._boundingSphereWC[0].center);
                 frameState.camera.lookAtTransform(transform, new Cartesian3(0.0, 0.0, primitive._boundingSphereWC[0].radius));
                 frameState.camera.rotateRight(-CesiumMath.PI_OVER_TWO);
-            };
+            }
             render3D(instance, afterView);
         });
 
         it('renders east wall', function() {
-            var afterView = function(frameState, primitive) {
+            function afterView(frameState, primitive) {
                 var transform = Transforms.eastNorthUpToFixedFrame(primitive._boundingSphereWC[0].center);
                 frameState.camera.lookAtTransform(transform, new Cartesian3(0.0, 0.0, primitive._boundingSphereWC[0].radius));
                 frameState.camera.rotateRight(CesiumMath.PI_OVER_TWO);
-            };
+            }
             render3D(instance, afterView);
         });
     }, 'WebGL');
@@ -1346,50 +1346,50 @@ defineSuite([
         });
 
         it('renders bottom', function() {
-            var afterView = function(frameState, primitive) {
+            function afterView(frameState, primitive) {
                 var height = geometryHeight * 0.5;
                 var transform = Matrix4.multiplyByTranslation(
                         Transforms.eastNorthUpToFixedFrame(primitive._boundingSphereWC[0].center),
                         new Cartesian3(0.0, 0.0, height), new Matrix4());
                 frameState.camera.lookAtTransform(transform, new Cartesian3(0.0, 0.0, primitive._boundingSphereWC[0].radius));
                 frameState.camera.rotateDown(CesiumMath.PI);
-            };
+            }
             render3D(instance, afterView);
         });
 
         it('renders north wall', function() {
-            var afterView = function(frameState, primitive) {
+            function afterView(frameState, primitive) {
                 var transform = Transforms.eastNorthUpToFixedFrame(primitive._boundingSphereWC[0].center);
                 frameState.camera.lookAtTransform(transform, new Cartesian3(0.0, 0.0, primitive._boundingSphereWC[0].radius));
                 frameState.camera.rotateDown(-CesiumMath.PI_OVER_TWO);
-            };
+            }
             render3D(instance, afterView);
         });
 
         it('renders south wall', function() {
-            var afterView = function(frameState, primitive) {
+            function afterView(frameState, primitive) {
                 var transform = Transforms.eastNorthUpToFixedFrame(primitive._boundingSphereWC[0].center);
                 frameState.camera.lookAtTransform(transform, new Cartesian3(0.0, 0.0, primitive._boundingSphereWC[0].radius));
                 frameState.camera.rotateDown(CesiumMath.PI_OVER_TWO);
-            };
+            }
             render3D(instance, afterView);
         });
 
         it('renders west wall', function() {
-            var afterView = function(frameState, primitive) {
+            function afterView(frameState, primitive) {
                 var transform = Transforms.eastNorthUpToFixedFrame(primitive._boundingSphereWC[0].center);
                 frameState.camera.lookAtTransform(transform, new Cartesian3(0.0, 0.0, primitive._boundingSphereWC[0].radius));
                 frameState.camera.rotateRight(-CesiumMath.PI_OVER_TWO);
-            };
+            }
             render3D(instance, afterView);
         });
 
         it('renders east wall', function() {
-            var afterView = function(frameState, primitive) {
+            function afterView(frameState, primitive) {
                 var transform = Transforms.eastNorthUpToFixedFrame(primitive._boundingSphereWC[0].center);
                 frameState.camera.lookAtTransform(transform, new Cartesian3(0.0, 0.0, primitive._boundingSphereWC[0].radius));
                 frameState.camera.rotateRight(CesiumMath.PI_OVER_TWO);
-            };
+            }
             render3D(instance, afterView);
         });
     }, 'WebGL');

--- a/Specs/Scene/GlobeSurfaceTileSpec.js
+++ b/Specs/Scene/GlobeSurfaceTileSpec.js
@@ -90,7 +90,7 @@ defineSuite([
             };
 
             realTerrainProvider = new CesiumTerrainProvider({
-                url : '//s3.amazonaws.com/cesiumjs/smallTerrain'
+                url : '//cesiumjs.org/smallTerrain'
             });
         });
 

--- a/Specs/Scene/GroundPrimitiveSpec.js
+++ b/Specs/Scene/GroundPrimitiveSpec.js
@@ -85,10 +85,9 @@ defineSuite([
         scene.destroyForSpecs();
     });
 
-    var MockGlobePrimitive = function(primitive) {
+    function MockGlobePrimitive(primitive) {
         this._primitive = primitive;
-    };
-
+    }
     MockGlobePrimitive.prototype.update = function(frameState) {
         var commandList = frameState.commandList;
         var startLength = commandList.length;

--- a/Specs/Scene/MultifrustumSpec.js
+++ b/Specs/Scene/MultifrustumSpec.js
@@ -212,7 +212,7 @@ defineSuite([
         bounded = defaultValue(bounded, true);
         closestFrustum = defaultValue(closestFrustum, false);
 
-        var Primitive = function() {
+        function Primitive() {
             this._va = undefined;
             this._sp = undefined;
             this._rs = undefined;
@@ -229,8 +229,7 @@ defineSuite([
                     return that._modelMatrix;
                 }
             };
-        };
-
+        }
         Primitive.prototype.update = function(frameState) {
             if (!defined(this._sp)) {
                 var vs = '';

--- a/Specs/Scene/ScreenSpaceCameraControllerSpec.js
+++ b/Specs/Scene/ScreenSpaceCameraControllerSpec.js
@@ -49,21 +49,20 @@ defineSuite([
     var camera;
     var controller;
 
-    var MockScene = function(canvas, camera, ellipsoid) {
+    function MockScene(canvas, camera, ellipsoid) {
         this.canvas = canvas;
         this.camera = camera;
         this.globe = undefined;
         this.mapProjection = new GeographicProjection(ellipsoid);
         this.terrainExaggeration = 1.0;
-    };
+    }
 
-    var MockGlobe = function(ellipsoid) {
+    function MockGlobe(ellipsoid) {
         this.ellipsoid = ellipsoid;
         this.getHeight = function(cartographic) {
             return 0.0;
         };
-    };
-
+    }
     beforeAll(function() {
         canvas = createCanvas(1024, 768);
     });

--- a/Specs/Widgets/BaseLayerPicker/BaseLayerPickerSpec.js
+++ b/Specs/Widgets/BaseLayerPicker/BaseLayerPickerSpec.js
@@ -13,10 +13,10 @@ defineSuite([
         DomEventSimulator) {
     "use strict";
 
-    var MockGlobe = function(){
+    function MockGlobe(){
         this.imageryLayers = new ImageryLayerCollection();
         this.terrainProvider = new EllipsoidTerrainProvider();
-    };
+    }
 
     it('can create and destroy', function() {
         var container = document.createElement('div');

--- a/Specs/Widgets/BaseLayerPicker/BaseLayerPickerViewModelSpec.js
+++ b/Specs/Widgets/BaseLayerPicker/BaseLayerPickerViewModelSpec.js
@@ -11,10 +11,10 @@ defineSuite([
         ProviderViewModel) {
     "use strict";
 
-    var MockGlobe = function() {
+    function MockGlobe() {
         this.imageryLayers = new ImageryLayerCollection();
         this.terrainProvider = new EllipsoidTerrainProvider();
-    };
+    }
 
     var testProvider = {
         isReady : function() {

--- a/Specs/Widgets/Viewer/viewerDragDropMixinSpec.js
+++ b/Specs/Widgets/Viewer/viewerDragDropMixinSpec.js
@@ -311,7 +311,7 @@ defineSuite([
         });
     });
 
-    var MockContainer = function() {
+    function MockContainer() {
         var events = {};
         this.events = events;
 
@@ -328,7 +328,7 @@ defineSuite([
             expect(subscribed.bubble).toEqual(bubble);
             delete events[name];
         };
-    };
+    }
 
     it('enable/disable subscribes to provided dropTarget.', function() {
         var dropTarget = new MockContainer();

--- a/Specs/createCamera.js
+++ b/Specs/createCamera.js
@@ -15,7 +15,7 @@ define([
         Camera) {
     "use strict";
 
-    var MockScene = function(canvas) {
+    function MockScene(canvas) {
         canvas = defaultValue(canvas, {
             clientWidth: 512,
             clientHeight: 384
@@ -25,7 +25,7 @@ define([
         this.drawingBufferWidth = canvas.clientWidth * 2;
         this.drawingBufferHeight = canvas.clientHeight * 2;
         this.mapProjection = new GeographicProjection();
-    };
+    }
 
     function createCamera(options) {
         options = defaultValue(options, defaultValue.EMPTY_OBJECT);

--- a/Specs/createFrameState.js
+++ b/Specs/createFrameState.js
@@ -15,7 +15,7 @@ define([
         FrameState) {
     "use strict";
 
-    var createFrameState = function(context, camera, frameNumber, time) {
+    function createFrameState(context, camera, frameNumber, time) {
         // Mock frame-state for testing.
         var frameState = new FrameState(context, new CreditDisplay(document.createElement('div')));
 
@@ -38,7 +38,7 @@ define([
         frameState.passes.pick = false;
 
         return frameState;
-    };
+    }
 
     return createFrameState;
 });

--- a/Specs/getArguments.js
+++ b/Specs/getArguments.js
@@ -17,9 +17,9 @@ define([], function() {
      * @alias getArguments
      * @return {Array} The arguments passed to the function.
      */
-    var getArguments = function() {
+    function getArguments() {
         return arguments;
-    };
+    }
 
     return getArguments;
 });

--- a/Specs/pollToPromise.js
+++ b/Specs/pollToPromise.js
@@ -9,7 +9,7 @@ define([
         when) {
 	'use strict';
 
-	var pollToPromise = function(f, options) {
+	function pollToPromise(f, options) {
 		options = defaultValue(options, defaultValue.EMPTY_OBJECT);
 
 		var pollInterval = defaultValue(options.pollInterval, 1);
@@ -35,7 +35,6 @@ define([
 		poller();
 
 		return deferred.promise;
-	};
-
+	}
 	return pollToPromise;
 });


### PR DESCRIPTION
As discussed in #3329, jsDoc used to require object declarations of the type `var foo = function()`, but now properly suppoers `function foo()`. This changes streamlines all of our code to use the same style and also ends up shrinking the minified release output by a couple of kilobytes.

This also updates the test-only smallTerrain urls, which recently broken this afternoon with cesiumjs.org server changes and were causing some failing tests in all branches.

As far as I can tell, everything, including doc, is working as expected; but a second set of eyes is always appreciated.