### PR TITLE
Fix Cartesian.normalize to return Cartesian.ZERO for zero vector

### DIFF
--- a/Source/Core/Cartesian2.js
+++ b/Source/Core/Cartesian2.js
@@ -353,6 +353,12 @@ define([
 
         var magnitude = Cartesian2.magnitude(cartesian);
 
+        if (magnitude === 0.0) {
+            result.x = 0.0;
+            result.y = 0.0;
+            return result;
+        }
+
         result.x = cartesian.x / magnitude;
         result.y = cartesian.y / magnitude;
         return result;

--- a/Source/Core/Cartesian3.js
+++ b/Source/Core/Cartesian3.js
@@ -385,6 +385,13 @@ define([
 
         var magnitude = Cartesian3.magnitude(cartesian);
 
+        if (magnitude === 0.0) {
+            result.x = 0.0;
+            result.y = 0.0;
+            result.z = 0.0;
+            return result;
+        }
+
         result.x = cartesian.x / magnitude;
         result.y = cartesian.y / magnitude;
         result.z = cartesian.z / magnitude;

--- a/Source/Core/Cartesian4.js
+++ b/Source/Core/Cartesian4.js
@@ -392,6 +392,14 @@ define([
 
         var magnitude = Cartesian4.magnitude(cartesian);
 
+        if (magnitude === 0.0) {
+            result.x = 0.0;
+            result.y = 0.0;
+            result.z = 0.0;
+            result.w = 0.0;
+            return result;
+        }
+
         result.x = cartesian.x / magnitude;
         result.y = cartesian.y / magnitude;
         result.z = cartesian.z / magnitude;

--- a/Specs/Core/Cartesian2Spec.js
+++ b/Specs/Core/Cartesian2Spec.js
@@ -293,6 +293,15 @@ defineSuite([
         expect(result).toEqual(expectedResult);
     });
 
+    it('normalize works with a zero vector parameter', function() {
+        var cartesian = new Cartesian2(0.0, 0.0);
+        var expectedResult = new Cartesian2(0.0, 0.0);
+        var result = new Cartesian2();
+        var returnedResult = Cartesian2.normalize(cartesian, result);
+        expect(result).toBe(returnedResult);
+        expect(result).toEqual(expectedResult);
+    });
+
     it('normalize works with a result parameter that is an input parameter', function() {
         var cartesian = new Cartesian2(2.0, 0.0);
         var expectedResult = new Cartesian2(1.0, 0.0);

--- a/Specs/Core/Cartesian3Spec.js
+++ b/Specs/Core/Cartesian3Spec.js
@@ -344,6 +344,15 @@ defineSuite([
         expect(cartesian).toEqual(expectedResult);
     });
 
+    it('normalize works with a zero vector parameter', function() {
+        var cartesian = new Cartesian3(0.0, 0.0, 0.0);
+        var expectedResult = new Cartesian3(0.0, 0.0, 0.0);
+        var result = new Cartesian3();
+        var returnedResult = Cartesian3.normalize(cartesian, result);
+        expect(result).toBe(returnedResult);
+        expect(result).toEqual(expectedResult);
+    });
+
     it('multiplyComponents works with a result parameter', function() {
         var left = new Cartesian3(2.0, 3.0, 6.0);
         var right = new Cartesian3(4.0, 5.0, 7.0);

--- a/Specs/Core/Cartesian4Spec.js
+++ b/Specs/Core/Cartesian4Spec.js
@@ -429,6 +429,15 @@ defineSuite([
         expect(result).toEqual(expectedResult);
     });
 
+    it('normalize works with a zero vector parameter', function() {
+        var cartesian = new Cartesian4(0.0, 0.0, 0.0, 0.0);
+        var expectedResult = new Cartesian4(0.0, 0.0, 0.0, 0.0);
+        var result = new Cartesian4();
+        var returnedResult = Cartesian4.normalize(cartesian, result);
+        expect(result).toBe(returnedResult);
+        expect(result).toEqual(expectedResult);
+    });
+
     it('normalize works with a result parameter that is an input parameter', function() {
         var cartesian = new Cartesian4(2.0, 0.0, 0.0, 0.0);
         var expectedResult = new Cartesian4(1.0, 0.0, 0.0, 0.0);

--- a/Specs/Core/IntersectionTestsSpec.js
+++ b/Specs/Core/IntersectionTestsSpec.js
@@ -678,10 +678,10 @@ defineSuite([
         expect(actual).toEqual(ray.origin);
     });
 
-    it('grazingAltitudeLocation is undefined', function() {
+    it('grazingAltitudeLocation with empty ray', function() {
         var ellipsoid = Ellipsoid.UNIT_SPHERE;
         var ray = new Ray(Cartesian3.ZERO, Cartesian3.UNIT_Z);
-        expect(IntersectionTests.grazingAltitudeLocation(ray, ellipsoid)).not.toBeDefined();
+        expect(IntersectionTests.grazingAltitudeLocation(ray, ellipsoid)).toEqual(ray.origin);
     });
 
     it('lineSegmentPlane intersects', function() {


### PR DESCRIPTION
I've noticed that `Cartesian.normalize(Cartesian.ZERO)` returns junk vector (e.g. for Cartesian2 it would be `{x: NaN, y: NaN}`). I know that there is no way to correctly normalize null vector (see more [here](http://stackoverflow.com/questions/722073/how-do-you-normalize-a-zero-vector)), but current implementation is very confusing. I assume returning Cartesian.ZERO is better than return undefined.