### PR TITLE
Add RegEx pattern to color map

### DIFF
--- a/Apps/Sandcastle/gallery/3D Tiles.html
+++ b/Apps/Sandcastle/gallery/3D Tiles.html
@@ -73,14 +73,14 @@ function loadTileset(url) {
         }
 
         tileset.style = new Cesium.Cesium3DTileStyle(tileset, {
-//            "color" : [255, 255, 255]
+//            "color" : "#ff00ff",
 //            "color" : {
 //                "propertyName" : "id",
 //                "map" : {
-//                    "1" : [255, 0, 0],
-//                    "2" : [0, 255, 0]
+//                    "1" : "#ff0000",
+//                    "2" : "#ff0000"
 //                },
-//                "default" : [255, 255, 255]
+//                "default" : "#ffffff"
 //            },
             "color" : {
                 "expression" : {
@@ -97,12 +97,12 @@ function loadTileset(url) {
                     100 // [100, infinity)
                 ],
                 "colors" : [
-                    [237, 248, 251],
-                    [191, 211, 230],
-                    [158, 188, 218],
-                    [140, 150, 198],
-                    [136, 86, 167],
-                    [129, 15, 124]
+                    "#ff00ff",
+                    "#ff0000",
+                    "#ffff00",
+                    "#00ff00",
+                    "#00ffff",
+                    "#0000ff"
                 ]
             },
 //                "show": false
@@ -390,11 +390,7 @@ var currentPropertyName = '';
 function getRandomColors() {
     var colors = [];
     for (var i = 0; i < numberofColors; ++i) {
-        var r = Math.floor(Cesium.Math.nextRandomNumber() * 255);
-        var g  = Math.floor(Cesium.Math.nextRandomNumber() * 255);
-        var b = Math.floor(Cesium.Math.nextRandomNumber() * 255);
-
-        colors[i] = [r, g, b];
+        colors[i] = Cesium.Color.fromRandom().toCssColorString();
     }
 
     return colors;

--- a/Apps/Sandcastle/gallery/3D Tiles.html
+++ b/Apps/Sandcastle/gallery/3D Tiles.html
@@ -81,7 +81,8 @@ function loadTileset(url) {
 //                "propertyName" : "id",
 //                "map" : {
 //                    "^[123]$" : "orange", // matches id's 1, 2, and 3
-//                    "1\\d" : "cyan"       // matches id's 10-19
+//                    "1\\d" : "cyan",       // matches id's 10-19
+//                    "4" : "grey"
 //                },
 //                "default" : "#ffffff"
 //            },

--- a/Apps/Sandcastle/gallery/3D Tiles.html
+++ b/Apps/Sandcastle/gallery/3D Tiles.html
@@ -80,8 +80,8 @@ function loadTileset(url) {
 //            "color" : {
 //                "propertyName" : "id",
 //                "map" : {
-//                    "1" : "#ff0000",
-//                    "2" : "#00ff00"
+//                    "^[123]$" : "orange", // matches id's 1, 2, and 3
+//                    "1\\d" : "cyan"       // matches id's 10-19
 //                },
 //                "default" : "#ffffff"
 //            },

--- a/Apps/Sandcastle/gallery/3D Tiles.html
+++ b/Apps/Sandcastle/gallery/3D Tiles.html
@@ -78,7 +78,7 @@ function loadTileset(url) {
 //                "propertyName" : "id",
 //                "map" : {
 //                    "1" : "#ff0000",
-//                    "2" : "#ff0000"
+//                    "2" : "#00ff00"
 //                },
 //                "default" : "#ffffff"
 //            },

--- a/Apps/Sandcastle/gallery/3D Tiles.html
+++ b/Apps/Sandcastle/gallery/3D Tiles.html
@@ -73,7 +73,10 @@ function loadTileset(url) {
         }
 
         tileset.style = new Cesium.Cesium3DTileStyle(tileset, {
-//            "color" : "#ff00ff",
+//            "color" : "#EAA56C",
+//            "color" : "cyan",
+//            "color" : "rgb(100, 255, 190)",
+//            "color" : "hsl(250, 60%, 70%)",
 //            "color" : {
 //                "propertyName" : "id",
 //                "map" : {

--- a/Source/Scene/Cesium3DTileStyle.js
+++ b/Source/Scene/Cesium3DTileStyle.js
@@ -27,7 +27,7 @@ define([
     // style/expression on mouse over, CZML may want to use this to evaluate expressions,
     // a UI might want to use it, etc.
 
-    var DEFAULT_JSON_COLOR_EXPRESSION = [255, 255, 255];
+    var DEFAULT_JSON_COLOR_EXPRESSION = "#ffffff";
     var DEFAULT_JSON_BOOLEAN_EXPRESSION = true;
 
     /**
@@ -52,7 +52,7 @@ define([
         this.timeDynamic = false;
 
         var color;
-        if (isArray(colorExpression)) {
+        if (typeof(colorExpression) === 'string') {
             color = new ConstantColorExpression(styleEngine, colorExpression);
         } else if (defined(colorExpression.map)) {
             color = new ColorMapExpression(styleEngine, colorExpression);

--- a/Source/Scene/ColorMapExpression.js
+++ b/Source/Scene/ColorMapExpression.js
@@ -93,7 +93,7 @@ define([
                 var color = Color.fromCssColorString(map[name]);
                 //>>includeStart('debug', pragmas.debug);
                 if (color === undefined) {
-                    throw new DeveloperError('color must be a valid CSS color');
+                    throw new DeveloperError('color must be defined');
                 }
                 //>>includeEnd('debug');
 

--- a/Source/Scene/ColorMapExpression.js
+++ b/Source/Scene/ColorMapExpression.js
@@ -107,12 +107,19 @@ define([
      * DOC_TBA
      */
     ColorMapExpression.prototype.evaluate = function(feature) {
-        var value = feature.getProperty(this._propertyName);
+        var name = feature.getProperty(this._propertyName);
 
         var defaultColor = this._runtimeDefault;
         var runtimeMap = this._runtimeMap;
         if (defined(runtimeMap)) {
-            return defaultValue(runtimeMap[value], defaultColor);
+            for (var value in runtimeMap) {
+                if (runtimeMap.hasOwnProperty(value)) {
+                    var exp = new RegExp(value);
+                    if (exp.test(name)) {
+                        return runtimeMap[value];
+                    }
+                }
+            }
         }
 
         return defaultColor;

--- a/Source/Scene/ColorMapExpression.js
+++ b/Source/Scene/ColorMapExpression.js
@@ -89,7 +89,7 @@ define([
         for (var name in map) {
             if (map.hasOwnProperty(name)) {
                 var color = map[name];
-                runtimeMap[name] = Color.fromBytes(color[0], color[1], color[2]);
+                runtimeMap[name] = Color.fromCssColorString(color);
             }
         }
 
@@ -97,7 +97,7 @@ define([
 
         var c = expression._default;
         if (defined(c)) {
-            expression._runtimeDefault = Color.fromBytes(c[0], c[1], c[2], 255, expression._runtimeDefault);
+            expression._runtimeDefault = Color.clone(Color.fromCssColorString(c), expression._runtimeDefault);
         } else {
             expression._runtimeDefault = Color.clone(Color.WHITE, expression._runtimeDefault);
         }

--- a/Source/Scene/ColorRampExpression.js
+++ b/Source/Scene/ColorRampExpression.js
@@ -80,7 +80,7 @@ define([
             runtimeIntervals[i] = {
 // TODO: what about intervals[0] and inclusive/exclusive flag?
                 maximum : (i !== length - 1) ? intervals[i + 1] : Number.POSITIVE_INFINITY,
-                color : Color.fromBytes(color[0], color[1], color[2])
+                color : Color.fromCssColorString(color)
             };
         }
 
@@ -180,7 +180,7 @@ define([
 
         var outColors = new Array(length);
         for (var j = 0; j < length; ++j) {
-            outColors[j] = chroma(computedColors[j]).rgb();
+            outColors[j] = chroma(computedColors[j]).hex();
         }
 
         return outColors;

--- a/Source/Scene/ColorRampExpression.js
+++ b/Source/Scene/ColorRampExpression.js
@@ -77,10 +77,18 @@ define([
         var runtimeIntervals = new Array(length);
         for (var i = 0; i < length; ++i) {
             var color = colors[i];
+            var c = Color.fromCssColorString(color);
+
+            //>>includeStart('debug', pragmas.debug);
+            if (c === undefined) {
+                throw new DeveloperError('color must be a valid CSS color');
+            }
+            //>>includeEnd('debug');
+
             runtimeIntervals[i] = {
 // TODO: what about intervals[0] and inclusive/exclusive flag?
                 maximum : (i !== length - 1) ? intervals[i + 1] : Number.POSITIVE_INFINITY,
-                color : Color.fromCssColorString(color)
+                color : c
             };
         }
 

--- a/Source/Scene/ConstantColorExpression.js
+++ b/Source/Scene/ConstantColorExpression.js
@@ -22,7 +22,7 @@ define([
     function ConstantColorExpression(styleEngine, literal) {
         this._styleEngine = styleEngine;
 
-        this._color = Color.fromBytes(literal[0], literal[1], literal[2]);
+        this._color = Color.fromCssColorString(literal);
     }
 
     defineProperties(ConstantColorExpression.prototype, {

--- a/Source/Scene/ConstantColorExpression.js
+++ b/Source/Scene/ConstantColorExpression.js
@@ -22,7 +22,15 @@ define([
     function ConstantColorExpression(styleEngine, literal) {
         this._styleEngine = styleEngine;
 
-        this._color = Color.fromCssColorString(literal);
+        var color = Color.fromCssColorString(literal);
+
+        //>>includeStart('debug', pragmas.debug);
+        if (color === undefined) {
+            throw new DeveloperError('color must be a valid CSS color');
+        }
+        //>>includeEnd('debug');
+
+        this._color = color;
     }
 
     defineProperties(ConstantColorExpression.prototype, {


### PR DESCRIPTION
Branched off of my `css-style-colors` branch.

I changed the `runtimeMap` property so that it's no longer a dictionary. I did this to avoid constructing a new `RegExp` from the dictionary key every time we need to check if a feature name matches the expression.

Instead I created a list in `setRuntime` where for each item in the map, I push an object that contains the pattern and the color, so we only have to construct the regExp once. During evaluate, I iterate through the list and test the pattern against the name, and return the color.

This returns the color of the first pattern that matches. What do we do about features that match more than one regex pattern in the map? Should we have the patterns listed first be higher priority than those below?

I also updated the sandcastle example to show using regex patterns.