### PR TITLE
Shadows globe shaders

### DIFF
--- a/Apps/Sandcastle/gallery/development/Shadows.html
+++ b/Apps/Sandcastle/gallery/development/Shadows.html
@@ -306,12 +306,31 @@ function createScene() {
     updateLightDirection();
     updateShadows();
 }
+
+// TODO : this is a very hacky way to reset the globe shaders when shadow properties change
+function resetGlobe() {
+    globe._surfaceShaderSet._shadersByTexturesFlags = [];
+}
+
+if (globeVisible) {
+    var getShaderProgram = Cesium.GlobeSurfaceShaderSet.prototype.getShaderProgram;
+    Cesium.GlobeSurfaceShaderSet.prototype.getShaderProgram = function() {
+        var surfaceShader = arguments[1].surfaceShader;
+        if (Cesium.defined(surfaceShader)) {
+            surfaceShader.flags = 0;
+        }
+        return getShaderProgram.apply(globe._surfaceShaderSet, arguments);
+    };
+}
+
 function resetShadows(shadowOptions) {
     // Changing the number of cascades or toggling cascade debug colors requires the receive-shadows shaders to recompile.
     // For testing purposes it is easier to clear the whole scene and start fresh rather than handling dynamic updates.
     scene.primitives.removeAll();
 
-    // TODO : reset terrain shaders
+    if (globeVisible) {
+        resetGlobe();
+    }
 
     scene.shadowMap.destroy();
     scene.shadowMap = new Cesium.ShadowMap(shadowOptions);

--- a/Apps/Sandcastle/gallery/development/Shadows.html
+++ b/Apps/Sandcastle/gallery/development/Shadows.html
@@ -118,7 +118,7 @@ var viewModel = {
     freeze : false,
     cascadeColors : false,
     fitNearFar : true,
-    softShadows : true,
+    softShadows : false,
     cascadeOptions : [1, 4],
     cascades : 4,
     lightSourceOptions : ['Freeform', 'Sun', 'Fixed', 'Point'],

--- a/Source/Renderer/AutomaticUniforms.js
+++ b/Source/Renderer/AutomaticUniforms.js
@@ -1535,30 +1535,16 @@ define([
         }),
 
         /**
-         * An automatic GLSL uniform representing the shadow map cascade offsets.
+         * An automatic GLSL uniform representing the shadow map cascade matrices.
          *
-         * @alias czm_shadowMapCascadeOffsets
+         * @alias czm_shadowMapCascadeMatrices
          * @glslUniform
          */
-        czm_shadowMapCascadeOffsets : new AutomaticUniform({
+        czm_shadowMapCascadeMatrices : new AutomaticUniform({
             size : 4,
-            datatype : WebGLConstants.FLOAT_VEC3,
+            datatype : WebGLConstants.FLOAT_MAT4,
             getValue : function(uniformState) {
-                return uniformState.shadowMap.cascadeOffsets;
-            }
-        }),
-
-        /**
-         * An automatic GLSL uniform representing the shadow map cascade scales.
-         *
-         * @alias czm_shadowMapCascadeScales
-         * @glslUniform
-         */
-        czm_shadowMapCascadeScales : new AutomaticUniform({
-            size : 4,
-            datatype : WebGLConstants.FLOAT_VEC3,
-            getValue : function(uniformState) {
-                return uniformState.shadowMap.cascadeScales;
+                return uniformState.shadowMap.cascadeMatrices;
             }
         }),
 

--- a/Source/Scene/Scene.js
+++ b/Source/Scene/Scene.js
@@ -1583,10 +1583,6 @@ define([
 
             us.updateFrustum(frustum);
 
-            if (scene.shadowMap.enabled) {
-                scene.shadowMap.updateShadowMapMatrix(us);
-            }
-
             clearDepth.execute(context, passState);
 
             us.updatePass(Pass.GLOBE);
@@ -1636,10 +1632,6 @@ define([
                 // Do not overlap frustums in the translucent pass to avoid blending artifacts
                 frustum.near = frustumCommands.near;
                 us.updateFrustum(frustum);
-
-                if (scene.shadowMap.enabled) {
-                    scene.shadowMap.updateShadowMapMatrix(us);
-                }
             }
 
             us.updatePass(Pass.TRANSLUCENT);

--- a/Source/Scene/ShadowMapShader.js
+++ b/Source/Scene/ShadowMapShader.js
@@ -218,14 +218,12 @@ define([
 
                 '    gl_FragColor.rgb *= visibility; \n' +
                 '} \n';
-        } else {
+        } else if (hasCascades) {
             fs +=
                 'void main() \n' +
                 '{ \n' +
                 '    czm_shadow_main(); \n' +
                 '    vec4 positionEC = getPositionEC(); \n' +
-
-                (hasCascades ?
                 '    // Get the cascade based on the eye-space depth \n' +
                 '    float depth = -positionEC.z; \n' +
                 '    // Stop early if the eye depth exceeds the last cascade \n' +
@@ -235,16 +233,26 @@ define([
                 '    vec4 weights = getCascadeWeights(-positionEC.z); \n' +
                 '    // Transform position into the cascade \n' +
                 '    vec4 shadowPosition = getCascadeMatrix(weights) * positionEC; \n' +
+
                 (debugVisualizeCascades ?
                 '    // Draw cascade colors for debugging \n' +
-                '    gl_FragColor *= getCascadeColor(weights); \n' : '') :
+                '    gl_FragColor *= getCascadeColor(weights); \n' : '') +
 
+                '    // Apply shadowing \n' +
+                '    float visibility = getVisibility(shadowPosition.xy, shadowPosition.z, czm_shadowMapLightDirectionEC); \n' +
+                '    gl_FragColor.rgb *= visibility; \n' +
+                '} \n';
+        } else {
+            fs +=
+                'void main() \n' +
+                '{ \n' +
+                '    czm_shadow_main(); \n' +
+                '    vec4 positionEC = getPositionEC(); \n' +
                 '    vec4 shadowPosition = czm_shadowMapMatrix * positionEC; \n' +
                 '    // Stop early if the fragment is not in the shadow bounds \n' +
                 '    if (any(lessThan(shadowPosition, vec4(0.0))) || any(greaterThan(shadowPosition, vec4(1.0)))) { \n' +
                 '        return; \n' +
-                '    } \n') +
-
+                '    } \n' +
                 '    // Apply shadowing \n' +
                 '    float visibility = getVisibility(shadowPosition.xy, shadowPosition.z, czm_shadowMapLightDirectionEC); \n' +
                 '    gl_FragColor.rgb *= visibility; \n' +


### PR DESCRIPTION
For #2594. Merge #3749 first.

This allows for dynamically updating the globe receive-shadows shaders. For too long the Sandcastle demo has not updated correctly when you switch light types, visualize cascades, etc.

I tried not to modify the Globe code, so instead I have a pretty hacky solution in `Shadows.html`.