### PR TITLE
Changed DeveloperError and RuntimeError to inherit from Error

### DIFF
--- a/Source/Core/DeveloperError.js
+++ b/Source/Core/DeveloperError.js
@@ -53,6 +53,9 @@ define([
         this.stack = stack;
     }
 
+    DeveloperError.prototype = Object.create(Error.prototype);
+    DeveloperError.prototype.constructor = DeveloperError;
+
     DeveloperError.prototype.toString = function() {
         var str = this.name + ': ' + this.message;
 

--- a/Source/Core/DeveloperError.js
+++ b/Source/Core/DeveloperError.js
@@ -17,6 +17,7 @@ define([
      *
      * @alias DeveloperError
      * @constructor
+     * @extends Error
      *
      * @param {String} [message] The error message for this exception.
      *

--- a/Source/Core/DeveloperError.js
+++ b/Source/Core/DeveloperError.js
@@ -54,8 +54,10 @@ define([
         this.stack = stack;
     }
 
-    DeveloperError.prototype = Object.create(Error.prototype);
-    DeveloperError.prototype.constructor = DeveloperError;
+    if (defined(Object.create)) {
+        DeveloperError.prototype = Object.create(Error.prototype);
+        DeveloperError.prototype.constructor = DeveloperError;
+    }
 
     DeveloperError.prototype.toString = function() {
         var str = this.name + ': ' + this.message;

--- a/Source/Core/RuntimeError.js
+++ b/Source/Core/RuntimeError.js
@@ -16,6 +16,7 @@ define([
      *
      * @alias RuntimeError
      * @constructor
+     * @extends Error
      *
      * @param {String} [message] The error message for this exception.
      *

--- a/Source/Core/RuntimeError.js
+++ b/Source/Core/RuntimeError.js
@@ -51,6 +51,10 @@ define([
          */
         this.stack = stack;
     }
+
+    RuntimeError.prototype = Object.create(Error.prototype);
+    RuntimeError.prototype.constructor = RuntimeError;
+
     RuntimeError.prototype.toString = function() {
         var str = this.name + ': ' + this.message;
 

--- a/Source/Core/RuntimeError.js
+++ b/Source/Core/RuntimeError.js
@@ -53,8 +53,10 @@ define([
         this.stack = stack;
     }
 
-    RuntimeError.prototype = Object.create(Error.prototype);
-    RuntimeError.prototype.constructor = RuntimeError;
+    if (defined(Object.create)) {
+        RuntimeError.prototype = Object.create(Error.prototype);
+        RuntimeError.prototype.constructor = RuntimeError;
+    }
 
     RuntimeError.prototype.toString = function() {
         var str = this.name + ': ' + this.message;


### PR DESCRIPTION
This shouldn't change anything. All tests still pass.

This is for use of Cesium in node with Bluebird. You can't catch specific errors unless they inherit from Error.