### PR TITLE
Removed duplicate scene param from documentation

### DIFF
--- a/Source/Widgets/VRButton/VRButton.js
+++ b/Source/Widgets/VRButton/VRButton.js
@@ -29,7 +29,6 @@ define([
      * @param {Element|String} container The DOM element or ID that will contain the widget.
      * @param {Scene} scene The scene.
      * @param {Element|String} [vrElement=document.body] The element or id to be placed into vr mode.
-     * @param {Scene} scene The scene.
      *
      * @exception {DeveloperError} Element with id "container" does not exist in the document.
      */


### PR DESCRIPTION
VRButton contains a duplicate @param scene javadoc, which should be removed.