### PR TITLE
Fix rotation for a GroundPrimitive with an EllipseGeometry

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,6 +24,7 @@ Change Log
 * Added `length` to `Matrix2`, `Matrix3` and `Matrix4` so these can be used as array-like objects.
 * Fixed bug in IntersectionTests.lineSegmentSphere where the ray origin was not set.
 * Added the ability to create empty geometries. Instead of errors getting thrown on creation, undefined will be returned. No rendering will occur.
+* Fixed issue that kept `GroundPrimitive` with an `EllipseGeometry` from having a `rotation`.
 
 ### 1.18 - 2016-02-01
 * Breaking changes

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -46,6 +46,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to Cesiu
 * [Aviture](http://aviture.us.com)
    * [Mike Macaulay](https://github.com/mmacaula)
    * [Nathan Schulte](https://github.com/nmschulte)
+   * [Jed Fong](https://github.com/jedfong)
 * [Inovaworks](http://www.inovaworks.com/)
    * [Sergio Flores](https://github.com/relfos)
 * [CubeWerx Inc.](http://www.cubewerx.com/)

--- a/Source/Core/EllipseGeometry.js
+++ b/Source/Core/EllipseGeometry.js
@@ -864,6 +864,7 @@ define([
             semiMajorAxis : ellipseGeometry._semiMajorAxis,
             semiMinorAxis : ellipseGeometry._semiMinorAxis,
             ellipsoid : ellipsoid,
+            rotation : ellipseGeometry._rotation,
             stRotation : ellipseGeometry._stRotation,
             granularity : granularity,
             extrudedHeight : minHeight,

--- a/Specs/Core/EllipseGeometrySpec.js
+++ b/Specs/Core/EllipseGeometrySpec.js
@@ -186,6 +186,48 @@ defineSuite([
         expect(geometry3).toBeUndefined();
     });
 
+    it('createShadowVolume uses properties from geometry', function() {
+        var m = new EllipseGeometry({
+            center : Cartesian3.fromDegrees(-75.59777, 40.03883),
+            semiMajorAxis : 3000.0,
+            semiMinorAxis : 1500.0,
+            ellipsoid : Ellipsoid.WGS84,
+            rotation : CesiumMath.PI_OVER_TWO,
+            stRotation : CesiumMath.PI_OVER_FOUR,
+            granularity : 10000,
+            extrudedHeight : 0,
+            height : 100,
+            vertexFormat : VertexFormat.ALL
+        });
+
+        var minHeightFunc = function() {
+            return 100;
+        };
+
+        var maxHeightFunc = function() {
+            return 1000;
+        };
+
+        var sv = EllipseGeometry.createShadowVolume(m, minHeightFunc, maxHeightFunc);
+
+        expect(sv._center.equals(m._center)).toBe(true);
+        expect(sv._semiMajorAxis).toBe(m._semiMajorAxis);
+        expect(sv._semiMinorAxis).toBe(m._semiMinorAxis);
+        expect(sv._ellipsoid.equals(m._ellipsoid)).toBe(true);
+        expect(sv._rotation).toBe(m._rotation);
+        expect(sv._stRotation).toBe(m._stRotation);
+        expect(sv._granularity).toBe(m._granularity);
+        expect(sv._extrudedHeight).toBe(minHeightFunc());
+        expect(sv._height).toBe(maxHeightFunc());
+
+        expect(sv._vertexFormat.binormal).toBe(VertexFormat.POSITION_ONLY.binormal);
+        expect(sv._vertexFormat.color).toBe(VertexFormat.POSITION_ONLY.color);
+        expect(sv._vertexFormat.normal).toBe(VertexFormat.POSITION_ONLY.normal);
+        expect(sv._vertexFormat.position).toBe(VertexFormat.POSITION_ONLY.position);
+        expect(sv._vertexFormat.st).toBe(VertexFormat.POSITION_ONLY.st);
+        expect(sv._vertexFormat.tangent).toBe(VertexFormat.POSITION_ONLY.tangent);
+    });
+
     var center = Cartesian3.fromDegrees(0,0);
     var ellipsoid = Ellipsoid.WGS84;
     var packableInstance = new EllipseGeometry({


### PR DESCRIPTION
This code fixes an issue with [EllipseGeometry.createShadowVolume](https://github.com/AnalyticalGraphicsInc/cesium/blob/master/Source/Core/EllipseGeometry.js#LC855) where the rotation was not used when creating the EllipseGeometry.