### PR TITLE
arrayRemoveDuplicates shouldn't throw exception for undefined array

### DIFF
--- a/Source/Core/arrayRemoveDuplicates.js
+++ b/Source/Core/arrayRemoveDuplicates.js
@@ -45,13 +45,14 @@ define([
      */
     function arrayRemoveDuplicates(values, equalsEpsilon, wrapAround) {
         //>>includeStart('debug', pragmas.debug);
-        if (!defined(values)) {
-            throw new DeveloperError('values is required.');
-        }
         if (!defined(equalsEpsilon)) {
             throw new DeveloperError('equalsEpsilon is required.');
         }
         //>>includeEnd('debug');
+
+        if (!defined(values)) {
+            return values;
+        }
 
         wrapAround = defaultValue(wrapAround, false);
 

--- a/Source/Core/arrayRemoveDuplicates.js
+++ b/Source/Core/arrayRemoveDuplicates.js
@@ -16,7 +16,7 @@ define([
     /**
      * Removes adjacent duplicate values in an array of values.
      *
-     * @param {Object[]} values The array of values.
+     * @param {Object[]} [values] The array of values.
      * @param {Function} equalsEpsilon Function to compare values with an epsilon. Boolean equalsEpsilon(left, right, epsilon).
      * @param {Boolean} [wrapAround=false] Compare the last value in the array against the first value.
      * @returns {Object[]|undefined} A new array of values with no adjacent duplicate values or the input array if no duplicates were found.
@@ -51,7 +51,7 @@ define([
         //>>includeEnd('debug');
 
         if (!defined(values)) {
-            return values;
+            return undefined;
         }
 
         wrapAround = defaultValue(wrapAround, false);

--- a/Specs/Core/arrayRemoveDuplicatesSpec.js
+++ b/Specs/Core/arrayRemoveDuplicatesSpec.js
@@ -125,10 +125,9 @@ defineSuite([
         expect(noDuplicates).toEqual(expectedPositions);
     });
 
-    it('removeDuplicates throws without positions', function() {
-        expect(function() {
-            arrayRemoveDuplicates();
-        }).toThrowDeveloperError();
+    it('removeDuplicates returns undefined', function() {
+        var noDuplicates = arrayRemoveDuplicates(undefined, Cartesian3.equalsEpsilon);
+        expect(noDuplicates).toBe(undefined);
     });
 
     it('removeDuplicates wrapping removes duplicate first and last points', function() {


### PR DESCRIPTION
Per @pjcozzi suggestion, arrayRemoveDuplicates shouldn't throw an exception if an undefined array is passed in. Similar to how clone works, if you pass in undefined, you'll just get undefined returned