### PR TITLE
More 3D Tiles reference doc

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,13 +6,8 @@ Change Log
 * Added support for [3D Tiles](https://github.com/AnalyticalGraphicsInc/3d-tiles/blob/master/README.md) for streaming massive heterogeneous 3D geospatial datasets.  The new Cesium types are:
    * `Cesium3DTileset`
    * `Cesium3DTile`
+   * `Cesium3DTileContentProvider`
    * `Cesium3DTileFeature`
-   * `Batched3DModel3DTileContentProvider`
-   * `Instanced3DModel3DTileContentProvider`
-   * `Points3DTileContentProvider`
-   * `Composite3DTileContentProvider`
-   * `Tileset3DTileContentProvider`
-   * `Empty3DTileContentProvider`
    
 TODO: these are still private:
 * Added `vertexShaderLoaded`, `fragmentShaderLoaded`, `uniformMapLoaded`, `pickVertexShaderLoaded`, `pickFragmentShaderLoaded`, and `pickUniformMapLoaded` callbacks to the `Model` constructor and `Model.fromGltf`.

--- a/Source/Scene/Batched3DModel3DTileContentProvider.js
+++ b/Source/Scene/Batched3DModel3DTileContentProvider.js
@@ -41,15 +41,11 @@ define([
      * Represents the contents of a
      * {@link https://github.com/AnalyticalGraphicsInc/3d-tiles/blob/master/TileFormats/Batched3DModel/README.md|Batched 3D Model}
      * tile in a {@link https://github.com/AnalyticalGraphicsInc/3d-tiles/blob/master/README.md|3D Tiles} tileset.
-     * <p>
-     * Use this to access and modify individual features (models) in the tile.
-     * </p>
-     * <p>
-     * Do not construct this directly.  Access it through {@link Cesium3DTile#content}.
-     * </p>
      *
      * @alias Batched3DModel3DTileContentProvider
      * @constructor
+     *
+     * @private
      */
     function Batched3DModel3DTileContentProvider(tileset, tile, url) {
         this._model = undefined;
@@ -59,22 +55,16 @@ define([
 
         /**
          * Part of the {@link Cesium3DTileContentProvider} interface.
-         *
-         * @private
          */
         this.state = Cesium3DTileContentState.UNLOADED;
 
         /**
          * Part of the {@link Cesium3DTileContentProvider} interface.
-         *
-         * @private
          */
         this.processingPromise = when.defer();
 
         /**
          * Part of the {@link Cesium3DTileContentProvider} interface.
-         *
-         * @private
          */
         this.readyPromise = when.defer();
 
@@ -85,16 +75,20 @@ define([
 
     defineProperties(Batched3DModel3DTileContentProvider.prototype, {
         /**
-         * Gets the number of features in the tile, i.e., the number of 3D models in the batch.
-         *
-         * @memberof Batched3DModel3DTileContentProvider.prototype
-         *
-         * @type {Number}
-         * @readonly
+         * Part of the {@link Cesium3DTileContentProvider} interface.
          */
         featuresLength : {
             get : function() {
                 return this._featuresLength;
+            }
+        },
+
+        /**
+         * Part of the {@link Cesium3DTileContentProvider} interface.
+         */
+        innerContents : {
+            get : function() {
+                return undefined;
             }
         }
     });
@@ -111,26 +105,15 @@ define([
         }
     }
 
-    /**
-     * Determines if the tile's batch table has a property.  If it does, each feature in
-     * the tile will have the property.
-     *
-     * @param {String} name The case-sensitive name of the property.
-     * @returns {Boolean} <code>true</code> if the property exists; otherwise, <code>false</code>.
+     /**
+     * Part of the {@link Cesium3DTileContentProvider} interface.
      */
     Batched3DModel3DTileContentProvider.prototype.hasProperty = function(name) {
         return this._batchTableResources.hasProperty(name);
     };
 
     /**
-     * Returns the {@link Cesium3DTileFeature} object for the feature with the
-     * given <code>batchId</code>.  This object is used to get and modify the
-     * feature's properties.
-     *
-     * @param {Number} batchId The batchId for the feature.
-     * @returns {Cesium3DTileFeature} The corresponding {@link Cesium3DTileFeature} object.
-     *
-     * @exception {DeveloperError} batchId must be between zero and {@link Batched3DModel3DTileContentProvider#featuresLength - 1}.
+     * Part of the {@link Cesium3DTileContentProvider} interface.
      */
     Batched3DModel3DTileContentProvider.prototype.getFeature = function(batchId) {
         var featuresLength = this._featuresLength;
@@ -148,8 +131,6 @@ define([
 
     /**
      * Part of the {@link Cesium3DTileContentProvider} interface.
-     *
-     * @private
      */
     Batched3DModel3DTileContentProvider.prototype.request = function() {
         var that = this;
@@ -178,8 +159,6 @@ define([
 
     /**
      * Part of the {@link Cesium3DTileContentProvider} interface.
-     *
-     * @private
      */
     Batched3DModel3DTileContentProvider.prototype.initialize = function(arrayBuffer, byteOffset) {
         var byteStart = defaultValue(byteOffset, 0);
@@ -261,8 +240,6 @@ define([
 
     /**
      * Part of the {@link Cesium3DTileContentProvider} interface.
-     *
-     * @private
      */
     Batched3DModel3DTileContentProvider.prototype.applyDebugSettings = function(enabled, color) {
         color = enabled ? color : Color.WHITE;
@@ -271,8 +248,6 @@ define([
 
     /**
      * Part of the {@link Cesium3DTileContentProvider} interface.
-     *
-     * @private
      */
     Batched3DModel3DTileContentProvider.prototype.update = function(tiles3D, frameState) {
         // In the PROCESSING state we may be calling update() to move forward
@@ -284,8 +259,6 @@ define([
 
     /**
      * Part of the {@link Cesium3DTileContentProvider} interface.
-     *
-     * @private
      */
     Batched3DModel3DTileContentProvider.prototype.isDestroyed = function() {
         return false;
@@ -293,8 +266,6 @@ define([
 
     /**
      * Part of the {@link Cesium3DTileContentProvider} interface.
-     *
-     * @private
      */
     Batched3DModel3DTileContentProvider.prototype.destroy = function() {
         this._model = this._model && this._model.destroy();

--- a/Source/Scene/Cesium3DTileContentProvider.js
+++ b/Source/Scene/Cesium3DTileContentProvider.js
@@ -8,7 +8,13 @@ define([
     "use strict";
 
     /**
+     * <p>
+     * Derived classes of this interface provide access to individual features in the tile.
+     * Access derived objects through {@link Cesium3DTile#content}.
+     * </p>
+     * <p>
      * This type describes an interface and is not intended to be instantiated directly.
+     * </p>
      *
      * @alias Cesium3DTileContentProvider
      * @constructor
@@ -19,15 +25,20 @@ define([
      * @see {@link Composite3DTileContentProvider}
      * @see {@link Tileset3DTileContentProvider}
      * @see {@link Empty3DTileContentProvider}
-     *
-     * @private
      */
     function Cesium3DTileContentProvider(tileset, tile, url) {
+        // Private members are not exposed in the public Cesium API, but derived classes
+        // need to implement them.  The scope should be treated like C#'s internal.  When
+        // we're ready, we'll add these members to the public API so users can implement
+        // new tile formats.
+
         /**
          * The current state of the tile's content.
          *
          * @type {Cesium3DTileContentState}
          * @readonly
+         *
+         * @private
          */
         this.state = undefined;
 
@@ -38,6 +49,8 @@ define([
          *
          * @type {Promise.<Cesium3DTileContentProvider>}
          * @readonly
+         *
+         * @private
          */
         this.processingPromise = undefined;
 
@@ -46,6 +59,8 @@ define([
          *
          * @type {Promise.<Cesium3DTileContentProvider>}
          * @readonly
+         *
+         * @private
          */
         this.readyPromise = undefined;
     }
@@ -60,6 +75,21 @@ define([
          * @readonly
          */
         featuresLength : {
+            get : function() {
+                DeveloperError.throwInstantiationError();
+            }
+        },
+
+        /**
+         * Gets the array of {@link Cesium3DTileContentProvider} objects that represent the
+         * content a composite's inner tiles, which can also be composites.
+         *
+         * @memberof Composite3DTileContentProvider.prototype
+         *
+         * @type {Arrays}
+         * @readonly
+         */
+        innerContents : {
             get : function() {
                 DeveloperError.throwInstantiationError();
             }
@@ -100,6 +130,8 @@ define([
      * This is used to implement the <code>Cesium3DTileContentProvider</code> interface, but is
      * not part of the public Cesium API.
      * </p>
+     *
+     * @private
      */
     Cesium3DTileContentProvider.prototype.request = function() {
         DeveloperError.throwInstantiationError();
@@ -116,17 +148,21 @@ define([
      *
      * @param {Object} arrayBuffer The array buffer containing the contents payload.
      * @param {Number} byteOffset The zero-based offset, in bytes, into the array buffer.
+     *
+     * @private
      */
     Cesium3DTileContentProvider.prototype.initialize = function(arrayBuffer, byteOffset) {
         DeveloperError.throwInstantiationError();
     };
 
     /**
-     * Called when the tileset's debugColorizeTiles is changed.
+     * Called when {@link Cesium3DTileset#debugColorizeTiles} changes.
      * <p>
      * This is used to implement the <code>Cesium3DTileContentProvider</code> interface, but is
      * not part of the public Cesium API.
      * </p>
+     *
+     * @private
      */
     Cesium3DTileContentProvider.prototype.applyDebugSettings = function(enabled, color) {
         DeveloperError.throwInstantiationError();
@@ -143,6 +179,8 @@ define([
      *
      * @param {Cesium3DTileset} tiles3D The tileset containing this tile.
      * @param {FrameState} frameState The frame state.
+     *
+     * @private
      */
     Cesium3DTileContentProvider.prototype.update = function(tiles3D, frameState) {
         DeveloperError.throwInstantiationError();
@@ -161,6 +199,8 @@ define([
      * @returns {Boolean} <code>true</code> if this object was destroyed; otherwise, <code>false</code>.
      *
      * @see Cesium3DTileContentProvider#destroy
+     *
+     * @private
      */
     Cesium3DTileContentProvider.prototype.isDestroyed = function() {
         DeveloperError.throwInstantiationError();
@@ -186,6 +226,8 @@ define([
      * content = content && content.destroy();
      *
      * @see Cesium3DTileContentProvider#isDestroyed
+     *
+     * @private
      */
     Cesium3DTileContentProvider.prototype.destroy = function() {
         DeveloperError.throwInstantiationError();

--- a/Source/Scene/Cesium3DTileContentProvider.js
+++ b/Source/Scene/Cesium3DTileContentProvider.js
@@ -86,7 +86,7 @@ define([
          *
          * @memberof Composite3DTileContentProvider.prototype
          *
-         * @type {Arrays}
+         * @type {Array}
          * @readonly
          */
         innerContents : {

--- a/Source/Scene/Cesium3DTileFeature.js
+++ b/Source/Scene/Cesium3DTileFeature.js
@@ -76,7 +76,7 @@ define([
         },
 
         /**
-         * Gets abd sets the highlight color multiplied with the feature's color.  When
+         * Gets and sets the highlight color multiplied with the feature's color.  When
          * this is white, the feature's color is not changed.
          * <p>
          * Only <code>red</code>, <code>green</code>, and <code>blue</code> components
@@ -142,7 +142,7 @@ define([
      * </p>
      *
      * @param {String} name The case-sensitive name of the property.
-     * @param {Any} The value of the property that will be copied.
+     * @param {Any} value The value of the property that will be copied.
      *
      * @example
      * var height = feature.getProperty('Height'); // e.g., the height of a building

--- a/Source/Scene/Cesium3DTileFeature.js
+++ b/Source/Scene/Cesium3DTileFeature.js
@@ -8,7 +8,38 @@ define([
     "use strict";
 
     /**
-     * DOC_TBA
+     * Provides access to a feature's properties stored in the 3D tile's batch table, as well
+     * as the ability to show/hide a feature and change its highlight color via
+     * {@link Cesium3DTileFeature#show} and {@link Cesium3DTileFeature#color}, respectively.
+     * <p>
+     * Modifications to a <code>Cesium3DTileFeature</code> object have the lifetime of the tile's
+     * content.  If the tile's content is unloaded, e.g., due to it going out of view and needing
+     * to free space in the cache for visible tiles, listen to the DOC_TBA event to save any
+     * modifications.
+     * </p>
+     * <p>
+     * Do not construct this directly.  Access it through {@link Cesium3DTileContentProvider#getFeature}
+     * or picking using {@link Scene#pick} and {@link Scene#pickPosition}.
+     * </p>
+     *
+     * @alias Cesium3DTileFeature
+     * @constructor
+     *
+     * @example
+     * // On mouse over, display all the properties for a feature in the console log.
+     * handler.setInputAction(function(movement) {
+     *     var feature = scene.pick(movement.endPosition);
+     *     if (Cesium.defined(feature) && (feature.primitive === tileset)) {
+     *         var properties = tileset.properties;
+     *         if (Cesium.defined(properties)) {
+     *             for (var name in properties) {
+     *                 if (properties.hasOwnProperty(name)) {
+     *                     console.log(name + ': ' + feature.getProperty(name));
+     *                 }
+     *             }
+     *         }
+     *     }
+     * }, Cesium.ScreenSpaceEventType.MOUSE_MOVE);
      */
     function Cesium3DTileFeature(tileset, batchTableResources, batchId) {
         this._batchTableResources = batchTableResources;
@@ -16,16 +47,24 @@ define([
         this._color = undefined;  // for calling getColor
 
         /**
-         * DOC_TBA
-         *
          * All objects returned by {@link Scene#pick} have a <code>primitive</code> property.
+         *
+         * @type {Cesium3DTileset}
+         *
+         * @private
          */
         this.primitive = tileset;
     }
 
     defineProperties(Cesium3DTileFeature.prototype, {
         /**
-         * DOC_TBA
+         * Gets and sets if the feature will be shown.
+         *
+         * @memberof Cesium3DTileFeature.prototype
+         *
+         * @type {Boolean}
+         *
+         * @default true
          */
         show : {
             get : function() {
@@ -37,7 +76,18 @@ define([
         },
 
         /**
-         * DOC_TBA
+         * Gets abd sets the highlight color multiplied with the feature's color.  When
+         * this is white, the feature's color is not changed.
+         * <p>
+         * Only <code>red</code>, <code>green</code>, and <code>blue</code> components
+         * are used; <code>alpha</code> is ignored.
+         * </p>
+         *
+         * @memberof Cesium3DTileFeature.prototype
+         *
+         * @type {Color}
+         *
+         * @default {@link Color.WHITE}
          */
         color : {
             get : function() {
@@ -53,14 +103,60 @@ define([
     });
 
     /**
-     * DOC_TBA
+     * Returns the value of the feature's property with the given name.
+     * <p>
+     * {@link Cesium3DTileFeature#show} and {@link Cesium3DTileFeature#color} are not equivalent to
+     * <code>'show'</code> and <code>'color'</code> properties; the former are runtime-specific properties
+     * that are not part of the feature's properties in the stored 3D Tileset.
+     * </p>
+     *
+     * @param {String} name The case-sensitive name of the property.
+     * @returns {Any} The value of the property or <code>undefined</code> if the property does not exist.
+     *
+     * @example
+     * // Display all the properties for a feature in the console log.
+     * var properties = tileset.properties;
+     * if (Cesium.defined(properties)) {
+     *     for (var name in properties) {
+     *         if (properties.hasOwnProperty(name)) {
+     *             console.log(name + ': ' + feature.getProperty(name));
+     *         }
+     *     }
+     * }
+     *
+     * @see {Cesium3DTileset#properties}
      */
     Cesium3DTileFeature.prototype.getProperty = function(name) {
         return this._batchTableResources.getProperty(this._batchId, name);
     };
 
     /**
-     * DOC_TBA
+     * Sets the value of the feature's property with the given name.
+     * <p>
+     * If a property with the given name doesn't exist, it is created.
+     * </p>
+     * <p>
+     * {@link Cesium3DTileFeature#show} and {@link Cesium3DTileFeature#color} are not equivalent to
+     * <code>'show'</code> and <code>'color'</code> properties; the former are runtime-specific properties
+     * that are not part of the feature's properties in the stored 3D Tileset.
+     * </p>
+     *
+     * @param {String} name The case-sensitive name of the property.
+     * @param {Any} The value of the property that will be copied.
+     *
+     * @example
+     * var height = feature.getProperty('Height'); // e.g., the height of a building
+     *
+     * @example
+     * var name = 'clicked';
+     * if (feature.getProperty(name)) {
+     *     console.log('already clicked');
+     * } else {
+     *     feature.setProperty(name, true);
+     *     console.log('first click');
+     * }
+     *
+     * @see {Cesium3DTileset#properties}
      */
     Cesium3DTileFeature.prototype.setProperty = function(name, value) {
         this._batchTableResources.setProperty(this._batchId, name, value);

--- a/Source/Scene/Cesium3DTileset.js
+++ b/Source/Scene/Cesium3DTileset.js
@@ -227,6 +227,14 @@ define([
         this.loadProgress = new Event();
         this._loadProgressEventsToRaise = [];
 
+        // TODO: since the show/color/setProperty values set with Cesium3DTileFeature only have the
+        // lifetime of the tile's content (e.g., if the content is unloaded, then reloaded later, the
+        // values wll be gown), we need to expose an event like loadProgress for when content is unloaded.
+        //
+        // We might also want to keep a separate data structure - or flag - so we know what property
+        // values changed (other than those derived from declarative styling, which can easily be
+        // reapplied).
+
         /**
          * This event fires once for each visible tile in a frame.  This can be used to style a tileset.
          * <p>
@@ -296,6 +304,9 @@ define([
          * @example
          * console.log('Maximum building height: ' + tileset.properties.height.maximum);
          * console.log('Minimum building height: ' + tileset.properties.height.minimum);
+         *
+         * {@see Cesium3DTileFeature#getProperty}
+         * {@see Cesium3DTileFeature#setProperty}
          */
         properties : {
             get : function() {

--- a/Source/Scene/Composite3DTileContentProvider.js
+++ b/Source/Scene/Composite3DTileContentProvider.js
@@ -31,15 +31,11 @@ define([
      * Represents the contents of a
      * {@link https://github.com/AnalyticalGraphicsInc/3d-tiles/blob/master/TileFormats/Composite/README.md|Composite}
      * tile in a {@link https://github.com/AnalyticalGraphicsInc/3d-tiles/blob/master/README.md|3D Tiles} tileset.
-     * <p>
-     * Use this to access the individual tiles (precisely, tile content) in the composite.
-     * </p>
-     * <p>
-     * Do not construct this directly.  Access it through {@link Cesium3DTile#content}.
-     * </p>
      *
      * @alias Composite3DTileContentProvider
      * @constructor
+     *
+     * @private
      */
     function Composite3DTileContentProvider(tileset, tile, url, factory) {
         this._url = url;
@@ -50,22 +46,16 @@ define([
 
         /**
          * Part of the {@link Cesium3DTileContentProvider} interface.
-         *
-         * @private
          */
         this.state = Cesium3DTileContentState.UNLOADED;
 
         /**
          * Part of the {@link Cesium3DTileContentProvider} interface.
-         *
-         * @private
          */
         this.processingPromise = when.defer();
 
         /**
          * Part of the {@link Cesium3DTileContentProvider} interface.
-         *
-         * @private
          */
         this.readyPromise = when.defer();
     }
@@ -74,11 +64,6 @@ define([
         /**
          * Part of the {@link Cesium3DTileContentProvider} interface.  <code>Composite3DTileContentProvider</code>
          * always returns <code>0</code>.  Instead call <code>featuresLength</code> for a tile in the composite.
-         *
-         * @memberof Composite3DTileContentProvider.prototype
-         *
-         * @type {Number}
-         * @readonly
          */
         featuresLength : {
             get : function() {
@@ -89,11 +74,6 @@ define([
         /**
          * Gets the array of {@link Cesium3DTileContentProvider} objects that represent the
          * content of the composite's inner tiles, which can also be composites.
-         *
-         * @memberof Composite3DTileContentProvider.prototype
-         *
-         * @type {Arrays}
-         * @readonly
          */
         innerContents : {
             get : function() {
@@ -105,9 +85,6 @@ define([
     /**
      * Part of the {@link Cesium3DTileContentProvider} interface.  <code>Composite3DTileContentProvider</code>
      * always returns <code>false</code>.  Instead call <code>hasProperty</code> for a tile in the composite.
-     *
-     * @param {String} name The case-sensitive name of the property.
-     * @returns {Boolean} <code>false</code>
      */
     Composite3DTileContentProvider.prototype.hasProperty = function(name) {
         return false;
@@ -116,9 +93,6 @@ define([
     /**
      * Part of the {@link Cesium3DTileContentProvider} interface.  <code>Composite3DTileContentProvider</code>
      * always returns <code>undefined</code>.  Instead call <code>getFeature</code> for a tile in the composite.
-     *
-     * @param {Number} batchId The batchId for the feature.
-     * @returns {Cesium3DTileFeature} <code>undefined</code>.
      */
     Composite3DTileContentProvider.prototype.getFeature = function(batchId) {
         return undefined;
@@ -128,8 +102,6 @@ define([
 
     /**
      * Part of the {@link Cesium3DTileContentProvider} interface.
-     *
-     * @private
      */
     Composite3DTileContentProvider.prototype.request = function() {
         var that = this;
@@ -158,8 +130,6 @@ define([
 
     /**
      * Part of the {@link Cesium3DTileContentProvider} interface.
-     *
-     * @private
      */
     Composite3DTileContentProvider.prototype.initialize = function(arrayBuffer, byteOffset) {
         byteOffset = defaultValue(byteOffset, 0);
@@ -225,7 +195,7 @@ define([
     };
 
     /**
-     * DOC_TBA
+     * Part of the {@link Cesium3DTileContentProvider} interface.
      */
     Composite3DTileContentProvider.prototype.applyDebugSettings = function(enabled, color) {
         var length = this._contentProviders.length;
@@ -236,8 +206,6 @@ define([
 
     /**
      * Part of the {@link Cesium3DTileContentProvider} interface.
-     *
-     * @private
      */
     Composite3DTileContentProvider.prototype.update = function(tiles3D, context, frameState, commandList) {
         var length = this._contentProviders.length;
@@ -248,8 +216,6 @@ define([
 
     /**
      * Part of the {@link Cesium3DTileContentProvider} interface.
-     *
-     * @private
      */
     Composite3DTileContentProvider.prototype.isDestroyed = function() {
         return false;
@@ -257,8 +223,6 @@ define([
 
     /**
      * Part of the {@link Cesium3DTileContentProvider} interface.
-     *
-     * @private
      */
     Composite3DTileContentProvider.prototype.destroy = function() {
         var length = this._contentProviders.length;

--- a/Source/Scene/Empty3DTileContentProvider.js
+++ b/Source/Scene/Empty3DTileContentProvider.js
@@ -1,9 +1,11 @@
 /*global define*/
 define([
+        '../Core/defineProperties',
         '../Core/destroyObject',
         '../ThirdParty/when',
         './Cesium3DTileContentState'
     ], function(
+        defineProperties,
         destroyObject,
         when,
         Cesium3DTileContentState) {
@@ -13,25 +15,20 @@ define([
      * Represents empty content for tiles in a
      * {@link https://github.com/AnalyticalGraphicsInc/3d-tiles/blob/master/README.md|3D Tiles} tileset that
      * do not have content, e.g., because they are used to optimize hierarchical culling.
-     * <p>
-     * Do not construct this directly.  Access it through {@link Cesium3DTile#content}.
-     * </p>
      *
      * @alias Empty3DTileContentProvider
      * @constructor
+     *
+     * @private
      */
     function Empty3DTileContentProvider() {
         /**
          * Part of the {@link Cesium3DTileContentProvider} interface.
-         *
-         * @private
          */
         this.state = undefined;
 
         /**
          * Part of the {@link Cesium3DTileContentProvider} interface.
-         *
-         * @private
          */
         this.processingPromise = when.defer();
 
@@ -41,8 +38,6 @@ define([
 
         /**
          * Part of the {@link Cesium3DTileContentProvider} interface.
-         *
-         * @private
          */
         this.readyPromise = when.defer();
 
@@ -51,12 +46,29 @@ define([
         this.readyPromise.resolve(this);
     }
 
+    defineProperties(Empty3DTileContentProvider.prototype, {
+        /**
+         * Part of the {@link Cesium3DTileContentProvider} interface.
+         */
+        featuresLength : {
+            get : function() {
+                return 0;
+            }
+        },
+
+        /**
+         * Part of the {@link Cesium3DTileContentProvider} interface.
+         */
+        innerContents : {
+            get : function() {
+                return undefined;
+            }
+        }
+    });
+
     /**
      * Part of the {@link Cesium3DTileContentProvider} interface.  <code>Empty3DTileContentProvider</code>
      * always returns <code>false</code> since a tile of this type does not have any features.
-     *
-     * @param {String} name The case-sensitive name of the property.
-     * @returns {Boolean} <code>false</code>
      */
     Empty3DTileContentProvider.prototype.hasProperty = function(name) {
         return false;
@@ -65,9 +77,6 @@ define([
     /**
      * Part of the {@link Cesium3DTileContentProvider} interface.  <code>Empty3DTileContentProvider</code>
      * always returns <code>undefined</code> since a tile of this type does not have any features.
-     *
-     * @param {Number} batchId The batchId for the feature.
-     * @returns {Cesium3DTileFeature} <code>undefined</code>.
      */
     Empty3DTileContentProvider.prototype.getFeature = function(batchId) {
         return undefined;
@@ -75,32 +84,24 @@ define([
 
     /**
      * Part of the {@link Cesium3DTileContentProvider} interface.
-     *
-     * @private
      */
     Empty3DTileContentProvider.prototype.request = function() {
     };
 
     /**
      * Part of the {@link Cesium3DTileContentProvider} interface.
-     *
-     * @private
      */
     Empty3DTileContentProvider.prototype.applyDebugSettings = function(enabled, color) {
     };
 
     /**
      * Part of the {@link Cesium3DTileContentProvider} interface.
-     *
-     * @private
      */
     Empty3DTileContentProvider.prototype.update = function(tiles3D, frameState) {
     };
 
     /**
      * Part of the {@link Cesium3DTileContentProvider} interface.
-     *
-     * @private
      */
     Empty3DTileContentProvider.prototype.isDestroyed = function() {
         return false;
@@ -108,8 +109,6 @@ define([
 
     /**
      * Part of the {@link Cesium3DTileContentProvider} interface.
-     *
-     * @private
      */
     Empty3DTileContentProvider.prototype.destroy = function() {
         return destroyObject(this);

--- a/Source/Scene/Instanced3DModel3DTileContentProvider.js
+++ b/Source/Scene/Instanced3DModel3DTileContentProvider.js
@@ -53,15 +53,11 @@ define([
      * Represents the contents of a
      * {@link https://github.com/AnalyticalGraphicsInc/3d-tiles/blob/master/TileFormats/Instanced3DModel/README.md|Instanced 3D Model}
      * tile in a {@link https://github.com/AnalyticalGraphicsInc/3d-tiles/blob/master/README.md|3D Tiles} tileset.
-     * <p>
-     * Use this to access and modify individual features (instances) in the tile.
-     * </p>
-     * <p>
-     * Do not construct this directly.  Access it through {@link Cesium3DTile#content}.
-     * </p>
      *
      * @alias Instanced3DModel3DTileContentProvider
      * @constructor
+     *
+     * @private
      */
     function Instanced3DModel3DTileContentProvider(tileset, tile, url) {
         this._modelInstanceCollection = undefined;
@@ -71,22 +67,16 @@ define([
 
         /**
          * Part of the {@link Cesium3DTileContentProvider} interface.
-         *
-         * @private
          */
         this.state = Cesium3DTileContentState.UNLOADED;
 
         /**
          * Part of the {@link Cesium3DTileContentProvider} interface.
-         *
-         * @private
          */
         this.processingPromise = when.defer();
 
         /**
          * Part of the {@link Cesium3DTileContentProvider} interface.
-         *
-         * @private
          */
         this.readyPromise = when.defer();
 
@@ -96,16 +86,20 @@ define([
 
     defineProperties(Instanced3DModel3DTileContentProvider.prototype, {
         /**
-         * Gets the number of features in the tile, i.e., the number of 3D models instances.
-         *
-         * @memberof Instanced3DModel3DTileContentProvider.prototype
-         *
-         * @type {Number}
-         * @readonly
+         * Part of the {@link Cesium3DTileContentProvider} interface.
          */
         featuresLength : {
             get : function() {
                 return this._modelInstanceCollection.length;
+            }
+        },
+
+        /**
+         * Part of the {@link Cesium3DTileContentProvider} interface.
+         */
+        innerContents : {
+            get : function() {
+                return undefined;
             }
         }
     });
@@ -123,25 +117,14 @@ define([
     }
 
     /**
-     * Determines if the tile's batch table has a property.  If it does, each feature in
-     * the tile will have the property.
-     *
-     * @param {String} name The case-sensitive name of the property.
-     * @returns {Boolean} <code>true</code> if the property exists; otherwise, <code>false</code>.
+     * Part of the {@link Cesium3DTileContentProvider} interface.
      */
     Instanced3DModel3DTileContentProvider.prototype.hasProperty = function(name) {
         return this._batchTableResources.hasProperty(name);
     };
 
     /**
-     * Returns the {@link Cesium3DTileFeature} object for the feature with the
-     * given <code>batchId</code>.  This object is used to get and modify the
-     * feature's properties.
-     *
-     * @param {Number} batchId The batchId for the feature.
-     * @returns {Cesium3DTileFeature} The corresponding {@link Cesium3DTileFeature} object.
-     *
-     * @exception {DeveloperError} batchId must be between zero and {@link Instanced3DModel3DTileContentProvider#featuresLength - 1}.
+     * Part of the {@link Cesium3DTileContentProvider} interface.
      */
     Instanced3DModel3DTileContentProvider.prototype.getFeature = function(batchId) {
         var featuresLength = this._modelInstanceCollection.length;
@@ -161,8 +144,6 @@ define([
 
     /**
      * Part of the {@link Cesium3DTileContentProvider} interface.
-     *
-     * @private
      */
     Instanced3DModel3DTileContentProvider.prototype.request = function() {
         var that = this;
@@ -191,8 +172,6 @@ define([
 
     /**
      * Part of the {@link Cesium3DTileContentProvider} interface.
-     *
-     * @private
      */
     Instanced3DModel3DTileContentProvider.prototype.initialize = function(arrayBuffer, byteOffset) {
         byteOffset = defaultValue(byteOffset, 0);
@@ -323,10 +302,7 @@ define([
     };
 
     /**
-     * DOC_TBA
      * Part of the {@link Cesium3DTileContentProvider} interface.
-     *
-     * @private
      */
     Instanced3DModel3DTileContentProvider.prototype.applyDebugSettings = function(enabled, color) {
         color = enabled ? color : Color.WHITE;
@@ -334,10 +310,7 @@ define([
     };
 
     /**
-     * DOC_TBA
      * Part of the {@link Cesium3DTileContentProvider} interface.
-     *
-     * @private
      */
     Instanced3DModel3DTileContentProvider.prototype.update = function(tiles3D, frameState) {
         // In the PROCESSING state we may be calling update() to move forward
@@ -349,8 +322,6 @@ define([
 
     /**
      * Part of the {@link Cesium3DTileContentProvider} interface.
-     *
-     * @private
      */
     Instanced3DModel3DTileContentProvider.prototype.isDestroyed = function() {
         return false;
@@ -358,8 +329,6 @@ define([
 
     /**
      * Part of the {@link Cesium3DTileContentProvider} interface.
-     *
-     * @private
      */
     Instanced3DModel3DTileContentProvider.prototype.destroy = function() {
         this._modelInstanceCollection = this._modelInstanceCollection && this._modelInstanceCollection.destroy();

--- a/Source/Scene/Points3DTileContentProvider.js
+++ b/Source/Scene/Points3DTileContentProvider.js
@@ -47,15 +47,11 @@ define([
      * Represents the contents of a
      * {@link https://github.com/AnalyticalGraphicsInc/3d-tiles/blob/master/TileFormats/Points/README.md|Points}
      * tile in a {@link https://github.com/AnalyticalGraphicsInc/3d-tiles/blob/master/README.md|3D Tiles} tileset.
-     * <p>
-     * Use this to access and modify individual features (points) in the tile.
-     * </p>
-     * <p>
-     * Do not construct this directly.  Access it through {@link Cesium3DTile#content}.
-     * </p>
      *
      * @alias Points3DTileContentProvider
      * @constructor
+     *
+     * @private
      */
     function Points3DTileContentProvider(tileset, tile, url) {
         this._primitive = undefined;
@@ -65,22 +61,16 @@ define([
 
         /**
          * Part of the {@link Cesium3DTileContentProvider} interface.
-         *
-         * @private
          */
         this.state = Cesium3DTileContentState.UNLOADED;
 
         /**
          * Part of the {@link Cesium3DTileContentProvider} interface.
-         *
-         * @private
          */
         this.processingPromise = when.defer();
 
         /**
          * Part of the {@link Cesium3DTileContentProvider} interface.
-         *
-         * @private
          */
         this.readyPromise = when.defer();
 
@@ -100,23 +90,26 @@ define([
     defineProperties(Points3DTileContentProvider.prototype, {
         /**
          * Part of the {@link Cesium3DTileContentProvider} interface.
-         *
-         * @private
          */
         featuresLength : {
             get : function() {
                 // TODO: implement batchTable for pnts tile format
                 return 0;
             }
+        },
+
+        /**
+         * Part of the {@link Cesium3DTileContentProvider} interface.
+         */
+        innerContents : {
+            get : function() {
+                return undefined;
+            }
         }
     });
 
     /**
-     * Determines if the tile's batch table has a property.  If it does, each feature in
-     * the tile will have the property.
-     *
-     * @param {String} name The case-sensitive name of the property.
-     * @returns {Boolean} <code>true</code> if the property exists; otherwise, <code>false</code>.
+     * Part of the {@link Cesium3DTileContentProvider} interface.
      */
     Points3DTileContentProvider.prototype.hasProperty = function(name) {
         // TODO: implement batchTable for pnts tile format
@@ -124,14 +117,7 @@ define([
     };
 
     /**
-     * Returns the {@link Cesium3DTileFeature} object for the feature with the
-     * given <code>batchId</code>.  This object is used to get and modify the
-     * feature's properties.
-     *
-     * @param {Number} batchId The batchId for the feature.
-     * @returns {Cesium3DTileFeature} The corresponding {@link Cesium3DTileFeature} object.
-     *
-     * @exception {DeveloperError} batchId must be between zero and {@link Points3DTileContentProvider#featuresLength - 1}.
+     * Part of the {@link Cesium3DTileContentProvider} interface.
      */
     Points3DTileContentProvider.prototype.getFeature = function(batchId) {
         // TODO: implement batchTable for pnts tile format
@@ -142,8 +128,6 @@ define([
 
     /**
      * Part of the {@link Cesium3DTileContentProvider} interface.
-     *
-     * @private
      */
     Points3DTileContentProvider.prototype.request = function() {
         var that = this;
@@ -172,8 +156,6 @@ define([
 
     /**
      * Part of the {@link Cesium3DTileContentProvider} interface.
-     *
-     * @private
      */
     Points3DTileContentProvider.prototype.initialize = function(arrayBuffer, byteOffset) {
         byteOffset = defaultValue(byteOffset, 0);
@@ -241,8 +223,6 @@ define([
 
     /**
      * Part of the {@link Cesium3DTileContentProvider} interface.
-     *
-     * @private
      */
     Points3DTileContentProvider.prototype.applyDebugSettings = function(enabled, color) {
         color = enabled ? color : Color.WHITE;
@@ -251,8 +231,6 @@ define([
 
     /**
      * Part of the {@link Cesium3DTileContentProvider} interface.
-     *
-     * @private
      */
     Points3DTileContentProvider.prototype.update = function(tiles3D, frameState) {
         // In the PROCESSING state we may be calling update() to move forward
@@ -263,8 +241,6 @@ define([
 
     /**
      * Part of the {@link Cesium3DTileContentProvider} interface.
-     *
-     * @private
      */
     Points3DTileContentProvider.prototype.isDestroyed = function() {
         return false;
@@ -272,8 +248,6 @@ define([
 
     /**
      * Part of the {@link Cesium3DTileContentProvider} interface.
-     *
-     * @private
      */
     Points3DTileContentProvider.prototype.destroy = function() {
         this._primitive = this._primitive && this._primitive.destroy();

--- a/Source/Scene/Tileset3DTileContentProvider.js
+++ b/Source/Scene/Tileset3DTileContentProvider.js
@@ -17,12 +17,11 @@ define([
      * Represents content for a tile in a
      * {@link https://github.com/AnalyticalGraphicsInc/3d-tiles/blob/master/README.md|3D Tiles} tileset whose
      * content points to another 3D Tiles tileset.
-     * <p>
-     * Do not construct this directly.  Access it through {@link Cesium3DTile#content}.
-     * </p>
      *
      * @alias Tileset3DTileContentProvider
      * @constructor
+     *
+     * @private
      */
     function Tileset3DTileContentProvider(tileset, tile, url) {
         this._tileset = tileset;
@@ -31,22 +30,16 @@ define([
 
         /**
          * Part of the {@link Cesium3DTileContentProvider} interface.
-         *
-         * @private
          */
         this.state = Cesium3DTileContentState.UNLOADED;
 
         /**
          * Part of the {@link Cesium3DTileContentProvider} interface.
-         *
-         * @private
          */
         this.processingPromise = when.defer();
 
         /**
          * Part of the {@link Cesium3DTileContentProvider} interface.
-         *
-         * @private
          */
         this.readyPromise = when.defer();
     }
@@ -54,12 +47,19 @@ define([
     defineProperties(Tileset3DTileContentProvider.prototype, {
         /**
          * Part of the {@link Cesium3DTileContentProvider} interface.
-         *
-         * @private
          */
         featuresLength : {
             get : function() {
                 return 0;
+            }
+        },
+
+        /**
+         * Part of the {@link Cesium3DTileContentProvider} interface.
+         */
+        innerContents : {
+            get : function() {
+                return undefined;
             }
         }
     });
@@ -67,9 +67,6 @@ define([
     /**
      * Part of the {@link Cesium3DTileContentProvider} interface.  <code>Tileset3DTileContentProvider</code>
      * always returns <code>false</code> since a tile of this type does not have any features.
-     *
-     * @param {String} name The case-sensitive name of the property.
-     * @returns {Boolean} <code>false</code>
      */
     Tileset3DTileContentProvider.prototype.hasProperty = function(name) {
         return false;
@@ -78,9 +75,6 @@ define([
     /**
      * Part of the {@link Cesium3DTileContentProvider} interface.  <code>Tileset3DTileContentProvider</code>
      * always returns <code>undefined</code> since a tile of this type does not have any features.
-     *
-     * @param {Number} batchId The batchId for the feature.
-     * @returns {Cesium3DTileFeature} <code>undefined</code>.
      */
     Tileset3DTileContentProvider.prototype.getFeature = function(batchId) {
         return undefined;
@@ -88,8 +82,6 @@ define([
 
     /**
      * Part of the {@link Cesium3DTileContentProvider} interface.
-     *
-     * @private
      */
     Tileset3DTileContentProvider.prototype.request = function() {
         var that = this;
@@ -112,24 +104,18 @@ define([
 
     /**
      * Part of the {@link Cesium3DTileContentProvider} interface.
-     *
-     * @private
      */
     Tileset3DTileContentProvider.prototype.applyDebugSettings = function(enabled, color) {
     };
 
     /**
      * Part of the {@link Cesium3DTileContentProvider} interface.
-     *
-     * @private
      */
     Tileset3DTileContentProvider.prototype.update = function(tiles3D, frameState) {
     };
 
     /**
      * Part of the {@link Cesium3DTileContentProvider} interface.
-     *
-     * @private
      */
     Tileset3DTileContentProvider.prototype.isDestroyed = function() {
         return false;
@@ -137,8 +123,6 @@ define([
 
     /**
      * Part of the {@link Cesium3DTileContentProvider} interface.
-     *
-     * @private
      */
     Tileset3DTileContentProvider.prototype.destroy = function() {
         return destroyObject(this);


### PR DESCRIPTION
* Added reference doc for `Cesium3DTileFeature`.
* Made `Cesium3DTileContentProvider` implementations private, so all public API interaction happens through the `Cesium3DTileContentProvider` interface.  We'll see if we can maintain this as we round out the interaction API.