### PR TITLE
Fixed broken test for ColorMapExpression

### DIFF
--- a/Source/Scene/ColorMapExpression.js
+++ b/Source/Scene/ColorMapExpression.js
@@ -22,7 +22,9 @@ define([
     function ColorMapExpression(styleEngine, jsonExpression) {
         this._styleEngine = styleEngine;
         this._propertyName = jsonExpression.propertyName;
-        this._pattern = new RegExp(jsonExpression.pattern);
+        if (defined(jsonExpression.pattern)) {
+            this._pattern = new RegExp(jsonExpression.pattern);
+        }
         this._map = clone(jsonExpression.map, true);
         this._default = jsonExpression.default;
 


### PR DESCRIPTION
This was caused by the fact that I didn't check if the `pattern` field in the json was defined before I constructed a regex.