### PR TITLE
Fix TMS tilemapresource.xml request

### DIFF
--- a/Source/Scene/createTileMapServiceImageryProvider.js
+++ b/Source/Scene/createTileMapServiceImageryProvider.js
@@ -271,7 +271,7 @@ define([
         }
 
         function requestMetadata() {
-            var resourceUrl = url + 'tilemapresource.xml';
+            var resourceUrl = joinUrls(url, 'tilemapresource.xml');
             var proxy = options.proxy;
             if (defined(proxy)) {
                 resourceUrl = proxy.getURL(resourceUrl);

--- a/Source/Scene/createTileMapServiceImageryProvider.js
+++ b/Source/Scene/createTileMapServiceImageryProvider.js
@@ -1,6 +1,5 @@
 /*global define*/
 define([
-        '../Core/appendForwardSlash',
         '../Core/Cartesian2',
         '../Core/Cartographic',
         '../Core/Credit',
@@ -19,7 +18,6 @@ define([
         '../ThirdParty/when',
         './UrlTemplateImageryProvider'
     ], function(
-        appendForwardSlash,
         Cartesian2,
         Cartographic,
         Credit,
@@ -98,7 +96,7 @@ define([
         }
         //>>includeEnd('debug');
 
-        var url = appendForwardSlash(options.url);
+        var url = options.url;
 
         var deferred = when.defer();
         var imageryProvider = new UrlTemplateImageryProvider(deferred.promise);

--- a/Specs/Scene/createTileMapServiceImageryProviderSpec.js
+++ b/Specs/Scene/createTileMapServiceImageryProviderSpec.js
@@ -254,6 +254,23 @@ defineSuite([
         });
     });
 
+    it('resource request takes a query string', function() {
+        /*jshint unused: false*/
+        var requestMetadata = when.defer();
+        spyOn(loadWithXhr, 'load').and.callFake(function(url, responseType, method, data, headers, deferred, overrideMimeType) {
+            requestMetadata.resolve(url);
+            deferred.reject(); //since the TMS server doesn't exist (and doesn't need too) we can just reject here.
+        });
+
+        var provider = createTileMapServiceImageryProvider({
+            url : 'server.invalid?query=1',
+        });
+
+        return requestMetadata.promise.then(function(url) {
+            expect(url.indexOf('?query=1')).not.toEqual(-1);
+        });
+    });
+
     it('routes tile requests through a proxy if one is specified', function() {
         var proxy = new DefaultProxy('/proxy/');
         var provider = createTileMapServiceImageryProvider({

--- a/Specs/Scene/createTileMapServiceImageryProviderSpec.js
+++ b/Specs/Scene/createTileMapServiceImageryProviderSpec.js
@@ -267,7 +267,7 @@ defineSuite([
         });
 
         return requestMetadata.promise.then(function(url) {
-            expect(url.indexOf('?query=1')).not.toEqual(-1);
+            expect(/\?query=1$/.test(url)).toEqual(true);
         });
     });
 


### PR DESCRIPTION
This fixes a bug that @mramato found regarding using query strings for a tile map service imagery provider.  I missed using `joinUrls` for the resource request.