### PR TITLE
Speed up build process

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,11 @@
 language: node_js
 node_js:
-  - '0.12'
+  - '4.3'
 sudo: false
 before_script:
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
 script:
-  - echo 'cloc' && echo -en 'travis_fold:start:script.cloc\\r'
-  - npm run cloc
-  - echo -en 'travis_fold:end:script.cloc\\r'
-
   - echo 'jsHint' && echo -en 'travis_fold:start:script.jsHint\\r'
   - npm run jsHint --failTaskOnError
   - echo -en 'travis_fold:end:script.jsHint\\r'
@@ -26,3 +22,7 @@ script:
   - echo 'test non-webgl release' && echo -en 'travis_fold:start:script test.release\\r'
   - npm run test -- --exclude WebGL --browsers Electron --failTaskOnError --release --suppressPassed
   - echo -en 'travis_fold:end:script test.release\\r'
+
+  - echo 'cloc' && echo -en 'travis_fold:start:script.cloc\\r'
+  - npm run cloc
+  - echo -en 'travis_fold:end:script.cloc\\r'

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -35,7 +35,16 @@ var karmaConfigFile = path.join(__dirname, 'Specs/karma.conf.js');
 //per-task variables.  We use the command line argument here to detect which task is being run.
 var taskName = process.argv[2];
 var noDevelopmentGallery = taskName === 'release' || taskName === 'makeZipFile';
+var buildingRelease = noDevelopmentGallery;
 var minifyShaders = taskName === 'minify' || taskName === 'minifyRelease' || taskName === 'release' || taskName === 'makeZipFile' || taskName === 'buildApps';
+
+var concurrency = Math.min(os.cpus().length, 8);
+
+//Since combine and minify run in parallel already, split concurrency in half when building both.
+//This can go away when gulp 4 comes out because it allows for synchronous tasks.
+if (buildingRelease) {
+    concurrency = concurrency / 2;
+}
 
 var sourceFiles = ['Source/**/*.js',
                    '!Source/*.js',
@@ -107,6 +116,13 @@ gulp.task('buildApps', function() {
 
 gulp.task('clean', function(done) {
     async.forEach(filesToClean, rimraf, done);
+});
+
+gulp.task('requirejs', function(done) {
+    var config = JSON.parse(new Buffer(process.argv[3].substring(2), 'base64').toString('utf8'));
+    requirejs.optimize(config, function() {
+        done();
+    }, done);
 });
 
 gulp.task('cloc', ['build'], function() {
@@ -495,7 +511,7 @@ gulp.task('sortRequires', function(done) {
 });
 
 function combineCesium(debug, optimizer, combineOutput) {
-    return requirejsOptimize({
+    return requirejsOptimize('Cesium.js', {
         wrap : true,
         useStrict : true,
         optimize : optimizer,
@@ -512,12 +528,13 @@ function combineCesium(debug, optimizer, combineOutput) {
 }
 
 function combineWorkers(debug, optimizer, combineOutput) {
-    return Promise.join(
-        globby(['Source/Workers/cesiumWorkerBootstrapper.js',
-                'Source/Workers/transferTypedArrayTest.js',
-                'Source/ThirdParty/Workers/*.js']).then(function(files) {
-            return Promise.all(files.map(function(file) {
-                return requirejsOptimize({
+    //This is done waterfall style for concurrency reasons.
+    return globby(['Source/Workers/cesiumWorkerBootstrapper.js',
+                   'Source/Workers/transferTypedArrayTest.js',
+                   'Source/ThirdParty/Workers/*.js'])
+        .then(function(files) {
+            return Promise.map(files, function(file) {
+                return requirejsOptimize(file, {
                     wrap : false,
                     useStrict : true,
                     optimize : optimizer,
@@ -530,15 +547,18 @@ function combineWorkers(debug, optimizer, combineOutput) {
                     include : filePathToModuleId(path.relative('Source', file)),
                     out : path.join(combineOutput, path.relative('Source', file))
                 });
-            }));
-        }),
-        globby(['Source/Workers/*.js',
-                '!Source/Workers/cesiumWorkerBootstrapper.js',
-                '!Source/Workers/transferTypedArrayTest.js',
-                '!Source/Workers/createTaskProcessorWorker.js',
-                '!Source/ThirdParty/Workers/*.js']).then(function(files) {
-            return Promise.all(files.map(function(file) {
-                return requirejsOptimize({
+            }, {concurrency : concurrency});
+        })
+        .then(function() {
+            return globby(['Source/Workers/*.js',
+                           '!Source/Workers/cesiumWorkerBootstrapper.js',
+                           '!Source/Workers/transferTypedArrayTest.js',
+                           '!Source/Workers/createTaskProcessorWorker.js',
+                           '!Source/ThirdParty/Workers/*.js']);
+        })
+        .then(function(files) {
+            return Promise.map(files, function(file) {
+                return requirejsOptimize(file, {
                     wrap : true,
                     useStrict : true,
                     optimize : optimizer,
@@ -550,15 +570,14 @@ function combineWorkers(debug, optimizer, combineOutput) {
                     include : filePathToModuleId(path.relative('Source', file)),
                     out : path.join(combineOutput, path.relative('Source', file))
                 });
-            }));
-        })
-    );
+            }, {concurrency : concurrency});
+        });
 }
 
 function minifyCSS(outputDirectory) {
     return globby('Source/**/*.css').then(function(files) {
-        return Promise.all(files.map(function(file) {
-            return requirejsOptimize({
+        return Promise.map(files, function(file) {
+            return requirejsOptimize(file, {
                 wrap : true,
                 useStrict : true,
                 optimizeCss : 'standard',
@@ -568,7 +587,7 @@ function minifyCSS(outputDirectory) {
                 cssIn : file,
                 out : path.join(outputDirectory, path.relative('Source', file))
             });
-        }));
+        }, {concurrency : concurrency});
     });
 }
 
@@ -830,7 +849,7 @@ function buildCesiumViewer() {
     mkdirp.sync(cesiumViewerOutputDirectory);
 
     var promise = Promise.join(
-        requirejsOptimize({
+        requirejsOptimize('CesiumViewer', {
             wrap : true,
             useStrict : true,
             optimizeCss : 'standard',
@@ -842,7 +861,7 @@ function buildCesiumViewer() {
             name : 'CesiumViewerStartup',
             out : cesiumViewerStartup
         }),
-        requirejsOptimize({
+        requirejsOptimize('CesiumViewer CSS', {
             wrap : true,
             useStrict : true,
             optimizeCss : 'standard',
@@ -908,10 +927,19 @@ function removeExtension(p) {
     return p.slice(0, -path.extname(p).length);
 }
 
-function requirejsOptimize(config) {
-    config.logLevel = 1;
+function requirejsOptimize(name, config) {
+    console.log('Building ' + name);
     return new Promise(function(resolve, reject) {
-        requirejs.optimize(config, resolve, reject);
+        var cmd = 'npm run requirejs -- --' + new Buffer(JSON.stringify(config)).toString('base64') + ' --silent';
+        child_process.exec(cmd, function(e) {
+            if (e) {
+                console.log('Error ' + name);
+                reject(e);
+                return;
+            }
+            console.log('Finished ' + name);
+            resolve();
+        });
     });
 }
 

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "cloc": "gulp cloc",
     "combine": "gulp combine",
     "combineRelease": "gulp combineRelease",
+    "requirejs": "gulp requirejs",
     "generateDocumentation": "gulp generateDocumentation",
     "instrumentForCoverage": "gulp instrumentForCoverage",
     "jsHint": "gulp jsHint",


### PR DESCRIPTION
Hot on the heels of #3658, some low-hanging fruit that came out of that discussion

1. Run travis under node 4.3.x (gives a decent improvement over 0.12.)
2. Move `cloc` to the end of the build since it's the least important.
3. Take advantage of multiple cores for combine/minification
4. Improved build output to not spew as much garbage but still produce relevant information.

Number 3 reduced `makeZipFile` times on my machine from 5:40 to 2:30, performance increase has transferred to travis as well (looks like it's down to 5-6 minutes).  Since travis reports 32 cores and trying to use them all results in travis killing the build (I think because of memory limitations), I put in a hardcoded limit of 8 for now.

My approach is a little hacky (I exec a separate npm script passing a base64 encoded string on the command line), but I couldn't determine a better way to handle it with gulp because there's no programmatic way to spawn a task (I think this is being fixed in gulp 4, so we'll revisit when that comes out).