### PR TITLE
Updates to color type

### DIFF
--- a/Source/Scene/Expression.js
+++ b/Source/Scene/Expression.js
@@ -174,7 +174,7 @@ define([
         } else if (call === 'rgb' || call === 'hsl') {
             //>>includeStart('debug', pragmas.debug);
             if (args.length < 3) {
-                throw new DeveloperError('Error: " + call + " requires three arguments');
+                throw new DeveloperError('Error: ' + call + ' requires three arguments');
             }
             //>>includeEnd('debug');
             val = [
@@ -186,7 +186,7 @@ define([
         } else if (call === 'rgba' || call === 'hsla') {
             //>>includeStart('debug', pragmas.debug);
             if (args.length < 4) {
-                throw new DeveloperError('Error: " + call + " requires four arguments');
+                throw new DeveloperError('Error: ' + call + ' requires four arguments');
             }
             //>>includeEnd('debug');
             val = [

--- a/Source/Scene/Expression.js
+++ b/Source/Scene/Expression.js
@@ -116,58 +116,38 @@ define([
         var args = ast.arguments;
         var val;
         
-        // TODO: Throw error if returned Color is not defined
-
         if (call === 'Color') {
-            val = Color.fromCssColorString(args[0].value);
+            val = createRuntimeAst(expression, args[0]);
             if (defined(args[1])) {
-                val = Color.fromAlpha(val, args[1].value);
+                var alpha = createRuntimeAst(expression, args[1]);
+                return new Node(ExpressionNodeType.LITERAL_COLOR, call, [val, alpha]);
             }
-            if (defined(val)) {
-               return new Node(ExpressionNodeType.LITERAL_COLOR, val);
-            }
-        } else if (call === 'rgb') {
+            return new Node(ExpressionNodeType.LITERAL_COLOR, call, [val]);
+        } else if (call === 'rgb' || call === 'hsl') {
             //>>includeStart('debug', pragmas.debug);
-            if (args.length !== 3) {
-                throw new DeveloperError('Error: rgb requires three arguments');
+            if (args.length < 3) {
+                throw new DeveloperError('Error: " + call + " requires three arguments');
             }
             //>>includeEnd('debug');
-            val = Color.fromBytes(args[0].value, args[1].value, args[2].value);
-            if (defined(val)) {
-               return new Node(ExpressionNodeType.LITERAL_COLOR, val);
-            }
-        } else if (call === 'hsl') {
+            val = [
+                createRuntimeAst(expression, args[0]),
+                createRuntimeAst(expression, args[1]),
+                createRuntimeAst(expression, args[2])
+            ];
+           return new Node(ExpressionNodeType.LITERAL_COLOR, call, val);
+        } else if (call === 'rgba' || call === 'hsla') {
             //>>includeStart('debug', pragmas.debug);
-            if (args.length !== 3) {
-                throw new DeveloperError('Error: hsl requires three arguments');
+            if (args.length < 4) {
+                throw new DeveloperError('Error: " + call + " requires four arguments');
             }
             //>>includeEnd('debug');
-            val = Color.fromHsl(args[0].value, args[1].value, args[2].value);
-            if (defined(val)) {
-               return new Node(ExpressionNodeType.LITERAL_COLOR, val);
-            }
-        } else if (call === 'rgba') {
-            //>>includeStart('debug', pragmas.debug);
-            if (args.length !== 4) {
-                throw new DeveloperError('Error: rgba requires four arguments');
-            }
-            //>>includeEnd('debug');
-            // convert between css alpha (0 to 1) and cesium alpha (0 to 255)
-            var a = args[3].value * 255;
-            val = Color.fromBytes(args[0].value, args[1].value, args[2].value, a);
-            if (defined(val)) {
-               return new Node(ExpressionNodeType.LITERAL_COLOR, val);
-            }
-        } else if (call === 'hsla') {
-            //>>includeStart('debug', pragmas.debug);
-            if (args.length !== 4) {
-                throw new DeveloperError('Error: hlsa requires four arguments');
-            }
-            //>>includeEnd('debug');
-            val = Color.fromHsl(args[0].value, args[1].value, args[2].value, args[3].value);
-            if (defined(val)) {
-               return new Node(ExpressionNodeType.LITERAL_COLOR, val);
-            }
+            val = [
+                createRuntimeAst(expression, args[0]),
+                createRuntimeAst(expression, args[1]),
+                createRuntimeAst(expression, args[2]),
+                createRuntimeAst(expression, args[3])
+            ];
+            return new Node(ExpressionNodeType.LITERAL_COLOR, call, val);
         } else if (call === 'isNaN') {
             if (args.length === 0) {
                 return new Node(ExpressionNodeType.LITERAL_BOOLEAN, true);
@@ -363,6 +343,8 @@ define([
             node.evaluate = node._evaluateVariable;
         } else if (node._type === ExpressionNodeType.VARIABLE_IN_STRING) {
             node.evaluate = node._evaluateVariableString;
+        } else if (node._type === ExpressionNodeType.LITERAL_COLOR) {
+            node.evaluate = node._evaluateLiteralColor;
         } else {
             node.evaluate = node._evaluateLiteral;
         }
@@ -370,6 +352,26 @@ define([
 
     Node.prototype._evaluateLiteral = function(feature) {
         return this._value;
+    };
+
+    Node.prototype._evaluateLiteralColor = function(feature) {
+        var args = this._left;
+        if (this._value === 'Color') {
+            if (args.length > 1) {
+                return Color.fromAlpha(Color.fromCssColorString(args[0].evaluate(feature)), args[1].evaluate(feature));
+            }
+            return Color.fromCssColorString(this._left[0].evaluate(feature));
+        } else if (this._value === 'rgb') {
+            return Color.fromBytes(args[0].evaluate(feature), args[1].evaluate(feature), args[2].evaluate(feature));
+        } else if (this._value === 'rgba') {
+            // convert between css alpha (0 to 1) and cesium alpha (0 to 255)
+            var a = args[3].evaluate(feature) * 255;
+            return Color.fromBytes(args[0].evaluate(feature), args[1].evaluate(feature), args[2].evaluate(feature), a);
+        } else if (this._value === 'hsl') {
+            return Color.fromHsl(args[0].evaluate(feature), args[1].evaluate(feature), args[2].evaluate(feature));
+        } else if (this._value === 'hsla') {
+            return Color.fromHsl(args[0].evaluate(feature), args[1].evaluate(feature), args[2].evaluate(feature), args[3].evaluate(feature));
+        }
     };
 
     Node.prototype._evaluateVariableString = function(feature) {

--- a/Specs/Scene/ExpressionSpec.js
+++ b/Specs/Scene/ExpressionSpec.js
@@ -260,7 +260,7 @@ defineSuite([
         expect(expression.evaluate(undefined)).toEqual(new Color(1.0, 1.0, 1.0, 0.5));
     });
 
-    it('evaluates literal color with expressions as arguments', function() {
+    it('evaluates color with expressions as arguments', function() {
         var feature = new MockFeature();
         feature.addProperty('hex6', '#ffffff');
         feature.addProperty('hex3', '#fff');
@@ -283,6 +283,73 @@ defineSuite([
         expect(expression.evaluate(feature).alpha).toEqual(0.8);
     });
 
+    it('evaluates rgb with expressions as arguments', function() {
+        var feature = new MockFeature();
+        feature.addProperty('red', 100);
+        feature.addProperty('green', 200);
+        feature.addProperty('blue', 255);
+
+        var expression = new Expression(new MockStyleEngine(), 'rgb(${red}, ${green}, ${blue})');
+        expect(expression.evaluate(feature)).toEqual(Color.fromBytes(100, 200, 255));
+
+        expression = new Expression(new MockStyleEngine(), 'rgb(${red}/2, ${green}/2, ${blue})');
+        expect(expression.evaluate(feature)).toEqual(Color.fromBytes(50, 100, 255));
+    });
+
+    it('evaluates hsl with expressions as arguments', function() {
+        var feature = new MockFeature();
+        feature.addProperty('h', 0.0);
+        feature.addProperty('s', 0.0);
+        feature.addProperty('l', 1.0);
+
+        var expression = new Expression(new MockStyleEngine(), 'hsl(${h}, ${s}, ${l})');
+        expect(expression.evaluate(feature)).toEqual(Color.WHITE);
+
+        expression = new Expression(new MockStyleEngine(), 'hsl(${h} + 0.2, ${s} + 1.0, ${l} - 0.5)');
+        expect(expression.evaluate(feature)).toEqual(Color.fromHsl(0.2, 1.0, 0.5));
+    });
+
+    it('evaluates rgba with expressions as arguments', function() {
+        var feature = new MockFeature();
+        feature.addProperty('red', 100);
+        feature.addProperty('green', 200);
+        feature.addProperty('blue', 255);
+        feature.addProperty('a', 0.3);
+
+        var expression = new Expression(new MockStyleEngine(), 'rgba(${red}, ${green}, ${blue}, ${a})');
+        expect(expression.evaluate(feature)).toEqual(Color.fromBytes(100, 200, 255, 0.3*255));
+
+        expression = new Expression(new MockStyleEngine(), 'rgba(${red}/2, ${green}/2, ${blue}, ${a} * 2)');
+        expect(expression.evaluate(feature)).toEqual(Color.fromBytes(50, 100, 255, 0.6*255));
+    });
+
+    it('evaluates hsla with expressions as arguments', function() {
+        var feature = new MockFeature();
+        feature.addProperty('h', 0.0);
+        feature.addProperty('s', 0.0);
+        feature.addProperty('l', 1.0);
+        feature.addProperty('a', 1.0);
+
+        var expression = new Expression(new MockStyleEngine(), 'hsla(${h}, ${s}, ${l}, ${a})');
+        expect(expression.evaluate(feature)).toEqual(Color.WHITE);
+
+        expression = new Expression(new MockStyleEngine(), 'hsla(${h} + 0.2, ${s} + 1.0, ${l} - 0.5, ${a} / 4)');
+        expect(expression.evaluate(feature)).toEqual(Color.fromHsl(0.2, 1.0, 0.5, 0.25));
+    });
+
+    it('evaluates rgba with expressions as arguments', function() {
+        var feature = new MockFeature();
+        feature.addProperty('red', 100);
+        feature.addProperty('green', 200);
+        feature.addProperty('blue', 255);
+        feature.addProperty('alpha', 0.5);
+
+        var expression = new Expression(new MockStyleEngine(), 'rgba(${red}, ${green}, ${blue}, ${alpha})');
+        expect(expression.evaluate(feature)).toEqual(Color.fromBytes(100, 200, 255, 0.5 * 255));
+
+        expression = new Expression(new MockStyleEngine(), 'rgba(${red}/2, ${green}/2, ${blue}, ${alpha} + 0.1)');
+        expect(expression.evaluate(feature)).toEqual(Color.fromBytes(50, 100, 255, 0.6 * 255));
+    });
 
     it('color constructors throw with wrong number of arguments', function() {
         expect(function() {

--- a/Specs/Scene/ExpressionSpec.js
+++ b/Specs/Scene/ExpressionSpec.js
@@ -255,6 +255,30 @@ defineSuite([
         expect(expression.evaluate(undefined)).toEqual(new Color(1.0, 1.0, 1.0, 0.5));
     });
 
+    it('evaluates literal color with expressions as arguments', function() {
+        var feature = new MockFeature();
+        feature.addProperty('hex6', '#ffffff');
+        feature.addProperty('hex3', '#fff');
+        feature.addProperty('keyword', 'white');
+        feature.addProperty('alpha', 0.2);
+
+        var expression = new Expression(new MockStyleEngine(), 'Color(${hex6})');
+        expect(expression.evaluate(feature)).toEqual(Color.WHITE);
+
+        expression = new Expression(new MockStyleEngine(), 'Color(${hex3})');
+        expect(expression.evaluate(feature)).toEqual(Color.WHITE);
+
+        expression = new Expression(new MockStyleEngine(), 'Color(${keyword})');
+        expect(expression.evaluate(feature)).toEqual(Color.WHITE);
+
+        expression = new Expression(new MockStyleEngine(), 'Color(${keyword}, ${alpha} + 0.6)');
+        expect(expression.evaluate(feature).red).toEqual(1.0);
+        expect(expression.evaluate(feature).green).toEqual(1.0);
+        expect(expression.evaluate(feature).blue).toEqual(1.0);
+        expect(expression.evaluate(feature).alpha).toEqual(0.8);
+    });
+
+
     it('color constructors throw with wrong number of arguments', function() {
         expect(function() {
             return new Expression(new MockStyleEngine(), 'rgb(255, 255)');


### PR DESCRIPTION
Color constructor and functions used to only take literals as arguments, now they can take expressions as arguments.

Also added more involved tests for each function.