### PR TITLE
Fix crash when adding/removing a path entity without rendering

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,7 @@ Change Log
 * Fixed issue where `Camera.computeViewRectangle` was incorrect when crossing the international date line [#3717](https://github.com/AnalyticalGraphicsInc/cesium/issues/3717)
 * Added `Rectangle` result parameter to `Camera.computeViewRectangle`
 * Fix bug when upsampling exaggerated terrain where the terrain heights were exaggerated at twice the value. [#3607](https://github.com/AnalyticalGraphicsInc/cesium/issues/3607)
+* Fixed a crash that would occur if you added and removed an `Entity` with a path without ever actually rendering it. [#3738](https://github.com/AnalyticalGraphicsInc/cesium/pull/3738)
 
 ### 1.19 - 2016-03-01
 

--- a/Source/DataSources/PathVisualizer.js
+++ b/Source/DataSources/PathVisualizer.js
@@ -529,7 +529,9 @@ define([
             entity = removed[i];
             item = items.get(entity.id);
             if (defined(item)) {
-                item.updater.removeObject(item);
+                if (defined(item.updater)) {
+                    item.updater.removeObject(item);
+                }
                 items.remove(entity.id);
             }
         }

--- a/Specs/DataSources/PathVisualizerSpec.js
+++ b/Specs/DataSources/PathVisualizerSpec.js
@@ -111,6 +111,25 @@ defineSuite([
         expect(scene.primitives.length).toEqual(0);
     });
 
+    it('adding and removing an entity path without rendering does not crash.', function() {
+        var times = [new JulianDate(0, 0), new JulianDate(1, 0)];
+        var positions = [new Cartesian3(1234, 5678, 9101112), new Cartesian3(5678, 1234, 1101112)];
+
+        var entityCollection = new EntityCollection();
+        visualizer = new PathVisualizer(scene, entityCollection);
+
+        var position = new SampledPositionProperty();
+        position.addSamples(times, positions);
+
+        var testObject = entityCollection.getOrCreateEntity('test');
+        testObject.position = position;
+        testObject.path = new PathGraphics();
+
+        //Before we fixed the issue, the below remove call would cause a crash
+        //when visualizer.update was not called at least once after the entity was added.
+        entityCollection.remove(testObject);
+    });
+
     it('A PathGraphics causes a primitive to be created and updated.', function() {
         var times = [new JulianDate(0, 0), new JulianDate(1, 0)];
         var updateTime = new JulianDate(0.5, 0);


### PR DESCRIPTION
If you added and removed an entity without ever actually rendering it, we would try and access a property that was never actually created (because it's delayed until rendering).  This code simply checks that the property exists and adds a test to verify the behavior doesn't crash.