### PR TITLE
Fix test failures in IE 11 for THREDDS XML, msGMLOutput formats

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ Change Log
 * Reduced the amount of CPU memory used by terrain by ~25% in Chrome.
 * Fixed a picking problem ([#3386](https://github.com/AnalyticalGraphicsInc/cesium/issues/3386)) that sometimes prevented objects being selected.
 * Added `Scene.useDepthPicking` to enable or disable picking using the depth buffer. [#3390](https://github.com/AnalyticalGraphicsInc/cesium/pull/3390)
+* Fixed a bug that prevented WMS feature picking from working with THREDDS XML and msGMLOutput in Internet Explorer 11.
 
 ### 1.17 - 2016-01-04
 

--- a/Source/Scene/GetFeatureInfoFormat.js
+++ b/Source/Scene/GetFeatureInfoFormat.js
@@ -242,7 +242,7 @@ define([
                 layer = children[i];
                 break;
             }
-        };
+        }
 
         var featureMembers = layer.childNodes;
         for (var featureIndex = 0; featureIndex < featureMembers.length; ++featureIndex) {

--- a/Source/Scene/GetFeatureInfoFormat.js
+++ b/Source/Scene/GetFeatureInfoFormat.js
@@ -194,10 +194,13 @@ define([
 
                 properties = {};
 
-                var featureInfoChildren = featureInfoElement.children;
+                // node.children is not supported in IE (not even IE11), so use childNodes and check that child.nodeType is an element
+                var featureInfoChildren = featureInfoElement.childNodes;
                 for (var childIndex = 0; childIndex < featureInfoChildren.length; ++childIndex) {
                     var child = featureInfoChildren[childIndex];
-                    properties[child.localName] = child.textContent;
+                    if (child.nodeType === 1) {  // type 1 is Node.ELEMENT_NODE
+                        properties[child.localName] = child.textContent;
+                    }
                 }
 
                 result.push(imageryLayerFeatureInfoFromDataAndProperties(featureInfoElement, properties));
@@ -230,15 +233,25 @@ define([
     function msGmlToFeatureInfo(xml) {
         var result = [];
 
-        var layer = xml.documentElement.children[0];
+        // Find the first child. Except for IE, this would work:
+        // var layer = xml.documentElement.children[0];
+        var layer;
+        var children = xml.documentElement.childNodes;
+        for (var i = 0; i < children.length; i++) {
+            if (children[i].nodeType === 1) {
+                layer = children[i];
+                break;
+            }
+        };
 
-        var featureMembers = layer.children;
+        var featureMembers = layer.childNodes;
         for (var featureIndex = 0; featureIndex < featureMembers.length; ++featureIndex) {
             var featureMember = featureMembers[featureIndex];
-
-            var properties = {};
-            getGmlPropertiesRecursively(featureMember, properties);
-            result.push(imageryLayerFeatureInfoFromDataAndProperties(featureMember, properties));
+            if (featureMember.nodeType === 1) {
+                var properties = {};
+                getGmlPropertiesRecursively(featureMember, properties);
+                result.push(imageryLayerFeatureInfoFromDataAndProperties(featureMember, properties));
+            }
         }
 
         return result;

--- a/Source/Scene/GetFeatureInfoFormat.js
+++ b/Source/Scene/GetFeatureInfoFormat.js
@@ -194,11 +194,11 @@ define([
 
                 properties = {};
 
-                // node.children is not supported in IE (not even IE11), so use childNodes and check that child.nodeType is an element
+                // node.children is not supported in IE9-11, so use childNodes and check that child.nodeType is an element
                 var featureInfoChildren = featureInfoElement.childNodes;
                 for (var childIndex = 0; childIndex < featureInfoChildren.length; ++childIndex) {
                     var child = featureInfoChildren[childIndex];
-                    if (child.nodeType === 1) {  // type 1 is Node.ELEMENT_NODE
+                    if (child.nodeType === Node.ELEMENT_NODE) {
                         properties[child.localName] = child.textContent;
                     }
                 }
@@ -238,7 +238,7 @@ define([
         var layer;
         var children = xml.documentElement.childNodes;
         for (var i = 0; i < children.length; i++) {
-            if (children[i].nodeType === 1) {
+            if (children[i].nodeType === Node.ELEMENT_NODE) {
                 layer = children[i];
                 break;
             }
@@ -247,7 +247,7 @@ define([
         var featureMembers = layer.childNodes;
         for (var featureIndex = 0; featureIndex < featureMembers.length; ++featureIndex) {
             var featureMember = featureMembers[featureIndex];
-            if (featureMember.nodeType === 1) {
+            if (featureMember.nodeType === Node.ELEMENT_NODE) {
                 var properties = {};
                 getGmlPropertiesRecursively(featureMember, properties);
                 result.push(imageryLayerFeatureInfoFromDataAndProperties(featureMember, properties));
@@ -260,8 +260,8 @@ define([
     function getGmlPropertiesRecursively(gmlNode, properties) {
         var isSingleValue = true;
 
-        for (var i = 0; i < gmlNode.children.length; ++i) {
-            var child = gmlNode.children[i];
+        for (var i = 0; i < gmlNode.childNodes.length; ++i) {
+            var child = gmlNode.childNodes[i];
 
             if (child.nodeType === Node.ELEMENT_NODE) {
                 isSingleValue = false;


### PR DESCRIPTION
Changes references to xml.children to xml.childNodes.

Fixes #2860.