### PR TITLE
Add version query string to tile requests

### DIFF
--- a/Source/Scene/Cesium3DTileset.js
+++ b/Source/Scene/Cesium3DTileset.js
@@ -412,6 +412,7 @@ define([
             }
 
             var baseUrl = joinUrls(tileset._baseUrl, '?v=' + tilesetJson.asset.version);
+            tileset._baseUrl = baseUrl;
             var rootTile = new Cesium3DTile(tileset, baseUrl, tilesetJson.root, parentTile);
 
             // If there is a parentTile, add the root of the currently loading tileset

--- a/Source/Scene/Cesium3DTileset.js
+++ b/Source/Scene/Cesium3DTileset.js
@@ -411,7 +411,7 @@ define([
                 throw new DeveloperError('The tileset must be 3D Tiles version 0.0.  See https://github.com/AnalyticalGraphicsInc/3d-tiles#spec-status');
             }
 
-            var baseUrl = tileset._baseUrl;
+            var baseUrl = joinUrls(tileset._baseUrl, '?v=' + tilesetJson.asset.version);
             var rootTile = new Cesium3DTile(tileset, baseUrl, tilesetJson.root, parentTile);
 
             // If there is a parentTile, add the root of the currently loading tileset

--- a/Specs/Scene/Cesium3DTilesetSpec.js
+++ b/Specs/Scene/Cesium3DTilesetSpec.js
@@ -203,6 +203,12 @@ defineSuite([
         });
     });
 
+    it('passes version in query string to tiles', function() {
+        return Cesium3DTilesTester.loadTileset(scene, tilesetUrl).then(function(tileset) {
+            expect(tileset._root.content._url).toEqual(tilesetUrl + 'parent.b3dm?v=0.0');
+        });
+    });
+
     it('loads tileset.json once request scheduler has available slots', function() {
         RequestScheduler.maximumRequests = 2;
         viewNothing();


### PR DESCRIPTION
This is a PR into 3d-tiles

It adds a version query parameter to the url for all tile requests to avoid caching issues when the version changes in the future.