### PR TITLE
Fix camera heading-pitch-roll example.

### DIFF
--- a/Apps/Sandcastle/gallery/Camera.html
+++ b/Apps/Sandcastle/gallery/Camera.html
@@ -140,7 +140,7 @@ function setHeadingPitchRoll() {
     
     var camera = viewer.camera;
     camera.setView({
-        position : Cesium.Cartesian3.fromDegrees(-75.5847, 40.0397, 1000.0),
+        destination : Cesium.Cartesian3.fromDegrees(-75.5847, 40.0397, 1000.0),
         orientation: {
             heading : -Cesium.Math.PI_OVER_TWO,
             pitch : -Cesium.Math.PI_OVER_FOUR,


### PR DESCRIPTION
Only the heading, pitch and roll were being set. `position` was never renamed to `destination`.