### PR TITLE
Travis and build improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,28 @@
 language: node_js
 node_js:
-  - "0.12"
+  - '0.12'
 sudo: false
+before_script:
+  - export DISPLAY=:99.0
+  - sh -e /etc/init.d/xvfb start
 script:
-  - npm run jsHint
+  - echo 'cloc' && echo -en 'travis_fold:start:script.cloc\\r'
+  - npm run cloc
+  - echo -en 'travis_fold:end:script.cloc\\r'
+
+  - echo 'jsHint' && echo -en 'travis_fold:start:script.jsHint\\r'
+  - npm run jsHint --failTaskOnError
+  - echo -en 'travis_fold:end:script.jsHint\\r'
+
+  - echo 'test non-webgl' && echo -en 'travis_fold:start:script.test\\r'
+  - npm run test -- --exclude WebGL --browsers Electron --failTaskOnError --suppressPassed
+  - echo -en 'travis_fold:end:script.test\\r'
+
+  - echo 'makeZipFile' && echo -en 'travis_fold:start:script.makeZipFile\\r'
+  - npm run clean
   - npm run makeZipFile
+  - echo -en 'travis_fold:end:script.makeZipFile\\r'
+
+  - echo 'test non-webgl release' && echo -en 'travis_fold:start:script test.release\\r'
+  - npm run test -- --exclude WebGL --browsers Electron --failTaskOnError --release --suppressPassed
+  - echo -en 'travis_fold:end:script test.release\\r'


### PR DESCRIPTION
1. Run non-webgl tests as part of travis using Electron.  They run in both module and release form.
2. Run cloc as part of the build process
3. jsHint no longer fails the gulp task when you run `npm run jsHint`, since that behavior was really annoying.  It still fails under travis or when passed the `--failTaskOnError` option.
4. Improve log output by using travis folding commands. Each part of the build is now collapsed into its own section.
5. Added `--suppressPassed` option to avoid showing passed tests in output. Our travis log got too big and travis refused to show it (even with the folding) unless you looked at raw test.

It's hard to understate how awesome this is now.  Next step, coverage for all.