### PR TITLE
Shadows cascades

### DIFF
--- a/Apps/Sandcastle/gallery/development/Shadows.html
+++ b/Apps/Sandcastle/gallery/development/Shadows.html
@@ -50,21 +50,34 @@ if (terrainEnabled) {
     terrainProvider = new Cesium.EllipsoidTerrainProvider();
 }
 
-viewer.terrainProvider = terrainProvider;
+if (globeVisible) {
+    viewer.terrainProvider = terrainProvider;
+}
 
-// Exton
+//// Exton
 //var centerLongitude = -1.31968;
 //var centerLatitude = 0.698874;
+//var height = 130.0;
+//var offset = 20.0;
+//var frustumSize = 15;
+//var frustumNear = 1.0;
+//var frustumFar = 100.0;
+//var tilt = 0.0;
 
 // Everest
 var centerLongitude = 1.517132688;
 var centerLatitude = 0.4884844964;
+var offset = 50.0;
+var frustumSize = 55.0;
+var frustumNear = 1.0;
+var frustumFar = 400.0;
+var tilt = 30.0;
 
 var scene = viewer.scene;
 var camera = scene.camera;
 var shadowMap = scene.sunShadowMap;
 shadowMap.debugShow = true;
-shadowMap.enabled = true;
+shadowMap.enabled = false;
 
 var positions = [new Cesium.Cartographic(centerLongitude, centerLatitude)];
 var promise = Cesium.sampleTerrain(terrainProvider, 11, positions);
@@ -75,6 +88,20 @@ Cesium.when(promise, function(updatedPositions) {
 
 function createScene(height) {
     height += 50.0;
+
+    var frustum = new Cesium.OrthographicFrustum();
+    frustum.left = -frustumSize;
+    frustum.right = frustumSize;
+    frustum.bottom = -frustumSize;
+    frustum.top = frustumSize;
+    frustum.near = frustumNear;
+    frustum.far = frustumFar;
+
+    var lightCamera = new Cesium.Camera(scene);
+    lightCamera.frustum = frustum;
+    lightCamera.lookAt(Cesium.Cartesian3.fromRadians(centerLongitude, centerLatitude, height), new Cesium.Cartesian3(tilt, tilt, offset));
+    shadowMap.camera = lightCamera;
+
     var center = Cesium.Cartesian3.fromRadians(centerLongitude, centerLatitude, height);
     var position1 = Cesium.Cartesian3.fromRadians(centerLongitude, centerLatitude, height + 5.0);
     var position2 = Cesium.Cartesian3.fromRadians(centerLongitude, centerLatitude, height + 10.0);
@@ -87,6 +114,7 @@ function createScene(height) {
     createBox(position3);
     createBoxRTC(position2);
     createSphere(position1);
+    shadowMap.enabled = true;
 }
 
 function createModel(url, origin) {
@@ -115,8 +143,6 @@ function createBoxRTC(origin) {
         vertexFormat : Cesium.PerInstanceColorAppearance.VERTEX_FORMAT,
         dimensions : new Cesium.Cartesian3(1.0, 1.0, 1.0)
     }));
-
-    console.log(boxGeometry);
 
     var positions = boxGeometry.attributes.position.values;
     var newPositions = new Float32Array(positions.length);

--- a/Apps/Sandcastle/gallery/development/Shadows.html
+++ b/Apps/Sandcastle/gallery/development/Shadows.html
@@ -28,8 +28,8 @@ function startup(Cesium) {
     'use strict';
 //Sandcastle_Begin
 
-var globeVisible = true;
-var terrainEnabled = true;
+var globeVisible = false;
+var terrainEnabled = false;
 
 var viewer = new Cesium.Viewer('cesiumContainer', {
     scene3DOnly : true,
@@ -54,24 +54,23 @@ if (globeVisible) {
     viewer.terrainProvider = terrainProvider;
 }
 
-//// Exton
-//var centerLongitude = -1.31968;
-//var centerLatitude = 0.698874;
-//var height = 130.0;
-//var offset = 20.0;
-//var frustumSize = 15;
-//var frustumNear = 1.0;
-//var frustumFar = 100.0;
-//var tilt = 0.0;
-
-// Everest
-var centerLongitude = 1.517132688;
-var centerLatitude = 0.4884844964;
-var offset = 50.0;
-var frustumSize = 55.0;
+// Exton
+var centerLongitude = -1.31968;
+var centerLatitude = 0.698874;
+var offset = 20.0;
+var frustumSize = 15;
 var frustumNear = 1.0;
-var frustumFar = 400.0;
+var frustumFar = 100.0;
 var tilt = 30.0;
+
+//// Everest
+//var centerLongitude = 1.517132688;
+//var centerLatitude = 0.4884844964;
+//var offset = 50.0;
+//var frustumSize = 55.0;
+//var frustumNear = 1.0;
+//var frustumFar = 400.0;
+//var tilt = 30.0;
 
 var scene = viewer.scene;
 var camera = scene.camera;
@@ -100,7 +99,7 @@ function createScene(height) {
     var lightCamera = new Cesium.Camera(scene);
     lightCamera.frustum = frustum;
     lightCamera.lookAt(Cesium.Cartesian3.fromRadians(centerLongitude, centerLatitude, height), new Cesium.Cartesian3(tilt, tilt, offset));
-    shadowMap.camera = lightCamera;
+    shadowMap._lightCamera = lightCamera;
 
     var center = Cesium.Cartesian3.fromRadians(centerLongitude, centerLatitude, height);
     var position1 = Cesium.Cartesian3.fromRadians(centerLongitude, centerLatitude, height + 5.0);

--- a/Apps/Sandcastle/gallery/development/Shadows.html
+++ b/Apps/Sandcastle/gallery/development/Shadows.html
@@ -109,11 +109,11 @@ function createScene(height) {
 
     camera.lookAt(center, new Cesium.Cartesian3(25.0, 25.0, 30.0));
 
-    //createModel('../../SampleData/models/CesiumAir/Cesium_Air.glb');
+    //createModel('../../SampleData/models/CesiumAir/Cesium_Air.glb', position3);
     createModel('../../SampleData/models/shadow_tester.gltf', center);
-//    createBox(position3);
-//    createBoxRTC(position2);
-//    createSphere(position1);
+    createBox(position3);
+    createBoxRTC(position2);
+    createSphere(position1);
     shadowMap.enabled = true;
 }
 

--- a/Apps/Sandcastle/gallery/development/Shadows.html
+++ b/Apps/Sandcastle/gallery/development/Shadows.html
@@ -36,7 +36,8 @@ var viewer = new Cesium.Viewer('cesiumContainer', {
     infoBox : false,
     selectionIndicator : false,
     globe : globeVisible ? undefined : false,
-    skyAtmosphere : globeVisible ? undefined : false
+    skyAtmosphere : globeVisible ? undefined : false,
+    timeline : false
 });
 
 var terrainProvider;
@@ -61,7 +62,7 @@ var offset = 20.0;
 var frustumSize = 15;
 var frustumNear = 1.0;
 var frustumFar = 100.0;
-var tilt = 30.0;
+var tilt = 0.0;
 
 //// Everest
 //var centerLongitude = 1.517132688;
@@ -110,9 +111,9 @@ function createScene(height) {
 
     //createModel('../../SampleData/models/CesiumAir/Cesium_Air.glb');
     createModel('../../SampleData/models/shadow_tester.gltf', center);
-    createBox(position3);
-    createBoxRTC(position2);
-    createSphere(position1);
+//    createBox(position3);
+//    createBoxRTC(position2);
+//    createSphere(position1);
     shadowMap.enabled = true;
 }
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@ Change Log
 * Added `Primitive.castShadows` and `Primitive.receiveShadows`.
 * Added `Globe.castShadows` and `Globe.receiveShadows`.
 * Added `Model.castShadows` and `Model.receiveShadows`.
+* Added `Matrix4.computeView`
 
 ### 1.19 - 2016-03-01
 * Breaking changes

--- a/Source/Core/Matrix4.js
+++ b/Source/Core/Matrix4.js
@@ -957,6 +957,54 @@ define([
     };
 
     /**
+     * Computes a Matrix4 instance that transforms from world space to view space.
+     *
+     * @param {Cartesian3} direction The forward direction.
+     * @param {Cartesian3} up The up direction.
+     * @param {Cartesian3} right The right direction.
+     * @param {Cartesian3} position The position of the camera.
+     * @param {Matrix4} result The object in which the result will be stored.
+     * @returns {Matrix4} The modified result parameter.
+     */
+    Matrix4.computeView = function(direction, up, right, position, result) {
+        //>>includeStart('debug', pragmas.debug);
+        if (!defined(direction)) {
+            throw new DeveloperError('direction is required');
+        }
+        if (!defined(up)) {
+            throw new DeveloperError('up is required');
+        }
+        if (!defined(right)) {
+            throw new DeveloperError('right is required');
+        }
+        if (!defined(position)) {
+            throw new DeveloperError('position is required');
+        }
+        if (!defined(result)) {
+            throw new DeveloperError('result is required');
+        }
+        //>>includeEnd('debug');
+
+        result[0] = right.x;
+        result[1] = up.x;
+        result[2] = -direction.x;
+        result[3] = 0.0;
+        result[4] = right.y;
+        result[5] = up.y;
+        result[6] = -direction.y;
+        result[7] = 0.0;
+        result[8] = right.z;
+        result[9] = up.z;
+        result[10] = -direction.z;
+        result[11] = 0.0;
+        result[12] = -Cartesian3.dot(right, position);
+        result[13] = -Cartesian3.dot(up, position);
+        result[14] = Cartesian3.dot(direction, position);
+        result[15] = 1.0;
+        return result;
+    };
+
+    /**
      * Computes an Array from the provided Matrix4 instance.
      * The array will be in column-major order.
      *

--- a/Source/Core/Matrix4.js
+++ b/Source/Core/Matrix4.js
@@ -58,6 +58,7 @@ define([
      * @see Matrix4.computePerspectiveOffCenter
      * @see Matrix4.computeInfinitePerspectiveOffCenter
      * @see Matrix4.computeViewportTransformation
+     * @see Matrix4.computeView
      * @see Matrix2
      * @see Matrix3
      * @see Packable

--- a/Source/Renderer/AutomaticUniforms.js
+++ b/Source/Renderer/AutomaticUniforms.js
@@ -1484,6 +1484,70 @@ define([
             getValue : function(uniformState) {
                 return uniformState.shadowMap.shadowMapMatrix;
             }
+        }),
+
+        /**
+         * An automatic GLSL uniform representing the sun's shadow map cascade far splits.
+         *
+         * @private
+         *
+         * @alias czm_sunShadowMapCascadeSplitsNear
+         * @glslUniform
+         */
+        czm_sunShadowMapCascadeSplitsNear : new AutomaticUniform({
+            size : 1,
+            datatype : WebGLConstants.FLOAT_VEC4,
+            getValue : function(uniformState) {
+                return uniformState.shadowMap.cascadeSplitsNear;
+            }
+        }),
+
+        /**
+         * An automatic GLSL uniform representing the sun's shadow map cascade near splits.
+         *
+         * @private
+         *
+         * @alias czm_sunShadowMapCascadeSplitsFar
+         * @glslUniform
+         */
+        czm_sunShadowMapCascadeSplitsFar : new AutomaticUniform({
+            size : 1,
+            datatype : WebGLConstants.FLOAT_VEC4,
+            getValue : function(uniformState) {
+                return uniformState.shadowMap.cascadeSplitsFar;
+            }
+        }),
+
+        /**
+         * An automatic GLSL uniform representing the sun's shadow map cascade offsets.
+         *
+         * @private
+         *
+         * @alias czm_sunShadowMapCascadeOffsets
+         * @glslUniform
+         */
+        czm_sunShadowMapCascadeOffsets : new AutomaticUniform({
+            size : 4,
+            datatype : WebGLConstants.FLOAT_VEC3,
+            getValue : function(uniformState) {
+                return uniformState.shadowMap.cascadeOffsets;
+            }
+        }),
+
+        /**
+         * An automatic GLSL uniform representing the sun's shadow map cascade scales.
+         *
+         * @private
+         *
+         * @alias czm_sunShadowMapCascadeScales
+         * @glslUniform
+         */
+        czm_sunShadowMapCascadeScales : new AutomaticUniform({
+            size : 4,
+            datatype : WebGLConstants.FLOAT_VEC3,
+            getValue : function(uniformState) {
+                return uniformState.shadowMap.cascadeScales;
+            }
         })
     };
 

--- a/Source/Renderer/AutomaticUniforms.js
+++ b/Source/Renderer/AutomaticUniforms.js
@@ -1457,8 +1457,6 @@ define([
         /**
          * An automatic GLSL uniform representing the sun's shadow map depth texture.
          *
-         * @private
-         *
          * @alias czm_sunShadowMapTexture
          * @glslUniform
          */
@@ -1473,8 +1471,6 @@ define([
         /**
          * An automatic GLSL uniform representing the sun's shadow map matrix.
          *
-         * @private
-         *
          * @alias czm_sunShadowMapMatrix
          * @glslUniform
          */
@@ -1487,9 +1483,7 @@ define([
         }),
 
         /**
-         * An automatic GLSL uniform representing the sun's shadow map cascade far splits.
-         *
-         * @private
+         * An automatic GLSL uniform representing the sun's shadow map cascade near splits.
          *
          * @alias czm_sunShadowMapCascadeSplitsNear
          * @glslUniform
@@ -1503,9 +1497,7 @@ define([
         }),
 
         /**
-         * An automatic GLSL uniform representing the sun's shadow map cascade near splits.
-         *
-         * @private
+         * An automatic GLSL uniform representing the sun's shadow map cascade far splits.
          *
          * @alias czm_sunShadowMapCascadeSplitsFar
          * @glslUniform
@@ -1521,8 +1513,6 @@ define([
         /**
          * An automatic GLSL uniform representing the sun's shadow map cascade offsets.
          *
-         * @private
-         *
          * @alias czm_sunShadowMapCascadeOffsets
          * @glslUniform
          */
@@ -1536,8 +1526,6 @@ define([
 
         /**
          * An automatic GLSL uniform representing the sun's shadow map cascade scales.
-         *
-         * @private
          *
          * @alias czm_sunShadowMapCascadeScales
          * @glslUniform

--- a/Source/Renderer/AutomaticUniforms.js
+++ b/Source/Renderer/AutomaticUniforms.js
@@ -1488,25 +1488,11 @@ define([
          * @alias czm_sunShadowMapCascadeSplitsNear
          * @glslUniform
          */
-        czm_sunShadowMapCascadeSplitsNear : new AutomaticUniform({
-            size : 1,
+        czm_sunShadowMapCascadeSplits : new AutomaticUniform({
+            size : 2,
             datatype : WebGLConstants.FLOAT_VEC4,
             getValue : function(uniformState) {
-                return uniformState.shadowMap.cascadeSplitsNear;
-            }
-        }),
-
-        /**
-         * An automatic GLSL uniform representing the sun's shadow map cascade far splits.
-         *
-         * @alias czm_sunShadowMapCascadeSplitsFar
-         * @glslUniform
-         */
-        czm_sunShadowMapCascadeSplitsFar : new AutomaticUniform({
-            size : 1,
-            datatype : WebGLConstants.FLOAT_VEC4,
-            getValue : function(uniformState) {
-                return uniformState.shadowMap.cascadeSplitsFar;
+                return uniformState.shadowMap.cascadeSplits;
             }
         }),
 

--- a/Source/Renderer/AutomaticUniforms.js
+++ b/Source/Renderer/AutomaticUniforms.js
@@ -1483,7 +1483,7 @@ define([
         }),
 
         /**
-         * An automatic GLSL uniform representing the sun's shadow map cascade near splits.
+         * An automatic GLSL uniform representing the sun's shadow map cascade splits.
          *
          * @alias czm_sunShadowMapCascadeSplitsNear
          * @glslUniform

--- a/Source/Renderer/AutomaticUniforms.js
+++ b/Source/Renderer/AutomaticUniforms.js
@@ -1485,7 +1485,7 @@ define([
         /**
          * An automatic GLSL uniform representing the sun's shadow map cascade splits.
          *
-         * @alias czm_sunShadowMapCascadeSplitsNear
+         * @alias czm_sunShadowMapCascadeSplits
          * @glslUniform
          */
         czm_sunShadowMapCascadeSplits : new AutomaticUniform({

--- a/Source/Renderer/RenderState.js
+++ b/Source/Renderer/RenderState.js
@@ -754,7 +754,7 @@ define([
             applyBlending(gl, renderState, passState);
         }
 
-        if (previousRenderState !== renderState || previousPassState.context !== passState.context) {
+        if (previousRenderState !== renderState || previousPassState !== passState || previousPassState.context !== passState.context) {
             applyViewport(gl, renderState, passState);
         }
     };

--- a/Source/Scene/Camera.js
+++ b/Source/Scene/Camera.js
@@ -247,30 +247,8 @@ define([
     Camera.DEFAULT_VIEW_FACTOR = 0.5;
 
     function updateViewMatrix(camera) {
-        var r = camera._right;
-        var u = camera._up;
-        var d = camera._direction;
-        var e = camera._position;
-
-        var viewMatrix = camera._viewMatrix;
-        viewMatrix[0] = r.x;
-        viewMatrix[1] = u.x;
-        viewMatrix[2] = -d.x;
-        viewMatrix[3] = 0.0;
-        viewMatrix[4] = r.y;
-        viewMatrix[5] = u.y;
-        viewMatrix[6] = -d.y;
-        viewMatrix[7] = 0.0;
-        viewMatrix[8] = r.z;
-        viewMatrix[9] = u.z;
-        viewMatrix[10] = -d.z;
-        viewMatrix[11] = 0.0;
-        viewMatrix[12] = -Cartesian3.dot(r, e);
-        viewMatrix[13] = -Cartesian3.dot(u, e);
-        viewMatrix[14] = Cartesian3.dot(d, e);
-        viewMatrix[15] = 1.0;
-
-        Matrix4.multiply(viewMatrix, camera._actualInvTransform, camera._viewMatrix);
+        Matrix4.computeView(camera._direction, camera._up, camera._right, camera._position, camera._viewMatrix);
+        Matrix4.multiply(camera._viewMatrix, camera._actualInvTransform, camera._viewMatrix);
         Matrix4.inverseTransformation(camera._viewMatrix, camera._invViewMatrix);
     }
 
@@ -2738,7 +2716,6 @@ define([
     Camera.clone = function(camera, result) {
         if (!defined(result)) {
             result = new Camera(camera._scene);
-            result.frustum = camera.frustum.clone();
         }
 
         Cartesian3.clone(camera.position, result.position);

--- a/Source/Scene/Camera.js
+++ b/Source/Scene/Camera.js
@@ -2716,6 +2716,7 @@ define([
     Camera.clone = function(camera, result) {
         if (!defined(result)) {
             result = new Camera(camera._scene);
+            result.frustum = camera.frustum.clone(); // Allocate a new frustum of the correct type
         }
 
         Cartesian3.clone(camera.position, result.position);
@@ -2723,7 +2724,11 @@ define([
         Cartesian3.clone(camera.up, result.up);
         Cartesian3.clone(camera.right, result.right);
         Matrix4.clone(camera._transform, result.transform);
-        camera.frustum.clone(result.frustum);
+
+        // Clone frustum only if it is the same type
+        if (defined(camera.frustum.left) === defined(result.frustum.left)) {
+            camera.frustum.clone(result.frustum);
+        }
 
         return result;
     };

--- a/Source/Scene/Camera.js
+++ b/Source/Scene/Camera.js
@@ -1011,7 +1011,7 @@ define([
      *     destination : Cesium.Rectangle.fromDegrees(west, south, east, north)
      * });
      *
-     * // 5. Setposition with an orientation using unit vectors.
+     * // 5. Set position with an orientation using unit vectors.
      * viewer.camera.setView({
      *     destination : Cesium.Cartesian3.fromDegrees(-122.19, 46.25, 5000.0),
      *     orientation : {
@@ -2738,6 +2738,7 @@ define([
     Camera.clone = function(camera, result) {
         if (!defined(result)) {
             result = new Camera(camera._scene);
+            result.frustum = camera.frustum.clone();
         }
 
         Cartesian3.clone(camera.position, result.position);
@@ -2745,6 +2746,7 @@ define([
         Cartesian3.clone(camera.up, result.up);
         Cartesian3.clone(camera.right, result.right);
         Matrix4.clone(camera._transform, result.transform);
+        camera.frustum.clone(result.frustum);
 
         return result;
     };

--- a/Source/Scene/GlobeSurfaceShaderSet.js
+++ b/Source/Scene/GlobeSurfaceShaderSet.js
@@ -192,8 +192,8 @@ define([
             vs.sources.push(get2DYPositionFraction(useWebMercatorProjection));
 
             if (receiveShadows) {
-                vs.sources[1] = ShadowMapShader.createReceiveShadowsVertexShader(vs.sources[1]);
-                fs.sources[0] = ShadowMapShader.createReceiveShadowsFragmentShader(fs.sources[0], frameState.context);
+                vs.sources[1] = ShadowMapShader.createShadowReceiveVertexShader(vs.sources[1]);
+                fs.sources[0] = ShadowMapShader.createShadowReceiveFragmentShader(fs.sources[0], frameState.context);
             }
 
             var shader = ShaderProgram.fromCache({

--- a/Source/Scene/Model.js
+++ b/Source/Scene/Model.js
@@ -1513,8 +1513,8 @@ define([
 
         // Modify draw program to receive shadows
         if (frameState.shadowsEnabled && model.receiveShadows) {
-            drawVS = ShadowMapShader.createReceiveShadowsVertexShader(drawVS);
-            drawFS = ShadowMapShader.createReceiveShadowsFragmentShader(drawFS, context);
+            drawVS = ShadowMapShader.createShadowReceiveVertexShader(drawVS);
+            drawFS = ShadowMapShader.createShadowReceiveFragmentShader(drawFS, context);
         }
 
         model._rendererResources.programs[id] = ShaderProgram.fromCache({

--- a/Source/Scene/Primitive.js
+++ b/Source/Scene/Primitive.js
@@ -1143,8 +1143,8 @@ define([
 
         // Modify program to receive shadows
         if (frameState.shadowsEnabled && primitive.receiveShadows) {
-            vs = ShadowMapShader.createReceiveShadowsVertexShader(vs);
-            fs = ShadowMapShader.createReceiveShadowsFragmentShader(fs, frameState.context);
+            vs = ShadowMapShader.createShadowReceiveVertexShader(vs);
+            fs = ShadowMapShader.createShadowReceiveFragmentShader(fs, frameState.context);
         }
 
         primitive._sp = ShaderProgram.replaceCache({

--- a/Source/Scene/Scene.js
+++ b/Source/Scene/Scene.js
@@ -1671,31 +1671,6 @@ define([
         return shadowMapCommands;
     }
 
-    function executeShadowMapCommandsNoCascades(scene, context, uniformState, shadowMap, renderState, passState) {
-        uniformState.updateCamera(shadowMap.shadowMapCamera);
-        var commands = getShadowMapCommands(scene);
-        var numberOfCommands = commands.length;
-        for (var j = 0; j < numberOfCommands; ++j) {
-            var command = commands[j];
-            executeCommand(command, scene, context, passState, renderState, command.shadowCastProgram);
-        }
-    }
-
-    function executeShadowMapCommandsCascades(scene, context, uniformState, shadowMap, renderState, passState) {
-        var commands = getShadowMapCommands(scene);
-        uniformState.updateCamera(shadowMap.shadowMapCamera);
-        var numberOfCascades = shadowMap.numberOfCascades;
-        for (var i = 0; i < numberOfCascades; ++i) {
-            uniformState.updateCamera(shadowMap.cascadeCameras[i]);
-            passState = shadowMap.cascadePassStates[i];
-            var numberOfCommands = commands.length;
-            for (var j = 0; j < numberOfCommands; ++j) {
-                var command = commands[j];
-                executeCommand(command, scene, context, passState, renderState, command.shadowCastProgram);
-            }
-        }
-    }
-
     function executeShadowMapCommands(scene) {
         var context = scene.context;
         var uniformState = context.uniformState;
@@ -1706,10 +1681,17 @@ define([
         // Clear shadow depth
         shadowMap.clearCommand.execute(context, passState);
 
-        if (shadowMap.cascadesEnabled) {
-            executeShadowMapCommandsCascades(scene, context, uniformState, shadowMap, renderState, passState);
-        } else {
-            executeShadowMapCommandsNoCascades(scene, context, uniformState, shadowMap, renderState, passState);
+        var commands = getShadowMapCommands(scene);
+        var numberOfCommands = commands.length;
+
+        var numberOfCascades = shadowMap.numberOfCascades;
+        for (var i = 0; i < numberOfCascades; ++i) {
+            uniformState.updateCamera(shadowMap.cascadeCameras[i]);
+            passState = shadowMap.cascadePassStates[i];
+            for (var j = 0; j < numberOfCommands; ++j) {
+                var command = commands[j];
+                executeCommand(command, scene, context, passState, renderState, command.shadowCastProgram);
+            }
         }
     }
 

--- a/Source/Scene/Scene.js
+++ b/Source/Scene/Scene.js
@@ -1661,7 +1661,7 @@ define([
         shadowMap.clearCommand.execute(context);
 
         // Render from the shadow's camera
-        uniformState.updateCamera(shadowMap.camera);
+        uniformState.updateCamera(shadowMap.shadowMapCamera);
 
         var shadowMapCommands = scene._frustumCommandsList[0]; // TODO : temporary solution
         if (defined(shadowMapCommands)) {

--- a/Source/Scene/ShadowMap.js
+++ b/Source/Scene/ShadowMap.js
@@ -116,8 +116,7 @@ define([
         this._cascadeViewports = new Array(maximumNumberOfCascades);
 
         // Uniforms
-        this._cascadeSplitsNear = new Cartesian4();
-        this._cascadeSplitsFar = new Cartesian4();
+        this._cascadeSplits = [new Cartesian4(), new Cartesian4()];
         this._cascadeOffsets = new Array(maximumNumberOfCascades);
         this._cascadeScales = new Array(maximumNumberOfCascades);
 
@@ -272,14 +271,9 @@ define([
                 return this._cascadeCameras;
             }
         },
-        cascadeSplitsNear : {
+        cascadeSplits : {
             get : function() {
-                return this._cascadeSplitsNear;
-            }
-        },
-        cascadeSplitsFar : {
-            get : function() {
-                return this._cascadeSplitsFar;
+                return this._cascadeSplits;
             }
         },
         cascadeOffsets : {
@@ -575,8 +569,8 @@ define([
             splitsFar[i] = split;
             splitsNear[i + 1] = split;
         }
-        Cartesian4.unpack(splitsNear, 0, shadowMap._cascadeSplitsNear);
-        Cartesian4.unpack(splitsFar, 0, shadowMap._cascadeSplitsFar);
+        Cartesian4.unpack(splitsNear, 0, shadowMap._cascadeSplits[0]);
+        Cartesian4.unpack(splitsFar, 0, shadowMap._cascadeSplits[1]);
 
         var left = shadowMapCamera.frustum.left;
         var right = shadowMapCamera.frustum.right;

--- a/Source/Scene/ShadowMap.js
+++ b/Source/Scene/ShadowMap.js
@@ -624,26 +624,6 @@ define([
         }
     }
 
-    function createViewMatrix(d, u, r, result) {
-        result[0] = r.x;
-        result[1] = u.x;
-        result[2] = -d.x;
-        result[3] = 0.0;
-        result[4] = r.y;
-        result[5] = u.y;
-        result[6] = -d.y;
-        result[7] = 0.0;
-        result[8] = r.z;
-        result[9] = u.z;
-        result[10] = -d.z;
-        result[11] = 0.0;
-        result[12] = 0.0;
-        result[13] = 0.0;
-        result[14] = 0.0;
-        result[15] = 1.0;
-        return result;
-    }
-
     var scratchLightView = new Matrix4();
     var scratchRight = new Cartesian3();
     var scratchUp = new Cartesian3();
@@ -664,8 +644,9 @@ define([
         var lightUp = sceneCamera.directionWC; // Align shadows to the camera view.
         var lightRight = Cartesian3.cross(lightDir, lightUp, scratchRight);
         lightUp = Cartesian3.cross(lightRight, lightDir, scratchUp); // Recalculate up now that right is derived
+        var lightPosition = Cartesian3.fromElements(0.0, 0.0, 0.0, scratchTranslation);
 
-        var lightView = createViewMatrix(lightDir, lightUp, lightRight, scratchLightView);
+        var lightView = Matrix4.computeView(lightDir, lightUp, lightRight, lightPosition, scratchLightView);
         var cameraToLight = Matrix4.multiply(lightView, inverseViewProjection, scratchMatrix);
 
         // Project each corner from NDC space to light view space, and calculate a min and max in light view space

--- a/Source/Scene/ShadowMap.js
+++ b/Source/Scene/ShadowMap.js
@@ -494,11 +494,12 @@ define([
         Matrix4.inverse(shadowMap._shadowMapCamera.getViewProjection(), shadowMap._debugLightFrustum.modelMatrix);
         shadowMap._debugLightFrustum.update(frameState);
 
-
-        for (var i = 0; i < shadowMap._numberOfCascades; ++i) {
-            shadowMap._debugCascadeFrustums[i] = shadowMap._debugCascadeFrustums[i] || createDebugFrustum(debugCascadeColors[i]);
-            Matrix4.inverse(shadowMap._cascadeCameras[i].getViewProjection(), shadowMap._debugCascadeFrustums[i].modelMatrix);
-            shadowMap._debugCascadeFrustums[i].update(frameState);
+        if (shadowMap._cascadesEnabled) {
+            for (var i = 0; i < shadowMap._numberOfCascades; ++i) {
+                shadowMap._debugCascadeFrustums[i] = shadowMap._debugCascadeFrustums[i] || createDebugFrustum(debugCascadeColors[i]);
+                Matrix4.inverse(shadowMap._cascadeCameras[i].getViewProjection(), shadowMap._debugCascadeFrustums[i].modelMatrix);
+                shadowMap._debugCascadeFrustums[i].update(frameState);
+            }
         }
 
         updateDebugShadowViewCommand(shadowMap, frameState);

--- a/Source/Scene/ShadowMap.js
+++ b/Source/Scene/ShadowMap.js
@@ -700,7 +700,7 @@ define([
 
         // 5. Update the shadow map camera
         Matrix4.clone(lightView, shadowMapCamera.viewMatrix);
-        Matrix4.inverseTransformation(lightView, shadowMapCamera.inverseViewMatrix);
+        Matrix4.inverse(lightView, shadowMapCamera.inverseViewMatrix);
         Matrix4.getTranslation(shadowMapCamera.inverseViewMatrix, shadowMapCamera.positionWC);
         Cartesian3.clone(lightDir, shadowMapCamera.directionWC);
         Cartesian3.clone(lightUp, shadowMapCamera.upWC);

--- a/Source/Scene/ShadowMap.js
+++ b/Source/Scene/ShadowMap.js
@@ -106,6 +106,8 @@ define([
         this._shadowMapCamera = new ShadowMapCamera();
         this._sceneCamera = undefined;
         this._farPlane = 100.0; // Limit the far plane of the scene camera
+
+        // When false, use the light camera as-is without fitting to the scene's camera
         this._fitToScene = true;
 
         var maximumNumberOfCascades = 4;
@@ -721,12 +723,12 @@ define([
 
         if (this._fitToScene) {
             fitShadowMapToScene(this);
-        }
 
-        if (this._numberOfCascades > 1) {
-            computeCascades(this);
-        } else {
-            this._cascadeCameras[0] = this._shadowMapCamera;
+            if (this._numberOfCascades > 1) {
+                computeCascades(this);
+            } else {
+                this._cascadeCameras[0].clone(this._shadowMapCamera);
+            }
         }
 
         if (this.debugShow) {

--- a/Source/Scene/ShadowMap.js
+++ b/Source/Scene/ShadowMap.js
@@ -497,14 +497,20 @@ define([
             return;
         }
 
-        shadowMap._debugLightFrustum = shadowMap._debugLightFrustum || createDebugFrustum(Color.YELLOW);
-        Matrix4.inverse(shadowMap._shadowMapCamera.getViewProjection(), shadowMap._debugLightFrustum.modelMatrix);
-        shadowMap._debugLightFrustum.update(frameState);
+        var debugLightFrustum = shadowMap._debugLightFrustum;
+        if (!defined(debugLightFrustum)) {
+            debugLightFrustum = shadowMap._debugLightFrustum = createDebugFrustum(Color.YELLOW);
+        }
+        Matrix4.inverse(shadowMap._shadowMapCamera.getViewProjection(), debugLightFrustum.modelMatrix);
+        debugLightFrustum.update(frameState);
 
         for (var i = 0; i < shadowMap._numberOfCascades; ++i) {
-            shadowMap._debugCascadeFrustums[i] = shadowMap._debugCascadeFrustums[i] || createDebugFrustum(debugCascadeColors[i]);
-            Matrix4.inverse(shadowMap._cascadeCameras[i].getViewProjection(), shadowMap._debugCascadeFrustums[i].modelMatrix);
-            shadowMap._debugCascadeFrustums[i].update(frameState);
+            var debugCascadeFrustum = shadowMap._debugCascadeFrustums[i];
+            if (!defined(debugCascadeFrustum)) {
+                debugCascadeFrustum = shadowMap._debugCascadeFrustums[i] = createDebugFrustum(debugCascadeColors[i]);
+            }
+            Matrix4.inverse(shadowMap._cascadeCameras[i].getViewProjection(), debugCascadeFrustum.modelMatrix);
+            debugCascadeFrustum.update(frameState);
         }
 
         updateDebugShadowViewCommand(shadowMap, frameState);
@@ -603,7 +609,7 @@ define([
                 Cartesian3.maximumByComponent(corner, max, max);
             }
 
-            // Limit min to 0.0, sometimes precision errors cause it to go slightly negative.
+            // Limit min to 0.0. Sometimes precision errors cause it to go slightly negative, which affects the frustum extent computations below.
             min.x = Math.max(min.x, 0.0);
             min.y = Math.max(min.y, 0.0);
 

--- a/Source/Scene/ShadowMapShader.js
+++ b/Source/Scene/ShadowMapShader.js
@@ -60,8 +60,8 @@ define([
             'vec4 getCascadeWeights(float depthEye) \n' +
             '{ \n' +
             '    // One component is set to 1.0 and all others set to 0.0. \n' +
-            '    vec4 near = step(czm_sunShadowMapCascadeSplitsNear, vec4(depthEye)); \n' +
-            '    vec4 far = step(depthEye, czm_sunShadowMapCascadeSplitsFar); \n' +
+            '    vec4 near = step(czm_sunShadowMapCascadeSplits[0], vec4(depthEye)); \n' +
+            '    vec4 far = step(depthEye, czm_sunShadowMapCascadeSplits[1]); \n' +
             '    return near * far; \n' +
             '} \n' +
             'vec4 getCascadeViewport(vec4 weights) \n' +

--- a/Source/Scene/ShadowMapShader.js
+++ b/Source/Scene/ShadowMapShader.js
@@ -52,7 +52,7 @@ define([
 
     ShadowMapShader.createShadowReceiveFragmentShader = function(fs, context) {
         var cascadesEnabled = true;
-        var debugVisualizeCascades = true;
+        var debugVisualizeCascades = false;
         fs = ShaderSource.replaceMain(fs, 'czm_shadow_main');
         fs +=
             'varying vec3 v_shadowPosition; \n' +

--- a/Source/Scene/ShadowMapShader.js
+++ b/Source/Scene/ShadowMapShader.js
@@ -38,41 +38,120 @@ define([
         return fs;
     };
 
-    ShadowMapShader.createReceiveShadowsVertexShader = function(vs) {
+    ShadowMapShader.createShadowReceiveVertexShader = function(vs) {
         vs = ShaderSource.replaceMain(vs, 'czm_shadow_main');
         vs +=
-            'varying vec3 czm_shadowMapCoordinate; \n' +
+            'varying vec3 v_shadowPosition; \n' +
             'void main() \n' +
             '{ \n' +
             '    czm_shadow_main(); \n' +
-            '    czm_shadowMapCoordinate = (czm_sunShadowMapMatrix * gl_Position).xyz; \n' +
+            '    v_shadowPosition = (czm_sunShadowMapMatrix * gl_Position).xyz; \n' +
             '} \n';
         return vs;
     };
 
-    ShadowMapShader.createReceiveShadowsFragmentShader = function(fs, context) {
+    ShadowMapShader.createShadowReceiveFragmentShader = function(fs, context) {
+        var cascadesEnabled = true;
+        var debugVisualizeCascades = true;
         fs = ShaderSource.replaceMain(fs, 'czm_shadow_main');
         fs +=
-            'varying vec3 czm_shadowMapCoordinate; \n' +
+            'varying vec3 v_shadowPosition; \n' +
+            ' \n' +
+            'vec4 getCascadeWeights(float depthEye) \n' +
+            '{ \n' +
+            '    // One component is set to 1.0 and all others set to 0.0. \n' +
+            '    vec4 near = step(czm_sunShadowMapCascadeSplitsNear, vec4(depthEye)); \n' +
+            '    vec4 far = step(depthEye, czm_sunShadowMapCascadeSplitsFar); \n' +
+            '    return near * far; \n' +
+            '} \n' +
+            'vec4 getCascadeViewport(vec4 weights) \n' +
+            '{ \n' +
+            '    return vec4(0.0, 0.0, 0.5, 0.5) * weights.x + \n' +
+            '           vec4(0.5, 0.0, 0.5, 0.5) * weights.y + \n' +
+            '           vec4(0.0, 0.5, 0.5, 0.5) * weights.z + \n' +
+            '           vec4(0.5, 0.5, 0.5, 0.5) * weights.w; \n' +
+            '} \n' +
+            'vec3 getCascadeOffset(vec4 weights) \n' +
+            '{ \n' +
+            '    return czm_sunShadowMapCascadeOffsets[0] * weights.x + \n' +
+            '           czm_sunShadowMapCascadeOffsets[1] * weights.y + \n' +
+            '           czm_sunShadowMapCascadeOffsets[2] * weights.z + \n' +
+            '           czm_sunShadowMapCascadeOffsets[3] * weights.w; \n' +
+            '} \n' +
+            'vec3 getCascadeScale(vec4 weights) \n' +
+            '{ \n' +
+            '    return czm_sunShadowMapCascadeScales[0] * weights.x + \n' +
+            '           czm_sunShadowMapCascadeScales[1] * weights.y + \n' +
+            '           czm_sunShadowMapCascadeScales[2] * weights.z + \n' +
+            '           czm_sunShadowMapCascadeScales[3] * weights.w; \n' +
+            '} \n' +
+            'vec4 getCascadeColor(vec4 weights) \n' +
+            '{ \n' +
+            '    return vec4(1.0, 0.0, 0.0, 1.0) * weights.x + \n' +
+            '           vec4(0.0, 1.0, 0.0, 1.0) * weights.y + \n' +
+            '           vec4(0.0, 0.0, 1.0, 1.0) * weights.z + \n' +
+            '           vec4(1.0, 0.0, 1.0, 1.0) * weights.w; \n' +
+            '} \n' +
+            ' \n' +
+            'float getDepthEye() \n' +
+            '{ \n' +
+            '    return czm_projection[3][2] / ((gl_FragCoord.z * 2.0 - 1.0) + czm_projection[2][2]); \n' +
+            '} \n' +
+            ' \n' +
+            'float sampleTexture(vec2 shadowCoordinate) \n' +
+            '{ \n' +
+
+            (context.depthTexture ?
+            '    return texture2D(czm_sunShadowMapTexture, shadowCoordinate).r; \n' :
+            '    return czm_unpackDepth(texture2D(czm_sunShadowMapTexture, shadowCoordinate)); \n') +
+
+            '} \n' +
+            ' \n' +
+            'float getVisibility(vec3 shadowPosition) \n' +
+            '{ \n' +
+            '    float depth = shadowPosition.z; \n' +
+            '    float shadowDepth = sampleTexture(shadowPosition.xy); \n' +
+            '    if (depth - 0.005 > shadowDepth) { \n' +
+            '        return 0.2; // In shadow \n' +
+            '    } else { \n' +
+            '        return 1.0; \n' +
+            '    } \n' +
+            '} \n' +
+            ' \n' +
             'void main() \n' +
             '{ \n' +
             '    czm_shadow_main(); \n' +
-            // TODO : remove this debugging code once frustum fits scene better
-            '    if (any(lessThan(czm_shadowMapCoordinate, vec3(0.0))) || any(greaterThan(czm_shadowMapCoordinate, vec3(1.0)))) \n' +
-            '    { \n' +
+            '    vec3 shadowPosition = v_shadowPosition; \n' +
+            '    // Do not apply shadowing if outside of the shadow map bounds \n' +
+            '    if (any(lessThan(shadowPosition, vec3(0.0))) || any(greaterThan(shadowPosition, vec3(1.0)))) { \n' +
             '        return; \n' +
             '    } \n' +
-            '    float depth = czm_shadowMapCoordinate.z; \n' +
+            ' \n' +
 
-            (context.depthTexture ?
-            '    float shadowDepth = texture2D(czm_sunShadowMapTexture, czm_shadowMapCoordinate.xy).r; \n' :
-            '    float shadowDepth = czm_unpackDepth(texture2D(czm_sunShadowMapTexture, czm_shadowMapCoordinate.xy)); \n') +
+            (cascadesEnabled ?
+            '    // Get the cascade \n' +
+            '    float depthEye = getDepthEye(); \n' +
+            '    vec4 weights = getCascadeWeights(depthEye); \n' +
+            ' \n' +
+            '    // Transform shadowPosition into the cascade \n' +
+            '    shadowPosition += getCascadeOffset(weights); \n' +
+            '    shadowPosition *= getCascadeScale(weights); \n' +
+            ' \n' +
+            '    // Modify texture coordinates to read from the correct cascade in the texture atlas \n' +
+            '    vec4 viewport = getCascadeViewport(weights); \n' +
+            '    shadowPosition.xy = shadowPosition.xy * viewport.zw + viewport.xy; \n' +
+            ' \n' +
 
-            // TODO : remove if
-            '    if (depth - 0.005 > shadowDepth) { \n' +
-            '        gl_FragColor.rgb *= 0.2; \n' +
-            '    } \n' +
+            (debugVisualizeCascades ?
+            '    // Draw cascade colors for debugging \n' +
+            '    gl_FragColor *= getCascadeColor(weights); \n' : '') : '') +
+
+            ' \n' +
+            '    // Apply shadowing \n' +
+            '    float visibility = getVisibility(shadowPosition); \n' +
+            '    gl_FragColor.rgb *= visibility; \n' +
             '} \n';
+
         return fs;
     };
 


### PR DESCRIPTION
For #2594 

Added support for cascaded shadow maps. The shadow map creates a tight-fitting light frustum around the scene's camera, and then partitions it into cascades based on distance from the camera.

There are a few things to fix before this is ready.
* Make the Sandcastle demo more interactive
* Fixing Primitives
* Testing on larger regions