### PR TITLE
Add `ImageryLayer.getViewableRectangle`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,6 +23,7 @@ Change Log
     ```
 * `GroundPrimitive` now supports batching geometry for better performance.
 * Added `BoundingSphere.fromEncodedCartesianVertices` to create bounding volumes from parallel arrays of the upper and lower bits of `EncodedCartesian3`s.
+* Added `ImageryLayer.getViewableRectangle` to make it easy to get the effective bounds of an imagery layer.
 * Fixed creating bounding volumes for `GroundPrimitive`s whose containing rectangle has a width greater than pi.
 * Fixed incorrect texture coordinates for polygons with large height.
 

--- a/Source/Scene/ImageryLayer.js
+++ b/Source/Scene/ImageryLayer.js
@@ -356,6 +356,28 @@ define([
     var clippedRectangleScratch = new Rectangle();
 
     /**
+     * Computes the intersection of this layer's rectangle with the imagery provider's availability rectangle,
+     * producing the overall bounds of imagery that can be produced by this layer.
+     *
+     * @returns {Promise} A promise to a rectangle which defines the overall bounds of imagery that can be produced by this layer.
+     *
+     * @example
+     * // Zoom to an imagery layer.
+     * imageryLayer.getViewableRectangle().then(function (rectangle) {
+     *     return camera.flyTo({
+     *         destination: rectangle
+     *     });
+     * });
+     */
+    ImageryLayer.prototype.getViewableRectangle = function() {
+        var imageryProvider = this._imageryProvider;
+        var rectangle = this._rectangle;
+        return imageryProvider.readyPromise.then(function() {
+            return Rectangle.intersection(imageryProvider.rectangle, rectangle);
+        });
+    };
+
+    /**
      * Create skeletons for the imagery tiles that partially or completely overlap a given terrain
      * tile.
      *

--- a/Specs/Scene/ImageryLayerSpec.js
+++ b/Specs/Scene/ImageryLayerSpec.js
@@ -237,6 +237,23 @@ defineSuite([
         });
     });
 
+    it('getViewableRectangle works', function() {
+        var providerRectangle = Rectangle.fromDegrees(8.2, 61.09, 8.5, 61.7);
+        var provider = new SingleTileImageryProvider({
+            url : 'Data/Images/Green4x4.png',
+            rectangle : providerRectangle
+        });
+
+        var layerRectangle = Rectangle.fromDegrees(7.2, 60.9, 9.0, 61.7);
+        var layer = new ImageryLayer(provider, {
+            rectangle : layerRectangle
+        });
+
+        return layer.getViewableRectangle().then(function(rectangle) {
+            expect(rectangle).toEqual(Rectangle.intersection(providerRectangle, layerRectangle));
+        });
+    });
+
     describe('createTileImagerySkeletons', function() {
         it('handles a base layer that does not cover the entire globe', function() {
             var provider = new TileMapServiceImageryProvider({


### PR DESCRIPTION
I discovered that zooming to an ImageryLayer was not as straightforward as it should be.  So I added
`ImageryLayer.getViewableRectangle` to make it easy to get the effective rectangle bounds to pass to the camera.

I'm also going to write up an issue to update `Viewer.zoomTo` and `Viewer.flyTo` to support `ImageryLayer` instances.