### PR TITLE
Added Rectangle.union and Rectangle.expand functions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -30,6 +30,7 @@ Change Log
 * Added `UrlTemplateImageryProvider.reinitialize` for changing imagery provider options without creating a new instance.
 * `UrlTemplateImageryProvider` now accepts a promise to an `options` object in addition to taking the object directly.
 * Added a Sandcastle example to "star burst" overlapping billboards and labels.
+* Added `Rectangle.union` and `Rectangle.expand`.
 
 ### 1.17 - 2016-01-04
 

--- a/Source/Core/Rectangle.js
+++ b/Source/Core/Rectangle.js
@@ -596,6 +596,66 @@ define([
     };
 
     /**
+     * Computes a rectangle that is the union of two rectangles.
+     *
+     * @param {Rectangle} rectangle A rectangle to enclose in rectangle.
+     * @param {Rectangle} otherRectangle A rectangle to enclose in a rectangle.
+     * @param {Rectangle} [result] The object onto which to store the result.
+     * @returns {Rectangle} The modified result parameter or a new Rectangle instance if none was provided.
+     */
+    Rectangle.union = function(rectangle, otherRectangle, result) {
+        //>>includeStart('debug', pragmas.debug);
+        if (!defined(rectangle)) {
+            throw new DeveloperError('rectangle is required');
+        }
+        if (!defined(otherRectangle)) {
+            throw new DeveloperError('otherRectangle is required.');
+        }
+        //>>includeEnd('debug');
+
+        if (!defined(result)) {
+            result = new Rectangle();
+        }
+
+        result.west = Math.min(rectangle.west, otherRectangle.west);
+        result.south = Math.min(rectangle.south, otherRectangle.south);
+        result.east = Math.max(rectangle.east, otherRectangle.east);
+        result.north = Math.max(rectangle.north, otherRectangle.north);
+
+        return result;
+    };
+
+    /**
+     * Computes a rectangle by enlarging the provided rectangle until it contains the provided cartographic.
+     *
+     * @param {Rectangle} rectangle A rectangle to expand.
+     * @param {Cartographic} cartographic A cartographic to enclose in a rectangle.
+     * @param {Rectangle} [result] The object onto which to store the result.
+     * @returns {Rectangle} The modified result parameter or a new Rectangle instance if one was not provided.
+     */
+    Rectangle.expand = function(rectangle, cartographic, result) {
+        //>>includeStart('debug', pragmas.debug);
+        if (!defined(rectangle)) {
+            throw new DeveloperError('rectangle is required.');
+        }
+        if (!defined(cartographic)) {
+            throw new DeveloperError('cartographic is required.');
+        }
+        //>>includeEnd('debug');
+
+        if (!defined(result)) {
+            result = new Rectangle();
+        }
+
+        result.west = Math.min(rectangle.west, cartographic.longitude);
+        result.south = Math.min(rectangle.south, cartographic.latitude);
+        result.east = Math.max(rectangle.east, cartographic.longitude);
+        result.north = Math.max(rectangle.north, cartographic.latitude);
+
+        return result;
+    };
+
+    /**
      * Returns true if the cartographic is on or inside the rectangle, false otherwise.
      *
      * @param {Rectangle} rectangle The rectangle

--- a/Specs/Core/RectangleSpec.js
+++ b/Specs/Core/RectangleSpec.js
@@ -501,6 +501,74 @@ defineSuite([
         expect(Rectangle.intersection(rectangle1, rectangle2)).not.toBeDefined();
         expect(Rectangle.intersection(rectangle2, rectangle1)).not.toBeDefined();
     });
+    
+    it('union works without a result parameter', function() {
+        var rectangle1 = new Rectangle(0.5, 0.1, 0.75, 0.9);
+        var rectangle2 = new Rectangle(0.4, 0.0, 0.85, 0.8);
+        var expected = new Rectangle(0.4, 0.0, 0.85, 0.9);
+        var returnedResult = Rectangle.union(rectangle1, rectangle2);
+        expect(returnedResult).toEqual(expected);
+    });
+
+    it('union works with a result parameter', function() {
+        var rectangle1 = new Rectangle(0.5, 0.1, 0.75, 0.9);
+        var rectangle2 = new Rectangle(0.4, 0.0, 0.85, 0.8);
+        var expected = new Rectangle(0.4, 0.0, 0.85, 0.9);
+        var result = new Rectangle(-1.0, -1.0, 10.0, 10.0);
+        var returnedResult = Rectangle.union(rectangle1, rectangle2, result);
+        expect(result).toBe(returnedResult);
+        expect(returnedResult).toEqual(expected);
+    });
+
+    it('expand works if rectangle needs to grow right', function() {
+        var rectangle = new Rectangle(0.5, 0.1, 0.75, 0.9);
+        var cartographic = new Cartographic(0.85, 0.5);
+        var expected = new Rectangle(0.5, 0.1, 0.85, 0.9);
+        var result = Rectangle.expand(rectangle, cartographic);
+        expect(result).toEqual(expected);
+    });
+
+    it('expand works if rectangle needs to grow left', function() {
+        var rectangle = new Rectangle(0.5, 0.1, 0.75, 0.9);
+        var cartographic = new Cartographic(0.4, 0.5);
+        var expected = new Rectangle(0.4, 0.1, 0.75, 0.9);
+        var result = Rectangle.expand(rectangle, cartographic);
+        expect(result).toEqual(expected);
+    });
+
+    it('expand works if rectangle needs to grow up', function() {
+        var rectangle = new Rectangle(0.5, 0.1, 0.75, 0.9);
+        var cartographic = new Cartographic(0.6, 1.0);
+        var expected = new Rectangle(0.5, 0.1, 0.75, 1.0);
+        var result = Rectangle.expand(rectangle, cartographic);
+        expect(result).toEqual(expected);
+    });
+
+    it('expand works if rectangle needs to grow down', function() {
+        var rectangle = new Rectangle(0.5, 0.1, 0.75, 0.9);
+        var cartographic = new Cartographic(0.6, 0.0);
+        var expected = new Rectangle(0.5, 0.0, 0.75, 0.9);
+        var result = Rectangle.expand(rectangle, cartographic);
+        expect(result).toEqual(expected);
+    });
+
+    it('expand works if rectangle does not need to grow', function() {
+        var rectangle = new Rectangle(0.5, 0.1, 0.75, 0.9);
+        var cartographic = new Cartographic(0.6, 0.5);
+        var expected = new Rectangle(0.5, 0.1, 0.75, 0.9);
+        var result = Rectangle.expand(rectangle, cartographic);
+        expect(result).toEqual(expected);
+    });
+
+    it('expand works with a result parameter', function() {
+        var rectangle = new Rectangle(0.5, 0.1, 0.75, 0.9);
+        var cartographic = new Cartographic(0.85, 1.0);
+        var expected = new Rectangle(0.5, 0.1, 0.85, 1.0);
+        var result = new Rectangle();
+        var returnedResult = Rectangle.expand(rectangle, cartographic, result);
+        expect(returnedResult).toBe(returnedResult);
+        expect(result).toEqual(expected);
+    });
 
     it('contains works', function() {
         var rectangle = new Rectangle(west, south, east, north);
@@ -646,6 +714,32 @@ defineSuite([
         var rectangle = new Rectangle(west, south, east, north);
         expect(function() {
             Rectangle.intersection(rectangle, undefined);
+        }).toThrowDeveloperError();
+    });
+
+    it('union throws with no rectangle', function() {
+        expect(function() {
+            Rectangle.union(undefined);
+        }).toThrowDeveloperError();
+    });
+
+    it('union throws with no otherRectangle', function() {
+        var rectangle = new Rectangle(west, south, east, north);
+        expect(function() {
+            Rectangle.intersection(rectangle, undefined);
+        }).toThrowDeveloperError();
+    });
+
+    it('expand throws with no rectangle', function() {
+        expect(function() {
+            Rectangle.expand(undefined);
+        }).toThrowDeveloperError();
+    });
+
+    it('expand throws with no cartographic', function() {
+        var rectangle = new Rectangle(west, south, east, north);
+        expect(function() {
+            Rectangle.expand(rectangle, undefined);
         }).toThrowDeveloperError();
     });
 


### PR DESCRIPTION
Added `Rectangle.union` and `Rectangle.expand` functions for convenience and to help clean up the 3d-tiles generation code. There's a bit of duplicate work since `BoundingRectangle` has these functions, but I think that's ok. 