### PR TITLE
Move home button logic to Camera.flyHome

### DIFF
--- a/Apps/Sandcastle/gallery/CZML.html
+++ b/Apps/Sandcastle/gallery/CZML.html
@@ -40,7 +40,7 @@ Sandcastle.addToolbarButton('Vehicle', function() {
 
 Sandcastle.reset = function() {
     viewer.dataSources.removeAll();
-    viewer.homeButton.viewModel.command();
+    viewer.camera.flyHome(0);
 };
 //Sandcastle_End
     Sandcastle.finishedLoading();

--- a/Apps/Sandcastle/gallery/KML.html
+++ b/Apps/Sandcastle/gallery/KML.html
@@ -33,13 +33,13 @@ var viewer = new Cesium.Viewer('cesiumContainer');
 Sandcastle.addToolbarMenu([{
     text : 'KML - Global Science Facilities',
     onselect : function() {
-        viewer.homeButton.viewModel.command();
+        viewer.camera.flyHome(0);
         viewer.dataSources.add(Cesium.KmlDataSource.load('../../SampleData/kml/facilities/facilities.kml'));
     }
 }, {
     text : 'KMZ with embedded data - GDP per capita',
     onselect : function() {
-        viewer.homeButton.viewModel.command();
+        viewer.camera.flyHome(0);
         viewer.dataSources.add(Cesium.KmlDataSource.load('../../SampleData/kml/gdpPerCapita2008.kmz'));
     }
 }, {

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@ Change Log
 * Deprecated
    *   
 * Fixed bug for causing `navigator is not defined` reference error in node
+* Added `Camera.flyHome` function for resetting the camera to the home view
 
 ### 1.18 - 2016-02-01
 * Breaking changes

--- a/Source/Scene/Camera.js
+++ b/Source/Scene/Camera.js
@@ -966,6 +966,7 @@ define([
             pitch : undefined,
             roll : undefined
         },
+        convert: undefined,
         endTransform : undefined
     };
 
@@ -977,6 +978,8 @@ define([
      * @param {Object} [options.orientation] An object that contains either direction and up properties or heading, pith and roll properties. By default, the direction will point
      * towards the center of the frame in 3D and in the negative z direction in Columbus view or 2D. The up direction will point towards local north in 3D and in the positive
      * y direction in Columbus view or 2D.
+     * @param {Boolean} [options.convert=true] When <code>true</code>, the destination is converted to the correct coordinate system for each scene mode. When <code>false</code>, the destination is expected
+     * to be in the correct coordinate system.
      * @param {Matrix4} [options.endTransform] Transform matrix representing the reference frame of the camera.
      *
      * @example
@@ -1032,7 +1035,7 @@ define([
             this._setTransform(options.endTransform);
         }
 
-        var convert = true;
+        var convert = defaultValue(options.convert, true);
         var destination = defaultValue(options.destination, Cartesian3.clone(this.positionWC, scratchSetViewCartesian));
         if (defined(destination) && defined(destination.west)) {
             destination = this.getRectangleCameraCoordinates(destination, scratchSetViewCartesian);
@@ -1053,6 +1056,58 @@ define([
             setView2D(this, destination, heading, convert);
         } else {
             setViewCV(this, destination, heading, pitch, roll, convert);
+        }
+    };
+
+    var pitchScratch = new Cartesian3();
+    /**
+     * Fly the camera to the home view.  Use {@link Camera#.DEFAULT_VIEW_RECTANGLE} to set
+     * the default view fro the 3D scene.  The home view for 2D and columbus view shows the
+     * entire map.
+     *
+     * @param {Number} [duration] The number of seconds to complete the camera flight to home. See {@link Camera#flyTo}
+     */
+    Camera.prototype.flyHome = function(duration) {
+        var mode = this._mode;
+
+        if (mode === SceneMode.MORPHING) {
+            this._scene.completeMorph();
+        }
+
+        if (mode === SceneMode.SCENE2D) {
+            this.flyTo({
+                destination : Rectangle.MAX_VALUE,
+                duration : duration,
+                endTransform : Matrix4.IDENTITY
+            });
+        } else if (mode === SceneMode.SCENE3D) {
+            var destination = this.getRectangleCameraCoordinates(Camera.DEFAULT_VIEW_RECTANGLE);
+
+            var mag = Cartesian3.magnitude(destination);
+            mag += mag * Camera.DEFAULT_VIEW_FACTOR;
+            Cartesian3.normalize(destination, destination);
+            Cartesian3.multiplyByScalar(destination, mag, destination);
+
+            this.flyTo({
+                destination : destination,
+                duration : duration,
+                endTransform : Matrix4.IDENTITY
+            });
+        } else if (mode === SceneMode.COLUMBUS_VIEW) {
+            var maxRadii = this._projection.ellipsoid.maximumRadius;
+            var position = new Cartesian3(0.0, -1.0, 1.0);
+            position = Cartesian3.multiplyByScalar(Cartesian3.normalize(position, position), 5.0 * maxRadii, position);
+            this.flyTo({
+                destination : position,
+                duration : duration,
+                orientation : {
+                    heading : 0.0,
+                    pitch : -Math.acos(Cartesian3.normalize(position, pitchScratch).z),
+                    roll : 0.0
+                },
+                endTransform : Matrix4.IDENTITY,
+                convert : false
+            });
         }
     };
 
@@ -2483,6 +2538,7 @@ define([
             setViewOptions.orientation.heading = orientation.heading;
             setViewOptions.orientation.pitch = orientation.pitch;
             setViewOptions.orientation.roll = orientation.roll;
+            setViewOptions.convert = options.convert;
             setViewOptions.endTransform = options.endTransform;
             this.setView(setViewOptions);
             if (typeof options.complete === 'function'){

--- a/Source/Scene/Camera.js
+++ b/Source/Scene/Camera.js
@@ -978,8 +978,6 @@ define([
      * @param {Object} [options.orientation] An object that contains either direction and up properties or heading, pith and roll properties. By default, the direction will point
      * towards the center of the frame in 3D and in the negative z direction in Columbus view or 2D. The up direction will point towards local north in 3D and in the positive
      * y direction in Columbus view or 2D.
-     * @param {Boolean} [options.convert=true] When <code>true</code>, the destination is converted to the correct coordinate system for each scene mode. When <code>false</code>, the destination is expected
-     * to be in the correct coordinate system.
      * @param {Matrix4} [options.endTransform] Transform matrix representing the reference frame of the camera.
      *
      * @example
@@ -1062,7 +1060,7 @@ define([
     var pitchScratch = new Cartesian3();
     /**
      * Fly the camera to the home view.  Use {@link Camera#.DEFAULT_VIEW_RECTANGLE} to set
-     * the default view fro the 3D scene.  The home view for 2D and columbus view shows the
+     * the default view for the 3D scene.  The home view for 2D and columbus view shows the
      * entire map.
      *
      * @param {Number} [duration] The number of seconds to complete the camera flight to home. See {@link Camera#flyTo}
@@ -2476,8 +2474,6 @@ define([
      * @param {Camera~FlightCompleteCallback} [options.complete] The function to execute when the flight is complete.
      * @param {Camera~FlightCancelledCallback} [options.cancel] The function to execute if the flight is cancelled.
      * @param {Matrix4} [options.endTransform] Transform matrix representing the reference frame the camera will be in when the flight is completed.
-     * @param {Boolean} [options.convert=true] When <code>true</code>, the destination is converted to the correct coordinate system for each scene mode. When <code>false</code>, the destination is expected
-     *                  to be in the correct coordinate system.
      * @param {Number} [options.maximumHeight] The maximum height at the peak of the flight.
      * @param {EasingFunction|EasingFunction~Callback} [options.easingFunction] Controls how the time is interpolated over the duration of the flight.
      *

--- a/Source/Widgets/HomeButton/HomeButtonViewModel.js
+++ b/Source/Widgets/HomeButton/HomeButtonViewModel.js
@@ -25,51 +25,6 @@ define([
         createCommand) {
     "use strict";
 
-    var pitchScratch = new Cartesian3();
-    function viewHome(scene, duration) {
-        var mode = scene.mode;
-
-        if (defined(scene) && mode === SceneMode.MORPHING) {
-            scene.completeMorph();
-        }
-
-        if (mode === SceneMode.SCENE2D) {
-            scene.camera.flyTo({
-                destination : Rectangle.MAX_VALUE,
-                duration : duration,
-                endTransform : Matrix4.IDENTITY
-            });
-        } else if (mode === SceneMode.SCENE3D) {
-            var destination = scene.camera.getRectangleCameraCoordinates(Camera.DEFAULT_VIEW_RECTANGLE);
-
-            var mag = Cartesian3.magnitude(destination);
-            mag += mag * Camera.DEFAULT_VIEW_FACTOR;
-            Cartesian3.normalize(destination, destination);
-            Cartesian3.multiplyByScalar(destination, mag, destination);
-
-            scene.camera.flyTo({
-                destination : destination,
-                duration : duration,
-                endTransform : Matrix4.IDENTITY
-            });
-        } else if (mode === SceneMode.COLUMBUS_VIEW) {
-            var maxRadii = scene.globe.ellipsoid.maximumRadius;
-            var position = new Cartesian3(0.0, -1.0, 1.0);
-            position = Cartesian3.multiplyByScalar(Cartesian3.normalize(position, position), 5.0 * maxRadii, position);
-            scene.camera.flyTo({
-                destination : position,
-                duration : duration,
-                orientation : {
-                    heading : 0.0,
-                    pitch : -Math.acos(Cartesian3.normalize(position, pitchScratch).z),
-                    roll : 0.0
-                },
-                endTransform : Matrix4.IDENTITY,
-                convert : false
-            });
-        }
-    }
-
     /**
      * The view model for {@link HomeButton}.
      * @alias HomeButtonViewModel
@@ -90,7 +45,7 @@ define([
 
         var that = this;
         this._command = createCommand(function() {
-            viewHome(that._scene, that._duration);
+            that._scene.camera.flyHome(that._duration);
         });
 
         /**

--- a/Specs/Scene/CameraSpec.js
+++ b/Specs/Scene/CameraSpec.js
@@ -2185,6 +2185,46 @@ defineSuite([
         expect(camera.up).toEqualEpsilon(up, CesiumMath.EPSILON6);
     });
 
+    it('flyHome works in 3D', function() {
+        camera._mode = SceneMode.SCENE3D;
+
+        var destination = Cartesian3.fromDegrees(30, 20, 1000);
+        camera.setView({
+            destination: destination
+        });
+        camera.flyHome(0);
+        expect(camera.position).toEqualEpsilon(new Cartesian3(2515865.110478756, -19109892.759980734, 13550929.353715947), CesiumMath.EPSILON8);
+        expect(camera.direction).toEqualEpsilon(new Cartesian3(-0.10654051334260287, 0.8092555423939248, -0.5777149696185906), CesiumMath.EPSILON8);
+        expect(camera.up).toEqualEpsilon(new Cartesian3(-0.07540693517283716, 0.5727725379670786, 0.8162385765685121), CesiumMath.EPSILON8);
+    });
+
+    it ('flyHome works in 2D', function() {
+        camera._mode = SceneMode.SCENE2D;
+
+        var destination = Cartesian3.fromDegrees(30, 20, 1000);
+        camera.setView({
+            destination: destination
+        });
+        camera.flyHome(0);
+        expect(camera.position).toEqualEpsilon(Cartesian3.UNIT_Z, CesiumMath.EPSILON8);
+        expect(camera.direction).toEqualEpsilon(new Cartesian3(0, 0, -1), CesiumMath.EPSILON8);
+        expect(camera.up).toEqualEpsilon(Cartesian3.UNIT_Y, CesiumMath.EPSILON8);
+    });
+
+    it('flyHome works in CV', function() {
+        var sq2Over2 = Math.sqrt(2)*0.5;
+        camera._mode = SceneMode.COLUMBUS_VIEW;
+
+        var destination = Cartesian3.fromDegrees(30, 20, 1000);
+        camera.setView({
+            destination: destination
+        });
+        camera.flyHome(0);
+        expect(camera.position).toEqualEpsilon(new Cartesian3(0, -22550119.620184112, 22550119.62018411), CesiumMath.EPSILON8);
+        expect(camera.direction).toEqualEpsilon(new Cartesian3(0, sq2Over2, -sq2Over2), CesiumMath.EPSILON8);
+        expect(camera.up).toEqualEpsilon(new Cartesian3(0, sq2Over2, sq2Over2), CesiumMath.EPSILON8);
+    });
+
     it('viewBoundingSphere', function() {
         scene.mode = SceneMode.SCENE3D;
 


### PR DESCRIPTION
Resolves #1798

I moved the code from the HomeButtonViewModel to `Camera.flyHome` to make resetting the camera view more easily accessible.

I also fixed a bug when using `Camera.flyTo` with a `duration = 0` and `convert = false`.  The `convert` parameter wasn't being sent to `Camera.setView`.