### PR TITLE
Added back in setting of ray origin to IntersectionTests.lineSegmentS…

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,6 +22,7 @@ Change Log
 * Added `owner` property to `CompositeEntityCollection`.
 * Added `Color.add`, `Color.subtract`, `Color.multiply`, `Color.divide`, `Color.mod`, `Color.multiplyByScalar`, and `Color.divideByScalar` functions to perform arithmetic operations on colors.
 * Added `length` to `Matrix2`, `Matrix3` and `Matrix4` so these can be used as array-like objects.
+* Fixed bug in IntersectionTests.lineSegmentSphere where the ray origin was not set.
 
 ### 1.18 - 2016-02-01
 * Breaking changes

--- a/Source/Core/IntersectionTests.js
+++ b/Source/Core/IntersectionTests.js
@@ -343,6 +343,7 @@ define([
         //>>includeEnd('debug');
 
         var ray = scratchLineSegmentRay;
+        var origin = Cartesian3.clone(p0, ray.origin);
         var direction = Cartesian3.subtract(p1, p0, ray.direction);
 
         var maxT = Cartesian3.magnitude(direction);

--- a/Source/Core/IntersectionTests.js
+++ b/Source/Core/IntersectionTests.js
@@ -343,7 +343,7 @@ define([
         //>>includeEnd('debug');
 
         var ray = scratchLineSegmentRay;
-        var origin = Cartesian3.clone(p0, ray.origin);
+        Cartesian3.clone(p0, ray.origin);
         var direction = Cartesian3.subtract(p1, p0, ray.direction);
 
         var maxT = Cartesian3.magnitude(direction);


### PR DESCRIPTION
Fix for IntersectionTests.lineSegmentSphere where the ray origin wasn't set.

Adds back in line that was removed here
https://github.com/AnalyticalGraphicsInc/cesium/commit/86b7a495687c33b3b497e0e728b9e1e7a9ae663b#diff-455bf7b88a31361988ed51ee3e4683a1L347

