### PR TITLE
Changed isReady to contentReady property

### DIFF
--- a/Source/Scene/Cesium3DTile.js
+++ b/Source/Scene/Cesium3DTile.js
@@ -342,20 +342,23 @@ define([
             get : function() {
                 return this._requestServer;
             }
+        },
+
+        /**
+         * Determines if the tile is ready to render. <code>true</code> if the tile
+         * is ready to render; otherwise, <code>false</code>.
+         *
+         * @memberof Cesium3DTile.prototype
+         *
+         * @type {boolean}
+         * @readonly
+         */
+        contentReady : {
+            get : function() {
+                return this._content.state === Cesium3DTileContentState.READY;
+            }
         }
     });
-
-    /**
-     * Determines if the tile is ready to render.
-     *
-     * @returns {Boolean} <code>true</code> if the tile is ready to render; otherwise, <code>false</code>.
-     *
-     * @private
-     */
-    Cesium3DTile.prototype.isReady = function() {
-        return this._content.state === Cesium3DTileContentState.READY;
-    };
-
 
     /**
      * Determines if the tile's content has not be requested.

--- a/Source/Scene/Cesium3DTileset.js
+++ b/Source/Scene/Cesium3DTileset.js
@@ -556,7 +556,7 @@ define([
     function selectTile(selectedTiles, tile, fullyVisible, frameState) {
         // There may also be a tight box around just the tile's contents, e.g., for a city, we may be
         // zoomed into a neighborhood and can cull the skyscrapers in the root node.
-        if (tile.isReady() && (fullyVisible || (tile.contentsVisibility(frameState.cullingVolume) !== Intersect.OUTSIDE))) {
+        if (tile.contentReady && (fullyVisible || (tile.contentsVisibility(frameState.cullingVolume) !== Intersect.OUTSIDE))) {
             selectedTiles.push(tile);
             tile.selected = true;
         }
@@ -624,7 +624,7 @@ define([
                 // If tile has tileset content, skip it and process its child instead (the tileset root)
                 // No need to check visibility or sse of the child because its bounding volume
                 // and geometric error are equal to its parent.
-                if (t.isReady()) {
+                if (t.contentReady) {
                     child = t.children[0];
                     child.parentPlaneMask = t.parentPlaneMask;
                     child.distanceToCamera = t.distanceToCamera;


### PR DESCRIPTION
For #3241 

Replaced `Cesium3DTile#isReady` function with a readonly `Cesium3DTile.contentReady` property and added documentation.

Do I need to mention any changes in `CHANGES.md`?