### PR TITLE
Fix ellipse outline indices bug, clean up geometry specs

### DIFF
--- a/Source/Core/EllipseOutlineGeometry.js
+++ b/Source/Core/EllipseOutlineGeometry.js
@@ -67,9 +67,6 @@ define([
     var topBoundingSphere = new BoundingSphere();
     var bottomBoundingSphere = new BoundingSphere();
     function computeExtrudedEllipse(options) {
-        var numberOfVerticalLines = defaultValue(options.numberOfVerticalLines, 16);
-        numberOfVerticalLines = Math.max(numberOfVerticalLines, 0);
-
         var center = options.center;
         var ellipsoid = options.ellipsoid;
         var semiMajorAxis = options.semiMajorAxis;
@@ -93,6 +90,9 @@ define([
         positions = attributes.position.values;
         var boundingSphere = BoundingSphere.union(topBoundingSphere, bottomBoundingSphere);
         var length = positions.length/3;
+        var numberOfVerticalLines = defaultValue(options.numberOfVerticalLines, 16);
+        numberOfVerticalLines = CesiumMath.clamp(numberOfVerticalLines, 0, length/2);
+
         var indices = IndexDatatype.createTypedArray(length, length * 2 + numberOfVerticalLines * 2);
 
         length /= 2;
@@ -109,11 +109,8 @@ define([
         if (numberOfVerticalLines > 0) {
             var numSideLines = Math.min(numberOfVerticalLines, length);
             numSide = Math.round(length / numSideLines);
-        }
 
-
-        var maxI = Math.min(numSide * numberOfVerticalLines, length);
-        if (numberOfVerticalLines > 0) {
+            var maxI = Math.min(numSide * numberOfVerticalLines, length);
             for (i = 0; i < maxI; i += numSide) {
                 indices[index++] = i;
                 indices[index++] = i + length;

--- a/Specs/Core/BoxGeometrySpec.js
+++ b/Specs/Core/BoxGeometrySpec.js
@@ -36,8 +36,8 @@ defineSuite([
             vertexFormat : VertexFormat.POSITION_ONLY
         }));
 
-        expect(m.attributes.position.values.length).toEqual(8 * 3);
-        expect(m.indices.length).toEqual(12 * 3);
+        expect(m.attributes.position.values.length).toEqual(8 * 3); // 8 corners
+        expect(m.indices.length).toEqual(12 * 3); // 6 sides x 2 triangles per side
     });
 
     it('constructor computes all vertex attributes', function() {
@@ -49,13 +49,15 @@ defineSuite([
             vertexFormat : VertexFormat.ALL
         }));
 
-        expect(m.attributes.position.values.length).toEqual(6 * 4 * 3);
-        expect(m.attributes.normal.values.length).toEqual(6 * 4 * 3);
-        expect(m.attributes.tangent.values.length).toEqual(6 * 4 * 3);
-        expect(m.attributes.binormal.values.length).toEqual(6 * 4 * 3);
-        expect(m.attributes.st.values.length).toEqual(6 * 4 * 2);
+        var numVertices = 24; //3 points x 8 corners
+        var numTriangles = 12; //6 sides x 2 triangles per side
+        expect(m.attributes.position.values.length).toEqual(numVertices * 3);
+        expect(m.attributes.normal.values.length).toEqual(numVertices * 3);
+        expect(m.attributes.tangent.values.length).toEqual(numVertices * 3);
+        expect(m.attributes.binormal.values.length).toEqual(numVertices * 3);
+        expect(m.attributes.st.values.length).toEqual(numVertices * 2);
 
-        expect(m.indices.length).toEqual(12 * 3);
+        expect(m.indices.length).toEqual(numTriangles * 3);
 
         expect(m.boundingSphere.center).toEqual(Cartesian3.ZERO);
         expect(m.boundingSphere.radius).toEqual(Cartesian3.magnitude(maximumCorner) * 0.5);

--- a/Specs/Core/CircleGeometrySpec.js
+++ b/Specs/Core/CircleGeometrySpec.js
@@ -50,8 +50,10 @@ defineSuite([
             radius : 1.0
         }));
 
-        expect(m.attributes.position.values.length).toEqual(3 * 16);
-        expect(m.indices.length).toEqual(3 * 22);
+        var numVertices = 16; //rows of 1 + 4 + 6 + 4 + 1
+        var numTriangles = 22; //rows of 3 + 8 + 8 + 3
+        expect(m.attributes.position.values.length).toEqual(16 * 3);
+        expect(m.indices.length).toEqual(22 * 3);
         expect(m.boundingSphere.radius).toEqual(1);
     });
 
@@ -64,12 +66,14 @@ defineSuite([
             radius : 1.0
         }));
 
-        expect(m.attributes.position.values.length).toEqual(3 * 16);
-        expect(m.attributes.st.values.length).toEqual(2 * 16);
-        expect(m.attributes.normal.values.length).toEqual(3 * 16);
-        expect(m.attributes.tangent.values.length).toEqual(3 * 16);
-        expect(m.attributes.binormal.values.length).toEqual(3 * 16);
-        expect(m.indices.length).toEqual(3 * 22);
+        var numVertices = 16;
+        var numTriangles = 22;
+        expect(m.attributes.position.values.length).toEqual(numVertices * 3);
+        expect(m.attributes.st.values.length).toEqual(numVertices * 2);
+        expect(m.attributes.normal.values.length).toEqual(numVertices * 3);
+        expect(m.attributes.tangent.values.length).toEqual(numVertices * 3);
+        expect(m.attributes.binormal.values.length).toEqual(numVertices * 3);
+        expect(m.indices.length).toEqual(numTriangles * 3);
     });
 
     it('computes positions extruded', function() {
@@ -82,8 +86,10 @@ defineSuite([
             extrudedHeight: 10000
         }));
 
-        expect(m.attributes.position.values.length).toEqual(3 * (16 + 8) * 2);
-        expect(m.indices.length).toEqual(3 * (22 + 8) * 2);
+        var numVertices = 48; // 16 top circle + 16 bottom circle + 8 top edge + 8 bottom edge
+        var numTriangles = 60; // 22 to fill each circle + 16 for edge wall
+        expect(m.attributes.position.values.length).toEqual(numVertices * 3);
+        expect(m.indices.length).toEqual(numTriangles * 3);
     });
 
     it('compute all vertex attributes extruded', function() {
@@ -96,12 +102,14 @@ defineSuite([
             extrudedHeight: 10000
         }));
 
-        expect(m.attributes.position.values.length).toEqual(3 * (16 + 8) * 2);
-        expect(m.attributes.st.values.length).toEqual(2 * (16 + 8) * 2);
-        expect(m.attributes.normal.values.length).toEqual(3 * (16 + 8) * 2);
-        expect(m.attributes.tangent.values.length).toEqual(3 * (16 + 8) * 2);
-        expect(m.attributes.binormal.values.length).toEqual(3 * (16 + 8) * 2);
-        expect(m.indices.length).toEqual(3 * (22 + 8) * 2);
+        var numVertices = 48;
+        var numTriangles = 60;
+        expect(m.attributes.position.values.length).toEqual(numVertices * 3);
+        expect(m.attributes.st.values.length).toEqual(numVertices * 2);
+        expect(m.attributes.normal.values.length).toEqual(numVertices * 3);
+        expect(m.attributes.tangent.values.length).toEqual(numVertices * 3);
+        expect(m.attributes.binormal.values.length).toEqual(numVertices * 3);
+        expect(m.indices.length).toEqual(numTriangles * 3);
     });
 
     it('compute texture coordinates with rotation', function() {

--- a/Specs/Core/CircleOutlineGeometrySpec.js
+++ b/Specs/Core/CircleOutlineGeometrySpec.js
@@ -45,8 +45,8 @@ defineSuite([
             radius : 1.0
         }));
 
-        expect(m.attributes.position.values.length).toEqual(3 * 8);
-        expect(m.indices.length).toEqual(2 * 8);
+        expect(m.attributes.position.values.length).toEqual(8 * 3);
+        expect(m.indices.length).toEqual(8 * 2);
         expect(m.boundingSphere.radius).toEqual(1);
     });
 
@@ -56,11 +56,11 @@ defineSuite([
             center : Cartesian3.fromDegrees(0,0),
             granularity : 0.1,
             radius : 1.0,
-            extrudedHeight : 10000
+            extrudedHeight : 5
         }));
 
-        expect(m.attributes.position.values.length).toEqual(2 * 8 * 3);
-        expect(m.indices.length).toEqual(2 * 8 * 2 + 16 * 2);
+        expect(m.attributes.position.values.length).toEqual(16 * 3); //8 top circle + 8 bottom circle
+        expect(m.indices.length).toEqual(24 * 2); //8 top + 8 bottom + 8 vertical
     });
 
     it('computes positions extruded, no lines between top and bottom', function() {
@@ -73,8 +73,8 @@ defineSuite([
             numberOfVerticalLines : 0
         }));
 
-        expect(m.attributes.position.values.length).toEqual(2 * 8 * 3);
-        expect(m.indices.length).toEqual(2 * 8 * 2);
+        expect(m.attributes.position.values.length).toEqual(16 * 3);
+        expect(m.indices.length).toEqual(16 * 2);
     });
 
     it('undefined is returned if radius is equal to or less than zero', function () {

--- a/Specs/Core/CorridorGeometrySpec.js
+++ b/Specs/Core/CorridorGeometrySpec.js
@@ -37,7 +37,7 @@ defineSuite([
             ]),
             width: 10000
         }));
-        expect(geometry).not.toBeDefined();
+        expect(geometry).toBeUndefined();
     });
 
     it('computes positions', function() {
@@ -51,8 +51,10 @@ defineSuite([
             width : 30000
         }));
 
-        expect(m.attributes.position.values.length).toEqual(3 * 12);
-        expect(m.indices.length).toEqual(3 * 10);
+        var numVertices = 12; //6 left + 6 right
+        var numTriangles = 10; //5 segments x 2 triangles per segment
+        expect(m.attributes.position.values.length).toEqual(numVertices * 3);
+        expect(m.indices.length).toEqual(numTriangles * 3);
     });
 
     it('compute all vertex attributes', function() {
@@ -66,12 +68,14 @@ defineSuite([
             width : 30000
         }));
 
-        expect(m.attributes.position.values.length).toEqual(3 * 12);
-        expect(m.attributes.st.values.length).toEqual(2 * 12);
-        expect(m.attributes.normal.values.length).toEqual(3 * 12);
-        expect(m.attributes.tangent.values.length).toEqual(3 * 12);
-        expect(m.attributes.binormal.values.length).toEqual(3 * 12);
-        expect(m.indices.length).toEqual(3 * 10);
+        var numVertices = 12;
+        var numTriangles = 10;
+        expect(m.attributes.position.values.length).toEqual(numVertices * 3);
+        expect(m.attributes.st.values.length).toEqual(numVertices * 2);
+        expect(m.attributes.normal.values.length).toEqual(numVertices * 3);
+        expect(m.attributes.tangent.values.length).toEqual(numVertices * 3);
+        expect(m.attributes.binormal.values.length).toEqual(numVertices * 3);
+        expect(m.indices.length).toEqual(numTriangles * 3);
     });
 
     it('computes positions extruded', function() {
@@ -86,8 +90,10 @@ defineSuite([
             extrudedHeight: 30000
         }));
 
-        expect(m.attributes.position.values.length).toEqual(3 * 24 * 3);
-        expect(m.indices.length).toEqual(3 * 10 * 2 + 24 * 3);
+        var numVertices = 72; // 6 positions x 4 for a box at each position x 3 to duplicate for normals
+        var numTriangles = 44; // 5 segments * 8 triangles per segment + 2 triangles x 2 ends
+        expect(m.attributes.position.values.length).toEqual(numVertices * 3);
+        expect(m.indices.length).toEqual(numTriangles * 3);
     });
 
     it('compute all vertex attributes extruded', function() {
@@ -102,12 +108,14 @@ defineSuite([
             extrudedHeight: 30000
         }));
 
-        expect(m.attributes.position.values.length).toEqual(3 * 24 * 3);
-        expect(m.attributes.st.values.length).toEqual(2 * 24 * 3);
-        expect(m.attributes.normal.values.length).toEqual(3 * 24 * 3);
-        expect(m.attributes.tangent.values.length).toEqual(3 * 24 * 3);
-        expect(m.attributes.binormal.values.length).toEqual(3 * 24 * 3);
-        expect(m.indices.length).toEqual(3 * 10 * 2 + 24 * 3);
+        var numVertices = 72;
+        var numTriangles = 44;
+        expect(m.attributes.position.values.length).toEqual(numVertices * 3);
+        expect(m.attributes.st.values.length).toEqual(numVertices * 2);
+        expect(m.attributes.normal.values.length).toEqual(numVertices * 3);
+        expect(m.attributes.tangent.values.length).toEqual(numVertices * 3);
+        expect(m.attributes.binormal.values.length).toEqual(numVertices * 3);
+        expect(m.indices.length).toEqual(numTriangles * 3);
     });
 
     it('computes right turn', function() {
@@ -122,8 +130,8 @@ defineSuite([
             width : 30000
         }));
 
-        expect(m.attributes.position.values.length).toEqual(3 * 8);
-        expect(m.indices.length).toEqual(3 * 6);
+        expect(m.attributes.position.values.length).toEqual(8 * 3); // 4 left + 4 right
+        expect(m.indices.length).toEqual(6 * 3); // 3 segments * 2 triangles per segment
     });
 
     it('computes left turn', function() {
@@ -138,8 +146,8 @@ defineSuite([
             width : 30000
         }));
 
-        expect(m.attributes.position.values.length).toEqual(3 * 8);
-        expect(m.indices.length).toEqual(3 * 6);
+        expect(m.attributes.position.values.length).toEqual(8 * 3);
+        expect(m.indices.length).toEqual(6 * 3);
     });
 
     it('computes with rounded corners', function() {
@@ -155,11 +163,13 @@ defineSuite([
             width : 30000
         }));
 
-        var endCaps = 180/5*2;
-        var corners = 90/5*2;
-        expect(m.attributes.position.values.length).toEqual(3 * (11 + endCaps + corners));
-        expect(m.attributes.st.values.length).toEqual(2 * (11 + endCaps + corners));
-        expect(m.indices.length).toEqual(3 * (9 + endCaps + corners));
+        var endCaps = 72; // 36 points * 2 end caps
+        var corners = 37; // 18 for one corner + 19 for the other
+        var numVertices = 10 + endCaps + corners;
+        var numTriangles = 8 + endCaps + corners;
+        expect(m.attributes.position.values.length).toEqual(numVertices * 3);
+        expect(m.attributes.st.values.length).toEqual(numVertices * 2);
+        expect(m.indices.length).toEqual(numTriangles * 3);
     });
 
     it('computes with beveled corners', function() {
@@ -175,8 +185,8 @@ defineSuite([
             width : 30000
         }));
 
-        expect(m.attributes.position.values.length).toEqual(3 * 10);
-        expect(m.indices.length).toEqual(3 * 8);
+        expect(m.attributes.position.values.length).toEqual(10 * 3);
+        expect(m.indices.length).toEqual(8 * 3);
     });
 
     it('computes sharp turns', function() {
@@ -193,8 +203,8 @@ defineSuite([
             width : 100
         }));
 
-        expect(m.attributes.position.values.length).toEqual(3 * 13);
-        expect(m.indices.length).toEqual(3 * 11);
+        expect(m.attributes.position.values.length).toEqual(13 * 3); // 3 points * 3 corners + 2 points * 2 ends
+        expect(m.indices.length).toEqual(11 * 3); // 4 segments * 2 triangles + 3 corners * 1 triangle
     });
 
     it('computes straight corridors', function() {
@@ -210,8 +220,8 @@ defineSuite([
             granularity : Math.PI / 6.0
         }));
 
-        expect(m.attributes.position.values.length).toEqual(3 * 4);
-        expect(m.indices.length).toEqual(3 * 2);
+        expect(m.attributes.position.values.length).toEqual(4 * 3);
+        expect(m.indices.length).toEqual(2 * 3);
     });
 
     it('undefined is returned if there are less than two positions or the width is equal to ' +

--- a/Specs/Core/CorridorOutlineGeometrySpec.js
+++ b/Specs/Core/CorridorOutlineGeometrySpec.js
@@ -35,7 +35,7 @@ defineSuite([
             ]),
             width: 10000
         }));
-        expect(geometry).not.toBeDefined();
+        expect(geometry).toBeUndefined();
     });
 
     it('computes positions', function() {
@@ -48,8 +48,8 @@ defineSuite([
             width : 30000
         }));
 
-        expect(m.attributes.position.values.length).toEqual(3 * 12);
-        expect(m.indices.length).toEqual(2 * 12);
+        expect(m.attributes.position.values.length).toEqual(12 * 3); // 6 left + 6 right
+        expect(m.indices.length).toEqual(12 * 2);
     });
 
     it('computes positions extruded', function() {
@@ -63,8 +63,8 @@ defineSuite([
             extrudedHeight: 30000
         }));
 
-        expect(m.attributes.position.values.length).toEqual(3 * 24);
-        expect(m.indices.length).toEqual(2 * 12 * 2 + 8);
+        expect(m.attributes.position.values.length).toEqual(24 * 3); // 6 positions * 4 for a box at each position
+        expect(m.indices.length).toEqual(28 * 2); // 5 segments * 4 lines per segment + 4 lines * 2 ends
     });
 
     it('computes right turn', function() {
@@ -78,8 +78,8 @@ defineSuite([
             width : 30000
         }));
 
-        expect(m.attributes.position.values.length).toEqual(3 * 8);
-        expect(m.indices.length).toEqual(2 * 8);
+        expect(m.attributes.position.values.length).toEqual(8 * 3);
+        expect(m.indices.length).toEqual(8 * 2);
     });
 
     it('computes left turn', function() {
@@ -93,8 +93,8 @@ defineSuite([
             width : 30000
         }));
 
-        expect(m.attributes.position.values.length).toEqual(3 * 8);
-        expect(m.indices.length).toEqual(2 * 8);
+        expect(m.attributes.position.values.length).toEqual(8 * 3);
+        expect(m.indices.length).toEqual(8 * 2);
     });
 
     it('computes with rounded corners', function() {
@@ -109,10 +109,12 @@ defineSuite([
             width : 30000
         }));
 
-        var endCaps = 180/5*2;
-        var corners = 90/5*2;
-        expect(m.attributes.position.values.length).toEqual(3 * (11 + endCaps + corners));
-        expect(m.indices.length).toEqual(2 * (11 + endCaps + corners));
+        var endCaps = 72; // 36 points * 2 end caps
+        var corners = 37; // 18 for one corner + 19 for the other
+        var numVertices = 10 + endCaps + corners;
+        var numLines = 10 + endCaps + corners;
+        expect(m.attributes.position.values.length).toEqual(numVertices * 3);
+        expect(m.indices.length).toEqual(numLines * 2);
     });
 
     it('computes with beveled corners', function() {
@@ -127,8 +129,8 @@ defineSuite([
             width : 30000
         }));
 
-        expect(m.attributes.position.values.length).toEqual(3 * 10);
-        expect(m.indices.length).toEqual(2 * 10);
+        expect(m.attributes.position.values.length).toEqual(10 * 3);
+        expect(m.indices.length).toEqual(10 * 2);
     });
 
     it('undefined is returned if there are less than two positions or the width is equal to ' +

--- a/Specs/Core/CylinderGeometrySpec.js
+++ b/Specs/Core/CylinderGeometrySpec.js
@@ -52,8 +52,10 @@ defineSuite([
             slices: 3
         }));
 
-        expect(m.attributes.position.values.length).toEqual(3 * 3 * 4);
-        expect(m.indices.length).toEqual(8 * 3);
+        var numVertices = 12; // (3 top + 3 bottom) * 2 to duplicate for sides
+        var numTriangles = 8; // 1 top  + 1 bottom + 2 triangles * 3 sides
+        expect(m.attributes.position.values.length).toEqual(numVertices * 3);
+        expect(m.indices.length).toEqual(numTriangles * 3);
     });
 
     it('compute all vertex attributes', function() {
@@ -65,12 +67,14 @@ defineSuite([
             slices: 3
         }));
 
-        expect(m.attributes.position.values.length).toEqual(3 * 3 * 4);
-        expect(m.attributes.st.values.length).toEqual(2 * 3 * 4);
-        expect(m.attributes.normal.values.length).toEqual(3 * 3 * 4);
-        expect(m.attributes.tangent.values.length).toEqual(3 * 3 * 4);
-        expect(m.attributes.binormal.values.length).toEqual(3 * 3 * 4);
-        expect(m.indices.length).toEqual(8 * 3);
+        var numVertices = 12;
+        var numTriangles = 8;
+        expect(m.attributes.position.values.length).toEqual(numVertices * 3);
+        expect(m.attributes.st.values.length).toEqual(numVertices * 2);
+        expect(m.attributes.normal.values.length).toEqual(numVertices * 3);
+        expect(m.attributes.tangent.values.length).toEqual(numVertices * 3);
+        expect(m.attributes.binormal.values.length).toEqual(numVertices * 3);
+        expect(m.indices.length).toEqual(numTriangles * 3);
     });
 
     it('computes positions with topRadius equals 0', function() {
@@ -82,8 +86,10 @@ defineSuite([
             slices: 3
         }));
 
-        expect(m.attributes.position.values.length).toEqual(3 * 3 * 4);
-        expect(m.indices.length).toEqual(8 * 3);
+        var numVertices = 12; //(3 top 3 bottom) duplicated
+        var numTriangles = 8; //1 top 1 bottom, 2 on each of 3 sides
+        expect(m.attributes.position.values.length).toEqual(numVertices * 3);
+        expect(m.indices.length).toEqual(numTriangles * 3);
     });
 
     it('computes positions with bottomRadius equals 0', function() {
@@ -95,8 +101,10 @@ defineSuite([
             slices: 3
         }));
 
-        expect(m.attributes.position.values.length).toEqual(3 * 3 * 4);
-        expect(m.indices.length).toEqual(8 * 3);
+        var numVertices = 12; //(3 top 3 bottom) duplicated
+        var numTriangles = 8; //1 top 1 bottom, 2 on each of 3 sides
+        expect(m.attributes.position.values.length).toEqual(numVertices * 3);
+        expect(m.indices.length).toEqual(numTriangles * 3);
     });
 
     it('undefined is returned if the length is less than or equal to zero or if ' +

--- a/Specs/Core/CylinderOutlineGeometrySpec.js
+++ b/Specs/Core/CylinderOutlineGeometrySpec.js
@@ -49,8 +49,8 @@ defineSuite([
             slices: 3
         }));
 
-        expect(m.attributes.position.values.length).toEqual(3 * 3 * 2);
-        expect(m.indices.length).toEqual(9 * 2);
+        expect(m.attributes.position.values.length).toEqual(6 * 3); // 3 top + 3 bottom
+        expect(m.indices.length).toEqual(9 * 2); // 3 top + 3 bottom + 3 sides
     });
 
     it('computes positions with no lines along the length', function() {
@@ -62,8 +62,10 @@ defineSuite([
             numberOfVerticalLines: 0
         }));
 
-        expect(m.attributes.position.values.length).toEqual(3 * 3 * 2);
-        expect(m.indices.length).toEqual(6 * 2);
+        var numVertices = 6; //3 top 3 bottom
+        var numLines = 6; //3 top 3 bottom
+        expect(m.attributes.position.values.length).toEqual(numVertices * 3);
+        expect(m.indices.length).toEqual(numLines * 2);
     });
 
     it('undefined is returned if the length is less than or equal to zero or if ' +

--- a/Specs/Core/EllipseGeometrySpec.js
+++ b/Specs/Core/EllipseGeometrySpec.js
@@ -73,8 +73,8 @@ defineSuite([
             semiMinorAxis : 1.0
         }));
 
-        expect(m.attributes.position.values.length).toEqual(3 * 16);
-        expect(m.indices.length).toEqual(3 * 22);
+        expect(m.attributes.position.values.length).toEqual(16 * 3); // rows of 1 + 4 + 6 + 4 + 1
+        expect(m.indices.length).toEqual(22 * 3); // rows of 3 + 8 + 8 + 3
         expect(m.boundingSphere.radius).toEqual(1);
     });
 
@@ -88,12 +88,14 @@ defineSuite([
             semiMinorAxis : 1.0
         }));
 
-        expect(m.attributes.position.values.length).toEqual(3 * 16);
-        expect(m.attributes.st.values.length).toEqual(2 * 16);
-        expect(m.attributes.normal.values.length).toEqual(3 * 16);
-        expect(m.attributes.tangent.values.length).toEqual(3 * 16);
-        expect(m.attributes.binormal.values.length).toEqual(3 * 16);
-        expect(m.indices.length).toEqual(3 * 22);
+        var numVertices = 16;
+        var numTriangles = 22;
+        expect(m.attributes.position.values.length).toEqual(numVertices * 3);
+        expect(m.attributes.st.values.length).toEqual(numVertices * 2);
+        expect(m.attributes.normal.values.length).toEqual(numVertices * 3);
+        expect(m.attributes.tangent.values.length).toEqual(numVertices * 3);
+        expect(m.attributes.binormal.values.length).toEqual(numVertices * 3);
+        expect(m.indices.length).toEqual(numTriangles * 3);
     });
 
     it('compute texture coordinates with rotation', function() {
@@ -111,9 +113,11 @@ defineSuite([
         var st = m.attributes.st.values;
         var length = st.length;
 
-        expect(positions.length).toEqual(3 * 16);
-        expect(length).toEqual(2 * 16);
-        expect(m.indices.length).toEqual(3 * 22);
+        var numVertices = 16;
+        var numTriangles = 22;
+        expect(positions.length).toEqual(numVertices * 3);
+        expect(length).toEqual(numVertices * 2);
+        expect(m.indices.length).toEqual(numTriangles * 3);
 
         expect(st[length - 2]).toEqualEpsilon(0.5, CesiumMath.EPSILON2);
         expect(st[length - 1]).toEqualEpsilon(0.0, CesiumMath.EPSILON2);
@@ -130,8 +134,10 @@ defineSuite([
             extrudedHeight : 50000
         }));
 
-        expect(m.attributes.position.values.length).toEqual(3 * (16 + 8) * 2);
-        expect(m.indices.length).toEqual(3 * (22 + 8) * 2);
+        var numVertices = 48; // 16 top + 16 bottom + 8 top edge + 8 bottom edge
+        var numTriangles = 60; // 22 top fill + 22 bottom fill + 2 triangles * 8 sides
+        expect(m.attributes.position.values.length).toEqual(numVertices * 3);
+        expect(m.indices.length).toEqual(numTriangles * 3);
     });
 
     it('compute all vertex attributes extruded', function() {
@@ -145,12 +151,14 @@ defineSuite([
             extrudedHeight : 50000
         }));
 
-        expect(m.attributes.position.values.length).toEqual(3 * (16 + 8) * 2);
-        expect(m.attributes.st.values.length).toEqual(2 * (16 + 8) * 2);
-        expect(m.attributes.normal.values.length).toEqual(3 * (16 + 8) * 2);
-        expect(m.attributes.tangent.values.length).toEqual(3 * (16 + 8) * 2);
-        expect(m.attributes.binormal.values.length).toEqual(3 * (16 + 8) * 2);
-        expect(m.indices.length).toEqual(3 * (22 + 8) * 2);
+        var numVertices = 48;
+        var numTriangles = 60;
+        expect(m.attributes.position.values.length).toEqual(numVertices * 3);
+        expect(m.attributes.st.values.length).toEqual(numVertices * 2);
+        expect(m.attributes.normal.values.length).toEqual(numVertices * 3);
+        expect(m.attributes.tangent.values.length).toEqual(numVertices * 3);
+        expect(m.attributes.binormal.values.length).toEqual(numVertices * 3);
+        expect(m.indices.length).toEqual(numTriangles * 3);
     });
 
     it('undefined is returned if the minor axis is equal to or less than zero', function() {

--- a/Specs/Core/EllipseOutlineGeometrySpec.js
+++ b/Specs/Core/EllipseOutlineGeometrySpec.js
@@ -68,8 +68,8 @@ defineSuite([
             semiMinorAxis : 1.0
         }));
 
-        expect(m.attributes.position.values.length).toEqual(3 * 8);
-        expect(m.indices.length).toEqual(2 * 8);
+        expect(m.attributes.position.values.length).toEqual(8 * 3);
+        expect(m.indices.length).toEqual(8 * 2);
         expect(m.boundingSphere.radius).toEqual(1);
     });
 
@@ -80,11 +80,11 @@ defineSuite([
             granularity : 0.1,
             semiMajorAxis : 1.0,
             semiMinorAxis : 1.0,
-            extrudedHeight : 50000
+            extrudedHeight : 5.0
         }));
 
-        expect(m.attributes.position.values.length).toEqual(3 * 8 * 2);
-        expect(m.indices.length).toEqual(2 * 8 * 2 + 16 * 2);
+        expect(m.attributes.position.values.length).toEqual(16 * 3); // 8 top  + 8 bottom
+        expect(m.indices.length).toEqual(24 * 2); // 8 top + 8 bottom + 8 sides
     });
 
     it('computes positions extruded, no lines drawn between top and bottom', function() {
@@ -94,12 +94,12 @@ defineSuite([
             granularity : 0.1,
             semiMajorAxis : 1.0,
             semiMinorAxis : 1.0,
-            extrudedHeight : 50000,
+            extrudedHeight : 5.0,
             numberOfVerticalLines : 0
         }));
 
-        expect(m.attributes.position.values.length).toEqual(3 * 8 * 2);
-        expect(m.indices.length).toEqual(2 * 8 * 2);
+        expect(m.attributes.position.values.length).toEqual(16 * 3);
+        expect(m.indices.length).toEqual(16 * 2);
     });
 
     it('undefined is returned if the minor axis is equal to or less than zero', function() {

--- a/Specs/Core/EllipsoidGeometrySpec.js
+++ b/Specs/Core/EllipsoidGeometrySpec.js
@@ -36,8 +36,10 @@ defineSuite([
             stackPartitions: 3
         }));
 
-        expect(m.attributes.position.values.length).toEqual(3 * 16);
-        expect(m.indices.length).toEqual(3 * 12);
+        var numVertices = 16; // 4 rows * 4 positions
+        var numTriangles = 12; //3 top + 3 bottom + 6 around the sides
+        expect(m.attributes.position.values.length).toEqual(numVertices * 3);
+        expect(m.indices.length).toEqual(numTriangles * 3);
         expect(m.boundingSphere.radius).toEqual(1);
     });
 
@@ -48,12 +50,14 @@ defineSuite([
             stackPartitions: 3
         }));
 
-        expect(m.attributes.position.values.length).toEqual(3 * 16);
-        expect(m.attributes.st.values.length).toEqual(2 * 16);
-        expect(m.attributes.normal.values.length).toEqual(3 * 16);
-        expect(m.attributes.tangent.values.length).toEqual(3 * 16);
-        expect(m.attributes.binormal.values.length).toEqual(3 * 16);
-        expect(m.indices.length).toEqual(3 * 12);
+        var numVertices = 16;
+        var numTriangles = 12;
+        expect(m.attributes.position.values.length).toEqual(numVertices * 3);
+        expect(m.attributes.st.values.length).toEqual(numVertices * 2);
+        expect(m.attributes.normal.values.length).toEqual(numVertices * 3);
+        expect(m.attributes.tangent.values.length).toEqual(numVertices * 3);
+        expect(m.attributes.binormal.values.length).toEqual(numVertices * 3);
+        expect(m.indices.length).toEqual(numTriangles * 3);
     });
 
     it('computes attributes for a unit sphere', function() {

--- a/Specs/Core/PolygonGeometrySpec.js
+++ b/Specs/Core/PolygonGeometrySpec.js
@@ -52,7 +52,7 @@ defineSuite([
                 0.0, 0.0
             ])
         }));
-        expect(geometry).not.toBeDefined();
+        expect(geometry).toBeUndefined();
     });
 
     it('createGeometry returns undefined due to duplicate positions extruded', function() {
@@ -64,7 +64,7 @@ defineSuite([
             ]),
             extrudedHeight: 2
         }));
-        expect(geometry).not.toBeDefined();
+        expect(geometry).toBeUndefined();
     });
 
     it('createGeometry returns undefined due to duplicate hierarchy positions', function() {
@@ -84,40 +84,40 @@ defineSuite([
         };
 
         var geometry = PolygonGeometry.createGeometry(new PolygonGeometry({ polygonHierarchy : hierarchy }));
-        expect(geometry).not.toBeDefined();
+        expect(geometry).toBeUndefined();
     });
 
     it('computes positions', function() {
         var p = PolygonGeometry.createGeometry(PolygonGeometry.fromPositions({
-            vertexformat : VertexFormat.POSITION_ONLY,
+            vertexFormat : VertexFormat.POSITION_ONLY,
             positions : Cartesian3.fromDegreesArray([
-                -50.0, -50.0,
-                50.0, -50.0,
-                50.0, 50.0,
-                -50.0, 50.0
+                -1.0, -1.0,
+                1.0, -1.0,
+                1.0, 1.0,
+                -1.0, 1.0
             ]),
-            granularity : CesiumMath.PI_OVER_THREE
+            granularity: CesiumMath.RADIANS_PER_DEGREE
         }));
 
-        expect(p.attributes.position.values.length).toEqual(3 * 11);
-        expect(p.indices.length).toEqual(3 * 14);
+        expect(p.attributes.position.values.length).toEqual(13 * 3); // 8 around edge + 5 in the middle
+        expect(p.indices.length).toEqual(16 * 3); //4 squares * 4 triangles per square
     });
 
     it('computes positions with per position heights', function() {
         var ellipsoid = Ellipsoid.WGS84;
+        var height = 100.0;
         var positions = Cartesian3.fromDegreesArrayHeights([
-           -50.0, -50.0, 100000.0,
-           50.0, -50.0, 0.0,
-           50.0, 50.0, 0.0,
-           -50.0, 50.0, 0.0
+           -1.0, -1.0, height,
+           1.0, -1.0, 0.0,
+           1.0, 1.0, 0.0,
+           -1.0, 1.0, 0.0
        ]);
         var p = PolygonGeometry.createGeometry(PolygonGeometry.fromPositions({
             positions : positions,
-            granularity : CesiumMath.PI_OVER_THREE,
             perPositionHeight : true
         }));
 
-        expect(ellipsoid.cartesianToCartographic(Cartesian3.fromArray(p.attributes.position.values, 0)).height).toEqualEpsilon(100000, CesiumMath.EPSILON6);
+        expect(ellipsoid.cartesianToCartographic(Cartesian3.fromArray(p.attributes.position.values, 0)).height).toEqualEpsilon(height, CesiumMath.EPSILON6);
         expect(ellipsoid.cartesianToCartographic(Cartesian3.fromArray(p.attributes.position.values, 3)).height).toEqualEpsilon(0, CesiumMath.EPSILON6);
     });
 
@@ -125,20 +125,21 @@ defineSuite([
         var p = PolygonGeometry.createGeometry(PolygonGeometry.fromPositions({
             vertexFormat : VertexFormat.ALL,
             positions : Cartesian3.fromDegreesArray([
-                -50.0, -50.0,
-                50.0, -50.0,
-                50.0, 50.0,
-                -50.0, 50.0
-            ]),
-            granularity : CesiumMath.PI_OVER_THREE
+                -1.0, -1.0,
+                1.0, -1.0,
+                1.0, 1.0,
+                -1.0, 1.0
+            ])
         }));
 
-        expect(p.attributes.position.values.length).toEqual(3 * 11);
-        expect(p.attributes.st.values.length).toEqual(2 * 11);
-        expect(p.attributes.normal.values.length).toEqual(3 * 11);
-        expect(p.attributes.tangent.values.length).toEqual(3 * 11);
-        expect(p.attributes.binormal.values.length).toEqual(3 * 11);
-        expect(p.indices.length).toEqual(3 * 14);
+        var numVertices = 13;
+        var numTriangles = 16;
+        expect(p.attributes.position.values.length).toEqual(numVertices * 3);
+        expect(p.attributes.st.values.length).toEqual(numVertices * 2);
+        expect(p.attributes.normal.values.length).toEqual(numVertices * 3);
+        expect(p.attributes.tangent.values.length).toEqual(numVertices * 3);
+        expect(p.attributes.binormal.values.length).toEqual(numVertices * 3);
+        expect(p.indices.length).toEqual(numTriangles * 3);
     });
 
     it('creates a polygon from hierarchy', function() {
@@ -168,13 +169,13 @@ defineSuite([
         };
 
         var p = PolygonGeometry.createGeometry(new PolygonGeometry({
-            vertexformat : VertexFormat.POSITION_ONLY,
+            vertexFormat : VertexFormat.POSITION_ONLY,
             polygonHierarchy : hierarchy,
             granularity : CesiumMath.PI_OVER_THREE
         }));
 
-        expect(p.attributes.position.values.length).toEqual(3 * 14);
-        expect(p.indices.length).toEqual(3 * 10);
+        expect(p.attributes.position.values.length).toEqual(14 * 3); // 4 points * 3 rectangles + 2 points duplicated at corner
+        expect(p.indices.length).toEqual(10 * 3);
     });
 
     it('removes duplicates in polygon hierarchy', function() {
@@ -207,13 +208,13 @@ defineSuite([
         };
 
         var p = PolygonGeometry.createGeometry(new PolygonGeometry({
-            vertexformat : VertexFormat.POSITION_ONLY,
+            vertexFormat : VertexFormat.POSITION_ONLY,
             polygonHierarchy : hierarchy,
             granularity : CesiumMath.PI_OVER_THREE
         }));
 
-        expect(p.attributes.position.values.length).toEqual(3 * 14);
-        expect(p.indices.length).toEqual(3 * 10);
+        expect(p.attributes.position.values.length).toEqual(14 * 3);
+        expect(p.indices.length).toEqual(10 * 3);
     });
 
     it('creates a polygon from clockwise hierarchy', function() {
@@ -243,13 +244,13 @@ defineSuite([
         };
 
         var p = PolygonGeometry.createGeometry(new PolygonGeometry({
-            vertexformat : VertexFormat.POSITION_ONLY,
+            vertexFormat : VertexFormat.POSITION_ONLY,
             polygonHierarchy : hierarchy,
             granularity : CesiumMath.PI_OVER_THREE
         }));
 
-        expect(p.attributes.position.values.length).toEqual(3 * 14);
-        expect(p.indices.length).toEqual(3 * 10);
+        expect(p.attributes.position.values.length).toEqual(14 * 3);
+        expect(p.indices.length).toEqual(10 * 3);
     });
 
     it('doesn\'t reverse clockwise input array', function() {
@@ -282,7 +283,7 @@ defineSuite([
         };
 
         PolygonGeometry.createGeometry(new PolygonGeometry({
-            vertexformat : VertexFormat.POSITION_ONLY,
+            vertexFormat : VertexFormat.POSITION_ONLY,
             polygonHierarchy : hierarchy,
             granularity : CesiumMath.PI_OVER_THREE
         }));
@@ -364,35 +365,35 @@ defineSuite([
         var p = PolygonGeometry.createGeometry(PolygonGeometry.fromPositions({
             vertexFormat : VertexFormat.POSITION_ONLY,
             positions : Cartesian3.fromDegreesArray([
-                -50.0, -50.0,
-                50.0, -50.0,
-                50.0, 50.0,
-                -50.0, 50.0
+                -1.0, -1.0,
+                1.0, -1.0,
+                1.0, 1.0,
+                -1.0, 1.0
             ]),
-            granularity : CesiumMath.PI_OVER_THREE,
             extrudedHeight: 30000
         }));
 
-        expect(p.attributes.position.values.length).toEqual(3 * 21 * 2);
-        expect(p.indices.length).toEqual(3 * 20 * 2);
+        var numVertices = 50; // 13 top + 13 bottom + 8 top edge + 8 bottom edge + 4 top corner + 4 bottom corner
+        var numTriangles = 48; // 16 top fill + 16 bottom fill + 2 triangles * 4 sides
+        expect(p.attributes.position.values.length).toEqual(numVertices * 3);
+        expect(p.indices.length).toEqual(numTriangles * 3);
     });
 
     it('removes duplicates extruded', function() {
         var p = PolygonGeometry.createGeometry(PolygonGeometry.fromPositions({
             vertexFormat : VertexFormat.POSITION_ONLY,
             positions : Cartesian3.fromDegreesArray([
-                -50.0, -50.0,
-                50.0, -50.0,
-                50.0, 50.0,
-                -50.0, 50.0,
-                -50.0, -50.0
+                -1.0, -1.0,
+                1.0, -1.0,
+                1.0, 1.0,
+                -1.0, 1.0,
+                -1.0, -1.0
             ]),
-            granularity : CesiumMath.PI_OVER_THREE,
             extrudedHeight: 30000
         }));
 
-        expect(p.attributes.position.values.length).toEqual(3 * 21 * 2);
-        expect(p.indices.length).toEqual(3 * 20 * 2);
+        expect(p.attributes.position.values.length).toEqual(50 * 3);
+        expect(p.indices.length).toEqual(48 * 3);
     });
 
     it('computes all attributes extruded', function() {
@@ -400,21 +401,22 @@ defineSuite([
             vertexFormat : VertexFormat.ALL,
             polygonHierarchy: {
                 positions : Cartesian3.fromDegreesArray([
-                    -50.0, -50.0,
-                    50.0, -50.0,
-                    50.0, 50.0,
-                    -50.0, 50.0
+                    -1.0, -1.0,
+                    1.0, -1.0,
+                    1.0, 1.0,
+                    -1.0, 1.0
                 ])},
-            granularity : CesiumMath.PI_OVER_THREE,
             extrudedHeight: 30000
         }));
 
-        expect(p.attributes.position.values.length).toEqual(3 * 21 * 2);
-        expect(p.attributes.st.values.length).toEqual(2 * 21 * 2);
-        expect(p.attributes.normal.values.length).toEqual(3 * 21 * 2);
-        expect(p.attributes.tangent.values.length).toEqual(3 * 21 * 2);
-        expect(p.attributes.binormal.values.length).toEqual(3 * 21 * 2);
-        expect(p.indices.length).toEqual(3 * 20 * 2);
+        var numVertices = 50;
+        var numTriangles = 48;
+        expect(p.attributes.position.values.length).toEqual(numVertices * 3);
+        expect(p.attributes.st.values.length).toEqual(numVertices * 2);
+        expect(p.attributes.normal.values.length).toEqual(numVertices * 3);
+        expect(p.attributes.tangent.values.length).toEqual(numVertices * 3);
+        expect(p.attributes.binormal.values.length).toEqual(numVertices * 3);
+        expect(p.indices.length).toEqual(numTriangles * 3);
     });
 
     it('computes correct texture coordinates for polygon with height', function() {
@@ -492,8 +494,10 @@ defineSuite([
             extrudedHeight: 30000
         }));
 
-        expect(p.attributes.position.values.length).toEqual(3 * 38 * 2);
-        expect(p.indices.length).toEqual(3 * 22 * 2);
+        // (4 points * 3 rectangles * 3 to duplicate for normals + 2 duplicated at corner) * 2 for top and bottom
+        expect(p.attributes.position.values.length).toEqual(76 * 3);
+        // 10 top + 10 bottom + 2 triangles * 12 walls
+        expect(p.indices.length).toEqual(44 * 3);
     });
 
     it('undefined is returned if there are less than 3 positions', function() {

--- a/Specs/Core/PolygonOutlineGeometrySpec.js
+++ b/Specs/Core/PolygonOutlineGeometrySpec.js
@@ -49,7 +49,7 @@ defineSuite([
                 0.0, 0.0
             ])
         }));
-        expect(geometry).not.toBeDefined();
+        expect(geometry).toBeUndefined();
     });
 
     it('createGeometry returns undefined due to duplicate positions extruded', function() {
@@ -61,7 +61,7 @@ defineSuite([
             ]),
             extrudedHeight: 2
         }));
-        expect(geometry).not.toBeDefined();
+        expect(geometry).toBeUndefined();
     });
 
     it('createGeometry returns undefined due to duplicate hierarchy positions', function() {
@@ -81,39 +81,38 @@ defineSuite([
         };
 
         var geometry = PolygonOutlineGeometry.createGeometry(new PolygonOutlineGeometry({ polygonHierarchy : hierarchy }));
-        expect(geometry).not.toBeDefined();
+        expect(geometry).toBeUndefined();
     });
 
     it('computes positions', function() {
         var p = PolygonOutlineGeometry.createGeometry(PolygonOutlineGeometry.fromPositions({
             positions : Cartesian3.fromDegreesArray([
-                -50.0, -50.0,
-                50.0, -50.0,
-                50.0, 50.0,
-                -50.0, 50.0
-            ]),
-            granularity : CesiumMath.PI_OVER_THREE
+                -1.0, -1.0,
+                1.0, -1.0,
+                1.0, 1.0,
+                -1.0, 1.0
+            ])
         }));
 
-        expect(p.attributes.position.values.length).toEqual(3 * 6);
-        expect(p.indices.length).toEqual(2 * 6);
+        expect(p.attributes.position.values.length).toEqual(8 * 3);
+        expect(p.indices.length).toEqual(8 * 2);
     });
 
     it('computes positions with per position heights', function() {
         var ellipsoid = Ellipsoid.WGS84;
+        var height = 100.0;
         var positions = Cartesian3.fromDegreesArrayHeights([
-           -50.0, -50.0, 100000.0,
-           50.0, -50.0, 0.0,
-           50.0, 50.0, 0.0,
-           -50.0, 50.0, 0.0
+           -1.0, -1.0, height,
+           1.0, -1.0, 0.0,
+           1.0, 1.0, 0.0,
+           -1.0, 1.0, 0.0
        ]);
         var p = PolygonOutlineGeometry.createGeometry(PolygonOutlineGeometry.fromPositions({
             positions : positions,
-            granularity : CesiumMath.PI_OVER_THREE,
             perPositionHeight : true
         }));
 
-        expect(ellipsoid.cartesianToCartographic(Cartesian3.fromArray(p.attributes.position.values, 0)).height).toEqualEpsilon(100000, CesiumMath.EPSILON6);
+        expect(ellipsoid.cartesianToCartographic(Cartesian3.fromArray(p.attributes.position.values, 0)).height).toEqualEpsilon(height, CesiumMath.EPSILON6);
         expect(ellipsoid.cartesianToCartographic(Cartesian3.fromArray(p.attributes.position.values, 3)).height).toEqualEpsilon(0, CesiumMath.EPSILON6);
     });
 
@@ -148,8 +147,8 @@ defineSuite([
             granularity : CesiumMath.PI_OVER_THREE
         }));
 
-        expect(p.attributes.position.values.length).toEqual(3 * 12);
-        expect(p.indices.length).toEqual(2 * 12);
+        expect(p.attributes.position.values.length).toEqual(12 * 3); // 4 corners * 3 rectangles
+        expect(p.indices.length).toEqual(12 * 2);
     });
 
     it('creates a polygon from clockwise hierarchy', function() {
@@ -183,8 +182,8 @@ defineSuite([
             granularity : CesiumMath.PI_OVER_THREE
         }));
 
-        expect(p.attributes.position.values.length).toEqual(3 * 12);
-        expect(p.indices.length).toEqual(2 * 12);
+        expect(p.attributes.position.values.length).toEqual(12 * 3);
+        expect(p.indices.length).toEqual(12 * 2);
     });
 
     it('doesn\'t reverse clockwise input array', function() {
@@ -283,17 +282,16 @@ defineSuite([
     it('computes positions extruded', function() {
         var p = PolygonOutlineGeometry.createGeometry(PolygonOutlineGeometry.fromPositions({
             positions : Cartesian3.fromDegreesArray([
-                -50.0, -50.0,
-                50.0, -50.0,
-                50.0, 50.0,
-                -50.0, 50.0
+                -1.0, -1.0,
+                1.0, -1.0,
+                1.0, 1.0,
+                -1.0, 1.0
             ]),
-            granularity : CesiumMath.PI_OVER_THREE,
             extrudedHeight: 30000
         }));
 
-        expect(p.attributes.position.values.length).toEqual(3 * 6 * 2);
-        expect(p.indices.length).toEqual(2 * 6 * 2 + 4*2);
+        expect(p.attributes.position.values.length).toEqual(16 * 3); // 8 top + 8 bottom
+        expect(p.indices.length).toEqual(20 * 2); // 8 top + 8 bottom + 4 edges
     });
 
     it('creates a polygon from hierarchy extruded', function() {
@@ -328,8 +326,8 @@ defineSuite([
             extrudedHeight: 30000
         }));
 
-        expect(p.attributes.position.values.length).toEqual(3 * 12 * 2);
-        expect(p.indices.length).toEqual(2 * 12 * 2 + 12*2);
+        expect(p.attributes.position.values.length).toEqual(24 * 3); // 12 top + 12 bottom
+        expect(p.indices.length).toEqual(36 * 2); // 12 top + 12 bottom + 12 edges
     });
 
     it('undefined is returned if there are less than 3 positions', function() {

--- a/Specs/Core/PolylineVolumeGeometrySpec.js
+++ b/Specs/Core/PolylineVolumeGeometrySpec.js
@@ -19,7 +19,7 @@ defineSuite([
     var shape;
 
     beforeAll(function() {
-        shape = [new Cartesian2(-10000, -10000), new Cartesian2(10000, -10000), new Cartesian2(10000, 10000), new Cartesian2(-10000, 10000)];
+        shape = [new Cartesian2(-100, -100), new Cartesian2(100, -100), new Cartesian2(100, 100), new Cartesian2(-100, 100)];
     });
 
     it('throws without polyline positions', function() {
@@ -41,7 +41,7 @@ defineSuite([
             polylinePositions: [new Cartesian3()],
             shapePositions: shape
         }));
-        expect(geometry).not.toBeDefined();
+        expect(geometry).toBeUndefined();
     });
 
     it('createGeometry returnes undefined without 3 unique shape positions', function() {
@@ -49,7 +49,7 @@ defineSuite([
             polylinePositions: [Cartesian3.UNIT_X, Cartesian3.UNIT_Y],
             shapePositions: [Cartesian2.UNIT_X, Cartesian2.UNIT_X, Cartesian2.UNIT_X]
         }));
-        expect(geometry).not.toBeDefined();
+        expect(geometry).toBeUndefined();
     });
 
     it('computes positions', function() {
@@ -63,8 +63,10 @@ defineSuite([
             shapePositions: shape
         }));
 
-        expect(m.attributes.position.values.length).toEqual(3 * (4 * 2 + 4 * 2 * 6));
-        expect(m.indices.length).toEqual(3 * 10 * 2 + 24 * 3);
+        // 6 positions * 4 box positions * 2 to duplicate for normals + 4 positions * 2 ends
+        expect(m.attributes.position.values.length).toEqual(56 * 3);
+        // 5 segments + 8 triangles per segment + 2 triangles * 2 ends
+        expect(m.indices.length).toEqual(44 * 3);
     });
 
     it('computes positions, clockwise shape', function() {
@@ -78,8 +80,8 @@ defineSuite([
             shapePositions: shape.reverse()
         }));
 
-        expect(m.attributes.position.values.length).toEqual(3 * (4 * 2 + 4 * 2 * 6));
-        expect(m.indices.length).toEqual(3 * 10 * 2 + 24 * 3);
+        expect(m.attributes.position.values.length).toEqual(56 * 3);
+        expect(m.indices.length).toEqual(44 * 3);
     });
 
     it('compute all vertex attributes', function() {
@@ -93,12 +95,14 @@ defineSuite([
             shapePositions: shape
         }));
 
-        expect(m.attributes.position.values.length).toEqual(3 * (4 * 2 + 4 * 2 * 6));
-        expect(m.attributes.st.values.length).toEqual(2 * (4 * 2 + 4 * 2 * 6));
-        expect(m.attributes.normal.values.length).toEqual(3 * (4 * 2 + 4 * 2 * 6));
-        expect(m.attributes.tangent.values.length).toEqual(3 * (4 * 2 + 4 * 2 * 6));
-        expect(m.attributes.binormal.values.length).toEqual(3 * (4 * 2 + 4 * 2 * 6));
-        expect(m.indices.length).toEqual(3 * 10 * 2 + 24 * 3);
+        var numVertices = 56;
+        var numTriangles = 44;
+        expect(m.attributes.position.values.length).toEqual(numVertices * 3);
+        expect(m.attributes.st.values.length).toEqual(numVertices * 2);
+        expect(m.attributes.normal.values.length).toEqual(numVertices * 3);
+        expect(m.attributes.tangent.values.length).toEqual(numVertices * 3);
+        expect(m.attributes.binormal.values.length).toEqual(numVertices * 3);
+        expect(m.indices.length).toEqual(numTriangles * 3);
     });
 
     it('computes right turn', function() {
@@ -113,8 +117,10 @@ defineSuite([
             shapePositions: shape
         }));
 
-        expect(m.attributes.position.values.length).toEqual(3 * (4 * 2 + 4 * 2 * 6));
-        expect(m.indices.length).toEqual(3 * 10 * 2 + 24 * 3);
+        // (3 duplicates * 2 ends + 2 duplicates * 2 middle points + 4 duplicates * 1 corner) * 4 box positions
+        expect(m.attributes.position.values.length).toEqual(56 * 3);
+        // 8 triangles * 5 segments + 2 triangles * 2 ends
+        expect(m.indices.length).toEqual(44 * 3);
     });
 
     it('computes left turn', function() {
@@ -129,8 +135,8 @@ defineSuite([
             shapePositions: shape
         }));
 
-        expect(m.attributes.position.values.length).toEqual(3 * (4 * 2 + 4 * 2 * 6));
-        expect(m.indices.length).toEqual(3 * 10 * 2 + 24 * 3);
+        expect(m.attributes.position.values.length).toEqual(56 * 3);
+        expect(m.indices.length).toEqual(44 * 3);
     });
 
     it('computes with rounded corners', function() {
@@ -146,9 +152,11 @@ defineSuite([
             shapePositions: shape
         }));
 
-        var corners = 90/5 * 2;
-        expect(m.attributes.position.values.length).toEqual(3 * (corners * 4 * 2 * 2 + 4 * 2 * 9));
-        expect(m.indices.length).toEqual(3 * (corners * 4 * 2 * 2 + 4 * 7 * 2 + 4));
+        var corners = 36 * 4 * 4; // positions * 4 for shape * 4 for normal duplication
+        var numVertices = corners + 72; // corners + 9 positions * 2 for normal duplication * 4 for shape
+        var numTriangles = corners + 60; // corners + 8 triangles * 7 segments + 2 on each end
+        expect(m.attributes.position.values.length).toEqual(numVertices * 3);
+        expect(m.indices.length).toEqual(numTriangles * 3);
     });
 
     it('computes with beveled corners', function() {
@@ -164,8 +172,11 @@ defineSuite([
             shapePositions: shape
         }));
 
-        expect(m.attributes.position.values.length).toEqual(3 * (2 * 8 + 4 * 2 * 9));
-        expect(m.indices.length).toEqual(3 * (8 * 2 + 4 * 7 * 2 + 4));
+        var corners = 4 * 4; // 4 for shape * 4 for normal duplication
+        var numVertices = corners + 72; // corners + 9 positions * 2 for normal duplication * 4 for shape
+        var numTriangles = corners + 60; // corners + 8 triangles * 7 segments + 2 on each end
+        expect(m.attributes.position.values.length).toEqual(numVertices * 3);
+        expect(m.indices.length).toEqual(3 * numTriangles);
     });
 
     it('computes sharp turns', function() {
@@ -182,8 +193,10 @@ defineSuite([
             shapePositions: shape
         }));
 
-        expect(m.attributes.position.values.length).toEqual(360);
-        expect(m.indices.length).toEqual(324);
+        // (8 positions * 3 duplications + 1 duplication * 6 corners) * 4 for shape
+        expect(m.attributes.position.values.length).toEqual(120 * 3);
+        // 13 segments * 8 triangles per segment + 2 * 2 for ends
+        expect(m.indices.length).toEqual(108 * 3);
     });
 
     it('computes straight volume', function() {
@@ -199,8 +212,8 @@ defineSuite([
             granularity : Math.PI / 6.0
         }));
 
-        expect(m.attributes.position.values.length).toEqual(3 * 32);
-        expect(m.indices.length).toEqual(3 * 20);
+        expect(m.attributes.position.values.length).toEqual(32 * 3); // 4 positions * 2 for duplication * 4 for shape
+        expect(m.indices.length).toEqual(20 * 3); // 2 segments * 8 triangles per segment + 2 * 2 ends
     });
 
     var positions = [new Cartesian3(1.0, 0.0, 0.0), new Cartesian3(0.0, 1.0, 0.0), new Cartesian3(0.0, 0.0, 1.0)];

--- a/Specs/Core/PolylineVolumeOutlineGeometrySpec.js
+++ b/Specs/Core/PolylineVolumeOutlineGeometrySpec.js
@@ -18,7 +18,7 @@ defineSuite([
     var shape;
 
     beforeAll(function() {
-        shape = [new Cartesian2(-10000, -10000), new Cartesian2(10000, -10000), new Cartesian2(10000, 10000), new Cartesian2(-10000, 10000)];
+        shape = [new Cartesian2(-100, -100), new Cartesian2(100, -100), new Cartesian2(100, 100), new Cartesian2(-100, 100)];
     });
 
     it('throws without polyline positions', function() {
@@ -40,7 +40,7 @@ defineSuite([
             polylinePositions: [new Cartesian3()],
             shapePositions: shape
         }));
-        expect(geometry).not.toBeDefined();
+        expect(geometry).toBeUndefined();
     });
 
     it('createGeometry returnes undefined without 3 unique shape positions', function() {
@@ -48,7 +48,7 @@ defineSuite([
             polylinePositions: [Cartesian3.UNIT_X, Cartesian3.UNIT_Y],
             shapePositions: [Cartesian2.UNIT_X, Cartesian2.UNIT_X, Cartesian2.UNIT_X]
         }));
-        expect(geometry).not.toBeDefined();
+        expect(geometry).toBeUndefined();
     });
 
     it('computes positions', function() {
@@ -61,8 +61,8 @@ defineSuite([
             cornerType: CornerType.MITERED
         }));
 
-        expect(m.attributes.position.values.length).toEqual(3 * 6 * 4);
-        expect(m.indices.length).toEqual(2 * 24 + 8);
+        expect(m.attributes.position.values.length).toEqual(24 * 3); // 6 polyline positions * 4 box positions
+        expect(m.indices.length).toEqual(28 * 2); // 4 lines * 5 positions + 4 lines * 2 end caps
     });
 
     it('computes positions, clockwise shape', function() {
@@ -75,8 +75,8 @@ defineSuite([
             cornerType: CornerType.MITERED
         }));
 
-        expect(m.attributes.position.values.length).toEqual(3 * 6 * 4);
-        expect(m.indices.length).toEqual(2 * 24 + 8);
+        expect(m.attributes.position.values.length).toEqual(24 * 3);
+        expect(m.indices.length).toEqual(28 * 2);
     });
 
     it('computes right turn', function() {
@@ -90,8 +90,8 @@ defineSuite([
             shapePositions: shape
         }));
 
-        expect(m.attributes.position.values.length).toEqual(3 * 5 * 4);
-        expect(m.indices.length).toEqual(2 * 24);
+        expect(m.attributes.position.values.length).toEqual(20 * 3); // (2 ends + 3 corner positions) * 4 box positions
+        expect(m.indices.length).toEqual(24 * 2); // 4 lines * 4 positions + 4 lines * 2 end caps
     });
 
     it('computes left turn', function() {
@@ -105,8 +105,8 @@ defineSuite([
             shapePositions: shape
         }));
 
-        expect(m.attributes.position.values.length).toEqual(3 * 5 * 4);
-        expect(m.indices.length).toEqual(2 * 24);
+        expect(m.attributes.position.values.length).toEqual(20 * 3);
+        expect(m.indices.length).toEqual(24 * 2);
     });
 
     it('computes with rounded corners', function() {
@@ -121,9 +121,11 @@ defineSuite([
             shapePositions: shape
         }));
 
-        var corners = 90/5*2;
-        expect(m.attributes.position.values.length).toEqual(3 * (corners * 4 + 7 * 4));
-        expect(m.indices.length).toEqual(2 * (corners * 4 + 6 * 4 + 8));
+        var corners = 36 * 4;
+        var numVertices = corners + 28; // corners + 7 positions * 4 for shape
+        var numLines = corners + 32; // corners + 6 segments * 4 lines per segment + 4 lines * 2 ends
+        expect(m.attributes.position.values.length).toEqual(numVertices * 3);
+        expect(m.indices.length).toEqual(numLines * 2);
     });
 
     it('computes with beveled corners', function() {
@@ -138,8 +140,8 @@ defineSuite([
             shapePositions: shape
         }));
 
-        expect(m.attributes.position.values.length).toEqual(3 * 20 * 2);
-        expect(m.indices.length).toEqual(2 * 20 * 2 + 8);
+        expect(m.attributes.position.values.length).toEqual(40 * 3); // 10 positions * 4 for shape
+        expect(m.indices.length).toEqual(44 * 2); // 9 segments * 4 lines per segment + 4 lines * 2 ends
     });
 
     var positions = [new Cartesian3(1.0, 0.0, 0.0), new Cartesian3(0.0, 1.0, 0.0), new Cartesian3(0.0, 0.0, 1.0)];

--- a/Specs/Core/RectangleGeometrySpec.js
+++ b/Specs/Core/RectangleGeometrySpec.js
@@ -66,12 +66,14 @@ defineSuite([
             rectangle : new Rectangle(-2.0, -1.0, 0.0, 1.0),
             granularity : 1.0
         }));
-        expect(m.attributes.position.values.length).toEqual(9 * 3);
-        expect(m.attributes.st.values.length).toEqual(9 * 2);
-        expect(m.attributes.normal.values.length).toEqual(9 * 3);
-        expect(m.attributes.tangent.values.length).toEqual(9 * 3);
-        expect(m.attributes.binormal.values.length).toEqual(9 * 3);
-        expect(m.indices.length).toEqual(8 * 3);
+        var numVertices = 9; // 8 around edge + 1 in middle
+        var numTriangles = 8; // 4 squares * 2 triangles per square
+        expect(m.attributes.position.values.length).toEqual(numVertices * 3);
+        expect(m.attributes.st.values.length).toEqual(numVertices * 2);
+        expect(m.attributes.normal.values.length).toEqual(numVertices * 3);
+        expect(m.attributes.tangent.values.length).toEqual(numVertices * 3);
+        expect(m.attributes.binormal.values.length).toEqual(numVertices * 3);
+        expect(m.indices.length).toEqual(numTriangles * 3);
     });
 
     it('compute positions with rotation', function() {
@@ -176,8 +178,8 @@ defineSuite([
         }));
         var positions = m.attributes.position.values;
 
-        expect(positions.length).toEqual((9 + 8 + 4) * 3 * 2);
-        expect(m.indices.length).toEqual((8 * 2 + 4 * 4) * 3);
+        expect(positions.length).toEqual(42 * 3); // (9 fill + 8 edge + 4 corners) * 2 to duplicate for bottom
+        expect(m.indices.length).toEqual(32 * 3); // 8 * 2 for fill top and bottom + 4 triangles * 4 walls
     });
 
     it('computes all attributes extruded', function() {
@@ -187,12 +189,14 @@ defineSuite([
             granularity : 1.0,
             extrudedHeight : 2
         }));
-        expect(m.attributes.position.values.length).toEqual((9 + 8 + 4) * 3 * 2);
-        expect(m.attributes.st.values.length).toEqual((9 + 8 + 4) * 2 * 2);
-        expect(m.attributes.normal.values.length).toEqual((9 + 8 + 4) * 3 * 2);
-        expect(m.attributes.tangent.values.length).toEqual((9 + 8 + 4) * 3 * 2);
-        expect(m.attributes.binormal.values.length).toEqual((9 + 8 + 4) * 3 * 2);
-        expect(m.indices.length).toEqual((8 * 2 + 4 * 4) * 3);
+        var numVertices = 42;
+        var numTriangles = 32;
+        expect(m.attributes.position.values.length).toEqual(numVertices * 3);
+        expect(m.attributes.st.values.length).toEqual(numVertices * 2);
+        expect(m.attributes.normal.values.length).toEqual(numVertices * 3);
+        expect(m.attributes.tangent.values.length).toEqual(numVertices * 3);
+        expect(m.attributes.binormal.values.length).toEqual(numVertices * 3);
+        expect(m.indices.length).toEqual(numTriangles * 3);
     });
 
     it('compute positions with rotation extruded', function() {
@@ -208,8 +212,8 @@ defineSuite([
         var positions = m.attributes.position.values;
         var length = positions.length;
 
-        expect(length).toEqual((9 + 8 + 4) * 3 * 2);
-        expect(m.indices.length).toEqual((8 * 2 + 4 * 4) * 3);
+        expect(length).toEqual(42 * 3);
+        expect(m.indices.length).toEqual(32 * 3);
 
         var unrotatedSECorner = Rectangle.southeast(rectangle);
         var projection = new GeographicProjection();
@@ -231,6 +235,8 @@ defineSuite([
         }));
         var positions = m.attributes.position.values;
 
+        var numVertices = 9;
+        var numTriangles = 8;
         expect(positions.length).toEqual(9 * 3);
         expect(m.indices.length).toEqual(8 * 3);
     });

--- a/Specs/Core/RectangleOutlineGeometrySpec.js
+++ b/Specs/Core/RectangleOutlineGeometrySpec.js
@@ -59,9 +59,8 @@ defineSuite([
             granularity : 1.0
         }));
         var positions = m.attributes.position.values;
-        var length = positions.length;
 
-        expect(length).toEqual(8 * 3);
+        expect(positions.length).toEqual(8 * 3);
         expect(m.indices.length).toEqual(8 * 2);
 
         var unrotatedNWCorner = Rectangle.northwest(rectangle);
@@ -106,8 +105,8 @@ defineSuite([
         }));
         var positions = m.attributes.position.values;
 
-        expect(positions.length).toEqual(8 * 3 * 2);
-        expect(m.indices.length).toEqual(8 * 2 * 2 + 4 * 2);
+        expect(positions.length).toEqual(16 * 3); // 8 top + 8 bottom
+        expect(m.indices.length).toEqual(20 * 2); // 8 top + 8 bottom + 4 edges
     });
 
     it('compute positions with rotation extruded', function() {
@@ -120,10 +119,9 @@ defineSuite([
             extrudedHeight : 2
         }));
         var positions = m.attributes.position.values;
-        var length = positions.length;
 
-        expect(length).toEqual(8 * 3 * 2);
-        expect(m.indices.length).toEqual(8 * 2 * 2 + 4 * 2);
+        expect(positions.length).toEqual(16 * 3);
+        expect(m.indices.length).toEqual(20 * 2);
 
         var unrotatedNWCorner = Rectangle.northwest(rectangle);
         var projection = new GeographicProjection();

--- a/Specs/Core/SphereGeometrySpec.js
+++ b/Specs/Core/SphereGeometrySpec.js
@@ -37,8 +37,8 @@ defineSuite([
             slicePartitions: 3
         }));
 
-        expect(m.attributes.position.values.length).toEqual(3 * 16);
-        expect(m.indices.length).toEqual(3 * 12);
+        expect(m.attributes.position.values.length).toEqual(16 * 3); // 4 positions * 4 rows
+        expect(m.indices.length).toEqual(12 * 3); //3 top + 3 bottom + 2 triangles * 3 sides
         expect(m.boundingSphere.radius).toEqual(1);
     });
 
@@ -50,12 +50,14 @@ defineSuite([
             slicePartitions: 3
         }));
 
-        expect(m.attributes.position.values.length).toEqual(3 * 16);
-        expect(m.attributes.st.values.length).toEqual(2 * 16);
-        expect(m.attributes.normal.values.length).toEqual(3 * 16);
-        expect(m.attributes.tangent.values.length).toEqual(3 * 16);
-        expect(m.attributes.binormal.values.length).toEqual(3 * 16);
-        expect(m.indices.length).toEqual(3 * 12);
+        var numVertices = 16;
+        var numTriangles = 12;
+        expect(m.attributes.position.values.length).toEqual(numVertices * 3);
+        expect(m.attributes.st.values.length).toEqual(numVertices * 2);
+        expect(m.attributes.normal.values.length).toEqual(numVertices * 3);
+        expect(m.attributes.tangent.values.length).toEqual(numVertices * 3);
+        expect(m.attributes.binormal.values.length).toEqual(numVertices * 3);
+        expect(m.indices.length).toEqual(numTriangles * 3);
     });
 
     it('computes attributes for a unit sphere', function() {

--- a/Specs/Core/WallOutlineGeometrySpec.js
+++ b/Specs/Core/WallOutlineGeometrySpec.js
@@ -81,7 +81,7 @@ defineSuite([
         }));
 
         var positions = w.attributes.position.values;
-        expect(positions.length).toEqual(2 * 2 * 3);
+        expect(positions.length).toEqual(4 * 3);
         expect(w.indices.length).toEqual(4 * 2);
 
         var cartographic = ellipsoid.cartesianToCartographic(Cartesian3.fromArray(positions, 0));
@@ -103,7 +103,7 @@ defineSuite([
         }));
 
         var positions = w.attributes.position.values;
-        expect(positions.length).toEqual(2 * 2 * 3);
+        expect(positions.length).toEqual(4 * 3);
         expect(w.indices.length).toEqual(4 * 2);
 
         var cartographic = ellipsoid.cartesianToCartographic(Cartesian3.fromArray(positions, 0));
@@ -133,8 +133,8 @@ defineSuite([
         }));
 
         var positions = w.attributes.position.values;
-        expect(positions.length).toEqual(3 * 2 * 3);
-        expect(w.indices.length).toEqual(7 * 2);
+        expect(positions.length).toEqual(6 * 3);
+        expect(w.indices.length).toEqual(7 * 2); //3 vertical + 4 horizontal
 
         var cartographic = ellipsoid.cartesianToCartographic(Cartesian3.fromArray(positions, 0));
         expect(cartographic.height).toEqualEpsilon(0.0, CesiumMath.EPSILON8);
@@ -163,8 +163,8 @@ defineSuite([
         }));
 
         var positions = w.attributes.position.values;
-        expect(positions.length).toEqual(2 * 2 * 3);
-        expect(w.indices.length).toEqual(2 * 4);
+        expect(positions.length).toEqual(4 * 3);
+        expect(w.indices.length).toEqual(4 * 2);
 
         var cartographic = ellipsoid.cartesianToCartographic(Cartesian3.fromArray(positions, 0));
         expect(cartographic.height).toEqualEpsilon(min, CesiumMath.EPSILON8);
@@ -188,4 +188,3 @@ defineSuite([
     var packedInstance = [3.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 1.0, 1.0, 0.01];
     createPackableSpecs(WallOutlineGeometry, wall, packedInstance);
 });
-


### PR DESCRIPTION
This fixes a bug in `EllipseOutlineGeometry` where the length of the indices array was longer than the number of indices for small extruded ellipses (where the number of positions around the edge was less than the number of vertical lines we wanted)

While fixing other geometry bugs, I've been cleaning up and adding comments to the geometry specs to demystify what the numbers represent.  Those changes are also in the PR.