### PR TITLE
Fix Polylines in a PolylineCollection that cross the IDL

### DIFF
--- a/Source/Scene/PolylineCollection.js
+++ b/Source/Scene/PolylineCollection.js
@@ -1535,7 +1535,9 @@ define([
                     scratchWritePrevPosition.z = 0.0;
                     scratchWritePosition.z = 0.0;
                     scratchWriteNextPosition.z = 0.0;
+                }
 
+                if (mode === SceneMode.SCENE2D || mode === SceneMode.MORPHING) {
                     if ((segmentStart || segmentEnd) && maxLon - Math.abs(scratchWritePosition.x) < 1.0) {
                         if ((scratchWritePosition.x < 0.0 && scratchWritePrevPosition.x > 0.0) ||
                             (scratchWritePosition.x > 0.0 && scratchWritePrevPosition.x < 0.0)) {


### PR DESCRIPTION
Fix adjacency information for lines in a `PolylineCollection` that cross the IDL. Similar to #3714.

Here's an example for a simple polyline and one that is subdivided to fit the ellipsoid:
```javascript
var viewer = new Cesium.Viewer('cesiumContainer', { sceneMode : Cesium.SceneMode.SCENE2D });

var polylines = viewer.scene.primitives.add(new Cesium.PolylineCollection());
polylines.add({
    positions : Cesium.Cartesian3.fromDegreesArray([-170.0, 30.0, 170.0, 30.0]),
    material : Cesium.Material.fromType('Color', {
        color : new Cesium.Color(1.0, 1.0, 0.0, 1.0)
    }),
    width : 10.0
});

polylines.add({
    positions : Cesium.PolylinePipeline.generateCartesianArc({
        positions : Cesium.Cartesian3.fromDegreesArray([170.0, -40.0, -170.0, -30.0])
    }),
    material : Cesium.Material.fromType('Color', {
        color : new Cesium.Color(0.0, 1.0, 1.0, 1.0)
    }),
    width : 10.0
});
```