### PR TITLE
Primitives bug fix

### DIFF
--- a/Source/Scene/Primitive.js
+++ b/Source/Scene/Primitive.js
@@ -493,11 +493,18 @@ define([
     }
 
     function cloneGeometryInstanceAttribute(attribute) {
+        var clonedValue;
+        if(attribute.value.constructor === Array) {
+            clonedValue = attribute.value.slice(0);
+        }
+        else {
+            clonedValue = new attribute.value.constructor(attribute.value);
+        }
         return new GeometryInstanceAttribute({
             componentDatatype : attribute.componentDatatype,
             componentsPerAttribute : attribute.componentsPerAttribute,
             normalize : attribute.normalize,
-            value : new attribute.value.constructor(attribute.value)
+            value : clonedValue
         });
     }
 

--- a/Source/Scene/Primitive.js
+++ b/Source/Scene/Primitive.js
@@ -462,10 +462,9 @@ define([
 
     function cloneAttribute(attribute) {
         var clonedValues;
-        if(isArray(attribute.values)) {
+        if (isArray(attribute.values)) {
             clonedValues = attribute.values.slice(0);
-        }
-        else {
+        } else {
             clonedValues = new attribute.values.constructor(attribute.values);
         }
         return new GeometryAttribute({
@@ -501,10 +500,9 @@ define([
 
     function cloneGeometryInstanceAttribute(attribute) {
         var clonedValue;
-        if(isArray(attribute.value)) {
+        if (isArray(attribute.value)) {
             clonedValue = attribute.value.slice(0);
-        }
-        else {
+        } else {
             clonedValue = new attribute.value.constructor(attribute.value);
         }
         return new GeometryInstanceAttribute({

--- a/Source/Scene/Primitive.js
+++ b/Source/Scene/Primitive.js
@@ -461,11 +461,18 @@ define([
     });
 
     function cloneAttribute(attribute) {
+        var clonedValue;
+        if(attribute.value.constructor === Array) {
+            clonedValue = attribute.value.slice(0);
+        }
+        else {
+            clonedValue = new attribute.value.constructor(attribute.value);
+        }
         return new GeometryAttribute({
             componentDatatype : attribute.componentDatatype,
             componentsPerAttribute : attribute.componentsPerAttribute,
             normalize : attribute.normalize,
-            values : new attribute.values.constructor(attribute.values)
+            values : clonedValue
         });
     }
 

--- a/Source/Scene/Primitive.js
+++ b/Source/Scene/Primitive.js
@@ -461,18 +461,18 @@ define([
     });
 
     function cloneAttribute(attribute) {
-        var clonedValue;
-        if(attribute.value.constructor === Array) {
-            clonedValue = attribute.value.slice(0);
+        var clonedValues;
+        if(isArray(attribute.values)) {
+            clonedValues = attribute.values.slice(0);
         }
         else {
-            clonedValue = new attribute.value.constructor(attribute.value);
+            clonedValues = new attribute.values.constructor(attribute.values);
         }
         return new GeometryAttribute({
             componentDatatype : attribute.componentDatatype,
             componentsPerAttribute : attribute.componentsPerAttribute,
             normalize : attribute.normalize,
-            values : clonedValue
+            values : clonedValues
         });
     }
 
@@ -501,7 +501,7 @@ define([
 
     function cloneGeometryInstanceAttribute(attribute) {
         var clonedValue;
-        if(attribute.value.constructor === Array) {
+        if(isArray(attribute.value)) {
             clonedValue = attribute.value.slice(0);
         }
         else {

--- a/Source/Scene/PrimitivePipeline.js
+++ b/Source/Scene/PrimitivePipeline.js
@@ -153,7 +153,7 @@ define([
             var attribute = instanceAttributes[name];
             var componentDatatype = attribute.componentDatatype;
             var value = attribute.value;
-            var componentsPerAttribute = value.length;
+            var componentsPerAttribute = attribute.componentsPerAttribute;
 
             var buffer = ComponentDatatype.createTypedArray(componentDatatype, numberOfVertices * componentsPerAttribute);
             for (var k = 0; k < numberOfVertices; ++k) {


### PR DESCRIPTION
When the attributes of a Primitive are cloned, it calls the attribute's constructor. If that attribute is an array, it wraps itself in another array, as in:

```javascript
var arr = [1,2,3];
var cloneArr = new Array(arr);
cloneArr == [[1,2,3]]; //true
```

This fix resolves that issue.