### PR TITLE
Added czm_pass automatic GLSL uniform

### DIFF
--- a/Source/Renderer/AutomaticUniforms.js
+++ b/Source/Renderer/AutomaticUniforms.js
@@ -1396,6 +1396,30 @@ define([
         }),
 
         /**
+         * An automatic GLSL uniform representing the current rendering pass.
+         *
+         * @alias czm_pass
+         * @glslUniform
+         *
+         * @example
+         * // GLSL declaration
+         * uniform float czm_pass;
+         *
+         * // Example
+         * if ((czm_pass == czm_passTranslucent) && isOpaque())
+         * {
+         *     gl_Position *= 0.0; // Cull opaque geometry in the translucent pass
+         * }
+         */
+        czm_pass : new AutomaticUniform({
+            size : 1,
+            datatype : WebGLConstants.FLOAT,
+            getValue : function(uniformState) {
+                return uniformState.pass;
+            }
+        }),
+
+        /**
          * An automatic GLSL uniform representing a 3x3 rotation matrix that transforms
          * from True Equator Mean Equinox (TEME) axes to the pseudo-fixed axes at the current scene time.
          *

--- a/Source/Renderer/UniformState.js
+++ b/Source/Renderer/UniformState.js
@@ -138,6 +138,7 @@ define([
         this._sunDirectionEC = new Cartesian3();
         this._moonDirectionEC = new Cartesian3();
 
+        this._pass = undefined;
         this._mode = undefined;
         this._mapProjection = undefined;
         this._cameraDirection = new Cartesian3();
@@ -766,6 +767,16 @@ define([
             get : function() {
                 return this._fogDensity;
             }
+        },
+
+        /**
+         * @memberof UniformState.prototype
+         * @type {Pass}
+         */
+        pass : {
+            get : function() {
+                return this._pass;
+            }
         }
     });
 
@@ -868,6 +879,10 @@ define([
         this._frustumPlanes.y = frustum.bottom;
         this._frustumPlanes.z = frustum.left;
         this._frustumPlanes.w = frustum.right;
+    };
+
+    UniformState.prototype.updatePass = function(pass) {
+        this._pass = pass;
     };
 
     /**

--- a/Source/Scene/Pass.js
+++ b/Source/Scene/Pass.js
@@ -11,17 +11,21 @@ define([
      * @private
      */
     var Pass = {
+        // If you add/modify/remove Pass constants, also change the automatic GLSL constants
+        // that start with 'czm_pass'
+        //
         // Commands are executed in order by pass up to the translucent pass.
         // Translucent geometry needs special handling (sorting/OIT). The compute pass
         // is executed first and the overlay pass is executed last. Both are not sorted
         // by frustum.
-        COMPUTE : 0,
-        GLOBE : 1,
-        GROUND : 2,
-        OPAQUE : 3,
-        TRANSLUCENT : 4,
-        OVERLAY : 5,
-        NUMBER_OF_PASSES : 6
+        ENVIRONMENT : 0,
+        COMPUTE : 1,
+        GLOBE : 2,
+        GROUND : 3,
+        OPAQUE : 4,
+        TRANSLUCENT : 5,
+        OVERLAY : 6,
+        NUMBER_OF_PASSES : 7
     };
 
     return freezeObject(Pass);

--- a/Source/Scene/Scene.js
+++ b/Source/Scene/Scene.js
@@ -1477,6 +1477,7 @@ define([
         frustum.near = camera.frustum.near;
         frustum.far = camera.frustum.far;
         us.updateFrustum(frustum);
+        us.updatePass(Pass.ENVIRONMENT);
 
         var environmentState = scene._environmentState;
         var skyBoxCommand = environmentState.skyBoxCommand;
@@ -1551,6 +1552,7 @@ define([
             us.updateFrustum(frustum);
             clearDepth.execute(context, passState);
 
+            us.updatePass(Pass.GLOBE);
             var commands = frustumCommands.commands[Pass.GLOBE];
             var length = frustumCommands.indices[Pass.GLOBE];
             for (j = 0; j < length; ++j) {
@@ -1566,6 +1568,7 @@ define([
                 passState.framebuffer = fb;
             }
 
+            us.updatePass(Pass.GROUND);
             commands = frustumCommands.commands[Pass.GROUND];
             length = frustumCommands.indices[Pass.GROUND];
             for (j = 0; j < length; ++j) {
@@ -1584,6 +1587,7 @@ define([
             var startPass = Pass.GROUND + 1;
             var endPass = Pass.TRANSLUCENT;
             for (var pass = startPass; pass < endPass; ++pass) {
+                us.updatePass(pass);
                 commands = frustumCommands.commands[pass];
                 length = frustumCommands.indices[pass];
                 for (j = 0; j < length; ++j) {
@@ -1597,6 +1601,7 @@ define([
                 us.updateFrustum(frustum);
             }
 
+            us.updatePass(Pass.TRANSLUCENT);
             commands = frustumCommands.commands[Pass.TRANSLUCENT];
             commands.length = frustumCommands.indices[Pass.TRANSLUCENT];
             executeTranslucentCommands(scene, executeCommand, passState, commands);
@@ -1611,6 +1616,9 @@ define([
     }
 
     function executeComputeCommands(scene) {
+        var us = scene.context.uniformState;
+        us.updatePass(Pass.COMPUTE);
+
         var sunComputeCommand = scene._environmentState.sunComputeCommand;
         if (defined(sunComputeCommand)) {
             sunComputeCommand.execute(scene._computeEngine);
@@ -1624,6 +1632,9 @@ define([
     }
 
     function executeOverlayCommands(scene, passState) {
+        var us = scene.context.uniformState;
+        us.updatePass(Pass.OVERLAY);
+
         var context = scene.context;
         var commandList = scene._overlayCommandList;
         var length = commandList.length;

--- a/Source/Shaders/Builtin/Constants/passCompute.glsl
+++ b/Source/Shaders/Builtin/Constants/passCompute.glsl
@@ -1,0 +1,9 @@
+/**
+ * The automatic GLSL constant for {@link Pass#COMPUTE}
+ *
+ * @name czm_passCompute
+ * @glslConstant
+ *
+ * @see czm_pass
+ */
+const float czm_passCompute = 1.0;

--- a/Source/Shaders/Builtin/Constants/passEnvironment.glsl
+++ b/Source/Shaders/Builtin/Constants/passEnvironment.glsl
@@ -1,0 +1,9 @@
+/**
+ * The automatic GLSL constant for {@link Pass#ENVIRONMENT}
+ *
+ * @name czm_passEnvironment
+ * @glslConstant
+ *
+ * @see czm_pass
+ */
+const float czm_passEnvironment = 0.0;

--- a/Source/Shaders/Builtin/Constants/passGlobe.glsl
+++ b/Source/Shaders/Builtin/Constants/passGlobe.glsl
@@ -1,0 +1,9 @@
+/**
+ * The automatic GLSL constant for {@link Pass#GLOBE}
+ *
+ * @name czm_passGlobe
+ * @glslConstant
+ *
+ * @see czm_pass
+ */
+const float czm_passGlobe = 2.0;

--- a/Source/Shaders/Builtin/Constants/passGround.glsl
+++ b/Source/Shaders/Builtin/Constants/passGround.glsl
@@ -1,0 +1,9 @@
+/**
+ * The automatic GLSL constant for {@link Pass#GROUND}
+ *
+ * @name czm_passGround
+ * @glslConstant
+ *
+ * @see czm_pass
+ */
+const float czm_passGround = 3.0;

--- a/Source/Shaders/Builtin/Constants/passOpaque.glsl
+++ b/Source/Shaders/Builtin/Constants/passOpaque.glsl
@@ -1,0 +1,9 @@
+/**
+ * The automatic GLSL constant for {@link Pass#OPAQUE}
+ *
+ * @name czm_passOpaque
+ * @glslConstant
+ *
+ * @see czm_pass
+ */
+const float czm_passOpaque = 4.0;

--- a/Source/Shaders/Builtin/Constants/passOverlay.glsl
+++ b/Source/Shaders/Builtin/Constants/passOverlay.glsl
@@ -1,0 +1,9 @@
+/**
+ * The automatic GLSL constant for {@link Pass#OVERLAY}
+ *
+ * @name czm_passOverlay
+ * @glslConstant
+ *
+ * @see czm_pass
+ */
+const float czm_passOverlay = 6.0;

--- a/Source/Shaders/Builtin/Constants/passTranslucent.glsl
+++ b/Source/Shaders/Builtin/Constants/passTranslucent.glsl
@@ -1,0 +1,9 @@
+/**
+ * The automatic GLSL constant for {@link Pass#TRANSLUCENT}
+ *
+ * @name czm_passTranslucent
+ * @glslConstant
+ *
+ * @see czm_pass
+ */
+const float czm_passTranslucent = 5.0;

--- a/Specs/Renderer/AutomaticUniformSpec.js
+++ b/Specs/Renderer/AutomaticUniformSpec.js
@@ -6,6 +6,7 @@ defineSuite([
         'Core/Matrix4',
         'Renderer/Texture',
         'Scene/OrthographicFrustum',
+        'Scene/Pass',
         'Scene/SceneMode',
         'Specs/createCamera',
         'Specs/createContext',
@@ -17,6 +18,7 @@ defineSuite([
         Matrix4,
         Texture,
         OrthographicFrustum,
+        Pass,
         SceneMode,
         createCamera,
         createContext,
@@ -850,6 +852,83 @@ defineSuite([
             '    (czm_temeToPseudoFixed[0][1] != 0.0) && (czm_temeToPseudoFixed[1][1] != 0.0) && (czm_temeToPseudoFixed[2][1] == 0.0) && ' +
             '    (czm_temeToPseudoFixed[0][2] == 0.0) && (czm_temeToPseudoFixed[1][2] == 0.0) && (czm_temeToPseudoFixed[2][2] == 1.0) ' +
             '  ); ' +
+            '}';
+        context.verifyDrawForSpecs(fs);
+    });
+
+    it('has czm_pass and czm_passEnvironment', function() {
+        var us = context.uniformState;
+        us.updatePass(Pass.ENVIRONMENT);
+
+        var fs =
+            'void main() { ' +
+            '  gl_FragColor = vec4(czm_pass == czm_passEnvironment);' +
+            '}';
+        context.verifyDrawForSpecs(fs);
+    });
+
+    it('has czm_pass and czm_passCompute', function() {
+        var us = context.uniformState;
+        us.updatePass(Pass.COMPUTE);
+
+        var fs =
+            'void main() { ' +
+            '  gl_FragColor = vec4(czm_pass == czm_passCompute);' +
+            '}';
+        context.verifyDrawForSpecs(fs);
+    });
+
+    it('has czm_pass and czm_passGlobe', function() {
+        var us = context.uniformState;
+        us.updatePass(Pass.GLOBE);
+
+        var fs =
+            'void main() { ' +
+            '  gl_FragColor = vec4(czm_pass == czm_passGlobe);' +
+            '}';
+        context.verifyDrawForSpecs(fs);
+    });
+
+    it('has czm_pass and czm_passGround', function() {
+        var us = context.uniformState;
+        us.updatePass(Pass.GROUND);
+
+        var fs =
+            'void main() { ' +
+            '  gl_FragColor = vec4(czm_pass == czm_passGround);' +
+            '}';
+        context.verifyDrawForSpecs(fs);
+    });
+
+    it('has czm_pass and czm_passOpaque', function() {
+        var us = context.uniformState;
+        us.updatePass(Pass.OPAQUE);
+
+        var fs =
+            'void main() { ' +
+            '  gl_FragColor = vec4(czm_pass == czm_passOpaque);' +
+            '}';
+        context.verifyDrawForSpecs(fs);
+    });
+
+    it('has czm_pass and czm_passTranslucent', function() {
+        var us = context.uniformState;
+        us.updatePass(Pass.TRANSLUCENT);
+
+        var fs =
+            'void main() { ' +
+            '  gl_FragColor = vec4(czm_pass == czm_passTranslucent);' +
+            '}';
+        context.verifyDrawForSpecs(fs);
+    });
+
+    it('has czm_pass and czm_passOverlay', function() {
+        var us = context.uniformState;
+        us.updatePass(Pass.OVERLAY);
+
+        var fs =
+            'void main() { ' +
+            '  gl_FragColor = vec4(czm_pass == czm_passOverlay);' +
             '}';
         context.verifyDrawForSpecs(fs);
     });


### PR DESCRIPTION
This is part of the `3d-tiles-style-translucent` branch for culling opaque/translucent geometry in the vertex shader, e.g., so we can render a batched tile twice: once for the opaque parts and once for the translucent parts.

@bagnell can you carefully review the changes to Scene.js and make sure I didn't miss any pass updates?

@lilleyse does this fit in OK with the renderer changes you are making for shadows?