### PR TITLE
Fix wall indices and height

### DIFF
--- a/Source/Core/WallGeometry.js
+++ b/Source/Core/WallGeometry.js
@@ -297,7 +297,7 @@ define([
      *   maximumHeight : 10000.0
      * });
      * var geometry = Cesium.WallGeometry.createGeometry(wall);
-     * 
+     *
      * @see WallGeometry#createGeometry
      */
     WallGeometry.fromConstantHeights = function(options) {
@@ -358,10 +358,6 @@ define([
         var granularity = wallGeometry._granularity;
         var ellipsoid = wallGeometry._ellipsoid;
 
-        if (wallPositions.length < 2) {
-            return;
-        }
-
         var pos = WallGeometryLibrary.computePositions(ellipsoid, wallPositions, maximumHeights, minimumHeights, granularity, true);
         if (!defined(pos)) {
             return;
@@ -369,6 +365,7 @@ define([
 
         var bottomPositions = pos.bottomPositions;
         var topPositions = pos.topPositions;
+        var numCorners = pos.numCorners;
 
         var length = topPositions.length;
         var size = length * 2;
@@ -536,7 +533,7 @@ define([
         //
 
         var numVertices = size / 3;
-        size -= 6;
+        size -= 6 * (numCorners + 1);
         var indices = IndexDatatype.createTypedArray(numVertices, size);
 
         var edgeIndex = 0;

--- a/Source/Core/WallGeometryLibrary.js
+++ b/Source/Core/WallGeometryLibrary.js
@@ -33,11 +33,12 @@ define([
     function removeDuplicates(ellipsoid, positions, topHeights, bottomHeights) {
         var length = positions.length;
         if (length < 2) {
-            return { positions: positions };
+            return;
         }
 
-        var hasBottomHeights = (defined(bottomHeights));
-        var hasTopHeights = (defined(topHeights));
+        var hasBottomHeights = defined(bottomHeights);
+        var hasTopHeights = defined(topHeights);
+        var hasAllZeroHeights = true;
 
         var cleanedPositions = new Array(length);
         var cleanedTopHeights = new Array(length);
@@ -50,6 +51,9 @@ define([
         if (hasTopHeights) {
             c0.height = topHeights[0];
         }
+
+        hasAllZeroHeights = hasAllZeroHeights && c0.height <= 0;
+
         cleanedTopHeights[0] = c0.height;
 
         if (hasBottomHeights) {
@@ -65,6 +69,7 @@ define([
             if (hasTopHeights) {
                 c1.height = topHeights[i];
             }
+            hasAllZeroHeights = hasAllZeroHeights && c1.height <= 0;
 
             if (!latLonEquals(c0, c1)) {
                 cleanedPositions[index] = v1; // Shallow copy!
@@ -81,6 +86,10 @@ define([
             } else if (c0.height < c1.height) {
                 cleanedTopHeights[index - 1] = c1.height;
             }
+        }
+
+        if (hasAllZeroHeights) {
+            return;
         }
 
         cleanedPositions.length = index;
@@ -109,13 +118,13 @@ define([
     WallGeometryLibrary.computePositions = function(ellipsoid, wallPositions, maximumHeights, minimumHeights, granularity, duplicateCorners) {
         var o = removeDuplicates(ellipsoid, wallPositions, maximumHeights, minimumHeights);
 
+        if (!defined(o) || o.positions.length < 2) {
+            return;
+        }
+
         wallPositions = o.positions;
         maximumHeights = o.topHeights;
         minimumHeights = o.bottomHeights;
-
-        if (wallPositions.length < 2) {
-            return undefined;
-        }
 
         if (wallPositions.length >= 3) {
             // Order positions counter-clockwise
@@ -130,6 +139,7 @@ define([
         }
 
         var length = wallPositions.length;
+        var numCorners = length - 2;
         var topPositions;
         var bottomPositions;
 
@@ -184,7 +194,8 @@ define([
 
         return {
             bottomPositions: bottomPositions,
-            topPositions: topPositions
+            topPositions: topPositions,
+            numCorners: numCorners
         };
     };
 

--- a/Source/Core/WallGeometryLibrary.js
+++ b/Source/Core/WallGeometryLibrary.js
@@ -88,7 +88,7 @@ define([
             }
         }
 
-        if (hasAllZeroHeights) {
+        if (hasAllZeroHeights || index < 2) {
             return;
         }
 
@@ -118,7 +118,7 @@ define([
     WallGeometryLibrary.computePositions = function(ellipsoid, wallPositions, maximumHeights, minimumHeights, granularity, duplicateCorners) {
         var o = removeDuplicates(ellipsoid, wallPositions, maximumHeights, minimumHeights);
 
-        if (!defined(o) || o.positions.length < 2) {
+        if (!defined(o)) {
             return;
         }
 

--- a/Source/Core/WallOutlineGeometry.js
+++ b/Source/Core/WallOutlineGeometry.js
@@ -274,7 +274,7 @@ define([
      *   maximumHeight : 10000.0
      * });
      * var geometry = Cesium.WallOutlineGeometry.createGeometry(wall);
-     * 
+     *
      * @see WallOutlineGeometry#createGeometry
      */
     WallOutlineGeometry.fromConstantHeights = function(options) {
@@ -332,10 +332,6 @@ define([
         var maximumHeights = wallGeometry._maximumHeights;
         var granularity = wallGeometry._granularity;
         var ellipsoid = wallGeometry._ellipsoid;
-
-        if (wallPositions.length < 2) {
-            return;
-        }
 
         var pos = WallGeometryLibrary.computePositions(ellipsoid, wallPositions, maximumHeights, minimumHeights, granularity, false);
         if (!defined(pos)) {

--- a/Specs/Core/WallGeometrySpec.js
+++ b/Specs/Core/WallGeometrySpec.js
@@ -41,7 +41,7 @@ defineSuite([
         }).toThrowDeveloperError();
     });
 
-    it('createGeometry returnes undefined with less than 2 unique positions', function() {
+    it('returns undefined with less than 2 unique positions', function() {
         var geometry = WallGeometry.createGeometry(new WallGeometry({
             positions : Cartesian3.fromDegreesArrayHeights([
                 49.0, 18.0, 1000.0,
@@ -49,7 +49,28 @@ defineSuite([
                 49.0, 18.0, 1000.0
             ])
         }));
-        expect(geometry).not.toBeDefined();
+        expect(geometry).toBeUndefined();
+    });
+
+    it('returns undefined with no heights', function() {
+        var geometry = WallGeometry.createGeometry(new WallGeometry({
+            positions : Cartesian3.fromDegreesArray([
+                49.0, 18.0,
+                49.0, 18.0,
+                49.0, 18.0
+            ])
+        }));
+        expect(geometry).toBeUndefined();
+
+        geometry = WallGeometry.createGeometry(new WallGeometry({
+            positions : Cartesian3.fromDegreesArray([
+                49.0, 18.0,
+                49.0, 18.0,
+                49.0, 18.0
+            ]),
+            maximumHeights: [0, 0, 0]
+        }));
+        expect(geometry).toBeUndefined();
     });
 
     it('does not throw when positions are unique but close', function() {
@@ -72,8 +93,10 @@ defineSuite([
         }));
 
         var positions = w.attributes.position.values;
-        expect(positions.length).toEqual(2 * 2 * 3);
-        expect(w.indices.length).toEqual(2 * 3);
+        var numPositions = 4;
+        var numTriangles = 2;
+        expect(positions.length).toEqual(numPositions * 3);
+        expect(w.indices.length).toEqual(numTriangles * 3);
 
         var cartographic = ellipsoid.cartesianToCartographic(Cartesian3.fromArray(positions, 0));
         expect(cartographic.height).toEqualEpsilon(0.0, CesiumMath.EPSILON8);
@@ -94,8 +117,10 @@ defineSuite([
         }));
 
         var positions = w.attributes.position.values;
-        expect(positions.length).toEqual(2 * 2 * 3);
-        expect(w.indices.length).toEqual(2 * 3);
+        var numPositions = 4;
+        var numTriangles = 2;
+        expect(positions.length).toEqual(numPositions * 3);
+        expect(w.indices.length).toEqual(numTriangles * 3);
 
         var cartographic = ellipsoid.cartesianToCartographic(Cartesian3.fromArray(positions, 0));
         expect(cartographic.height).toEqualEpsilon(1000.0, CesiumMath.EPSILON8);
@@ -124,9 +149,11 @@ defineSuite([
             ])
         }));
 
+        var numPositions = 8;
+        var numTriangles = 4;
         var positions = w.attributes.position.values;
-        expect(positions.length).toEqual(4 * 2 * 3);
-        expect(w.indices.length).toEqual((4 * 2 - 2) * 3);
+        expect(positions.length).toEqual(numPositions * 3);
+        expect(w.indices.length).toEqual(numTriangles * 3);
 
         var cartographic = ellipsoid.cartesianToCartographic(Cartesian3.fromArray(positions, 0));
         expect(cartographic.height).toEqualEpsilon(0.0, CesiumMath.EPSILON8);
@@ -173,9 +200,11 @@ defineSuite([
             ])
         }));
 
+        var numPositions = 8;
+        var numTriangles = 4;
         var positions = w.attributes.position.values;
-        expect(positions.length).toEqual(4 * 2 * 3);
-        expect(w.indices.length).toEqual((4 * 2 - 2) * 3);
+        expect(positions.length).toEqual(numPositions * 3);
+        expect(w.indices.length).toEqual(numTriangles * 3);
 
         var cartographic = ellipsoid.cartesianToCartographic(Cartesian3.fromArray(positions, 0));
         expect(cartographic.height).toEqualEpsilon(0.0, CesiumMath.EPSILON8);
@@ -194,12 +223,14 @@ defineSuite([
             ])
         }));
 
-        expect(w.attributes.position.values.length).toEqual(4 * 2 * 3);
-        expect(w.attributes.normal.values.length).toEqual(4 * 2 * 3);
-        expect(w.attributes.tangent.values.length).toEqual(4 * 2 * 3);
-        expect(w.attributes.binormal.values.length).toEqual(4 * 2 * 3);
-        expect(w.attributes.st.values.length).toEqual(4 * 2 * 2);
-        expect(w.indices.length).toEqual((4 * 2 - 2) * 3);
+        var numPositions = 8;
+        var numTriangles = 4;
+        expect(w.attributes.position.values.length).toEqual(numPositions * 3);
+        expect(w.attributes.normal.values.length).toEqual(numPositions * 3);
+        expect(w.attributes.tangent.values.length).toEqual(numPositions * 3);
+        expect(w.attributes.binormal.values.length).toEqual(numPositions * 3);
+        expect(w.attributes.st.values.length).toEqual(numPositions * 2);
+        expect(w.indices.length).toEqual(numTriangles * 3);
     });
 
     it('creates correct texture coordinates', function() {
@@ -245,9 +276,11 @@ defineSuite([
             maximumHeight : max
         }));
 
+        var numPositions = 4;
+        var numTriangles = 2;
         var positions = w.attributes.position.values;
-        expect(positions.length).toEqual(2 * 2 * 3);
-        expect(w.indices.length).toEqual(2 * 3);
+        expect(positions.length).toEqual(numPositions * 3);
+        expect(w.indices.length).toEqual(numTriangles * 3);
 
         var cartographic = ellipsoid.cartesianToCartographic(Cartesian3.fromArray(positions, 0));
         expect(cartographic.height).toEqualEpsilon(min, CesiumMath.EPSILON8);
@@ -260,20 +293,6 @@ defineSuite([
 
         cartographic = ellipsoid.cartesianToCartographic(Cartesian3.fromArray(positions, 9));
         expect(cartographic.height).toEqualEpsilon(max, CesiumMath.EPSILON8);
-    });
-
-    it('undefined is returned if there are less than two positions', function() {
-        var wall = WallGeometry.fromConstantHeights({
-            positions : Cartesian3.fromDegreesArray([
-                19.0, 47.0
-            ]),
-            minimumHeight : 20000.0,
-            maximumHeight : 10000.0
-        });
-
-        var geometry = WallGeometry.createGeometry(wall);
-
-        expect(geometry).toBeUndefined();
     });
 
     var positions = [new Cartesian3(1.0, 0.0, 0.0), new Cartesian3(0.0, 1.0, 0.0), new Cartesian3(0.0, 0.0, 1.0)];

--- a/Specs/Core/WallOutlineGeometrySpec.js
+++ b/Specs/Core/WallOutlineGeometrySpec.js
@@ -39,7 +39,7 @@ defineSuite([
         }).toThrowDeveloperError();
     });
 
-    it('createGeometry returnes undefined with less than 2 unique positions', function() {
+    it('returns undefined with less than 2 unique positions', function() {
         var geometry = WallOutlineGeometry.createGeometry(new WallOutlineGeometry({
             positions : Cartesian3.fromDegreesArrayHeights([
                 49.0, 18.0, 1000.0,
@@ -47,7 +47,28 @@ defineSuite([
                 49.0, 18.0, 1000.0
             ])
         }));
-        expect(geometry).not.toBeDefined();
+        expect(geometry).toBeUndefined();
+    });
+
+    it('returns undefined with no heights', function() {
+        var geometry = WallOutlineGeometry.createGeometry(new WallOutlineGeometry({
+            positions : Cartesian3.fromDegreesArray([
+                49.0, 18.0,
+                49.0, 18.0,
+                49.0, 18.0
+            ])
+        }));
+        expect(geometry).toBeUndefined();
+
+        geometry = WallOutlineGeometry.createGeometry(new WallOutlineGeometry({
+            positions : Cartesian3.fromDegreesArray([
+                49.0, 18.0,
+                49.0, 18.0,
+                49.0, 18.0
+            ]),
+            maximumHeights: [0, 0, 0]
+        }));
+        expect(geometry).toBeUndefined();
     });
 
     it('creates positions relative to ellipsoid', function() {
@@ -156,20 +177,6 @@ defineSuite([
 
         cartographic = ellipsoid.cartesianToCartographic(Cartesian3.fromArray(positions, 9));
         expect(cartographic.height).toEqualEpsilon(max, CesiumMath.EPSILON8);
-    });
-
-    it('undefined is returned if there are less than two positions', function() {
-        var wallOutline = WallOutlineGeometry.fromConstantHeights({
-                positions : Cartesian3.fromDegreesArray([
-                19.0, 47.0
-            ]),
-            minimumHeight : 20000.0,
-            maximumHeight : 10000.0
-        });
-
-        var geometry = WallOutlineGeometry.createGeometry(wallOutline);
-
-        expect(geometry).toBeUndefined();
     });
 
     var positions = [new Cartesian3(1.0, 0.0, 0.0), new Cartesian3(0.0, 1.0, 0.0), new Cartesian3(0.0, 0.0, 1.0)];

--- a/Specs/DataSources/WallGeometryUpdaterSpec.js
+++ b/Specs/DataSources/WallGeometryUpdaterSpec.js
@@ -63,11 +63,11 @@ defineSuite([
 
     function createBasicWall() {
         var wall = new WallGraphics();
-        wall.positions = new ConstantProperty(Cartesian3.fromRadiansArray([
-            0, 0,
-            1, 0,
-            1, 1,
-            0, 1
+        wall.positions = new ConstantProperty(Cartesian3.fromRadiansArrayHeights([
+            0, 0, 1,
+            1, 0, 1,
+            1, 1, 1,
+            0, 1, 1
         ]));
         var entity = new Entity();
         entity.wall = wall;


### PR DESCRIPTION
Fixes #3611: Bad Indices
The calculation of the count of triangles didn't account for the fact that corner positions are duplicated.  This removes the extra length.

Fixes #3610: Heights > 0
Returns undefined if all positions on the wall have a height of 0, resulting in an empty geometry.