### PR TITLE
readyPromise to contentReadyPromise

### DIFF
--- a/Source/Scene/Cesium3DTile.js
+++ b/Source/Scene/Cesium3DTile.js
@@ -174,7 +174,7 @@ define([
          *
          * @private
          */
-        this.readyPromise = when.defer();
+        this.contentReadyPromise = when.defer();
 
         var content;
         var hasContent;
@@ -243,12 +243,12 @@ define([
                 --that.parent.numberOfChildrenWithoutContent;
             }
 
-            that.readyPromise.resolve(that);
+            that.contentReadyPromise.resolve(that);
         }).otherwise(function(error) {
             // In this case, that.parent.numberOfChildrenWithoutContent will never reach zero
             // and therefore that.parent will never refine.  If this becomes an issue, failed
             // requests can be reissued.
-            that.readyPromise.reject(error);
+            that.contentReadyPromise.reject(error);
         });
 
         // Members that are updated every frame for tree traversal and rendering optimizations:

--- a/Source/Scene/Cesium3DTileset.js
+++ b/Source/Scene/Cesium3DTileset.js
@@ -549,7 +549,7 @@ define([
 
             var removeFunction = removeFromProcessingQueue(tiles3D, tile);
             when(tile.contentReadyToProcessPromise).then(addToProcessingQueue(tiles3D, tile)).otherwise(removeFunction);
-            when(tile.readyPromise).then(removeFunction).otherwise(removeFunction);
+            when(tile.contentReadyPromise).then(removeFunction).otherwise(removeFunction);
         }
     }
 

--- a/Specs/Scene/Cesium3DTilesetSpec.js
+++ b/Specs/Scene/Cesium3DTilesetSpec.js
@@ -612,7 +612,7 @@ defineSuite([
             // Set view so that root's content is requested
             viewRootOnly();
             scene.renderForSpecs();
-            return root.readyPromise.then(function() {
+            return root.contentReadyPromise.then(function() {
                 // Root has one child now, the root of the external tileset
                 expect(root.children.length).toEqual(1);
 
@@ -830,7 +830,7 @@ defineSuite([
             expect(stats.numberOfPendingRequests).toEqual(1);
             scene.primitives.remove(tileset);
 
-            return root.readyPromise.then(function(root) {
+            return root.contentReadyPromise.then(function(root) {
                 fail('should not resolve');
             }).otherwise(function(error) {
                 // Expect the root to not have added any children from the external tileset.json
@@ -850,7 +850,7 @@ defineSuite([
             scene.renderForSpecs(); // Request root
             scene.primitives.remove(tileset);
 
-            return root.readyPromise.then(function(root) {
+            return root.contentReadyPromise.then(function(root) {
                 fail('should not resolve');
             }).otherwise(function(error) {
                 expect(content.state).toEqual(Cesium3DTileContentState.FAILED);


### PR DESCRIPTION
Renamed `Cesium3DTile#readyPromise` to `Cesium3DTile#contentReadyPromise`.

For #3241 