### PR TITLE
Color Type Expression Fixes

### DIFF
--- a/Source/Scene/Expression.js
+++ b/Source/Scene/Expression.js
@@ -75,35 +75,58 @@ define([
         var val;
 
         // TODO: Check number of arguments for each function
-        // TODO: Throw error if returned color is not defined
+        // TODO: Throw error if returned Color is not defined
 
-        if (call === 'color') {
-           val = Color.fromCssColorString(args[0].value);
-           if (defined(val)) {
+        if (call === 'Color') {
+            val = Color.fromCssColorString(args[0].value);
+            if (defined(args[1])) {
+                val = Color.fromAlpha(val, args[1].value);
+            }
+            if (defined(val)) {
                return new Node(ExpressionNodeType.LITERAL_COLOR, val);
-           }
+            }
         } else if (call === 'rgb') {
-           val = Color.fromBytes(args[0].value, args[1].value, args[2].value);
-           if (defined(val)) {
+            //>>includeStart('debug', pragmas.debug);
+            if (args.length !== 3) {
+                throw new DeveloperError('Error: rgb requires three arguments');
+            }
+            //>>includeEnd('debug');
+            val = Color.fromBytes(args[0].value, args[1].value, args[2].value);
+            if (defined(val)) {
                return new Node(ExpressionNodeType.LITERAL_COLOR, val);
-           }
+            }
         } else if (call === 'hsl') {
-           val = Color.fromHsl(args[0].value, args[1].value, args[2].value);
-           if (defined(val)) {
+            //>>includeStart('debug', pragmas.debug);
+            if (args.length !== 3) {
+                throw new DeveloperError('Error: hsl requires three arguments');
+            }
+            //>>includeEnd('debug');
+            val = Color.fromHsl(args[0].value, args[1].value, args[2].value);
+            if (defined(val)) {
                return new Node(ExpressionNodeType.LITERAL_COLOR, val);
-           }
+            }
         } else if (call === 'rgba') {
-           // convert between css alpha (0 to 1) and cesium alpha (0 to 255)
-           var a = args[3].value * 255;
-           val = Color.fromBytes(args[0].value, args[1].value, args[2].value, a);
-           if (defined(val)) {
+            //>>includeStart('debug', pragmas.debug);
+            if (args.length !== 4) {
+                throw new DeveloperError('Error: rgba requires four arguments');
+            }
+            //>>includeEnd('debug');
+            // convert between css alpha (0 to 1) and cesium alpha (0 to 255)
+            var a = args[3].value * 255;
+            val = Color.fromBytes(args[0].value, args[1].value, args[2].value, a);
+            if (defined(val)) {
                return new Node(ExpressionNodeType.LITERAL_COLOR, val);
-           }
+            }
         } else if (call === 'hsla') {
-           val = Color.fromHsl(args[0].value, args[1].value, args[2].value, args[3].value);
-           if (defined(val)) {
+            //>>includeStart('debug', pragmas.debug);
+            if (args.length !== 4) {
+                throw new DeveloperError('Error: hlsa requires four arguments');
+            }
+            //>>includeEnd('debug');
+            val = Color.fromHsl(args[0].value, args[1].value, args[2].value, args[3].value);
+            if (defined(val)) {
                return new Node(ExpressionNodeType.LITERAL_COLOR, val);
-           }
+            }
         }
 
         //>>includeStart('debug', pragmas.debug);

--- a/Source/Scene/Expression.js
+++ b/Source/Scene/Expression.js
@@ -73,8 +73,7 @@ define([
         var call = ast.callee.name;
         var args = ast.arguments;
         var val;
-
-        // TODO: Check number of arguments for each function
+        
         // TODO: Throw error if returned Color is not defined
 
         if (call === 'Color') {

--- a/Specs/Scene/ExpressionSpec.js
+++ b/Specs/Scene/ExpressionSpec.js
@@ -120,14 +120,17 @@ defineSuite([
     });
 
     it('evaluates literal color', function() {
-        var expression = new Expression(new MockStyleEngine(), 'color(\'#ffffff\')');
+        var expression = new Expression(new MockStyleEngine(), 'Color(\'#ffffff\')');
         expect(expression.evaluate(undefined)).toEqual(Color.WHITE);
 
-        expression = new Expression(new MockStyleEngine(), 'color(\'#fff\')');
+        expression = new Expression(new MockStyleEngine(), 'Color(\'#fff\')');
         expect(expression.evaluate(undefined)).toEqual(Color.WHITE);
 
-        expression = new Expression(new MockStyleEngine(), 'color(\'white\')');
+        expression = new Expression(new MockStyleEngine(), 'Color(\'white\')');
         expect(expression.evaluate(undefined)).toEqual(Color.WHITE);
+
+        expression = new Expression(new MockStyleEngine(), 'Color(\'white\', 0.5)');
+        expect(expression.evaluate(undefined)).toEqual(new Color(1.0, 1.0, 1.0, 0.5));
 
         expression = new Expression(new MockStyleEngine(), 'rgb(255, 255, 255)');
         expect(expression.evaluate(undefined)).toEqual(Color.WHITE);
@@ -140,6 +143,24 @@ defineSuite([
 
         expression = new Expression(new MockStyleEngine(), 'hsla(0, 0, 1, 0.5)');
         expect(expression.evaluate(undefined)).toEqual(new Color(1.0, 1.0, 1.0, 0.5));
+    });
+
+    it('color constructors throw with wrong number of arguments', function() {
+        expect(function() {
+            return new Expression(new MockStyleEngine(), 'rgb(255, 255)');
+        }).toThrowDeveloperError();
+
+        expect(function() {
+            return new Expression(new MockStyleEngine(), 'hsl(1, 1)');
+        }).toThrowDeveloperError();
+
+        expect(function() {
+            return new Expression(new MockStyleEngine(), 'rgba(255, 255, 255)');
+        }).toThrowDeveloperError();
+
+        expect(function() {
+            return new Expression(new MockStyleEngine(), 'hsla(1, 1, 1)');
+        }).toThrowDeveloperError();
     });
 
     it('evaluates unary not', function() {
@@ -238,7 +259,7 @@ defineSuite([
             expression.evaluate(undefined);
         }).toThrowDeveloperError();
 
-        expression = new Expression(new MockStyleEngine(), 'color(\'blue\') < 10');
+        expression = new Expression(new MockStyleEngine(), 'Color(\'blue\') < 10');
         expect(function() {
             expression.evaluate(undefined);
         }).toThrowDeveloperError();
@@ -259,7 +280,7 @@ defineSuite([
             expression.evaluate(undefined);
         }).toThrowDeveloperError();
 
-        expression = new Expression(new MockStyleEngine(), 'color(\'blue\') <= 10');
+        expression = new Expression(new MockStyleEngine(), 'Color(\'blue\') <= 10');
         expect(function() {
             expression.evaluate(undefined);
         }).toThrowDeveloperError();
@@ -280,7 +301,7 @@ defineSuite([
             expression.evaluate(undefined);
         }).toThrowDeveloperError();
 
-        expression = new Expression(new MockStyleEngine(), 'color(\'blue\') > 10');
+        expression = new Expression(new MockStyleEngine(), 'Color(\'blue\') > 10');
         expect(function() {
             expression.evaluate(undefined);
         }).toThrowDeveloperError();
@@ -301,7 +322,7 @@ defineSuite([
             expression.evaluate(undefined);
         }).toThrowDeveloperError();
 
-        expression = new Expression(new MockStyleEngine(), 'color(\'blue\') >= 10');
+        expression = new Expression(new MockStyleEngine(), 'Color(\'blue\') >= 10');
         expect(function() {
             expression.evaluate(undefined);
         }).toThrowDeveloperError();
@@ -317,7 +338,7 @@ defineSuite([
         expression = new Expression(new MockStyleEngine(), 'true && true');
         expect(expression.evaluate(undefined)).toEqual(true);
 
-        expression = new Expression(new MockStyleEngine(), '2 && color(\'red\')');
+        expression = new Expression(new MockStyleEngine(), '2 && Color(\'red\')');
         expect(function() {
             expression.evaluate(undefined);
         }).toThrowDeveloperError();
@@ -333,7 +354,7 @@ defineSuite([
         expression = new Expression(new MockStyleEngine(), 'true || true');
         expect(expression.evaluate(undefined)).toEqual(true);
 
-        expression = new Expression(new MockStyleEngine(), '2 || color(\'red\')');
+        expression = new Expression(new MockStyleEngine(), '2 || Color(\'red\')');
         expect(function() {
             expression.evaluate(undefined);
         }).toThrowDeveloperError();
@@ -364,10 +385,10 @@ defineSuite([
         expression = new Expression(new MockStyleEngine(), 'rgba(255, 255, 255, 1.0) % rgba(255, 255, 255, 1.0)');
         expect(expression.evaluate(undefined)).toEqual(new Color(0, 0, 0, 0));
 
-        expression = new Expression(new MockStyleEngine(), 'color(\'green\') === color(\'green\')');
+        expression = new Expression(new MockStyleEngine(), 'Color(\'green\') === Color(\'green\')');
         expect(expression.evaluate(undefined)).toEqual(true);
 
-        expression = new Expression(new MockStyleEngine(), 'color(\'green\') !== color(\'green\')');
+        expression = new Expression(new MockStyleEngine(), 'Color(\'green\') !== Color(\'green\')');
         expect(expression.evaluate(undefined)).toEqual(false);
     });
 });


### PR DESCRIPTION
Added some fixes to the color type to be up to date with the Spec- 
- Made `color()` Pascal case - `Color()`
- Gave `Color()` an optional second argument for alpha
- `rgb`, `hsl`, `rgba`, and `hsla` requie all their arguments. 

And updated the tests to reflect these changes.
