### PR TITLE
Shadows Fix

### DIFF
--- a/Source/Renderer/UniformState.js
+++ b/Source/Renderer/UniformState.js
@@ -228,8 +228,6 @@ define([
                 this._inverseTransposeModelDirty = true;
                 this._modelViewDirty = true;
                 this._inverseModelViewDirty = true;
-                this._viewProjectionDirty = true;
-                this._inverseViewProjectionDirty = true;
                 this._modelViewRelativeToEyeDirty = true;
                 this._inverseModelViewDirty = true;
                 this._modelViewProjectionDirty = true;
@@ -783,6 +781,7 @@ define([
         uniformState._inverseModelViewDirty = true;
         uniformState._inverseModelView3DDirty = true;
         uniformState._viewProjectionDirty = true;
+        uniformState._inverseViewProjectionDirty = true;
         uniformState._modelViewProjectionDirty = true;
         uniformState._modelViewProjectionRelativeToEyeDirty = true;
         uniformState._modelViewInfiniteProjectionDirty = true;
@@ -803,6 +802,7 @@ define([
         uniformState._inverseProjectionDirty = true;
         uniformState._inverseProjectionOITDirty = true;
         uniformState._viewProjectionDirty = true;
+        uniformState._inverseViewProjectionDirty = true;
         uniformState._modelViewProjectionDirty = true;
         uniformState._modelViewProjectionRelativeToEyeDirty = true;
     }

--- a/Source/Scene/Scene.js
+++ b/Source/Scene/Scene.js
@@ -1558,6 +1558,11 @@ define([
             }
 
             us.updateFrustum(frustum);
+
+            if (scene.sunShadowMap.enabled) {
+                scene.sunShadowMap.updateShadowMapMatrix(us);
+            }
+
             clearDepth.execute(context, passState);
 
             var commands = frustumCommands.commands[Pass.GLOBE];
@@ -1604,6 +1609,10 @@ define([
                 // Do not overlap frustums in the translucent pass to avoid blending artifacts
                 frustum.near = frustumCommands.near;
                 us.updateFrustum(frustum);
+
+                if (scene.sunShadowMap.enabled) {
+                    scene.sunShadowMap.updateShadowMapMatrix(us);
+                }
             }
 
             commands = frustumCommands.commands[Pass.TRANSLUCENT];
@@ -1952,11 +1961,11 @@ define([
         scene.fog.update(frameState);
 
         var shadowMap = scene.sunShadowMap;
+        us.update(frameState, shadowMap);
+
         if (shadowMap.enabled) {
             shadowMap.update(frameState);
         }
-
-        us.update(frameState, shadowMap);
 
         scene._computeCommandList.length = 0;
         scene._overlayCommandList.length = 0;

--- a/Source/Scene/ShadowMap.js
+++ b/Source/Scene/ShadowMap.js
@@ -436,15 +436,12 @@ define([
     var scaleBiasMatrix = new Matrix4(0.5, 0.0, 0.0, 0.5, 0.0, 0.5, 0.0, 0.5, 0.0, 0.0, 0.5, 0.5, 0.0, 0.0, 0.0, 1.0);
 
     ShadowMap.prototype.update = function(frameState) {
-        var context = frameState.context;
-        var uniformState = context.uniformState;
-
         applyDebugSettings(this, frameState);
+        updateFramebuffer(this, frameState.context);
+    };
 
-        updateFramebuffer(this, context);
-
+    ShadowMap.prototype.updateShadowMapMatrix = function(uniformState) {
         // Calculate shadow map matrix. It converts gl_Position to shadow map texture space.
-        // TODO : only compute matrix when dirty
         var viewMatrix = this.camera.viewMatrix;
         var projectionMatrix = this._frustum.projectionMatrix;
         var shadowMapMatrix = Matrix4.multiplyTransformation(projectionMatrix, viewMatrix, this._shadowMapMatrix);


### PR DESCRIPTION
For #2594 

This should fix the glitchiness from before. The shadow map matrix wasn't using the correct inverse view-projection matrix. It needed to update per-frustum rather than just once with the entire frustum range.

Thanks @bagnell for the help with this!