### PR TITLE
Shadows - reorganize shaders

### DIFF
--- a/Apps/Sandcastle/gallery/development/Shadows.html
+++ b/Apps/Sandcastle/gallery/development/Shadows.html
@@ -118,7 +118,7 @@ var viewModel = {
     freeze : false,
     cascadeColors : false,
     fitNearFar : true,
-    softShadows : true,
+    softShadows : false,
     cascadeOptions : [1, 4],
     cascades : 4,
     lightSourceOptions : ['Freeform', 'Sun', 'Fixed', 'Point'],

--- a/Source/Renderer/AutomaticUniforms.js
+++ b/Source/Renderer/AutomaticUniforms.js
@@ -1535,30 +1535,16 @@ define([
         }),
 
         /**
-         * An automatic GLSL uniform representing the shadow map cascade offsets.
+         * An automatic GLSL uniform representing the shadow map cascade matrices.
          *
-         * @alias czm_shadowMapCascadeOffsets
+         * @alias czm_shadowMapCascadeMatrices
          * @glslUniform
          */
-        czm_shadowMapCascadeOffsets : new AutomaticUniform({
+        czm_shadowMapCascadeMatrices : new AutomaticUniform({
             size : 4,
-            datatype : WebGLConstants.FLOAT_VEC3,
+            datatype : WebGLConstants.FLOAT_MAT4,
             getValue : function(uniformState) {
-                return uniformState.shadowMap.cascadeOffsets;
-            }
-        }),
-
-        /**
-         * An automatic GLSL uniform representing the shadow map cascade scales.
-         *
-         * @alias czm_shadowMapCascadeScales
-         * @glslUniform
-         */
-        czm_shadowMapCascadeScales : new AutomaticUniform({
-            size : 4,
-            datatype : WebGLConstants.FLOAT_VEC3,
-            getValue : function(uniformState) {
-                return uniformState.shadowMap.cascadeScales;
+                return uniformState.shadowMap.cascadeMatrices;
             }
         }),
 

--- a/Source/Scene/Scene.js
+++ b/Source/Scene/Scene.js
@@ -1583,10 +1583,6 @@ define([
 
             us.updateFrustum(frustum);
 
-            if (scene.shadowMap.enabled) {
-                scene.shadowMap.updateShadowMapMatrix(us);
-            }
-
             clearDepth.execute(context, passState);
 
             us.updatePass(Pass.GLOBE);
@@ -1636,10 +1632,6 @@ define([
                 // Do not overlap frustums in the translucent pass to avoid blending artifacts
                 frustum.near = frustumCommands.near;
                 us.updateFrustum(frustum);
-
-                if (scene.shadowMap.enabled) {
-                    scene.shadowMap.updateShadowMapMatrix(us);
-                }
             }
 
             us.updatePass(Pass.TRANSLUCENT);

--- a/Source/Scene/ShadowMapShader.js
+++ b/Source/Scene/ShadowMapShader.js
@@ -230,7 +230,7 @@ define([
                 '    if (depth > czm_shadowMapCascadeSplits[1].w) { \n' +
                 '        return; \n' +
                 '    } \n' +
-                '    vec4 weights = getCascadeWeights(-positionEC.z); \n' +
+                '    vec4 weights = getCascadeWeights(depth); \n' +
                 '    // Transform position into the cascade \n' +
                 '    vec4 shadowPosition = getCascadeMatrix(weights) * positionEC; \n' +
 

--- a/Source/Scene/ShadowMapShader.js
+++ b/Source/Scene/ShadowMapShader.js
@@ -218,14 +218,12 @@ define([
 
                 '    gl_FragColor.rgb *= visibility; \n' +
                 '} \n';
-        } else {
+        } else if (hasCascades) {
             fs +=
                 'void main() \n' +
                 '{ \n' +
                 '    czm_shadow_main(); \n' +
                 '    vec4 positionEC = getPositionEC(); \n' +
-
-                (hasCascades ?
                 '    // Get the cascade based on the eye-space depth \n' +
                 '    float depth = -positionEC.z; \n' +
                 '    // Stop early if the eye depth exceeds the last cascade \n' +
@@ -235,16 +233,26 @@ define([
                 '    vec4 weights = getCascadeWeights(-positionEC.z); \n' +
                 '    // Transform position into the cascade \n' +
                 '    vec4 shadowPosition = getCascadeMatrix(weights) * positionEC; \n' +
+
                 (debugVisualizeCascades ?
                 '    // Draw cascade colors for debugging \n' +
-                '    gl_FragColor *= getCascadeColor(weights); \n' : '') :
+                '    gl_FragColor *= getCascadeColor(weights); \n' : '') +
 
+                '    // Apply shadowing \n' +
+                '    float visibility = getVisibility(shadowPosition.xy, shadowPosition.z, czm_shadowMapLightDirectionEC); \n' +
+                '    gl_FragColor.rgb *= visibility; \n' +
+                '} \n';
+        } else {
+            fs +=
+                'void main() \n' +
+                '{ \n' +
+                '    czm_shadow_main(); \n' +
+                '    vec4 positionEC = getPositionEC(); \n' +
                 '    vec4 shadowPosition = czm_shadowMapMatrix * positionEC; \n' +
                 '    // Stop early if the fragment is not in the shadow bounds \n' +
                 '    if (any(lessThan(shadowPosition, vec4(0.0))) || any(greaterThan(shadowPosition, vec4(1.0)))) { \n' +
                 '        return; \n' +
-                '    } \n') +
-
+                '    } \n' +
                 '    // Apply shadowing \n' +
                 '    float visibility = getVisibility(shadowPosition.xy, shadowPosition.z, czm_shadowMapLightDirectionEC); \n' +
                 '    gl_FragColor.rgb *= visibility; \n' +


### PR DESCRIPTION
I removed the scale and offset uniforms and instead just use cascade matrices. This simplified the shadow-receive vertex shader and removed the need to update the shadow map matrix for each frustum in the scene's multifrustum setup.

One problem this introduced is after clipping the camera against the surface the shadows don't seem to work. The root cause may also be responsible for https://github.com/AnalyticalGraphicsInc/cesium/issues/3178. I'll make a separate PR into cesium if I find the problem.