### PR TITLE
Added Regex Constructors and Match Operator

### DIFF
--- a/Source/Scene/Expression.js
+++ b/Source/Scene/Expression.js
@@ -35,8 +35,6 @@ define([
         }
         //>>includeEnd('debug');
 
-        jsep.addBinaryOp("=~", 0);
-
         var ast;
         try {
             ast = jsep(replaceVariables(removeBackslashes(expression)));
@@ -141,11 +139,12 @@ define([
         if (ast.callee.type === 'MemberExpression') {
             call = ast.callee.property.name;
             if (call === 'test') {
+                // Make sure test is called on a valid type
+                //>>includeStart('debug', pragmas.debug);
                 if (ast.callee.object.callee.name !== 'RegExp') {
-                    //>>includeStart('debug', pragmas.debug);
                     throw new DeveloperError('Error: test is not a function');
-                    //>>includeEnd('debug');
                 }
+                //>>includeEnd('debug');
                 if (args.length === 0) {
                     return new Node(ExpressionNodeType.LITERAL_BOOLEAN, false);
                 }
@@ -248,9 +247,18 @@ define([
                 return new Node(ExpressionNodeType.LITERAL_REGEX, new RegExp());
             }
             val = args[0];
+            if (args.length > 1) {
+                try {
+                    return new Node(ExpressionNodeType.LITERAL_REGEX, new RegExp(replaceBackslashes(val.value), args[1].value));
+                } catch (e) {
+                    //>>includeStart('debug', pragmas.debug);
+                    throw new DeveloperError(e);
+                    //>>includeEnd('debug');
+                }
+            }
             //>>includeStart('debug', pragmas.debug);
             if (val.type !== 'Literal') {
-                throw new DeveloperError('Error: RegExp constructor requires a string');
+                throw new DeveloperError('Error: RegExp requires a string');
             }
             //>>includeEnd('debug');
             return new Node(ExpressionNodeType.LITERAL_REGEX, new RegExp(replaceBackslashes(val.value)));

--- a/Source/Scene/Expression.js
+++ b/Source/Scene/Expression.js
@@ -226,7 +226,7 @@ define([
             }
             val = args[0];
             //>>includeStart('debug', pragmas.debug);
-            if (val.type !== 'Literal' && typeof(val.value) !== 'string') {
+            if (val.type !== 'Literal') {
                 throw new DeveloperError('Error: RegExp constructor requires a string');
             }
             //>>includeEnd('debug');

--- a/Source/Scene/ExpressionNodeType.js
+++ b/Source/Scene/ExpressionNodeType.js
@@ -19,7 +19,8 @@ define([
         LITERAL_NUMBER : 7,
         LITERAL_STRING: 8,
         LITERAL_COLOR: 9,
-        VARIABLE_IN_STRING : 10
+        LITERAL_REGEX: 10,
+        VARIABLE_IN_STRING : 11
     };
 
     return freezeObject(ExpressionNodeType);

--- a/Source/Scene/ExpressionNodeType.js
+++ b/Source/Scene/ExpressionNodeType.js
@@ -14,14 +14,15 @@ define([
         BINARY : 2,
         CONDITIONAL : 3,
         MEMBER : 4,
-        ARRAY : 5,
-        LITERAL_NULL : 6,
-        LITERAL_BOOLEAN : 7,
-        LITERAL_NUMBER : 8,
-        LITERAL_STRING: 9,
-        LITERAL_COLOR: 10,
-        LITERAL_REGEX: 11,
-        VARIABLE_IN_STRING : 12
+        FUNCTION_CALL : 5,
+        ARRAY : 6,
+        LITERAL_NULL : 7,
+        LITERAL_BOOLEAN : 8,
+        LITERAL_NUMBER : 9,
+        LITERAL_STRING: 10,
+        LITERAL_COLOR: 11,
+        LITERAL_REGEX: 12,
+        VARIABLE_IN_STRING : 13
     };
 
     return freezeObject(ExpressionNodeType);

--- a/Specs/Scene/ExpressionSpec.js
+++ b/Specs/Scene/ExpressionSpec.js
@@ -710,26 +710,23 @@ defineSuite([
         var feature = new MockFeature();
         feature.addProperty('property', 'abc');
 
-        var expression = new Expression(new MockStyleEngine(), '"abc" =~ RegExp("a")');
+        var expression = new Expression(new MockStyleEngine(), 'RegExp("a").test("abc")');
         expect(expression.evaluate(undefined)).toEqual(true);
 
-        expression = new Expression(new MockStyleEngine(), 'RegExp("a") =~ "abc"');
-        expect(expression.evaluate(undefined)).toEqual(true);
-
-        expression = new Expression(new MockStyleEngine(), 'RegExp("a") =~ "bcd"');
+        expression = new Expression(new MockStyleEngine(), 'RegExp("a").test("bcd")');
         expect(expression.evaluate(undefined)).toEqual(false);
 
-        expression = new Expression(new MockStyleEngine(), '"bcd" =~ RegExp("a")');
+        expression = new Expression(new MockStyleEngine(), 'RegExp("a").test()');
         expect(expression.evaluate(undefined)).toEqual(false);
-
-        expression = new Expression(new MockStyleEngine(), '${property} =~ RegExp("a")');
-        expect(expression.evaluate(feature)).toEqual(true);
     });
 
-    it('throws if regex match operator does not have regex as argument', function() {
+    it('throws if test is not call with a RegExp', function() {
         expect(function() {
-            var expression = new Expression(new MockStyleEngine(), '"abc" =~ "abc"');
-            expression.evaluate(undefined);
+            return new Expression(new MockStyleEngine(), 'Color("blue").test()');
+        }).toThrowDeveloperError();
+
+        expect(function() {
+            return new Expression(new MockStyleEngine(), '"blue".test()');
         }).toThrowDeveloperError();
     });
 

--- a/Specs/Scene/ExpressionSpec.js
+++ b/Specs/Scene/ExpressionSpec.js
@@ -724,7 +724,7 @@ defineSuite([
         }).toThrowDeveloperError();
     });
 
-    it('evaluates regex matches operator', function() {
+    it('evaluates regex test function', function() {
         var feature = new MockFeature();
         feature.addProperty('property', 'abc');
 
@@ -736,6 +736,17 @@ defineSuite([
 
         expression = new Expression(new MockStyleEngine(), 'RegExp("a").test()');
         expect(expression.evaluate(undefined)).toEqual(false);
+    });
+
+    it('evaluates regex exec function', function() {
+        var feature = new MockFeature();
+        feature.addProperty('property', 'abc');
+
+        var expression = new Expression(new MockStyleEngine(), 'RegExp("a(.)").exec("abc")');
+        expect(expression.evaluate(undefined)).toEqual('b');
+
+        expression = new Expression(new MockStyleEngine(), 'RegExp("a(.)").exec("qbc")');
+        expect(expression.evaluate(undefined)).toEqual(null);
     });
 
     it('throws if test is not call with a RegExp', function() {

--- a/Specs/Scene/ExpressionSpec.js
+++ b/Specs/Scene/ExpressionSpec.js
@@ -698,11 +698,29 @@ defineSuite([
 
         expression = new Expression(new MockStyleEngine(), 'RegExp(true)');
         expect(expression.evaluate(undefined)).toEqual(/true/);
+
+        expression = new Expression(new MockStyleEngine(), 'RegExp()');
+        expect(expression.evaluate(undefined)).toEqual(/(?:)/);
+
+    });
+
+    it ('constructs regex with flags', function() {
+        var expression = new Expression(new MockStyleEngine(), 'RegExp("a", "i")');
+        expect(expression.evaluate(undefined)).toEqual(/a/i);
+
+        expression = new Expression(new MockStyleEngine(), 'RegExp("a", "mg")');
+        expect(expression.evaluate(undefined)).toEqual(/a/mg);
     });
 
     it('throws if regex constructor does not have literal as argument', function() {
         expect(function() {
             return new Expression(new MockStyleEngine(), 'RegExp(1+1)');
+        }).toThrowDeveloperError();
+    });
+
+    it('throws if regex constructor has invalid flags', function() {
+        expect(function() {
+            return new Expression(new MockStyleEngine(), 'RegExp("a", "q")');
         }).toThrowDeveloperError();
     });
 

--- a/Specs/Scene/ExpressionSpec.js
+++ b/Specs/Scene/ExpressionSpec.js
@@ -25,6 +25,11 @@ defineSuite([
         return this._properties[name];
     };
 
+    it ('parses backslashes', function() {
+        var expression = new Expression(new MockStyleEngine(), '"\\he\\\\\\ll\\\\o"');
+        expect(expression.evaluate(undefined)).toEqual('\\he\\\\\\ll\\\\o');
+    });
+
     it('evaluates variable', function() {
         var feature = new MockFeature();
         feature.addProperty('height', 10);
@@ -679,5 +684,46 @@ defineSuite([
 
         expression = new Expression(new MockStyleEngine(), '${feature} === ${feature.feature}');
         expect(expression.evaluate(feature)).toEqual(true);
+    });
+
+    it('constructs regex', function() {
+        var expression = new Expression(new MockStyleEngine(), 'RegExp("a")');
+        expect(expression.evaluate(undefined)).toEqual(/a/);
+
+        expression = new Expression(new MockStyleEngine(), 'RegExp("\\w")');
+        expect(expression.evaluate(undefined)).toEqual(/\w/);
+
+        expression = new Expression(new MockStyleEngine(), 'RegExp(1)');
+        expect(expression.evaluate(undefined)).toEqual(/1/);
+
+        expression = new Expression(new MockStyleEngine(), 'RegExp(true)');
+        expect(expression.evaluate(undefined)).toEqual(/true/);
+    });
+
+    it('throws if regex constructor does not have literal as argument', function() {
+        expect(function() {
+            return new Expression(new MockStyleEngine(), 'RegExp(1+1)');
+        }).toThrowDeveloperError();
+    });
+
+    it('evaluates regex matches operator', function() {
+        var expression = new Expression(new MockStyleEngine(), '"abc" =~ RegExp("a")');
+        expect(expression.evaluate(undefined)).toEqual(true);
+
+        expression = new Expression(new MockStyleEngine(), 'RegExp("a") =~ "abc"');
+        expect(expression.evaluate(undefined)).toEqual(true);
+
+        expression = new Expression(new MockStyleEngine(), 'RegExp("a") =~ "bcd"');
+        expect(expression.evaluate(undefined)).toEqual(false);
+
+        expression = new Expression(new MockStyleEngine(), '"bcd" =~ RegExp("a")');
+        expect(expression.evaluate(undefined)).toEqual(false);
+    });
+
+    it('throws if regex match operator does not have regex as argument', function() {
+        expect(function() {
+            var expression = new Expression(new MockStyleEngine(), '"abc" =~ "abc"');
+            expression.evaluate(undefined);
+        }).toThrowDeveloperError();
     });
 });

--- a/Specs/Scene/ExpressionSpec.js
+++ b/Specs/Scene/ExpressionSpec.js
@@ -754,6 +754,9 @@ defineSuite([
         expression = new Expression(new MockStyleEngine(), 'RegExp("a(.)").exec("qbc")');
         expect(expression.evaluate(undefined)).toEqual(null);
 
+        expression = new Expression(new MockStyleEngine(), 'RegExp("a(.)").exec()');
+        expect(expression.evaluate(undefined)).toEqual(null);
+
         expression = new Expression(new MockStyleEngine(), 'RegExp("quick\\s(b.*n).+?(jumps)", "ig").exec("The Quick Brown Fox Jumps Over The Lazy Dog")');
         expect(expression.evaluate(undefined)).toEqual('Brown');
 

--- a/Specs/Scene/ExpressionSpec.js
+++ b/Specs/Scene/ExpressionSpec.js
@@ -707,6 +707,9 @@ defineSuite([
     });
 
     it('evaluates regex matches operator', function() {
+        var feature = new MockFeature();
+        feature.addProperty('property', 'abc');
+
         var expression = new Expression(new MockStyleEngine(), '"abc" =~ RegExp("a")');
         expect(expression.evaluate(undefined)).toEqual(true);
 
@@ -718,6 +721,9 @@ defineSuite([
 
         expression = new Expression(new MockStyleEngine(), '"bcd" =~ RegExp("a")');
         expect(expression.evaluate(undefined)).toEqual(false);
+
+        expression = new Expression(new MockStyleEngine(), '${property} =~ RegExp("a")');
+        expect(expression.evaluate(feature)).toEqual(true);
     });
 
     it('throws if regex match operator does not have regex as argument', function() {

--- a/Specs/Scene/ExpressionSpec.js
+++ b/Specs/Scene/ExpressionSpec.js
@@ -734,8 +734,14 @@ defineSuite([
         expression = new Expression(new MockStyleEngine(), 'RegExp("a").test("bcd")');
         expect(expression.evaluate(undefined)).toEqual(false);
 
+        expression = new Expression(new MockStyleEngine(), 'RegExp("quick\\s(brown).+?(jumps)", "ig").test("The Quick Brown Fox Jumps Over The Lazy Dog")');
+        expect(expression.evaluate(undefined)).toEqual(true);
+
         expression = new Expression(new MockStyleEngine(), 'RegExp("a").test()');
         expect(expression.evaluate(undefined)).toEqual(false);
+
+        expression = new Expression(new MockStyleEngine(), 'RegExp("a").test(${property})');
+        expect(expression.evaluate(feature)).toEqual(true);
     });
 
     it('evaluates regex exec function', function() {
@@ -747,6 +753,12 @@ defineSuite([
 
         expression = new Expression(new MockStyleEngine(), 'RegExp("a(.)").exec("qbc")');
         expect(expression.evaluate(undefined)).toEqual(null);
+
+        expression = new Expression(new MockStyleEngine(), 'RegExp("quick\\s(b.*n).+?(jumps)", "ig").exec("The Quick Brown Fox Jumps Over The Lazy Dog")');
+        expect(expression.evaluate(undefined)).toEqual('Brown');
+
+        expression = new Expression(new MockStyleEngine(), 'RegExp("a(.)").exec(${property})');
+        expect(expression.evaluate(feature)).toEqual('b');
     });
 
     it('throws if test is not call with a RegExp', function() {


### PR DESCRIPTION
Firstly, I added functions to replace all backlashes with an obscure string before using jsep, (I'm using `@#%`), and back after parsing. I added a test to make sure this is happening correctly.

I also added a constructor function to create a regex `RegExp()`. It requires either no arguments (which creates an empty regex `/(?:)/`) or a literal. If a literal is not received, an error is thrown. Like the javascript `RegExp()` constructor, it can take other literal types as arguments. For example, `RegExp(1)` is legal and evaluates to `/1/`. It will not take a color. I added tests to check for constructing with strings, numbers, and booleans.

Since JavaScript does not have an operator to indicate regex matching, I also used the `=~` operator to check regex matches, as @pierotofy suggested. It is treated as commutative, and return `true` if the regex matches and `false` otherwise. It throws an error if one of the arguments is not a regex. I added tests to check for these cases.

Once this PR is closed, I'll implement the `!~` operator, and an operator to that returns the first captured match.