### PR TITLE
Remove remaining 'new TileMapServiceImageryProvider'

### DIFF
--- a/Specs/Scene/TileMapServiceImageryProviderSpec.js
+++ b/Specs/Scene/TileMapServiceImageryProviderSpec.js
@@ -1,6 +1,6 @@
 /*global defineSuite*/
 defineSuite([
-        'Scene/TileMapServiceImageryProvider',
+        'Scene/createTileMapServiceImageryProvider',
         'Core/Cartesian2',
         'Core/Cartographic',
         'Core/DefaultProxy',
@@ -20,7 +20,7 @@ defineSuite([
         'Specs/pollToPromise',
         'ThirdParty/when'
     ], function(
-        TileMapServiceImageryProvider,
+        createTileMapServiceImageryProvider,
         Cartesian2,
         Cartographic,
         DefaultProxy,
@@ -47,11 +47,11 @@ defineSuite([
     });
 
     it('conforms to ImageryProvider interface', function() {
-        expect(TileMapServiceImageryProvider).toConformToInterface(ImageryProvider);
+        expect(createTileMapServiceImageryProvider).toConformToInterface(ImageryProvider);
     });
 
     it('resolves readyPromise', function() {
-        var provider = new TileMapServiceImageryProvider({
+        var provider = createTileMapServiceImageryProvider({
             url : 'made/up/tms/server/'
         });
 
@@ -85,7 +85,7 @@ defineSuite([
             }, 1);
         };
 
-        var provider = new TileMapServiceImageryProvider({
+        var provider = createTileMapServiceImageryProvider({
             url : 'made/up/tms/server'
         });
 
@@ -99,13 +99,13 @@ defineSuite([
 
     it('requires the url to be specified', function() {
         function createWithoutUrl() {
-            return new TileMapServiceImageryProvider({});
+            return createTileMapServiceImageryProvider({});
         }
         expect(createWithoutUrl).toThrowDeveloperError();
     });
 
     it('returns valid value for hasAlphaChannel', function() {
-        var provider = new TileMapServiceImageryProvider({
+        var provider = createTileMapServiceImageryProvider({
             url : 'made/up/tms/server/'
         });
 
@@ -117,7 +117,7 @@ defineSuite([
     });
 
     it('supports a slash at the end of the URL', function() {
-        var provider = new TileMapServiceImageryProvider({
+        var provider = createTileMapServiceImageryProvider({
             url : 'made/up/tms/server/'
         });
 
@@ -139,7 +139,7 @@ defineSuite([
     });
 
     it('supports no slash at the endof the URL', function() {
-        var provider = new TileMapServiceImageryProvider({
+        var provider = createTileMapServiceImageryProvider({
             url : 'made/up/tms/server'
         });
 
@@ -161,7 +161,7 @@ defineSuite([
     });
 
     it('supports a query string at the end of the URL', function() {
-        var provider = new TileMapServiceImageryProvider({
+        var provider = createTileMapServiceImageryProvider({
             url : 'made/up/tms/server/?a=some&b=query'
         });
 
@@ -183,7 +183,7 @@ defineSuite([
     });
 
     it('requestImage returns a promise for an image and loads it for cross-origin use', function() {
-        var provider = new TileMapServiceImageryProvider({
+        var provider = createTileMapServiceImageryProvider({
             url : 'made/up/tms/server/'
         });
 
@@ -211,7 +211,7 @@ defineSuite([
     });
 
     it('when no credit is supplied, the provider has no logo', function() {
-        var provider = new TileMapServiceImageryProvider({
+        var provider = createTileMapServiceImageryProvider({
             url : 'made/up/tms/server'
         });
         return pollToPromise(function() {
@@ -222,7 +222,7 @@ defineSuite([
     });
 
     it('turns the supplied credit into a logo', function() {
-        var providerWithCredit = new TileMapServiceImageryProvider({
+        var providerWithCredit = createTileMapServiceImageryProvider({
             url : 'made/up/gms/server',
             credit : 'Thanks to our awesome made up source of this imagery!'
         });
@@ -242,7 +242,7 @@ defineSuite([
             deferred.reject(); //since the TMS server doesn't exist (and doesn't need too) we can just reject here.
         });
 
-        var provider = new TileMapServiceImageryProvider({
+        var provider = createTileMapServiceImageryProvider({
             url : 'server.invalid',
             proxy : proxy
         });
@@ -254,7 +254,7 @@ defineSuite([
 
     it('routes tile requests through a proxy if one is specified', function() {
         var proxy = new DefaultProxy('/proxy/');
-        var provider = new TileMapServiceImageryProvider({
+        var provider = createTileMapServiceImageryProvider({
             url : 'made/up/tms/server',
             proxy : proxy
         });
@@ -280,7 +280,7 @@ defineSuite([
 
     it('rectangle passed to constructor does not affect tile numbering', function() {
         var rectangle = new Rectangle(0.1, 0.2, 0.3, 0.4);
-        var provider = new TileMapServiceImageryProvider({
+        var provider = createTileMapServiceImageryProvider({
             url : 'made/up/tms/server',
             rectangle : rectangle
         });
@@ -310,7 +310,7 @@ defineSuite([
     });
 
     it('uses maximumLevel passed to constructor', function() {
-        var provider = new TileMapServiceImageryProvider({
+        var provider = createTileMapServiceImageryProvider({
             url : 'made/up/tms/server',
             maximumLevel : 5
         });
@@ -323,7 +323,7 @@ defineSuite([
     });
 
     it('raises error event when image cannot be loaded', function() {
-        var provider = new TileMapServiceImageryProvider({
+        var provider = createTileMapServiceImageryProvider({
             url : 'made/up/tms/server'
         });
 
@@ -386,7 +386,7 @@ defineSuite([
             deferred.resolve(xml);
         };
 
-        var provider = new TileMapServiceImageryProvider({
+        var provider = createTileMapServiceImageryProvider({
             url : 'made/up/tms/server'
         });
 
@@ -424,7 +424,7 @@ defineSuite([
             deferred.resolve(xml);
         };
 
-        var provider = new TileMapServiceImageryProvider({
+        var provider = createTileMapServiceImageryProvider({
             url : 'made/up/tms/server'
         });
 
@@ -456,7 +456,7 @@ defineSuite([
             deferred.resolve(xml);
         };
 
-        var provider = new TileMapServiceImageryProvider({
+        var provider = createTileMapServiceImageryProvider({
             url : 'made/up/tms/server'
         });
 
@@ -488,7 +488,7 @@ defineSuite([
             deferred.resolve(xml);
         };
 
-        var provider = new TileMapServiceImageryProvider({
+        var provider = createTileMapServiceImageryProvider({
             url : 'made/up/tms/server'
         });
 
@@ -520,7 +520,7 @@ defineSuite([
             deferred.resolve(xml);
         };
 
-        var provider = new TileMapServiceImageryProvider({
+        var provider = createTileMapServiceImageryProvider({
             url : 'made/up/tms/server'
         });
 
@@ -561,7 +561,7 @@ defineSuite([
             deferred.resolve(xml);
         };
 
-        var provider = new TileMapServiceImageryProvider({
+        var provider = createTileMapServiceImageryProvider({
             url : 'made/up/tms/server'
         });
 
@@ -601,7 +601,7 @@ defineSuite([
             deferred.resolve(xml);
         };
 
-        var provider = new TileMapServiceImageryProvider({
+        var provider = createTileMapServiceImageryProvider({
             url : 'made/up/tms/server'
         });
 
@@ -641,7 +641,7 @@ defineSuite([
             deferred.resolve(xml);
         };
 
-        var provider = new TileMapServiceImageryProvider({
+        var provider = createTileMapServiceImageryProvider({
             url : 'made/up/tms/server'
         });
 
@@ -685,7 +685,7 @@ defineSuite([
             }, 1);
         };
 
-        var provider = new TileMapServiceImageryProvider({
+        var provider = createTileMapServiceImageryProvider({
             url : 'made/up/tms/server'
         });
 


### PR DESCRIPTION
For issue #3238.
@pjcozzi I'm getting 3 errors after running the tests:
```
Error: Expected function 'getTileCredits' to exist on createTileMapServiceImageryProvider because it should implement interface ImageryProvider.
    at stack (http://localhost:8080/ThirdParty/jasmine-2.2.0/jasmine.js:1475:17)
    at buildExpectationResult (http://localhost:8080/ThirdParty/jasmine-2.2.0/jasmine.js:1445:14)
    at Spec.Env.expectationResultFactory (http://localhost:8080/ThirdParty/jasmine-2.2.0/jasmine.js:584:18)
    at Spec.addExpectationResult (http://localhost:8080/ThirdParty/jasmine-2.2.0/jasmine.js:332:34)
    at Expectation.addExpectationResult (http://localhost:8080/ThirdParty/jasmine-2.2.0/jasmine.js:528:21)
    at Expectation.toConformToInterface (http://localhost:8080/ThirdParty/jasmine-2.2.0/jasmine.js:1399:12)
    at http://localhost:8080/Specs/Scene/TileMapServiceImageryProviderSpec.js:50:53
    at Object.<anonymous> (http://localhost:8080/Specs/spec-main.js:139:30)
    at attemptAsync (http://localhost:8080/ThirdParty/jasmine-2.2.0/jasmine.js:1793:24)
    at QueueRunner.run (http://localhost:8080/ThirdParty/jasmine-2.2.0/jasmine.js:1746:26)

```
Shall I implement the `ImageryProvider` interface in `createTileMapServiceImageryProvider.js` like it's done in `TileMapServiceImageryProvider.js`?
```
Error: Expected undefined to equal 'made/up/tms/server/'.
    at stack (http://localhost:8080/ThirdParty/jasmine-2.2.0/jasmine.js:1475:17)
    at buildExpectationResult (http://localhost:8080/ThirdParty/jasmine-2.2.0/jasmine.js:1445:14)
    at Spec.Env.expectationResultFactory (http://localhost:8080/ThirdParty/jasmine-2.2.0/jasmine.js:584:18)
    at Spec.addExpectationResult (http://localhost:8080/ThirdParty/jasmine-2.2.0/jasmine.js:332:34)
    at Expectation.addExpectationResult (http://localhost:8080/ThirdParty/jasmine-2.2.0/jasmine.js:528:21)
    at Expectation.toEqual (http://localhost:8080/ThirdParty/jasmine-2.2.0/jasmine.js:1399:12)
    at http://localhost:8080/Specs/Scene/TileMapServiceImageryProviderSpec.js:190:30
    at Object.<anonymous> (http://localhost:8080/Specs/spec-main.js:139:30)
    at attemptAsync (http://localhost:8080/ThirdParty/jasmine-2.2.0/jasmine.js:1793:24)
    at QueueRunner.run (http://localhost:8080/ThirdParty/jasmine-2.2.0/jasmine.js:1746:26)
```
Don't know why `provider.url` is undefined. I think this might go away once we have getter functions or their equivalents for all the properties.
```
Error: Expected Rectangle({ west: 0.09999999999999964, south: 0.2, east: 0.3000000000000007, north: 0.4 }) to equal Rectangle({ west: 0.1, south: 0.2, east: 0.3, north: 0.4 }).
    at stack (http://localhost:8080/ThirdParty/jasmine-2.2.0/jasmine.js:1475:17)
    at buildExpectationResult (http://localhost:8080/ThirdParty/jasmine-2.2.0/jasmine.js:1445:14)
    at Spec.Env.expectationResultFactory (http://localhost:8080/ThirdParty/jasmine-2.2.0/jasmine.js:584:18)
    at Spec.addExpectationResult (http://localhost:8080/ThirdParty/jasmine-2.2.0/jasmine.js:332:34)
    at Expectation.addExpectationResult (http://localhost:8080/ThirdParty/jasmine-2.2.0/jasmine.js:528:21)
    at Expectation.toEqual (http://localhost:8080/ThirdParty/jasmine-2.2.0/jasmine.js:1399:12)
    at http://localhost:8080/Specs/Scene/TileMapServiceImageryProviderSpec.js:295:40
    at Object.then (http://localhost:8080/Source/ThirdParty/when.js:196:34)
    at http://localhost:8080/Source/ThirdParty/when.js:297:13
    at processQueue (http://localhost:8080/Source/ThirdParty/when.js:647:4)

```

Shall I also completely delete `Source/Scene/TileMapServiceImageryProvider.js` ?