### PR TITLE
Fix polygon texture coordinates for polygon with position heights

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@ Change Log
 * Fixed bug for causing `navigator is not defined` reference error in node
 * Added `Camera.flyHome` function for resetting the camera to the home view
 * Fix an issue when changing a billboard's position property multiple times per frame. [#3511](https://github.com/AnalyticalGraphicsInc/cesium/pull/3511)
+* Fixed texture coordinates for polygon with position heights
 
 ### 1.18 - 2016-02-01
 * Breaking changes

--- a/Source/Core/PolygonGeometry.js
+++ b/Source/Core/PolygonGeometry.js
@@ -54,6 +54,10 @@ define([
     var computeBoundingRectangleQuaternion = new Quaternion();
     var computeBoundingRectangleMatrix3 = new Matrix3();
 
+    function zeroToOne(n){
+        return Math.min(Math.max(n, 0), 1);
+    }
+
     function computeBoundingRectangle(tangentPlane, positions, angle, result) {
         var rotation = Quaternion.fromAxisAngle(tangentPlane._plane.normal, angle, computeBoundingRectangleQuaternion);
         var textureMatrix = Matrix3.fromQuaternion(rotation, computeBoundingRectangleMatrix3);
@@ -99,12 +103,18 @@ define([
     var appendTextureCoordinatesQuaternion = new Quaternion();
     var appendTextureCoordinatesMatrix3 = new Matrix3();
 
-    function computeAttributes(vertexFormat, geometry, outerPositions, ellipsoid, stRotation, bottom, wall) {
+    function computeAttributes(options) {
+        var vertexFormat = options.vertexFormat;
+        var geometry = options.geometry;
         if (vertexFormat.st || vertexFormat.normal || vertexFormat.tangent || vertexFormat.binormal) {
             // PERFORMANCE_IDEA: Compute before subdivision, then just interpolate during subdivision.
             // PERFORMANCE_IDEA: Compute with createGeometryFromPositions() for fast path when there's no holes.
-            var tangentPlane = EllipsoidTangentPlane.fromPoints(outerPositions, ellipsoid);
-            var boundingRectangle = computeBoundingRectangle(tangentPlane, outerPositions, stRotation, scratchBoundingRectangle);
+            var boundingRectangle = options.boundingRectangle;
+            var tangentPlane = options.tangentPlane;
+            var ellipsoid = options.ellipsoid;
+            var stRotation = options.stRotation;
+            var bottom = options.bottom;
+            var wall = options.wall;
 
             var origin = appendTextureCoordinatesOrigin;
             origin.x = boundingRectangle.x;
@@ -145,13 +155,15 @@ define([
                     var st = tangentPlane.projectPointOntoPlane(p, appendTextureCoordinatesCartesian2);
                     Cartesian2.subtract(st, origin, st);
 
+                    var stx = zeroToOne(st.x / boundingRectangle.width);
+                    var sty = zeroToOne(st.y / boundingRectangle.height);
                     if (bottom) {
-                        textureCoordinates[textureCoordIndex + bottomOffset2] = st.x / boundingRectangle.width;
-                        textureCoordinates[textureCoordIndex + 1 + bottomOffset2] = st.y / boundingRectangle.height;
+                        textureCoordinates[textureCoordIndex + bottomOffset2] = stx;
+                        textureCoordinates[textureCoordIndex + 1 + bottomOffset2] = sty;
                     }
 
-                    textureCoordinates[textureCoordIndex] = st.x / boundingRectangle.width;
-                    textureCoordinates[textureCoordIndex + 1] = st.y / boundingRectangle.height;
+                    textureCoordinates[textureCoordIndex] = stx;
+                    textureCoordinates[textureCoordIndex + 1] = sty;
 
                     textureCoordIndex += 2;
                 }
@@ -661,30 +673,48 @@ define([
         var results = PolygonGeometryLibrary.polygonsFromHierarchy(polygonHierarchy);
         var hierarchy = results.hierarchy;
         var polygons = results.polygons;
+        var i;
 
         if (polygons.length === 0) {
             return undefined;
         }
 
-        outerPositions = polygons[0];
+        outerPositions = polygons[0].slice();
+        for (i = 0; i < outerPositions.length; i++) {
+            outerPositions[i] = ellipsoid.scaleToGeodeticSurface(outerPositions[i]);
+        }
+
+        var tangentPlane = EllipsoidTangentPlane.fromPoints(outerPositions, ellipsoid);
+        var boundingRectangle = computeBoundingRectangle(tangentPlane, outerPositions, stRotation, scratchBoundingRectangle);
 
         var geometry;
         var geometries = [];
-        var i;
 
+        var options = {
+            vertexFormat: vertexFormat,
+            geometry: undefined,
+            tangentPlane: tangentPlane,
+            boundingRectangle: boundingRectangle,
+            ellipsoid: ellipsoid,
+            stRotation: stRotation,
+            bottom: false,
+            wall: false
+        };
         if (extrude) {
+            options.bottom = true;
             for (i = 0; i < polygons.length; i++) {
                 geometry = createGeometryFromPositionsExtruded(ellipsoid, polygons[i], granularity, hierarchy[i], perPositionHeight);
                 topAndBottom = geometry.topAndBottom;
-                topAndBottom.geometry = PolygonGeometryLibrary.scaleToGeodeticHeightExtruded(topAndBottom.geometry, height, extrudedHeight, ellipsoid, perPositionHeight);
-                topAndBottom.geometry = computeAttributes(vertexFormat, topAndBottom.geometry, outerPositions, ellipsoid, stRotation, true, false);
+                options.geometry = PolygonGeometryLibrary.scaleToGeodeticHeightExtruded(topAndBottom.geometry, height, extrudedHeight, ellipsoid, perPositionHeight);
+                topAndBottom.geometry = computeAttributes(options);
                 geometries.push(topAndBottom);
 
                 walls = geometry.walls;
+                options.wall = true;
                 for ( var k = 0; k < walls.length; k++) {
                     var wall = walls[k];
-                    wall.geometry = PolygonGeometryLibrary.scaleToGeodeticHeightExtruded(wall.geometry, height, extrudedHeight, ellipsoid, perPositionHeight);
-                    wall.geometry = computeAttributes(vertexFormat, wall.geometry, outerPositions, ellipsoid, stRotation, true, true);
+                    options.geometry = PolygonGeometryLibrary.scaleToGeodeticHeightExtruded(wall.geometry, height, extrudedHeight, ellipsoid, perPositionHeight);
+                    wall.geometry = computeAttributes(options);
                     geometries.push(wall);
                 }
             }
@@ -693,8 +723,8 @@ define([
                 geometry = new GeometryInstance({
                     geometry : PolygonGeometryLibrary.createGeometryFromPositions(ellipsoid, polygons[i], granularity, perPositionHeight)
                 });
-                geometry.geometry = PolygonPipeline.scaleToGeodeticHeight(geometry.geometry, height, ellipsoid, !perPositionHeight);
-                geometry.geometry = computeAttributes(vertexFormat, geometry.geometry, outerPositions, ellipsoid, stRotation, false, false);
+                options.geometry = PolygonPipeline.scaleToGeodeticHeight(geometry.geometry, height, ellipsoid, !perPositionHeight);
+                geometry.geometry = computeAttributes(options);
                 geometries.push(geometry);
             }
         }

--- a/Specs/Core/PolygonGeometrySpec.js
+++ b/Specs/Core/PolygonGeometrySpec.js
@@ -421,9 +421,31 @@ defineSuite([
 
         var st = p.attributes.st.values;
         for (var i = 0; i < st.length; i++) {
-            expect(st[i] + CesiumMath.EPSILON10 >= 0 && st[i] - CesiumMath.EPSILON10 <= 1).toEqual(true);
+            expect(st[i]).toBeGreaterThanOrEqualTo(0);
+            expect(st[i]).toBeLessThanOrEqualTo(1);
         }
     });
+
+    it('computes correct texture coordinates for polygon with position heights', function() {
+        var p = PolygonGeometry.createGeometry(new PolygonGeometry({
+            vertexFormat : VertexFormat.POSITION_AND_ST,
+            polygonHierarchy: {
+                positions : Cartesian3.fromDegreesArrayHeights([
+                    -100.5, 30.0, 92,
+                    -100.0, 30.0, 92,
+                    -100.0, 30.5, 92,
+                    -100.5, 30.5, 92
+                ])},
+            granularity: CesiumMath.PI
+        }));
+
+        var st = p.attributes.st.values;
+        for (var i = 0; i < st.length; i++) {
+            expect(st[i]).toBeGreaterThanOrEqualTo(0);
+            expect(st[i]).toBeLessThanOrEqualTo(1);
+        }
+    });
+
 
     it('creates a polygon from hierarchy extruded', function() {
         var hierarchy = {


### PR DESCRIPTION
A similar fix was done in #3462, but missed the case where the input positions have a height
I scale them to the earth surface before generating the tangent plane.  Additionally I clamp the texture coordinates between 0 and 1.

This does make a copy of the outer ring of Cartesian3 positions with a height at zero to be sent to EllipsoidTangentPlane.fromPoints.  If that's a problem, I can remove that copy and just clamp the texture coordinates between 0 and 1.  I thought doing both was a better solution, but I'm not sure of the performance concerns.  @pjcozzi? @bagnell?

I also did minor code cleanup and changed it to generate the tangent plane and bounding rectangle once instead of for each polygon in the hierarchy.

Before : 
![image](https://cloud.githubusercontent.com/assets/3451886/12984302/148add60-d0bb-11e5-998b-95ddf02f1160.png)
After: 
![image](https://cloud.githubusercontent.com/assets/3451886/12984316/23a2d0d2-d0bb-11e5-966a-d59edc0e0691.png)
