### PR TITLE
Fix strange polygon texture coordinates

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -26,7 +26,6 @@ Change Log
 * Fixed creating bounding volumes for `GroundPrimitive`s whose containing rectangle has a width greater than pi.
 * Fixed incorrect texture coordinates for polygons with large height.
 
-
 ### 1.17 - 2016-01-04
 
 * Breaking changes

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,6 +24,8 @@ Change Log
 * `GroundPrimitive` now supports batching geometry for better performance.
 * Added `BoundingSphere.fromEncodedCartesianVertices` to create bounding volumes from parallel arrays of the upper and lower bits of `EncodedCartesian3`s.
 * Fixed creating bounding volumes for `GroundPrimitive`s whose containing rectangle has a width greater than pi.
+* Fixed incorrect texture coordinates for polygons with large height.
+
 
 ### 1.17 - 2016-01-04
 

--- a/Source/Core/PolygonGeometry.js
+++ b/Source/Core/PolygonGeometry.js
@@ -141,6 +141,7 @@ define([
 
                 if (vertexFormat.st) {
                     var p = Matrix3.multiplyByVector(textureMatrix, position, scratchPosition);
+                    p = ellipsoid.scaleToGeodeticSurface(p,p);
                     var st = tangentPlane.projectPointOntoPlane(p, appendTextureCoordinatesCartesian2);
                     Cartesian2.subtract(st, origin, st);
 

--- a/Source/Core/PolygonPipeline.js
+++ b/Source/Core/PolygonPipeline.js
@@ -978,10 +978,12 @@ define([
                     p = ellipsoid.scaleToGeodeticSurface(p, p);
                 }
 
-                n = ellipsoid.geodeticSurfaceNormal(p, n);
+                if (height !== 0) {
+                    n = ellipsoid.geodeticSurfaceNormal(p, n);
 
-                Cartesian3.multiplyByScalar(n, height, n);
-                Cartesian3.add(p, n, p);
+                    Cartesian3.multiplyByScalar(n, height, n);
+                    Cartesian3.add(p, n, p);
+                }
 
                 positions[i] = p.x;
                 positions[i + 1] = p.y;

--- a/Specs/Core/PolygonGeometrySpec.js
+++ b/Specs/Core/PolygonGeometrySpec.js
@@ -387,12 +387,12 @@ defineSuite([
         var p = PolygonGeometry.createGeometry(new PolygonGeometry({
             vertexFormat : VertexFormat.ALL,
             polygonHierarchy: {
-                    positions : Cartesian3.fromDegreesArray([
-                        -50.0, -50.0,
-                        50.0, -50.0,
-                        50.0, 50.0,
-                        -50.0, 50.0
-                    ])},
+                positions : Cartesian3.fromDegreesArray([
+                    -50.0, -50.0,
+                    50.0, -50.0,
+                    50.0, 50.0,
+                    -50.0, 50.0
+                ])},
             granularity : CesiumMath.PI_OVER_THREE,
             extrudedHeight: 30000
         }));
@@ -403,6 +403,26 @@ defineSuite([
         expect(p.attributes.tangent.values.length).toEqual(3 * 21 * 2);
         expect(p.attributes.binormal.values.length).toEqual(3 * 21 * 2);
         expect(p.indices.length).toEqual(3 * 20 * 2);
+    });
+
+    it('computes correct texture coordinates for polygon with height', function() {
+        var p = PolygonGeometry.createGeometry(new PolygonGeometry({
+            vertexFormat : VertexFormat.POSITION_AND_ST,
+            polygonHierarchy: {
+                positions : Cartesian3.fromDegreesArray([
+                    -100.5, 30.0,
+                    -100.0, 30.0,
+                    -100.0, 30.5,
+                    -100.5, 30.5
+                ])},
+            height: 150000,
+            granularity: CesiumMath.PI
+        }));
+
+        var st = p.attributes.st.values;
+        for (var i = 0; i < st.length; i++) {
+            expect(st[i] + CesiumMath.EPSILON10 >= 0 && st[i] - CesiumMath.EPSILON10 <= 1).toEqual(true);
+        }
     });
 
     it('creates a polygon from hierarchy extruded', function() {


### PR DESCRIPTION
Fix for #3447

Texture coordinates are computed for a polygon by projecting the points onto a tangent plane and finding where their coordinates lie in a bounding rectangle.  The bad texture coordinates where the result of projecting points with a large height onto the tangent plane being imprecise.  To fix it, I project the point back onto the ellipsoid surface before projecting it onto the tangent plane to get the texture coordinate.

I also threw in a minor improvement to a function in the `PolygonPipeline` that skips adding a vector of 0 length to the position when the height is 0.