### PR TITLE
Deploy zip and npm packages.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_script:
 script:
   - echo 'deployPending' && echo -en 'travis_fold:start:script.deployPending\\r'
   - npm run deploy-set-version -- --version $TRAVIS_BRANCH.$TRAVIS_BUILD_NUMBER
-  - npm run deploy-status -- --status pending --message Waiting for build
+  - npm run deploy-status -- --status pending --message 'Waiting for build'
   - echo -en 'travis_fold:end:script.deployPending\\r'
 
   - echo 'jsHint' && echo -en 'travis_fold:start:script.jsHint\\r'

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,11 @@ before_script:
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
 script:
+  - echo 'deployPending' && echo -en 'travis_fold:start:script.deployPending\\r'
+  - npm run deploy-set-version -- --version $TRAVIS_BRANCH.$TRAVIS_BUILD_NUMBER
+  - npm run deploy-status -- --status pending --message Waiting for build
+  - echo -en 'travis_fold:end:script.deployPending\\r'
+
   - echo 'jsHint' && echo -en 'travis_fold:start:script.jsHint\\r'
   - npm run jsHint -- --failTaskOnError
   - echo -en 'travis_fold:end:script.jsHint\\r'
@@ -17,12 +22,12 @@ script:
   - echo 'makeZipFile' && echo -en 'travis_fold:start:script.makeZipFile\\r'
   - npm run clean
   - npm run makeZipFile
+  - npm pack
   - echo -en 'travis_fold:end:script.makeZipFile\\r'
 
   - echo 'deploy' && echo -en 'travis_fold:start:script.deploy\\r'
-  - npm run deploy-status-pending
   - npm run deploy-s3 -- -b cesium-dev -d cesium/$TRAVIS_BRANCH --confirm -c 'no-cache'
-  - npm run deploy-status-success
+  - npm run deploy-status -- --status success --message Deployed
   - echo -en 'travis_fold:end:script.deploy\\r'
 
   - echo 'test non-webgl release' && echo -en 'travis_fold:start:script test.release\\r'

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "generateStubs": "gulp generateStubs",
     "sortRequires": "gulp sortRequires",
     "deploy-s3": "gulp deploy-s3",
-    "deploy-status-pending" : "gulp deploy-status-pending",
-    "deploy-status-success" : "gulp deploy-status-success"
+    "deploy-status": "gulp deploy-status",
+    "deploy-set-version": "gulp deploy-set-version"
   }
 }


### PR DESCRIPTION
This change allows travis to deploy the generate zip files and npm packages in addition to the build output.  Each package gets a unique name based on branch name and build number.  Also updated deployment step not to delete these packages so that they can be depended on until the branch is merged.

I had to open a PR just to test this change, so if everything works, you'll notice 3 items in the status below.