### PR TITLE
Support Viewer's zoomTo/flyTo with ImageLayer argument

### DIFF
--- a/Source/Widgets/Viewer/Viewer.js
+++ b/Source/Widgets/Viewer/Viewer.js
@@ -11,6 +11,7 @@ define([
         '../../Core/Fullscreen',
         '../../Core/isArray',
         '../../Core/Matrix4',
+        '../../Core/Rectangle',
         '../../Core/ScreenSpaceEventType',
         '../../DataSources/BoundingSphereState',
         '../../DataSources/ConstantPositionProperty',
@@ -19,6 +20,7 @@ define([
         '../../DataSources/Entity',
         '../../DataSources/EntityView',
         '../../DataSources/Property',
+        '../../Scene/ImageryLayer',
         '../../Scene/SceneMode',
         '../../ThirdParty/knockout',
         '../../ThirdParty/when',
@@ -52,6 +54,7 @@ define([
         Fullscreen,
         isArray,
         Matrix4,
+        Rectangle,
         ScreenSpaceEventType,
         BoundingSphereState,
         ConstantPositionProperty,
@@ -60,6 +63,7 @@ define([
         Entity,
         EntityView,
         Property,
+        ImageryLayer,
         SceneMode,
         knockout,
         when,
@@ -1580,7 +1584,7 @@ Either specify options.terrainProvider instead or set options.baseLayerPicker to
      * target will be the range. The heading will be determined from the offset. If the heading cannot be
      * determined from the offset, the heading will be north.</p>
      *
-     * @param {Entity|Entity[]|EntityCollection|DataSource|Promise.<Entity|Entity[]|EntityCollection|DataSource>} target The entity, array of entities, entity collection or data source to view. You can also pass a promise that resolves to one of the previously mentioned types.
+     * @param {Entity|Entity[]|EntityCollection|DataSource|ImageryLayer|Promise.<Entity|Entity[]|EntityCollection|DataSource|ImageryLayer>} target The entity, array of entities, entity collection, data source or imagery layer with rectangular imagery to view. You can also pass a promise that resolves to one of the previously mentioned types.
      * @param {HeadingPitchRange} [offset] The offset from the center of the entity in the local east-north-up reference frame.
      * @returns {Promise.<Boolean>} A Promise that resolves to true if the zoom was successful or false if the entity is not currently visualized in the scene or the zoom was cancelled.
      */
@@ -1603,7 +1607,7 @@ Either specify options.terrainProvider instead or set options.baseLayerPicker to
      * target will be the range. The heading will be determined from the offset. If the heading cannot be
      * determined from the offset, the heading will be north.</p>
      *
-     * @param {Entity|Entity[]|EntityCollection|DataSource|Promise.<Entity|Entity[]|EntityCollection|DataSource>} target The entity, array of entities, entity collection or data source to view. You can also pass a promise that resolves to one of the previously mentioned types.
+     * @param {Entity|Entity[]|EntityCollection|DataSource|ImageryLayer|Promise.<Entity|Entity[]|EntityCollection|DataSource|ImageryLayer>} target The entity, array of entities, entity collection, data source or imagery layer with rectangular imagery to view. You can also pass a promise that resolves to one of the previously mentioned types.
      * @param {Object} [options] Object with the following properties:
      * @param {Number} [options.duration=3.0] The duration of the flight in seconds.
      * @param {Number} [options.maximumHeight] The maximum height at the peak of the flight.
@@ -1638,8 +1642,17 @@ Either specify options.terrainProvider instead or set options.baseLayerPicker to
                 return;
             }
 
+            //If the zoom target is a rectangular imagery in an ImageLayer
+            if (zoomTarget instanceof ImageryLayer) {
+                zoomTarget.getViewableRectangle().then(function (rectangle) {
+                    //Only perform the zoom if it wasn't cancelled before the data source finished.
+                    if (that._zoomPromise === zoomPromise) {
+                        that._zoomTarget = rectangle;
+                    }
+                });
+            }
             //If the zoom target is a data source, and it's in the middle of loading, wait for it to finish loading.
-            if (zoomTarget.isLoading && defined(zoomTarget.loadingEvent)) {
+            else if (zoomTarget.isLoading && defined(zoomTarget.loadingEvent)) {
                 var removeEvent = zoomTarget.loadingEvent.addEventListener(function() {
                     removeEvent();
 
@@ -1698,6 +1711,26 @@ Either specify options.terrainProvider instead or set options.baseLayerPicker to
         }
 
         var zoomPromise = viewer._zoomPromise;
+        //Set camera
+        var scene = viewer.scene;
+        var camera = scene.camera;
+
+        //If entities are a single rectangular imagery
+        if(entities instanceof Rectangle) {
+            if(viewer._zoomIsFlight) {
+                camera.flyTo({
+                    destination: entities
+                });
+            } else {
+                camera.setView({
+                    destination: entities
+                });
+            }
+            clearZoom(viewer);
+            zoomPromise.resolve(true);
+            return;
+        }
+
         var boundingSpheres = [];
         for (var i = 0, len = entities.length; i < len; i++) {
             var state = viewer._dataSourceDisplay.getBoundingSphere(entities[i], false, boundingSphereScratch);
@@ -1717,9 +1750,6 @@ Either specify options.terrainProvider instead or set options.baseLayerPicker to
         //Stop tracking the current entity.
         viewer.trackedEntity = undefined;
 
-        //Set camera
-        var scene = viewer.scene;
-        var camera = scene.camera;
         var boundingSphere = BoundingSphere.fromBoundingSpheres(boundingSpheres);
         var controller = scene.screenSpaceCameraController;
         controller.minimumZoomDistance = Math.min(controller.minimumZoomDistance, boundingSphere.radius * 0.5);


### PR DESCRIPTION
For #3471.
Now `viewer.zoomTo` and `viewer.flyTo` take `ImageLayer` as an argument.
I've tested in `Helloworld.html` and it's working:
```
var viewer = new Cesium.Viewer('cesiumContainer');
var layerRectangle = Cesium.Rectangle.fromDegrees(15.2, 10.9, 15.3, 11.0);
var layer = new Cesium.ImageryLayer(new Cesium.ArcGisMapServerImageryProvider({
	url : 'http://server.arcgisonline.com/ArcGIS/rest/services/World_Street_Map/MapServer'
}), {
	rectangle : layerRectangle
});
viewer.zoomTo(layer);
//viewer.flyTo(layer);
```
Not sure if this is the desired way to implement this.