### PR TITLE
Fix billboard aligned axis

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@ Change Log
 * `GroundPrimitive` throws a `DeveloperError` when passed an unsupported geometry type instead of crashing.
 * `GeoJsonDataSource` now handles CRS `urn:ogc:def:crs:EPSG::4326`
 * Fixed loading for KML `NetworkLink` to not append a `?` if there isn't a query string.
+* Fix issue with billboard collections that have at least one billboard with an aligned axis and at least one billboard without an aligned axis. [#3318](https://github.com/AnalyticalGraphicsInc/cesium/issues/3318)
 
 ### 1.19 - 2016-03-01
 

--- a/Source/Shaders/BillboardCollectionVS.glsl
+++ b/Source/Shaders/BillboardCollectionVS.glsl
@@ -5,7 +5,7 @@ attribute vec4 positionHighAndScale;
 attribute vec4 positionLowAndRotation;   
 attribute vec4 compressedAttribute0;        // pixel offset, translate, horizontal origin, vertical origin, show, direction, texture coordinates (texture offset)
 attribute vec4 compressedAttribute1;        // aligned axis, translucency by distance, image width
-attribute vec4 compressedAttribute2;        // image height, color, pick color, 15 bits free
+attribute vec4 compressedAttribute2;        // image height, color, pick color, size in meters, valid aligned axis, 13 bits free
 attribute vec4 eyeOffset;                   // eye offset in meters, 4 bytes free (texture range)
 attribute vec4 scaleByDistance;             // near, nearScale, far, farScale
 attribute vec4 pixelOffsetScaleByDistance;  // near, nearScale, far, farScale
@@ -35,7 +35,7 @@ const float SHIFT_RIGHT3 = 1.0 / 8.0;
 const float SHIFT_RIGHT2 = 1.0 / 4.0;
 const float SHIFT_RIGHT1 = 1.0 / 2.0;
 
-vec4 computePositionWindowCoordinates(vec4 positionEC, vec2 imageSize, float scale, vec2 direction, vec2 origin, vec2 translate, vec2 pixelOffset, vec3 alignedAxis, float rotation, bool sizeInMeters)
+vec4 computePositionWindowCoordinates(vec4 positionEC, vec2 imageSize, float scale, vec2 direction, vec2 origin, vec2 translate, vec2 pixelOffset, vec3 alignedAxis, bool validAlignedAxis, float rotation, bool sizeInMeters)
 {
     vec2 halfSize = imageSize * scale * czm_resolutionScale;
     halfSize *= ((direction * 2.0) - 1.0);
@@ -57,10 +57,10 @@ vec4 computePositionWindowCoordinates(vec4 positionEC, vec2 imageSize, float sca
     }
     
 #if defined(ROTATION) || defined(ALIGNED_AXIS)
-    if (!all(equal(alignedAxis, vec3(0.0))) || rotation != 0.0)
+    if (validAlignedAxis || rotation != 0.0)
     {
         float angle = rotation;
-        if (!all(equal(alignedAxis, vec3(0.0))))
+        if (validAlignedAxis)
         {
             vec3 pos = positionEC.xyz + czm_encodedCameraPositionMCHigh + czm_encodedCameraPositionMCLow;
             vec3 normal = normalize(cross(alignedAxis, pos));
@@ -162,8 +162,11 @@ void main()
 
 #ifdef ALIGNED_AXIS
     vec3 alignedAxis = czm_octDecode(floor(compressedAttribute1.y * SHIFT_RIGHT8));
+    temp = compressedAttribute2.z * SHIFT_RIGHT5;
+    bool validAlignedAxis = (temp - floor(temp)) * SHIFT_LEFT1 > 0.0;
 #else
     vec3 alignedAxis = vec3(0.0);
+    bool validAlignedAxis = false;
 #endif
     
 #ifdef RENDER_FOR_PICK
@@ -180,7 +183,7 @@ void main()
     color.r = floor(temp);
     
     temp = compressedAttribute2.z * SHIFT_RIGHT8;
-    bool sizeInMeters = (temp - floor(temp)) * SHIFT_LEFT8 > 0.0;
+    bool sizeInMeters = floor((temp - floor(temp)) * SHIFT_LEFT7) > 0.0;
     temp = floor(temp) * SHIFT_RIGHT8;
     
 #ifdef RENDER_FOR_PICK
@@ -246,7 +249,7 @@ void main()
     origin.y = 1.0;
 #endif
 
-    vec4 positionWC = computePositionWindowCoordinates(positionEC, imageSize, scale, direction, origin, translate, pixelOffset, alignedAxis, rotation, sizeInMeters);
+    vec4 positionWC = computePositionWindowCoordinates(positionEC, imageSize, scale, direction, origin, translate, pixelOffset, alignedAxis, validAlignedAxis, rotation, sizeInMeters);
     gl_Position = czm_viewportOrthographic * vec4(positionWC.xy, -positionWC.z, 1.0);
     v_textureCoordinates = textureCoordinates;
 


### PR DESCRIPTION
For #3318.

Fix billboard collection that has at least one billboard with an aligned axis and at least one billboard without an aligned axis. Adds a bit to a compressed attribute for valid aligned axes since zero is a valid encoded unit vector.