### PR TITLE
Fix jsHint CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ before_script:
   - sh -e /etc/init.d/xvfb start
 script:
   - echo 'jsHint' && echo -en 'travis_fold:start:script.jsHint\\r'
-  - npm run jsHint --failTaskOnError
+  - npm run jsHint -- --failTaskOnError
   - echo -en 'travis_fold:end:script.jsHint\\r'
 
   - echo 'test non-webgl' && echo -en 'travis_fold:start:script.test\\r'

--- a/Specs/Core/CircleGeometrySpec.js
+++ b/Specs/Core/CircleGeometrySpec.js
@@ -52,8 +52,8 @@ defineSuite([
 
         var numVertices = 16; //rows of 1 + 4 + 6 + 4 + 1
         var numTriangles = 22; //rows of 3 + 8 + 8 + 3
-        expect(m.attributes.position.values.length).toEqual(16 * 3);
-        expect(m.indices.length).toEqual(22 * 3);
+        expect(m.attributes.position.values.length).toEqual(numVertices * 3);
+        expect(m.indices.length).toEqual(numTriangles * 3);
         expect(m.boundingSphere.radius).toEqual(1);
     });
 

--- a/Specs/Core/RectangleGeometrySpec.js
+++ b/Specs/Core/RectangleGeometrySpec.js
@@ -237,8 +237,8 @@ defineSuite([
 
         var numVertices = 9;
         var numTriangles = 8;
-        expect(positions.length).toEqual(9 * 3);
-        expect(m.indices.length).toEqual(8 * 3);
+        expect(positions.length).toEqual(numVertices * 3);
+        expect(m.indices.length).toEqual(numTriangles * 3);
     });
 
     it('undefined is returned if any side are of length zero', function() {


### PR DESCRIPTION
The travis command was missing `--` which was causing it to not fail in the event of an error.  This also means we let a couple of warnings slip into master (which I have also fixed).