### PR TITLE
Fire loadProgress once per frame instead of once per tile

### DIFF
--- a/Apps/Sandcastle/gallery/3D Tiles.html
+++ b/Apps/Sandcastle/gallery/3D Tiles.html
@@ -75,6 +75,14 @@ function loadTileset(url) {
                 }
             }
         }
+        tileset.loadProgress.addEventListener(function(numberOfPendingRequests, numberProcessing) {
+            if ((numberOfPendingRequests === 0) && (numberProcessing === 0)) {
+                //console.log('Stopped loading');
+                return;
+            }
+
+            console.log('Loading: requests: ' + numberOfPendingRequests + ', processing: ' + numberProcessing);
+        });
     });
 }
 
@@ -261,19 +269,6 @@ handler.setInputAction(function(movement) {
         current.building.show = false;
     }
 }, Cesium.ScreenSpaceEventType.MIDDLE_DOUBLE_CLICK);
-
-///////////////////////////////////////////////////////////////////////////////
-
-/*
-tileset.loadProgress.addEventListener(function(numberOfPendingRequests, numberProcessing) {
-    if ((numberOfPendingRequests === 0) && (numberProcessing === 0)) {
-        console.log('Stopped loading');
-        return;
-    }
-
-    console.log('Loading: requests: ' + numberOfPendingRequests + ', processing: ' + numberProcessing);
-});
-*/
 
 ///////////////////////////////////////////////////////////////////////////////
 

--- a/Source/Scene/Cesium3DTileset.js
+++ b/Source/Scene/Cesium3DTileset.js
@@ -875,12 +875,11 @@ define([
         var lastNumberOfPendingRequest = tileset._statistics.lastNumberOfPendingRequests;
         var lastNumberProcessing = tileset._statistics.lastNumberProcessing;
 
-        if ((numberOfPendingRequests === lastNumberOfPendingRequest) && (numberProcessing === lastNumberProcessing)) {
-            return;
+        if ((numberOfPendingRequests !== lastNumberOfPendingRequest) || (numberProcessing !== lastNumberProcessing)) {
+            frameState.afterRender.push(function() {
+                tileset.loadProgress.raiseEvent(numberOfPendingRequests, numberProcessing);
+            });
         }
-        frameState.afterRender.push(function() {
-            tileset.loadProgress.raiseEvent(numberOfPendingRequests, numberProcessing);
-        });
     }
 
     ///////////////////////////////////////////////////////////////////////////

--- a/Source/Scene/Cesium3DTileset.js
+++ b/Source/Scene/Cesium3DTileset.js
@@ -825,12 +825,6 @@ define([
             stats.lastNumberOfPendingRequests !== stats.numberOfPendingRequests ||
             stats.lastNumberProcessing !== stats.numberProcessing)) {
 
-            stats.lastVisited = stats.visited;
-            stats.lastNumberOfCommands = stats.numberOfCommands;
-            stats.lastSelected = tileset._selectedTiles.length;
-            stats.lastNumberOfPendingRequests = stats.numberOfPendingRequests;
-            stats.lastNumberProcessing = stats.numberProcessing;
-
             // Since the pick pass uses a smaller frustum around the pixel of interest,
             // the stats will be different than the normal render pass.
             var s = isPick ? '[Pick ]: ' : '[Color]: ';


### PR DESCRIPTION
For #3241 

As you see I've commented out `console.log('Stopped loading');` for debugging reasons. Anyhow when I run the `3DTiles` demo I get output when a new type of tile is loaded in. Did I approach this problem correctly or should I rethink?