### PR TITLE
Fix test failures in IE

### DIFF
--- a/Source/Scene/Scene.js
+++ b/Source/Scene/Scene.js
@@ -1741,7 +1741,7 @@ define([
         var projectionMatrix = camera.frustum.projectionMatrix;
 
         var x = camera.positionWC.y;
-        var eyePoint = Cartesian3.fromElements(Math.sign(x) * maxCoord.x - x, 0.0, -camera.positionWC.x, scratch2DViewportEyePoint);
+        var eyePoint = Cartesian3.fromElements(CesiumMath.sign(x) * maxCoord.x - x, 0.0, -camera.positionWC.x, scratch2DViewportEyePoint);
         var windowCoordinates = Transforms.pointToGLWindowCoordinates(projectionMatrix, viewportTransformation, eyePoint, scratch2DViewportWindowCoords);
 
         windowCoordinates.x = Math.floor(windowCoordinates.x);

--- a/Source/Scene/SceneTransforms.js
+++ b/Source/Scene/SceneTransforms.js
@@ -126,7 +126,7 @@ define([
             var projectionMatrix = camera.frustum.projectionMatrix;
 
             var x = camera.positionWC.y;
-            var eyePoint = Cartesian3.fromElements(Math.sign(x) * maxCoord.x - x, 0.0, -camera.positionWC.x);
+            var eyePoint = Cartesian3.fromElements(CesiumMath.sign(x) * maxCoord.x - x, 0.0, -camera.positionWC.x);
             var windowCoordinates = Transforms.pointToGLWindowCoordinates(projectionMatrix, viewportTransformation, eyePoint);
 
             if (x === 0.0 || windowCoordinates.x <= 0.0 || windowCoordinates.x >= canvas.clientWidth) {


### PR DESCRIPTION
IE does not support `Math.sign`. Use `CesiumMath.sign`.