### PR TITLE
Fix CESIUM_BASE_URL trailing slash bug

### DIFF
--- a/Source/Core/buildModuleUrl.js
+++ b/Source/Core/buildModuleUrl.js
@@ -4,12 +4,14 @@ define([
         './defined',
         './DeveloperError',
         './getAbsoluteUri',
+        './joinUrls',
         'require'
     ], function(
         Uri,
         defined,
         DeveloperError,
         getAbsoluteUri,
+        joinUrls,
         require) {
     'use strict';
     /*global CESIUM_BASE_URL*/
@@ -55,7 +57,7 @@ define([
     }
 
     function buildModuleUrlFromBaseUrl(moduleID) {
-        return new Uri(moduleID).resolve(getCesiumBaseUrl()).toString();
+        return joinUrls(getCesiumBaseUrl(), moduleID);
     }
 
     var implementation;


### PR DESCRIPTION
For Issue #3496.
I reproduced the bug on my machine:
```
var CESIUM_BASE_URL = '/home/sanuj/Projects/cesium/Build/CesiumUnminified/';
console.log(Cesium['buildModuleUrl']('MODULE'));
```
Result: `/home/sanuj/Projects/cesium/Build/CesiumUnminified/MODULE`
```
var CESIUM_BASE_URL = '/home/sanuj/Projects/cesium/Build/CesiumUnminified';
console.log(Cesium['buildModuleUrl']('MODULE'));
```
Result: `/home/sanuj/Projects/cesium/Build/MODULE`
This PR fixes this.