### PR TITLE
Shadows use scene near/far

### DIFF
--- a/Apps/Sandcastle/gallery/development/Shadows.html
+++ b/Apps/Sandcastle/gallery/development/Shadows.html
@@ -47,10 +47,10 @@
             </td>
         </tr>
         <tr>
-            <td>Shadow Far</td>
+            <td>Distance Limit</td>
             <td>
-                <input type="range" min="100.0" max="10000.0" step="1.0" data-bind="value: shadowFar, valueUpdate: 'input'">
-                <input type="text" size="2" data-bind="value: shadowFar">
+                <input type="range" min="100.0" max="10000.0" step="1.0" data-bind="value: distance, valueUpdate: 'input'">
+                <input type="text" size="2" data-bind="value: distance">
             </td>
         </tr>
         <tr>
@@ -99,7 +99,7 @@ function startup(Cesium) {
 var viewModel = {
     lightAngle : 0.0,
     lightHorizon : 0.0,
-    shadowFar : 1000.0,
+    distance : 1000.0,
     shadows : true,
     terrainCast : false,
     debug : true,
@@ -119,7 +119,7 @@ var toolbar = document.getElementById('toolbar');
 Cesium.knockout.applyBindings(viewModel, toolbar);
 Cesium.knockout.getObservable(viewModel, 'lightAngle').subscribe(updateLightDirection);
 Cesium.knockout.getObservable(viewModel, 'lightHorizon').subscribe(updateLightDirection);
-Cesium.knockout.getObservable(viewModel, 'shadowFar').subscribe(updateSettings);
+Cesium.knockout.getObservable(viewModel, 'distance').subscribe(updateSettings);
 Cesium.knockout.getObservable(viewModel, 'debug').subscribe(updateSettings);
 Cesium.knockout.getObservable(viewModel, 'freeze').subscribe(updateSettings);
 Cesium.knockout.getObservable(viewModel, 'shadows').subscribe(updateSettings);
@@ -143,7 +143,7 @@ function updateLightDirection() {
 }
 
 function updateSettings() {
-    shadowMap._farPlane = Number(viewModel.shadowFar);
+    shadowMap._distance = Number(viewModel.distance);
     shadowMap._fitNearFar = viewModel.fitNearFar;
     shadowMap.debugShow = viewModel.debug;
     shadowMap.debugFreezeFrame = viewModel.freeze;

--- a/Apps/Sandcastle/gallery/development/Shadows.html
+++ b/Apps/Sandcastle/gallery/development/Shadows.html
@@ -113,7 +113,7 @@ var viewModel = {
     sizeOptions : [256, 512, 1024, 2048],
     size : 1024
 };
-
+    
 Cesium.knockout.track(viewModel);
 var toolbar = document.getElementById('toolbar');
 Cesium.knockout.applyBindings(viewModel, toolbar);

--- a/Apps/Sandcastle/gallery/development/Shadows.html
+++ b/Apps/Sandcastle/gallery/development/Shadows.html
@@ -19,6 +19,9 @@
 <body class="sandcastle-loading" data-sandcastle-bucket="bucket-requirejs.html">
 <style>
     @import url(../templates/bucket.css);
+    #toolbar input[type=range] {
+        width : 70px;
+    }
     #toolbar input {
         vertical-align: middle;
         padding-top: 2px;
@@ -67,6 +70,10 @@
             <td><input type="checkbox" data-bind="checked: shadows"/></td>
         </tr>
         <tr>
+            <td>Terrain Cast</td>
+            <td><input type="checkbox" data-bind="checked: terrainCast"/></td>
+        </tr>
+        <tr>
             <td>Show debug</td>
             <td><input type="checkbox" data-bind="checked: debug"/></td>
         </tr>
@@ -77,6 +84,10 @@
         <tr>
             <td>Cascade colors</td>
             <td><input type="checkbox" data-bind="checked: cascadeColors"/></td>
+        </tr>
+        <tr>
+            <td>Fit near/far</td>
+            <td><input type="checkbox" data-bind="checked: fitNearFar"/></td>
         </tr>
     </tbody></table>
 </div>
@@ -90,9 +101,11 @@ var viewModel = {
     lightHorizon : 0.0,
     shadowFar : 1000.0,
     shadows : true,
+    terrainCast : false,
     debug : true,
     freeze : false,
     cascadeColors : false,
+    fitNearFar : true,
     shadowModeOptions : ['Cascades', 'Single'],
     shadowMode : 'Cascades',
     lightSourceOptions : ['Freeform', 'Sun', 'Fixed'],
@@ -110,6 +123,8 @@ Cesium.knockout.getObservable(viewModel, 'shadowFar').subscribe(updateSettings);
 Cesium.knockout.getObservable(viewModel, 'debug').subscribe(updateSettings);
 Cesium.knockout.getObservable(viewModel, 'freeze').subscribe(updateSettings);
 Cesium.knockout.getObservable(viewModel, 'shadows').subscribe(updateSettings);
+Cesium.knockout.getObservable(viewModel, 'terrainCast').subscribe(updateSettings);
+Cesium.knockout.getObservable(viewModel, 'fitNearFar').subscribe(updateSettings);
 Cesium.knockout.getObservable(viewModel, 'cascadeColors').subscribe(updateShadows);
 Cesium.knockout.getObservable(viewModel, 'shadowMode').subscribe(updateShadows);
 Cesium.knockout.getObservable(viewModel, 'lightSource').subscribe(updateShadows);
@@ -129,10 +144,15 @@ function updateLightDirection() {
 
 function updateSettings() {
     shadowMap._farPlane = Number(viewModel.shadowFar);
+    shadowMap._fitNearFar = viewModel.fitNearFar;
     shadowMap.debugShow = viewModel.debug;
     shadowMap.debugFreezeFrame = viewModel.freeze;
     shadowMap.enabled = viewModel.shadows;
     shadowMap.setSize(viewModel.size);
+
+    if (globeVisible) {
+        globe.castShadows = viewModel.terrainCast;
+    }
 }
 
 function updateShadows() {
@@ -218,6 +238,7 @@ var tilt = 0.0;
 var scene = viewer.scene;
 var context = scene.context;
 var camera = scene.camera;
+var globe = scene.globe;
 var shadowMap;
 var center;
 var height;

--- a/Source/Renderer/DrawCommand.js
+++ b/Source/Renderer/DrawCommand.js
@@ -132,6 +132,7 @@ define([
          * @type {Boolean}
          * @default false
          */
+        // TODO : not used right now, but keep if it proves useful
         this.receiveShadows = defaultValue(options.receiveShadows, false);
 
         /**

--- a/Source/Renderer/DrawCommand.js
+++ b/Source/Renderer/DrawCommand.js
@@ -127,6 +127,14 @@ define([
         this.castShadows = defaultValue(options.castShadows, false);
 
         /**
+         * Whether this command should receive shadows when shadowing is enabled.
+         *
+         * @type {Boolean}
+         * @default false
+         */
+        this.receiveShadows = defaultValue(options.receiveShadows, false);
+
+        /**
          * An object with functions whose names match the uniforms in the shader program
          * and return values to set those uniforms.
          *

--- a/Source/Scene/FrameState.js
+++ b/Source/Scene/FrameState.js
@@ -179,7 +179,7 @@ define([
         * The far plane of the scene's frustum commands. Used for fitting the shadow map.
         * @type {Number}
         */
-        this.shadowFar = 100.0;
+        this.shadowFar = 10000.0;
     }
 
     /**

--- a/Source/Scene/FrameState.js
+++ b/Source/Scene/FrameState.js
@@ -168,6 +168,18 @@ define([
         * @type {ShadowMap}
         */
         this.shadowMap = undefined;
+
+        /**
+        * The near plane of the scene's frustum commands. Used for fitting the shadow map.
+        * @type {Number}
+        */
+        this.shadowNear = 1.0;
+
+        /**
+        * The far plane of the scene's frustum commands. Used for fitting the shadow map.
+        * @type {Number}
+        */
+        this.shadowFar = 100.0;
     }
 
     /**

--- a/Source/Scene/GlobeSurfaceTileProvider.js
+++ b/Source/Scene/GlobeSurfaceTileProvider.js
@@ -1089,6 +1089,7 @@ define([
             command.shaderProgram = tileProvider._surfaceShaderSet.getShaderProgram(frameState, surfaceTile, numberOfDayTextures, applyBrightness, applyContrast, applyHue, applySaturation, applyGamma, applyAlpha, showReflectiveOcean, showOceanWaves, tileProvider.enableLighting, hasVertexNormals, useWebMercatorProjection, applyFog, receiveShadows);
             command.shadowCastProgram = tileProvider._surfaceShaderSet.getShadowCastProgram(frameState, surfaceTile, useWebMercatorProjection, castShadows);
             command.castShadows = castShadows;
+            command.receiveShadows = receiveShadows;
             command.renderState = renderState;
             command.primitiveType = PrimitiveType.TRIANGLES;
             command.vertexArray = surfaceTile.vertexArray;

--- a/Source/Scene/Model.js
+++ b/Source/Scene/Model.js
@@ -2615,6 +2615,7 @@ define([
                     shaderProgram : rendererPrograms[technique.program],
                     shadowCastProgram : rendererShadowCastPrograms[technique.program],
                     castShadows : model.castShadows,
+                    receiveShadows : model.receiveShadows,
                     uniformMap : uniformMap,
                     renderState : rs,
                     owner : owner,

--- a/Source/Scene/Primitive.js
+++ b/Source/Scene/Primitive.js
@@ -1215,6 +1215,7 @@ define([
                 colorCommand.shaderProgram = primitive._sp;
                 colorCommand.shadowCastProgram = primitive._shadowCastSP;
                 colorCommand.castShadows = primitive._castShadows;
+                colorCommand.receiveShadows = primitive._receiveShadows;
                 colorCommand.uniformMap = uniforms;
                 colorCommand.pass = pass;
 
@@ -1233,6 +1234,7 @@ define([
             colorCommand.shaderProgram = primitive._sp;
             colorCommand.shadowCastProgram = primitive._shadowCastSP;
             colorCommand.castShadows = primitive._castShadows;
+            colorCommand.receiveShadows = primitive._receiveShadows;
             colorCommand.uniformMap = uniforms;
             colorCommand.pass = pass;
 

--- a/Source/Scene/Scene.js
+++ b/Source/Scene/Scene.js
@@ -1253,6 +1253,10 @@ define([
             far = Math.max(Math.min(far, camera.frustum.far), near);
         }
 
+        // Use the computed near and far for shadows
+        frameState.shadowNear = near;
+        frameState.shadowFar = far;
+
         // Exploit temporal coherence. If the frustums haven't changed much, use the frustums computed
         // last frame, else compute the new frustums and sort them by frustum again.
         var farToNearRatio = scene.farToNearRatio;
@@ -1669,15 +1673,17 @@ define([
     function getShadowMapCommands(scene) {
         // TODO : temporary solution for testing
         var shadowMapCommands = [];
-        var frustumCommands = scene._frustumCommandsList[0];
-        if (defined(frustumCommands)) {
+        var frustumCommandsList = scene._frustumCommandsList;
+        var numFrustums = frustumCommandsList.length;
+        for (var i = 0; i < numFrustums; ++i) {
+            var frustumCommands = frustumCommandsList[i];
             var startPass = Pass.GLOBE;
             var endPass = Pass.TRANSLUCENT;
             for (var pass = startPass; pass <= endPass; ++pass) {
                 var commands = frustumCommands.commands[pass];
                 var length = frustumCommands.indices[pass];
-                for (var i = 0; i < length; ++i) {
-                    var command = commands[i];
+                for (var j = 0; j < length; ++j) {
+                    var command = commands[j];
                     if (command.castShadows) {
                         shadowMapCommands.push(command);
                     }

--- a/Source/Scene/ShadowMap.js
+++ b/Source/Scene/ShadowMap.js
@@ -139,6 +139,7 @@ define([
         this._farPlane = 1000.0; // Limit the far plane of the scene camera
 
         this._fitToScene = defaultValue(options.fitToScene, true);
+        this._fitNearFar = true;
 
         var maximumNumberOfCascades = 4;
         this._numberOfCascades = this._fitToScene ? defaultValue(options.numberOfCascades, maximumNumberOfCascades) : 1;
@@ -533,24 +534,23 @@ define([
     var debugCascadeColors = [Color.RED, Color.GREEN, Color.BLUE, Color.MAGENTA];
 
     function applyDebugSettings(shadowMap, frameState) {
-        if (!shadowMap.debugShow) {
-            return;
-        }
-
-        var debugLightFrustum = shadowMap._debugLightFrustum;
-        if (!defined(debugLightFrustum)) {
-            debugLightFrustum = shadowMap._debugLightFrustum = createDebugFrustum(Color.YELLOW);
-        }
-        Matrix4.inverse(shadowMap._shadowMapCamera.getViewProjection(), debugLightFrustum.modelMatrix);
-        debugLightFrustum.update(frameState);
-
-        for (var i = 0; i < shadowMap._numberOfCascades; ++i) {
-            var debugCascadeFrustum = shadowMap._debugCascadeFrustums[i];
-            if (!defined(debugCascadeFrustum)) {
-                debugCascadeFrustum = shadowMap._debugCascadeFrustums[i] = createDebugFrustum(debugCascadeColors[i]);
+        var showFrustumOutlines = !shadowMap._fitToScene || shadowMap.debugFreezeFrame;
+        if (showFrustumOutlines) {
+            var debugLightFrustum = shadowMap._debugLightFrustum;
+            if (!defined(debugLightFrustum)) {
+                debugLightFrustum = shadowMap._debugLightFrustum = createDebugFrustum(Color.YELLOW);
             }
-            Matrix4.inverse(shadowMap._cascadeCameras[i].getViewProjection(), debugCascadeFrustum.modelMatrix);
-            debugCascadeFrustum.update(frameState);
+            Matrix4.inverse(shadowMap._shadowMapCamera.getViewProjection(), debugLightFrustum.modelMatrix);
+            debugLightFrustum.update(frameState);
+
+            for (var i = 0; i < shadowMap._numberOfCascades; ++i) {
+                var debugCascadeFrustum = shadowMap._debugCascadeFrustums[i];
+                if (!defined(debugCascadeFrustum)) {
+                    debugCascadeFrustum = shadowMap._debugCascadeFrustums[i] = createDebugFrustum(debugCascadeColors[i]);
+                }
+                Matrix4.inverse(shadowMap._cascadeCameras[i].getViewProjection(), debugCascadeFrustum.modelMatrix);
+                debugCascadeFrustum.update(frameState);
+            }
         }
 
         updateDebugShadowViewCommand(shadowMap, frameState);
@@ -749,10 +749,12 @@ define([
         Cartesian3.clone(lightRight, shadowMapCamera.rightWC);
     }
 
-    function updateCameras(shadowMap, camera) {
+    function updateCameras(shadowMap, frameState) {
         if (shadowMap.debugFreezeFrame) {
             return;
         }
+
+        var camera = frameState.camera;
 
         // Clone light camera into the shadow map camera
         var shadowMapCamera = shadowMap._shadowMapCamera;
@@ -764,15 +766,23 @@ define([
         Cartesian3.normalize(lightDirection, lightDirection);
         Cartesian3.negate(lightDirection, lightDirection);
 
-        // Clone scene camera and limit the far plane
+        // Get the near and far of the scene camera
+        var near = camera.frustum.near;
+        var far = shadowMap._farPlane;
+
+        if (shadowMap._fitNearFar) {
+            near = frameState.shadowNear;
+            far = Math.min(frameState.shadowFar, near + shadowMap._farPlane); // Limit to the far plane
+        }
+
         shadowMap._sceneCamera = Camera.clone(camera, shadowMap._sceneCamera);
-        shadowMap._sceneCamera.frustum.near = camera.frustum.near;
-        shadowMap._sceneCamera.frustum.far = shadowMap._farPlane;
+        shadowMap._sceneCamera.frustum.near = near;
+        shadowMap._sceneCamera.frustum.far = far;
     }
 
     ShadowMap.prototype.update = function(frameState) {
         updateFramebuffer(this, frameState.context);
-        updateCameras(this, frameState.camera);
+        updateCameras(this, frameState);
 
         if (this._fitToScene) {
             fitShadowMapToScene(this);

--- a/Source/Scene/ShadowMap.js
+++ b/Source/Scene/ShadowMap.js
@@ -600,7 +600,7 @@ define([
         var numberOfCascades = shadowMap._numberOfCascades;
 
         // Split cascades. Use a mix of linear and log splits.
-        var lambda = 0.9;
+        var lambda = 1.0;
         var range = cameraFar - cameraNear;
         var ratio = cameraFar / cameraNear;
 

--- a/Source/Scene/ShadowMap.js
+++ b/Source/Scene/ShadowMap.js
@@ -600,7 +600,7 @@ define([
         var numberOfCascades = shadowMap._numberOfCascades;
 
         // Split cascades. Use a mix of linear and log splits.
-        var lambda = 1.0;
+        var lambda = 0.9;
         var range = cameraFar - cameraNear;
         var ratio = cameraFar / cameraNear;
 

--- a/Source/Scene/ShadowMap.js
+++ b/Source/Scene/ShadowMap.js
@@ -136,7 +136,7 @@ define([
         this._lightCamera = options.lightCamera;
         this._shadowMapCamera = new ShadowMapCamera();
         this._sceneCamera = undefined;
-        this._farPlane = 1000.0; // Limit the far plane of the scene camera
+        this._distance = 1000.0;
 
         this._fitToScene = defaultValue(options.fitToScene, true);
         this._fitNearFar = true;
@@ -767,12 +767,15 @@ define([
         Cartesian3.negate(lightDirection, lightDirection);
 
         // Get the near and far of the scene camera
-        var near = camera.frustum.near;
-        var far = shadowMap._farPlane;
-
+        var near;
+        var far;
         if (shadowMap._fitNearFar) {
+            // shadowFar can be very large, so limit to shadowMap._distance
             near = frameState.shadowNear;
-            far = Math.min(frameState.shadowFar, near + shadowMap._farPlane); // Limit to the far plane
+            far = Math.min(frameState.shadowFar, near + shadowMap._distance);
+        } else {
+            near = camera.frustum.near;
+            far = shadowMap._distance;
         }
 
         shadowMap._sceneCamera = Camera.clone(camera, shadowMap._sceneCamera);


### PR DESCRIPTION
For #2594 

* Added a few more demo options
    * `terrainCast` - toggle terrain casting shadows (off by default now)
    * `fitNearFar` - use the near and far computed in `createPotentiallyVisibleSet` to limit the shadow map bounds. This helps a lot with views that face the ground, and helps a little with horizon views because it uses a tighter near plane. There is still the problem where moving the camera causes large terrain tiles to load, which throws off the near and far computed from the draw commands. I've tried a few different approaches to recognize when this happens, but none are ideal yet.
* Added `DrawCommand.receiveShadows`. I removed the code that was using this, so nothing is using this right now, but it might be useful to keep. Since `DrawCommand.castShadows` exists, it doesn't stand out.
* Only draw debug frustum outlines if in freeze-frame mode, or the shadow map is fixed. Removes some visual clutter this way.