### PR TITLE
GroundPrimitive: throw instead of crash on invalid geometry type

### DIFF
--- a/Source/Scene/GroundPrimitive.js
+++ b/Source/Scene/GroundPrimitive.js
@@ -888,6 +888,8 @@ define([
                             id : instance.id,
                             pickPrimitive : this
                         });
+                    } else {
+                        groundInstances[i] = instance;
                     }
                 }
 

--- a/Source/Scene/GroundPrimitive.js
+++ b/Source/Scene/GroundPrimitive.js
@@ -889,7 +889,7 @@ define([
                             pickPrimitive : this
                         });
                     } else {
-                        groundInstances[i] = instance;
+                        throw new DeveloperError('Not all of the geometry instances have GroundPrimitive support.');
                     }
                 }
 


### PR DESCRIPTION
Resolves #3656

For the deprecated `groundInstance` property, if the instance was an invalid type (like an outline), the primitive would still be drawn on the ellipsoid surface.

This PR makes the new `groundInstances` property have the same behavior.
I'm not sure if this is the correct solution, but this fixes a crash caused because `undefined` was being sent down to `Primitive.update`.  Do we want to remove the invalid geometry instead of drawing it on the ellipsoid?