### PR TITLE
Messing with Z

### DIFF
--- a/Apps/Sandcastle/gallery/development/PointPrimitives.html
+++ b/Apps/Sandcastle/gallery/development/PointPrimitives.html
@@ -168,7 +168,7 @@ function add100kPoints() {
             pixelSize : 5,
             color : color,
             outlineColor : outlineColor,
-            outlineWidth : 0,
+            outlineWidth : 1.0,
             position : position
         });
     }

--- a/Source/Shaders/PointPrimitiveCollectionFS.glsl
+++ b/Source/Shaders/PointPrimitiveCollectionFS.glsl
@@ -1,3 +1,7 @@
+#ifdef GL_EXT_frag_depth
+#extension GL_EXT_frag_depth : enable
+#endif
+
 varying vec4 v_color;
 varying vec4 v_outlineColor;
 varying float v_innerPercent;
@@ -22,6 +26,11 @@ void main()
     {
         discard;
     }
+
+#ifdef GL_EXT_frag_depth
+    float z = gl_FragCoord.z;
+    gl_FragDepthEXT = z + ((1.0 - z) * (1.0 - wholeAlpha));
+#endif
 
 #ifdef RENDER_FOR_PICK
     gl_FragColor = v_pickColor;


### PR DESCRIPTION
Proposed fix for #2885!  Someone with `gl_FragDepthEXT` experience should review this, as I actually haven't messed with that extension before.

The basic idea is to push the Z values of the fringes of points, since they have low alpha values, towards the back of the current frustum.  That way, nearby objects have a better chance of winning any Z battles with those fringes.

I haven't done extensive testing on this, actually I just thought of it about an hour ago.  If it seems to work well, we might look for additional uses, for example the fringes around labels.