### PR TITLE
NaN and Infinity literals, isNaN() and isFinite() functions

### DIFF
--- a/Source/Scene/Expression.js
+++ b/Source/Scene/Expression.js
@@ -203,7 +203,7 @@ define([
                 //>>includeEnd('debug');
             }
         } else if (ast.type === 'Identifier') {
-            node = new parseKeywords(ast);
+            node = parseKeywords(ast);
         }
         //>>includeStart('debug', pragmas.debug);
         else if (ast.type === 'CompoundExpression') {

--- a/Specs/Scene/ExpressionSpec.js
+++ b/Specs/Scene/ExpressionSpec.js
@@ -391,4 +391,18 @@ defineSuite([
         expression = new Expression(new MockStyleEngine(), 'Color(\'green\') !== Color(\'green\')');
         expect(expression.evaluate(undefined)).toEqual(false);
     });
+
+    it('evaluates isNaN function', function() {
+        var expression = new Expression(new MockStyleEngine(), 'isNaN()');
+        expect(expression.evaluate(undefined)).toEqual(true);
+
+        //expression = new Expression(new MockStyleEngine(), 'isNaN(1)');
+        //expect(expression.evaluate(undefined)).toEqual(false);
+
+        //expression = new Expression(new MockStyleEngine(), 'isNaN(undefined)');
+        //expect(expression.evaluate(undefined)).toEqual(true);
+
+        //expression = new Expression(new MockStyleEngine(), 'isNaN(null)');
+        //expect(expression.evaluate(undefined)).toEqual(false);
+    });
 });

--- a/Specs/Scene/ExpressionSpec.js
+++ b/Specs/Scene/ExpressionSpec.js
@@ -112,6 +112,12 @@ defineSuite([
 
         expression = new Expression(new MockStyleEngine(), '0');
         expect(expression.evaluate(undefined)).toEqual(0);
+
+        expression = new Expression(new MockStyleEngine(), 'NaN');
+        expect(expression.evaluate(undefined)).toEqual(NaN);
+
+        expression = new Expression(new MockStyleEngine(), 'Infinity');
+        expect(expression.evaluate(undefined)).toEqual(Infinity);
     });
 
     it('evaluates literal string', function() {
@@ -396,13 +402,51 @@ defineSuite([
         var expression = new Expression(new MockStyleEngine(), 'isNaN()');
         expect(expression.evaluate(undefined)).toEqual(true);
 
-        //expression = new Expression(new MockStyleEngine(), 'isNaN(1)');
-        //expect(expression.evaluate(undefined)).toEqual(false);
+        expression = new Expression(new MockStyleEngine(), 'isNaN(NaN)');
+        expect(expression.evaluate(undefined)).toEqual(true);
 
-        //expression = new Expression(new MockStyleEngine(), 'isNaN(undefined)');
-        //expect(expression.evaluate(undefined)).toEqual(true);
+        expression = new Expression(new MockStyleEngine(), 'isNaN(1)');
+        expect(expression.evaluate(undefined)).toEqual(false);
 
-        //expression = new Expression(new MockStyleEngine(), 'isNaN(null)');
-        //expect(expression.evaluate(undefined)).toEqual(false);
+        expression = new Expression(new MockStyleEngine(), 'isNaN(Infinity)');
+        expect(expression.evaluate(undefined)).toEqual(false);
+
+        expression = new Expression(new MockStyleEngine(), 'isNaN(null)');
+        expect(expression.evaluate(undefined)).toEqual(false);
+
+        expression = new Expression(new MockStyleEngine(), 'isNaN(true)');
+        expect(expression.evaluate(undefined)).toEqual(false);
+
+        expression = new Expression(new MockStyleEngine(), 'isNaN("hello")');
+        expect(expression.evaluate(undefined)).toEqual(true);
+
+        expression = new Expression(new MockStyleEngine(), 'isNaN(Color("white"))');
+        expect(expression.evaluate(undefined)).toEqual(true);
+    });
+
+    it('evaluates isFinite function', function() {
+        var expression = new Expression(new MockStyleEngine(), 'isFinite()');
+        expect(expression.evaluate(undefined)).toEqual(false);
+
+        expression = new Expression(new MockStyleEngine(), 'isFinite(NaN)');
+        expect(expression.evaluate(undefined)).toEqual(false);
+
+        expression = new Expression(new MockStyleEngine(), 'isFinite(1)');
+        expect(expression.evaluate(undefined)).toEqual(true);
+
+        expression = new Expression(new MockStyleEngine(), 'isFinite(Infinity)');
+        expect(expression.evaluate(undefined)).toEqual(false);
+
+        expression = new Expression(new MockStyleEngine(), 'isFinite(null)');
+        expect(expression.evaluate(undefined)).toEqual(true);
+
+        expression = new Expression(new MockStyleEngine(), 'isFinite(true)');
+        expect(expression.evaluate(undefined)).toEqual(true);
+
+        expression = new Expression(new MockStyleEngine(), 'isFinite("hello")');
+        expect(expression.evaluate(undefined)).toEqual(false);
+
+        expression = new Expression(new MockStyleEngine(), 'isFinite(Color("white"))');
+        expect(expression.evaluate(undefined)).toEqual(false);
     });
 });


### PR DESCRIPTION
Add the literals `NaN` and 'Infinity`, as well as the functions `isNaN()` and `isFinite()` functions to be up to date with the numbers section of the spec, and added tests.

I went with default javascript behavior for all of the tests.