### PR TITLE
Fix terrain exaggeration bug

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,7 @@ Change Log
 * Fix issue where the `GroundPrimitive` volume was being clipped by the far plane. [#3706](https://github.com/AnalyticalGraphicsInc/cesium/issues/3706)
 * Fixed issue where `Camera.computeViewRectangle` was incorrect when crossing the international date line [#3717](https://github.com/AnalyticalGraphicsInc/cesium/issues/3717)
 * Added `Rectangle` result parameter to `Camera.computeViewRectangle`
+* Fix bug when upsampling exaggerated terrain where the terrain heights were exaggerated at twice the value. [#3607](https://github.com/AnalyticalGraphicsInc/cesium/issues/3607)
 
 ### 1.19 - 2016-03-01
 

--- a/Source/Core/HeightmapTerrainData.js
+++ b/Source/Core/HeightmapTerrainData.js
@@ -226,7 +226,8 @@ define([
                     result.occludeePointInScaledSpace,
                     6,
                     result.orientedBoundingBox,
-                    TerrainEncoding.clone(result.encoding));
+                    TerrainEncoding.clone(result.encoding),
+                    exaggeration);
 
             // Free memory received from server after mesh is created.
             that._buffer = undefined;
@@ -261,7 +262,8 @@ define([
             var buffer = this._mesh.vertices;
             var encoding = this._mesh.encoding;
             var skirtHeight = this._skirtHeight;
-            heightSample = interpolateMeshHeight(buffer, encoding, heightOffset, heightScale, skirtHeight, rectangle, width, height, longitude, latitude);
+            var exaggeration = this._mesh.exaggeration;
+            heightSample = interpolateMeshHeight(buffer, encoding, heightOffset, heightScale, skirtHeight, rectangle, width, height, longitude, latitude, exaggeration);
         } else {
             heightSample = interpolateHeight(this._buffer, elementsPerHeight, elementMultiplier, stride, isBigEndian, rectangle, width, height, longitude, latitude);
             heightSample = heightSample * heightScale + heightOffset;
@@ -335,6 +337,7 @@ define([
 
         var heightOffset = structure.heightOffset;
         var heightScale = structure.heightScale;
+        var exaggeration = meshData.exaggeration;
 
         var elementsPerHeight = structure.elementsPerHeight;
         var elementMultiplier = structure.elementMultiplier;
@@ -346,7 +349,7 @@ define([
             var latitude = CesiumMath.lerp(destinationRectangle.north, destinationRectangle.south, j / (height - 1));
             for (var i = 0; i < width; ++i) {
                 var longitude = CesiumMath.lerp(destinationRectangle.west, destinationRectangle.east, i / (width - 1));
-                var heightSample = interpolateMeshHeight(buffer, encoding, heightOffset, heightScale, skirtHeight, sourceRectangle, width, height, longitude, latitude);
+                var heightSample = interpolateMeshHeight(buffer, encoding, heightOffset, heightScale, skirtHeight, sourceRectangle, width, height, longitude, latitude, exaggeration);
                 setHeight(heights, elementsPerHeight, elementMultiplier, divisor, stride, isBigEndian, j * width + i, heightSample);
             }
         }
@@ -444,7 +447,7 @@ define([
         return triangleInterpolateHeight(dx, dy, southwestHeight, southeastHeight, northwestHeight, northeastHeight);
     }
 
-    function interpolateMeshHeight(buffer, encoding, heightOffset, heightScale, skirtHeight, sourceRectangle, width, height, longitude, latitude) {
+    function interpolateMeshHeight(buffer, encoding, heightOffset, heightScale, skirtHeight, sourceRectangle, width, height, longitude, latitude, exaggeration) {
         var fromWest = (longitude - sourceRectangle.west) * (width - 1) / (sourceRectangle.east - sourceRectangle.west);
         var fromSouth = (latitude - sourceRectangle.south) * (height - 1) / (sourceRectangle.north - sourceRectangle.south);
 
@@ -478,10 +481,10 @@ define([
         southInteger = height - 1 - southInteger;
         northInteger = height - 1 - northInteger;
 
-        var southwestHeight = (encoding.decodeHeight(buffer, southInteger * width + westInteger) - heightOffset) / heightScale;
-        var southeastHeight = (encoding.decodeHeight(buffer, southInteger * width + eastInteger) - heightOffset) / heightScale;
-        var northwestHeight = (encoding.decodeHeight(buffer, northInteger * width + westInteger) - heightOffset) / heightScale;
-        var northeastHeight = (encoding.decodeHeight(buffer, northInteger * width + eastInteger) - heightOffset) / heightScale;
+        var southwestHeight = (encoding.decodeHeight(buffer, southInteger * width + westInteger) / exaggeration - heightOffset) / heightScale;
+        var southeastHeight = (encoding.decodeHeight(buffer, southInteger * width + eastInteger) / exaggeration - heightOffset) / heightScale;
+        var northwestHeight = (encoding.decodeHeight(buffer, northInteger * width + westInteger) / exaggeration - heightOffset) / heightScale;
+        var northeastHeight = (encoding.decodeHeight(buffer, northInteger * width + eastInteger) / exaggeration - heightOffset) / heightScale;
 
         return triangleInterpolateHeight(dx, dy, southwestHeight, southeastHeight, northwestHeight, northeastHeight);
     }

--- a/Source/Core/QuantizedMeshTerrainData.js
+++ b/Source/Core/QuantizedMeshTerrainData.js
@@ -320,7 +320,8 @@ define([
                     occlusionPoint,
                     stride,
                     obb,
-                    terrainEncoding);
+                    terrainEncoding,
+                    exaggeration);
 
             // Free memory received from server after mesh is created.
             that._quantizedVertices = undefined;
@@ -408,7 +409,8 @@ define([
             isEastChild : isEastChild,
             isNorthChild : isNorthChild,
             childRectangle : childRectangle,
-            ellipsoid : ellipsoid
+            ellipsoid : ellipsoid,
+            exaggeration : mesh.exaggeration
         });
 
         if (!defined(upsamplePromise)) {

--- a/Source/Core/TerrainMesh.js
+++ b/Source/Core/TerrainMesh.js
@@ -30,7 +30,7 @@ define([
       *
       * @private
       */
-    function TerrainMesh(center, vertices, indices, minimumHeight, maximumHeight, boundingSphere3D, occludeePointInScaledSpace, vertexStride, orientedBoundingBox, encoding) {
+    function TerrainMesh(center, vertices, indices, minimumHeight, maximumHeight, boundingSphere3D, occludeePointInScaledSpace, vertexStride, orientedBoundingBox, encoding, exaggeration) {
         /**
          * The center of the tile.  Vertex positions are specified relative to this center.
          * @type {Cartesian3}
@@ -98,6 +98,12 @@ define([
          * @type {TerrainEncoding}
          */
         this.encoding = encoding;
+
+        /**
+         * The amount that this mesh was exaggerated.
+         * @type {Number}
+         */
+        this.exaggeration = exaggeration;
     }
 
     return TerrainMesh;

--- a/Source/Workers/upsampleQuantizedTerrainMesh.js
+++ b/Source/Workers/upsampleQuantizedTerrainMesh.js
@@ -80,6 +80,7 @@ define([
 
         var encoding = TerrainEncoding.clone(parameters.encoding);
         var hasVertexNormals = encoding.hasVertexNormals;
+        var exaggeration = parameters.exaggeration;
 
         var vertexCount = 0;
         var quantizedVertexCount = parameters.vertexCountWithoutSkirts;
@@ -98,7 +99,7 @@ define([
         var i, n;
         for (i = 0, n = 0; i < quantizedVertexCount; ++i, n += 2) {
             var texCoords = encoding.decodeTextureCoordinates(parentVertices, i, decodeTexCoordsScratch);
-            height  = encoding.decodeHeight(parentVertices, i);
+            height  = encoding.decodeHeight(parentVertices, i) / exaggeration;
 
             parentUBuffer[i] = CesiumMath.clamp((texCoords.x * maxShort) | 0, 0, maxShort);
             parentVBuffer[i] = CesiumMath.clamp((texCoords.y * maxShort) | 0, 0, maxShort);


### PR DESCRIPTION
Fixes #3607.

Upsampling exaggerated terrain wasn't taking into account the exaggeration. So the resulting upsampled terrain was exaggerated at `2.0 * frameState.terrainExaggeration`. The reason the screen shots in the issue look so different is because the first is quantized mesh terrain and the second is heightmap terrain.

The VR the World terrain set isn't loading. Maybe the link is broken? For testing heightmaps, use small terrain.