### PR TITLE
Add asset getter and version check to 3D Tiles

### DIFF
--- a/Source/Core/isDataUri.js
+++ b/Source/Core/isDataUri.js
@@ -1,0 +1,30 @@
+/*global define*/
+define([
+        './defined'
+    ], function(
+        defined) {
+    "use strict";
+
+    var dataUriRegex = /^data:(.*?)(;base64)?,(.*)$/;
+
+    /**
+     * DOC_TBA.
+     *
+     * @exports isArray
+     *
+     * @param {Object} value DOC_TBA.
+     * @returns {Boolean} true DOC_TBA.
+     *
+     * @private
+     */
+    function isDataUri(uri) {
+        if (defined(uri)) {
+            var result = dataUriRegex.exec(uri);
+            return (result !== null);
+        }
+
+        return false;
+    }
+
+    return isDataUri;
+});

--- a/Source/Core/isDataUri.js
+++ b/Source/Core/isDataUri.js
@@ -8,12 +8,12 @@ define([
     var dataUriRegex = /^data:(.*?)(;base64)?,(.*)$/;
 
     /**
-     * DOC_TBA.
+     * Determines if the specified uri is a data uri.
      *
-     * @exports isArray
+     * @exports isDataUri
      *
-     * @param {Object} value DOC_TBA.
-     * @returns {Boolean} true DOC_TBA.
+     * @param {String} uri The uri to test.
+     * @returns {Boolean} true when the uri is a data uri; otherwise, false.
      *
      * @private
      */

--- a/Source/Core/isDataUri.js
+++ b/Source/Core/isDataUri.js
@@ -19,8 +19,7 @@ define([
      */
     function isDataUri(uri) {
         if (defined(uri)) {
-            var result = dataUriRegex.exec(uri);
-            return (result !== null);
+            return dataUriRegex.test(uri);
         }
 
         return false;

--- a/Source/Scene/Cesium3DTileset.js
+++ b/Source/Scene/Cesium3DTileset.js
@@ -679,7 +679,7 @@ define([
     ///////////////////////////////////////////////////////////////////////////
 
     function loadTiles(tileset) {
-        var promise = tileset.  loadTilesJson(tileset._tilesetUrl, undefined);
+        var promise = tileset.loadTilesJson(tileset._tilesetUrl, undefined);
         if (defined(promise)) {
             tileset._state = Cesium3DTilesetState.LOADING;
             promise.then(function(data) {

--- a/Source/Scene/Cesium3DTileset.js
+++ b/Source/Scene/Cesium3DTileset.js
@@ -90,6 +90,7 @@ define([
         this._tilesetUrl = tilesetUrl;
         this._state = Cesium3DTilesetState.UNLOADED;
         this._root = undefined;
+        this._asset = undefined; // Metadata for the entire tileset
         this._properties = undefined; // Metadata for per-model/point/etc properties
         this._geometricError = undefined; // Geometric error when the tree is not rendered at all
         this._processingQueue = [];
@@ -162,6 +163,26 @@ define([
     }
 
     defineProperties(Cesium3DTileset.prototype, {
+        /**
+         * DOC_TBA
+         *
+         * @memberof Cesium3DTileset.prototype
+         *
+         * @type {Object}
+         * @readonly
+         */
+        asset : {
+            get : function() {
+                //>>includeStart('debug', pragmas.debug);
+                if (!this.ready) {
+                    throw new DeveloperError('The tileset is not loaded.  Use Cesium3DTileset.readyPromise or wait for Cesium3DTileset.ready to be true.');
+                }
+                //>>includeEnd('debug');
+
+                return this._asset;
+            }
+        },
+
         /**
          * DOC_TBA
          *
@@ -664,6 +685,7 @@ define([
             promise.then(function(data) {
                 var tilesetJson = data.tilesetJson;
                 tileset._state = Cesium3DTilesetState.READY;
+                tileset._asset = tilesetJson.asset;
                 tileset._properties = tilesetJson.properties;
                 tileset._geometricError = tilesetJson.geometricError;
                 tileset._root = data.root;

--- a/Source/Scene/Cesium3DTileset.js
+++ b/Source/Scene/Cesium3DTileset.js
@@ -231,13 +231,13 @@ define([
             return undefined;
         }
 
-        return promise.then(function(tree) {
+        return promise.then(function(tilesetJson) {
             if (tileset.isDestroyed()) {
                 return when.reject('tileset is destroyed');
             }
 
             var baseUrl = tileset.url;
-            var rootTile = new Cesium3DTile(tileset, baseUrl, tree.root, parentTile);
+            var rootTile = new Cesium3DTile(tileset, baseUrl, tilesetJson.root, parentTile);
 
             // If there is a parentTile, add the root of the currently loading tileset
             // to parentTile's children, and increment its numberOfChildrenWithoutContent
@@ -248,7 +248,7 @@ define([
 
             var stack = [];
             stack.push({
-                header : tree.root,
+                header : tilesetJson.root,
                 cesium3DTile : rootTile
             });
 
@@ -271,7 +271,7 @@ define([
             }
 
             return {
-                tree : tree,
+                tilesetJson : tilesetJson,
                 root : rootTile
             };
         });
@@ -647,14 +647,14 @@ define([
     ///////////////////////////////////////////////////////////////////////////
 
     function loadTiles(tileset) {
-        var promise = tileset.loadTilesJson(tileset._tilesJson, undefined);
+        var promise = tileset.  loadTilesJson(tileset._tilesJson, undefined);
         if (defined(promise)) {
             tileset._state = Cesium3DTilesetState.LOADING;
             promise.then(function(data) {
-                var tree = data.tree;
+                var tilesetJson = data.tilesetJson;
                 tileset._state = Cesium3DTilesetState.READY;
-                tileset._properties = tree.properties;
-                tileset._geometricError = tree.geometricError;
+                tileset._properties = tilesetJson.properties;
+                tileset._geometricError = tilesetJson.geometricError;
                 tileset._root = data.root;
                 tileset._readyPromise.resolve(tileset);
             }).otherwise(function(error) {

--- a/Specs/Core/isDataUriSpec.js
+++ b/Specs/Core/isDataUriSpec.js
@@ -1,0 +1,17 @@
+/*global defineSuite*/
+defineSuite([
+        'Core/isDataUri'
+    ], function(
+        isDataUri) {
+    "use strict";
+
+    it('Determines that a uri is not a data uri', function() {
+        expect(isDataUri(undefined)).toEqual(false);
+        expect(isDataUri('http://cesiumjs.org/')).toEqual(false);
+    });
+
+    it('Determines that a uri is a data uri', function() {
+        var uri = 'data:text/plain;base64,' + btoa('a data uri');
+        expect(isDataUri(uri)).toEqual(true);
+    });
+});

--- a/Specs/Data/Cesium3DTiles/Batched/BatchedWithBatchTable/tiles.json
+++ b/Specs/Data/Cesium3DTiles/Batched/BatchedWithBatchTable/tiles.json
@@ -1,4 +1,7 @@
 {
+    "asset" : {
+        "version": 0.0
+    },
     "properties": {
         "id": {
             "minimum": 0,

--- a/Specs/Data/Cesium3DTiles/Batched/BatchedWithBatchTable/tiles.json
+++ b/Specs/Data/Cesium3DTiles/Batched/BatchedWithBatchTable/tiles.json
@@ -1,6 +1,6 @@
 {
     "asset" : {
-        "version": 0.0
+        "version": "0.0"
     },
     "properties": {
         "id": {

--- a/Specs/Data/Cesium3DTiles/Tilesets/Tileset/tiles.json
+++ b/Specs/Data/Cesium3DTiles/Tilesets/Tileset/tiles.json
@@ -1,4 +1,7 @@
 {
+    "asset" : {
+        "version": 0.0
+    },
     "properties": {
         "id": {
             "minimum": 0,

--- a/Specs/Data/Cesium3DTiles/Tilesets/Tileset/tiles.json
+++ b/Specs/Data/Cesium3DTiles/Tilesets/Tileset/tiles.json
@@ -1,6 +1,7 @@
 {
     "asset" : {
-        "version": "0.0"
+        "version": "0.0",
+        "tilesetVersion": "1.2.3"
     },
     "properties": {
         "id": {

--- a/Specs/Data/Cesium3DTiles/Tilesets/Tileset/tiles.json
+++ b/Specs/Data/Cesium3DTiles/Tilesets/Tileset/tiles.json
@@ -1,6 +1,6 @@
 {
     "asset" : {
-        "version": 0.0
+        "version": "0.0"
     },
     "properties": {
         "id": {

--- a/Specs/Data/Cesium3DTiles/Tilesets/TilesetEmptyRoot/tiles.json
+++ b/Specs/Data/Cesium3DTiles/Tilesets/TilesetEmptyRoot/tiles.json
@@ -1,4 +1,7 @@
 {
+    "asset" : {
+        "version": 0.0
+    },
     "properties": {
         "id": {
             "minimum": 0,

--- a/Specs/Data/Cesium3DTiles/Tilesets/TilesetEmptyRoot/tiles.json
+++ b/Specs/Data/Cesium3DTiles/Tilesets/TilesetEmptyRoot/tiles.json
@@ -1,6 +1,6 @@
 {
     "asset" : {
-        "version": 0.0
+        "version": "0.0"
     },
     "properties": {
         "id": {

--- a/Specs/Data/Cesium3DTiles/Tilesets/TilesetInvalid/tiles.json
+++ b/Specs/Data/Cesium3DTiles/Tilesets/TilesetInvalid/tiles.json
@@ -1,4 +1,7 @@
 {
+    "asset" : {
+        "version": 0.0
+    },
     "properties": {
         "id": {
             "minimum": 0,

--- a/Specs/Data/Cesium3DTiles/Tilesets/TilesetInvalid/tiles.json
+++ b/Specs/Data/Cesium3DTiles/Tilesets/TilesetInvalid/tiles.json
@@ -1,6 +1,6 @@
 {
     "asset" : {
-        "version": 0.0
+        "version": "0.0"
     },
     "properties": {
         "id": {

--- a/Specs/Data/Cesium3DTiles/Tilesets/TilesetOfTilesets/tiles.json
+++ b/Specs/Data/Cesium3DTiles/Tilesets/TilesetOfTilesets/tiles.json
@@ -1,4 +1,7 @@
 {
+    "asset" : {
+        "version": 0.0
+    },
     "properties": {
         "id": {
             "minimum": 0,

--- a/Specs/Data/Cesium3DTiles/Tilesets/TilesetOfTilesets/tiles.json
+++ b/Specs/Data/Cesium3DTiles/Tilesets/TilesetOfTilesets/tiles.json
@@ -1,6 +1,6 @@
 {
     "asset" : {
-        "version": 0.0
+        "version": "0.0"
     },
     "properties": {
         "id": {

--- a/Specs/Data/Cesium3DTiles/Tilesets/TilesetOfTilesets/tiles2.json
+++ b/Specs/Data/Cesium3DTiles/Tilesets/TilesetOfTilesets/tiles2.json
@@ -1,4 +1,7 @@
 {
+    "asset" : {
+        "version": 0.0
+    },
     "root": {
         "boundingVolume": {
             "region": [

--- a/Specs/Data/Cesium3DTiles/Tilesets/TilesetOfTilesets/tiles2.json
+++ b/Specs/Data/Cesium3DTiles/Tilesets/TilesetOfTilesets/tiles2.json
@@ -1,6 +1,6 @@
 {
     "asset" : {
-        "version": 0.0
+        "version": "0.0"
     },
     "root": {
         "boundingVolume": {

--- a/Specs/Data/Cesium3DTiles/Tilesets/TilesetOfTilesets/tiles3.json
+++ b/Specs/Data/Cesium3DTiles/Tilesets/TilesetOfTilesets/tiles3.json
@@ -1,4 +1,7 @@
 {
+    "asset" : {
+        "version": 0.0
+    },
     "root": {
         "boundingVolume": {
             "region": [

--- a/Specs/Data/Cesium3DTiles/Tilesets/TilesetOfTilesets/tiles3.json
+++ b/Specs/Data/Cesium3DTiles/Tilesets/TilesetOfTilesets/tiles3.json
@@ -1,6 +1,6 @@
 {
     "asset" : {
-        "version": 0.0
+        "version": "0.0"
     },
     "root": {
         "boundingVolume": {

--- a/Specs/Data/Cesium3DTiles/Tilesets/TilesetRefinementMix/tiles.json
+++ b/Specs/Data/Cesium3DTiles/Tilesets/TilesetRefinementMix/tiles.json
@@ -1,4 +1,7 @@
 {
+    "asset" : {
+        "version": 0.0
+    },
     "properties": {
         "id": {
             "minimum": 0,

--- a/Specs/Data/Cesium3DTiles/Tilesets/TilesetRefinementMix/tiles.json
+++ b/Specs/Data/Cesium3DTiles/Tilesets/TilesetRefinementMix/tiles.json
@@ -1,6 +1,6 @@
 {
     "asset" : {
-        "version": 0.0
+        "version": "0.0"
     },
     "properties": {
         "id": {

--- a/Specs/Data/Cesium3DTiles/Tilesets/TilesetReplacement1/tiles.json
+++ b/Specs/Data/Cesium3DTiles/Tilesets/TilesetReplacement1/tiles.json
@@ -1,4 +1,7 @@
 {
+    "asset" : {
+        "version": 0.0
+    },
     "properties": {
         "id": {
             "minimum": 0,

--- a/Specs/Data/Cesium3DTiles/Tilesets/TilesetReplacement1/tiles.json
+++ b/Specs/Data/Cesium3DTiles/Tilesets/TilesetReplacement1/tiles.json
@@ -1,6 +1,6 @@
 {
     "asset" : {
-        "version": 0.0
+        "version": "0.0"
     },
     "properties": {
         "id": {

--- a/Specs/Data/Cesium3DTiles/Tilesets/TilesetReplacement2/tiles.json
+++ b/Specs/Data/Cesium3DTiles/Tilesets/TilesetReplacement2/tiles.json
@@ -1,4 +1,7 @@
 {
+    "asset" : {
+        "version": 0.0
+    },
     "properties": {
         "id": {
             "minimum": 0,

--- a/Specs/Data/Cesium3DTiles/Tilesets/TilesetReplacement2/tiles.json
+++ b/Specs/Data/Cesium3DTiles/Tilesets/TilesetReplacement2/tiles.json
@@ -1,6 +1,6 @@
 {
     "asset" : {
-        "version": 0.0
+        "version": "0.0"
     },
     "properties": {
         "id": {

--- a/Specs/Scene/Cesium3DTilesetSpec.js
+++ b/Specs/Scene/Cesium3DTilesetSpec.js
@@ -172,9 +172,17 @@ defineSuite([
 
     it('loads tiles.json', function() {
         return Cesium3DTilesTester.loadTileset(scene, tilesetUrl).then(function(tileset) {
+            var asset = tileset.asset;
+            expect(asset).toBeDefined();
+            expect(asset.version).toEqual('0.0');
+            expect(asset.tilesetVersion).toEqual('1.2.3');
+
             var properties = tileset.properties;
             expect(properties).toBeDefined();
             expect(properties.id).toBeDefined();
+            expect(properties.id.minimum).toEqual(0);
+            expect(properties.id.maximum).toEqual(99);
+
             expect(tileset._geometricError).toEqual(240.0);
             expect(tileset._root).toBeDefined();
             expect(tileset.url).toEqual(tilesetUrl);
@@ -204,6 +212,15 @@ defineSuite([
         }).then(function() {
             expect(tileset3._state).toEqual(Cesium3DTilesetState.LOADING);
         });
+    });
+
+    it('throws when getting asset and tileset is not ready', function() {
+        var tileset = new Cesium3DTileset({
+            url : tilesetUrl
+        });
+        expect(function() {
+            return tileset.asset;
+        }).toThrowDeveloperError();
     });
 
     it('throws when getting properties and tileset is not ready', function() {

--- a/Specs/Scene/Cesium3DTilesetSpec.js
+++ b/Specs/Scene/Cesium3DTilesetSpec.js
@@ -117,28 +117,49 @@ defineSuite([
         });
     });
 
+    it('rejects readyPromise with invalid tileset version', function() {
+        var tilesJson = {
+            "asset" : {
+                "version" : "2.0"
+            }
+        };
+
+        var uri = 'data:text/plain;base64,' + btoa(JSON.stringify(tilesJson));
+
+        var tileset = scene.primitives.add(new Cesium3DTileset({
+            url : uri
+        }));
+        scene.renderForSpecs();
+        return tileset.readyPromise.then(function(tileset) {
+            fail('should not resolve');
+        }).otherwise(function(error) {
+            expect(tileset.ready).toEqual(false);
+            expect(tileset._state).toEqual(Cesium3DTilesetState.FAILED);
+        });
+    });
+
     it('url and tilesJson set up correctly given tiles.json path', function() {
         var tileset = new Cesium3DTileset({
             url : './Data/Cesium3DTiles/Tilesets/TilesetOfTilesets/tiles3.json'
         });
-        expect(tileset._url).toEqual('./Data/Cesium3DTiles/Tilesets/TilesetOfTilesets/');
-        expect(tileset._tilesJson).toEqual('./Data/Cesium3DTiles/Tilesets/TilesetOfTilesets/tiles3.json');
+        expect(tileset.url).toEqual('./Data/Cesium3DTiles/Tilesets/TilesetOfTilesets/tiles3.json');
+        expect(tileset._tilesetUrl).toEqual('./Data/Cesium3DTiles/Tilesets/TilesetOfTilesets/tiles3.json');
     });
 
     it('url and tilesJson set up correctly given directory without trailing slash', function() {
         var tileset = new Cesium3DTileset({
             url : './Data/Cesium3DTiles/Tilesets/TilesetOfTilesets'
         });
-        expect(tileset._url).toEqual('./Data/Cesium3DTiles/Tilesets/TilesetOfTilesets/');
-        expect(tileset._tilesJson).toEqual('./Data/Cesium3DTiles/Tilesets/TilesetOfTilesets/tiles.json');
+        expect(tileset.url).toEqual('./Data/Cesium3DTiles/Tilesets/TilesetOfTilesets');
+        expect(tileset._tilesetUrl).toEqual('./Data/Cesium3DTiles/Tilesets/TilesetOfTilesets/tiles.json');
     });
 
     it('url and tilesJson set up correctly given directory with trailing slash', function() {
         var tileset = new Cesium3DTileset({
             url : './Data/Cesium3DTiles/Tilesets/TilesetOfTilesets/'
         });
-        expect(tileset._url).toEqual('./Data/Cesium3DTiles/Tilesets/TilesetOfTilesets/');
-        expect(tileset._tilesJson).toEqual('./Data/Cesium3DTiles/Tilesets/TilesetOfTilesets/tiles.json');
+        expect(tileset.url).toEqual('./Data/Cesium3DTiles/Tilesets/TilesetOfTilesets/');
+        expect(tileset._tilesetUrl).toEqual('./Data/Cesium3DTiles/Tilesets/TilesetOfTilesets/tiles.json');
     });
 
     it('resolves readyPromise', function() {


### PR DESCRIPTION
Code change for https://github.com/AnalyticalGraphicsInc/3d-tiles/pull/56.

Note that this does not pass `tilesetVersion` when making requests.  @mramato can handle that separately.