### PR TITLE
Fix billboard terrain clamping when used inside of iframes.

### DIFF
--- a/Source/Scene/QuadtreePrimitive.js
+++ b/Source/Scene/QuadtreePrimitive.js
@@ -662,9 +662,10 @@ define([
                     }
 
                     var tileDataAvailable = terrainProvider.getTileDataAvailable(child.x, child.y, child.level);
+                    var parentTile = tile.parent;
                     if ((defined(tileDataAvailable) && !tileDataAvailable) ||
-                        (defined(parent) && defined(parent.data) && defined(parent.data.terrainData) &&
-                         !parent.data.terrainData.isChildAvailable(parent.x, parent.y, child.x, child.y))) {
+                        (defined(parentTile) && defined(parentTile.data) && defined(parentTile.data.terrainData) &&
+                         !parentTile.data.terrainData.isChildAvailable(parentTile.x, parentTile.y, child.x, child.y))) {
                         data.removeFunc();
                     }
                 }


### PR DESCRIPTION
In the private `updateHeights` function of `QuadtreePrimitive`, the variable `parent` was being used without being defined. jsHint does not report an error for this because `parent` is a global variable on the `window` Since `parent.data` was undefined, we never actually got into the if block that tried to use it.  Since the if block is an optimization and not required, everything always ran properly without a hitch.

The one exception to this is when embedding cesium in an iframe.  When in an iframe, parent refers to the site that contains the iframe, which is illegal to access from within the iframe.  This triggered a cross-origin security error when trying to use terrain clamping in an iframe based Cesium window.

The solution is to simply define the loval `parent` variable properly as being `tile.parent`, but in order to prevent confusion in the future I also renamed it to `parentTile`.