### PR TITLE
NoSleep library doesn't check if navigator is undefined

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,13 @@
 Change Log
 ==========
 
+### 1.19 - 2016-03-01
+* Breaking changes
+   * 
+* Deprecated
+   *   
+* Fixed bug for causing `navigator is not defined` reference error in node
+
 ### 1.18 - 2016-02-01
 * Breaking changes
     * Removed support for `CESIUM_binary_glTF`. Use `KHR_binary_glTF` instead, which is the default for the online [COLLADA-to-glTF converter](http://cesiumjs.org/convertmodel.html).

--- a/Source/ThirdParty/NoSleep.js
+++ b/Source/ThirdParty/NoSleep.js
@@ -10,8 +10,8 @@ define(function() {
 
     // UA matching
     var ua = {
-        Android: /Android/ig.test(navigator.userAgent),
-        iOS: /AppleWebKit/.test(navigator.userAgent) && /Mobile\/\w+/.test(navigator.userAgent)
+        Android: typeof navigator !== 'undefined' && /Android/ig.test(navigator.userAgent),
+        iOS: typeof navigator !== 'undefined' && /AppleWebKit/.test(navigator.userAgent) && /Mobile\/\w+/.test(navigator.userAgent)
     };
 
     var media = {


### PR DESCRIPTION
This causes a `ReferenceError` when using cesium in node since navigator isn't defined

I'm going to submit a fix to the NoSleep repo too, to see if he'll take it.