### PR TITLE
Camera clipping terrain fix

### DIFF
--- a/Source/Scene/Camera.js
+++ b/Source/Scene/Camera.js
@@ -275,7 +275,10 @@ define([
         viewMatrix[15] = 1.0;
 
         Matrix4.multiply(viewMatrix, camera._actualInvTransform, camera._viewMatrix);
-        Matrix4.inverseTransformation(camera._viewMatrix, camera._invViewMatrix);
+
+        // Camera vectors may not be orthonormal when the camera clamps to the terrain
+        // so apply inverse instead of inverseTransformation
+        Matrix4.inverse(camera._viewMatrix, camera._invViewMatrix);
     }
 
     var scratchCartographic = new Cartographic();


### PR DESCRIPTION
Fixes #3178.

Also fixes the atmosphere flickering that happens when the camera is swiveled into the ground.

This fix doesn't really solve the underlying problem. `ScreenSpaceCameraController.adjustHeightForTerrain` generates non-orthonormal view vectors which causes `inverseTransformation` to not work as expected. I'm not completely sure how to fix that, but this is a quick fix that works at a slight computation cost.