### PR TITLE
Added examples from spec, tweaked conditional expression

### DIFF
--- a/Source/Scene/ConditionalExpression.js
+++ b/Source/Scene/ConditionalExpression.js
@@ -15,7 +15,7 @@ define([
         defineProperties) {
     'use strict';
 
-    var expressionPlaceholder = '${expression}';
+    var expressionPlaceholder = /\$\{expression}/g;
 
     /**
      * DOC_TBA

--- a/Specs/Scene/ConditionalExpressionSpec.js
+++ b/Specs/Scene/ConditionalExpressionSpec.js
@@ -40,6 +40,16 @@ defineSuite([
         }
     };
 
+    var jsonExpWithMultipleExpression = {
+        expression : '${Height}/2',
+        conditions : {
+            '${expression} > 50 && ${expression} < 100' : 'color("blue")',
+            '${expression} > 25 && ${expression} < 26' : 'color("red")',
+            'true' : 'color("green")'
+        }
+    };
+
+
     var jsonExpWithUndefinedExpression = {
         conditions : {
             '${expression} === undefined' : 'color("blue")',
@@ -81,6 +91,13 @@ defineSuite([
         var expression = new ConditionalExpression(new MockStyleEngine(), jsonExp);
         expect(expression.evaluate(new MockFeature('101'))).toEqual(Color.BLUE);
         expect(expression.evaluate(new MockFeature('52'))).toEqual(Color.RED);
+        expect(expression.evaluate(new MockFeature('3'))).toEqual(Color.GREEN);
+    });
+
+    it('evaluates conditional with multiple expressions', function() {
+        var expression = new ConditionalExpression(new MockStyleEngine(), jsonExpWithMultipleExpression);
+        expect(expression.evaluate(new MockFeature('101'))).toEqual(Color.BLUE);
+        expect(expression.evaluate(new MockFeature('52'))).toEqual(Color.GREEN);
         expect(expression.evaluate(new MockFeature('3'))).toEqual(Color.GREEN);
     });
 


### PR DESCRIPTION
Added the rest of examples from https://github.com/AnalyticalGraphicsInc/3d-tiles/pull/80#issuecomment-192020103 to `Cesium3DTileStyleSpec`.

Also updated `ConditionalExpression` and spec to handle multiple occurences of `${expression}` in the same condition expression.