### PR TITLE
Deploy to S3 as part of Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,3 +26,12 @@ script:
   - echo 'cloc' && echo -en 'travis_fold:start:script.cloc\\r'
   - npm run cloc
   - echo -en 'travis_fold:end:script.cloc\\r'
+deploy:
+  provider: s3
+  access_key_id: $AWS_ACCESS_KEY
+  secret_access_key: $AWS_SECRET_KEY
+  bucket: "cesium-dev"
+  skip_cleanup: true
+  upload-dir: cesium/$TRAVIS_BRANCH
+  on:
+    all_branches: true


### PR DESCRIPTION
Uploads Travis build to S3 at the URL `http://cesium-dev.s3-website-us-east-1.amazonaws.com/cesium/BRANCH_NAME/` on each push.

This branch is at http://cesium-dev.s3-website-us-east-1.amazonaws.com/cesium/deploy-s3/

This requires the person who owns the fork of cesium to have Travis turned on and the environment variables `$AWS_ACCESS_KEY` and `$AWS_SECRET_KEY` set with credentials that have write access to the s3 bucket. If the owner of the fork does not have the credentials, the deploy step will fail but it will not fail the build overall.

Sandcastle and the Apps work. The Jasmine tests run but there are a lot of errors and Documentation doesn't work unless we chose to build that. 

Uploading the whole directory is a lot a files and takes a while (34 minutes for the entire build). Are there directories we know we can exclude from the upload?


