### PR TITLE
Test Expression Examples

### DIFF
--- a/Source/Scene/Expression.js
+++ b/Source/Scene/Expression.js
@@ -150,10 +150,11 @@ define([
         // Member function calls
         if (ast.callee.type === 'MemberExpression') {
             call = ast.callee.property.name;
+            var object = ast.callee.object;
             if (call === 'test' || call === 'exec') {
                 // Make sure this is called on a valid type
                 //>>includeStart('debug', pragmas.debug);
-                if (ast.callee.object.callee.name !== 'regExp') {
+                if (object.callee.name !== 'regExp') {
                     throw new DeveloperError('Error: ' + call + ' is not a function.');
                 }
                 //>>includeEnd('debug');
@@ -164,9 +165,12 @@ define([
                         return new Node(ExpressionNodeType.LITERAL_NULL, null);
                     }
                 }
-                var left = createRuntimeAst(expression, ast.callee.object);
+                var left = createRuntimeAst(expression, object);
                 var right = createRuntimeAst(expression, args[0]);
                 return new Node(ExpressionNodeType.FUNCTION_CALL, call, left, right);
+            } else if (call === 'toString') {
+                val = createRuntimeAst(expression, object);
+                return new Node(ExpressionNodeType.FUNCTION_CALL, call, val);
             }
 
             //>>includeStart('debug', pragmas.debug);
@@ -177,6 +181,9 @@ define([
         // Non-member function calls
         call = ast.callee.name;
         if (call === 'color') {
+            if (args.length === 0) {
+                return new Node(ExpressionNodeType.LITERAL_COLOR, call);
+            }
             val = createRuntimeAst(expression, args[0]);
             if (defined(args[1])) {
                 var alpha = createRuntimeAst(expression, args[1]);
@@ -395,6 +402,8 @@ define([
                 node.evaluate = node._evaluateRegExpTest;
             } else if (node._value === 'exec') {
                 node.evaluate = node._evaluateRegExpExec;
+            } else if (node._value === 'toString') {
+                node.evaluate = node._evaluateToString;
             }
         } else if (node._type === ExpressionNodeType.BINARY) {
             if (node._value === '+') {
@@ -475,7 +484,9 @@ define([
         }
         var args = this._left;
         if (this._value === 'color') {
-            if (args.length > 1) {
+            if (!defined(args)) {
+                return Color.fromBytes(255, 255, 255, 255, result);
+            } else if (args.length > 1) {
                 Color.fromCssColorString(args[0].evaluate(feature, result), result);
                 Color.fromAlpha(result, args[1].evaluate(feature, result), result);
             } else {
@@ -780,6 +791,18 @@ define([
             return null;
         }
         return exec[1];
+    };
+
+    Node.prototype._evaluateToString = function(feature, result) {
+        var left = this._left.evaluate(feature, result);
+        if ((left instanceof RegExp) || (left instanceof Color)) {
+            return String(left);
+        }
+        //>>includeStart('debug', pragmas.debug);
+        else {
+            throw new DeveloperError('Error: Unexpected function call "' + this._value + '".');
+        }
+        //>>includeEnd('debug');
     };
 
     return Expression;

--- a/Specs/Scene/ExpressionSpec.js
+++ b/Specs/Scene/ExpressionSpec.js
@@ -270,6 +270,9 @@ defineSuite([
 
         expression = new Expression(new MockStyleEngine(), 'hsla(0, 0, 1, 0.5)');
         expect(expression.evaluate(undefined)).toEqual(new Color(1.0, 1.0, 1.0, 0.5));
+
+        expression = new Expression(new MockStyleEngine(), 'color()');
+        expect(expression.evaluate(undefined)).toEqual(Color.WHITE);
     });
 
     it('evaluates literal color with result parameter', function() {
@@ -306,6 +309,10 @@ defineSuite([
         expression = new Expression(new MockStyleEngine(), 'hsla(0, 0, 1, 0.5)');
         expect(expression.evaluateColor(undefined, color)).toEqual(new Color(1.0, 1.0, 1.0, 0.5));
         expect(color).toEqual(new Color(1.0, 1.0, 1.0, 0.5));
+
+        expression = new Expression(new MockStyleEngine(), 'color()');
+        expect(expression.evaluateColor(undefined, color)).toEqual(Color.WHITE);
+        expect(color).toEqual(Color.WHITE);
     });
 
     it('evaluates color with expressions as arguments', function() {
@@ -663,6 +670,20 @@ defineSuite([
         expect(expression.evaluate(undefined)).toEqual(false);
     });
 
+    it('evaluates color toString function', function() {
+        var feature = new MockFeature();
+        feature.addProperty('property', Color.BLUE);
+
+        var expression = new Expression(new MockStyleEngine(), 'color("red").toString()');
+        expect(expression.evaluate(undefined)).toEqual('(1, 0, 0, 1)');
+
+        expression = new Expression(new MockStyleEngine(), 'rgba(0, 0, 255, 0.5).toString()');
+        expect(expression.evaluate(undefined)).toEqual('(0, 0, 1, 0.5)');
+
+        expression = new Expression(new MockStyleEngine(), '${property}.toString()');
+        expect(expression.evaluate(feature)).toEqual('(0, 0, 1, 1)');
+    });
+
     it('evaluates isNaN function', function() {
         var expression = new Expression(new MockStyleEngine(), 'isNaN()');
         expect(expression.evaluate(undefined)).toEqual(true);
@@ -952,6 +973,30 @@ defineSuite([
 
         expect(function() {
             return new Expression(new MockStyleEngine(), '"blue".test()');
+        }).toThrowDeveloperError();
+    });
+
+    it('evaluates regExp toString function', function() {
+        var feature = new MockFeature();
+        feature.addProperty('property', 'abc');
+
+        var expression = new Expression(new MockStyleEngine(), 'regExp().toString()');
+        expect(expression.evaluate(undefined)).toEqual('/(?:)/');
+
+        expression = new Expression(new MockStyleEngine(), 'regExp("\\d\\s\\d", "ig").toString()');
+        expect(expression.evaluate(undefined)).toEqual('/\\d\\s\\d/gi');
+
+        expression = new Expression(new MockStyleEngine(), 'regExp(${property}).toString()');
+        expect(expression.evaluate(feature)).toEqual('/abc/');
+    });
+
+    it('throws when using toString on other type', function() {
+        var feature = new MockFeature();
+        feature.addProperty('property', 'abc');
+
+        var expression = new Expression(new MockStyleEngine(), '${property}.toString()');
+        expect(function() {
+            return expression.evaluate(feature);
         }).toThrowDeveloperError();
     });
 

--- a/Specs/Scene/ExpressionSpec.js
+++ b/Specs/Scene/ExpressionSpec.js
@@ -431,7 +431,7 @@ defineSuite([
         expression = new Expression(new MockStyleEngine(), 'rgb(255, 255, 0).green');
         expect(expression.evaluate(undefined)).toEqual(1);
 
-        expression = new Expression(new MockStyleEngine(), 'rgb("cyan").blue');
+        expression = new Expression(new MockStyleEngine(), 'color("cyan").blue');
         expect(expression.evaluate(undefined)).toEqual(1);
 
         expression = new Expression(new MockStyleEngine(), 'rgba(255, 255, 0, 0.5).alpha');

--- a/Specs/Scene/ExpressionSpec.js
+++ b/Specs/Scene/ExpressionSpec.js
@@ -424,6 +424,20 @@ defineSuite([
         }).toThrowDeveloperError();
     });
 
+    it('evaluates color properties', function() {
+        var expression = new Expression(new MockStyleEngine(), 'color(\'#ffffff\').red');
+        expect(expression.evaluate(undefined)).toEqual(1);
+
+        expression = new Expression(new MockStyleEngine(), 'rgb(255, 255, 0).green');
+        expect(expression.evaluate(undefined)).toEqual(1);
+
+        expression = new Expression(new MockStyleEngine(), 'rgb("cyan").blue');
+        expect(expression.evaluate(undefined)).toEqual(1);
+
+        expression = new Expression(new MockStyleEngine(), 'rgba(255, 255, 0, 0.5).alpha');
+        expect(expression.evaluate(undefined)).toEqual(0.5);
+    });
+
     it('evaluates unary not', function() {
         var expression = new Expression(new MockStyleEngine(), '!true');
         expect(expression.evaluate(undefined)).toEqual(false);


### PR DESCRIPTION
Part of https://github.com/AnalyticalGraphicsInc/3d-tiles/pull/80 for Expression section of the spec.

I made sure to have a test for each example (or close to that example).

I added some thing that were out of sync with the spec.
- default color constructor `color()` and tests
- explicit `toString` functions for `Color` and `RegExp` and tests