### PR TITLE
Remove async module

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
   },
   "devDependencies": {
     "almond": "0.3.1",
-    "async": "1.5.2",
     "aws-sdk": "2.2.45",
     "bluebird": "3.3.4",
     "compressible": "2.0.7",


### PR DESCRIPTION
While reviewing #3715, I realized we didn't need it.

Also ignored `karma.conf.js` as part of `sortRequires`, since it's not AMD.