### PR TITLE
Pass tileset version on tile requests

### DIFF
--- a/Source/Scene/Cesium3DTileset.js
+++ b/Source/Scene/Cesium3DTileset.js
@@ -423,6 +423,10 @@ define([
 
             // Append the version to the baseUrl
             var versionQuery = '?v=' + tilesetJson.asset.version;
+            var tilesetVersion = tilesetJson.asset.tilesetVersion;
+            if (defined(tilesetVersion)) {
+                versionQuery += '&tilesetVersion=' + tilesetVersion;
+            }
             that._baseUrl = joinUrls(that._baseUrl, versionQuery);
 
             // A tileset.json referenced from a tile may exist in a different directory than the root tileset.

--- a/Source/Scene/Cesium3DTileset.js
+++ b/Source/Scene/Cesium3DTileset.js
@@ -422,11 +422,7 @@ define([
             }
 
             // Append the version to the baseUrl
-            var versionQuery = '?v=' + tilesetJson.asset.version;
-            var tilesetVersion = tilesetJson.asset.tilesetVersion;
-            if (defined(tilesetVersion)) {
-                versionQuery += '&tilesetVersion=' + tilesetVersion;
-            }
+            var versionQuery = '?v=' + defaultValue(tilesetJson.asset.tilesetVersion, '0.0');
             that._baseUrl = joinUrls(that._baseUrl, versionQuery);
 
             // A tileset.json referenced from a tile may exist in a different directory than the root tileset.

--- a/Specs/Scene/Cesium3DTilesetSpec.js
+++ b/Specs/Scene/Cesium3DTilesetSpec.js
@@ -204,7 +204,7 @@ defineSuite([
 
     it('passes version in query string to tiles', function() {
         return Cesium3DTilesTester.loadTileset(scene, tilesetUrl).then(function(tileset) {
-            expect(tileset._root.content._url).toEqual(tilesetUrl + 'parent.b3dm?v=0.0&tilesetVersion=1.2.3');
+            expect(tileset._root.content._url).toEqual(tilesetUrl + 'parent.b3dm?v=1.2.3');
         });
     });
 

--- a/Specs/Scene/Cesium3DTilesetSpec.js
+++ b/Specs/Scene/Cesium3DTilesetSpec.js
@@ -204,7 +204,7 @@ defineSuite([
 
     it('passes version in query string to tiles', function() {
         return Cesium3DTilesTester.loadTileset(scene, tilesetUrl).then(function(tileset) {
-            expect(tileset._root.content._url).toEqual(tilesetUrl + 'parent.b3dm?v=0.0');
+            expect(tileset._root.content._url).toEqual(tilesetUrl + 'parent.b3dm?v=0.0&tilesetVersion=1.2.3');
         });
     });
 


### PR DESCRIPTION
The spec version doesn't really need to be sent to get the tile. This will help with caching issues when a tileset is upgraded instead of manually having to do it in your app.