### PR TITLE
Throw developer error on syntax error

### DIFF
--- a/Source/Scene/Expression.js
+++ b/Source/Scene/Expression.js
@@ -23,7 +23,9 @@ define([
         try {
             ast = jsep(expression);
         } catch (e) {
+            //>>includeStart('debug', pragmas.debug);
             throw new DeveloperError(e);
+            //>>includeEnd('debug');
         }
         console.log(ast);
 
@@ -85,7 +87,9 @@ define([
                     node = new Node(val);
                 }
             } else {
+                //>>includeStart('debug', pragmas.debug);
                 throw new DeveloperError('Error: Unexpected function call "' + call + '"');
+                //>>includeEnd('debug');
             }
         } else if (ast.type === 'UnaryExpression') {
             op = ast.operator;
@@ -93,7 +97,9 @@ define([
             if (op === '!' || op === '-') {
                 node = new Node(op, child);
             } else {
+                //>>includeStart('debug', pragmas.debug);
                 throw new DeveloperError('Error: Unexpected operator "' + op + '"');
+                //>>includeEnd('debug');
             }
         } else if (ast.type === 'BinaryExpression') {
             op = ast.operator;
@@ -104,13 +110,19 @@ define([
                 op === '!==') {
                 node = new Node(op, left, right);
             } else {
+                //>>includeStart('debug', pragmas.debug);
                 throw new DeveloperError('Error: Unexpected operator "' + op + '"');
+                //>>includeEnd('debug');
             }
         } else if (ast.type === 'CompoundExpression') {
             // empty expression or multiple expressions
+            //>>includeStart('debug', pragmas.debug);
             throw new DeveloperError('Error: Provide exactly one expression');
+            //>>includeEnd('debug');
         }  else {
+            //>>includeStart('debug', pragmas.debug);
             throw new DeveloperError('Error: Cannot parse expression');
+            //>>includeEnd('debug');
         }
 
         return node;

--- a/Specs/Scene/ExpressionSpec.js
+++ b/Specs/Scene/ExpressionSpec.js
@@ -13,6 +13,86 @@ defineSuite([
     MockStyleEngine.prototype.makeDirty = function() {
     };
 
+    it('throws on invalid expressions', function() {
+        expect(function() {
+            return new Expression(new MockStyleEngine(), false);
+        }).toThrowDeveloperError();
+
+        expect(function() {
+            return new Expression(new MockStyleEngine(), '');
+        }).toThrowDeveloperError();
+
+        expect(function() {
+            return new Expression(new MockStyleEngine(), '2 3');
+        }).toThrowDeveloperError();
+    });
+
+    it('throws on unknown characters', function() {
+        expect(function() {
+            return new Expression(new MockStyleEngine(), '#');
+        }).toThrowDeveloperError();
+    });
+
+    it('throws on unmatched parenthesis', function() {
+        expect(function() {
+            return new Expression(new MockStyleEngine(), '((true)');
+        }).toThrowDeveloperError();
+
+        expect(function() {
+            return new Expression(new MockStyleEngine(), '(true))');
+        }).toThrowDeveloperError();
+    });
+
+    it('throws on unknown identifiers', function() {
+        expect(function() {
+            return new Expression(new MockStyleEngine(), 'flse');
+        }).toThrowDeveloperError();
+    });
+
+    it('throws on unknown function calls', function() {
+        expect(function() {
+            return new Expression(new MockStyleEngine(), 'unknown()');
+        }).toThrowDeveloperError();
+    });
+
+    it('throws with unsupported operators', function() {
+        expect(function() {
+            return new Expression(new MockStyleEngine(), '~1');
+        }).toThrowDeveloperError();
+
+        expect(function() {
+            return new Expression(new MockStyleEngine(), '+1');
+        }).toThrowDeveloperError();
+
+        expect(function() {
+            return new Expression(new MockStyleEngine(), '2 | 3');
+        }).toThrowDeveloperError();
+
+        expect(function() {
+            return new Expression(new MockStyleEngine(), '2 & 3');
+        }).toThrowDeveloperError();
+
+        expect(function() {
+            return new Expression(new MockStyleEngine(), '2 == 3');
+        }).toThrowDeveloperError();
+
+        expect(function() {
+            return new Expression(new MockStyleEngine(), '2 != 3');
+        }).toThrowDeveloperError();
+
+        expect(function() {
+            return new Expression(new MockStyleEngine(), '2 << 3');
+        }).toThrowDeveloperError();
+
+        expect(function() {
+            return new Expression(new MockStyleEngine(), '2 >> 3');
+        }).toThrowDeveloperError();
+
+        expect(function() {
+            return new Expression(new MockStyleEngine(), '2 >>> 3');
+        }).toThrowDeveloperError();
+    });
+
     it('evaluates literal null', function() {
         var expression = new Expression(new MockStyleEngine(), 'null');
         expect(expression.evaluate(undefined)).toEqual(null);


### PR DESCRIPTION
I could not think of a simple way to indicate column number for the syntax errors, so I added that to the roadmap.

I catch the errors thrown by jsep when constructing the initial AST, and throw it again as a developer error. These errors have column numbers.

Other errors, I throw a developer error with similar messages to those thrown by jsep.

Besides those automatically thrown by jsep, I also throw for
- unknown function calls
- unsupported operators
- no expression or more than one expression
- non-string expressions
- lastly, I have a catch all for unsupported types of expressions. We still have plans to support some of these expressions, like logical and conditional expressions, so I would suggest coming back and making this error more specific when we know which types we are supporting and which we are not supporting for certain.
  - [json expression types](http://jsep.from.so/annotated_source/jsep.html#section-2)

I also added tests to check if developer error is thrown for these cases as well as some cases that should be caught by jsep, such as unmatched parenthesis or unknown character.