### PR TITLE
Fixed missing crs name for EPSG 4326 in GeoJsonDataSource

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@ Change Log
   * 
 * Fixed `TimeIntervalCollection.removeInterval` bug that resulted in too many intervals being removed
 * `GroundPrimitive` throws a `DeveloperError` when passed an unsupported geometry type instead of crashing.
+* `GeoJsonDataSource` now handles CRS `urn:ogc:def:crs:EPSG::4326`
 
 ### 1.19 - 2016-03-01
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -86,3 +86,4 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to Cesiu
 * [Sanuj Sharma](https://github.com/sanuj)
 * [Allen Korenevsky](https://github.com/theplatapi)
 * [Samy Beaudoux](https://github.com/vrittis)
+* [Mati Ostrovsky](https://github.com/mati-o)

--- a/Source/DataSources/GeoJsonDataSource.js
+++ b/Source/DataSources/GeoJsonDataSource.js
@@ -59,7 +59,8 @@ define([
 
     var crsNames = {
         'urn:ogc:def:crs:OGC:1.3:CRS84' : defaultCrsFunction,
-        'EPSG:4326' : defaultCrsFunction
+        'EPSG:4326' : defaultCrsFunction,
+        'urn:ogc:def:crs:EPSG::4326' : defaultCrsFunction
     };
 
     var crsLinkHrefs = {};

--- a/Specs/DataSources/GeoJsonDataSourceSpec.js
+++ b/Specs/DataSources/GeoJsonDataSourceSpec.js
@@ -99,6 +99,28 @@ defineSuite([
         }
     };
 
+    var pointNamedCrsOgc = {
+        type : 'Point',
+        coordinates : [102.0, 0.5],
+        crs : {
+            type : 'name',
+            properties : {
+                name : 'urn:ogc:def:crs:OGC:1.3:CRS84'
+            }
+        }
+    };
+
+    var pointNamedCrsEpsg = {
+        type : 'Point',
+        coordinates : [102.0, 0.5],
+        crs : {
+            type : 'name',
+            properties : {
+                name : 'urn:ogc:def:crs:EPSG::4326'
+            }
+        }
+    };
+
     var pointCrsLinkHref = {
         type : 'Point',
         coordinates : [102.0, 0.5],
@@ -755,6 +777,24 @@ defineSuite([
     it('Works with named crs', function() {
         var dataSource = new GeoJsonDataSource();
         return dataSource.load(pointNamedCrs).then(function() {
+            var entityCollection = dataSource.entities;
+            var entity = entityCollection.values[0];
+            expect(entity.position.getValue(time)).toEqual(coordinatesToCartesian(point.coordinates));
+        });
+    });
+
+    it('Works with named crs OGC:1.3:CRS84', function() {
+        var dataSource = new GeoJsonDataSource();
+        return dataSource.load(pointNamedCrsOgc).then(function() {
+            var entityCollection = dataSource.entities;
+            var entity = entityCollection.values[0];
+            expect(entity.position.getValue(time)).toEqual(coordinatesToCartesian(point.coordinates));
+        });
+    });
+
+    it('Works with named crs EPSG::4326', function() {
+        var dataSource = new GeoJsonDataSource();
+        return dataSource.load(pointNamedCrsEpsg).then(function() {
             var entityCollection = dataSource.entities;
             var entity = entityCollection.values[0];
             expect(entity.position.getValue(time)).toEqual(coordinatesToCartesian(point.coordinates));


### PR DESCRIPTION
@hpinkos 

Hannah, this is the pull-request for the issue described on the [forum](https://groups.google.com/d/topic/cesium-dev/HDfqUXuR_Cg) regarding crsNames property missing another constant for WGS84

This is ready