### PR TITLE
ColorRampExpression uses Cesium colors for setter

### DIFF
--- a/Source/Scene/ColorRampExpression.js
+++ b/Source/Scene/ColorRampExpression.js
@@ -74,7 +74,15 @@ define([
         var runtimeColors = new Array(length);
 
         for (var i = 0; i < length; ++i) {
-            runtimeColors[i] = Color.fromCssColorString(colors[i]);
+            var c = Color.fromCssColorString(colors[i]);
+
+            //>>includeStart('debug', pragmas.debug);
+            if (!defined(c)) {
+                throw new DeveloperError('color must be a valid CSS string');
+            }
+            //>>includeEnd('debug');
+
+            runtimeColors[i] = c;
         }
 
         expression._runtimeColors = runtimeColors;

--- a/Source/Scene/ColorRampExpression.js
+++ b/Source/Scene/ColorRampExpression.js
@@ -35,6 +35,7 @@ define([
         this._intervals = clone(jsonExpression.intervals, true);
 
         this._runtimeIntervals = undefined;
+        setRuntimeColors(this);
     }
 
     defineProperties(ColorRampExpression.prototype, {
@@ -43,10 +44,10 @@ define([
          */
         colors : {
             get : function() {
-                return this._colors;
+                return this._runtimeColors;
             },
             set : function(value) {
-                this._colors = clone(value, true);
+                this._runtimeColors = clone(value, true);
                 this._styleEngine.makeDirty();
                 this._runtimeIntervals = undefined; // Lazily computed in evaluate
             }
@@ -67,26 +68,28 @@ define([
         }
     });
 
-    function computeRuntimeIntervals(expression) {
+    function setRuntimeColors(expression) {
         var colors = expression._colors;
+        var length = colors.length;
+        var runtimeColors = new Array(length);
+
+        for (var i = 0; i < length; ++i) {
+            runtimeColors[i] = Color.fromCssColorString(colors[i]);
+        }
+
+        expression._runtimeColors = runtimeColors;
+    }
+
+    function computeRuntimeIntervals(expression) {
         var intervals = expression._intervals;
         var length = intervals.length;
 
         var runtimeIntervals = new Array(length);
         for (var i = 0; i < length; ++i) {
-            var color = colors[i];
-            var c = Color.fromCssColorString(color);
-
-            //>>includeStart('debug', pragmas.debug);
-            if (!defined(c)) {
-                throw new DeveloperError('color must be a valid CSS string');
-            }
-            //>>includeEnd('debug');
-
             runtimeIntervals[i] = {
 // TODO: what about intervals[0] and inclusive/exclusive flag?
                 maximum : (i !== length - 1) ? intervals[i + 1] : Number.POSITIVE_INFINITY,
-                color : c
+                color : expression._runtimeColors[i]
             };
         }
 

--- a/Specs/Scene/ColorRampExpressionSpec.js
+++ b/Specs/Scene/ColorRampExpressionSpec.js
@@ -43,14 +43,14 @@ defineSuite([
         var mockStyleEngine = new MockStyleEngine();
         var expression = new ColorRampExpression(mockStyleEngine, jsonExp);
         expect(expression.expression).toEqual(new NumberExpression(mockStyleEngine, jsonExp.expression));
-        expect(expression.colors).toEqual(['red', 'blue']);
+        expect(expression.colors).toEqual([Color.RED, Color.BLUE]);
         expect(expression.intervals).toEqual([5,10]);
     });
 
     it('sets colors', function() {
         var expression = new ColorRampExpression(new MockStyleEngine(), jsonExp);
-        expression.colors = ['purple', 'orange', 'green'];
-        expect(expression.colors).toEqual(['purple', 'orange', 'green']);
+        expression.colors = [Color.PURPLE, Color.ORANGE, Color.GREEN];
+        expect(expression.colors).toEqual([Color.PURPLE, Color.ORANGE, Color.GREEN]);
     });
 
     it('sets intervals', function() {

--- a/Specs/Scene/ColorRampExpressionSpec.js
+++ b/Specs/Scene/ColorRampExpressionSpec.js
@@ -53,6 +53,26 @@ defineSuite([
         expect(expression.colors).toEqual([Color.PURPLE, Color.ORANGE, Color.GREEN]);
     });
 
+    it('throws error on invalid color', function() {
+        var invalidExp = {
+            'expression' : {
+                'leftOperand' : '${Height}',
+                'operator' : '+',
+                'rightOperand' : 0
+            },
+            'colors' : [
+                'invalidRed'
+            ],
+            'intervals': [
+                5
+            ]
+        };
+
+        expect(function() {
+            return new ColorRampExpression(new MockStyleEngine(), invalidExp);
+        }).toThrowDeveloperError();
+    });
+
     it('sets intervals', function() {
         var expression = new ColorRampExpression(new MockStyleEngine(), jsonExp);
         expression.intervals = [1, 2, 3];


### PR DESCRIPTION
Getting and setting `ColorRampExpression.colors` uses compiled Cesium colors instead of css format strings.

Added a test to the spec to confirm invalid CSS format strings throw a `developerError`.