### PR TITLE
Fix Hello World bug

### DIFF
--- a/Source/Core/buildModuleUrl.js
+++ b/Source/Core/buildModuleUrl.js
@@ -44,7 +44,7 @@ define([
             throw new DeveloperError('Unable to determine Cesium base URL automatically, try defining a global variable called CESIUM_BASE_URL.');
         }
 
-        baseUrl = getAbsoluteUri(baseUrlString);
+        baseUrl = new Uri(getAbsoluteUri(baseUrlString));
 
         return baseUrl;
     }


### PR DESCRIPTION
Fixes #3428 

I wrapped the `baseUrl` in a `new Uri()` because in the other place that `getAbsoluteUri` is used a string is needed. This is the only spot where a `new Uri()` is needed. 