### PR TITLE
Fix texture loading and re-projection bug

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@ Change Log
 * Fixed `TimeIntervalCollection.removeInterval` bug that resulted in too many intervals being removed
 * `GroundPrimitive` throws a `DeveloperError` when passed an unsupported geometry type instead of crashing.
 * `GeoJsonDataSource` now handles CRS `urn:ogc:def:crs:EPSG::4326`
+* Fix a race condition that would cause the terrain to continue loading and unloading or cause a crash when changing terrain providers. [#3690](https://github.com/AnalyticalGraphicsInc/cesium/issues/3690)
 
 ### 1.19 - 2016-03-01
 

--- a/Source/Scene/Globe.js
+++ b/Source/Scene/Globe.js
@@ -426,7 +426,7 @@ define([
 
                     that._oceanNormalMap = that._oceanNormalMap && that._oceanNormalMap.destroy();
                     that._oceanNormalMap = new Texture({
-                        context : context,
+                        context : frameState.context,
                         source : image
                     });
                 });

--- a/Source/Scene/GlobeSurfaceTileProvider.js
+++ b/Source/Scene/GlobeSurfaceTileProvider.js
@@ -294,7 +294,7 @@ define([
         // update collection: imagery indices, base layers, raise layer show/hide event
         imageryLayers._update();
         // update each layer for texture reprojection.
-        imageryLayers.update(frameState);
+        imageryLayers.queueReprojectionCommands(frameState);
 
         if (this._layerOrderChanged) {
             this._layerOrderChanged = false;

--- a/Source/Scene/GlobeSurfaceTileProvider.js
+++ b/Source/Scene/GlobeSurfaceTileProvider.js
@@ -314,6 +314,8 @@ define([
                 creditDisplay.addCredit(imageryProvider.credit);
             }
         }
+
+        imageryLayers.update(frameState);
     };
 
     /**
@@ -405,6 +407,13 @@ define([
         for (var i = 0, length = this._usedDrawCommands; i < length; ++i) {
             addPickCommandsForTile(this, drawCommands[i], frameState);
         }
+    };
+
+    /**
+     * Cancels any imagery re-projections in the queue.
+     */
+    GlobeSurfaceTileProvider.prototype.cancelReprojections = function() {
+        this._imageryLayers.cancelReprojections();
     };
 
     /**

--- a/Source/Scene/GlobeSurfaceTileProvider.js
+++ b/Source/Scene/GlobeSurfaceTileProvider.js
@@ -289,7 +289,12 @@ define([
      * @param {FrameState} frameState The frame state.
      */
     GlobeSurfaceTileProvider.prototype.initialize = function(frameState) {
-        this._imageryLayers._update();
+        var imageryLayers = this._imageryLayers;
+
+        // update collection: imagery indices, base layers, raise layer show/hide event
+        imageryLayers._update();
+        // update each layer for texture reprojection.
+        imageryLayers.update(frameState);
 
         if (this._layerOrderChanged) {
             this._layerOrderChanged = false;
@@ -307,15 +312,12 @@ define([
             creditDisplay.addCredit(this._terrainProvider.credit);
         }
 
-        var imageryLayers = this._imageryLayers;
         for (var i = 0, len = imageryLayers.length; i < len; ++i) {
             var imageryProvider = imageryLayers.get(i).imageryProvider;
             if (imageryProvider.ready && defined(imageryProvider.credit)) {
                 creditDisplay.addCredit(imageryProvider.credit);
             }
         }
-
-        imageryLayers.update(frameState);
     };
 
     /**

--- a/Source/Scene/ImageryLayer.js
+++ b/Source/Scene/ImageryLayer.js
@@ -788,7 +788,7 @@ define([
      *
      * @param {FrameState} frameState The frameState.
      */
-    ImageryLayer.prototype.update = function(frameState) {
+    ImageryLayer.prototype.queueReprojectionCommands = function(frameState) {
         var computeCommands = this._reprojectComputeCommands;
         var length = computeCommands.length;
         for (var i = 0; i < length; ++i) {

--- a/Source/Scene/ImageryLayer.js
+++ b/Source/Scene/ImageryLayer.js
@@ -235,6 +235,8 @@ define([
         this._isBaseLayer = false;
 
         this._requestImageError = undefined;
+
+        this._reprojectComputeCommands = [];
     }
 
     defineProperties(ImageryLayer.prototype, {
@@ -739,7 +741,7 @@ define([
     }
 
     /**
-     * Reproject a texture to a {@link GeographicProjection}, if necessary, and generate
+     * Enqueues a command re-projecting a texture to a {@link GeographicProjection} on the next update, if necessary, and generate
      * mipmaps for the geographic texture.
      *
      * @private
@@ -773,10 +775,35 @@ define([
                         finalizeReprojectTexture(that, context, imagery, outputTexture);
                     }
                 });
-                frameState.commandList.push(computeCommand);
+                this._reprojectComputeCommands.push(computeCommand);
         } else {
             finalizeReprojectTexture(this, context, imagery, texture);
         }
+    };
+
+    /**
+     * Updates frame state to execute any queued texture re-projections.
+     *
+     * @private
+     *
+     * @param {FrameState} frameState The frameState.
+     */
+    ImageryLayer.prototype.update = function(frameState) {
+        var computeCommands = this._reprojectComputeCommands;
+        var length = computeCommands.length;
+        for (var i = 0; i < length; ++i) {
+            frameState.commandList.push(computeCommands[i]);
+        }
+        computeCommands.length = 0;
+    };
+
+    /**
+     * Cancels re-projection commands queued for the next frame.
+     *
+     * @private
+     */
+    ImageryLayer.prototype.cancelReprojections = function() {
+        this._reprojectComputeCommands.length = 0;
     };
 
     ImageryLayer.prototype.getImageryFromCache = function(x, y, level, imageryRectangle) {

--- a/Source/Scene/ImageryLayerCollection.js
+++ b/Source/Scene/ImageryLayerCollection.js
@@ -466,10 +466,10 @@ define([
      *
      * @param {FrameState} frameState The frameState.
      */
-    ImageryLayerCollection.prototype.update = function(frameState) {
+    ImageryLayerCollection.prototype.queueReprojectionCommands = function(frameState) {
         var layers = this._layers;
         for (var i = 0, len = layers.length; i < len; ++i) {
-            layers[i].update(frameState);
+            layers[i].queueReprojectionCommands(frameState);
         }
     };
 

--- a/Source/Scene/ImageryLayerCollection.js
+++ b/Source/Scene/ImageryLayerCollection.js
@@ -460,6 +460,32 @@ define([
     };
 
     /**
+     * Updates frame state to execute any queued texture re-projections.
+     *
+     * @private
+     *
+     * @param {FrameState} frameState The frameState.
+     */
+    ImageryLayerCollection.prototype.update = function(frameState) {
+        var layers = this._layers;
+        for (var i = 0, len = layers.length; i < len; ++i) {
+            layers[i].update(frameState);
+        }
+    };
+
+    /**
+     * Cancels re-projection commands queued for the next frame.
+     *
+     * @private
+     */
+    ImageryLayerCollection.prototype.cancelReprojections = function() {
+        var layers = this._layers;
+        for (var i = 0, len = layers.length; i < len; ++i) {
+            layers[i].cancelReprojections();
+        }
+    };
+
+    /**
      * Returns true if this object was destroyed; otherwise, false.
      * <br /><br />
      * If this object was destroyed, it should not be used; calling any function other than

--- a/Source/Scene/QuadtreePrimitive.js
+++ b/Source/Scene/QuadtreePrimitive.js
@@ -193,6 +193,8 @@ define([
         }
 
         this._levelZeroTiles = undefined;
+
+        this._tileProvider.cancelReprojections();
     };
 
     /**
@@ -268,6 +270,7 @@ define([
             return;
         }
 
+        // Gets commands for any texture re-projections and updates the credit display
         this._tileProvider.initialize(frameState);
 
         var debug = this._debug;
@@ -280,8 +283,6 @@ define([
         debug.tilesCulled = 0;
         debug.tilesRendered = 0;
         debug.tilesWaitingForChildren = 0;
-
-        processTileLoadQueue(this, frameState);
 
         this._tileLoadQueue.length = 0;
         this._tileReplacementQueue.markStartOfRenderFrame();
@@ -316,6 +317,8 @@ define([
             return;
         }
 
+        // Load/create resources for terrain and imagery. Prepare texture re-projections for the next frame.
+        processTileLoadQueue(this, frameState);
         updateHeights(this, frameState);
 
         var debug = this._debug;

--- a/Specs/Scene/ImageryLayerSpec.js
+++ b/Specs/Scene/ImageryLayerSpec.js
@@ -181,7 +181,7 @@ defineSuite([
                 }).then(function() {
                     var textureBeforeReprojection = imagery.texture;
                     layer._reprojectTexture(frameState, imagery);
-                    layer.update(frameState);
+                    layer.queueReprojectionCommands(frameState);
                     frameState.commandList[0].execute(computeEngine);
 
                     return pollToPromise(function() {
@@ -216,7 +216,7 @@ defineSuite([
                 }).then(function() {
                     layer._reprojectTexture(frameState, imagery);
                     layer.cancelReprojections();
-                    layer.update(frameState);
+                    layer.queueReprojectionCommands(frameState);
                     expect(frameState.commandList.length).toEqual(0);
                 });
             });

--- a/Specs/Scene/ImageryLayerSpec.js
+++ b/Specs/Scene/ImageryLayerSpec.js
@@ -176,6 +176,7 @@ defineSuite([
                 }).then(function() {
                     var textureBeforeReprojection = imagery.texture;
                     layer._reprojectTexture(frameState, imagery);
+                    layer.update(frameState);
                     frameState.commandList[0].execute(computeEngine);
 
                     return pollToPromise(function() {


### PR DESCRIPTION
Move loading terrain and imagery to the end of the quadtree update. Queue any texture re-projections to be executed the next frame.

For #3690.