### PR TITLE
Fix running tests from command line

### DIFF
--- a/Specs/karma.conf.js
+++ b/Specs/karma.conf.js
@@ -12,30 +12,7 @@ module.exports = function(config) {
 
         detectBrowsers : {
             enabled : false,
-
-            usePhantomJS : false,
-
-            // post processing of browsers list
-            // here you can edit the list of browsers used by karma
-            postDetection : function(availableBrowser) {
-                //Add IE Emulation
-                var result = availableBrowser;
-
-                if (availableBrowser.indexOf('IE') > -1) {
-                    result.push('IE9');
-                }
-
-                //Remove PhantomJS if another browser has been detected
-                if (availableBrowser.length > 1 && availableBrowser.indexOf('PhantomJS') > -1) {
-                    var i = result.indexOf('PhantomJS');
-
-                    if (i !== -1) {
-                        result.splice(i, 1);
-                    }
-                }
-
-                return result;
-            }
+            usePhantomJS : false
         },
 
         // list of files / patterns to load in the browser

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -310,7 +310,7 @@ gulp.task('test', function(done) {
     var failTaskOnError = argv.failTaskOnError ? argv.failTaskOnError : false;
     var suppressPassed = argv.suppressPassed ? argv.suppressPassed : false;
 
-    var browsers;
+    var browsers = ['Chrome'];
     if (argv.browsers) {
         browsers = argv.browsers.split(',');
     }

--- a/package.json
+++ b/package.json
@@ -28,14 +28,14 @@
     "email": "cesium-dev@googlegroups.com"
   },
   "dependencies": {
-    "requirejs": "2.1.22"
+    "requirejs": "2.2.0"
   },
   "devDependencies": {
     "almond": "0.3.1",
     "async": "1.5.2",
     "bluebird": "3.3.4",
     "compression": "1.6.1",
-    "electron-prebuilt": "0.36.10",
+    "electron-prebuilt": "0.37.2",
     "event-stream": "3.3.2",
     "express": "4.13.4",
     "globby": "4.0.0",
@@ -49,21 +49,21 @@
     "jsdoc": "3.4.0",
     "jshint": "2.9.1",
     "jshint-stylish": "2.1.0",
-    "karma": "0.13.21",
+    "karma": "0.13.22",
     "karma-chrome-launcher": "0.2.2",
     "karma-detect-browsers": "2.0.2",
     "karma-electron-launcher": "0.1.0",
     "karma-firefox-launcher": "0.1.7",
     "karma-ie-launcher": "0.2.0",
-    "karma-jasmine": "0.3.7",
-    "karma-requirejs": "0.2.5",
+    "karma-jasmine": "0.3.8",
+    "karma-requirejs": "0.2.6",
     "karma-safari-launcher": "0.1.1",
     "karma-spec-reporter": "0.0.24",
     "mkdirp": "0.5.1",
     "request": "2.69.0",
     "rimraf": "2.5.2",
     "strip-comments": "0.3.2",
-    "yargs": "4.2.0"
+    "yargs": "4.3.2"
   },
   "scripts": {
     "start": "node server.js",


### PR DESCRIPTION
Also updated npm modules (most of which were testing related).

Fixes #3732 

I'm getting some failures under Firefox that I'm not seeing when running the legacy jasmine implementation, but I think that's an unrelated issue (that we should look into eventually)