### PR TITLE
Cleanup PolygonGeometry changes

### DIFF
--- a/Source/Core/PolygonGeometry.js
+++ b/Source/Core/PolygonGeometry.js
@@ -54,10 +54,6 @@ define([
     var computeBoundingRectangleQuaternion = new Quaternion();
     var computeBoundingRectangleMatrix3 = new Matrix3();
 
-    function zeroToOne(n){
-        return Math.min(Math.max(n, 0), 1);
-    }
-
     function computeBoundingRectangle(tangentPlane, positions, angle, result) {
         var rotation = Quaternion.fromAxisAngle(tangentPlane._plane.normal, angle, computeBoundingRectangleQuaternion);
         var textureMatrix = Matrix3.fromQuaternion(rotation, computeBoundingRectangleMatrix3);
@@ -155,8 +151,8 @@ define([
                     var st = tangentPlane.projectPointOntoPlane(p, appendTextureCoordinatesCartesian2);
                     Cartesian2.subtract(st, origin, st);
 
-                    var stx = zeroToOne(st.x / boundingRectangle.width);
-                    var sty = zeroToOne(st.y / boundingRectangle.height);
+                    var stx = CesiumMath.clamp(st.x / boundingRectangle.width, 0, 1);
+                    var sty = CesiumMath.clamp(st.y / boundingRectangle.height, 0, 1);
                     if (bottom) {
                         textureCoordinates[textureCoordIndex + bottomOffset2] = stx;
                         textureCoordinates[textureCoordIndex + 1 + bottomOffset2] = sty;
@@ -670,7 +666,7 @@ define([
         var topAndBottom;
         var outerPositions;
 
-        var results = PolygonGeometryLibrary.polygonsFromHierarchy(polygonHierarchy);
+        var results = PolygonGeometryLibrary.polygonsFromHierarchy(polygonHierarchy, perPositionHeight, ellipsoid);
         var hierarchy = results.hierarchy;
         var polygons = results.polygons;
         var i;
@@ -679,9 +675,13 @@ define([
             return undefined;
         }
 
-        outerPositions = polygons[0].slice();
-        for (i = 0; i < outerPositions.length; i++) {
-            outerPositions[i] = ellipsoid.scaleToGeodeticSurface(outerPositions[i]);
+        if (perPositionHeight) {
+            outerPositions = polygons[0].slice();
+            for (i = 0; i < outerPositions.length; i++) {
+                outerPositions[i] = ellipsoid.scaleToGeodeticSurface(outerPositions[i]);
+            }
+        } else {
+            outerPositions = polygons[0];
         }
 
         var tangentPlane = EllipsoidTangentPlane.fromPoints(outerPositions, ellipsoid);

--- a/Source/Core/PolygonGeometryLibrary.js
+++ b/Source/Core/PolygonGeometryLibrary.js
@@ -202,7 +202,7 @@ define([
         return geometry;
     };
 
-    PolygonGeometryLibrary.polygonsFromHierarchy = function(polygonHierarchy) {
+    PolygonGeometryLibrary.polygonsFromHierarchy = function(polygonHierarchy, perPositionHeight, ellipsoid) {
         // create from a polygon hierarchy
         // Algorithm adapted from http://www.geometrictools.com/Documentation/TriangulationByEarClipping.pdf
         var polygons = [];
@@ -223,8 +223,8 @@ define([
 
             var numChildren = defined(holes) ? holes.length : 0;
             var polygonHoles = [];
-
-            for (var i = 0; i < numChildren; i++) {
+            var i;
+            for (i = 0; i < numChildren; i++) {
                 var hole = holes[i];
                 hole.positions = PolygonPipeline.removeDuplicates(hole.positions);
                 if (hole.positions.length < 3) {
@@ -242,6 +242,14 @@ define([
                 }
             }
 
+            if (!perPositionHeight) {
+                for (i = 0; i < outerRing.length; i++) {
+                    ellipsoid.scaleToGeodeticSurface(outerRing[i], outerRing[i]);
+                }
+                for (i = 0; i < polygonHoles.length; i++) {
+                    ellipsoid.scaleToGeodeticSurface(polygonHoles[i], polygonHoles[i]);
+                }
+            }
             hierarchy.push({
                 outerRing : outerRing,
                 holes : polygonHoles

--- a/Specs/Core/PolygonGeometrySpec.js
+++ b/Specs/Core/PolygonGeometrySpec.js
@@ -287,24 +287,36 @@ defineSuite([
             granularity : CesiumMath.PI_OVER_THREE
         }));
 
-        expect(p).toEqual(Cartesian3.fromDegreesArray([
-                                                       -124.0, 35.0,
-                                                       -124.0, 40.0,
-                                                       -110.0, 40.0,
-                                                       -110.0, 35.0
-                                                   ]));
-        expect(h1).toEqual(Cartesian3.fromDegreesArray([
-                                                        -122.0, 36.0,
-                                                        -112.0, 36.0,
-                                                        -112.0, 39.0,
-                                                        -122.0, 39.0
-                                                    ]));
-        expect(h2).toEqual(Cartesian3.fromDegreesArray([
-                                                        -120.0, 36.5,
-                                                        -120.0, 38.5,
-                                                        -114.0, 38.5,
-                                                        -114.0, 36.5
-                                                    ]));
+        var i;
+        var pExpected = Cartesian3.fromDegreesArray([
+                                              -124.0, 35.0,
+                                              -124.0, 40.0,
+                                              -110.0, 40.0,
+                                              -110.0, 35.0
+                                          ]);
+        for (i = 0; i < p.length; i++) {
+            expect(p[i]).toEqualEpsilon(pExpected[i], CesiumMath.EPSILON10);
+        }
+
+        var h1Expected = Cartesian3.fromDegreesArray([
+                                               -122.0, 36.0,
+                                               -112.0, 36.0,
+                                               -112.0, 39.0,
+                                               -122.0, 39.0
+                                           ]);
+        for (i = 0; i < h1.length; i++) {
+            expect(h1[i]).toEqualEpsilon(h1Expected[i], CesiumMath.EPSILON10);
+        }
+
+        var h2Expected = Cartesian3.fromDegreesArray([
+                                               -120.0, 36.5,
+                                               -120.0, 38.5,
+                                               -114.0, 38.5,
+                                               -114.0, 36.5
+                                           ]);
+        for (i = 0; i <h2.length; i++) {
+            expect(h2[i]).toEqualEpsilon(h2Expected[i], CesiumMath.EPSILON10);
+        }
     });
 
     it('computes correct bounding sphere at height 0', function() {


### PR DESCRIPTION
This is a followup to #3552.
Instead of making a copy of all the outer positions for every polygon, this changes it so it only makes a copy when perPositionHeight = true.  Otherwise, all input positions are scaled to the ellipsoid surface at the beginning of the pipeline to avoid errors later down.

@pjcozzi This doesn't copy the elements for the most common case, and still fixes the texture coordinate problem for the usual case of `perPositionHeight = true` so I thought it would be the best solution.

The only thing I could foresee being a problem is that it alters the value of the user's input Cartesian3 positions by scaling them to the surface.  But for a polygon that's supposed to be drawn on the surface, I don't think that's a big deal.  It also goes back to the question of whether or not the user surrenders ownership of their position values when they're passed into the geometry, which I think should be yes.