### PR TITLE
Fix travis timeout

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,5 @@ node_js:
   - "0.12"
 sudo: false
 script:
-  - travis_wait npm run jsHint && npm run release
+  - npm run jsHint
+  - npm run makeZipFile

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -854,6 +854,7 @@ function removeExtension(p) {
 }
 
 function requirejsOptimize(config) {
+    config.logLevel = 1;
     return new Promise(function(resolve, reject) {
         requirejs.optimize(config, resolve, reject);
     });


### PR DESCRIPTION
Apparently #3430 is still an issue and the travis_wait command added as part of #3432 does not work as advertised. To address the issue once and for all, I turned up the loglevel on requirejs so that it always outputs progress to the build log (this was actually requested by @shunter and a few others after the logging went away when we moved to gulp anyway).

Long story short we should finally stop seeing travis timeouts.

I also make jsHint run as a separate step and instead of `release` we run `makeZipFile` to be sure the entire build process works.  If `makeZipFile` were to error, the previous configuration wouldn't have
caught it.