### PR TITLE
The depth plane should only be rendered in 3D.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,6 +25,7 @@ Change Log
 * Fixed a crash that would occur if you added and removed an `Entity` with a path without ever actually rendering it. [#3738](https://github.com/AnalyticalGraphicsInc/cesium/pull/3738)
 * Added a new sample to Sandcastle using the Pennsylvania terrain data as shown [here](http://cesiumjs.org/2016/03/15/New-Cesium-Terrain-Service-Covering-Pennsylvania/).
 * Added infinite horizontal scrolling in 2D.
+* Fixed issue causing parts of geometry and billboards/labels to be clipped. [#3748](https://github.com/AnalyticalGraphicsInc/cesium/issues/3748)
 
 ### 1.19 - 2016-03-01
 

--- a/Source/Scene/Scene.js
+++ b/Source/Scene/Scene.js
@@ -1531,7 +1531,7 @@ define([
         }
 
         var clearGlobeDepth = environmentState.clearGlobeDepth;
-        var useDepthPlane = environmentState.clearGlobeDepth;
+        var useDepthPlane = environmentState.useDepthPlane;
         var clearDepth = scene._depthClearCommand;
         var depthPlane = scene._depthPlane;
 


### PR DESCRIPTION
Fixes #3748.

The depth plane should only be rendered in 3D. This is probably a copy-paste error that went unnoticed during on of the Scene was refactors.