### PR TITLE
3D Tiles cache management

### DIFF
--- a/Apps/Sandcastle/gallery/3D Tiles.html
+++ b/Apps/Sandcastle/gallery/3D Tiles.html
@@ -108,6 +108,10 @@ function loadTileset(url) {
             //console.log('Loading: requests: ' + numberOfPendingRequests + ', processing: ' + numberProcessing);
         });
 
+        tileset.tileUnload.addEventListener(function(tile) {
+            //console.log('Tile unloaded.')
+        });
+
         addExpressionUI();
     });
 }

--- a/Apps/Sandcastle/gallery/3D Tiles.html
+++ b/Apps/Sandcastle/gallery/3D Tiles.html
@@ -52,7 +52,9 @@ function loadTileset(url) {
     reset();
 
     tileset = scene.primitives.add(new Cesium.Cesium3DTileset({
-        url : url
+        url : url,
+        debugShowStatistics : true,
+        maximumNumberOfLoadedTiles : 3
     }));
 
     return Cesium.when(tileset.readyPromise).then(function(tileset) {
@@ -103,7 +105,7 @@ function loadTileset(url) {
                 return;
             }
 
-            console.log('Loading: requests: ' + numberOfPendingRequests + ', processing: ' + numberProcessing);
+            //console.log('Loading: requests: ' + numberOfPendingRequests + ', processing: ' + numberProcessing);
         });
 
         addExpressionUI();
@@ -372,6 +374,10 @@ Sandcastle.addToolbarButton('SSE++', function() {
 Sandcastle.addToolbarButton('SSE--', function() {
     tileset.maximumScreenSpaceError = Math.max(tileset.maximumScreenSpaceError - 1, 0);
     console.log('New max SSE: ' + tileset.maximumScreenSpaceError);
+});
+
+Sandcastle.addToolbarButton('Trim tiles (cache)', function() {
+    tileset.trimLoadedTiles();
 });
 
 // Styling ////////////////////////////////////////////////////////////////////

--- a/Source/Core/DoublyLinkedList.js
+++ b/Source/Core/DoublyLinkedList.js
@@ -1,0 +1,111 @@
+/*global define*/
+define([
+       '../Core/defined',
+       '../Core/defineProperties',
+       '../Core/DeveloperError'
+    ], function(
+        defined,
+        defineProperties,
+        DeveloperError) {
+    'use strict';
+
+    /**
+     * @private
+     */
+    function DoublyLinkedList() {
+        this.head = undefined;
+        this.tail = undefined;
+        this._length = 0;
+    }
+
+    defineProperties(DoublyLinkedList.prototype, {
+        length : {
+            get : function() {
+                return this._length;
+            }
+        }
+    });
+
+    function DoublyLinkedListNode(item, previous, next) {
+        this.item = item;
+        this.previous  = previous;
+        this.next = next;
+    }
+
+    DoublyLinkedList.prototype.add = function(item) {
+        var node = new DoublyLinkedListNode(item, this.tail, undefined);
+
+        if (defined(this.tail)) {
+            this.tail.next = node;
+            this.tail = node;
+        } else {
+            // Insert into empty linked list
+            this.head = node;
+            this.tail = node;
+        }
+
+        ++this._length;
+
+        return node;
+    };
+
+    function remove(list, node) {
+        if (defined(node.previous) && defined(node.next)) {
+            node.previous.next = node.next;
+            node.next.previous = node.previous;
+        } else if (defined(node.previous)) {
+            // Remove last node
+            node.previous.next = undefined;
+            list.tail = node.previous;
+        } else if (defined(node.next)) {
+            // Remove first node
+            node.next.previous = undefined;
+            list.head = node.next;
+        } else {
+            // Remove last node in the linked list
+            list.head = undefined;
+            list.tail = undefined;
+        }
+
+        node.next = undefined;
+        node.previous = undefined;
+    }
+
+    DoublyLinkedList.prototype.remove = function(node) {
+        if (!defined(node)) {
+            return;
+        }
+
+        remove(this, node);
+
+        --this._length;
+    };
+
+    DoublyLinkedList.prototype.splice = function(node, nextNode) {
+        if (!defined(node) || !defined(nextNode)) {
+            throw new DeveloperError('node and nextNode are required.');
+        }
+
+        if (node === nextNode) {
+            return;
+        }
+
+        // Remove nextNode, then insert after node
+        remove(this, nextNode);
+
+        var oldNodeNext = node.next;
+        node.next = nextNode;
+
+        // nextNode is the new tail
+        if (this.tail === node) {
+            this.tail = nextNode;
+        } else {
+            oldNodeNext.previous = nextNode;
+        }
+
+        nextNode.next = oldNodeNext;
+        nextNode.previous = node;
+    }
+    
+    return DoublyLinkedList;
+});

--- a/Source/Core/DoublyLinkedList.js
+++ b/Source/Core/DoublyLinkedList.js
@@ -105,7 +105,7 @@ define([
 
         nextNode.next = oldNodeNext;
         nextNode.previous = node;
-    }
+    };
     
     return DoublyLinkedList;
 });

--- a/Source/Scene/Cesium3DTile.js
+++ b/Source/Scene/Cesium3DTile.js
@@ -237,7 +237,7 @@ define([
         /**
          * The corresponding node in the cache replacement list.
          *
-         * @type {DoublyLinkedList}
+         * @type {DoublyLinkedListNode}
          * @readonly
          *
          * @private

--- a/Source/Scene/Cesium3DTile.js
+++ b/Source/Scene/Cesium3DTile.js
@@ -235,7 +235,10 @@ define([
         this.hasTilesetContent = hasTilesetContent;
 
         /**
-         * DOC_TBA
+         * The corresponding node in the cache replacement list.
+         *
+         * @type {DoublyLinkedList}
+         * @readonly
          *
          * @private
          */

--- a/Source/Scene/Cesium3DTile.js
+++ b/Source/Scene/Cesium3DTile.js
@@ -280,17 +280,6 @@ define([
         this.lastSelectedFrameNumber = 0;
 
         /**
-         * The last frame number the tile was visited during tile selection.  A tile may be touched,
-         * but not selected because, for example, it is a parent using replacement refinement and
-         * its children are selected.  A selected tile will always be touched.
-         *
-         * @type {Number}
-         *
-         * @private
-         */
-        this.lastTouchedFrameNumber = 0;
-
-        /**
          * The time when a style was last applied to this tile.
          *
          * @type {Number}
@@ -441,7 +430,6 @@ define([
         this.parentPlaneMask = 0;
         this.selected = false;
         this.lastSelectedFrameNumber = 0;
-        this.lastTouchedFrameNumber = 0;
         this.lastStyleTime = 0;
 
         this._debugBoundingVolume = this._debugBoundingVolume && this._debugBoundingVolume.destroy();

--- a/Source/Scene/Cesium3DTile.js
+++ b/Source/Scene/Cesium3DTile.js
@@ -166,20 +166,10 @@ define([
          */
         this.numberOfChildrenWithoutContent = defined(header.children) ? header.children.length : 0;
 
-        /**
-         * Gets the promise that will be resolved when the tile's content is ready to render.
-         *
-         * @type {Promise.<Cesium3DTile>}
-         * @readonly
-         *
-         * @private
-         */
-        this.contentReadyPromise = when.defer();
-
-        var content;
         var hasContent;
         var hasTilesetContent;
         var requestServer;
+        var createContent;
 
         if (defined(contentHeader)) {
             var contentUrl = contentHeader.url;
@@ -202,14 +192,23 @@ define([
             }
             //>>includeEnd('debug');
 
-            content = contentFactory(tileset, this, url);
+            var that = this;
+            createContent = function() {
+                return contentFactory(tileset, that, url);
+            };
         } else {
-            content = new Empty3DTileContent();
             hasContent = false;
             hasTilesetContent = false;
+
+            createContent = function() {
+                return new Empty3DTileContent();
+            };
         }
 
-        this._content = content;
+        this._createContent = createContent;
+        this._content = createContent();
+        addContentReadyPromise(this);
+
         this._requestServer = requestServer;
 
         /**
@@ -235,21 +234,12 @@ define([
          */
         this.hasTilesetContent = hasTilesetContent;
 
-        var that = this;
-
-        // Content enters the READY state
-        when(content.readyPromise).then(function(content) {
-            if (defined(that.parent)) {
-                --that.parent.numberOfChildrenWithoutContent;
-            }
-
-            that.contentReadyPromise.resolve(that);
-        }).otherwise(function(error) {
-            // In this case, that.parent.numberOfChildrenWithoutContent will never reach zero
-            // and therefore that.parent will never refine.  If this becomes an issue, failed
-            // requests can be reissued.
-            that.contentReadyPromise.reject(error);
-        });
+        /**
+         * DOC_TBA
+         *
+         * @private
+         */
+        this.replacementNode = undefined;
 
         // Members that are updated every frame for tree traversal and rendering optimizations:
 
@@ -281,13 +271,24 @@ define([
         this.selected = false;
 
         /**
-         * The last frame number the tile was visible in.
+         * The last frame number the tile was selected in.
          *
          * @type {Number}
          *
          * @private
          */
-        this.lastFrameNumber = 0;
+        this.lastSelectedFrameNumber = 0;
+
+        /**
+         * The last frame number the tile was visited during tile selection.  A tile may be touched,
+         * but not selected because, for example, it is a parent using replacement refinement and
+         * its children are selected.  A selected tile will always be touched.
+         *
+         * @type {Number}
+         *
+         * @private
+         */
+        this.lastTouchedFrameNumber = 0;
 
         /**
          * The time when a style was last applied to this tile.
@@ -337,24 +338,6 @@ define([
         },
 
         /**
-         * Gets the promise that will be resolved when the tile's content is ready to process.
-         * This happens after the content is downloaded but before the content is ready
-         * to render.
-         *
-         * @memberof Cesium3DTile.prototype
-         *
-         * @type {Promise.<Cesium3DTileContent>}
-         * @readonly
-         *
-         * @private
-         */
-        contentReadyToProcessPromise : {
-            get : function() {
-                return this._content.contentReadyToProcessPromise;
-            }
-        },
-
-        /**
          * @readonly
          * @private
          */
@@ -395,6 +378,19 @@ define([
         }
     });
 
+    function addContentReadyPromise(tile) {
+        // Content enters the READY state
+        when(tile._content.readyPromise).then(function(content) {
+            if (defined(tile.parent)) {
+                --tile.parent.numberOfChildrenWithoutContent;
+            }
+        }).otherwise(function(error) {
+            // In this case, that.parent.numberOfChildrenWithoutContent will never reach zero
+            // and therefore that.parent will never refine.  If this becomes an issue, failed
+            // requests can be reissued.
+        });
+    }
+
     /**
      * Requests the tile's content.
      * <p>
@@ -421,6 +417,35 @@ define([
             return true;
         }
         return this._requestServer.hasAvailableRequests();
+    };
+
+    /**
+     * Unloads the tile's content and returns the tile's state to the state of when
+     * it was first created, before its content were loaded.
+     *
+     * @private
+     */
+    Cesium3DTile.prototype.unloadContent = function() {
+        if (defined(this.parent)) {
+            ++this.parent.numberOfChildrenWithoutContent;
+        }
+
+        this._content = this._content && this._content.destroy();
+        this._content = this._createContent();
+        addContentReadyPromise(this);
+
+        this.replacementNode = undefined;
+
+        // Restore properties set per frame to their defaults
+        this.distanceToCamera = 0;
+        this.parentPlaneMask = 0;
+        this.selected = false;
+        this.lastSelectedFrameNumber = 0;
+        this.lastTouchedFrameNumber = 0;
+        this.lastStyleTime = 0;
+
+        this._debugBoundingVolume = this._debugBoundingVolume && this._debugBoundingVolume.destroy();
+        this._debugContentBoundingVolume = this._debugContentBoundingVolume && this._debugContentBoundingVolume.destroy();
     };
 
     /**

--- a/Source/Scene/Cesium3DTileBatchTableResources.js
+++ b/Source/Scene/Cesium3DTileBatchTableResources.js
@@ -506,14 +506,14 @@ define([
                     '    { \n' +
                     '        if (!isStyleTranslucent && !tile_translucentCommand) \n' + // Do not render opaque features in the translucent pass
                     '        { \n' +
-                    '            gl_Position *= 0.0; \n' +
+                    '            discard; \n' +
                     '        } \n' +
                     '    } \n' +
                     '    else \n' +
                     '    { \n' +
                     '        if (isStyleTranslucent) \n' + // Do not render translucent features in the opaque pass
                     '        { \n' +
-                    '            gl_Position *= 0.0; \n' +
+                    '            discard; \n' +
                     '        } \n' +
                     '    } \n' +
                     '    tile_main(); \n' +

--- a/Source/Scene/Cesium3DTileStyleEngine.js
+++ b/Source/Scene/Cesium3DTileStyleEngine.js
@@ -16,14 +16,6 @@ define([
         this._style = undefined;      // The style provided by the user
         this._styleDirty = false;     // true when the style is reassigned
         this._lastStyleTime = 0;      // The "time" when the last style was assigned
-
-        this.statistics = {
-            numberOfTilesStyled : 0,
-            numberOfFeaturesStyled : 0,
-
-            lastNumberOfTilesStyled : -1,
-            lastNumberOfFeaturesStyled : -1
-        };
     }
 
     defineProperties(Cesium3DTileStyleEngine.prototype, {
@@ -64,7 +56,7 @@ define([
         }
 
         var lastStyleTime = this._lastStyleTime;
-        var stats = this.statistics;
+        var stats = tileset._statistics;
 
         // If a new style was assigned, loop through all the visible tiles; otherwise, loop through
         // only the tiles that are newly visible, i.e., they are visible this frame, but were not
@@ -82,7 +74,7 @@ define([
                 //   2) this tile is now visible, but it wasn't visible when the style was first assigned
                 if (tile.lastStyleTime !== lastStyleTime) {
                     tile.lastStyleTime = lastStyleTime;
-                    styleCompositeContent(this, tile.content);
+                    styleCompositeContent(this, tile.content, stats);
 
                     ++stats.numberOfTilesStyled;
                 }
@@ -90,27 +82,27 @@ define([
         }
     };
 
-    function styleCompositeContent(styleEngine, content) {
+    function styleCompositeContent(styleEngine, content, stats) {
         var innerContents = content.innerContents;
         if (defined(innerContents)) {
             var length = innerContents.length;
             for (var i = 0; i < length; ++i) {
                 // Recurse for composites of composites
-                styleCompositeContent(styleEngine, innerContents[i]);
+                styleCompositeContent(styleEngine, innerContents[i], stats);
             }
         } else {
             // Not a composite tile
-            styleContent(styleEngine, content);
+            styleContent(styleEngine, content, stats);
         }
     }
 
     var scratchColor = new Color();
 
-    function styleContent(styleEngine, content) {
+    function styleContent(styleEngine, content, stats) {
         var length = content.featuresLength;
         var style = styleEngine._style;
 
-        styleEngine.statistics.numberOfFeaturesStyled += length;
+        stats.numberOfFeaturesStyled += length;
 
         if (!defined(style)) {
             clearStyle(content);

--- a/Source/Scene/Cesium3DTileset.js
+++ b/Source/Scene/Cesium3DTileset.js
@@ -51,22 +51,6 @@ define([
         SceneMode) {
     'use strict';
 
-// TODO: since the show/color/setProperty values set with Cesium3DTileFeature only have the
-// lifetime of the tile's content (e.g., if the content is unloaded, then reloaded later, the
-// values wll be gown), we need to expose an event like loadProgress for when content is unloaded.
-//
-// We might also want to keep a separate data structure - or flag - so we know what property
-// values changed (other than those derived from declarative styling, which can easily be
-// reapplied).
-
-// TODO: Refactor TileReplacementQueue to use DoublyLinkedList?
-// TODO: good default for maximumNumberOfLoadedTiles
-// TODO: track stats for cache trashing
-// TODO: research strategies for proactive cache trimming: number of seconds/frame a tile was not selected, how far out of view a tile is, etc.
-// TODO: More precise size than number of tiles?  Count composite tiles as more?  Include geometry/texture cost with each tile?
-// TODO: unload sub-trees from tiles with tileset.json content
-// TODO: vertex/texture cache across tiles
-
     /**
      * A {@link https://github.com/AnalyticalGraphicsInc/3d-tiles/blob/master/README.md|3D Tiles tileset},
      * used for streaming massive heterogeneous 3D geospatial datasets.

--- a/Source/Scene/Cesium3DTileset.js
+++ b/Source/Scene/Cesium3DTileset.js
@@ -344,7 +344,7 @@ define([
         this.numberTotal = -1;
         this.numberOfTilesStyled = -1;
         this.numberOfFeaturesStyled = -1;
-    };
+    }
 
     defineProperties(Cesium3DTileset.prototype, {
         /**

--- a/Source/Scene/Cesium3DTileset.js
+++ b/Source/Scene/Cesium3DTileset.js
@@ -1025,10 +1025,11 @@ define([
     ///////////////////////////////////////////////////////////////////////////
 
     function raiseLoadProgressEvent(tileset, frameState) {
-        var numberOfPendingRequests = tileset._statistics.numberOfPendingRequests;
-        var numberProcessing = tileset._statistics.numberProcessing;
-        var lastNumberOfPendingRequest = tileset._statistics.lastNumberOfPendingRequests;
-        var lastNumberProcessing = tileset._statistics.lastNumberProcessing;
+        var stats = tileset._statistics;
+        var numberOfPendingRequests = stats.numberOfPendingRequests;
+        var numberProcessing = stats.numberProcessing;
+        var lastNumberOfPendingRequest = stats.lastColor.numberOfPendingRequests;
+        var lastNumberProcessing = stats.lastColor.numberProcessing;
 
         if ((numberOfPendingRequests !== lastNumberOfPendingRequest) || (numberProcessing !== lastNumberProcessing)) {
             frameState.afterRender.push(function() {

--- a/Source/Scene/Cesium3DTileset.js
+++ b/Source/Scene/Cesium3DTileset.js
@@ -145,12 +145,14 @@ define([
             // Loading stats
             numberOfPendingRequests : 0,
             numberProcessing : 0,
+            numberReady : 0, // Number of tiles with content loaded
 
             lastSelected : -1,
             lastVisited : -1,
             lastNumberOfCommands : -1,
             lastNumberOfPendingRequests : -1,
-            lastNumberProcessing : -1
+            lastNumberProcessing : -1,
+            lastNumberReady : -1
         };
 
         /**
@@ -883,6 +885,7 @@ define([
                 // Remove from processing queue
                 tileset._processingQueue.splice(index, 1);
                 --tileset._statistics.numberProcessing;
+                ++tileset._statistics.numberReady;
             } else {
                 // Not in processing queue
                 // For example, when a url request fails and the ready promise is rejected
@@ -924,6 +927,7 @@ define([
             stats.lastSelected !== tileset._selectedTiles.length ||
             stats.lastNumberOfPendingRequests !== stats.numberOfPendingRequests ||
             stats.lastNumberProcessing !== stats.numberProcessing ||
+            stats.lastNumberReady !== stats.numberReady ||
             styleStats.lastNumberOfTilesStyled !== styleStats.numberOfTilesStyled ||
             styleStats.lastNumberOfFeaturesStyled !== styleStats.numberOfFeaturesStyled)) {
 
@@ -940,6 +944,7 @@ define([
                 ', Commands: ' + stats.numberOfCommands +
                 ', Requests: ' + stats.numberOfPendingRequests +
                 ', Processing: ' + stats.numberProcessing +
+                ', Ready: ' + stats.numberReady +
                 ', Tiles styled: ' + styleStats.numberOfTilesStyled +
                 ', Features styled: ' + styleStats.numberOfFeaturesStyled;
 
@@ -952,6 +957,7 @@ define([
         stats.lastSelected = tileset._selectedTiles.length;
         stats.lastNumberOfPendingRequests = stats.numberOfPendingRequests;
         stats.lastNumberProcessing = stats.numberProcessing;
+        stats.lastNumberReady = stats.numberReady;
         styleStats.lastNumberOfTilesStyled = styleStats.numberOfTilesStyled;
         styleStats.lastNumberOfFeaturesStyled = styleStats.numberOfFeaturesStyled;
     }

--- a/Source/Scene/Cesium3DTileset.js
+++ b/Source/Scene/Cesium3DTileset.js
@@ -727,10 +727,9 @@ define([
         }
     }
 
-    function touch(tileset, tile, frameState) {
+    function touch(tileset, tile) {
         var node = tile.replacementNode;
         if (defined(node)) {
-            tile.lastTouchedFrameNumber = frameState.frameNumber;
             tileset._replacementList.splice(tileset._replacementSentinel, node);
         }
     }
@@ -789,7 +788,7 @@ define([
             }
             var fullyVisible = (planeMask === CullingVolume.MASK_INSIDE);
 
-            touch(tileset, t, frameState);
+            touch(tileset, t);
 
             // Tile is inside/intersects the view frustum.  How many pixels is its geometric error?
             var sse = getScreenSpaceError(t.geometricError, t, frameState);

--- a/Source/Scene/Cesium3DTileset.js
+++ b/Source/Scene/Cesium3DTileset.js
@@ -116,7 +116,7 @@ define([
 
         // [head, sentinel) -> tiles that weren't selected this frame and may be replaced
         // (sentinel, tail] -> tiles that were selected this frame
-        this._replacementList = replacementList; // Tiles with content loaded.  For cache management
+        this._replacementList = replacementList; // Tiles with content loaded.  For cache management.
         this._replacementSentinel  = replacementList.add();
         this._trimTiles = false;
 
@@ -256,7 +256,7 @@ define([
          * The unloaded {@link Cesium3DTile} is passed to the event listener.
          * </p>
          * <p>
-         * This event is immediately before the tile's content is unloaded while the frame is being
+         * This event is fired immediately before the tile's content is unloaded while the frame is being
          * rendered so that the event listener has access to the tile's content.  Do not create
          * or modify Cesium entities or primitives during the event listener.
          * </p>

--- a/Source/Scene/Cesium3DTileset.js
+++ b/Source/Scene/Cesium3DTileset.js
@@ -146,13 +146,15 @@ define([
             numberOfPendingRequests : 0,
             numberProcessing : 0,
             numberReady : 0, // Number of tiles with content loaded
+            numberTotal : 0, // Number of tiles in tileset.json (and other tileset.json files as they are loaded)
 
             lastSelected : -1,
             lastVisited : -1,
             lastNumberOfCommands : -1,
             lastNumberOfPendingRequests : -1,
             lastNumberProcessing : -1,
-            lastNumberReady : -1
+            lastNumberReady : -1,
+            lastNumberTotal : -1
         };
 
         /**
@@ -500,6 +502,8 @@ define([
                 throw new DeveloperError('The tileset must be 3D Tiles version 0.0.  See https://github.com/AnalyticalGraphicsInc/3d-tiles#spec-status');
             }
 
+            var stats = that._statistics;
+
             // Append the version to the baseUrl
             var versionQuery = '?v=' + defaultValue(tilesetJson.asset.tilesetVersion, '0.0');
             that._baseUrl = joinUrls(that._baseUrl, versionQuery);
@@ -516,6 +520,7 @@ define([
                 parentTile.children.push(rootTile);
                 ++parentTile.numberOfChildrenWithoutContent;
             }
+            ++stats.numberTotal;
 
             var refiningTiles = [];
 
@@ -536,6 +541,7 @@ define([
                         var childHeader = children[k];
                         var childTile = new Cesium3DTile(that, baseUrl, childHeader, tile3D);
                         tile3D.children.push(childTile);
+                        ++stats.numberTotal;
                         stack.push({
                             header : childHeader,
                             cesium3DTile : childTile
@@ -928,6 +934,7 @@ define([
             stats.lastNumberOfPendingRequests !== stats.numberOfPendingRequests ||
             stats.lastNumberProcessing !== stats.numberProcessing ||
             stats.lastNumberReady !== stats.numberReady ||
+            stats.lastNumberTotal !== stats.numberTotal ||
             styleStats.lastNumberOfTilesStyled !== styleStats.numberOfTilesStyled ||
             styleStats.lastNumberOfFeaturesStyled !== styleStats.numberOfFeaturesStyled)) {
 
@@ -945,6 +952,9 @@ define([
                 ', Requests: ' + stats.numberOfPendingRequests +
                 ', Processing: ' + stats.numberProcessing +
                 ', Ready: ' + stats.numberReady +
+                // Total number of tiles includes tiles without content, so "Ready" may never reach
+                // "Total."  Total also will increase when a tile with a tileset.json content is loaded.
+                ', Total: ' + stats.numberTotal +
                 ', Tiles styled: ' + styleStats.numberOfTilesStyled +
                 ', Features styled: ' + styleStats.numberOfFeaturesStyled;
 
@@ -958,6 +968,7 @@ define([
         stats.lastNumberOfPendingRequests = stats.numberOfPendingRequests;
         stats.lastNumberProcessing = stats.numberProcessing;
         stats.lastNumberReady = stats.numberReady;
+        stats.lastNumberTotal = stats.numberTotal;
         styleStats.lastNumberOfTilesStyled = styleStats.numberOfTilesStyled;
         styleStats.lastNumberOfFeaturesStyled = styleStats.numberOfFeaturesStyled;
     }

--- a/Source/Scene/Empty3DTileContent.js
+++ b/Source/Scene/Empty3DTileContent.js
@@ -85,6 +85,12 @@ define([
     /**
      * Part of the {@link Cesium3DTileContent} interface.
      */
+    Empty3DTileContent.prototype.initialize = function(arrayBuffer, byteOffset) {
+    };
+
+    /**
+     * Part of the {@link Cesium3DTileContent} interface.
+     */
     Empty3DTileContent.prototype.applyDebugSettings = function(enabled, color) {
     };
 

--- a/Source/Scene/Tileset3DTileContent.js
+++ b/Source/Scene/Tileset3DTileContent.js
@@ -95,6 +95,12 @@ define([
     /**
      * Part of the {@link Cesium3DTileContent} interface.
      */
+    Tileset3DTileContent.prototype.initialize = function(arrayBuffer, byteOffset) {
+    };
+
+    /**
+     * Part of the {@link Cesium3DTileContent} interface.
+     */
     Tileset3DTileContent.prototype.applyDebugSettings = function(enabled, color) {
     };
 

--- a/Specs/Core/DoublyLinkedListSpec.js
+++ b/Specs/Core/DoublyLinkedListSpec.js
@@ -1,0 +1,381 @@
+/*global defineSuite*/
+fdefineSuite([
+        'Core/DoublyLinkedList'
+    ], function(
+    DoublyLinkedList) {
+    'use strict';
+
+    it('constructs', function() {
+        var list = new DoublyLinkedList();
+        expect(list.head).not.toBeDefined();
+        expect(list.tail).not.toBeDefined();
+        expect(list.length).toEqual(0);
+    });
+
+    it('adds items', function() {
+        var list = new DoublyLinkedList();
+        var node = list.add(1);
+
+        //   node
+        //  ^     ^
+        //  |     |
+        // head  tail
+        expect(list.head).toEqual(node);
+        expect(list.tail).toEqual(node);
+        expect(list.length).toEqual(1);
+
+        expect(node).toBeDefined();
+        expect(node.item).toEqual(1);
+        expect(node.previous).not.toBeDefined();
+        expect(node.next).not.toBeDefined();
+
+        var node2 = list.add(2);
+
+        //  node <-> node2
+        //  ^         ^
+        //  |         |
+        // head      tail
+        expect(list.head).toEqual(node);
+        expect(list.tail).toEqual(node2);
+        expect(list.length).toEqual(2);
+
+        expect(node2).toBeDefined();
+        expect(node2.item).toEqual(2);
+        expect(node2.previous).toEqual(node);
+        expect(node2.next).not.toBeDefined();
+
+        expect(node.next).toEqual(node2);
+
+        var node3 = list.add(3);
+
+        //  node <-> node2 <-> node3
+        //  ^                    ^
+        //  |                    |
+        // head                 tail
+        expect(list.head).toEqual(node);
+        expect(list.tail).toEqual(node3);
+        expect(list.length).toEqual(3);
+
+        expect(node3).toBeDefined();
+        expect(node3.item).toEqual(3);
+        expect(node3.previous).toEqual(node2);
+        expect(node3.next).not.toBeDefined();
+
+        expect(node2.next).toEqual(node3);
+    });
+
+    it('removes from a list with one item', function() {
+        var list = new DoublyLinkedList();
+        var node = list.add(1);
+
+        list.remove(node);
+
+        expect(list.head).not.toBeDefined();
+        expect(list.tail).not.toBeDefined();
+        expect(list.length).toEqual(0);
+    });
+
+    it('removes head of list', function() {
+        var list = new DoublyLinkedList();
+        var node = list.add(1);
+        var node2 = list.add(2);
+
+        list.remove(node);
+
+        expect(list.head).toEqual(node2);
+        expect(list.tail).toEqual(node2);
+        expect(list.length).toEqual(1);
+    });
+
+    it('removes tail of list', function() {
+        var list = new DoublyLinkedList();
+        var node = list.add(1);
+        var node2 = list.add(2);
+
+        list.remove(node2);
+
+        expect(list.head).toEqual(node);
+        expect(list.tail).toEqual(node);
+        expect(list.length).toEqual(1);
+    });
+
+    it('removes middle of list', function() {
+        var list = new DoublyLinkedList();
+        var node = list.add(1);
+        var node2 = list.add(2);
+        var node3 = list.add(2);
+
+        list.remove(node2);
+
+        expect(list.head).toEqual(node);
+        expect(list.tail).toEqual(node3);
+        expect(list.length).toEqual(2);
+    });
+
+    it('removes nothing', function() {
+        var list = new DoublyLinkedList();
+        var node = list.add(1);
+
+        list.remove(undefined);
+
+        expect(list.head).toEqual(node);
+        expect(list.tail).toEqual(node);
+        expect(list.length).toEqual(1);
+    });
+
+    function expectOrder(list, nodes) {
+        // Assumes at least one node is in the list
+        var length = nodes.length;
+
+        expect(list.length).toEqual(length);
+
+        // Verify head and tail pointers
+        expect(list.head).toEqual(nodes[0]);
+        expect(list.tail).toEqual(nodes[length - 1]);
+
+        // Verify that linked list has nodes in the expected order
+        var node = list.head;
+        for (var i = 0; i < length; ++i) {
+            var nextNode = (i === length - 1) ? undefined : nodes[i + 1];
+            var previousNode = (i === 0) ? undefined : nodes[i - 1];
+
+            expect(node).toEqual(nodes[i]);
+            expect(node.next).toEqual(nextNode);
+            expect(node.previous).toEqual(previousNode);
+
+            node = node.next;
+        }
+    }
+
+    it('splices nextNode before node', function() {
+        var list = new DoublyLinkedList();
+        var node = list.add(1);
+        var node2 = list.add(2);
+        var node3 = list.add(3);
+        var node4 = list.add(4);
+        var node5 = list.add(5);
+
+        // Before:
+        //
+        //  node <-> node2 <-> node3 <-> node4 <-> node5
+        //  ^          ^                   ^          ^
+        //  |          |                   |          |
+        // head     nextNode             node        tail
+
+        // After:
+        //
+        //  node <-> node3 <-> node4 <-> node2 <-> node5
+        //  ^                                         ^
+        //  |                                         |
+        // head                                      tail
+
+        // Move node2 after node4
+        list.splice(node4, node2);
+        expectOrder(list, [node, node3, node4, node2, node5]);
+    });
+
+    it('splices nextNode after node', function() {
+        var list = new DoublyLinkedList();
+        var node = list.add(1);
+        var node2 = list.add(2);
+        var node3 = list.add(3);
+        var node4 = list.add(4);
+        var node5 = list.add(5);
+
+        // Before:
+        //
+        //  node <-> node2 <-> node3 <-> node4 <-> node5
+        //  ^          ^                   ^          ^
+        //  |          |                   |          |
+        // head      node              nextNode      tail
+
+        // After:
+        //
+        //  node <-> node2 <-> node4 <-> node3 <-> node5
+        //  ^                                         ^
+        //  |                                         |
+        // head                                      tail
+
+        // Move node4 after node2
+        list.splice(node2, node4);
+        expectOrder(list, [node, node2, node4, node3, node5]);
+    });
+
+    it('splices nextNode immediately before node', function() {
+        var list = new DoublyLinkedList();
+        var node = list.add(1);
+        var node2 = list.add(2);
+        var node3 = list.add(3);
+        var node4 = list.add(4);
+
+        // Before:
+        //
+        //  node <-> node2 <-> node3 <-> node4
+        //  ^          ^         ^         ^
+        //  |          |         |         |
+        // head     nextNode    node      tail
+
+        // After:
+        //
+        //  node <-> node3 <-> node2 <-> node4
+        //  ^                              ^
+        //  |                              |
+        // head                           tail
+
+        // Move node2 after node4
+        list.splice(node3, node2);
+        expectOrder(list, [node, node3, node2, node4]);
+    });
+
+    it('splices nextNode immediately after node', function() {
+        var list = new DoublyLinkedList();
+        var node = list.add(1);
+        var node2 = list.add(2);
+        var node3 = list.add(3);
+        var node4 = list.add(4);
+
+        // Before:
+        //
+        //  node <-> node2 <-> node3 <-> node4
+        //  ^          ^         ^         ^
+        //  |          |         |         |
+        // head      node    nextNode     tail
+
+        // After: does not change
+
+        list.splice(node2, node3);
+        expectOrder(list, [node, node2, node3, node4]);
+    });
+
+    it('splices node === nextNode', function() {
+        var list = new DoublyLinkedList();
+        var node = list.add(1);
+        var node2 = list.add(2);
+        var node3 = list.add(3);
+
+        // Before:
+        //
+        //  node <-> node2 <-> node3
+        //  ^          ^         ^
+        //  |          |         |
+        // head  node/nextNode  tail
+
+        // After: does not change
+
+        list.splice(node2, node2);
+        expectOrder(list, [node, node2, node3]);
+    });
+
+    it('splices when nextNode was tail', function() {
+        var list = new DoublyLinkedList();
+        var node = list.add(1);
+        var node2 = list.add(2);
+        var node3 = list.add(3);
+        var node4 = list.add(4);
+
+        // Before:
+        //
+        //  node <-> node2 <-> node3 <-> node4
+        //  ^          ^                   ^
+        //  |          |                   |
+        // head      node           tail/nextNode
+
+        // After:
+        //
+        //  node <-> node2 <-> node4 <-> node3
+        //  ^                               ^
+        //  |                               |
+        // head                            tail
+
+        list.splice(node2, node4);
+        expectOrder(list, [node, node2, node4, node3]);
+    });
+
+    it('splices when node was tail', function() {
+        var list = new DoublyLinkedList();
+        var node = list.add(1);
+        var node2 = list.add(2);
+        var node3 = list.add(3);
+        var node4 = list.add(4);
+
+        // Before:
+        //
+        //  node <-> node2 <-> node3 <-> node4
+        //  ^          ^                   ^
+        //  |          |                   |
+        // head      nextNode           tail/node
+
+        // After:
+        //
+        //  node <-> node3 <-> node4 <-> node2
+        //  ^                              ^
+        //  |                              |
+        // head                         tail/node
+
+        list.splice(node4, node2);
+        expectOrder(list, [node, node3, node4, node2]);
+    });
+
+    it('splices when nextNode was head', function() {
+        var list = new DoublyLinkedList();
+        var node = list.add(1);
+        var node2 = list.add(2);
+        var node3 = list.add(3);
+        var node4 = list.add(4);
+
+        // Before:
+        //
+        //  node <-> node2 <-> node3 <-> node4
+        //  ^                   ^         ^
+        //  |                   |         |
+        // head/nextNode       node      tail
+
+        // After:
+        //
+        //  node2 <-> node3 <-> node <-> node4
+        //  ^                              ^
+        //  |                              |
+        // head                           tail
+
+        list.splice(node3, node);
+        expectOrder(list, [node2, node3, node, node4]);
+    });
+
+    it('splices when node was head', function() {
+        var list = new DoublyLinkedList();
+        var node = list.add(1);
+        var node2 = list.add(2);
+        var node3 = list.add(3);
+        var node4 = list.add(4);
+
+        // Before:
+        //
+        //  node <-> node2 <-> node3 <-> node4
+        //  ^                   ^         ^
+        //  |                   |         |
+        // head/node        nextNode      tail
+
+        // After:
+        //
+        //  node <-> node3 <-> node2 <-> node4
+        //  ^                              ^
+        //  |                              |
+        // head                           tail
+
+        list.splice(node, node3);
+        expectOrder(list, [node, node3, node2, node4]);
+    });
+
+    it('splice throws without nodes', function() {
+        var list = new DoublyLinkedList();
+        var node = list.add(1);
+
+        expect(function() {
+            list.splice(undefined, node);
+        }).toThrowDeveloperError();
+
+        expect(function() {
+            list.splice(node, undefined);
+        }).toThrowDeveloperError();
+    });
+});

--- a/Specs/Core/DoublyLinkedListSpec.js
+++ b/Specs/Core/DoublyLinkedListSpec.js
@@ -1,5 +1,5 @@
 /*global defineSuite*/
-fdefineSuite([
+defineSuite([
         'Core/DoublyLinkedList'
     ], function(
     DoublyLinkedList) {

--- a/Specs/Core/DoublyLinkedListSpec.js
+++ b/Specs/Core/DoublyLinkedListSpec.js
@@ -2,7 +2,7 @@
 defineSuite([
         'Core/DoublyLinkedList'
     ], function(
-    DoublyLinkedList) {
+        DoublyLinkedList) {
     'use strict';
 
     it('constructs', function() {
@@ -103,7 +103,7 @@ defineSuite([
         var list = new DoublyLinkedList();
         var node = list.add(1);
         var node2 = list.add(2);
-        var node3 = list.add(2);
+        var node3 = list.add(3);
 
         list.remove(node2);
 

--- a/Specs/Scene/Cesium3DTilesetSpec.js
+++ b/Specs/Scene/Cesium3DTilesetSpec.js
@@ -846,6 +846,7 @@ defineSuite([
         viewNothing();
         return Cesium3DTilesTester.loadTileset(scene, tilesetOfTilesetsUrl).then(function(tileset) {
             var root = tileset._root;
+            var content = root.content;
 
             viewRootOnly();
             scene.renderForSpecs(); // Request external tileset.json
@@ -854,9 +855,13 @@ defineSuite([
             expect(stats.numberOfPendingRequests).toEqual(1);
             scene.primitives.remove(tileset);
 
-            expect(root.content).not.toBeDefined();
-            // Expect the root to not have added any children from the external tileset.json
-            expect(root.children.length).toEqual(0);
+            return content.readyPromise.then(function(root) {
+                fail('should not resolve');
+            }).otherwise(function(error) {
+                // Expect the root to not have added any children from the external tileset.json
+                expect(root.children.length).toEqual(0);
+                expect(RequestScheduler.getNumberOfAvailableRequests()).toEqual(RequestScheduler.maximumRequests);
+            });
         });
     });
 
@@ -864,12 +869,18 @@ defineSuite([
         viewNothing();
         return Cesium3DTilesTester.loadTileset(scene, tilesetUrl).then(function(tileset) {
             var root = tileset._root;
+            var content = root.content;
 
             viewRootOnly();
             scene.renderForSpecs(); // Request root
             scene.primitives.remove(tileset);
 
-            expect(root.content).not.toBeDefined();
+            return content.readyPromise.then(function(root) {
+                fail('should not resolve');
+            }).otherwise(function(error) {
+                expect(content.state).toEqual(Cesium3DTileContentState.FAILED);
+                expect(RequestScheduler.getNumberOfAvailableRequests()).toEqual(RequestScheduler.maximumRequests);
+            });
         });
     });
 

--- a/Specs/Scene/Cesium3DTilesetSpec.js
+++ b/Specs/Scene/Cesium3DTilesetSpec.js
@@ -1292,15 +1292,14 @@ defineSuite([
             expect(stats.numberReady).toEqual(5); // Root + four grandchildren (does not include empty children)
 
             // Zoom out so only root tile is needed to meet SSE.  This unloads
-            // two of the four children so three tiles are still loaded (the
-            // root and two children) since the max number of loaded tiles is three.
+            // all grandchildren since the max number of loaded tiles is one.
             viewRootOnly();
             scene.renderForSpecs();
 
             expect(stats.numberOfCommands).toEqual(1);
             expect(stats.numberReady).toEqual(1);
 
-            // Zoom back in so the two children are re-requested.
+            // Zoom back in so the four children are re-requested.
             viewAllTiles();
 
             return Cesium3DTilesTester.waitForPendingRequests(scene, tileset).then(function() {

--- a/Specs/Scene/Cesium3DTilesetSpec.js
+++ b/Specs/Scene/Cesium3DTilesetSpec.js
@@ -874,7 +874,6 @@ defineSuite([
         viewNothing();
         return Cesium3DTilesTester.loadTileset(scene, tilesetUrl).then(function(tileset) {
             var root = tileset._root;
-            var content = root.content;
 
             viewRootOnly();
             scene.renderForSpecs(); // Request root

--- a/Specs/Scene/Cesium3DTilesetSpec.js
+++ b/Specs/Scene/Cesium3DTilesetSpec.js
@@ -673,9 +673,6 @@ defineSuite([
         spyOn(console, 'log');
 
         return Cesium3DTilesTester.loadTileset(scene, tilesetUrl).then(function(tileset) {
-            scene.renderForSpecs();
-            expect(console.log).not.toHaveBeenCalled();
-
             tileset.debugShowStatistics = true;
             scene.renderForSpecs();
             expect(console.log).toHaveBeenCalled();
@@ -686,9 +683,6 @@ defineSuite([
         spyOn(console, 'log');
 
         return Cesium3DTilesTester.loadTileset(scene, tilesetUrl).then(function(tileset) {
-            scene.pickForSpecs();
-            expect(console.log).not.toHaveBeenCalled();
-
             tileset.debugShowPickStatistics = true;
             scene.pickForSpecs();
             expect(console.log).toHaveBeenCalled();

--- a/Specs/Scene/Cesium3DTilesetSpec.js
+++ b/Specs/Scene/Cesium3DTilesetSpec.js
@@ -603,7 +603,7 @@ defineSuite([
             // Set view so that root's content is requested
             viewRootOnly();
             scene.renderForSpecs();
-            return root.contentReadyPromise.then(function() {
+            return root.content.readyPromise.then(function() {
                 // Root has one child now, the root of the external tileset
                 expect(root.children.length).toEqual(1);
 
@@ -639,7 +639,7 @@ defineSuite([
             viewRootOnly();
             scene.renderForSpecs();
 
-            return tileset._root.contentReadyPromise;
+            return tileset._root.content.readyPromise;
         }).then(function() {
             //Make sure tileset2.json was requested with query parameters and version
             var queryParamsWithVersion = queryParams + '&v=0.0';
@@ -760,7 +760,7 @@ defineSuite([
             viewRootOnly();
             scene.renderForSpecs(); // Request root
             expect(tileset._statistics.numberOfPendingRequests).toEqual(1);
-            return tileset._root.contentReadyToProcessPromise.then(function() {
+            return tileset._root.content.contentReadyToProcessPromise.then(function() {
                 scene.pickForSpecs();
                 expect(spy).not.toHaveBeenCalled();
                 scene.renderForSpecs();
@@ -864,13 +864,9 @@ defineSuite([
             expect(stats.numberOfPendingRequests).toEqual(1);
             scene.primitives.remove(tileset);
 
-            return root.contentReadyPromise.then(function(root) {
-                fail('should not resolve');
-            }).otherwise(function(error) {
-                // Expect the root to not have added any children from the external tileset.json
-                expect(root.children.length).toEqual(0);
-                expect(RequestScheduler.getNumberOfAvailableRequests()).toEqual(RequestScheduler.maximumRequests);
-            });
+            expect(root.content).not.toBeDefined();
+            // Expect the root to not have added any children from the external tileset.json
+            expect(root.children.length).toEqual(0);
         });
     });
 
@@ -884,12 +880,7 @@ defineSuite([
             scene.renderForSpecs(); // Request root
             scene.primitives.remove(tileset);
 
-            return root.contentReadyPromise.then(function(root) {
-                fail('should not resolve');
-            }).otherwise(function(error) {
-                expect(content.state).toEqual(Cesium3DTileContentState.FAILED);
-                expect(RequestScheduler.getNumberOfAvailableRequests()).toEqual(RequestScheduler.maximumRequests);
-            });
+            expect(root.content).not.toBeDefined();
         });
     });
 

--- a/Specs/Scene/Cesium3DTilesetSpec.js
+++ b/Specs/Scene/Cesium3DTilesetSpec.js
@@ -677,8 +677,24 @@ defineSuite([
         spyOn(console, 'log');
 
         return Cesium3DTilesTester.loadTileset(scene, tilesetUrl).then(function(tileset) {
+            scene.renderForSpecs();
+            expect(console.log).not.toHaveBeenCalled();
+
             tileset.debugShowStatistics = true;
             scene.renderForSpecs();
+            expect(console.log).toHaveBeenCalled();
+        });
+    });
+
+    it('debugShowPickStatistics', function() {
+        spyOn(console, 'log');
+
+        return Cesium3DTilesTester.loadTileset(scene, tilesetUrl).then(function(tileset) {
+            scene.pickForSpecs();
+            expect(console.log).not.toHaveBeenCalled();
+
+            tileset.debugShowPickStatistics = true;
+            scene.pickForSpecs();
             expect(console.log).toHaveBeenCalled();
         });
     });

--- a/Specs/Scene/Cesium3DTilesetSpec.js
+++ b/Specs/Scene/Cesium3DTilesetSpec.js
@@ -423,8 +423,6 @@ defineSuite([
 
     it('additive refinement - selects root when sse is met', function() {
         return Cesium3DTilesTester.loadTileset(scene, tilesetUrl).then(function(tileset) {
-            tileset._root.refine = Cesium3DTileRefine.ADD;
-
             // Meets screen space error, only root tile is rendered
             viewRootOnly();
             scene.renderForSpecs();
@@ -437,8 +435,6 @@ defineSuite([
 
     it('additive refinement - selects all tiles when sse is not met', function() {
         return Cesium3DTilesTester.loadTileset(scene, tilesetUrl).then(function(tileset) {
-            tileset._root.refine = Cesium3DTileRefine.ADD;
-
             // Does not meet screen space error, all tiles are visible
             viewAllTiles();
             scene.renderForSpecs();
@@ -883,6 +879,9 @@ defineSuite([
         });
     });
 
+    ///////////////////////////////////////////////////////////////////////////
+    // Styling tests
+
     it('applies show style to a tileset', function() {
         return Cesium3DTilesTester.loadTileset(scene, withoutBatchTableUrl).then(function(tileset) {
             var showColor = scene.renderForSpecs();
@@ -982,12 +981,6 @@ defineSuite([
         color = scene.renderForSpecs();
         expect(color).toEqual(originalColor);
     }
-
-    xit('applies color style to a tileset with translucent tiles', function() {
-        return Cesium3DTilesTester.loadTileset(scene, translucentUrl).then(function(tileset) {
-            expectColorStyle(tileset);
-        });
-    });
 
     it('applies color style to a tileset with translucent tiles', function() {
         return Cesium3DTilesTester.loadTileset(scene, translucentUrl).then(function(tileset) {
@@ -1125,6 +1118,277 @@ defineSuite([
             tileset.makeStyleDirty();
             expect(scene.renderForSpecs()).toEqual(showColor);
         });
+    });
+
+    ///////////////////////////////////////////////////////////////////////////
+    // Cache replacement tests
+
+    it('Unload all cached tiles not required to meet SSE', function() {
+        return Cesium3DTilesTester.loadTileset(scene, tilesetUrl).then(function(tileset) {
+            tileset.maximumNumberOfLoadedTiles = 1;
+
+            // Render parent and four children (using additive refinement)
+            viewAllTiles();
+            scene.renderForSpecs();
+
+            var stats = tileset._statistics;
+            expect(stats.numberOfCommands).toEqual(5);
+            expect(stats.numberReady).toEqual(5); // Five loaded tiles
+
+            // Zoom out so only root tile is needed to meet SSE.  This unloads
+            // the four children since the max number of loaded tiles is one.
+            viewRootOnly();
+            scene.renderForSpecs();
+
+            expect(stats.numberOfCommands).toEqual(1);
+            expect(stats.numberReady).toEqual(1);
+
+            // Zoom back in so all four children are re-requested.
+            viewAllTiles();
+
+            return Cesium3DTilesTester.waitForPendingRequests(scene, tileset).then(function() {
+                scene.renderForSpecs();
+                expect(stats.numberOfCommands).toEqual(5);
+                expect(stats.numberReady).toEqual(5); // Five loaded tiles
+            });
+        });
+    });
+
+    it('Unload some cached tiles not required to meet SSE', function() {
+        return Cesium3DTilesTester.loadTileset(scene, tilesetUrl).then(function(tileset) {
+            tileset.maximumNumberOfLoadedTiles = 3;
+
+            // Render parent and four children (using additive refinement)
+            viewAllTiles();
+            scene.renderForSpecs();
+
+            var stats = tileset._statistics;
+            expect(stats.numberOfCommands).toEqual(5);
+            expect(stats.numberReady).toEqual(5); // Five loaded tiles
+
+            // Zoom out so only root tile is needed to meet SSE.  This unloads
+            // two of the four children so three tiles are still loaded (the
+            // root and two children) since the max number of loaded tiles is three.
+            viewRootOnly();
+            scene.renderForSpecs();
+
+            expect(stats.numberOfCommands).toEqual(1);
+            expect(stats.numberReady).toEqual(3);
+
+            // Zoom back in so the two children are re-requested.
+            viewAllTiles();
+
+            return Cesium3DTilesTester.waitForPendingRequests(scene, tileset).then(function() {
+                scene.renderForSpecs();
+                expect(stats.numberOfCommands).toEqual(5);
+                expect(stats.numberReady).toEqual(5); // Five loaded tiles
+            });
+        });
+    });
+
+    it('Unloads cached tiles outside of the view frustum', function() {
+        return Cesium3DTilesTester.loadTileset(scene, tilesetUrl).then(function(tileset) {
+            tileset.maximumNumberOfLoadedTiles = 0;
+
+            scene.renderForSpecs();
+            var stats = tileset._statistics;
+            expect(stats.numberOfCommands).toEqual(5);
+            expect(stats.numberReady).toEqual(5);
+
+            // Orient camera to face the sky
+            var center = Cartesian3.fromRadians(centerLongitude, centerLatitude, 100);
+            scene.camera.lookAt(center, new HeadingPitchRange(0.0, 1.57, 10.0));
+
+            // All tiles are unloaded
+            scene.renderForSpecs();
+            expect(stats.numberOfCommands).toEqual(0);
+            expect(stats.numberReady).toEqual(0);
+
+            // Reset camera so all tiles are reloaded
+            viewAllTiles();
+
+            return Cesium3DTilesTester.waitForPendingRequests(scene, tileset).then(function() {
+                scene.renderForSpecs();
+                expect(stats.numberOfCommands).toEqual(5);
+                expect(stats.numberReady).toEqual(5);
+            });
+        });
+    });
+
+    it('Unloads cached tiles in a tileset with external tileset.json', function() {
+        return Cesium3DTilesTester.loadTileset(scene, tilesetOfTilesetsUrl).then(function(tileset) {
+            var stats = tileset._statistics;
+            var replacementList = tileset._replacementList;
+
+            tileset.maximumNumberOfLoadedTiles = 2;
+
+            scene.renderForSpecs();
+            expect(stats.numberOfCommands).toEqual(5);
+            expect(stats.numberReady).toEqual(7); // 5 with b3dm content + 2 empty/tileset.json
+            expect(replacementList.length - 1).toEqual(5); // Only tiles with content are on the replacement list. -1 for sentinel.
+
+            // Zoom out so only root tile is needed to meet SSE.  This unloads
+            // all tiles except the root and one of the b3dm children
+            viewRootOnly();
+            scene.renderForSpecs();
+
+            expect(stats.numberOfCommands).toEqual(1);
+            expect(stats.numberReady).toEqual(4); // 2 with b3dm content + 2 empty/tileset.json
+            expect(replacementList.length - 1).toEqual(2);
+
+            // Reset camera so all tiles are reloaded
+            viewAllTiles();
+
+            return Cesium3DTilesTester.waitForPendingRequests(scene, tileset).then(function() {
+                scene.renderForSpecs();
+                expect(stats.numberOfCommands).toEqual(5);
+                expect(stats.numberReady).toEqual(7);
+                expect(replacementList.length - 1).toEqual(5);
+            });
+        });
+    });
+
+    it('Unloads cached tiles in a tileset with empty tiles', function() {
+        return Cesium3DTilesTester.loadTileset(scene, tilesetEmptyRootUrl).then(function(tileset) {
+            var stats = tileset._statistics;
+            var replacementList = tileset._replacementList;
+
+            tileset.maximumNumberOfLoadedTiles = 2;
+
+            scene.renderForSpecs();
+            expect(stats.numberOfCommands).toEqual(4);
+            expect(stats.numberReady).toEqual(4); // 4 children with b3dm content (does not include empty root)
+
+            // Orient camera to face the sky
+            var center = Cartesian3.fromRadians(centerLongitude, centerLatitude, 100);
+            scene.camera.lookAt(center, new HeadingPitchRange(0.0, 1.57, 10.0));
+
+            // Unload tiles to meet cache size
+            scene.renderForSpecs();
+            expect(stats.numberOfCommands).toEqual(0);
+            expect(stats.numberReady).toEqual(2); // 2 children with b3dm content (does not include empty root)
+
+            // Reset camera so all tiles are reloaded
+            viewAllTiles();
+
+            return Cesium3DTilesTester.waitForPendingRequests(scene, tileset).then(function() {
+                scene.renderForSpecs();
+                expect(stats.numberOfCommands).toEqual(4);
+                expect(stats.numberReady).toEqual(4);
+            });
+        });
+    });
+
+    it('Unload cached tiles when a tileset uses replacement refinement', function() {
+        // No children have content, but all grandchildren have content
+        //
+        //          C
+        //      E       E
+        //    C   C   C   C
+        //
+        return Cesium3DTilesTester.loadTileset(scene, tilesetReplacement1Url).then(function(tileset) {
+            tileset.maximumNumberOfLoadedTiles = 1;
+
+            // Render parent and four children (using additive refinement)
+            viewAllTiles();
+            scene.renderForSpecs();
+
+            var stats = tileset._statistics;
+            expect(stats.numberOfCommands).toEqual(4); // 4 grandchildren. Root is replaced.
+            expect(stats.numberReady).toEqual(5); // Root + four grandchildren (does not include empty children)
+
+            // Zoom out so only root tile is needed to meet SSE.  This unloads
+            // two of the four children so three tiles are still loaded (the
+            // root and two children) since the max number of loaded tiles is three.
+            viewRootOnly();
+            scene.renderForSpecs();
+
+            expect(stats.numberOfCommands).toEqual(1);
+            expect(stats.numberReady).toEqual(1);
+
+            // Zoom back in so the two children are re-requested.
+            viewAllTiles();
+
+            return Cesium3DTilesTester.waitForPendingRequests(scene, tileset).then(function() {
+                scene.renderForSpecs();
+                expect(stats.numberOfCommands).toEqual(4);
+                expect(stats.numberReady).toEqual(5);
+            });
+        });
+    });
+
+    it('Explicitly unloads cached tiles with trimLoadedTiles', function() {
+        return Cesium3DTilesTester.loadTileset(scene, tilesetUrl).then(function(tileset) {
+            tileset.maximumNumberOfLoadedTiles = 5;
+
+            // Render parent and four children (using additive refinement)
+            viewAllTiles();
+            scene.renderForSpecs();
+
+            var stats = tileset._statistics;
+            expect(stats.numberOfCommands).toEqual(5);
+            expect(stats.numberReady).toEqual(5); // Five loaded tiles
+
+            // Zoom out so only root tile is needed to meet SSE.  The children
+            // are not unloaded since max number of loaded tiles is five.
+            viewRootOnly();
+            scene.renderForSpecs();
+
+            expect(stats.numberOfCommands).toEqual(1);
+            expect(stats.numberReady).toEqual(5);
+
+            tileset.trimLoadedTiles();
+            scene.renderForSpecs();
+
+            expect(stats.numberOfCommands).toEqual(1);
+            expect(stats.numberReady).toEqual(1);
+        });
+    });
+
+    it('tileUnload event is raised', function() {
+        return Cesium3DTilesTester.loadTileset(scene, tilesetUrl).then(function(tileset) {
+            tileset.maximumNumberOfLoadedTiles = 1;
+
+            // Render parent and four children (using additive refinement)
+            viewAllTiles();
+            scene.renderForSpecs();
+
+            var stats = tileset._statistics;
+            expect(stats.numberOfCommands).toEqual(5);
+            expect(stats.numberReady).toEqual(5); // Five loaded tiles
+
+            // Zoom out so only root tile is needed to meet SSE.  All the
+            // children are unloaded since max number of loaded tiles is one.
+            viewRootOnly();
+            var spyUpdate = jasmine.createSpy('listener');
+            tileset.tileUnload.addEventListener(spyUpdate);
+            scene.renderForSpecs();
+
+            expect(tileset._root.visibility(scene.frameState.cullingVolume)).not.toEqual(CullingVolume.MASK_OUTSIDE);
+            expect(spyUpdate.calls.count()).toEqual(4);
+            expect(spyUpdate.calls.argsFor(0)[0]).toBe(tileset._root.children[0]);
+            expect(spyUpdate.calls.argsFor(1)[0]).toBe(tileset._root.children[1]);
+            expect(spyUpdate.calls.argsFor(2)[0]).toBe(tileset._root.children[2]);
+            expect(spyUpdate.calls.argsFor(3)[0]).toBe(tileset._root.children[3]);
+        });
+    });
+
+    it('maximumNumberOfLoadedTiles throws when negative', function() {
+        var tileset = new Cesium3DTileset({
+            url : tilesetUrl
+        });
+        expect(function() {
+            tileset.maximumNumberOfLoadedTiles = -1;
+        }).toThrowDeveloperError();
+    });
+
+    it('maximumScreenSpaceError throws when negative', function() {
+        var tileset = new Cesium3DTileset({
+            url : tilesetUrl
+        });
+        expect(function() {
+            tileset.maximumScreenSpaceError = -1;
+        }).toThrowDeveloperError();
     });
 
 }, 'WebGL');


### PR DESCRIPTION
3D Tiles now maintain a LRU cache of tiles to ensure only a maximum number of tiles, specified by the user, are loaded (unless more are needed to meet the SSE for the current view).

There's lots of interesting future work in the **Cache Management** section of the roadmap, https://github.com/AnalyticalGraphicsInc/cesium/issues/3241.