### PR TITLE
CZML referenceFrame cleanup

### DIFF
--- a/Source/DataSources/CompositePositionProperty.js
+++ b/Source/DataSources/CompositePositionProperty.js
@@ -24,6 +24,8 @@ define([
      *
      * @alias CompositePositionProperty
      * @constructor
+     *
+     * @param {ReferenceFrame} [referenceFrame=ReferenceFrame.FIXED] The reference frame in which the position is defined.
      */
     function CompositePositionProperty(referenceFrame) {
         this._referenceFrame = defaultValue(referenceFrame, ReferenceFrame.FIXED);

--- a/Source/DataSources/CzmlDataSource.js
+++ b/Source/DataSources/CzmlDataSource.js
@@ -600,7 +600,10 @@ define([
         var hasInterval = defined(combinedInterval) && !combinedInterval.equals(Iso8601.MAXIMUM_INTERVAL);
 
         if (!isReference) {
-            referenceFrame = defaultValue(ReferenceFrame[packetData.referenceFrame], undefined);
+            if (defined(packetData.referenceFrame)) {
+                referenceFrame = ReferenceFrame[packetData.referenceFrame];
+            }
+            referenceFrame = defaultValue(referenceFrame, ReferenceFrame.FIXED);
             unwrappedInterval = unwrapCartesianInterval(packetData);
             unwrappedIntervalLength = defaultValue(unwrappedInterval.length, 1);
             isSampled = unwrappedIntervalLength > packedLength;

--- a/Source/DataSources/PositionPropertyArray.js
+++ b/Source/DataSources/PositionPropertyArray.js
@@ -27,6 +27,7 @@ define([
      * @constructor
      *
      * @param {Property[]} [value] An array of Property instances.
+     * @param {ReferenceFrame} [referenceFrame=ReferenceFrame.FIXED] The reference frame in which the position is defined.
      */
     function PositionPropertyArray(value, referenceFrame) {
         this._value = undefined;

--- a/Specs/DataSources/CzmlDataSourceSpec.js
+++ b/Specs/DataSources/CzmlDataSourceSpec.js
@@ -660,6 +660,22 @@ defineSuite([
         expect(entity.position.referenceFrame).toBe(ReferenceFrame.FIXED);
     });
 
+    it('uses FIXED as default if not specified in CZML', function() {
+        var epoch = JulianDate.now();
+        var dataSource = new CzmlDataSource();
+
+        var czml = {
+            position : {
+                epoch : JulianDate.toIso8601(epoch),
+                cartesian : [1.0, 2.0, 3.0]
+            }
+        };
+
+        dataSource.load(makePacket(czml));
+        var entity = dataSource.entities.values[0];
+        expect(entity.position.referenceFrame).toBe(ReferenceFrame.FIXED);
+    });
+
     it('Default reference frame on existing interval does not reset value to FIXED.', function() {
         var epoch = JulianDate.now();
         var dataSource = new CzmlDataSource();


### PR DESCRIPTION
* add missing documentation for types that take referenceFrame as constructor parameter
* Make logic for reference frame selection more clear.  `defaultValue(foo, undefined)` is misleading.
* Add specific test that ensures default referenceFrame is FIXED (as specified in the CZML jsonschema)