### PR TITLE
Revert gulp-zip to 3.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "gulp-jshint": "2.0.0",
     "gulp-rename": "1.2.2",
     "gulp-replace": "0.5.4",
-    "gulp-zip": "3.1.0",
+    "gulp-zip": "3.0.2",
     "jsdoc": "3.4.0",
     "jshint": "2.9.1",
     "jshint-stylish": "2.1.0",


### PR DESCRIPTION
To fix a bug introduced in gulp-zip 3.1.0 that creates invalid folder permissions for zip files archived on Windows and extracted on Linux