### PR TITLE
 Fix sandcastle development links in reference documentation #3020 

### DIFF
--- a/Source/Core/BoxOutlineGeometry.js
+++ b/Source/Core/BoxOutlineGeometry.js
@@ -39,8 +39,6 @@ define([
      * @see BoxOutlineGeometry.createGeometry
      * @see Packable
      *
-     * @demo {@link http://cesiumjs.org/Cesium/Apps/Sandcastle/index.html?src=Box%20Outline.html|Cesium Sandcastle Box Outline Demo}
-     *
      * @example
      * var box = new Cesium.BoxOutlineGeometry({
      *   maximum : new Cesium.Cartesian3(250000.0, 250000.0, 250000.0),

--- a/Source/Core/CircleGeometry.js
+++ b/Source/Core/CircleGeometry.js
@@ -41,8 +41,6 @@ define([
      * @see CircleGeometry.createGeometry
      * @see Packable
      *
-     * @demo {@link http://cesiumjs.org/Cesium/Apps/Sandcastle/index.html?src=Circle.html|Cesium Sandcastle Circle Demo}
-     *
      * @example
      * // Create a circle.
      * var circle = new Cesium.CircleGeometry({

--- a/Source/Core/CircleOutlineGeometry.js
+++ b/Source/Core/CircleOutlineGeometry.js
@@ -36,8 +36,6 @@ define([
      * @see CircleOutlineGeometry.createGeometry
      * @see Packable
      *
-     * @demo {@link http://cesiumjs.org/Cesium/Apps/Sandcastle/index.html?src=Circle%20Outline.html|Cesium Sandcastle Circle Outline Demo}
-     *
      * @example
      * // Create a circle.
      * var circle = new Cesium.CircleOutlineGeometry({

--- a/Source/Core/CorridorOutlineGeometry.js
+++ b/Source/Core/CorridorOutlineGeometry.js
@@ -317,8 +317,6 @@ define([
      *
      * @see CorridorOutlineGeometry.createGeometry
      *
-     * @demo {@link http://cesiumjs.org/Cesium/Apps/Sandcastle/index.html?src=Corridor%20Outline.html|Cesium Sandcastle Corridor Outline Demo}
-     *
      * @example
      * var corridor = new Cesium.CorridorOutlineGeometry({
      *   positions : Cesium.Cartesian3.fromDegreesArray([-72.0, 40.0, -70.0, 35.0]),

--- a/Source/Core/CylinderGeometry.js
+++ b/Source/Core/CylinderGeometry.js
@@ -61,8 +61,6 @@ define([
      *
      * @see CylinderGeometry.createGeometry
      *
-     * @demo {@link http://cesiumjs.org/Cesium/Apps/Sandcastle/index.html?src=Cylinder.html|Cesium Sandcastle Cylinder Demo}
-     *
      * @example
      * // create cylinder geometry
      * var cylinder = new Cesium.CylinderGeometry({

--- a/Source/Core/CylinderOutlineGeometry.js
+++ b/Source/Core/CylinderOutlineGeometry.js
@@ -52,8 +52,6 @@ define([
      *
      * @see CylinderOutlineGeometry.createGeometry
      *
-     * @demo {@link http://cesiumjs.org/Cesium/Apps/Sandcastle/index.html?src=Cylinder%20Outline.html|Cesium Sandcastle Cylinder Outline Demo}
-     *
      * @example
      * // create cylinder geometry
      * var cylinder = new Cesium.CylinderOutlineGeometry({

--- a/Source/Core/EllipseOutlineGeometry.js
+++ b/Source/Core/EllipseOutlineGeometry.js
@@ -150,8 +150,6 @@ define([
      *
      * @see EllipseOutlineGeometry.createGeometry
      *
-     * @demo {@link http://cesiumjs.org/Cesium/Apps/Sandcastle/index.html?src=Ellipse%20Outline.html|Cesium Sandcastle Ellipse Outline Demo}
-     *
      * @example
      * var ellipse = new Cesium.EllipseOutlineGeometry({
      *   center : Cesium.Cartesian3.fromDegrees(-75.59777, 40.03883),

--- a/Source/Core/EllipsoidGeometry.js
+++ b/Source/Core/EllipsoidGeometry.js
@@ -60,8 +60,6 @@ define([
      *
      * @see EllipsoidGeometry#createGeometry
      *
-     * @demo {@link http://cesiumjs.org/Cesium/Apps/Sandcastle/index.html?src=Ellipsoid.html|Cesium Sandcastle Ellipsoid Demo}
-     *
      * @example
      * var ellipsoid = new Cesium.EllipsoidGeometry({
      *   vertexFormat : Cesium.VertexFormat.POSITION_ONLY,

--- a/Source/Core/EllipsoidOutlineGeometry.js
+++ b/Source/Core/EllipsoidOutlineGeometry.js
@@ -49,8 +49,6 @@ define([
      * @exception {DeveloperError} options.slicePartitions must be greater than or equal to zero.
      * @exception {DeveloperError} options.subdivisions must be greater than or equal to zero.
      *
-     * @demo {@link http://cesiumjs.org/Cesium/Apps/Sandcastle/index.html?src=Ellipsoid%20Outline.html|Cesium Sandcastle Ellipsoid Outline Demo}
-     *
      * @example
      * var ellipsoid = new Cesium.EllipsoidOutlineGeometry({
      *   radii : new Cesium.Cartesian3(1000000.0, 500000.0, 500000.0),

--- a/Source/Core/PolygonOutlineGeometry.js
+++ b/Source/Core/PolygonOutlineGeometry.js
@@ -213,8 +213,6 @@ define([
      * @see PolygonOutlineGeometry#createGeometry
      * @see PolygonOutlineGeometry#fromPositions
      *
-     * @demo {@link http://cesiumjs.org/Cesium/Apps/Sandcastle/index.html?src=Polygon%20Outline.html|Cesium Sandcastle Polygon Outline Demo}
-     *
      * @example
      * // 1. create a polygon outline from points
      * var polygon = new Cesium.PolygonOutlineGeometry({

--- a/Source/Core/PolylineVolumeOutlineGeometry.js
+++ b/Source/Core/PolylineVolumeOutlineGeometry.js
@@ -110,8 +110,6 @@ define([
      *
      * @see PolylineVolumeOutlineGeometry#createGeometry
      *
-     * @demo {@link http://cesiumjs.org/Cesium/Apps/Sandcastle/index.html?src=Polyline%20Volume%20Outline.html|Cesium Sandcastle Polyline Volume Outline Demo}
-     *
      * @example
      * function computeCircle(radius) {
      *   var positions = [];

--- a/Source/Core/RectangleOutlineGeometry.js
+++ b/Source/Core/RectangleOutlineGeometry.js
@@ -183,8 +183,6 @@ define([
      *
      * @see RectangleOutlineGeometry#createGeometry
      *
-     * @demo {@link http://cesiumjs.org/Cesium/Apps/Sandcastle/index.html?src=Rectangle%20Outline.html|Cesium Sandcastle Rectangle Outline Demo}
-     *
      * @example
      * var rectangle = new Cesium.RectangleOutlineGeometry({
      *   ellipsoid : Cesium.Ellipsoid.WGS84,

--- a/Source/Core/SimplePolylineGeometry.js
+++ b/Source/Core/SimplePolylineGeometry.js
@@ -93,8 +93,6 @@ define([
      *
      * @see SimplePolylineGeometry#createGeometry
      *
-     * @demo {@link http://cesiumjs.org/Cesium/Apps/Sandcastle/index.html?src=Simple%20Polyline.html|Cesium Sandcastle Simple Polyline Demo}
-     *
      * @example
      * // A polyline with two connected line segments
      * var polyline = new Cesium.SimplePolylineGeometry({

--- a/Source/Core/SphereGeometry.js
+++ b/Source/Core/SphereGeometry.js
@@ -32,8 +32,6 @@ define([
      *
      * @see SphereGeometry#createGeometry
      *
-     * @demo {@link http://cesiumjs.org/Cesium/Apps/Sandcastle/index.html?src=Sphere.html|Cesium Sandcastle Sphere Demo}
-     *
      * @example
      * var sphere = new Cesium.SphereGeometry({
      *   radius : 100.0,

--- a/Source/Core/SphereOutlineGeometry.js
+++ b/Source/Core/SphereOutlineGeometry.js
@@ -29,8 +29,6 @@ define([
      * @exception {DeveloperError} options.slicePartitions must be greater than or equal to zero.
      * @exception {DeveloperError} options.subdivisions must be greater than or equal to zero.
      *
-     * @demo {@link http://cesiumjs.org/Cesium/Apps/Sandcastle/index.html?src=Sphere%20Outline.html|Cesium Sandcastle Sphere Outline Demo}
-     *
      * @example
      * var sphere = new Cesium.SphereOutlineGeometry({
      *   radius : 100.0,

--- a/Source/Core/WallOutlineGeometry.js
+++ b/Source/Core/WallOutlineGeometry.js
@@ -57,8 +57,6 @@ define([
      * @see WallGeometry#createGeometry
      * @see WallGeometry#fromConstantHeight
      *
-     * @demo {@link http://cesiumjs.org/Cesium/Apps/Sandcastle/index.html?src=Wall%20Outline.html|Cesium Sandcastle Wall Outline Demo}
-     *
      * @example
      * // create a wall outline that spans from ground level to 10000 meters
      * var wall = new Cesium.WallOutlineGeometry({

--- a/Source/DataSources/CylinderGraphics.js
+++ b/Source/DataSources/CylinderGraphics.js
@@ -37,7 +37,6 @@ define([
      * @param {Property} [options.numberOfVerticalLines=16] A numeric Property specifying the number of vertical lines to draw along the perimeter for the outline.
      * @param {Property} [options.slices=128] The number of edges around perimeter of the cylinder.
      *
-     * @demo {@link http://cesiumjs.org/Cesium/Apps/Sandcastle/index.html?src=Cylinder.html|Cesium Sandcastle Cylinder Demo}
      */
     function CylinderGraphics(options) {
         this._length = undefined;

--- a/Source/Scene/EllipsoidSurfaceAppearance.js
+++ b/Source/Scene/EllipsoidSurfaceAppearance.js
@@ -41,8 +41,6 @@ define([
      *
      * @see {@link https://github.com/AnalyticalGraphicsInc/cesium/wiki/Fabric|Fabric}
      *
-     * @demo {@link http://cesiumjs.org/Cesium/Apps/Sandcastle/index.html?src=Ellipsoid%20Surface.html|Cesium Sandcastle Ellipsoid Surface Appearance Demo}
-     *
      * @example
      * var primitive = new Cesium.Primitive({
      *   geometryInstances : new Cesium.GeometryInstance({

--- a/Source/Scene/PerInstanceColorAppearance.js
+++ b/Source/Scene/PerInstanceColorAppearance.js
@@ -36,8 +36,6 @@ define([
      * @param {String} [options.fragmentShaderSource] Optional GLSL fragment shader source to override the default fragment shader.
      * @param {RenderState} [options.renderState] Optional render state to override the default render state.
      *
-     * @demo {@link http://cesiumjs.org/Cesium/Apps/Sandcastle/index.html?src=Per%20Instance%20Color.html|Cesium Sandcastle Per Instance Color Appearance Demo}
-     *
      * @example
      * // A solid white line segment
      * var primitive = new Cesium.Primitive({

--- a/Source/Scene/Polyline.js
+++ b/Source/Scene/Polyline.js
@@ -39,7 +39,6 @@ define([
      *
      * @see PolylineCollection
      *
-     * @demo {@link http://cesiumjs.org/Cesium/Apps/Sandcastle/index.html?src=Polylines.html|Cesium Sandcastle Polyline Demo}
      */
     function Polyline(options, polylineCollection) {
         options = defaultValue(options, defaultValue.EMPTY_OBJECT);

--- a/Source/Scene/PolylineCollection.js
+++ b/Source/Scene/PolylineCollection.js
@@ -121,7 +121,6 @@ define([
      * @see PolylineCollection#remove
      * @see Polyline
      * @see LabelCollection
-     * @demo {@link http://cesiumjs.org/Cesium/Apps/Sandcastle/index.html?src=Polylines.html|Cesium Sandcastle Polyline Demo}
      *
      * @example
      * // Create a polyline collection with two polylines

--- a/Source/Scene/PolylineColorAppearance.js
+++ b/Source/Scene/PolylineColorAppearance.js
@@ -34,8 +34,6 @@ define([
      * @param {String} [options.fragmentShaderSource] Optional GLSL fragment shader source to override the default fragment shader.
      * @param {RenderState} [options.renderState] Optional render state to override the default render state.
      *
-     *@demo {@link http://cesiumjs.org/Cesium/Apps/Sandcastle/index.html?src=Polyline%20Color.html|Cesium Sandcastle Polyline Color Appearance Demo}
-     *
      * @example
      * // A solid white line segment
      * var primitive = new Cesium.Primitive({

--- a/Source/Scene/PolylineMaterialAppearance.js
+++ b/Source/Scene/PolylineMaterialAppearance.js
@@ -38,7 +38,6 @@ define([
      * @param {RenderState} [options.renderState] Optional render state to override the default render state.
      *
      * @see {@link https://github.com/AnalyticalGraphicsInc/cesium/wiki/Fabric|Fabric}
-     * @demo {@link http://cesiumjs.org/Cesium/Apps/Sandcastle/index.html?src=Polyline%20Material.html|Cesium Sandcastle Polyline Material Appearance Demo}
      *
      * @example
      * var primitive = new Cesium.Primitive({


### PR DESCRIPTION
I don't know why but when I am pushing the changed files all the files with extension .js~ also gets pushed.Will I have to remove this from here or its fine.