### PR TITLE
Non visual properties

### DIFF
--- a/Apps/Sandcastle/gallery/3D Tiles.html
+++ b/Apps/Sandcastle/gallery/3D Tiles.html
@@ -89,7 +89,10 @@ function loadTileset(url) {
                 }
             },
 //          "show": false
-            "show" : "${Height} > 0"
+            "show" : "${Height} > 0",
+            "meta" : {
+                "description" : "'Building id ${id} has height ${Height}.'"
+            }
         });
 
         tileset.loadProgress.addEventListener(function(numberOfPendingRequests, numberProcessing) {
@@ -207,8 +210,10 @@ handler.setInputAction(function(movement) {
                 }
             }
 
-            // evaluate feature color
-            console.log("Evaluated Color : " + tileset.style.color.evaluate(building));
+            // evaluate feature description
+            if (Cesium.defined(tileset.style.meta.description)) {
+                console.log("Description : " + tileset.style.meta.description.evaluate(building));
+            }
 
             building.setProperty('clicked', true);
         }

--- a/Source/Scene/Cesium3DTileStyle.js
+++ b/Source/Scene/Cesium3DTileStyle.js
@@ -1,5 +1,6 @@
 /*global define*/
 define([
+        '../Core/clone',
        '../Core/defaultValue',
        '../Core/defined',
        '../Core/defineProperties',
@@ -11,6 +12,7 @@ define([
        './ConditionsExpression',
        './Expression'
     ], function(
+        clone,
         defaultValue,
         defined,
         defineProperties,
@@ -38,6 +40,7 @@ define([
 
         this._color = undefined;
         this._show = undefined;
+        this._meta = undefined;
         this._readyPromise = when.defer();
         this._ready = false;
 
@@ -79,6 +82,19 @@ define([
         }
 
         that._show = show;
+
+        var meta = {};
+        var json = styleJson.meta;
+        if(defined(json)) {
+            for (var property in json) {
+                if (json.hasOwnProperty(property)) {
+                    var exp = json[property];
+                    meta[property] = new Expression(styleEngine, exp);
+                }
+            }
+        }
+
+        that.meta = meta;
 
         that._ready = true;
     }
@@ -134,7 +150,25 @@ define([
             set : function(value) {
                 this._color = value;
             }
-        }
+        },
+
+        /**
+         * DOC_TBA
+         */
+        meta : {
+            get : function() {
+                //>>includeStart('debug', pragmas.debug);
+                if (!this._ready) {
+                    throw new DeveloperError('The style is not loaded.  Use Cesium3DTileStyle.readyPromise or wait for Cesium3DTileStyle.ready to be true.');
+                }
+                //>>includeEnd('debug');
+                return this._meta;
+            },
+            set : function(value) {
+                this._meta = value;
+            }
+        },
+
     });
 
     return Cesium3DTileStyle;

--- a/Source/Scene/Cesium3DTileStyle.js
+++ b/Source/Scene/Cesium3DTileStyle.js
@@ -62,6 +62,7 @@ define([
         styleJson = defaultValue(styleJson, defaultValue.EMPTY_OBJECT);
         var colorExpression = defaultValue(styleJson.color, DEFAULT_JSON_COLOR_EXPRESSION);
         var showExpression = defaultValue(styleJson.show, DEFAULT_JSON_BOOLEAN_EXPRESSION);
+        var metaJson = defaultValue(styleJson.meta, defaultValue.EMPTY_OBJECT);
 
         var styleEngine = tileset.styleEngine;
 
@@ -84,16 +85,13 @@ define([
         that._show = show;
 
         var meta = {};
-        var metaJson = styleJson.meta;
-        if(defined(metaJson)) {
-            for (var property in metaJson) {
-                if (metaJson.hasOwnProperty(property)) {
-                    meta[property] = new Expression(styleEngine, metaJson[property]);
-                }
+        for (var property in metaJson) {
+            if (metaJson.hasOwnProperty(property)) {
+                meta[property] = new Expression(styleEngine, metaJson[property]);
             }
         }
 
-        that.meta = meta;
+        that._meta = meta;
 
         that._ready = true;
     }

--- a/Source/Scene/Cesium3DTileStyle.js
+++ b/Source/Scene/Cesium3DTileStyle.js
@@ -84,12 +84,11 @@ define([
         that._show = show;
 
         var meta = {};
-        var json = styleJson.meta;
-        if(defined(json)) {
-            for (var property in json) {
-                if (json.hasOwnProperty(property)) {
-                    var exp = json[property];
-                    meta[property] = new Expression(styleEngine, exp);
+        var metaJson = styleJson.meta;
+        if(defined(metaJson)) {
+            for (var property in metaJson) {
+                if (metaJson.hasOwnProperty(property)) {
+                    meta[property] = new Expression(styleEngine, metaJson[property]);
                 }
             }
         }

--- a/Source/Scene/Cesium3DTileStyle.js
+++ b/Source/Scene/Cesium3DTileStyle.js
@@ -62,7 +62,6 @@ define([
         styleJson = defaultValue(styleJson, defaultValue.EMPTY_OBJECT);
         var colorExpression = defaultValue(styleJson.color, DEFAULT_JSON_COLOR_EXPRESSION);
         var showExpression = defaultValue(styleJson.show, DEFAULT_JSON_BOOLEAN_EXPRESSION);
-        var metaJson = defaultValue(styleJson.meta, defaultValue.EMPTY_OBJECT);
 
         var styleEngine = tileset.styleEngine;
 
@@ -85,9 +84,12 @@ define([
         that._show = show;
 
         var meta = {};
-        for (var property in metaJson) {
-            if (metaJson.hasOwnProperty(property)) {
-                meta[property] = new Expression(styleEngine, metaJson[property]);
+        if (defined(styleJson.meta)) {
+            var metaJson = defaultValue(styleJson.meta, defaultValue.EMPTY_OBJECT);
+            for (var property in metaJson) {
+                if (metaJson.hasOwnProperty(property)) {
+                    meta[property] = new Expression(styleEngine, metaJson[property]);
+                }
             }
         }
 

--- a/Specs/Scene/Cesium3DTileStyleSpec.js
+++ b/Specs/Scene/Cesium3DTileStyleSpec.js
@@ -269,9 +269,6 @@ defineSuite([
 
         style = new Cesium3DTileStyle(tileset, { meta: {} });
         expect(style.meta).toEqual({});
-
-        style = new Cesium3DTileStyle(tileset, { meta: 1 });
-        expect(style.meta).toEqual(undefined);
     });
 
     it ('throws on accessing meta if not ready', function() {

--- a/Specs/Scene/Cesium3DTileStyleSpec.js
+++ b/Specs/Scene/Cesium3DTileStyleSpec.js
@@ -43,6 +43,8 @@ defineSuite([
     feature1.addProperty('blue', 82);
     feature1.addProperty('volume', 128);
     feature1.addProperty('Height', 100);
+    feature1.addProperty('Width', 20);
+    feature1.addProperty('Depth', 20);
     feature1.addProperty('id', 11);
     feature1.addProperty('name', 'Hello');
 
@@ -229,14 +231,22 @@ defineSuite([
     it ('sets meta properties', function() {
         var styleEngine = new MockStyleEngine();
         var tileset = new MockTileset(styleEngine);
-        var jsonExp = {
+
+        var style = new Cesium3DTileStyle(tileset, {
             meta : {
                 description : '"Hello, ${name}"'
             }
-        };
-
-        var style = new Cesium3DTileStyle(tileset, jsonExp);
+        });
         expect(style.meta.description.evaluate(feature1)).toEqual("Hello, Hello");
+
+        style = new Cesium3DTileStyle(tileset, {
+            meta : {
+                featureColor : 'rgb(${red}, ${green}, ${blue})',
+                volume : '${Height} * ${Width} * ${Depth}'
+            }
+        });
+        expect(style.meta.featureColor.evaluate(feature1)).toEqual(Color.fromBytes(38, 255, 82));
+        expect(style.meta.volume.evaluate(feature1)).toEqual(20 * 20 * 100);
     });
 
     it ('default meta has no properties', function() {
@@ -261,7 +271,7 @@ defineSuite([
         expect(style.meta).toEqual({});
 
         style = new Cesium3DTileStyle(tileset, { meta: 1 });
-        expect(style.meta).toEqual({});
+        expect(style.meta).toEqual(undefined);
     });
 
     it ('throws on accessing meta if not ready', function() {

--- a/Specs/Scene/Cesium3DTileStyleSpec.js
+++ b/Specs/Scene/Cesium3DTileStyleSpec.js
@@ -44,6 +44,7 @@ defineSuite([
     feature1.addProperty('volume', 128);
     feature1.addProperty('Height', 100);
     feature1.addProperty('id', 11);
+    feature1.addProperty('name', 'Hello');
 
     var feature2 = new MockFeature();
     feature2.addProperty('ZipCode', '19342');
@@ -213,7 +214,7 @@ defineSuite([
         }).toThrowDeveloperError();
     });
 
-    it ('throws on accessing color if not ready', function() {
+    it ('throws on accessing show if not ready', function() {
         var styleEngine = new MockStyleEngine();
         var tileset = new MockTileset(styleEngine);
 
@@ -225,6 +226,55 @@ defineSuite([
         }).toThrowDeveloperError();
     });
 
+    it ('sets meta properties', function() {
+        var styleEngine = new MockStyleEngine();
+        var tileset = new MockTileset(styleEngine);
+        var jsonExp = {
+            meta : {
+                description : '"Hello, ${name}"'
+            }
+        };
+
+        var style = new Cesium3DTileStyle(tileset, jsonExp);
+        expect(style.meta.description.evaluate(feature1)).toEqual("Hello, Hello");
+    });
+
+    it ('default meta has no properties', function() {
+        var styleEngine = new MockStyleEngine();
+        var tileset = new MockTileset(styleEngine);
+
+        var style = new Cesium3DTileStyle(tileset, {});
+        expect(style.meta).toEqual({});
+
+        style = new Cesium3DTileStyle(tileset, { meta: {} });
+        expect(style.meta).toEqual({});
+    });
+
+    it ('default meta has no properties', function() {
+        var styleEngine = new MockStyleEngine();
+        var tileset = new MockTileset(styleEngine);
+
+        var style = new Cesium3DTileStyle(tileset, {});
+        expect(style.meta).toEqual({});
+
+        style = new Cesium3DTileStyle(tileset, { meta: {} });
+        expect(style.meta).toEqual({});
+
+        style = new Cesium3DTileStyle(tileset, { meta: 1 });
+        expect(style.meta).toEqual({});
+    });
+
+    it ('throws on accessing meta if not ready', function() {
+        var styleEngine = new MockStyleEngine();
+        var tileset = new MockTileset(styleEngine);
+
+        var style = new Cesium3DTileStyle(tileset, {});
+        style._ready = false;
+
+        expect(function() {
+            return style.meta;
+        }).toThrowDeveloperError();
+    });
 
     // Tests for examples from the style spec
 


### PR DESCRIPTION
Added `meta` property to `Cesium3DTileStyle` to evaluate non-visual properties.

ex.
```
"style" : {
    "meta" : {
        "description" : "Hello, ${FeatureName}"
    }
}
```

```
var str = style.meta.description.evaluate(feature);
```

If meta is not supplied, or something other than the meta properties are supplied, (such as "meta" : 1), `meta` defaults to `{}`.

Added tests and updated sandcastle example.