### PR TITLE
Fix typo setting a render state for OIT.

### DIFF
--- a/Source/Scene/OIT.js
+++ b/Source/Scene/OIT.js
@@ -315,7 +315,7 @@ define([
         }
 
         if (this._adjustTranslucentCommand) {
-            this._adjustTranslucentCommand.renderstate = this._rs;
+            this._adjustTranslucentCommand.renderState = this._rs;
         }
 
         if (defined(this._adjustAlphaCommand)) {


### PR DESCRIPTION
Also, fixes an issue when using MRT with multiple viewports. See https://github.com/AnalyticalGraphicsInc/cesium/pull/3621#issuecomment-199376090, which also happens after using the cardboard button.