### PR TITLE
Remove buildApps dependencies.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -101,7 +101,7 @@ gulp.task('build-watch', function() {
     gulp.watch(buildFiles, ['build']);
 });
 
-gulp.task('buildApps', ['combine', 'minifyRelease'], function() {
+gulp.task('buildApps', function() {
     return buildCesiumViewer();
 });
 


### PR DESCRIPTION
buildApps technically depends on minifyRelease, but having it as a dependancy means you can't run it on it's own without rebuilding the whole thing (since we don't have incremental builds).  combine should not have ever been there to begin with.