### PR TITLE
optimization of replacement refinement selection/loading: only request visible tile children

### DIFF
--- a/Source/Scene/Cesium3DTile.js
+++ b/Source/Scene/Cesium3DTile.js
@@ -24,6 +24,7 @@ define([
         './Cesium3DTileContentProviderFactory',
         './Cesium3DTileContentState',
         './Cesium3DTileRefine',
+        './CullingVolume',
         './Empty3DTileContentProvider',
         './PerInstanceColorAppearance',
         './Primitive',
@@ -56,6 +57,7 @@ define([
         Cesium3DTileContentProviderFactory,
         Cesium3DTileContentState,
         Cesium3DTileRefine,
+        CullingVolume,
         Empty3DTileContentProvider,
         PerInstanceColorAppearance,
         Primitive,
@@ -133,8 +135,6 @@ define([
          */
         this.numberOfChildrenWithoutContent = defined(header.children) ? header.children.length : 0;
 
-        this._numberOfUnrefinableChildren = this.numberOfChildrenWithoutContent;
-
         this.refining = false;
 
         this.hasContent = true;
@@ -164,7 +164,6 @@ define([
             if (type === 'json') {
                 this.hasTilesetContent = true;
                 this.hasContent = false;
-                this._numberOfUnrefinableChildren = 1;
             }
 
             //>>includeStart('debug', pragmas.debug);
@@ -180,20 +179,6 @@ define([
         }
         this._content = content;
 
-        function setRefinable(tile) {
-            var parent = tile.parent;
-            if (defined(parent) && (tile.hasContent || tile.isRefinable())) {
-                // When a tile with content is loaded, its parent can safely refine to it without any gaps in rendering
-                // Since an empty tile doesn't have content of its own, its descendants with content need to be loaded
-                // before the parent is able to refine to it.
-                --parent._numberOfUnrefinableChildren;
-                // If the parent is empty, traverse up the tree to update ancestor tiles.
-                if (!parent.hasContent) {
-                    setRefinable(parent);
-                }
-            }
-        }
-
         var that = this;
 
         // Content enters the READY state
@@ -201,8 +186,6 @@ define([
             if (defined(that.parent)) {
                 --that.parent.numberOfChildrenWithoutContent;
             }
-
-            setRefinable(that);
 
             that.readyPromise.resolve(that);
         }).otherwise(function(error) {
@@ -276,8 +259,40 @@ define([
     /**
      * DOC_TBA
      */
-    Cesium3DTile.prototype.isRefinable = function() {
-        return this._numberOfUnrefinableChildren === 0;
+    Cesium3DTile.prototype.isRefinable = function(cullingVolume) {
+        //>>includeStart('debug', pragmas.debug);
+        if (!defined(cullingVolume)) {
+            throw new DeveloperError('cullingVolume must be defined');
+        }
+        //>>includeEnd('debug');
+
+        var visibleChildren = [];
+        var child;
+        var k;
+
+        for (k = 0; k < this.children.length; ++k) {
+            child = this.children[k];
+            if (child.visibility(cullingVolume) !== CullingVolume.MASK_OUTSIDE) {
+                visibleChildren.push(child);
+            }
+        }
+
+        var refinable = true;
+        for (k = 0; k < visibleChildren.length; ++k) {
+            child = visibleChildren[k];
+            // A tile is not refinable if a child has tileset content but
+            // is not refinable.
+            if ((child.hasTilesetContent || !child.hasContent) && !child.isRefinable(cullingVolume)) {
+                refinable = false;
+                break;
+            } else if (!child.isReady()) {
+                // if a child is visible but not loaded, the tile is not refinable
+                refinable = false;
+                break;
+            }
+        }
+
+        return refinable;
     };
 
     /**

--- a/Source/Scene/Cesium3DTileset.js
+++ b/Source/Scene/Cesium3DTileset.js
@@ -501,17 +501,8 @@ define([
                 } else {
                     // Tile does not meet SSE.
 
-                    // Save result to avoid doing unnecessary
-                    // isRefinable() multiple times
-                    var tileIsRefinable = t.isRefinable(cullingVolume);
-                    var visibleChildren = [];
-
-                    for (k = 0; k < childrenLength; ++k) {
-                        child = children[k];
-                        if (child.visibility(cullingVolume) !== CullingVolume.MASK_OUTSIDE) {
-                            visibleChildren.push(child);
-                        }
-                    }
+                    var visibleChildren = t.getVisibleChildren(cullingVolume);
+                    var tileIsRefinable = t.isRefinable(visibleChildren, cullingVolume);
 
                     // Only sort children by distance if we are going to refine to them
                     // or slots are available to request them.  If we are just rendering the
@@ -537,7 +528,7 @@ define([
 
                             if (child.isContentUnloaded()) {
                                 requestContent(tiles3D, child, outOfCore);
-                            } else if (!child.hasContent && !child.isRefinable(cullingVolume)) {
+                            } else if (!child.hasContent && !child.isRefinable(visibleChildren, cullingVolume)) {
                                 // If the child is empty, start loading its descendants. Mark as refining so they aren't selected.
                                 child.refining = true;
                                 // Store the plane mask so that the child can optimize based on its parent's returned mask

--- a/Specs/Scene/Cesium3DTilesetSpec.js
+++ b/Specs/Scene/Cesium3DTilesetSpec.js
@@ -494,7 +494,7 @@ defineSuite([
             scene.renderForSpecs();
 
             var stats = tileset._statistics;
-            expect(root.isRefinable()).toEqual(false);
+            expect(root.isRefinable(scene.frameState.cullingVolume)).toEqual(false);
             expect(stats.visited).toEqual(1);
             expect(stats.numberOfCommands).toEqual(1);
             expect(stats.numberOfPendingRequests).toEqual(4);
@@ -520,14 +520,14 @@ defineSuite([
             return when.join(root.children[0].readyPromise, root.children[1].readyPromise).then(function() {
                 // Even though root's children are loaded, the grandchildren need to be loaded before it becomes refinable
                 scene.renderForSpecs();
-                expect(root.isRefinable()).toEqual(false);
+                expect(root.isRefinable(scene.frameState.cullingVolume)).toEqual(false);
                 expect(root.numberOfChildrenWithoutContent).toEqual(0); // Children are loaded
                 expect(stats.numberOfCommands).toEqual(1); // Render root
                 expect(stats.numberOfPendingRequests).toEqual(4); // Loading grandchildren
 
                 return Cesium3DTilesTester.waitForPendingRequests(scene, tileset).then(function() {
                     scene.renderForSpecs();
-                    expect(root.isRefinable()).toEqual(true);
+                    expect(root.isRefinable(scene.frameState.cullingVolume)).toEqual(true);
                     expect(stats.numberOfCommands).toEqual(4); // Render children
                 });
             });
@@ -552,7 +552,7 @@ defineSuite([
             var root = tileset._root;
             return Cesium3DTilesTester.waitForPendingRequests(scene, tileset).then(function() {
                 scene.renderForSpecs();
-                expect(root.isRefinable()).toEqual(false);
+                expect(root.isRefinable(scene.frameState.cullingVolume)).toEqual(false);
                 expect(stats.numberOfCommands).toEqual(0);
 
                 setZoom(5.0); // Zoom into the last tile, when it is ready the root is refinable
@@ -560,7 +560,7 @@ defineSuite([
 
                 return Cesium3DTilesTester.waitForPendingRequests(scene, tileset).then(function() {
                     scene.renderForSpecs();
-                    expect(root.isRefinable()).toEqual(true);
+                    expect(root.isRefinable(scene.frameState.cullingVolume)).toEqual(true);
                     expect(stats.numberOfCommands).toEqual(2); // Renders two content tiles
                 });
             });

--- a/Specs/Scene/Cesium3DTilesetSpec.js
+++ b/Specs/Scene/Cesium3DTilesetSpec.js
@@ -494,7 +494,8 @@ defineSuite([
             scene.renderForSpecs();
 
             var stats = tileset._statistics;
-            expect(root.isRefinable(scene.frameState.cullingVolume)).toEqual(false);
+            var visibleChildren = root.getVisibleChildren(scene.frameState.cullingVolume);
+            expect(root.isRefinable(visibleChildren, scene.frameState.cullingVolume)).toEqual(false);
             expect(stats.visited).toEqual(1);
             expect(stats.numberOfCommands).toEqual(1);
             expect(stats.numberOfPendingRequests).toEqual(4);
@@ -517,17 +518,20 @@ defineSuite([
 
             var stats = tileset._statistics;
             var root = tileset._root;
+            var visibleChildren;
             return when.join(root.children[0].readyPromise, root.children[1].readyPromise).then(function() {
                 // Even though root's children are loaded, the grandchildren need to be loaded before it becomes refinable
                 scene.renderForSpecs();
-                expect(root.isRefinable(scene.frameState.cullingVolume)).toEqual(false);
+                visibleChildren = root.getVisibleChildren(scene.frameState.cullingVolume);
+                expect(root.isRefinable(visibleChildren, scene.frameState.cullingVolume)).toEqual(false);
                 expect(root.numberOfChildrenWithoutContent).toEqual(0); // Children are loaded
                 expect(stats.numberOfCommands).toEqual(1); // Render root
                 expect(stats.numberOfPendingRequests).toEqual(4); // Loading grandchildren
 
                 return Cesium3DTilesTester.waitForPendingRequests(scene, tileset).then(function() {
                     scene.renderForSpecs();
-                    expect(root.isRefinable(scene.frameState.cullingVolume)).toEqual(true);
+                    visibleChildren = root.getVisibleChildren(scene.frameState.cullingVolume);
+                    expect(root.isRefinable(visibleChildren, scene.frameState.cullingVolume)).toEqual(true);
                     expect(stats.numberOfCommands).toEqual(4); // Render children
                 });
             });
@@ -550,9 +554,11 @@ defineSuite([
 
             var stats = tileset._statistics;
             var root = tileset._root;
+            var visibleChildren;
             return Cesium3DTilesTester.waitForPendingRequests(scene, tileset).then(function() {
                 scene.renderForSpecs();
-                expect(root.isRefinable(scene.frameState.cullingVolume)).toEqual(false);
+                visibleChildren = root.getVisibleChildren(scene.frameState.cullingVolume);
+                expect(root.isRefinable(visibleChildren, scene.frameState.cullingVolume)).toEqual(false);
                 expect(stats.numberOfCommands).toEqual(0);
 
                 setZoom(5.0); // Zoom into the last tile, when it is ready the root is refinable
@@ -560,7 +566,8 @@ defineSuite([
 
                 return Cesium3DTilesTester.waitForPendingRequests(scene, tileset).then(function() {
                     scene.renderForSpecs();
-                    expect(root.isRefinable(scene.frameState.cullingVolume)).toEqual(true);
+                    visibleChildren = root.getVisibleChildren(scene.frameState.cullingVolume);
+                    expect(root.isRefinable(visibleChildren, scene.frameState.cullingVolume)).toEqual(true);
                     expect(stats.numberOfCommands).toEqual(2); // Renders two content tiles
                 });
             });


### PR DESCRIPTION
This commit implements part of the optimizations discussed in https://github.com/AnalyticalGraphicsInc/cesium/issues/3424#issuecomment-172064629.

The `selectTiles` function will now be slightly more expensive as we dynamically need to find out whether a tile is refinable every time it comes off the stack. Finding this out requires checking the current visibility of its children, as opposed to before when we merely kept count of how many children had their contents loaded.

@pjcozzi and @lilleyse please review.
