### PR TITLE
Polyline geometry split at the IDL

### DIFF
--- a/Source/Core/GeometryPipeline.js
+++ b/Source/Core/GeometryPipeline.js
@@ -2183,7 +2183,7 @@ define([
     var cartesian4Scratch0 = new Cartesian4();
 
     var offsetScalar = 5.0 * CesiumMath.EPSILON9;
-    var coplanarOffset = CesiumMath.EPSILON1;
+    var coplanarOffset = CesiumMath.EPSILON6;
 
     function splitLongitudePolyline(instance) {
         var geometry = instance.geometry;

--- a/Source/Core/GeometryPipeline.js
+++ b/Source/Core/GeometryPipeline.js
@@ -2211,47 +2211,27 @@ define([
             var p0 = Cartesian3.fromArray(positions, i0 * 3, cartesian3Scratch0);
             var p2 = Cartesian3.fromArray(positions, i2 * 3, cartesian3Scratch2);
 
+            // Offset points that are close to the 180 longitude and change the previous/next point
+            // to be the same offset point so it can be projected to 2D. There is special handling in the
+            // shader for when position == prevPosition || position == nextPosition.
             if (Math.abs(p0.y) < coplanarOffset) {
-                if (p2.y < 0.0) {
-                    p0.y = -coplanarOffset;
+                p0.y = coplanarOffset * (p2.y < 0.0 ? -1.0 : 1.0);
+                positions[i * 3 + 1] = p0.y;
+                positions[(i + 1) * 3 + 1] = p0.y;
 
-                    positions[i * 3 + 1] = p0.y;
-                    positions[(i + 1) * 3 + 1] = p0.y;
-
-                    for (j = i0 * 3; j < i0 * 3 + 4 * 3; ++j) {
-                        prevPositions[j] = positions[j];
-                    }
-                } else {
-                    p0.y = coplanarOffset;
-
-                    positions[i * 3 + 1] = p0.y;
-                    positions[(i + 1) * 3 + 1] = p0.y;
-
-                    for (j = i0 * 3; j < i0 * 3 + 4 * 3; ++j) {
-                        nextPositions[j] = positions[j];
-                    }
+                for (j = i0 * 3; j < i0 * 3 + 4 * 3; ++j) {
+                    prevPositions[j] = positions[j];
                 }
             }
 
+            // Do the same but for when the line crosses 180 longitude in the opposite direction.
             if (Math.abs(p2.y) < coplanarOffset) {
-                if (p0.y < 0.0) {
-                    p2.y = coplanarOffset;
+                p2.y = coplanarOffset * (p0.y < 0.0 ? -1.0 : 1.0);
+                positions[(i + 2) * 3 + 1] = p2.y;
+                positions[(i + 3) * 3 + 1] = p2.y;
 
-                    positions[(i + 2) * 3 + 1] = p2.y;
-                    positions[(i + 3) * 3 + 1] = p2.y;
-
-                    for (j = i0 * 3; j < i0 * 3 + 4 * 3; ++j) {
-                        nextPositions[j] = positions[j];
-                    }
-                } else {
-                    p2.y = -coplanarOffset;
-
-                    positions[(i + 2) * 3 + 1] = p2.y;
-                    positions[(i + 3) * 3 + 1] = p2.y;
-
-                    for (j = i0 * 3; j < i0 * 3 + 4 * 3; ++j) {
-                        prevPositions[j] = positions[j];
-                    }
+                for (j = i0 * 3; j < i0 * 3 + 4 * 3; ++j) {
+                    nextPositions[j] = positions[j];
                 }
             }
 
@@ -2277,9 +2257,8 @@ define([
                 p0Attributes.position.values.push(offsetPoint.x, offsetPoint.y, offsetPoint.z);
                 p0Attributes.position.values.push(offsetPoint.x, offsetPoint.y, offsetPoint.z);
 
-                for (j = i0 * 3; j < i0 * 3 + 2 * 3; ++j) {
-                    p0Attributes.prevPosition.values.push(prevPositions[j]);
-                }
+                p0Attributes.prevPosition.values.push(prevPositions[i0 * 3], prevPositions[i0 * 3 + 1], prevPositions[i0 * 3 + 2]);
+                p0Attributes.prevPosition.values.push(prevPositions[i0 * 3 + 3], prevPositions[i0 * 3 + 4], prevPositions[i0 * 3 + 5]);
                 p0Attributes.prevPosition.values.push(p0.x, p0.y, p0.z, p0.x, p0.y, p0.z);
 
                 p0Attributes.nextPosition.values.push(offsetPoint.x, offsetPoint.y, offsetPoint.z);
@@ -2299,9 +2278,8 @@ define([
                 p2Attributes.prevPosition.values.push(offsetPoint.x, offsetPoint.y, offsetPoint.z);
 
                 p2Attributes.nextPosition.values.push(p2.x, p2.y, p2.z, p2.x, p2.y, p2.z);
-                for (j = i2 * 3; j < i2 * 3 + 2 * 3; ++j) {
-                    p2Attributes.nextPosition.values.push(nextPositions[j]);
-                }
+                p2Attributes.nextPosition.values.push(nextPositions[i2 * 3], nextPositions[i2 * 3 + 1], nextPositions[i2 * 3 + 2]);
+                p2Attributes.nextPosition.values.push(nextPositions[i2 * 3 + 3], nextPositions[i2 * 3 + 4], nextPositions[i2 * 3 + 5]);
 
                 var ew0 = Cartesian2.fromArray(expandAndWidths, i0 * 2, cartesian2Scratch0);
                 var width = Math.abs(ew0.y);

--- a/Source/Core/GeometryPipeline.js
+++ b/Source/Core/GeometryPipeline.js
@@ -2174,7 +2174,6 @@ define([
     var cartesian2Scratch1 = new Cartesian2();
 
     var cartesian3Scratch0 = new Cartesian3();
-    var cartesian3Scratch1 = new Cartesian3();
     var cartesian3Scratch2 = new Cartesian3();
     var cartesian3Scratch3 = new Cartesian3();
     var cartesian3Scratch4 = new Cartesian3();
@@ -2182,6 +2181,9 @@ define([
     var cartesian3Scratch6 = new Cartesian3();
 
     var cartesian4Scratch0 = new Cartesian4();
+
+    var offsetScalar = 5.0 * CesiumMath.EPSILON9;
+    var coplanarOffset = CesiumMath.EPSILON1;
 
     function splitLongitudePolyline(instance) {
         var geometry = instance.geometry;
@@ -2204,23 +2206,53 @@ define([
         var length = positions.length / 3;
         for (i = 0; i < length; i += 4) {
             var i0 = i;
-            var i1 = i + 1;
             var i2 = i + 2;
-            var i3 = i + 3;
 
             var p0 = Cartesian3.fromArray(positions, i0 * 3, cartesian3Scratch0);
-            var p1 = Cartesian3.fromArray(positions, i1 * 3, cartesian3Scratch1);
             var p2 = Cartesian3.fromArray(positions, i2 * 3, cartesian3Scratch2);
-            var p3 = Cartesian3.fromArray(positions, i3 * 3, cartesian3Scratch3);
 
-            if (Math.abs(p0.y) < CesiumMath.EPSILON6) {
-                p0.y = CesiumMath.EPSILON6 * (p2.y < 0.0 ? -1.0 : 1.0);
-                p1.y = p0.y;
+            if (Math.abs(p0.y) < coplanarOffset) {
+                if (p2.y < 0.0) {
+                    p0.y = -coplanarOffset;
+
+                    positions[i * 3 + 1] = p0.y;
+                    positions[(i + 1) * 3 + 1] = p0.y;
+
+                    for (j = i0 * 3; j < i0 * 3 + 4 * 3; ++j) {
+                        prevPositions[j] = positions[j];
+                    }
+                } else {
+                    p0.y = coplanarOffset;
+
+                    positions[i * 3 + 1] = p0.y;
+                    positions[(i + 1) * 3 + 1] = p0.y;
+
+                    for (j = i0 * 3; j < i0 * 3 + 4 * 3; ++j) {
+                        nextPositions[j] = positions[j];
+                    }
+                }
             }
 
-            if (Math.abs(p2.y) < CesiumMath.EPSILON6) {
-                p2.y = CesiumMath.EPSILON6 * (p0.y < 0.0 ? -1.0 : 1.0);
-                p3.y = p2.y;
+            if (Math.abs(p2.y) < coplanarOffset) {
+                if (p0.y < 0.0) {
+                    p2.y = coplanarOffset;
+
+                    positions[(i + 2) * 3 + 1] = p2.y;
+                    positions[(i + 3) * 3 + 1] = p2.y;
+
+                    for (j = i0 * 3; j < i0 * 3 + 4 * 3; ++j) {
+                        nextPositions[j] = positions[j];
+                    }
+                } else {
+                    p2.y = -coplanarOffset;
+
+                    positions[(i + 2) * 3 + 1] = p2.y;
+                    positions[(i + 3) * 3 + 1] = p2.y;
+
+                    for (j = i0 * 3; j < i0 * 3 + 4 * 3; ++j) {
+                        prevPositions[j] = positions[j];
+                    }
+                }
             }
 
             var p0Attributes = eastGeometry.attributes;
@@ -2231,7 +2263,7 @@ define([
             var intersection = IntersectionTests.lineSegmentPlane(p0, p2, xzPlane, cartesian3Scratch4);
             if (defined(intersection)) {
                 // move point on the xz-plane slightly away from the plane
-                var offset = Cartesian3.multiplyByScalar(Cartesian3.UNIT_Y, 5.0 * CesiumMath.EPSILON9, cartesian3Scratch5);
+                var offset = Cartesian3.multiplyByScalar(Cartesian3.UNIT_Y, offsetScalar, cartesian3Scratch5);
                 if (p0.y < 0.0) {
                     Cartesian3.negate(offset, offset);
                     p0Attributes = westGeometry.attributes;
@@ -2241,29 +2273,31 @@ define([
                 }
 
                 var offsetPoint = Cartesian3.add(intersection, offset, cartesian3Scratch6);
-                p0Attributes.position.values.push(p0.x, p0.y, p0.z, p1.x, p1.y, p1.z);
+                p0Attributes.position.values.push(p0.x, p0.y, p0.z, p0.x, p0.y, p0.z);
                 p0Attributes.position.values.push(offsetPoint.x, offsetPoint.y, offsetPoint.z);
                 p0Attributes.position.values.push(offsetPoint.x, offsetPoint.y, offsetPoint.z);
-
-                Cartesian3.negate(offset, offset);
-                Cartesian3.add(intersection, offset, offsetPoint);
-                p2Attributes.position.values.push(offsetPoint.x, offsetPoint.y, offsetPoint.z);
-                p2Attributes.position.values.push(offsetPoint.x, offsetPoint.y, offsetPoint.z);
-                p2Attributes.position.values.push(p2.x, p2.y, p2.z, p3.x, p3.y, p3.z);
 
                 for (j = i0 * 3; j < i0 * 3 + 2 * 3; ++j) {
                     p0Attributes.prevPosition.values.push(prevPositions[j]);
                 }
                 p0Attributes.prevPosition.values.push(p0.x, p0.y, p0.z, p0.x, p0.y, p0.z);
-                p2Attributes.prevPosition.values.push(p0.x, p0.y, p0.z, p0.x, p0.y, p0.z);
-                for (j = i2 * 3; j < i2 * 3 + 2 * 3; ++j) {
-                    p2Attributes.prevPosition.values.push(prevPositions[j]);
-                }
 
-                for (j = i0 * 3; j < i0 * 3 + 2 * 3; ++j) {
-                    p0Attributes.nextPosition.values.push(nextPositions[j]);
-                }
-                p0Attributes.nextPosition.values.push(p2.x, p2.y, p2.z, p2.x, p2.y, p2.z);
+                p0Attributes.nextPosition.values.push(offsetPoint.x, offsetPoint.y, offsetPoint.z);
+                p0Attributes.nextPosition.values.push(offsetPoint.x, offsetPoint.y, offsetPoint.z);
+                p0Attributes.nextPosition.values.push(offsetPoint.x, offsetPoint.y, offsetPoint.z);
+                p0Attributes.nextPosition.values.push(offsetPoint.x, offsetPoint.y, offsetPoint.z);
+
+                Cartesian3.negate(offset, offset);
+                Cartesian3.add(intersection, offset, offsetPoint);
+                p2Attributes.position.values.push(offsetPoint.x, offsetPoint.y, offsetPoint.z);
+                p2Attributes.position.values.push(offsetPoint.x, offsetPoint.y, offsetPoint.z);
+                p2Attributes.position.values.push(p2.x, p2.y, p2.z, p2.x, p2.y, p2.z);
+
+                p2Attributes.prevPosition.values.push(offsetPoint.x, offsetPoint.y, offsetPoint.z);
+                p2Attributes.prevPosition.values.push(offsetPoint.x, offsetPoint.y, offsetPoint.z);
+                p2Attributes.prevPosition.values.push(offsetPoint.x, offsetPoint.y, offsetPoint.z);
+                p2Attributes.prevPosition.values.push(offsetPoint.x, offsetPoint.y, offsetPoint.z);
+
                 p2Attributes.nextPosition.values.push(p2.x, p2.y, p2.z, p2.x, p2.y, p2.z);
                 for (j = i2 * 3; j < i2 * 3 + 2 * 3; ++j) {
                     p2Attributes.nextPosition.values.push(nextPositions[j]);
@@ -2339,9 +2373,9 @@ define([
                 }
 
                 currentAttributes.position.values.push(p0.x, p0.y, p0.z);
-                currentAttributes.position.values.push(p1.x, p1.y, p1.z);
+                currentAttributes.position.values.push(p0.x, p0.y, p0.z);
                 currentAttributes.position.values.push(p2.x, p2.y, p2.z);
-                currentAttributes.position.values.push(p3.x, p3.y, p3.z);
+                currentAttributes.position.values.push(p2.x, p2.y, p2.z);
 
                 for (j = i * 3; j < i * 3 + 4 * 3; ++j) {
                     currentAttributes.prevPosition.values.push(prevPositions[j]);

--- a/Source/Core/PolylineGeometry.js
+++ b/Source/Core/PolylineGeometry.js
@@ -297,8 +297,6 @@ define([
         var granularity = polylineGeometry._granularity;
         var ellipsoid = polylineGeometry._ellipsoid;
 
-        var minDistance = CesiumMath.chordLength(granularity, ellipsoid.maximumRadius);
-
         var i;
         var j;
         var k;
@@ -312,6 +310,7 @@ define([
 
         if (followSurface) {
             var heights = PolylinePipeline.extractHeights(positions, ellipsoid);
+            var minDistance = CesiumMath.chordLength(granularity, ellipsoid.maximumRadius);
 
             if (defined(colors)) {
                 var colorLength = 1;

--- a/Source/Shaders/PolylineCommon.glsl
+++ b/Source/Shaders/PolylineCommon.glsl
@@ -59,11 +59,11 @@ vec4 getPolylineWindowCoordinates(vec4 position, vec4 previous, vec4 next, float
     float expandWidth = width * 0.5;
     vec2 direction;
 
-    if (czm_equalsEpsilon(normalize(previous.xyz - position.xyz), vec3(0.0), czm_epsilon1) || czm_equalsEpsilon(prevWC, -nextWC, czm_epsilon1))
+    if (czm_equalsEpsilon(previous.xyz - position.xyz, vec3(0.0), czm_epsilon1) || czm_equalsEpsilon(prevWC, -nextWC, czm_epsilon1))
     {
         direction = vec2(-nextWC.y, nextWC.x);
     }
-    else if (czm_equalsEpsilon(normalize(next.xyz - position.xyz), vec3(0.0), czm_epsilon1) || clipped)
+    else if (czm_equalsEpsilon(next.xyz - position.xyz, vec3(0.0), czm_epsilon1) || clipped)
     {
         direction = vec2(prevWC.y, -prevWC.x);
     }

--- a/Specs/Core/GeometryPipelineSpec.js
+++ b/Specs/Core/GeometryPipelineSpec.js
@@ -2578,140 +2578,279 @@ defineSuite([
         expect(positions).toEqual([1.0, 1.0, 0.0, 1.0, 1.0, 2.0]);
     });
 
-    it('splitLongitude subdivides wide line crossing the international date line', function() {
-        var instance = new GeometryInstance({
-            geometry : new Geometry({
-                attributes : {
-                    position : new GeometryAttribute({
-                        componentDatatype : ComponentDatatype.DOUBLE,
-                        componentsPerAttribute : 3,
-                        values : new Float64Array([-1.0, -1.0, 0.0, -1.0, -1.0, 0.0, -1.0, 1.0, 2.0, -1.0, 1.0, 2.0])
-                    }),
-                    nextPosition : new GeometryAttribute({
-                        componentDatatype : ComponentDatatype.DOUBLE,
-                        componentsPerAttribute : 3,
-                        values : new Float64Array([-1.0, 1.0, 2.0, -1.0, 1.0, 2.0, -1.0, 2.0, 3.0, -1.0, 2.0, 3.0])
-                    }),
-                    prevPosition : new GeometryAttribute({
-                        componentDatatype : ComponentDatatype.DOUBLE,
-                        componentsPerAttribute : 3,
-                        values : new Float64Array([-1.0, -2.0, -1.0, -1.0, -2.0, -1.0, -1.0, -1.0, 0.0, -1.0, -1.0, 0.0])
-                    }),
-                    expandAndWidth : new GeometryAttribute({
-                        componentDatatype : ComponentDatatype.FLOAT,
-                        componentsPerAttribute : 2,
-                        values : new Float32Array([-1.0, 5.0, 1.0, 5.0, -1.0, -5.0, 1.0, -5.0])
-                    })
-                },
-                indices : new Uint16Array([0, 2, 1, 1, 2, 3]),
-                primitiveType : PrimitiveType.TRIANGLES,
-                geometryType : GeometryType.POLYLINES
-            })
+    describe('splitLongitude polylines', function() {
+        it('subdivides wide line crossing the international date line', function() {
+            var instance = new GeometryInstance({
+                geometry : new Geometry({
+                    attributes : {
+                        position : new GeometryAttribute({
+                            componentDatatype : ComponentDatatype.DOUBLE,
+                            componentsPerAttribute : 3,
+                            values : new Float64Array([-1.0, -1.0, 0.0, -1.0, -1.0, 0.0, -1.0, 1.0, 2.0, -1.0, 1.0, 2.0])
+                        }),
+                        nextPosition : new GeometryAttribute({
+                            componentDatatype : ComponentDatatype.DOUBLE,
+                            componentsPerAttribute : 3,
+                            values : new Float64Array([-1.0, 1.0, 2.0, -1.0, 1.0, 2.0, -1.0, 2.0, 3.0, -1.0, 2.0, 3.0])
+                        }),
+                        prevPosition : new GeometryAttribute({
+                            componentDatatype : ComponentDatatype.DOUBLE,
+                            componentsPerAttribute : 3,
+                            values : new Float64Array([-1.0, -2.0, -1.0, -1.0, -2.0, -1.0, -1.0, -1.0, 0.0, -1.0, -1.0, 0.0])
+                        }),
+                        expandAndWidth : new GeometryAttribute({
+                            componentDatatype : ComponentDatatype.FLOAT,
+                            componentsPerAttribute : 2,
+                            values : new Float32Array([-1.0, 5.0, 1.0, 5.0, -1.0, -5.0, 1.0, -5.0])
+                        })
+                    },
+                    indices : new Uint16Array([0, 2, 1, 1, 2, 3]),
+                    primitiveType : PrimitiveType.TRIANGLES,
+                    geometryType : GeometryType.POLYLINES
+                })
+            });
+            GeometryPipeline.splitLongitude(instance);
+            expect(instance.geometry).not.toBeDefined();
+
+            expect(instance.westHemisphereGeometry).toBeDefined();
+            expect(instance.westHemisphereGeometry.indices).toBeDefined();
+            expect(instance.westHemisphereGeometry.indices.length).toEqual(6);
+            expect(instance.westHemisphereGeometry.attributes.position).toBeDefined();
+            expect(instance.westHemisphereGeometry.attributes.position.values.length).toEqual(4 * 3);
+            expect(instance.westHemisphereGeometry.attributes.nextPosition).toBeDefined();
+            expect(instance.westHemisphereGeometry.attributes.nextPosition.values.length).toEqual(4 * 3);
+            expect(instance.westHemisphereGeometry.attributes.prevPosition).toBeDefined();
+            expect(instance.westHemisphereGeometry.attributes.prevPosition.values.length).toEqual(4 * 3);
+            expect(instance.westHemisphereGeometry.attributes.expandAndWidth).toBeDefined();
+            expect(instance.westHemisphereGeometry.attributes.expandAndWidth.values.length).toEqual(4 * 2);
+
+            expect(instance.eastHemisphereGeometry).toBeDefined();
+            expect(instance.eastHemisphereGeometry.indices).toBeDefined();
+            expect(instance.eastHemisphereGeometry.indices.length).toEqual(6);
+            expect(instance.eastHemisphereGeometry.attributes.position).toBeDefined();
+            expect(instance.eastHemisphereGeometry.attributes.position.values.length).toEqual(4 * 3);
+            expect(instance.eastHemisphereGeometry.attributes.nextPosition).toBeDefined();
+            expect(instance.eastHemisphereGeometry.attributes.nextPosition.values.length).toEqual(4 * 3);
+            expect(instance.eastHemisphereGeometry.attributes.prevPosition).toBeDefined();
+            expect(instance.eastHemisphereGeometry.attributes.prevPosition.values.length).toEqual(4 * 3);
+            expect(instance.eastHemisphereGeometry.attributes.expandAndWidth).toBeDefined();
+            expect(instance.eastHemisphereGeometry.attributes.expandAndWidth.values.length).toEqual(4 * 2);
         });
-        GeometryPipeline.splitLongitude(instance);
-        expect(instance.geometry).not.toBeDefined();
 
-        expect(instance.westHemisphereGeometry).toBeDefined();
-        expect(instance.westHemisphereGeometry.indices).toBeDefined();
-        expect(instance.westHemisphereGeometry.indices.length).toEqual(6);
-        expect(instance.westHemisphereGeometry.attributes.position).toBeDefined();
-        expect(instance.westHemisphereGeometry.attributes.position.values.length).toEqual(4 * 3);
-        expect(instance.westHemisphereGeometry.attributes.nextPosition).toBeDefined();
-        expect(instance.westHemisphereGeometry.attributes.nextPosition.values.length).toEqual(4 * 3);
-        expect(instance.westHemisphereGeometry.attributes.prevPosition).toBeDefined();
-        expect(instance.westHemisphereGeometry.attributes.prevPosition.values.length).toEqual(4 * 3);
-        expect(instance.westHemisphereGeometry.attributes.expandAndWidth).toBeDefined();
-        expect(instance.westHemisphereGeometry.attributes.expandAndWidth.values.length).toEqual(4 * 2);
+        it('returns offset wide line with first point on the IDL and the second is east', function() {
+            var instance = new GeometryInstance({
+                geometry : new Geometry({
+                    attributes : {
+                        position : new GeometryAttribute({
+                            componentDatatype : ComponentDatatype.DOUBLE,
+                            componentsPerAttribute : 3,
+                            values : new Float64Array([-1.0, 0.0, 0.0, -1.0, 0.0, 0.0, -1.0, 1.0, 2.0, -1.0, 1.0, 2.0])
+                        }),
+                        nextPosition : new GeometryAttribute({
+                            componentDatatype : ComponentDatatype.DOUBLE,
+                            componentsPerAttribute : 3,
+                            values : new Float64Array([-1.0, 1.0, 2.0, -1.0, 1.0, 2.0, -1.0, 2.0, 3.0, -1.0, 2.0, 3.0])
+                        }),
+                        prevPosition : new GeometryAttribute({
+                            componentDatatype : ComponentDatatype.DOUBLE,
+                            componentsPerAttribute : 3,
+                            values : new Float64Array([-1.0, -2.0, -1.0, -1.0, -2.0, -1.0, -1.0, 0.0, 0.0, -1.0, 0.0, 0.0])
+                        }),
+                        expandAndWidth : new GeometryAttribute({
+                            componentDatatype : ComponentDatatype.FLOAT,
+                            componentsPerAttribute : 2,
+                            values : new Float32Array([-1.0, 5.0, 1.0, 5.0, -1.0, -5.0, 1.0, -5.0])
+                        })
+                    },
+                    indices : new Uint16Array([0, 2, 1, 1, 2, 3]),
+                    primitiveType : PrimitiveType.TRIANGLES,
+                    geometryType : GeometryType.POLYLINES
+                })
+            });
+            GeometryPipeline.splitLongitude(instance);
+            var geometry = instance.geometry;
 
-        expect(instance.eastHemisphereGeometry).toBeDefined();
-        expect(instance.eastHemisphereGeometry.indices).toBeDefined();
-        expect(instance.eastHemisphereGeometry.indices.length).toEqual(6);
-        expect(instance.eastHemisphereGeometry.attributes.position).toBeDefined();
-        expect(instance.eastHemisphereGeometry.attributes.position.values.length).toEqual(4 * 3);
-        expect(instance.eastHemisphereGeometry.attributes.nextPosition).toBeDefined();
-        expect(instance.eastHemisphereGeometry.attributes.nextPosition.values.length).toEqual(4 * 3);
-        expect(instance.eastHemisphereGeometry.attributes.prevPosition).toBeDefined();
-        expect(instance.eastHemisphereGeometry.attributes.prevPosition.values.length).toEqual(4 * 3);
-        expect(instance.eastHemisphereGeometry.attributes.expandAndWidth).toBeDefined();
-        expect(instance.eastHemisphereGeometry.attributes.expandAndWidth.values.length).toEqual(4 * 2);
-    });
+            expect(geometry.indices).toEqual([0, 2, 1, 1, 2, 3]);
 
-    it('splitLongitude returns offset wide line that touches the international date line', function() {
-        var instance = new GeometryInstance({
-            geometry : new Geometry({
-                attributes : {
-                    position : new GeometryAttribute({
-                        componentDatatype : ComponentDatatype.DOUBLE,
-                        componentsPerAttribute : 3,
-                        values : new Float64Array([-1.0, 0.0, 0.0, -1.0, 0.0, 0.0, -1.0, 1.0, 2.0, -1.0, 1.0, 2.0])
-                    }),
-                    nextPosition : new GeometryAttribute({
-                        componentDatatype : ComponentDatatype.DOUBLE,
-                        componentsPerAttribute : 3,
-                        values : new Float64Array([-1.0, 1.0, 2.0, -1.0, 1.0, 2.0, -1.0, 2.0, 3.0, -1.0, 2.0, 3.0])
-                    }),
-                    prevPosition : new GeometryAttribute({
-                        componentDatatype : ComponentDatatype.DOUBLE,
-                        componentsPerAttribute : 3,
-                        values : new Float64Array([-1.0, -2.0, -1.0, -1.0, -2.0, -1.0, -1.0, 0.0, 0.0, -1.0, 0.0, 0.0])
-                    }),
-                    expandAndWidth : new GeometryAttribute({
-                        componentDatatype : ComponentDatatype.FLOAT,
-                        componentsPerAttribute : 2,
-                        values : new Float32Array([-1.0, 5.0, 1.0, 5.0, -1.0, -5.0, 1.0, -5.0])
-                    })
-                },
-                indices : new Uint16Array([0, 2, 1, 1, 2, 3]),
-                primitiveType : PrimitiveType.TRIANGLES,
-                geometryType : GeometryType.POLYLINES
-            })
+            var positions = geometry.attributes.position.values;
+            var nextPositions = geometry.attributes.nextPosition.values;
+            var prevPositions = geometry.attributes.prevPosition.values;
+
+            expect(positions).toEqual([-1.0, CesiumMath.EPSILON6, 0.0, -1.0, CesiumMath.EPSILON6, 0.0, -1.0, 1.0, 2.0, -1.0, 1.0, 2.0]);
+            expect(prevPositions).toEqual(positions);
+            expect(nextPositions).toEqual([-1.0, 1.0, 2.0, -1.0, 1.0, 2.0, -1.0, 2.0, 3.0, -1.0, 2.0, 3.0]);
         });
-        GeometryPipeline.splitLongitude(instance);
-        var geometry = instance.geometry;
 
-        expect(geometry.indices).toEqual([0, 2, 1, 1, 2, 3]);
+        it('returns offset wide line with first point on the IDL and the second is west', function() {
+            var instance = new GeometryInstance({
+                geometry : new Geometry({
+                    attributes : {
+                        position : new GeometryAttribute({
+                            componentDatatype : ComponentDatatype.DOUBLE,
+                            componentsPerAttribute : 3,
+                            values : new Float64Array([-1.0, 0.0, 0.0, -1.0, 0.0, 0.0, -1.0, -1.0, 2.0, -1.0, -1.0, 2.0])
+                        }),
+                        nextPosition : new GeometryAttribute({
+                            componentDatatype : ComponentDatatype.DOUBLE,
+                            componentsPerAttribute : 3,
+                            values : new Float64Array([-1.0, -1.0, 2.0, -1.0, -1.0, 2.0, -1.0, -2.0, 0.0, -1.0, -2.0, 0.0])
+                        }),
+                        prevPosition : new GeometryAttribute({
+                            componentDatatype : ComponentDatatype.DOUBLE,
+                            componentsPerAttribute : 3,
+                            values : new Float64Array([-1.0, 1.0, -1.0, -1.0, 1.0, -1.0, -1.0, 0.0, 0.0, -1.0, 0.0, 0.0])
+                        }),
+                        expandAndWidth : new GeometryAttribute({
+                            componentDatatype : ComponentDatatype.FLOAT,
+                            componentsPerAttribute : 2,
+                            values : new Float32Array([-1.0, 5.0, 1.0, 5.0, -1.0, -5.0, 1.0, -5.0])
+                        })
+                    },
+                    indices : new Uint16Array([0, 2, 1, 1, 2, 3]),
+                    primitiveType : PrimitiveType.TRIANGLES,
+                    geometryType : GeometryType.POLYLINES
+                })
+            });
+            GeometryPipeline.splitLongitude(instance);
+            var geometry = instance.geometry;
 
-        var positions = geometry.attributes.position.values;
-        expect(positions).toEqual([-1.0, CesiumMath.EPSILON6, 0.0, -1.0, CesiumMath.EPSILON6, 0.0, -1.0, 1.0, 2.0, -1.0, 1.0, 2.0]);
-    });
+            expect(geometry.indices).toEqual([0, 2, 1, 1, 2, 3]);
 
-    it('splitLongitude returns the same points if the wide line doesn\'t cross the international date line', function() {
-        var instance = new GeometryInstance({
-            geometry : new Geometry({
-                attributes : {
-                    position : new GeometryAttribute({
-                        componentDatatype : ComponentDatatype.DOUBLE,
-                        componentsPerAttribute : 3,
-                        values : new Float64Array([-1.0, 1.0, 0.0, -1.0, 1.0, 0.0, -1.0, 1.0, 2.0, -1.0, 1.0, 2.0])
-                    }),
-                    nextPosition : new GeometryAttribute({
-                        componentDatatype : ComponentDatatype.DOUBLE,
-                        componentsPerAttribute : 3,
-                        values : new Float64Array([-1.0, 1.0, 2.0, -1.0, 1.0, 2.0, -1.0, 2.0, 3.0, -1.0, 2.0, 3.0])
-                    }),
-                    prevPosition : new GeometryAttribute({
-                        componentDatatype : ComponentDatatype.DOUBLE,
-                        componentsPerAttribute : 3,
-                        values : new Float64Array([-1.0, -2.0, -1.0, -1.0, -2.0, -1.0, -1.0, 0.0, 0.0, -1.0, 0.0, 0.0])
-                    }),
-                    expandAndWidth : new GeometryAttribute({
-                        componentDatatype : ComponentDatatype.FLOAT,
-                        componentsPerAttribute : 2,
-                        values : new Float32Array([-1.0, 5.0, 1.0, 5.0, -1.0, -5.0, 1.0, -5.0])
-                    })
-                },
-                indices : new Uint16Array([0, 2, 1, 1, 2, 3]),
-                primitiveType : PrimitiveType.TRIANGLES,
-                geometryType : GeometryType.POLYLINES
-            })
+            var positions = geometry.attributes.position.values;
+            var nextPositions = geometry.attributes.nextPosition.values;
+            var prevPositions = geometry.attributes.prevPosition.values;
+
+            expect(positions).toEqual([-1.0, -CesiumMath.EPSILON6, 0.0, -1.0, -CesiumMath.EPSILON6, 0.0, -1.0, -1.0, 2.0, -1.0, -1.0, 2.0]);
+            expect(prevPositions).toEqual(positions);
+            expect(nextPositions).toEqual([-1.0, -1.0, 2.0, -1.0, -1.0, 2.0, -1.0, -2.0, 0.0, -1.0, -2.0, 0.0]);
         });
-        GeometryPipeline.splitLongitude(instance);
-        var geometry = instance.geometry;
 
-        expect(geometry.indices).toEqual([0, 2, 1, 1, 2, 3]);
+        it('returns offset wide line with first point is east and the second is on the IDL', function() {
+            var instance = new GeometryInstance({
+                geometry : new Geometry({
+                    attributes : {
+                        position : new GeometryAttribute({
+                            componentDatatype : ComponentDatatype.DOUBLE,
+                            componentsPerAttribute : 3,
+                            values : new Float64Array([-1.0, 1.0, 2.0, -1.0, 1.0, 2.0, -1.0, 0.0, 0.0, -1.0, 0.0, 0.0])
+                        }),
+                        nextPosition : new GeometryAttribute({
+                            componentDatatype : ComponentDatatype.DOUBLE,
+                            componentsPerAttribute : 3,
+                            values : new Float64Array([-1.0, 0.0, 0.0, -1.0, 0.0, 0.0, -1.0, -1.0, 2.0, -1.0, -1.0, 2.0])
+                        }),
+                        prevPosition : new GeometryAttribute({
+                            componentDatatype : ComponentDatatype.DOUBLE,
+                            componentsPerAttribute : 3,
+                            values : new Float64Array([-2.0, 2.0, 2.0, -1.0, 2.0, 2.0, -1.0, 1.0, 2.0, -1.0, 1.0, 2.0])
+                        }),
+                        expandAndWidth : new GeometryAttribute({
+                            componentDatatype : ComponentDatatype.FLOAT,
+                            componentsPerAttribute : 2,
+                            values : new Float32Array([-1.0, 5.0, 1.0, 5.0, -1.0, -5.0, 1.0, -5.0])
+                        })
+                    },
+                    indices : new Uint16Array([0, 2, 1, 1, 2, 3]),
+                    primitiveType : PrimitiveType.TRIANGLES,
+                    geometryType : GeometryType.POLYLINES
+                })
+            });
+            GeometryPipeline.splitLongitude(instance);
+            var geometry = instance.geometry;
 
-        var positions = geometry.attributes.position.values;
-        expect(positions).toEqual([-1.0, 1.0, 0.0, -1.0, 1.0, 0.0, -1.0, 1.0, 2.0, -1.0, 1.0, 2.0]);
+            expect(geometry.indices).toEqual([0, 2, 1, 1, 2, 3]);
+
+            var positions = geometry.attributes.position.values;
+            var nextPositions = geometry.attributes.nextPosition.values;
+            var prevPositions = geometry.attributes.prevPosition.values;
+
+            expect(positions).toEqual([-1.0, 1.0, 2.0, -1.0, 1.0, 2.0, -1.0, CesiumMath.EPSILON6, 0.0, -1.0, CesiumMath.EPSILON6, 0.0]);
+            expect(nextPositions).toEqual(positions);
+            expect(prevPositions).toEqual([-2.0, 2.0, 2.0, -1.0, 2.0, 2.0, -1.0, 1.0, 2.0, -1.0, 1.0, 2.0]);
+        });
+
+        it('returns offset wide line with first point is west and the second is on the IDL', function() {
+            var instance = new GeometryInstance({
+                geometry : new Geometry({
+                    attributes : {
+                        position : new GeometryAttribute({
+                            componentDatatype : ComponentDatatype.DOUBLE,
+                            componentsPerAttribute : 3,
+                            values : new Float64Array([-1.0, -1.0, 2.0, -1.0, -1.0, 2.0, -1.0, 0.0, 0.0, -1.0, 0.0, 0.0])
+                        }),
+                        nextPosition : new GeometryAttribute({
+                            componentDatatype : ComponentDatatype.DOUBLE,
+                            componentsPerAttribute : 3,
+                            values : new Float64Array([-1.0, 0.0, 0.0, -1.0, 0.0, 0.0, -1.0, 1.0, 2.0, -1.0, 1.0, 2.0])
+                        }),
+                        prevPosition : new GeometryAttribute({
+                            componentDatatype : ComponentDatatype.DOUBLE,
+                            componentsPerAttribute : 3,
+                            values : new Float64Array([-2.0, -2.0, 2.0, -1.0, -2.0, 2.0, -1.0, -1.0, 2.0, -1.0, -1.0, 2.0])
+                        }),
+                        expandAndWidth : new GeometryAttribute({
+                            componentDatatype : ComponentDatatype.FLOAT,
+                            componentsPerAttribute : 2,
+                            values : new Float32Array([-1.0, 5.0, 1.0, 5.0, -1.0, -5.0, 1.0, -5.0])
+                        })
+                    },
+                    indices : new Uint16Array([0, 2, 1, 1, 2, 3]),
+                    primitiveType : PrimitiveType.TRIANGLES,
+                    geometryType : GeometryType.POLYLINES
+                })
+            });
+            GeometryPipeline.splitLongitude(instance);
+            var geometry = instance.geometry;
+
+            expect(geometry.indices).toEqual([0, 2, 1, 1, 2, 3]);
+
+            var positions = geometry.attributes.position.values;
+            var nextPositions = geometry.attributes.nextPosition.values;
+            var prevPositions = geometry.attributes.prevPosition.values;
+
+            expect(positions).toEqual([-1.0, -1.0, 2.0, -1.0, -1.0, 2.0, -1.0, -CesiumMath.EPSILON6, 0.0, -1.0, -CesiumMath.EPSILON6, 0.0]);
+            expect(nextPositions).toEqual(positions);
+            expect(prevPositions).toEqual([-2.0, -2.0, 2.0, -1.0, -2.0, 2.0, -1.0, -1.0, 2.0, -1.0, -1.0, 2.0]);
+        });
+
+        it('returns the same points if the wide line doesn\'t cross the international date line', function() {
+            var instance = new GeometryInstance({
+                geometry : new Geometry({
+                    attributes : {
+                        position : new GeometryAttribute({
+                            componentDatatype : ComponentDatatype.DOUBLE,
+                            componentsPerAttribute : 3,
+                            values : new Float64Array([-1.0, 1.0, 0.0, -1.0, 1.0, 0.0, -1.0, 1.0, 2.0, -1.0, 1.0, 2.0])
+                        }),
+                        nextPosition : new GeometryAttribute({
+                            componentDatatype : ComponentDatatype.DOUBLE,
+                            componentsPerAttribute : 3,
+                            values : new Float64Array([-1.0, 1.0, 2.0, -1.0, 1.0, 2.0, -1.0, 2.0, 3.0, -1.0, 2.0, 3.0])
+                        }),
+                        prevPosition : new GeometryAttribute({
+                            componentDatatype : ComponentDatatype.DOUBLE,
+                            componentsPerAttribute : 3,
+                            values : new Float64Array([-1.0, -2.0, -1.0, -1.0, -2.0, -1.0, -1.0, 0.0, 0.0, -1.0, 0.0, 0.0])
+                        }),
+                        expandAndWidth : new GeometryAttribute({
+                            componentDatatype : ComponentDatatype.FLOAT,
+                            componentsPerAttribute : 2,
+                            values : new Float32Array([-1.0, 5.0, 1.0, 5.0, -1.0, -5.0, 1.0, -5.0])
+                        })
+                    },
+                    indices : new Uint16Array([0, 2, 1, 1, 2, 3]),
+                    primitiveType : PrimitiveType.TRIANGLES,
+                    geometryType : GeometryType.POLYLINES
+                })
+            });
+            GeometryPipeline.splitLongitude(instance);
+            var geometry = instance.geometry;
+
+            expect(geometry.indices).toEqual([0, 2, 1, 1, 2, 3]);
+
+            var positions = geometry.attributes.position.values;
+            expect(positions).toEqual([-1.0, 1.0, 0.0, -1.0, 1.0, 0.0, -1.0, 1.0, 2.0, -1.0, 1.0, 2.0]);
+        });
     });
 
     it('splitLongitude throws when geometry is undefined', function() {


### PR DESCRIPTION
For #3621, though the problem is not specific to the branch of that PR.

This fixes `PolylineGeometry` that crosses the IDL. Does not address lines added to a `PolylineCollection`. I'll be looking at that separately.

Here is an example to draw a polyline correctly in this branch and barely visible in master:
```javascript
var viewer = new Cesium.Viewer('cesiumContainer', { sceneMode : Cesium.SceneMode.SCENE2D });

viewer.scene.primitives.add(new Cesium.Primitive({
    geometryInstances : new Cesium.GeometryInstance({
        geometry : new Cesium.PolylineGeometry({
            positions : Cesium.Cartesian3.fromDegreesArrayHeights([
                                                                      179.0, 20.0, 0.0,
                                                                      -179.0, 20.0, 0.0
                                                                  ]),
            width : 5.0,
            vertexFormat : Cesium.PolylineColorAppearance.VERTEX_FORMAT
        }),
        attributes: {
            color: Cesium.ColorGeometryInstanceAttribute.fromColor(Cesium.Color.BLUE)
        }
    }),
    appearance : new Cesium.PolylineColorAppearance(),
    asynchronous : false
}));
```