### PR TITLE
Added operator overloads for RegExp

### DIFF
--- a/Source/Scene/Expression.js
+++ b/Source/Scene/Expression.js
@@ -16,7 +16,7 @@ define([
     "use strict";
 
     var unaryOperators = ['!', '-', '+'];
-    var binaryOperators = ['+', '-', '*', '/', '%', '===', '!==', '>', '>=', '<', '<=', '&&', '||'];
+    var binaryOperators = ['+', '-', '*', '/', '%', '===', '!==', '>', '>=', '<', '<=', '&&', '||', '!~', '=~'];
 
     var variableRegex = /\${(.*?)}/g;
     var backslashRegex = /\\/g;
@@ -39,6 +39,10 @@ define([
         //>>includeEnd('debug');
 
         expression = replaceVariables(removeBackslashes(expression));
+
+        // customize jsep operators
+        jsep.addBinaryOp("=~", 0);
+        jsep.addBinaryOp("!~", 0);
 
         var ast;
         try {
@@ -434,6 +438,10 @@ define([
                 node.evaluate = node._evaluateAnd;
             } else if (node._value === '||') {
                 node.evaluate = node._evaluateOr;
+            } else if (node._value === '=~') {
+                node.evaluate = node._evaluateRegExpMatch;
+            } else if (node._value === '!~') {
+                node.evaluate = node._evaluateRegExpNotMatch;
             }
         } else if (node._type === ExpressionNodeType.UNARY) {
             if (node._value === '!') {
@@ -724,6 +732,8 @@ define([
         var right = this._right.evaluate(feature, result);
         if ((right instanceof Color) && (left instanceof Color)) {
             return Color.equals(left, right);
+        } else if ((right instanceof RegExp) && (left instanceof RegExp)) {
+            return left.toString() === right.toString();
         }
         return left === right;
     };
@@ -785,6 +795,30 @@ define([
 
     Node.prototype._evaluateRegExpTest = function(feature, result) {
         return this._left.evaluate(feature, result).test(this._right.evaluate(feature, result));
+    };
+
+    Node.prototype._evaluateRegExpMatch = function(feature, result) {
+        var left = this._left.evaluate(feature, result);
+        var right = this._right.evaluate(feature, result);
+        if (left instanceof RegExp) {
+            return left.test(right);
+        } else if (right instanceof RegExp) {
+            return right.test(left);
+        } else {
+            return false;
+        }
+    };
+
+    Node.prototype._evaluateRegExpNotMatch = function(feature, result) {
+        var left = this._left.evaluate(feature, result);
+        var right = this._right.evaluate(feature, result);
+        if (left instanceof RegExp) {
+            return !(left.test(right));
+        } else if (right instanceof RegExp) {
+            return !(right.test(left));
+        } else {
+            return false;
+        }
     };
 
     Node.prototype._evaluateRegExpExec = function(feature, result) {

--- a/Source/Scene/Expression.js
+++ b/Source/Scene/Expression.js
@@ -732,8 +732,6 @@ define([
         var right = this._right.evaluate(feature, result);
         if ((right instanceof Color) && (left instanceof Color)) {
             return Color.equals(left, right);
-        } else if ((right instanceof RegExp) && (left instanceof RegExp)) {
-            return left.toString() === right.toString();
         }
         return left === right;
     };

--- a/Specs/Scene/ExpressionSpec.js
+++ b/Specs/Scene/ExpressionSpec.js
@@ -1060,6 +1060,84 @@ defineSuite([
         expect(expression.evaluate(feature)).toEqual('1');
     });
 
+    it('evaluates regex match operator', function() {
+        var feature = new MockFeature();
+        feature.addProperty('property', 'abc');
+
+        var expression = new Expression(new MockStyleEngine(), 'regExp("a") =~ "abc"');
+        expect(expression.evaluate(undefined)).toEqual(true);
+
+        expression = new Expression(new MockStyleEngine(), '"abc" =~ regExp("a")');
+        expect(expression.evaluate(undefined)).toEqual(true);
+
+        expression = new Expression(new MockStyleEngine(), 'regExp("a") =~ "bcd"');
+        expect(expression.evaluate(undefined)).toEqual(false);
+
+        expression = new Expression(new MockStyleEngine(), '"bcd" =~ regExp("a")');
+        expect(expression.evaluate(undefined)).toEqual(false);
+
+        expression = new Expression(new MockStyleEngine(), 'regExp("quick\\s(brown).+?(jumps)", "ig") =~ "The Quick Brown Fox Jumps Over The Lazy Dog"');
+        expect(expression.evaluate(undefined)).toEqual(true);
+
+        expression = new Expression(new MockStyleEngine(), 'regExp("a") =~ 1');
+        expect(expression.evaluate(undefined)).toEqual(false);
+
+        expression = new Expression(new MockStyleEngine(), '1 =~ regExp("a")');
+        expect(expression.evaluate(undefined)).toEqual(false);
+
+        expression = new Expression(new MockStyleEngine(), '1 =~ 1');
+        expect(expression.evaluate(undefined)).toEqual(false);
+
+        expression = new Expression(new MockStyleEngine(), 'regExp(${property}) =~ ${property}');
+        expect(expression.evaluate(feature)).toEqual(true);
+    });
+
+    it('evaluates regex not match operator', function() {
+        var feature = new MockFeature();
+        feature.addProperty('property', 'abc');
+
+        var expression = new Expression(new MockStyleEngine(), 'regExp("a") !~ "abc"');
+        expect(expression.evaluate(undefined)).toEqual(false);
+
+        expression = new Expression(new MockStyleEngine(), '"abc" !~ regExp("a")');
+        expect(expression.evaluate(undefined)).toEqual(false);
+
+        expression = new Expression(new MockStyleEngine(), 'regExp("a") !~ "bcd"');
+        expect(expression.evaluate(undefined)).toEqual(true);
+
+        expression = new Expression(new MockStyleEngine(), '"bcd" !~ regExp("a")');
+        expect(expression.evaluate(undefined)).toEqual(true);
+
+        expression = new Expression(new MockStyleEngine(), 'regExp("quick\\s(brown).+?(jumps)", "ig") !~ "The Quick Brown Fox Jumps Over The Lazy Dog"');
+        expect(expression.evaluate(undefined)).toEqual(false);
+
+        expression = new Expression(new MockStyleEngine(), 'regExp("a") !~ 1');
+        expect(expression.evaluate(undefined)).toEqual(true);
+
+        expression = new Expression(new MockStyleEngine(), '1 !~ regExp("a")');
+        expect(expression.evaluate(undefined)).toEqual(true);
+
+        expression = new Expression(new MockStyleEngine(), '1 !~ 1');
+        expect(expression.evaluate(undefined)).toEqual(false);
+
+        expression = new Expression(new MockStyleEngine(), 'regExp(${property}) !~ ${property}');
+        expect(expression.evaluate(feature)).toEqual(false);
+    });
+
+    it('evaluates regex equals operator', function() {
+        var feature = new MockFeature();
+        feature.addProperty('property', 'abc');
+
+        var expression = new Expression(new MockStyleEngine(), 'regExp("a") === regExp("a")');
+        expect(expression.evaluate(undefined)).toEqual(true);
+
+        expression = new Expression(new MockStyleEngine(), 'regExp("a") === regExp("b")');
+        expect(expression.evaluate(undefined)).toEqual(false);
+
+        expression = new Expression(new MockStyleEngine(), 'regExp("a") === "a"');
+        expect(expression.evaluate(undefined)).toEqual(false);
+    });
+
     it('throws if test is not call with a RegExp', function() {
         expect(function() {
             return new Expression(new MockStyleEngine(), 'color("blue").test()');

--- a/Specs/Scene/ExpressionSpec.js
+++ b/Specs/Scene/ExpressionSpec.js
@@ -1124,20 +1124,6 @@ defineSuite([
         expect(expression.evaluate(feature)).toEqual(false);
     });
 
-    it('evaluates regex equals operator', function() {
-        var feature = new MockFeature();
-        feature.addProperty('property', 'abc');
-
-        var expression = new Expression(new MockStyleEngine(), 'regExp("a") === regExp("a")');
-        expect(expression.evaluate(undefined)).toEqual(true);
-
-        expression = new Expression(new MockStyleEngine(), 'regExp("a") === regExp("b")');
-        expect(expression.evaluate(undefined)).toEqual(false);
-
-        expression = new Expression(new MockStyleEngine(), 'regExp("a") === "a"');
-        expect(expression.evaluate(undefined)).toEqual(false);
-    });
-
     it('throws if test is not call with a RegExp', function() {
         expect(function() {
             return new Expression(new MockStyleEngine(), 'color("blue").test()');


### PR DESCRIPTION
Added the `=~` and `!=` operators.

`=~` is treated as `RegExp.test()` and is communicative. If neither side of the expression is a `RegExp`, `false` is returned.

`!~` is treated as `!(RegExp.test())` and is communicative. If neither side of the expression is a `RegExp`, `false` is returned.

I also overloaded the `===` operator if both sides of the Expression are of the type `RegExp`. In that case, we return true if both the `RegExp.toString()`'s are the same. If only one side is a `RegExp`, it uses default JavaScript behavior.

Added tests for each of the new operators.