### PR TITLE
Added new Color operations

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@ Change Log
 * Added `Camera.flyHome` function for resetting the camera to the home view
 * Fix an issue when changing a billboard's position property multiple times per frame. [#3511](https://github.com/AnalyticalGraphicsInc/cesium/pull/3511)
 * Fixed texture coordinates for polygon with position heights
+* Added `Color.add`, `Color.subtract`, `Color.multiply`, `Color.divide`, `Color.mod`, `Color.multiplyByScalar`, and `Color.divideByScalar` functions to perform arithmetic operations on colors.
 
 ### 1.18 - 2016-02-01
 * Breaking changes

--- a/Source/Core/Color.js
+++ b/Source/Core/Color.js
@@ -715,6 +715,202 @@ define([
     };
 
     /**
+     * Computes the componentwise sum of two Colors.
+     *
+     * @param {Color} left The first Color.
+     * @param {Color} right The second Color.
+     * @param {Color} result The object onto which to store the result.
+     * @returns {Color} The modified result parameter.
+     */
+    Color.add = function(left, right, result) {
+        //>>includeStart('debug', pragmas.debug);
+        if (!defined(left)) {
+            throw new DeveloperError('left is required');
+        }
+        if (!defined(right)) {
+            throw new DeveloperError('right is required');
+        }
+        if (!defined(result)) {
+            throw new DeveloperError('result is required');
+        }
+        //>>includeEnd('debug');
+
+        result.red = left.red + right.red;
+        result.green = left.green + right.green;
+        result.blue = left.blue + right.blue;
+        result.alpha = left.alpha + right.alpha;
+        return result;
+    };
+
+    /**
+     * Computes the componentwise difference of two Colors.
+     *
+     * @param {Color} left The first Color.
+     * @param {Color} right The second Color.
+     * @param {Color} result The object onto which to store the result.
+     * @returns {Color} The modified result parameter.
+     */
+    Color.subtract = function(left, right, result) {
+        //>>includeStart('debug', pragmas.debug);
+        if (!defined(left)) {
+            throw new DeveloperError('left is required');
+        }
+        if (!defined(right)) {
+            throw new DeveloperError('right is required');
+        }
+        if (!defined(result)) {
+            throw new DeveloperError('result is required');
+        }
+        //>>includeEnd('debug');
+
+        result.red = left.red - right.red;
+        result.green = left.green - right.green;
+        result.blue = left.blue - right.blue;
+        result.alpha = left.alpha - right.alpha;
+        return result;
+    };
+
+    /**
+     * Computes the componentwise product of two Colors.
+     *
+     * @param {Color} left The first Color.
+     * @param {Color} right The second Color.
+     * @param {Color} result The object onto which to store the result.
+     * @returns {Color} The modified result parameter.
+     */
+    Color.multiply = function(left, right, result) {
+        //>>includeStart('debug', pragmas.debug);
+        if (!defined(left)) {
+            throw new DeveloperError('left is required');
+        }
+        if (!defined(right)) {
+            throw new DeveloperError('right is required');
+        }
+        if (!defined(result)) {
+            throw new DeveloperError('result is required');
+        }
+        //>>includeEnd('debug');
+
+        result.red = left.red * right.red;
+        result.green = left.green * right.green;
+        result.blue = left.blue * right.blue;
+        result.alpha = left.alpha * right.alpha;
+        return result;
+    };
+
+    /**
+     * Computes the componentwise quotient of two Colors.
+     *
+     * @param {Color} left The first Color.
+     * @param {Color} right The second Color.
+     * @param {Color} result The object onto which to store the result.
+     * @returns {Color} The modified result parameter.
+     */
+    Color.divide = function(left, right, result) {
+        //>>includeStart('debug', pragmas.debug);
+        if (!defined(left)) {
+            throw new DeveloperError('left is required');
+        }
+        if (!defined(right)) {
+            throw new DeveloperError('right is required');
+        }
+        if (!defined(result)) {
+            throw new DeveloperError('result is required');
+        }
+        //>>includeEnd('debug');
+
+        result.red = left.red / right.red;
+        result.green = left.green / right.green;
+        result.blue = left.blue / right.blue;
+        result.alpha = left.alpha / right.alpha;
+        return result;
+    };
+
+    /**
+     * Computes the componentwise modulus of two Colors.
+     *
+     * @param {Color} left The first Color.
+     * @param {Color} right The second Color.
+     * @param {Color} result The object onto which to store the result.
+     * @returns {Color} The modified result parameter.
+     */
+    Color.mod = function(left, right, result) {
+        //>>includeStart('debug', pragmas.debug);
+        if (!defined(left)) {
+            throw new DeveloperError('left is required');
+        }
+        if (!defined(right)) {
+            throw new DeveloperError('right is required');
+        }
+        if (!defined(result)) {
+            throw new DeveloperError('result is required');
+        }
+        //>>includeEnd('debug');
+
+        result.red = left.red % right.red;
+        result.green = left.green % right.green;
+        result.blue = left.blue % right.blue;
+        result.alpha = left.alpha % right.alpha;
+        return result;
+    };
+
+    /**
+     * Multiplies the provided Color componentwise by the provided scalar.
+     *
+     * @param {Color} color The Color to be scaled.
+     * @param {Number} scalar The scalar to multiply with.
+     * @param {Color} result The object onto which to store the result.
+     * @returns {Color} The modified result parameter.
+     */
+    Color.multiplyByScalar = function(color, scalar, result) {
+        //>>includeStart('debug', pragmas.debug);
+        if (!defined(color)) {
+            throw new DeveloperError('cartesian is required');
+        }
+        if (typeof scalar !== 'number') {
+            throw new DeveloperError('scalar is required and must be a number.');
+        }
+        if (!defined(result)) {
+            throw new DeveloperError('result is required');
+        }
+        //>>includeEnd('debug');
+
+        result.red = color.red * scalar;
+        result.green = color.green * scalar;
+        result.blue = color.blue * scalar;
+        result.alpha = color.alpha * scalar;
+        return result;
+    };
+
+    /**
+     * Divides the provided Color componentwise by the provided scalar.
+     *
+     * @param {Color} color The Color to be divided.
+     * @param {Number} scalar The scalar to divide with.
+     * @param {Color} result The object onto which to store the result.
+     * @returns {Color} The modified result parameter.
+     */
+    Color.divideByScalar = function(color, scalar, result) {
+        //>>includeStart('debug', pragmas.debug);
+        if (!defined(color)) {
+            throw new DeveloperError('cartesian is required');
+        }
+        if (typeof scalar !== 'number') {
+            throw new DeveloperError('scalar is required and must be a number.');
+        }
+        if (!defined(result)) {
+            throw new DeveloperError('result is required');
+        }
+        //>>includeEnd('debug');
+
+        result.red = color.red / scalar;
+        result.green = color.green / scalar;
+        result.blue = color.blue / scalar;
+        result.alpha = color.alpha / scalar;
+        return result;
+    };
+
+    /**
      * An immutable Color instance initialized to CSS color #F0F8FF
      * <span class="colorSwath" style="background: #F0F8FF;"></span>
      *

--- a/Specs/Core/ColorSpec.js
+++ b/Specs/Core/ColorSpec.js
@@ -473,5 +473,239 @@ defineSuite([
         }).toThrowDeveloperError();
     });
 
+    it('Can add', function() {
+        var left = new Color(0.1, 0.2, 0.3, 0.4);
+        var right = new Color(0.3, 0.3, 0.3, 0.3);
+        var result = Color.add(left, right, new Color());
+        expect(result.red).toEqual(0.4);
+        expect(result.green).toEqual(0.5);
+        expect(result.blue).toEqual(0.6);
+        expect(result.alpha).toEqual(0.7);
+    });
+
+    it('add throws with undefined parameters', function() {
+        expect(function() {
+            Color.add(undefined, new Color(), new Color());
+        }).toThrowDeveloperError();
+
+        expect(function() {
+            Color.add(new Color(), undefined, new Color());
+        }).toThrowDeveloperError();
+
+        expect(function() {
+            Color.add(new Color(), new Color(), undefined);
+        }).toThrowDeveloperError();
+    });
+
+    it('can add with a result parameter that is an input parameter', function() {
+        var left = new Color(0.1, 0.2, 0.3, 0.4);
+        var right = new Color(0.3, 0.3, 0.3, 0.3);
+        var result = Color.add(left, right, left);
+        expect(result.red).toEqual(0.4);
+        expect(result.green).toEqual(0.5);
+        expect(result.blue).toEqual(0.6);
+        expect(result.alpha).toEqual(0.7);
+    });
+
+    it('Can subtract', function() {
+        var left = new Color(1.0, 1.0, 1.0, 1.0);
+        var right = new Color(0.1, 0.2, 0.3, 0.4);
+        var result = Color.subtract(left, right, new Color());
+        expect(result.red).toEqual(0.9);
+        expect(result.green).toEqual(0.8);
+        expect(result.blue).toEqual(0.7);
+        expect(result.alpha).toEqual(0.6);
+    });
+
+    it('subtract throws with undefined parameters', function() {
+        expect(function() {
+            Color.subtract(undefined, new Color(), new Color());
+        }).toThrowDeveloperError();
+
+        expect(function() {
+            Color.subtract(new Color(), undefined, new Color());
+        }).toThrowDeveloperError();
+
+        expect(function() {
+            Color.subtract(new Color(), new Color(), undefined);
+        }).toThrowDeveloperError();
+    });
+
+    it('subtract multiply with a result parameter that is an input parameter', function() {
+        var left = new Color(1.0, 1.0, 1.0, 1.0);
+        var right = new Color(0.1, 0.2, 0.3, 0.4);
+        var result = Color.subtract(left, right, left);
+        expect(result.red).toEqual(0.9);
+        expect(result.green).toEqual(0.8);
+        expect(result.blue).toEqual(0.7);
+        expect(result.alpha).toEqual(0.6);
+    });
+
+    it('Can multiply', function() {
+        var left = new Color(0.1, 0.2, 0.3, 0.4);
+        var right = new Color(0.2, 0.2, 0.2, 0.2);
+        var result = Color.multiply(left, right, new Color());
+        expect(result.red).toEqualEpsilon(0.02, CesiumMath.EPSILON15);
+        expect(result.green).toEqualEpsilon(0.04, CesiumMath.EPSILON15);
+        expect(result.blue).toEqualEpsilon(0.06, CesiumMath.EPSILON15);
+        expect(result.alpha).toEqualEpsilon(0.08, CesiumMath.EPSILON15);
+    });
+
+    it('multiply throws with undefined parameters', function() {
+        expect(function() {
+            Color.multiply(undefined, new Color(), new Color());
+        }).toThrowDeveloperError();
+
+        expect(function() {
+            Color.multiply(new Color(), undefined, new Color());
+        }).toThrowDeveloperError();
+
+        expect(function() {
+            Color.multiply(new Color(), new Color(), undefined);
+        }).toThrowDeveloperError();
+    });
+
+    it('can multiply with a result parameter that is an input parameter', function() {
+        var left = new Color(0.1, 0.2, 0.3, 0.4);
+        var right = new Color(0.2, 0.2, 0.2, 0.2);
+        var result = Color.multiply(left, right, left);
+        expect(result.red).toEqualEpsilon(0.02, CesiumMath.EPSILON15);
+        expect(result.green).toEqualEpsilon(0.04, CesiumMath.EPSILON15);
+        expect(result.blue).toEqualEpsilon(0.06, CesiumMath.EPSILON15);
+        expect(result.alpha).toEqualEpsilon(0.08, CesiumMath.EPSILON15);
+    });
+
+    it('Can divide', function() {
+        var left = new Color(0.1, 0.2, 0.1, 0.2);
+        var right = new Color(0.2, 0.2, 0.4, 0.4);
+        var result = Color.divide(left, right, new Color());
+        expect(result.red).toEqualEpsilon(0.5, CesiumMath.EPSILON15);
+        expect(result.green).toEqualEpsilon(1.0, CesiumMath.EPSILON15);
+        expect(result.blue).toEqualEpsilon(0.25, CesiumMath.EPSILON15);
+        expect(result.alpha).toEqualEpsilon(0.5, CesiumMath.EPSILON15);
+    });
+
+    it('divide throws with undefined parameters', function() {
+        expect(function() {
+            Color.divide(undefined, new Color(), new Color());
+        }).toThrowDeveloperError();
+
+        expect(function() {
+            Color.divide(new Color(), undefined, new Color());
+        }).toThrowDeveloperError();
+
+        expect(function() {
+            Color.divide(new Color(), new Color(), undefined);
+        }).toThrowDeveloperError();
+    });
+
+    it('can divide with a result parameter that is an input parameter', function() {
+        var left = new Color(0.1, 0.2, 0.1, 0.2);
+        var right = new Color(0.2, 0.2, 0.4, 0.4);
+        var result = Color.divide(left, right, left);
+        expect(result.red).toEqualEpsilon(0.5, CesiumMath.EPSILON15);
+        expect(result.green).toEqualEpsilon(1.0, CesiumMath.EPSILON15);
+        expect(result.blue).toEqualEpsilon(0.25, CesiumMath.EPSILON15);
+        expect(result.alpha).toEqualEpsilon(0.5, CesiumMath.EPSILON15);
+    });
+
+    it('Can mod', function() {
+        var left = new Color(0.1, 0.2, 0.3, 0.2);
+        var right = new Color(0.2, 0.2, 0.2, 0.4);
+        var result = Color.mod(left, right, new Color());
+        expect(result.red).toEqualEpsilon(0.1, CesiumMath.EPSILON15);
+        expect(result.green).toEqualEpsilon(0.0, CesiumMath.EPSILON15);
+        expect(result.blue).toEqualEpsilon(0.1, CesiumMath.EPSILON15);
+        expect(result.alpha).toEqualEpsilon(0.2, CesiumMath.EPSILON15);
+    });
+
+    it('mod throws with undefined parameters', function() {
+        expect(function() {
+            Color.mod(undefined, new Color(), new Color());
+        }).toThrowDeveloperError();
+
+        expect(function() {
+            Color.mod(new Color(), undefined, new Color());
+        }).toThrowDeveloperError();
+
+        expect(function() {
+            Color.mod(new Color(), new Color(), undefined);
+        }).toThrowDeveloperError();
+    });
+
+    it('can mod with a result parameter that is an input parameter', function() {
+        var left = new Color(0.1, 0.2, 0.3, 0.2);
+        var right = new Color(0.2, 0.2, 0.2, 0.4);
+        var result = Color.mod(left, right, left);
+        expect(result.red).toEqualEpsilon(0.1, CesiumMath.EPSILON15);
+        expect(result.green).toEqualEpsilon(0.0, CesiumMath.EPSILON15);
+        expect(result.blue).toEqualEpsilon(0.1, CesiumMath.EPSILON15);
+        expect(result.alpha).toEqualEpsilon(0.2, CesiumMath.EPSILON15);
+    });
+
+    it('Can multiply by scalar', function() {
+        var color = new Color(0.1, 0.2, 0.3, 0.4);
+        var result = Color.multiplyByScalar(color, 2.0, new Color());
+        expect(result.red).toEqualEpsilon(0.2, CesiumMath.EPSILON15);
+        expect(result.green).toEqualEpsilon(0.4, CesiumMath.EPSILON15);
+        expect(result.blue).toEqualEpsilon(0.6, CesiumMath.EPSILON15);
+        expect(result.alpha).toEqualEpsilon(0.8, CesiumMath.EPSILON15);
+    });
+
+    it('multiply by scalar throws with undefined parameters', function() {
+        expect(function() {
+            Color.multiplyByScalar(undefined, new Color(), new Color());
+        }).toThrowDeveloperError();
+
+        expect(function() {
+            Color.multiplyByScalar(new Color(), undefined, new Color());
+        }).toThrowDeveloperError();
+
+        expect(function() {
+            Color.multiplyByScalar(new Color(), new Color(), undefined);
+        }).toThrowDeveloperError();
+    });
+
+    it('can multiply by scalar with a result parameter that is an input parameter', function() {
+        var color = new Color(0.1, 0.2, 0.3, 0.4);
+        var result = Color.multiplyByScalar(color, 2.0, color);
+        expect(result.red).toEqualEpsilon(0.2, CesiumMath.EPSILON15);
+        expect(result.green).toEqualEpsilon(0.4, CesiumMath.EPSILON15);
+        expect(result.blue).toEqualEpsilon(0.6, CesiumMath.EPSILON15);
+        expect(result.alpha).toEqualEpsilon(0.8, CesiumMath.EPSILON15);
+    });
+
+    it('Can divide by scalar', function() {
+        var color = new Color(0.1, 0.2, 0.3, 0.4);
+        var result = Color.divideByScalar(color, 2.0, new Color());
+        expect(result.red).toEqualEpsilon(0.05, CesiumMath.EPSILON15);
+        expect(result.green).toEqualEpsilon(0.1, CesiumMath.EPSILON15);
+        expect(result.blue).toEqualEpsilon(0.15, CesiumMath.EPSILON15);
+        expect(result.alpha).toEqualEpsilon(0.2, CesiumMath.EPSILON15);
+    });
+
+    it('divide by scalar throws with undefined parameters', function() {
+        expect(function() {
+            Color.divideByScalar(undefined, new Color(), new Color());
+        }).toThrowDeveloperError();
+
+        expect(function() {
+            Color.divideByScalar(new Color(), undefined, new Color());
+        }).toThrowDeveloperError();
+
+        expect(function() {
+            Color.divideByScalar(new Color(), new Color(), undefined);
+        }).toThrowDeveloperError();
+    });
+
+    it('can divide by scalar with a result parameter that is an input parameter', function() {
+        var color = new Color(0.1, 0.2, 0.3, 0.4);
+        var result = Color.divideByScalar(color, 2.0, color);
+        expect(result.red).toEqualEpsilon(0.05, CesiumMath.EPSILON15);
+        expect(result.green).toEqualEpsilon(0.1, CesiumMath.EPSILON15);
+        expect(result.blue).toEqualEpsilon(0.15, CesiumMath.EPSILON15);
+        expect(result.alpha).toEqualEpsilon(0.2, CesiumMath.EPSILON15);
+    });
+
     createPackableSpecs(Color, new Color(0.1, 0.2, 0.3, 0.4), [0.1, 0.2, 0.3, 0.4]);
 });


### PR DESCRIPTION
Added new functions to `Color`, including:
  - `add` - Adds two colors componentwise
  - `subtract` - Subtracts two colors componentwise
  - `multiply` - Multiplies two colors componentwise
  - `divide` - Divide two colors componentwise
  - `mod` - Mod two colors componentwise
  - `multiplyByScalar` - Multiply a color by a scalar componentwise
  - `divideByScalar` - Divide a color by a scalar componentwise

And updated `ColorSpec` for each of these new functions