### PR TITLE
Added member expressions

### DIFF
--- a/Source/Scene/Expression.js
+++ b/Source/Scene/Expression.js
@@ -205,7 +205,7 @@ define([
         var obj = createRuntimeAst(expression, ast.object);
         if (ast.computed) {
             var val = createRuntimeAst(expression, ast.property);
-            return new Node(ExpressionNodeType.MEMBER, 'computed', obj, val);
+            return new Node(ExpressionNodeType.MEMBER, 'brackets', obj, val);
         } else {
             return new Node(ExpressionNodeType.MEMBER, 'dot', obj, ast.property.name);
         }
@@ -330,8 +330,8 @@ define([
                 node.evaluate = node._evaluateIsFinite;
             }
         } else if (node._type === ExpressionNodeType.MEMBER) {
-            if (node._value === 'computed') {
-                node.evaluate = node._evaluateMemberComputed;
+            if (node._value === 'brackets') {
+                node.evaluate = node._evaluateMemberBrackets;
             } else {
                 node.evaluate = node._evaluateMemberDot;
             }
@@ -385,7 +385,7 @@ define([
         return property[this._right];
     };
 
-    Node.prototype._evaluateMemberComputed = function(feature) {
+    Node.prototype._evaluateMemberBrackets = function(feature) {
         if(checkFeature(this._left)) {
             return feature.getProperty(this._right.evaluate(feature));
         }

--- a/Source/Scene/Expression.js
+++ b/Source/Scene/Expression.js
@@ -187,18 +187,36 @@ define([
         //>>includeEnd('debug');
     }
 
-    function parseKeywordsAndVariables(expression, ast) {
+    function parseKeywordsAndVariables(ast) {
         if (ast.name === 'NaN') {
             return new Node(ExpressionNodeType.LITERAL_NUMBER, NaN);
         } else if (ast.name === 'Infinity') {
             return new Node(ExpressionNodeType.LITERAL_NUMBER, Infinity);
-        } else if (ast.name.substr(0, 4) === 'czm_') {
-            return new Node(ExpressionNodeType.VARIABLE, ast.name.substr(4));
+        } else if (isVariable(ast.name)) {
+            return new Node(ExpressionNodeType.VARIABLE, getPropertyName(ast.name));
         }
 
         //>>includeStart('debug', pragmas.debug);
         throw new DeveloperError('Error: ' + ast.name + ' is not defined');
         //>>includeEnd('debug');
+    }
+
+    function parseMemberExpression(expression, ast) {
+        var obj = createRuntimeAst(expression, ast.object);
+        if (ast.computed) {
+            var val = createRuntimeAst(expression, ast.property);
+            return new Node(ExpressionNodeType.MEMBER, 'computed', obj, val);
+        } else {
+            return new Node(ExpressionNodeType.MEMBER, 'dot', obj, ast.property.name);
+        }
+    }
+
+    function isVariable(name) {
+        return (name.substr(0, 4) === 'czm_');
+    }
+
+    function getPropertyName(variable) {
+        return variable.substr(4);
     }
 
     function createRuntimeAst(expression, ast) {
@@ -212,7 +230,7 @@ define([
         } else if (ast.type === 'CallExpression') {
             node = parseCall(expression, ast);
         } else if (ast.type === 'Identifier') {
-            node = parseKeywordsAndVariables(expression, ast);
+            node = parseKeywordsAndVariables(ast);
         } else if (ast.type === 'UnaryExpression') {
             op = ast.operator;
             var child = createRuntimeAst(expression, ast.argument);
@@ -253,6 +271,8 @@ define([
             left = createRuntimeAst(expression, ast.consequent);
             right = createRuntimeAst(expression, ast.alternate);
             node = new Node(ExpressionNodeType.CONDITIONAL, '?', left, right, test);
+        } else if (ast.type === 'MemberExpression') {
+            node = parseMemberExpression(expression, ast);
         }
         //>>includeStart('debug', pragmas.debug);
         else if (ast.type === 'CompoundExpression') {
@@ -309,6 +329,12 @@ define([
             } else if (node._value === 'isFinite') {
                 node.evaluate = node._evaluateIsFinite;
             }
+        } else if (node._type === ExpressionNodeType.MEMBER) {
+            if (node._value === 'computed') {
+                node.evaluate = node._evaluateMemberComputed;
+            } else {
+                node.evaluate = node._evaluateMemberDot;
+            }
         } else if (node._type === ExpressionNodeType.VARIABLE) {
             node.evaluate = node._evaluateVariable;
         } else if (node._type === ExpressionNodeType.VARIABLE_IN_STRING) {
@@ -342,6 +368,34 @@ define([
         // evaluates to undefined if the property name is not defined for that feature
         return feature.getProperty(this._value);
     };
+
+    function checkFeature (ast) {
+        return (ast._value === 'feature');
+    }
+
+    // PERFORMANCE_IDEA: Determine if parent property needs to be computed before runtime
+    Node.prototype._evaluateMemberDot = function(feature) {
+        if(checkFeature(this._left)) {
+            return feature.getProperty(this._right);
+        }
+        var property = this._left.evaluate(feature);
+        if (!defined(property)) {
+            return undefined;
+        }
+        return property[this._right];
+    };
+
+    Node.prototype._evaluateMemberComputed = function(feature) {
+        if(checkFeature(this._left)) {
+            return feature.getProperty(this._right.evaluate(feature));
+        }
+        var property = this._left.evaluate(feature);
+        if (!defined(property)) {
+            return undefined;
+        }
+        return property[this._right.evaluate(feature)];
+    };
+
 
     Node.prototype._evaluateNot = function(feature) {
         return !(this._left.evaluate(feature));

--- a/Source/Scene/ExpressionNodeType.js
+++ b/Source/Scene/ExpressionNodeType.js
@@ -13,12 +13,13 @@ define([
         UNARY : 1,
         BINARY : 2,
         CONDITIONAL : 3,
-        LITERAL_NULL : 4,
-        LITERAL_BOOLEAN : 5,
-        LITERAL_NUMBER : 6,
-        LITERAL_STRING: 7,
-        LITERAL_COLOR: 8,
-        VARIABLE_IN_STRING : 9
+        MEMBER : 4,
+        LITERAL_NULL : 5,
+        LITERAL_BOOLEAN : 6,
+        LITERAL_NUMBER : 7,
+        LITERAL_STRING: 8,
+        LITERAL_COLOR: 9,
+        VARIABLE_IN_STRING : 10
     };
 
     return freezeObject(ExpressionNodeType);

--- a/Specs/Scene/ExpressionSpec.js
+++ b/Specs/Scene/ExpressionSpec.js
@@ -530,7 +530,7 @@ defineSuite([
         expect(expression.evaluate(undefined)).toEqual(2);
     });
 
-    it('evaluates member expression', function() {
+    it('evaluates member expression with dot', function() {
         var feature = new MockFeature();
         feature.addProperty('height', 10);
         feature.addProperty('width', 5);
@@ -565,13 +565,9 @@ defineSuite([
 
         expression = new Expression(new MockStyleEngine(), '${feature.color.red}');
         expect(expression.evaluate(feature)).toEqual(1.0);
-
-        expect(function() {
-            return new Expression(new MockStyleEngine(), 'color.red');
-        }).toThrowDeveloperError();
     });
 
-    it('evaluates computed member expression', function() {
+    it('evaluates member expression with brackets', function() {
         var feature = new MockFeature();
         feature.addProperty('height', 10);
         feature.addProperty('width', 5);
@@ -615,9 +611,25 @@ defineSuite([
 
         expression = new Expression(new MockStyleEngine(), '${feature["feature.color"]}');
         expect(expression.evaluate(feature)).toEqual(Color.GREEN);
+    });
+
+    it('member expressions throw without variable notation', function() {
+        expect(function() {
+            return new Expression(new MockStyleEngine(), 'color.red');
+        }).toThrowDeveloperError();
 
         expect(function() {
             return new Expression(new MockStyleEngine(), 'color["red"]');
+        }).toThrowDeveloperError();
+    });
+
+    it('member expression throws with variable property', function() {
+        var feature = new MockFeature();
+        feature.addProperty('color', Color.RED);
+        feature.addProperty('colorName', 'red');
+
+        expect(function() {
+            return new Expression(new MockStyleEngine(), '${color[${colorName}]}');
         }).toThrowDeveloperError();
     });
 

--- a/Specs/Scene/ExpressionSpec.js
+++ b/Specs/Scene/ExpressionSpec.js
@@ -586,7 +586,6 @@ defineSuite([
         feature.addProperty('null', null);
         feature.addProperty('undefined', undefined);
 
-
         var expression = new Expression(new MockStyleEngine(), '${color["red"]}');
         expect(expression.evaluate(feature)).toEqual(1.0);
 

--- a/Specs/Scene/ExpressionSpec.js
+++ b/Specs/Scene/ExpressionSpec.js
@@ -529,4 +529,111 @@ defineSuite([
         expression = new Expression(new MockStyleEngine(), '(!(1 + 2 > 3)) ? (2 > 1 ? 1 + 1 : 0) : (2 > 1 ? -1 + -1 : 0)');
         expect(expression.evaluate(undefined)).toEqual(2);
     });
+
+    it('evaluates member expression', function() {
+        var feature = new MockFeature();
+        feature.addProperty('height', 10);
+        feature.addProperty('width', 5);
+        feature.addProperty('string', 'hello');
+        feature.addProperty('boolean', true);
+        feature.addProperty('color', Color.RED);
+        feature.addProperty('color.red', 'something else');
+        feature.addProperty('feature.color', Color.GREEN);
+        feature.addProperty('feature', {
+            color : Color.BLUE
+        });
+        feature.addProperty('null', null);
+        feature.addProperty('undefined', undefined);
+
+        var expression = new Expression(new MockStyleEngine(), '${color.red}');
+        expect(expression.evaluate(feature)).toEqual(1.0);
+
+        expression = new Expression(new MockStyleEngine(), '${color.blue}');
+        expect(expression.evaluate(feature)).toEqual(0.0);
+
+        expression = new Expression(new MockStyleEngine(), '${height.blue}');
+        expect(expression.evaluate(feature)).toEqual(undefined);
+
+        expression = new Expression(new MockStyleEngine(), '${undefined.blue}');
+        expect(expression.evaluate(feature)).toEqual(undefined);
+
+        expression = new Expression(new MockStyleEngine(), '${feature.color}');
+        expect(expression.evaluate(feature)).toEqual(Color.RED);
+
+        expression = new Expression(new MockStyleEngine(), '${feature.feature.color}');
+        expect(expression.evaluate(feature)).toEqual(Color.BLUE);
+
+        expression = new Expression(new MockStyleEngine(), '${feature.color.red}');
+        expect(expression.evaluate(feature)).toEqual(1.0);
+
+        expect(function() {
+            return new Expression(new MockStyleEngine(), 'color.red');
+        }).toThrowDeveloperError();
+    });
+
+    it('evaluates computed member expression', function() {
+        var feature = new MockFeature();
+        feature.addProperty('height', 10);
+        feature.addProperty('width', 5);
+        feature.addProperty('string', 'hello');
+        feature.addProperty('boolean', true);
+        feature.addProperty('color', Color.RED);
+        feature.addProperty('color.red', 'something else');
+        feature.addProperty('feature.color', Color.GREEN);
+        feature.addProperty('feature', {
+            color : Color.BLUE
+        });
+        feature.addProperty('null', null);
+        feature.addProperty('undefined', undefined);
+
+
+        var expression = new Expression(new MockStyleEngine(), '${color["red"]}');
+        expect(expression.evaluate(feature)).toEqual(1.0);
+
+        expression = new Expression(new MockStyleEngine(), '${color["blue"]}');
+        expect(expression.evaluate(feature)).toEqual(0.0);
+
+        expression = new Expression(new MockStyleEngine(), '${height["blue"]}');
+        expect(expression.evaluate(feature)).toEqual(undefined);
+
+        expression = new Expression(new MockStyleEngine(), '${undefined["blue"]}');
+        expect(expression.evaluate(feature)).toEqual(undefined);
+
+        expression = new Expression(new MockStyleEngine(), '${feature["color"]}');
+        expect(expression.evaluate(feature)).toEqual(Color.RED);
+
+        expression = new Expression(new MockStyleEngine(), '${feature.color["red"]}');
+        expect(expression.evaluate(feature)).toEqual(1.0);
+
+        expression = new Expression(new MockStyleEngine(), '${feature["color"].red}');
+        expect(expression.evaluate(feature)).toEqual(1.0);
+
+        expression = new Expression(new MockStyleEngine(), '${feature["color.red"]}');
+        expect(expression.evaluate(feature)).toEqual('something else');
+
+        expression = new Expression(new MockStyleEngine(), '${feature.feature["color"]}');
+        expect(expression.evaluate(feature)).toEqual(Color.BLUE);
+
+        expression = new Expression(new MockStyleEngine(), '${feature["feature.color"]}');
+        expect(expression.evaluate(feature)).toEqual(Color.GREEN);
+
+        expect(function() {
+            return new Expression(new MockStyleEngine(), 'color["red"]');
+        }).toThrowDeveloperError();
+    });
+
+    it('evaluates feature property', function() {
+        var feature = new MockFeature();
+        feature.addProperty('feature', {
+            color : Color.BLUE
+        });
+
+        var expression = new Expression(new MockStyleEngine(), '${feature}');
+        expect(expression.evaluate(feature)).toEqual({
+            color : Color.BLUE
+        });
+
+        expression = new Expression(new MockStyleEngine(), '${feature} === ${feature.feature}');
+        expect(expression.evaluate(feature)).toEqual(true);
+    });
 });


### PR DESCRIPTION
This is just member expressions, not arrays, though after this arrays should be simple to add.

I ended up using `${feature.a.b}` and `${feature['a.b']}` because it ended up being more straightforward from an implementation perspective. I will update this on the spec.

In this case `${feature} === ${feature.feature}` is true.

I added a new `ExpressionNodeType`, `MEMBER`. I added it before the literal types, because if for some reason we need to check if something is any kind of literal in the future, we can use type `>= ExpressionNodeType.LITERAL_NULL`.

During parsing, we determine if the expression determining the property needs to be computed or not, then assigns the proper evaluation function to the node.

If the parent property if undefined, we simply return undefined, and if the child is not there, we also return undefined. Like when evaluating variables, we don't want to throw developer errors in thr case of non-homogeneous data sets.

I added tests for different iterations of using the dot member expression as well as the bracket member expressions. I also added a test to confirm `${feature}` works and `${feature} === ${feature.feature}` is true.

