### PR TITLE
Allow EntityCollection events to be reentrant

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,7 @@ Change Log
 * Fix issue where the `GroundPrimitive` volume was being clipped by the far plane. [#3706](https://github.com/AnalyticalGraphicsInc/cesium/issues/3706)
 * Fixed issue where `Camera.computeViewRectangle` was incorrect when crossing the international date line [#3717](https://github.com/AnalyticalGraphicsInc/cesium/issues/3717)
 * Added `Rectangle` result parameter to `Camera.computeViewRectangle`
+* Fixed a reentrancy bug in `EntityCollection.collectionChanged`. [#3739](https://github.com/AnalyticalGraphicsInc/cesium/pull/3739)
 * Fix bug when upsampling exaggerated terrain where the terrain heights were exaggerated at twice the value. [#3607](https://github.com/AnalyticalGraphicsInc/cesium/issues/3607)
 
 ### 1.19 - 2016-03-01

--- a/Source/DataSources/EntityCollection.js
+++ b/Source/DataSources/EntityCollection.js
@@ -43,9 +43,9 @@ define([
                 collection._firing = true;
                 do {
                     collection._refire = false;
-                    var addedArray = collection._addedEntities.values.slice(0);
-                    var removedArray = collection._removedEntities.values.slice(0);
-                    var changedArray = collection._changedEntities.values.slice(0);
+                    var addedArray = added.values.slice(0);
+                    var removedArray = removed.values.slice(0);
+                    var changedArray = changed.values.slice(0);
 
                     added.removeAll();
                     removed.removeAll();

--- a/Source/DataSources/EntityCollection.js
+++ b/Source/DataSources/EntityCollection.js
@@ -40,6 +40,7 @@ define([
             var removed = collection._removedEntities;
             var changed = collection._changedEntities;
             if (changed.length !== 0 || added.length !== 0 || removed.length !== 0) {
+                collection._firing = true;
                 do {
                     collection._refire = false;
                     var addedArray = collection._addedEntities.values.slice(0);
@@ -51,6 +52,7 @@ define([
                     changed.removeAll();
                     collection._collectionChanged.raiseEvent(collection, addedArray, removedArray, changedArray);
                 } while (collection._refire);
+                collection._firing = false;
             }
         }
     }

--- a/Specs/DataSources/EntityCollectionSpec.js
+++ b/Specs/DataSources/EntityCollectionSpec.js
@@ -143,6 +143,11 @@ defineSuite([
         entityCollection.add(entity);
         entityCollection.add(entity2);
 
+        var entityToDelete = new Entity();
+        entityCollection.add(entityToDelete);
+
+        var entityToAdd = new Entity();
+
         var inCallback = false;
         var listener = jasmine.createSpy('listener').and.callFake(function(collection, added, removed, changed) {
             //When we set the name to `newName` below, this code will modify entity2's name, thus triggering
@@ -156,6 +161,12 @@ defineSuite([
             if (entity2.name !== 'Bob') {
                 entity2.name = 'Bob';
             }
+            if (entityCollection.contains(entityToDelete)) {
+                entityCollection.removeById(entityToDelete.id);
+            }
+            if (!entityCollection.contains(entityToAdd)) {
+                entityCollection.add(entityToAdd);
+            }
             inCallback = false;
         });
         entityCollection.collectionChanged.addEventListener(listener);
@@ -163,7 +174,12 @@ defineSuite([
         entity.name = 'newName';
         expect(listener.calls.count()).toBe(2);
         expect(listener.calls.argsFor(0)).toEqual([entityCollection, [], [], [entity]]);
-        expect(listener.calls.argsFor(1)).toEqual([entityCollection, [], [], [entity2]]);
+        expect(listener.calls.argsFor(1)).toEqual([entityCollection, [entityToAdd], [entityToDelete], [entity2]]);
+
+        expect(entity.name).toEqual('newName');
+        expect(entity2.name).toEqual('Bob');
+        expect(entityCollection.contains(entityToDelete)).toEqual(false);
+        expect(entityCollection.contains(entityToAdd)).toEqual(true);
     });
 
     it('suspended add/remove raises expected events', function() {

--- a/Specs/DataSources/EntityCollectionSpec.js
+++ b/Specs/DataSources/EntityCollectionSpec.js
@@ -143,13 +143,20 @@ defineSuite([
         entityCollection.add(entity);
         entityCollection.add(entity2);
 
+        var inCallback = false;
         var listener = jasmine.createSpy('listener').and.callFake(function(collection, added, removed, changed) {
             //When we set the name to `newName` below, this code will modify entity2's name, thus triggering
             //another event firing that occurs after all current subscribers have been notified of the
             //event we are inside of.
+
+            //By checking that inCallback is false, we are making sure the entity2.name assignment
+            //is delayed until after the first round of events is fired.
+            expect(inCallback).toBe(false);
+            inCallback = true;
             if (entity2.name !== 'Bob') {
                 entity2.name = 'Bob';
             }
+            inCallback = false;
         });
         entityCollection.collectionChanged.addEventListener(listener);
 


### PR DESCRIPTION
The `EntityCollection.collectionChanged` event would have odd behavior if you modified an entity inside the collection from within a `collectionChanged` callback.  The added/removed/changed entity would get appended to the current arrays being passed around and a new event would get raised immedediately which included duplicates of all current event parameters plus the new entity.  At the same time, remaining handlers would ultimately end up seeing the second event but not the first.

This change makes the code rentrant safe and causes all reentrant events to be queued and then properly raised at the end of the current event cycle.