### PR TITLE
Fix TimeIntervalCollection.removeInterval

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,12 @@
 Change Log
 ==========
 
+### 1.20 - 2016-04-01
+
+* Breaking changes
+  *
+* Fixed TimeIntervalCollection.removeInterval bug that resulted in too many intervals being removed
+
 ### 1.19 - 2016-03-01
 
 * Breaking changes

--- a/Source/Core/TimeIntervalCollection.js
+++ b/Source/Core/TimeIntervalCollection.js
@@ -525,10 +525,10 @@ define([
         }
 
         // Remove any intervals that are completely overlapped by the input interval.
-        while (index < intervals.length &&
-                JulianDate.greaterThan(intervalStop, indexInterval.stop)) {
+        while (index < intervals.length && JulianDate.greaterThan(intervalStop, indexInterval.stop)) {
             result = true;
             intervals.splice(index, 1);
+            indexInterval = intervals[index];
         }
 
         // Check for the case where the input interval ends on the same date

--- a/Specs/Core/TimeIntervalCollectionSpec.js
+++ b/Specs/Core/TimeIntervalCollectionSpec.js
@@ -689,6 +689,47 @@ defineSuite([
         expect(intervals.get(1).isStopIncluded).toEqual(true);
     });
 
+    it('removeInterval removes overlapped intervals', function() {
+        var intervals = new TimeIntervalCollection();
+
+        intervals.addInterval(new TimeInterval({
+            start : new JulianDate(1),
+            stop : new JulianDate(2),
+            isStartIncluded : true,
+            isStopIncluded : false
+        }));
+        intervals.addInterval(new TimeInterval({
+            start : new JulianDate(2),
+            stop : new JulianDate(3),
+            isStartIncluded : false,
+            isStopIncluded : false
+        }));
+        intervals.addInterval(new TimeInterval({
+            start : new JulianDate(3),
+            stop : new JulianDate(4),
+            isStartIncluded : false,
+            isStopIncluded : false
+        }));
+        intervals.addInterval(new TimeInterval({
+            start : new JulianDate(4),
+            stop : new JulianDate(5),
+            isStartIncluded : false,
+            isStopIncluded : true
+        }));
+
+        var removedInterval = new TimeInterval({
+            start : new JulianDate(2),
+            stop : new JulianDate(4),
+            isStartIncluded : false,
+            isStopIncluded : false
+        });
+
+        expect(intervals.length).toEqual(4);
+        expect(intervals.removeInterval(removedInterval)).toEqual(true);
+
+        expect(intervals.length).toEqual(2);
+    });
+
     it('intersect works with an empty collection', function() {
         var left = new TimeIntervalCollection();
         left.addInterval(new TimeInterval({


### PR DESCRIPTION
Reported on the forum: https://groups.google.com/forum/?hl=en#!topic/cesium-dev/SGcYfC6lPLk

The missing update in the while loop caused all intervals after an overlapped one to be removed from the collection.  This properly halts the loop once it reaches an end time outside the removed interval.

@mramato confirmed this was left out by mistake when the code was ported