### PR TITLE
Fix fullscreen in firefox

### DIFF
--- a/Source/Core/Fullscreen.js
+++ b/Source/Core/Fullscreen.js
@@ -173,11 +173,11 @@ define([
 
             // casing of Fullscreen differs across browsers
             name = prefix + 'FullscreenEnabled';
-            if (defined(document[name])) {
+            if (document[name] !== undefined) {
                 _names.fullscreenEnabled = name;
             } else {
                 name = prefix + 'FullScreenEnabled';
-                if (defined(document[name])) {
+                if (document[name] !== undefined) {
                     _names.fullscreenEnabled = name;
                 }
             }
@@ -188,7 +188,7 @@ define([
                 _names.fullscreenElement = name;
             } else {
                 name = prefix + 'FullScreenElement';
-                if (defined(document[name])) {
+                if (document[name] !== undefined) {
                     _names.fullscreenElement = name;
                 }
             }

--- a/Source/Scene/FrameRateMonitor.js
+++ b/Source/Scene/FrameRateMonitor.js
@@ -103,15 +103,15 @@ define([
             update(that, time);
         });
 
-        this._hiddenPropertyName = defined(document.hidden) ? 'hidden' :
-                                   defined(document.mozHidden) ? 'mozHidden' :
-                                   defined(document.msHidden) ? 'msHidden' :
-                                   defined(document.webkitHidden) ? 'webkitHidden' : undefined;
+        this._hiddenPropertyName = (document.hidden !== undefined) ? 'hidden' :
+                                   (document.mozHidden !== undefined) ? 'mozHidden' :
+                                   (document.msHidden !== undefined) ? 'msHidden' :
+                                   (document.webkitHidden !== undefined) ? 'webkitHidden' : undefined;
 
-        var visibilityChangeEventName = defined(document.hidden) ? 'visibilitychange' :
-            defined(document.mozHidden) ? 'mozvisibilitychange' :
-            defined(document.msHidden) ? 'msvisibilitychange' :
-            defined(document.webkitHidden) ? 'webkitvisibilitychange' : undefined;
+        var visibilityChangeEventName = (document.hidden !== undefined) ? 'visibilitychange' :
+            (document.mozHidden !== undefined) ? 'mozvisibilitychange' :
+            (document.msHidden !== undefined) ? 'msvisibilitychange' :
+            (document.webkitHidden !== undefined) ? 'webkitvisibilitychange' : undefined;
 
         function visibilityChangeListener() {
             visibilityChanged(that);


### PR DESCRIPTION
Firefox was failing on a few fullscreen tests and the fullscreen button wasn't working. Like #3649 this was related to the `defined` check on `document` properties. I also fixed this in `FrameRateMonitor`.