### PR TITLE
joinUrls trailing slash bug

### DIFF
--- a/Source/Core/joinUrls.js
+++ b/Source/Core/joinUrls.js
@@ -64,7 +64,7 @@ define([
         if (defined(baseUri.authority)) {
             url += '//' + baseUri.authority;
 
-            if (baseUri.path !== '') {
+            if (baseUri.path !== '' && baseUri.path !== '/') {
                 url = url.replace(/\/?$/, '/');
                 baseUri.path = baseUri.path.replace(/^\/?/g, '');
             }

--- a/Specs/Core/joinUrlsSpec.js
+++ b/Specs/Core/joinUrlsSpec.js
@@ -155,4 +155,9 @@ defineSuite([
         var result = joinUrls(absolutePath, absolutePath + fragment);
         expect(result).toEqual(expectedAbsolutePath + fragment);
     });
+
+    it('works with trailing slash for first url', function() {
+        var result = joinUrls('http://www.xyz.com/', 'MODULE');
+        expect(result).toEqual('http://www.xyz.com/MODULE');
+    });
 });


### PR DESCRIPTION
Reported by @sanuj in #3556

`joinUrls('http://www.xyz.com/', 'MODULE')` was producing `http://www.xyz.com//MODULE` because the `/` at the end was being treated as a path