### PR TITLE
Added evaluation of color operations and literals supporting color alpha

### DIFF
--- a/Source/Scene/Expression.js
+++ b/Source/Scene/Expression.js
@@ -65,6 +65,16 @@ define([
                 if (defined(val)) {
                     node = new Node(val);
                 }
+            } else if (call === 'rgba') {
+                val = Color.fromBytes(args[0].value, args[1].value, args[2].value, args[3].value);
+                if (defined(val)) {
+                    node = new Node(val);
+                }
+            } else if (call === 'hsla') {
+                val = Color.fromHsl(args[0].value, args[1].value, args[2].value, args[3].value);
+                if (defined(val)) {
+                    node = new Node(val);
+                }
             }
         } else if (ast.type === 'UnaryExpression') {
             op = ast.operator;
@@ -127,31 +137,72 @@ define([
     };
 
     Node.prototype._evaluatePlus = function(feature) {
-        return this._left.evaluate(feature) + this._right.evaluate(feature);
+        var left = this._left.evaluate(feature);
+        var right = this._right.evaluate(feature);
+        if (right instanceof Color && left instanceof Color) {
+            return Color.add(left, right, new Color());
+        }
+        return left + right;
     };
 
     Node.prototype._evaluateMinus = function(feature) {
-        return this._left.evaluate(feature) - this._right.evaluate(feature);
+        var left = this._left.evaluate(feature);
+        var right = this._right.evaluate(feature);
+        if (right instanceof Color && left instanceof Color) {
+            return Color.subtract(left, right, new Color());
+        }
+        return left - right;
     };
 
     Node.prototype._evaluateTimes = function(feature) {
-        return this._left.evaluate(feature) * this._right.evaluate(feature);
+        var left = this._left.evaluate(feature);
+        var right = this._right.evaluate(feature);
+        if (right instanceof Color && left instanceof Color) {
+            return Color.multiply(left, right, new Color());
+        } else if (right instanceof Color && typeof(left) === 'number') {
+            return Color.multiplyByScalar(right, left, new Color());
+        } else if (left instanceof Color && typeof(right) === 'number') {
+            return Color.multiplyByScalar(left, right, new Color());
+        }
+        return left * right;
     };
 
     Node.prototype._evaluateDivide = function(feature) {
-        return this._left.evaluate(feature) / this._right.evaluate(feature);
+        var left = this._left.evaluate(feature);
+        var right = this._right.evaluate(feature);
+        if (right instanceof Color && left instanceof Color) {
+            return Color.divide(left, right, new Color());
+        } else if (left instanceof Color && typeof(right) === 'number') {
+            return Color.divideByScalar(left, right, new Color());
+        }
+        return left / right;
     };
 
     Node.prototype._evaluateMod = function(feature) {
-        return this._left.evaluate(feature) % this._right.evaluate(feature);
+        var left = this._left.evaluate(feature);
+        var right = this._right.evaluate(feature);
+        if (right instanceof Color && left instanceof Color) {
+            return Color.mod(left, right, new Color());
+        }
+        return left % right;
     };
 
     Node.prototype._evaluateEquals = function(feature) {
-        return this._left.evaluate(feature) === this._right.evaluate(feature);
+        var left = this._left.evaluate(feature);
+        var right = this._right.evaluate(feature);
+        if (right instanceof Color && left instanceof Color) {
+            return Color.equals(left, right);
+        }
+        return left === right;
     };
 
     Node.prototype._evaluateNotEquals = function(feature) {
-        return this._left.evaluate(feature) !== this._right.evaluate(feature);
+        var left = this._left.evaluate(feature);
+        var right = this._right.evaluate(feature);
+        if (right instanceof Color && left instanceof Color) {
+            return !Color.equals(left, right);
+        }
+        return left !== right;
     };
 
     return Expression;

--- a/Source/Scene/Expression.js
+++ b/Source/Scene/Expression.js
@@ -66,7 +66,9 @@ define([
                     node = new Node(val);
                 }
             } else if (call === 'rgba') {
-                val = Color.fromBytes(args[0].value, args[1].value, args[2].value, args[3].value);
+                // convert between css alpha (0 to 1) and cesium alpha (0 to 255)
+                var a = args[3].value * 255;
+                val = Color.fromBytes(args[0].value, args[1].value, args[2].value, a);
                 if (defined(val)) {
                     node = new Node(val);
                 }

--- a/Source/Scene/Expression.js
+++ b/Source/Scene/Expression.js
@@ -136,6 +136,8 @@ define([
         return -(this._left.evaluate(feature));
     };
 
+    // PERFORMANCE_IDEA: Have "fast path" functions that deal only with specific types
+    // that we can assign if we know the types before runtime
     Node.prototype._evaluatePlus = function(feature) {
         var left = this._left.evaluate(feature);
         var right = this._right.evaluate(feature);

--- a/Specs/Scene/ExpressionSpec.js
+++ b/Specs/Scene/ExpressionSpec.js
@@ -52,11 +52,11 @@ defineSuite([
         expression = new Expression(new MockStyleEngine(), 'hsl(0, 0, 1)');
         expect(expression.evaluate(undefined)).toEqual(Color.WHITE);
 
-        expression = new Expression(new MockStyleEngine(), 'rgba(0, 0, 0, 0)');
-        expect(expression.evaluate(undefined)).toEqual(Color.TRANSPARENT);
+        expression = new Expression(new MockStyleEngine(), 'rgba(255, 255, 255, 0.5)');
+        expect(expression.evaluate(undefined)).toEqual(new Color(1.0, 1.0, 1.0, 0.5));
 
-        expression = new Expression(new MockStyleEngine(), 'hsla(0, 0, 0, 0)');
-        expect(expression.evaluate(undefined)).toEqual(Color.TRANSPARENT);
+        expression = new Expression(new MockStyleEngine(), 'hsla(0, 0, 1, 0.5)');
+        expect(expression.evaluate(undefined)).toEqual(new Color(1.0, 1.0, 1.0, 0.5));
     });
 
     it('evaluates unary not', function() {
@@ -141,28 +141,28 @@ defineSuite([
     });
 
     it('evaluates color operations', function() {
-        var expression = new Expression(new MockStyleEngine(), 'rgba(255, 0, 0, 200) + rgba(0, 0, 255, 55)');
+        var expression = new Expression(new MockStyleEngine(), 'rgba(255, 0, 0, 0.5) + rgba(0, 0, 255, 0.5)');
         expect(expression.evaluate(undefined)).toEqual(Color.MAGENTA);
 
-        expression = new Expression(new MockStyleEngine(), 'rgba(0, 255, 255, 255) - rgba(0, 255, 0, 0)');
+        expression = new Expression(new MockStyleEngine(), 'rgba(0, 255, 255, 1.0) - rgba(0, 255, 0, 0)');
         expect(expression.evaluate(undefined)).toEqual(Color.BLUE);
 
-        expression = new Expression(new MockStyleEngine(), 'rgba(255, 255, 255, 255) * rgba(255, 0, 0, 255)');
+        expression = new Expression(new MockStyleEngine(), 'rgba(255, 255, 255, 1.0) * rgba(255, 0, 0, 1.0)');
         expect(expression.evaluate(undefined)).toEqual(Color.RED);
 
-        expression = new Expression(new MockStyleEngine(), 'rgba(255, 255, 0, 255) * 1');
+        expression = new Expression(new MockStyleEngine(), 'rgba(255, 255, 0, 1.0) * 1.0');
         expect(expression.evaluate(undefined)).toEqual(Color.YELLOW);
 
-        expression = new Expression(new MockStyleEngine(), '1 * rgba(255, 255, 0, 255)');
+        expression = new Expression(new MockStyleEngine(), '1 * rgba(255, 255, 0, 1.0)');
         expect(expression.evaluate(undefined)).toEqual(Color.YELLOW);
 
-        expression = new Expression(new MockStyleEngine(), 'rgba(255, 255, 255, 255) / rgba(255, 255, 255, 255)');
+        expression = new Expression(new MockStyleEngine(), 'rgba(255, 255, 255, 1.0) / rgba(255, 255, 255, 1.0)');
         expect(expression.evaluate(undefined)).toEqual(Color.WHITE);
 
-        expression = new Expression(new MockStyleEngine(), 'rgba(255, 255, 255, 255) / 2');
+        expression = new Expression(new MockStyleEngine(), 'rgba(255, 255, 255, 1.0) / 2');
         expect(expression.evaluate(undefined)).toEqual(new Color(0.5, 0.5, 0.5, 0.5));
 
-        expression = new Expression(new MockStyleEngine(), 'rgba(255, 255, 255, 255) % rgba(255, 255, 255, 255)');
+        expression = new Expression(new MockStyleEngine(), 'rgba(255, 255, 255, 1.0) % rgba(255, 255, 255, 1.0)');
         expect(expression.evaluate(undefined)).toEqual(new Color(0, 0, 0, 0));
 
         expression = new Expression(new MockStyleEngine(), 'color(\'green\') === color(\'green\')');

--- a/Specs/Scene/ExpressionSpec.js
+++ b/Specs/Scene/ExpressionSpec.js
@@ -52,11 +52,11 @@ defineSuite([
         expression = new Expression(new MockStyleEngine(), 'hsl(0, 0, 1)');
         expect(expression.evaluate(undefined)).toEqual(Color.WHITE);
 
-        expression = new Expression(new MockStyleEngine(), 'rgba(255, 255, 255, 255)');
-        expect(expression.evaluate(undefined)).toEqual(Color.WHITE);
+        expression = new Expression(new MockStyleEngine(), 'rgba(0, 0, 0, 0)');
+        expect(expression.evaluate(undefined)).toEqual(Color.TRANSPARENT);
 
-        expression = new Expression(new MockStyleEngine(), 'hsla(0, 0, 1.0, 1.0)');
-        expect(expression.evaluate(undefined)).toEqual(Color.WHITE);
+        expression = new Expression(new MockStyleEngine(), 'hsla(0, 0, 0, 0)');
+        expect(expression.evaluate(undefined)).toEqual(Color.TRANSPARENT);
     });
 
     it('evaluates unary not', function() {

--- a/Specs/Scene/ExpressionSpec.js
+++ b/Specs/Scene/ExpressionSpec.js
@@ -51,6 +51,12 @@ defineSuite([
 
         expression = new Expression(new MockStyleEngine(), 'hsl(0, 0, 1)');
         expect(expression.evaluate(undefined)).toEqual(Color.WHITE);
+
+        expression = new Expression(new MockStyleEngine(), 'rgba(255, 255, 255, 255)');
+        expect(expression.evaluate(undefined)).toEqual(Color.WHITE);
+
+        expression = new Expression(new MockStyleEngine(), 'hsla(0, 0, 1.0, 1.0)');
+        expect(expression.evaluate(undefined)).toEqual(Color.WHITE);
     });
 
     it('evaluates unary not', function() {
@@ -132,5 +138,37 @@ defineSuite([
 
         expression = new Expression(new MockStyleEngine(), 'false !== true !== false');
         expect(expression.evaluate(undefined)).toEqual(true);
+    });
+
+    it('evaluates color operations', function() {
+        var expression = new Expression(new MockStyleEngine(), 'rgba(255, 0, 0, 200) + rgba(0, 0, 255, 55)');
+        expect(expression.evaluate(undefined)).toEqual(Color.MAGENTA);
+
+        expression = new Expression(new MockStyleEngine(), 'rgba(0, 255, 255, 255) - rgba(0, 255, 0, 0)');
+        expect(expression.evaluate(undefined)).toEqual(Color.BLUE);
+
+        expression = new Expression(new MockStyleEngine(), 'rgba(255, 255, 255, 255) * rgba(255, 0, 0, 255)');
+        expect(expression.evaluate(undefined)).toEqual(Color.RED);
+
+        expression = new Expression(new MockStyleEngine(), 'rgba(255, 255, 0, 255) * 1');
+        expect(expression.evaluate(undefined)).toEqual(Color.YELLOW);
+
+        expression = new Expression(new MockStyleEngine(), '1 * rgba(255, 255, 0, 255)');
+        expect(expression.evaluate(undefined)).toEqual(Color.YELLOW);
+
+        expression = new Expression(new MockStyleEngine(), 'rgba(255, 255, 255, 255) / rgba(255, 255, 255, 255)');
+        expect(expression.evaluate(undefined)).toEqual(Color.WHITE);
+
+        expression = new Expression(new MockStyleEngine(), 'rgba(255, 255, 255, 255) / 2');
+        expect(expression.evaluate(undefined)).toEqual(new Color(0.5, 0.5, 0.5, 0.5));
+
+        expression = new Expression(new MockStyleEngine(), 'rgba(255, 255, 255, 255) % rgba(255, 255, 255, 255)');
+        expect(expression.evaluate(undefined)).toEqual(new Color(0, 0, 0, 0));
+
+        expression = new Expression(new MockStyleEngine(), 'color(\'green\') === color(\'green\')');
+        expect(expression.evaluate(undefined)).toEqual(true);
+
+        expression = new Expression(new MockStyleEngine(), 'color(\'green\') !== color(\'green\')');
+        expect(expression.evaluate(undefined)).toEqual(false);
     });
 });


### PR DESCRIPTION
Added literals for `rgba(...)` and `hsla(...)`.

I merged in my changes to `Color.js` into this branch and implemented evaluation of colors.

I do the check for type in the evaluation function, because we cannot know for sure the type of the operands until they are evaluated. In the future we can probably put in a faster evaluation if we know the types before runtime.

I also added tests for color operations and evaluation of literal colors with alpha.