### PR TITLE
Use relative paths in 3d tiles sandcastle

### DIFF
--- a/Apps/Sandcastle/gallery/3D Tiles.html
+++ b/Apps/Sandcastle/gallery/3D Tiles.html
@@ -37,11 +37,11 @@ var scene = viewer.scene;
 scene.fog.enabled = false;
 scene.debugShowFramesPerSecond = true;
 
-var tilesetUrl = 'http://localhost:8080/Specs/Data/Cesium3DTiles/Tilesets/Tileset/';
-var batchedUrl = 'http://localhost:8080/Specs/Data/Cesium3DTiles/Batched/BatchedWithBatchTable/';
-var instancedUrl = 'http://localhost:8080/Specs/Data/Cesium3DTiles/Instanced/InstancedWithBatchTable/';
-var compositeUrl = 'http://localhost:8080/Specs/Data/Cesium3DTiles/Composite/Composite/';
-var pointsUrl = 'http://localhost:8080/Specs/Data/Cesium3DTiles/Points/Points/';
+var tilesetUrl = '../../../Specs/Data/Cesium3DTiles/Tilesets/Tileset/';
+var batchedUrl = '../../../Specs/Data/Cesium3DTiles/Batched/BatchedWithBatchTable/';
+var instancedUrl = '../../../Specs/Data/Cesium3DTiles/Instanced/InstancedWithBatchTable/';
+var compositeUrl = '../../../Specs/Data/Cesium3DTiles/Composite/Composite/';
+var pointsUrl = '../../../Specs/Data/Cesium3DTiles/Points/Points/';
 
 var tileset;
 


### PR DESCRIPTION
Using relative paths instead as suggested in this comment: https://github.com/AnalyticalGraphicsInc/cesium/pull/3463#discussion_r50911297

For now I'm still referencing files in the Specs folder because it will make it easier to manage the data if it's only in one place. Once 3d tiles is more stable, we can copy the data to the Apps folder. This is in the roadmap https://github.com/AnalyticalGraphicsInc/cesium/issues/3241.
