### PR TITLE
Added evaluation of variable expressions

### DIFF
--- a/Source/Scene/Expression.js
+++ b/Source/Scene/Expression.js
@@ -15,6 +15,8 @@ define([
         ExpressionNodeType) {
     "use strict";
 
+    var variableRegex = /\${(.*?)}/g;
+
     /**
      * DOC_TBA
      */
@@ -325,8 +327,7 @@ define([
 
     Node.prototype._evaluateVariableString = function(feature) {
         var result = this._value;
-        var regex = /\${(.*?)}/g;
-        var match = regex.exec(result);
+        var match = variableRegex.exec(result);
         while (match !== null) {
             var placeholder = match[0];
             var variableName = match[1];
@@ -335,7 +336,7 @@ define([
                 property = '';
             }
             result = result.replace(placeholder, property);
-            match = regex.exec(result);
+            match = variableRegex.exec(result);
         }
         return result;
     };

--- a/Source/Scene/Expression.js
+++ b/Source/Scene/Expression.js
@@ -282,18 +282,20 @@ define([
     };
 
     Node.prototype._evaluateVariableString = function(feature) {
-        var val = this._value;
-        var re = /\${(.*?)}/;
-        var match = re.exec(val);
+        var result = this._value;
+        var regex = /\${(.*?)}/g;
+        var match = regex.exec(result);
         while (match !== null) {
-            var prop = feature.getProperty(match[1]);
-            if (!defined(prop)) {
-                prop = '';
+            var placeholder = match[0];
+            var variableName = match[1];
+            var property = feature.getProperty(variableName);
+            if (!defined(property)) {
+                property = '';
             }
-            val = val.replace('\${' + match[1] + '}', prop);
-            match = re.exec(val);
+            result = result.replace(placeholder, property);
+            match = regex.exec(result);
         }
-        return val;
+        return result;
     };
 
     Node.prototype._evaluateVariable = function(feature) {

--- a/Source/Scene/Expression.js
+++ b/Source/Scene/Expression.js
@@ -59,6 +59,11 @@ define([
         while (i >= 0) {
             result += exp.substr(0, i);
             var j = exp.indexOf('}');
+            if (j < 0) {
+                //>>includeStart('debug', pragmas.debug);
+                throw new DeveloperError('Error: unmatched {');
+                //>>includeEnd('debug');
+            }
             result += "czm_" + exp.substr(i+2, j-(i+2));
             exp = exp.substr(j+1);
             i = exp.indexOf('${');

--- a/Source/Scene/ExpressionNodeType.js
+++ b/Source/Scene/ExpressionNodeType.js
@@ -17,7 +17,8 @@ define([
         LITERAL_BOOLEAN : 5,
         LITERAL_NUMBER : 6,
         LITERAL_STRING: 7,
-        LITERAL_COLOR: 8
+        LITERAL_COLOR: 8,
+        VARIABLE_STRING : 9
     };
 
     return freezeObject(ExpressionNodeType);

--- a/Source/Scene/ExpressionNodeType.js
+++ b/Source/Scene/ExpressionNodeType.js
@@ -18,7 +18,7 @@ define([
         LITERAL_NUMBER : 6,
         LITERAL_STRING: 7,
         LITERAL_COLOR: 8,
-        VARIABLE_STRING : 9
+        VARIABLE_IN_STRING : 9
     };
 
     return freezeObject(ExpressionNodeType);

--- a/Specs/Scene/ExpressionSpec.js
+++ b/Specs/Scene/ExpressionSpec.js
@@ -50,6 +50,9 @@ defineSuite([
         expression = new Expression(new MockStyleEngine(), '\'replace ${string}\'');
         expect(expression.evaluate(feature)).toEqual('replace hello');
 
+        expression = new Expression(new MockStyleEngine(), '\'replace ${string} multiple ${height}\'');
+        expect(expression.evaluate(feature)).toEqual('replace hello multiple 10');
+
         expression = new Expression(new MockStyleEngine(), '"replace ${string}"');
         expect(expression.evaluate(feature)).toEqual('replace hello');
 

--- a/Specs/Scene/ExpressionSpec.js
+++ b/Specs/Scene/ExpressionSpec.js
@@ -56,6 +56,9 @@ defineSuite([
         expression = new Expression(new MockStyleEngine(), '"replace ${string}"');
         expect(expression.evaluate(feature)).toEqual('replace hello');
 
+        expression = new Expression(new MockStyleEngine(), '"do not replace \${string}"');
+        expect(expression.evaluate(feature)).toEqual('do not replace ${string}');
+
         expression = new Expression(new MockStyleEngine(), '\'replace ${string\'');
         expect(expression.evaluate(feature)).toEqual('replace ${string');
 

--- a/Specs/Scene/ExpressionSpec.js
+++ b/Specs/Scene/ExpressionSpec.js
@@ -13,6 +13,33 @@ defineSuite([
     MockStyleEngine.prototype.makeDirty = function() {
     };
 
+    function MockFeature() {
+        this._properties = {};
+    }
+
+    MockFeature.prototype.addProperty = function(name, value) {
+        this._properties[name] = value;
+    };
+
+    MockFeature.prototype.getProperty = function(name) {
+        return this._properties[name];
+    };
+
+    it('evaluates variable', function() {
+        var feature = new MockFeature();
+        feature.addProperty('height', 10);
+        feature.addProperty('width', 5);
+
+        var expression = new Expression(new MockStyleEngine(), '${height}');
+        expect(expression.evaluate(feature)).toEqual(10);
+
+        expression = new Expression(new MockStyleEngine(), '${height}/${width}');
+        expect(expression.evaluate(feature)).toEqual(2);
+
+        expression = new Expression(new MockStyleEngine(), '${depth}');
+        expect(expression.evaluate(feature)).toEqual(undefined);
+    });
+
     it('throws on invalid expressions', function() {
         expect(function() {
             return new Expression(new MockStyleEngine(), false);

--- a/Specs/Scene/ExpressionSpec.js
+++ b/Specs/Scene/ExpressionSpec.js
@@ -38,6 +38,9 @@ defineSuite([
         var expression = new Expression(new MockStyleEngine(), '${height}');
         expect(expression.evaluate(feature)).toEqual(10);
 
+        expression = new Expression(new MockStyleEngine(), '\'${height}\'');
+        expect(expression.evaluate(feature)).toEqual('10');
+
         expression = new Expression(new MockStyleEngine(), '${height}/${width}');
         expect(expression.evaluate(feature)).toEqual(2);
 
@@ -47,18 +50,35 @@ defineSuite([
         expression = new Expression(new MockStyleEngine(), '\'replace ${string}\'');
         expect(expression.evaluate(feature)).toEqual('replace hello');
 
+        expression = new Expression(new MockStyleEngine(), '"replace ${string}"');
+        expect(expression.evaluate(feature)).toEqual('replace hello');
+
+        expression = new Expression(new MockStyleEngine(), '\'replace ${string\'');
+        expect(expression.evaluate(feature)).toEqual('replace ${string');
+
         expression = new Expression(new MockStyleEngine(), '${boolean}');
         expect(expression.evaluate(feature)).toEqual(true);
+
+        expression = new Expression(new MockStyleEngine(), '\'${boolean}\'');
+        expect(expression.evaluate(feature)).toEqual('true');
 
         expression = new Expression(new MockStyleEngine(), '${color}');
         expect(expression.evaluate(feature)).toEqual(Color.RED);
 
+        expression = new Expression(new MockStyleEngine(), '\'${color}\'');
+        expect(expression.evaluate(feature)).toEqual(Color.RED.toString());
 
         expression = new Expression(new MockStyleEngine(), '${null}');
         expect(expression.evaluate(feature)).toEqual(null);
 
+        expression = new Expression(new MockStyleEngine(), '\'${null}\'');
+        expect(expression.evaluate(feature)).toEqual('');
+
         expression = new Expression(new MockStyleEngine(), '${undefined}');
         expect(expression.evaluate(feature)).toEqual(undefined);
+
+        expression = new Expression(new MockStyleEngine(), '\'${undefined}\'');
+        expect(expression.evaluate(feature)).toEqual('');
 
         expect(function() {
             return new Expression(new MockStyleEngine(), '${height');

--- a/Specs/Scene/ExpressionSpec.js
+++ b/Specs/Scene/ExpressionSpec.js
@@ -31,6 +31,7 @@ defineSuite([
         feature.addProperty('width', 5);
         feature.addProperty('string', 'hello');
         feature.addProperty('boolean', true);
+        feature.addProperty('color', Color.RED);
         feature.addProperty('null', null);
         feature.addProperty('undefined', undefined);
 
@@ -48,6 +49,10 @@ defineSuite([
 
         expression = new Expression(new MockStyleEngine(), '${boolean}');
         expect(expression.evaluate(feature)).toEqual(true);
+
+        expression = new Expression(new MockStyleEngine(), '${color}');
+        expect(expression.evaluate(feature)).toEqual(Color.RED);
+
 
         expression = new Expression(new MockStyleEngine(), '${null}');
         expect(expression.evaluate(feature)).toEqual(null);

--- a/Specs/Scene/ExpressionSpec.js
+++ b/Specs/Scene/ExpressionSpec.js
@@ -29,6 +29,10 @@ defineSuite([
         var feature = new MockFeature();
         feature.addProperty('height', 10);
         feature.addProperty('width', 5);
+        feature.addProperty('string', 'hello');
+        feature.addProperty('boolean', true);
+        feature.addProperty('null', null);
+        feature.addProperty('undefined', undefined);
 
         var expression = new Expression(new MockStyleEngine(), '${height}');
         expect(expression.evaluate(feature)).toEqual(10);
@@ -36,8 +40,24 @@ defineSuite([
         expression = new Expression(new MockStyleEngine(), '${height}/${width}');
         expect(expression.evaluate(feature)).toEqual(2);
 
-        expression = new Expression(new MockStyleEngine(), '${depth}');
+        expression = new Expression(new MockStyleEngine(), '${string}');
+        expect(expression.evaluate(feature)).toEqual('hello');
+
+        expression = new Expression(new MockStyleEngine(), '\'replace ${string}\'');
+        expect(expression.evaluate(feature)).toEqual('replace hello');
+
+        expression = new Expression(new MockStyleEngine(), '${boolean}');
+        expect(expression.evaluate(feature)).toEqual(true);
+
+        expression = new Expression(new MockStyleEngine(), '${null}');
+        expect(expression.evaluate(feature)).toEqual(null);
+
+        expression = new Expression(new MockStyleEngine(), '${undefined}');
         expect(expression.evaluate(feature)).toEqual(undefined);
+
+        expect(function() {
+            return new Expression(new MockStyleEngine(), '${height');
+        }).toThrowDeveloperError();
     });
 
     it('throws on invalid expressions', function() {

--- a/Specs/Scene/ExpressionSpec.js
+++ b/Specs/Scene/ExpressionSpec.js
@@ -56,9 +56,6 @@ defineSuite([
         expression = new Expression(new MockStyleEngine(), '"replace ${string}"');
         expect(expression.evaluate(feature)).toEqual('replace hello');
 
-        expression = new Expression(new MockStyleEngine(), '"do not replace \${string}"');
-        expect(expression.evaluate(feature)).toEqual('do not replace ${string}');
-
         expression = new Expression(new MockStyleEngine(), '\'replace ${string\'');
         expect(expression.evaluate(feature)).toEqual('replace ${string');
 


### PR DESCRIPTION
Added evaluation of variable expressions.

I added a helper function to take all occurrences of `${name}` and translate them to `czm_name` before running the expression through jsep. 

Currently, if the feature does not have that property name, it returns `undefined`. I think this behavior is better than throwing an error in case of data sets that don't uniformly have every property defined for each feature.

Also updated the specs.