### PR TITLE
Multiple Globe updates

### DIFF
--- a/Source/Scene/Globe.js
+++ b/Source/Scene/Globe.js
@@ -401,16 +401,8 @@ define([
     /**
      * @private
      */
-    Globe.prototype.initialize = function(frameState) {
+    Globe.prototype.beginFrame = function(frameState) {
         if (!this.show) {
-            return;
-        }
-
-        var context = frameState.context;
-        var width = context.drawingBufferWidth;
-        var height = context.drawingBufferHeight;
-
-        if (width === 0 || height === 0) {
             return;
         }
 
@@ -465,7 +457,7 @@ define([
             tileProvider.oceanNormalMap = this._oceanNormalMap;
             tileProvider.enableLighting = this.enableLighting;
 
-            surface.initialize(frameState);
+            surface.beginFrame(frameState);
         }
     };
 
@@ -474,14 +466,6 @@ define([
      */
     Globe.prototype.update = function(frameState) {
         if (!this.show) {
-            return;
-        }
-
-        var context = frameState.context;
-        var width = context.drawingBufferWidth;
-        var height = context.drawingBufferHeight;
-
-        if (width === 0 || height === 0) {
             return;
         }
 
@@ -500,21 +484,13 @@ define([
     /**
      * @private
      */
-    Globe.prototype.finalize = function(frameState) {
+    Globe.prototype.endFrame = function(frameState) {
         if (!this.show) {
             return;
         }
 
-        var context = frameState.context;
-        var width = context.drawingBufferWidth;
-        var height = context.drawingBufferHeight;
-
-        if (width === 0 || height === 0) {
-            return;
-        }
-
         if (frameState.passes.render) {
-            this._surface.finalize(frameState);
+            this._surface.endFrame(frameState);
         }
     };
 

--- a/Source/Scene/Globe.js
+++ b/Source/Scene/Globe.js
@@ -401,7 +401,7 @@ define([
     /**
      * @private
      */
-    Globe.prototype.update = function(frameState) {
+    Globe.prototype.initialize = function(frameState) {
         if (!this.show) {
             return;
         }
@@ -465,11 +465,56 @@ define([
             tileProvider.oceanNormalMap = this._oceanNormalMap;
             tileProvider.enableLighting = this.enableLighting;
 
+            surface.initialize(frameState);
+        }
+    };
+
+    /**
+     * @private
+     */
+    Globe.prototype.update = function(frameState) {
+        if (!this.show) {
+            return;
+        }
+
+        var context = frameState.context;
+        var width = context.drawingBufferWidth;
+        var height = context.drawingBufferHeight;
+
+        if (width === 0 || height === 0) {
+            return;
+        }
+
+        var surface = this._surface;
+        var pass = frameState.passes;
+
+        if (pass.render) {
             surface.update(frameState);
         }
 
         if (pass.pick) {
             surface.update(frameState);
+        }
+    };
+
+    /**
+     * @private
+     */
+    Globe.prototype.finalize = function(frameState) {
+        if (!this.show) {
+            return;
+        }
+
+        var context = frameState.context;
+        var width = context.drawingBufferWidth;
+        var height = context.drawingBufferHeight;
+
+        if (width === 0 || height === 0) {
+            return;
+        }
+
+        if (frameState.passes.render) {
+            this._surface.finalize(frameState);
         }
     };
 
@@ -502,7 +547,7 @@ define([
      *
      * @example
      * globe = globe && globe.destroy();
-     * 
+     *
      * @see Globe#isDestroyed
      */
     Globe.prototype.destroy = function() {

--- a/Source/Scene/GlobeSurfaceTileProvider.js
+++ b/Source/Scene/GlobeSurfaceTileProvider.js
@@ -286,7 +286,7 @@ define([
      * Called at the beginning of each render frame, before {@link QuadtreeTileProvider#showTileThisFrame}
      * or any other functions.
      *
-     * @param {FrameState} frameState the frame state.
+     * @param {FrameState} frameState The frame state.
      */
     GlobeSurfaceTileProvider.prototype.initialize = function(frameState) {
         this._imageryLayers._update();

--- a/Source/Scene/GlobeSurfaceTileProvider.js
+++ b/Source/Scene/GlobeSurfaceTileProvider.js
@@ -283,12 +283,12 @@ define([
     }
 
     /**
-     * Called at the beginning of the update cycle for each render frame, before {@link QuadtreeTileProvider#showTileThisFrame}
+     * Called at the beginning of each render frame, before {@link QuadtreeTileProvider#showTileThisFrame}
      * or any other functions.
      *
-     * @param {FrameState} frameState The frame state.
+     * @param {FrameState} frameState the frame state.
      */
-    GlobeSurfaceTileProvider.prototype.beginUpdate = function(frameState) {
+    GlobeSurfaceTileProvider.prototype.initialize = function(frameState) {
         this._imageryLayers._update();
 
         if (this._layerOrderChanged) {
@@ -300,19 +300,6 @@ define([
             });
         }
 
-        var i;
-        var len;
-
-        var tilesToRenderByTextureCount = this._tilesToRenderByTextureCount;
-        for (i = 0, len = tilesToRenderByTextureCount.length; i < len; ++i) {
-            var tiles = tilesToRenderByTextureCount[i];
-            if (defined(tiles)) {
-                tiles.length = 0;
-            }
-        }
-
-        this._usedDrawCommands = 0;
-
         // Add credits for terrain and imagery providers.
         var creditDisplay = frameState.creditDisplay;
 
@@ -321,12 +308,30 @@ define([
         }
 
         var imageryLayers = this._imageryLayers;
-        for (i = 0, len = imageryLayers.length; i < len; ++i) {
+        for (var i = 0, len = imageryLayers.length; i < len; ++i) {
             var imageryProvider = imageryLayers.get(i).imageryProvider;
             if (imageryProvider.ready && defined(imageryProvider.credit)) {
                 creditDisplay.addCredit(imageryProvider.credit);
             }
         }
+    };
+
+    /**
+     * Called at the beginning of the update cycle for each render frame, before {@link QuadtreeTileProvider#showTileThisFrame}
+     * or any other functions.
+     *
+     * @param {FrameState} frameState The frame state.
+     */
+    GlobeSurfaceTileProvider.prototype.beginUpdate = function(frameState) {
+        var tilesToRenderByTextureCount = this._tilesToRenderByTextureCount;
+        for (var i = 0, len = tilesToRenderByTextureCount.length; i < len; ++i) {
+            var tiles = tilesToRenderByTextureCount[i];
+            if (defined(tiles)) {
+                tiles.length = 0;
+            }
+        }
+
+        this._usedDrawCommands = 0;
     };
 
     /**
@@ -567,7 +572,7 @@ define([
      *
      * @example
      * provider = provider && provider();
-     * 
+     *
      * @see GlobeSurfaceTileProvider#isDestroyed
      */
     GlobeSurfaceTileProvider.prototype.destroy = function() {

--- a/Source/Scene/QuadtreePrimitive.js
+++ b/Source/Scene/QuadtreePrimitive.js
@@ -260,12 +260,35 @@ define([
     };
 
     /**
-     * Updates the primitive.
-     *
-     * @param {Context} context The rendering context to use.
-     * @param {FrameState} frameState The state of the current frame.
-     * @param {DrawCommand[]} commandList The list of draw commands.  The primitive will usually add
-     *        commands to this array during the update call.
+     * @private
+     */
+    QuadtreePrimitive.prototype.initialize = function(frameState) {
+        var passes = frameState.passes;
+        if (!passes.render) {
+            return;
+        }
+
+        this._tileProvider.initialize(frameState);
+
+        var debug = this._debug;
+        if (debug.suspendLodUpdate) {
+            return;
+        }
+
+        debug.maxDepth = 0;
+        debug.tilesVisited = 0;
+        debug.tilesCulled = 0;
+        debug.tilesRendered = 0;
+        debug.tilesWaitingForChildren = 0;
+
+        processTileLoadQueue(this, frameState);
+
+        this._tileLoadQueue.length = 0;
+        this._tileReplacementQueue.markStartOfRenderFrame();
+    };
+
+    /**
+     * @private
      */
     QuadtreePrimitive.prototype.update = function(frameState) {
         var passes = frameState.passes;
@@ -274,7 +297,6 @@ define([
             this._tileProvider.beginUpdate(frameState);
 
             selectTilesForRendering(this, frameState);
-            processTileLoadQueue(this, frameState);
             createRenderCommandsForSelectedTiles(this, frameState);
 
             this._tileProvider.endUpdate(frameState);
@@ -282,6 +304,40 @@ define([
 
         if (passes.pick && this._tilesToRender.length > 0) {
             this._tileProvider.updateForPick(frameState);
+        }
+    };
+
+    /**
+     * @private
+     */
+    QuadtreePrimitive.prototype.finalize = function(frameState) {
+        var passes = frameState.passes;
+        if (!passes.render) {
+            return;
+        }
+
+        updateHeights(this, frameState);
+
+        var debug = this._debug;
+        if (debug.suspendLodUpdate) {
+            return;
+        }
+
+        if (debug.enableDebugOutput) {
+            if (debug.tilesVisited !== debug.lastTilesVisited ||
+                debug.tilesRendered !== debug.lastTilesRendered ||
+                debug.tilesCulled !== debug.lastTilesCulled ||
+                debug.maxDepth !== debug.lastMaxDepth ||
+                debug.tilesWaitingForChildren !== debug.lastTilesWaitingForChildren) {
+
+                console.log('Visited ' + debug.tilesVisited + ', Rendered: ' + debug.tilesRendered + ', Culled: ' + debug.tilesCulled + ', Max Depth: ' + debug.maxDepth + ', Waiting for children: ' + debug.tilesWaitingForChildren);
+
+                debug.lastTilesVisited = debug.tilesVisited;
+                debug.lastTilesRendered = debug.tilesRendered;
+                debug.lastTilesCulled = debug.tilesCulled;
+                debug.lastMaxDepth = debug.maxDepth;
+                debug.lastTilesWaitingForChildren = debug.tilesWaitingForChildren;
+            }
         }
     };
 
@@ -318,7 +374,7 @@ define([
      *
      * @example
      * primitive = primitive && primitive.destroy();
-     * 
+     *
      * @see QuadtreePrimitive#isDestroyed
      */
     QuadtreePrimitive.prototype.destroy = function() {
@@ -327,7 +383,6 @@ define([
 
     function selectTilesForRendering(primitive, frameState) {
         var debug = primitive._debug;
-
         if (debug.suspendLodUpdate) {
             return;
         }
@@ -341,15 +396,6 @@ define([
 
         var traversalQueue = primitive._tileTraversalQueue;
         traversalQueue.clear();
-
-        debug.maxDepth = 0;
-        debug.tilesVisited = 0;
-        debug.tilesCulled = 0;
-        debug.tilesRendered = 0;
-        debug.tilesWaitingForChildren = 0;
-
-        primitive._tileLoadQueue.length = 0;
-        primitive._tileReplacementQueue.markStartOfRenderFrame();
 
         // We can't render anything before the level zero tiles exist.
         if (!defined(primitive._levelZeroTiles)) {
@@ -440,23 +486,6 @@ define([
         }
 
         raiseTileLoadProgressEvent(primitive);
-
-        if (debug.enableDebugOutput) {
-            if (debug.tilesVisited !== debug.lastTilesVisited ||
-                debug.tilesRendered !== debug.lastTilesRendered ||
-                debug.tilesCulled !== debug.lastTilesCulled ||
-                debug.maxDepth !== debug.lastMaxDepth ||
-                debug.tilesWaitingForChildren !== debug.lastTilesWaitingForChildren) {
-
-                console.log('Visited ' + debug.tilesVisited + ', Rendered: ' + debug.tilesRendered + ', Culled: ' + debug.tilesCulled + ', Max Depth: ' + debug.maxDepth + ', Waiting for children: ' + debug.tilesWaitingForChildren);
-
-                debug.lastTilesVisited = debug.tilesVisited;
-                debug.lastTilesRendered = debug.tilesRendered;
-                debug.lastTilesCulled = debug.tilesCulled;
-                debug.lastMaxDepth = debug.maxDepth;
-                debug.lastTilesWaitingForChildren = debug.tilesWaitingForChildren;
-            }
-        }
     }
 
     /**
@@ -634,9 +663,9 @@ define([
 
                     var tileDataAvailable = terrainProvider.getTileDataAvailable(child.x, child.y, child.level);
                     if ((defined(tileDataAvailable) && !tileDataAvailable) ||
-                           (defined(parent) && defined(parent.data) && defined(parent.data.terrainData) &&
-                                   !parent.data.terrainData.isChildAvailable(parent.x, parent.y, child.x, child.y))) {
-                            data.removeFunc();
+                        (defined(parent) && defined(parent.data) && defined(parent.data.terrainData) &&
+                         !parent.data.terrainData.isChildAvailable(parent.x, parent.y, child.x, child.y))) {
+                        data.removeFunc();
                     }
                 }
 
@@ -676,8 +705,6 @@ define([
             }
             tile._frameRendered = frameState.frameNumber;
         }
-
-        updateHeights(primitive, frameState);
     }
 
     return QuadtreePrimitive;

--- a/Source/Scene/QuadtreePrimitive.js
+++ b/Source/Scene/QuadtreePrimitive.js
@@ -262,7 +262,7 @@ define([
     /**
      * @private
      */
-    QuadtreePrimitive.prototype.initialize = function(frameState) {
+    QuadtreePrimitive.prototype.beginFrame = function(frameState) {
         var passes = frameState.passes;
         if (!passes.render) {
             return;
@@ -310,7 +310,7 @@ define([
     /**
      * @private
      */
-    QuadtreePrimitive.prototype.finalize = function(frameState) {
+    QuadtreePrimitive.prototype.endFrame = function(frameState) {
         var passes = frameState.passes;
         if (!passes.render) {
             return;

--- a/Source/Scene/Scene.js
+++ b/Source/Scene/Scene.js
@@ -1937,6 +1937,10 @@ define([
         viewport.width = context.drawingBufferWidth;
         viewport.height = context.drawingBufferHeight;
 
+        if (defined(scene.globe)) {
+            scene.globe.initialize(frameState);
+        }
+
         updateEnvironment(scene);
         updatePrimitives(scene);
         createPotentiallyVisibleSet(scene);
@@ -1945,6 +1949,10 @@ define([
         executeViewportCommands(scene, passState);
         resolveFramebuffers(scene, passState);
         executeOverlayCommands(scene, passState);
+
+        if (defined(scene.globe)) {
+            scene.globe.finalize(frameState);
+        }
 
         frameState.creditDisplay.endFrame();
 
@@ -2120,10 +2128,10 @@ define([
         scratchRectangle.y = (this.drawingBufferHeight - drawingBufferPosition.y) - ((rectangleHeight - 1.0) * 0.5);
 
         var passState = this._pickFramebuffer.begin(scratchRectangle);
+
         updatePrimitives(this);
         createPotentiallyVisibleSet(this);
         updateAndClearFramebuffers(this, passState, scratchColorZero, true);
-
         executeCommands(this, passState);
         resolveFramebuffers(this, passState);
 

--- a/Source/Scene/Scene.js
+++ b/Source/Scene/Scene.js
@@ -1938,7 +1938,7 @@ define([
         viewport.height = context.drawingBufferHeight;
 
         if (defined(scene.globe)) {
-            scene.globe.initialize(frameState);
+            scene.globe.beginFrame(frameState);
         }
 
         updateEnvironment(scene);
@@ -1951,7 +1951,7 @@ define([
         executeOverlayCommands(scene, passState);
 
         if (defined(scene.globe)) {
-            scene.globe.finalize(frameState);
+            scene.globe.endFrame(frameState);
         }
 
         frameState.creditDisplay.endFrame();

--- a/Specs/Scene/GlobeSurfaceTileProviderSpec.js
+++ b/Specs/Scene/GlobeSurfaceTileProviderSpec.js
@@ -88,9 +88,9 @@ defineSuite([
     function updateUntilDone(globe) {
         // update until the load queue is empty.
         return pollToPromise(function() {
-            globe.initialize(frameState);
+            globe.beginFrame(frameState);
             globe.update(frameState);
-            globe.finalize(frameState);
+            globe.endFrame(frameState);
             return globe._surface.tileProvider.ready && !defined(globe._surface._tileLoadQueue.head) && globe._surface._debug.tilesWaitingForChildren === 0;
         });
     }

--- a/Specs/Scene/GlobeSurfaceTileProviderSpec.js
+++ b/Specs/Scene/GlobeSurfaceTileProviderSpec.js
@@ -88,7 +88,9 @@ defineSuite([
     function updateUntilDone(globe) {
         // update until the load queue is empty.
         return pollToPromise(function() {
+            globe.initialize(frameState);
             globe.update(frameState);
+            globe.finalize(frameState);
             return globe._surface.tileProvider.ready && !defined(globe._surface._tileLoadQueue.head) && globe._surface._debug.tilesWaitingForChildren === 0;
         });
     }

--- a/Specs/Scene/QuadtreePrimitiveSpec.js
+++ b/Specs/Scene/QuadtreePrimitiveSpec.js
@@ -91,14 +91,14 @@ defineSuite([
         });
 
         // determine what tiles to load
-        quadtree.initialize(frameState);
+        quadtree.beginFrame(frameState);
         quadtree.update(frameState);
-        quadtree.finalize(frameState);
+        quadtree.endFrame(frameState);
 
         // load tiles
-        quadtree.initialize(frameState);
+        quadtree.beginFrame(frameState);
         quadtree.update(frameState);
-        quadtree.finalize(frameState);
+        quadtree.endFrame(frameState);
 
         expect(tileProvider.initialize).toHaveBeenCalled();
         expect(tileProvider.beginUpdate).toHaveBeenCalled();
@@ -119,14 +119,14 @@ defineSuite([
         });
 
         // determine what tiles to load
-        quadtree.initialize(frameState);
+        quadtree.beginFrame(frameState);
         quadtree.update(frameState);
-        quadtree.finalize(frameState);
+        quadtree.endFrame(frameState);
 
         // load tiles
-        quadtree.initialize(frameState);
+        quadtree.beginFrame(frameState);
         quadtree.update(frameState);
-        quadtree.finalize(frameState);
+        quadtree.endFrame(frameState);
 
         expect(tileProvider.showTileThisFrame).toHaveBeenCalled();
     });
@@ -147,19 +147,19 @@ defineSuite([
         });
 
         // determine what tiles to load
-        quadtree.initialize(frameState);
+        quadtree.beginFrame(frameState);
         quadtree.update(frameState);
-        quadtree.finalize(frameState);
+        quadtree.endFrame(frameState);
 
         // load tiles
-        quadtree.initialize(frameState);
+        quadtree.beginFrame(frameState);
         quadtree.update(frameState);
-        quadtree.finalize(frameState);
+        quadtree.endFrame(frameState);
         expect(calls).toBe(2);
 
-        quadtree.initialize(frameState);
+        quadtree.beginFrame(frameState);
         quadtree.update(frameState);
-        quadtree.finalize(frameState);
+        quadtree.endFrame(frameState);
         expect(calls).toBe(2);
     });
 
@@ -178,14 +178,14 @@ defineSuite([
         eventHelper.add(quadtree.tileLoadProgressEvent, progressEventSpy);
 
         // Initial update to get the zero-level tiles set up.
-        quadtree.initialize(frameState);
+        quadtree.beginFrame(frameState);
         quadtree.update(frameState);
-        quadtree.finalize(frameState);
+        quadtree.endFrame(frameState);
 
         // load zero-level tiles
-        quadtree.initialize(frameState);
+        quadtree.beginFrame(frameState);
         quadtree.update(frameState);
-        quadtree.finalize(frameState);
+        quadtree.endFrame(frameState);
 
         // There will now be two zero-level tiles in the load queue.
         expect(progressEventSpy.calls.mostRecent().args[0]).toEqual(2);
@@ -193,9 +193,9 @@ defineSuite([
         // Change one to loaded and update again
         quadtree._levelZeroTiles[0].state = QuadtreeTileLoadState.DONE;
         quadtree._levelZeroTiles[1].state = QuadtreeTileLoadState.LOADING;
-        quadtree.initialize(frameState);
+        quadtree.beginFrame(frameState);
         quadtree.update(frameState);
-        quadtree.finalize(frameState);
+        quadtree.endFrame(frameState);
 
         // Now there should only be one left in the update queue
         expect(progressEventSpy.calls.mostRecent().args[0]).toEqual(1);
@@ -207,9 +207,9 @@ defineSuite([
         ];
         quadtree._levelZeroTiles[1].state = QuadtreeTileLoadState.DONE;
         quadtree._levelZeroTiles[1].renderable = true;
-        quadtree.initialize(frameState);
+        quadtree.beginFrame(frameState);
         quadtree.update(frameState);
-        quadtree.finalize(frameState);
+        quadtree.endFrame(frameState);
 
         // Now this should be back to 2.
         expect(progressEventSpy.calls.mostRecent().args[0]).toEqual(2);
@@ -232,23 +232,23 @@ defineSuite([
         });
 
         // determine what tiles to load
-        quadtree.initialize(frameState);
+        quadtree.beginFrame(frameState);
         quadtree.update(frameState);
-        quadtree.finalize(frameState);
+        quadtree.endFrame(frameState);
 
         // load tiles
-        quadtree.initialize(frameState);
+        quadtree.beginFrame(frameState);
         quadtree.update(frameState);
-        quadtree.finalize(frameState);
+        quadtree.endFrame(frameState);
 
         // Don't load further tiles.
         tileProvider.loadTile.and.callFake(function(frameState, tile) {
             tile.state = QuadtreeTileLoadState.START;
         });
 
-        quadtree.initialize(frameState);
+        quadtree.beginFrame(frameState);
         quadtree.update(frameState);
-        quadtree.finalize(frameState);
+        quadtree.endFrame(frameState);
 
         quadtree.forEachLoadedTile(function(tile) {
             expect(tile.state).not.toBe(QuadtreeTileLoadState.START);
@@ -280,14 +280,14 @@ defineSuite([
         });
 
         // determine what tiles to load
-        quadtree.initialize(frameState);
+        quadtree.beginFrame(frameState);
         quadtree.update(frameState);
-        quadtree.finalize(frameState);
+        quadtree.endFrame(frameState);
 
         // load tiles
-        quadtree.initialize(frameState);
+        quadtree.beginFrame(frameState);
         quadtree.update(frameState);
-        quadtree.finalize(frameState);
+        quadtree.endFrame(frameState);
 
         var addedCallback = false;
         quadtree.forEachLoadedTile(function(tile) {
@@ -297,9 +297,9 @@ defineSuite([
         expect(addedCallback).toEqual(true);
 
         removeFunc();
-        quadtree.initialize(frameState);
+        quadtree.beginFrame(frameState);
         quadtree.update(frameState);
-        quadtree.finalize(frameState);
+        quadtree.endFrame(frameState);
 
         var removedCallback = true;
         quadtree.forEachLoadedTile(function(tile) {
@@ -345,22 +345,22 @@ defineSuite([
         });
 
         // determine what tiles to load
-        quadtree.initialize(frameState);
+        quadtree.beginFrame(frameState);
         quadtree.update(frameState);
-        quadtree.finalize(frameState);
+        quadtree.endFrame(frameState);
 
         // load tiles
-        quadtree.initialize(frameState);
+        quadtree.beginFrame(frameState);
         quadtree.update(frameState);
-        quadtree.finalize(frameState);
+        quadtree.endFrame(frameState);
 
         expect(position).toEqual(Cartesian3.ZERO);
 
         currentPosition = updatedPosition;
 
-        quadtree.initialize(frameState);
+        quadtree.beginFrame(frameState);
         quadtree.update(frameState);
-        quadtree.finalize(frameState);
+        quadtree.endFrame(frameState);
 
         expect(position).toEqual(updatedPosition);
     });


### PR DESCRIPTION
The globe can be updated multiple times in a single frame to get terrain tiles for multiple render passes, for example, multiple camera views, viewports, framebuffers, etc.

```javascript
scene.globe.initialize(frameState);

updateEnvironment(scene);

// set viewport/camera/ framebuffer

updatePrimitives(scene);
createPotentiallyVisibleSet(scene);
updateAndClearFramebuffers(scene, passState, color);
executeComputeCommands(scene);
executeCommands(scene, passState);

// update viewport/camera/framebuffer

updatePrimitives(scene);
createPotentiallyVisibleSet(scene);
executeCommands(scene, passState);

// any more updates/renders

resolveFramebuffers(scene, passState);
executeOverlayCommands(scene, passState);

scene.globe.finalize(frameState);
```

`Globe.initialize` and `Globe.finalize` (I'm open to name suggestions) will set up the globe for rendering and manage tile loading/unloading which only happens once per frame. `Globe.update` selects already loaded tiles for rendering based on the current view.

For #2594 and the `infinite-2D` branch.