### PR TITLE
Fix gzip compression settings.

### DIFF
--- a/server.js
+++ b/server.js
@@ -48,23 +48,13 @@
 
     var app = express();
     app.use(compression());
-    app.get('*.b3dm', function(req, res, next) {
-        res.header('Content-Encoding', 'gzip');
-        next();
-    });
-    app.get('*.pnts', function(req, res, next) {
-        res.header('Content-Encoding', 'gzip');
-        next();
-    });
-    app.get('*.i3dm', function(req, res, next) {
-        res.header('Content-Encoding', 'gzip');
-        next();
-    });
-    app.get('*.cmpt', function(req, res, next) {
-        res.header('Content-Encoding', 'gzip');
-        next();
-    });
-    app.use(express.static(__dirname));
+    app.use(express.static(__dirname, {
+        setHeaders : function(res, url) {
+            if (/(b3dm|pnts|i3dm|cmpt)$/.test(url)) {
+                res.header('Content-Encoding', 'gzip');
+            }
+        }
+    }));
 
     function getRemoteUrlFromParam(req) {
         var remoteUrl = req.params[0];


### PR DESCRIPTION
The server was blindly adding `Content-Encoding=gzip` too all requests for b3dm files. When the request was for a non-existent tile, the 404 message would also be marked as gzip, causing the browser to fail decoding it (different browsers have different behavior in this case).

The correct solution is to use the `setHeaders` callback as part of express static serving, which will only get called to set the headers when the file actually exists.

Fixes #3694