### PR TITLE
Use CSS format colors throughout

### DIFF
--- a/Apps/Sandcastle/gallery/3D Tiles.html
+++ b/Apps/Sandcastle/gallery/3D Tiles.html
@@ -73,14 +73,14 @@ function loadTileset(url) {
         }
 
         tileset.style = new Cesium.Cesium3DTileStyle(tileset, {
-//            "color" : [255, 255, 255]
+//            "color" : "#ff00ff",
 //            "color" : {
 //                "propertyName" : "id",
 //                "map" : {
-//                    "1" : [255, 0, 0],
-//                    "2" : [0, 255, 0]
+//                    "1" : "#ff0000",
+//                    "2" : "#ff0000"
 //                },
-//                "default" : [255, 255, 255]
+//                "default" : "#ffffff"
 //            },
             "color" : {
                 "expression" : {
@@ -97,12 +97,12 @@ function loadTileset(url) {
                     100 // [100, infinity)
                 ],
                 "colors" : [
-                    [237, 248, 251],
-                    [191, 211, 230],
-                    [158, 188, 218],
-                    [140, 150, 198],
-                    [136, 86, 167],
-                    [129, 15, 124]
+                    "#ff00ff",
+                    "#ff0000",
+                    "#ffff00",
+                    "#00ff00",
+                    "#00ffff",
+                    "#0000ff"
                 ]
             },
 //                "show": false
@@ -390,11 +390,7 @@ var currentPropertyName = '';
 function getRandomColors() {
     var colors = [];
     for (var i = 0; i < numberofColors; ++i) {
-        var r = Math.floor(Cesium.Math.nextRandomNumber() * 255);
-        var g  = Math.floor(Cesium.Math.nextRandomNumber() * 255);
-        var b = Math.floor(Cesium.Math.nextRandomNumber() * 255);
-
-        colors[i] = [r, g, b];
+        colors[i] = Cesium.Color.fromRandom().toCssColorString();
     }
 
     return colors;

--- a/Apps/Sandcastle/gallery/3D Tiles.html
+++ b/Apps/Sandcastle/gallery/3D Tiles.html
@@ -78,7 +78,7 @@ function loadTileset(url) {
 //                "propertyName" : "id",
 //                "map" : {
 //                    "1" : "#ff0000",
-//                    "2" : "#ff0000"
+//                    "2" : "#00ff00"
 //                },
 //                "default" : "#ffffff"
 //            },

--- a/Apps/Sandcastle/gallery/3D Tiles.html
+++ b/Apps/Sandcastle/gallery/3D Tiles.html
@@ -73,7 +73,10 @@ function loadTileset(url) {
         }
 
         tileset.style = new Cesium.Cesium3DTileStyle(tileset, {
-//            "color" : "#ff00ff",
+//            "color" : "#EAA56C",
+//            "color" : "cyan",
+//            "color" : "rgb(100, 255, 190)",
+//            "color" : "hsl(250, 60%, 70%)",
 //            "color" : {
 //                "propertyName" : "id",
 //                "map" : {

--- a/Source/Scene/Cesium3DTileStyle.js
+++ b/Source/Scene/Cesium3DTileStyle.js
@@ -27,7 +27,7 @@ define([
     // style/expression on mouse over, CZML may want to use this to evaluate expressions,
     // a UI might want to use it, etc.
 
-    var DEFAULT_JSON_COLOR_EXPRESSION = [255, 255, 255];
+    var DEFAULT_JSON_COLOR_EXPRESSION = "#ffffff";
     var DEFAULT_JSON_BOOLEAN_EXPRESSION = true;
 
     /**
@@ -52,7 +52,7 @@ define([
         this.timeDynamic = false;
 
         var color;
-        if (isArray(colorExpression)) {
+        if (typeof(colorExpression) === 'string') {
             color = new ConstantColorExpression(styleEngine, colorExpression);
         } else if (defined(colorExpression.map)) {
             color = new ColorMapExpression(styleEngine, colorExpression);

--- a/Source/Scene/ColorMapExpression.js
+++ b/Source/Scene/ColorMapExpression.js
@@ -89,7 +89,7 @@ define([
         for (var name in map) {
             if (map.hasOwnProperty(name)) {
                 var color = map[name];
-                runtimeMap[name] = Color.fromBytes(color[0], color[1], color[2]);
+                runtimeMap[name] = Color.fromCssColorString(color);
             }
         }
 
@@ -97,7 +97,7 @@ define([
 
         var c = expression._default;
         if (defined(c)) {
-            expression._runtimeDefault = Color.fromBytes(c[0], c[1], c[2], 255, expression._runtimeDefault);
+            expression._runtimeDefault = Color.clone(Color.fromCssColorString(c), expression._runtimeDefault);
         } else {
             expression._runtimeDefault = Color.clone(Color.WHITE, expression._runtimeDefault);
         }

--- a/Source/Scene/ColorRampExpression.js
+++ b/Source/Scene/ColorRampExpression.js
@@ -80,7 +80,7 @@ define([
             runtimeIntervals[i] = {
 // TODO: what about intervals[0] and inclusive/exclusive flag?
                 maximum : (i !== length - 1) ? intervals[i + 1] : Number.POSITIVE_INFINITY,
-                color : Color.fromBytes(color[0], color[1], color[2])
+                color : Color.fromCssColorString(color)
             };
         }
 
@@ -180,7 +180,7 @@ define([
 
         var outColors = new Array(length);
         for (var j = 0; j < length; ++j) {
-            outColors[j] = chroma(computedColors[j]).rgb();
+            outColors[j] = chroma(computedColors[j]).hex();
         }
 
         return outColors;

--- a/Source/Scene/ColorRampExpression.js
+++ b/Source/Scene/ColorRampExpression.js
@@ -80,8 +80,8 @@ define([
             var c = Color.fromCssColorString(color);
 
             //>>includeStart('debug', pragmas.debug);
-            if (c === undefined) {
-                throw new DeveloperError('color must be a valid CSS color');
+            if (!defined(c)) {
+                throw new DeveloperError('color must be defined');
             }
             //>>includeEnd('debug');
 

--- a/Source/Scene/ColorRampExpression.js
+++ b/Source/Scene/ColorRampExpression.js
@@ -77,10 +77,18 @@ define([
         var runtimeIntervals = new Array(length);
         for (var i = 0; i < length; ++i) {
             var color = colors[i];
+            var c = Color.fromCssColorString(color);
+
+            //>>includeStart('debug', pragmas.debug);
+            if (c === undefined) {
+                throw new DeveloperError('color must be a valid CSS color');
+            }
+            //>>includeEnd('debug');
+
             runtimeIntervals[i] = {
 // TODO: what about intervals[0] and inclusive/exclusive flag?
                 maximum : (i !== length - 1) ? intervals[i + 1] : Number.POSITIVE_INFINITY,
-                color : Color.fromCssColorString(color)
+                color : c
             };
         }
 

--- a/Source/Scene/ConstantColorExpression.js
+++ b/Source/Scene/ConstantColorExpression.js
@@ -22,7 +22,7 @@ define([
     function ConstantColorExpression(styleEngine, literal) {
         this._styleEngine = styleEngine;
 
-        this._color = Color.fromBytes(literal[0], literal[1], literal[2]);
+        this._color = Color.fromCssColorString(literal);
     }
 
     defineProperties(ConstantColorExpression.prototype, {

--- a/Source/Scene/ConstantColorExpression.js
+++ b/Source/Scene/ConstantColorExpression.js
@@ -22,7 +22,15 @@ define([
     function ConstantColorExpression(styleEngine, literal) {
         this._styleEngine = styleEngine;
 
-        this._color = Color.fromCssColorString(literal);
+        var color = Color.fromCssColorString(literal);
+
+        //>>includeStart('debug', pragmas.debug);
+        if (color === undefined) {
+            throw new DeveloperError('color must be a valid CSS color');
+        }
+        //>>includeEnd('debug');
+
+        this._color = color;
     }
 
     defineProperties(ConstantColorExpression.prototype, {

--- a/Source/Scene/ConstantColorExpression.js
+++ b/Source/Scene/ConstantColorExpression.js
@@ -26,7 +26,7 @@ define([
 
         //>>includeStart('debug', pragmas.debug);
         if (color === undefined) {
-            throw new DeveloperError('color must be a valid CSS color');
+            throw new DeveloperError('color must be defined');
         }
         //>>includeEnd('debug');
 


### PR DESCRIPTION
Used CSS format colors throughout.

To generate a random color in the css format for the sandcastle, I used `Cesium.Color.fromRandom().toCssColorString()`. 

Should we throw a better error or default to white if a non-valid color string is used? Currently if you specify a non-valid string, rendering stop and the error looks like this:
```
DeveloperError: value is required.
Error
    at new DeveloperError (http://localhost:8080/Source/Core/DeveloperError.js:43:19)
    at Cesium3DTileBatchTableResources.setColor (http://localhost:8080/Source/Scene/Cesium3DTileBatchTableResources.js:162:19)
    at Cesium3DTileFeature.defineProperties.color.set (http://localhost:8080/Source/Scene/Cesium3DTileFeature.js:100:43)
    at styleContent 
    ...
```