### PR TITLE
Add jspm package configuration (for production/minified build flavor)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -29,6 +29,7 @@ Change Log
 * `Camera.flyTo` now honors max and min zoom settings in `ScreenSpaceCameraController`.
 * Fixed flying to `latitude, longitude, height` in the Geocoder.
 * Upgraded Knockout from version 3.2.0 to 3.4.0.
+* Added jspm configuration description to package.json
 
 ### 1.18 - 2016-02-01
 * Breaking changes

--- a/package.json
+++ b/package.json
@@ -72,5 +72,15 @@
     "release": "gulp release",
     "generateStubs": "gulp generateStubs",
     "sortRequires": "gulp sortRequires"
+  },
+  "jspm": {
+    "main": "Build/Cesium/Cesium",
+    "format": "global",
+    "shim": {
+      "Build/Cesium/Cesium": {
+        "exports": "Cesium"
+      }
+    },
+    "registry": "npm"
   }
 }


### PR DESCRIPTION
This change adds a [jspm](https://github.com/jspm/jspm-cli#jspm-cli) package configuration description to `package.json`, making the GitHub repository (and published npm package) ready for use with jspm.  [The commit comment](https://github.com/AnalyticalGraphicsInc/cesium/commit/c5a5727b78fdc5b9e17d7c0e09f1a4d93abe1746) has the details, but this exposes the production (bundled) build flavor.  Other possible flavors include the `index.js`/CommonJS-wrapped-RequireJS (bundled) flavor, the "raw"/Source (bundled) flavor (no AMD/RequireJS run-time), and an unbundled "raw"/Source flavor (no run-time).  I plan to feel these various configurations out in the future.

Note this changeset includes (and requires) the [Knockout 3.4.0 upgrade](#3629) to work properly; let me know if this should be handled in a different manner.
