### PR TITLE
GroundPrimitive bounding volume

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,6 +22,8 @@ Change Log
     }
     ```
 * `GroundPrimitive` now supports batching geometry for better performance.
+* Added `BoundingSphere.fromEncodedCartesianVertices` to create bounding volumes from parallel arrays of the upper and lower bits of `EncodedCartesian3`s.
+* Fixed creating bounding volumes for `GroundPrimitive`s whose containing rectangle has a width greater than pi.
 
 ### 1.17 - 2016-01-04
 

--- a/Source/Core/BoundingSphere.js
+++ b/Source/Core/BoundingSphere.js
@@ -513,7 +513,7 @@ define([
         }
 
         var currentPos = fromPointsCurrentPos;
-        currentPos.x = positionsHigh[0] + positionsLow[0]
+        currentPos.x = positionsHigh[0] + positionsLow[0];
         currentPos.y = positionsHigh[1] + positionsLow[1];
         currentPos.z = positionsHigh[2] + positionsLow[2];
 

--- a/Source/Core/BoundingSphere.js
+++ b/Source/Core/BoundingSphere.js
@@ -322,7 +322,6 @@ define([
      * @param {BoundingSphere} [result] The object onto which to store the result.
      * @returns {BoundingSphere} The modified result parameter or a new BoundingSphere instance if one was not provided.
      *
-     * 
      * @example
      * // Compute the bounding sphere from 3 positions, each specified relative to a center.
      * // In addition to the X, Y, and Z coordinates, the points array contains two additional
@@ -332,7 +331,7 @@ define([
      *               4.0, 5.0, 6.0, 0.1, 0.2,
      *               7.0, 8.0, 9.0, 0.1, 0.2];
      * var sphere = Cesium.BoundingSphere.fromVertices(points, center, 5);
-     * 
+     *
      * @see {@link http://blogs.agi.com/insight3d/index.php/2008/02/04/a-bounding/|Bounding Sphere computation article}
      */
     BoundingSphere.fromVertices = function(positions, center, stride, result) {
@@ -454,6 +453,163 @@ define([
             currentPos.x = positions[i] + center.x;
             currentPos.y = positions[i + 1] + center.y;
             currentPos.z = positions[i + 2] + center.z;
+
+            // Find the furthest point from the naive center to calculate the naive radius.
+            var r = Cartesian3.magnitude(Cartesian3.subtract(currentPos, naiveCenter, fromPointsScratch));
+            if (r > naiveRadius) {
+                naiveRadius = r;
+            }
+
+            // Make adjustments to the Ritter Sphere to include all points.
+            var oldCenterToPointSquared = Cartesian3.magnitudeSquared(Cartesian3.subtract(currentPos, ritterCenter, fromPointsScratch));
+            if (oldCenterToPointSquared > radiusSquared) {
+                var oldCenterToPoint = Math.sqrt(oldCenterToPointSquared);
+                // Calculate new radius to include the point that lies outside
+                ritterRadius = (ritterRadius + oldCenterToPoint) * 0.5;
+                radiusSquared = ritterRadius * ritterRadius;
+                // Calculate center of new Ritter sphere
+                var oldToNew = oldCenterToPoint - ritterRadius;
+                ritterCenter.x = (ritterRadius * ritterCenter.x + oldToNew * currentPos.x) / oldCenterToPoint;
+                ritterCenter.y = (ritterRadius * ritterCenter.y + oldToNew * currentPos.y) / oldCenterToPoint;
+                ritterCenter.z = (ritterRadius * ritterCenter.z + oldToNew * currentPos.z) / oldCenterToPoint;
+            }
+        }
+
+        if (ritterRadius < naiveRadius) {
+            Cartesian3.clone(ritterCenter, result.center);
+            result.radius = ritterRadius;
+        } else {
+            Cartesian3.clone(naiveCenter, result.center);
+            result.radius = naiveRadius;
+        }
+
+        return result;
+    };
+
+    /**
+     * Computes a tight-fitting bounding sphere enclosing a list of {@link EncodedCartesian3}s, where the points are
+     * stored in parallel flat arrays in X, Y, Z, order.  The bounding sphere is computed by running two
+     * algorithms, a naive algorithm and Ritter's algorithm. The smaller of the two spheres is used to
+     * ensure a tight fit.
+     *
+     * @param {Number[]} positionsHigh An array of high bits of the encoded cartesians that the bounding sphere will enclose.  Each point
+     *        is formed from three elements in the array in the order X, Y, Z.
+     * @param {Number[]} positionsLow An array of low bits of the encoded cartesians that the bounding sphere will enclose.  Each point
+     *        is formed from three elements in the array in the order X, Y, Z.
+     * @param {BoundingSphere} [result] The object onto which to store the result.
+     * @returns {BoundingSphere} The modified result parameter or a new BoundingSphere instance if one was not provided.
+     *
+     * @see {@link http://blogs.agi.com/insight3d/index.php/2008/02/04/a-bounding/|Bounding Sphere computation article}
+     */
+    BoundingSphere.fromEncodedCartesianVertices = function(positionsHigh, positionsLow, result) {
+        if (!defined(result)) {
+            result = new BoundingSphere();
+        }
+
+        if (!defined(positionsHigh) || !defined(positionsLow) || positionsHigh.length !== positionsLow.length || positionsHigh.length === 0) {
+            result.center = Cartesian3.clone(Cartesian3.ZERO, result.center);
+            result.radius = 0.0;
+            return result;
+        }
+
+        var currentPos = fromPointsCurrentPos;
+        currentPos.x = positionsHigh[0] + positionsLow[0]
+        currentPos.y = positionsHigh[1] + positionsLow[1];
+        currentPos.z = positionsHigh[2] + positionsLow[2];
+
+        var xMin = Cartesian3.clone(currentPos, fromPointsXMin);
+        var yMin = Cartesian3.clone(currentPos, fromPointsYMin);
+        var zMin = Cartesian3.clone(currentPos, fromPointsZMin);
+
+        var xMax = Cartesian3.clone(currentPos, fromPointsXMax);
+        var yMax = Cartesian3.clone(currentPos, fromPointsYMax);
+        var zMax = Cartesian3.clone(currentPos, fromPointsZMax);
+
+        var numElements = positionsHigh.length;
+        for (var i = 0; i < numElements; i += 3) {
+            var x = positionsHigh[i] + positionsLow[i];
+            var y = positionsHigh[i + 1] + positionsLow[i + 1];
+            var z = positionsHigh[i + 2] + positionsLow[i + 2];
+
+            currentPos.x = x;
+            currentPos.y = y;
+            currentPos.z = z;
+
+            // Store points containing the the smallest and largest components
+            if (x < xMin.x) {
+                Cartesian3.clone(currentPos, xMin);
+            }
+
+            if (x > xMax.x) {
+                Cartesian3.clone(currentPos, xMax);
+            }
+
+            if (y < yMin.y) {
+                Cartesian3.clone(currentPos, yMin);
+            }
+
+            if (y > yMax.y) {
+                Cartesian3.clone(currentPos, yMax);
+            }
+
+            if (z < zMin.z) {
+                Cartesian3.clone(currentPos, zMin);
+            }
+
+            if (z > zMax.z) {
+                Cartesian3.clone(currentPos, zMax);
+            }
+        }
+
+        // Compute x-, y-, and z-spans (Squared distances b/n each component's min. and max.).
+        var xSpan = Cartesian3.magnitudeSquared(Cartesian3.subtract(xMax, xMin, fromPointsScratch));
+        var ySpan = Cartesian3.magnitudeSquared(Cartesian3.subtract(yMax, yMin, fromPointsScratch));
+        var zSpan = Cartesian3.magnitudeSquared(Cartesian3.subtract(zMax, zMin, fromPointsScratch));
+
+        // Set the diameter endpoints to the largest span.
+        var diameter1 = xMin;
+        var diameter2 = xMax;
+        var maxSpan = xSpan;
+        if (ySpan > maxSpan) {
+            maxSpan = ySpan;
+            diameter1 = yMin;
+            diameter2 = yMax;
+        }
+        if (zSpan > maxSpan) {
+            maxSpan = zSpan;
+            diameter1 = zMin;
+            diameter2 = zMax;
+        }
+
+        // Calculate the center of the initial sphere found by Ritter's algorithm
+        var ritterCenter = fromPointsRitterCenter;
+        ritterCenter.x = (diameter1.x + diameter2.x) * 0.5;
+        ritterCenter.y = (diameter1.y + diameter2.y) * 0.5;
+        ritterCenter.z = (diameter1.z + diameter2.z) * 0.5;
+
+        // Calculate the radius of the initial sphere found by Ritter's algorithm
+        var radiusSquared = Cartesian3.magnitudeSquared(Cartesian3.subtract(diameter2, ritterCenter, fromPointsScratch));
+        var ritterRadius = Math.sqrt(radiusSquared);
+
+        // Find the center of the sphere found using the Naive method.
+        var minBoxPt = fromPointsMinBoxPt;
+        minBoxPt.x = xMin.x;
+        minBoxPt.y = yMin.y;
+        minBoxPt.z = zMin.z;
+
+        var maxBoxPt = fromPointsMaxBoxPt;
+        maxBoxPt.x = xMax.x;
+        maxBoxPt.y = yMax.y;
+        maxBoxPt.z = zMax.z;
+
+        var naiveCenter = Cartesian3.multiplyByScalar(Cartesian3.add(minBoxPt, maxBoxPt, fromPointsScratch), 0.5, fromPointsNaiveCenterScratch);
+
+        // Begin 2nd pass to find naive radius and modify the ritter sphere.
+        var naiveRadius = 0;
+        for (i = 0; i < numElements; i += 3) {
+            currentPos.x = positionsHigh[i] + positionsLow[i];
+            currentPos.y = positionsHigh[i + 1] + positionsLow[i + 1];
+            currentPos.z = positionsHigh[i + 2] + positionsLow[i + 2];
 
             // Find the furthest point from the naive center to calculate the naive radius.
             var r = Cartesian3.magnitude(Cartesian3.subtract(currentPos, naiveCenter, fromPointsScratch));

--- a/Source/Scene/GroundPrimitive.js
+++ b/Source/Scene/GroundPrimitive.js
@@ -558,8 +558,12 @@ define([
         rectangle.east = maxLon;
         rectangle.west = minLon;
 
-        var obb = OrientedBoundingBox.fromRectangle(rectangle, GroundPrimitive._maxHeight, GroundPrimitive._minOBBHeight, ellipsoid);
-        primitive._boundingVolumes.push(obb);
+        if (rectangle.width < CesiumMath.PI) {
+            var obb = OrientedBoundingBox.fromRectangle(rectangle, GroundPrimitive._maxHeight, GroundPrimitive._minOBBHeight, ellipsoid);
+            primitive._boundingVolumes.push(obb);
+        } else {
+            primitive._boundingVolumes.push(BoundingSphere.fromEncodedCartesianVertices(highPositions, lowPositions));
+        }
 
         if (!frameState.scene3DOnly) {
             var projection = frameState.mapProjection;

--- a/Source/Scene/GroundPrimitive.js
+++ b/Source/Scene/GroundPrimitive.js
@@ -558,6 +558,7 @@ define([
         rectangle.east = maxLon;
         rectangle.west = minLon;
 
+        // Use an oriented bounding box by default, but switch to a bounding sphere if bounding box creation would fail.
         if (rectangle.width < CesiumMath.PI) {
             var obb = OrientedBoundingBox.fromRectangle(rectangle, GroundPrimitive._maxHeight, GroundPrimitive._minOBBHeight, ellipsoid);
             primitive._boundingVolumes.push(obb);

--- a/Specs/Core/BoundingSphereSpec.js
+++ b/Specs/Core/BoundingSphereSpec.js
@@ -5,6 +5,7 @@ defineSuite([
         'Core/Cartesian4',
         'Core/Cartographic',
         'Core/Ellipsoid',
+        'Core/EncodedCartesian3',
         'Core/GeographicProjection',
         'Core/Intersect',
         'Core/Interval',
@@ -20,6 +21,7 @@ defineSuite([
         Cartesian4,
         Cartographic,
         Ellipsoid,
+        EncodedCartesian3,
         GeographicProjection,
         Intersect,
         Interval,
@@ -70,6 +72,25 @@ defineSuite([
             result.push(4.56);
         }
         return result;
+    }
+
+    function getPositionsAsEncodedFlatArray() {
+        var positions = getPositions();
+        var high = [];
+        var low = [];
+        for (var i = 0; i < positions.length; ++i) {
+            var encoded = EncodedCartesian3.fromCartesian(positions[i]);
+            high.push(encoded.high.x);
+            high.push(encoded.high.y);
+            high.push(encoded.high.z);
+            low.push(encoded.low.x);
+            low.push(encoded.low.y);
+            low.push(encoded.low.z);
+        }
+        return {
+            high : high,
+            low : low
+        };
     }
 
     it('default constructing produces expected values', function() {
@@ -267,6 +288,85 @@ defineSuite([
         var sphere = BoundingSphere.fromVertices(getPositionsAsFlatArrayWithStride5(), center, 5, result);
         expect(sphere).toEqual(result);
         expect(result.center).toEqual(Cartesian3.add(positionsCenter, center, new Cartesian3()));
+        expect(result.radius).toEqual(positionsRadius);
+    });
+
+    it('fromEncodedCartesianVertices without positions returns an empty sphere', function() {
+        var sphere = BoundingSphere.fromEncodedCartesianVertices();
+        expect(sphere.center).toEqual(Cartesian3.ZERO);
+        expect(sphere.radius).toEqual(0.0);
+    });
+
+    it('fromEncodedCartesianVertices without positions of different lengths returns an empty sphere', function() {
+        var positions = getPositionsAsEncodedFlatArray();
+        positions.low.length = positions.low.length - 1;
+        var sphere = BoundingSphere.fromEncodedCartesianVertices(positions.high, positions.low);
+        expect(sphere.center).toEqual(Cartesian3.ZERO);
+        expect(sphere.radius).toEqual(0.0);
+    });
+
+    it('fromEncodedCartesianVertices computes a center from points', function() {
+        var positions = getPositionsAsEncodedFlatArray();
+        var sphere = BoundingSphere.fromEncodedCartesianVertices(positions.high, positions.low);
+        expect(sphere.center).toEqual(positionsCenter);
+        expect(sphere.radius).toEqual(positionsRadius);
+    });
+
+    it('fromEncodedCartesianVertices contains all points (naive)', function() {
+        var positions = getPositionsAsEncodedFlatArray();
+        var sphere = BoundingSphere.fromEncodedCartesianVertices(positions.high, positions.low);
+        var radius = sphere.radius;
+        var center = sphere.center;
+
+        var r = new Cartesian3(radius, radius, radius);
+        var max = Cartesian3.add(r, center, new Cartesian3());
+        var min = Cartesian3.subtract(center, r, new Cartesian3());
+
+        positions = getPositions();
+        var numPositions = positions.length;
+        for ( var i = 0; i < numPositions; i++) {
+            var currentPos = positions[i];
+            expect(currentPos.x <= max.x && currentPos.x >= min.x).toEqual(true);
+            expect(currentPos.y <= max.y && currentPos.y >= min.y).toEqual(true);
+            expect(currentPos.z <= max.z && currentPos.z >= min.z).toEqual(true);
+        }
+    });
+
+    it('fromEncodedCartesianVertices contains all points (ritter)', function() {
+        var positions = getPositionsAsEncodedFlatArray();
+        var appendedPositions = [new Cartesian3(1, 1, 1), new Cartesian3(2, 2, 2), new Cartesian3(3, 3, 3)];
+        for (var j = 0; j < appendedPositions.length; ++j) {
+            var encoded = EncodedCartesian3.fromCartesian(Cartesian3.add(appendedPositions[j], center, new Cartesian3()));
+            positions.high.push(encoded.high.x);
+            positions.high.push(encoded.high.y);
+            positions.high.push(encoded.high.z);
+            positions.low.push(encoded.low.x);
+            positions.low.push(encoded.low.y);
+            positions.low.push(encoded.low.z);
+        }
+
+        var sphere = BoundingSphere.fromEncodedCartesianVertices(positions.high, positions.low);
+        var radius = sphere.radius;
+        var sphereCenter = sphere.center;
+
+        var r = new Cartesian3(radius, radius, radius);
+        var max = Cartesian3.add(r, sphereCenter, new Cartesian3());
+        var min = Cartesian3.subtract(sphereCenter, r, new Cartesian3());
+
+        var numElements = positions.length;
+        for (var i = 0; i < numElements; i += 3) {
+            expect(positions[i] <= max.x && positions[i] >= min.x).toEqual(true);
+            expect(positions[i + 1] <= max.y && positions[i + 1] >= min.y).toEqual(true);
+            expect(positions[i + 2] <= max.z && positions[i + 2] >= min.z).toEqual(true);
+        }
+    });
+
+    it('fromEncodedCartesianVertices fills result parameter if specified', function() {
+        var positions = getPositionsAsEncodedFlatArray();
+        var result = new BoundingSphere();
+        var sphere = BoundingSphere.fromEncodedCartesianVertices(positions.high, positions.low, result);
+        expect(sphere).toEqual(result);
+        expect(result.center).toEqual(positionsCenter);
         expect(result.radius).toEqual(positionsRadius);
     });
 


### PR DESCRIPTION
The ground primitive would fail to create an oriented bounding box if the rectangle containing it had a width greater than pi. This change makes it fall back to creating a bounding sphere.

The bug was reported by @mramato in #3406. I believe the polygon covering Antarctica was causing the crash.