### PR TITLE
Remove invalid triangles from north and south pole of EllipsoidGeometry

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -32,6 +32,7 @@ Change Log
 * Added `Color.add`, `Color.subtract`, `Color.multiply`, `Color.divide`, `Color.mod`, `Color.multiplyByScalar`, and `Color.divideByScalar` functions to perform arithmetic operations on colors.
 * Fixed bug causing `navigator is not defined` reference error when Cesium is used with Node.js.
 * Upgraded Knockout from version 3.2.0 to 3.4.0.
+* Fixed hole that appeared in the top of in dynamic ellipsoids
 
 ### 1.18 - 2016-02-01
 * Breaking changes

--- a/Source/Core/EllipsoidGeometry.js
+++ b/Source/Core/EllipsoidGeometry.js
@@ -200,7 +200,7 @@ define([
         var vertexCount = stackPartitions * slicePartitions;
         var positions = new Float64Array(vertexCount * 3);
 
-        var numIndices = 6 * (slicePartitions - 1) * (stackPartitions - 1);
+        var numIndices = 6 * (slicePartitions - 1) * (stackPartitions - 2);
         var indices = IndexDatatype.createTypedArray(vertexCount, numIndices);
 
         var normals = (vertexFormat.normal) ? new Float32Array(vertexCount * 3) : undefined;
@@ -244,7 +244,7 @@ define([
 
         for (i = 0; i < slicePartitions; i++) {
             // duplicate first point for correct
-            // texture coordinates at the north pole.
+            // texture coordinates at the south pole.
             positions[index++] = 0.0;
             positions[index++] = 0.0;
             positions[index++] = -radii.z;
@@ -356,9 +356,17 @@ define([
         }
 
         index = 0;
-        for (i = 0; i < stackPartitions; i++) {
-            var topOffset = i * slicePartitions;
-            var bottomOffset = (i + 1) * slicePartitions;
+        for (j = 0; j < slicePartitions - 1; j++) {
+            indices[index++] = slicePartitions + j;
+            indices[index++] = slicePartitions + j + 1;
+            indices[index++] = j + 1;
+        }
+
+        var topOffset;
+        var bottomOffset;
+        for (i = 1; i < stackPartitions - 2; i++) {
+            topOffset = i * slicePartitions;
+            bottomOffset = (i + 1) * slicePartitions;
 
             for (j = 0; j < slicePartitions - 1; j++) {
                 indices[index++] = bottomOffset + j;
@@ -369,6 +377,16 @@ define([
                 indices[index++] = topOffset + j + 1;
                 indices[index++] = topOffset + j;
             }
+        }
+
+        i = stackPartitions - 2;
+        topOffset = i * slicePartitions;
+        bottomOffset = (i + 1) * slicePartitions;
+
+        for (j = 0; j < slicePartitions - 1; j++) {
+            indices[index++] = bottomOffset + j;
+            indices[index++] = topOffset + j + 1;
+            indices[index++] = topOffset + j;
         }
 
         return new Geometry({

--- a/Specs/Core/EllipsoidGeometrySpec.js
+++ b/Specs/Core/EllipsoidGeometrySpec.js
@@ -37,7 +37,7 @@ defineSuite([
         }));
 
         expect(m.attributes.position.values.length).toEqual(3 * 16);
-        expect(m.indices.length).toEqual(6 * 9);
+        expect(m.indices.length).toEqual(3 * 12);
         expect(m.boundingSphere.radius).toEqual(1);
     });
 
@@ -53,7 +53,7 @@ defineSuite([
         expect(m.attributes.normal.values.length).toEqual(3 * 16);
         expect(m.attributes.tangent.values.length).toEqual(3 * 16);
         expect(m.attributes.binormal.values.length).toEqual(3 * 16);
-        expect(m.indices.length).toEqual(6 * 9);
+        expect(m.indices.length).toEqual(3 * 12);
     });
 
     it('computes attributes for a unit sphere', function() {

--- a/Specs/Core/SphereGeometrySpec.js
+++ b/Specs/Core/SphereGeometrySpec.js
@@ -38,7 +38,7 @@ defineSuite([
         }));
 
         expect(m.attributes.position.values.length).toEqual(3 * 16);
-        expect(m.indices.length).toEqual(6 * 9);
+        expect(m.indices.length).toEqual(3 * 12);
         expect(m.boundingSphere.radius).toEqual(1);
     });
 
@@ -55,7 +55,7 @@ defineSuite([
         expect(m.attributes.normal.values.length).toEqual(3 * 16);
         expect(m.attributes.tangent.values.length).toEqual(3 * 16);
         expect(m.attributes.binormal.values.length).toEqual(3 * 16);
-        expect(m.indices.length).toEqual(6 * 9);
+        expect(m.indices.length).toEqual(3 * 12);
     });
 
     it('computes attributes for a unit sphere', function() {


### PR DESCRIPTION
Fixes #3045
There wasn't actually a hole in the ellipsoid; the shading for the top slice (and bottom slice, I presume) was off because the normal vector had NaNs due to adjacent triangles with no area.

So this PR removes a bunch of triangles being added with two corners at the same position.
The top and bottom of the ellipsoid needed to be triangulated with a fan instead of a strip.