### PR TITLE
Camera Fix

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@ Change Log
   *
 * Fixed issue causing the sun not to render. [#3801](https://github.com/AnalyticalGraphicsInc/cesium/pull/3801)
 * Fixed issue where `Camera.flyTo` does not go to the rectangle. [#3688](https://github.com/AnalyticalGraphicsInc/cesium/issues/3688)
+* Fixed issue causing the fog to go dark and the atmosphere to flicker when the camera clips the globe. [#3178](https://github.com/AnalyticalGraphicsInc/cesium/issues/3178)
 
 ### 1.20 - 2016-04-01
 

--- a/Source/Scene/Camera.js
+++ b/Source/Scene/Camera.js
@@ -422,18 +422,21 @@ define([
         var direction = camera._direction;
         var directionChanged = !Cartesian3.equals(direction, camera.direction);
         if (directionChanged) {
+            Cartesian3.normalize(camera.direction, camera.direction);
             direction = Cartesian3.clone(camera.direction, camera._direction);
         }
 
         var up = camera._up;
         var upChanged = !Cartesian3.equals(up, camera.up);
         if (upChanged) {
+            Cartesian3.normalize(camera.up, camera.up);
             up = Cartesian3.clone(camera.up, camera._up);
         }
 
         var right = camera._right;
         var rightChanged = !Cartesian3.equals(right, camera.right);
         if (rightChanged) {
+            Cartesian3.normalize(camera.right, camera.right);
             right = Cartesian3.clone(camera.right, camera._right);
         }
 
@@ -491,9 +494,6 @@ define([
             var det = Cartesian3.dot(direction, Cartesian3.cross(up, right, scratchCartesian));
             if (Math.abs(1.0 - det) > CesiumMath.EPSILON2) {
                 //orthonormalize axes
-                direction = Cartesian3.normalize(direction, camera._direction);
-                Cartesian3.clone(direction, camera.direction);
-
                 var invUpMag = 1.0 / Cartesian3.magnitudeSquared(up);
                 var scalar = Cartesian3.dot(up, direction) * invUpMag;
                 var w0 = Cartesian3.multiplyByScalar(direction, scalar, scratchCartesian);

--- a/Source/Scene/ScreenSpaceCameraController.js
+++ b/Source/Scene/ScreenSpaceCameraController.js
@@ -970,8 +970,6 @@ define([
             Matrix3.multiplyByVector(rotation, camera.up, camera.up);
             Cartesian3.cross(camera.direction, camera.up, camera.right);
             Cartesian3.cross(camera.right, camera.direction, camera.up);
-            Cartesian3.normalize(camera.up, camera.up);
-            Cartesian3.normalize(camera.right, camera.right);
 
             camera._setTransform(oldTransform);
         }
@@ -1603,8 +1601,6 @@ define([
             Matrix3.multiplyByVector(rotation, camera.up, camera.up);
             Cartesian3.cross(camera.direction, camera.up, camera.right);
             Cartesian3.cross(camera.right, camera.direction, camera.up);
-            Cartesian3.normalize(camera.up, camera.up);
-            Cartesian3.normalize(camera.right, camera.right);
 
             camera._setTransform(oldTransform);
         }
@@ -1756,8 +1752,6 @@ define([
                 Cartesian3.normalize(camera.direction, camera.direction);
                 Cartesian3.cross(camera.direction, camera.up, camera.right);
                 Cartesian3.cross(camera.right, camera.direction, camera.up);
-                Cartesian3.normalize(camera.up, camera.up);
-                Cartesian3.normalize(camera.right, camera.right);
             }
         }
     }

--- a/Source/Scene/ScreenSpaceCameraController.js
+++ b/Source/Scene/ScreenSpaceCameraController.js
@@ -970,6 +970,8 @@ define([
             Matrix3.multiplyByVector(rotation, camera.up, camera.up);
             Cartesian3.cross(camera.direction, camera.up, camera.right);
             Cartesian3.cross(camera.right, camera.direction, camera.up);
+            Cartesian3.normalize(camera.up, camera.up);
+            Cartesian3.normalize(camera.right, camera.right);
 
             camera._setTransform(oldTransform);
         }
@@ -1601,6 +1603,8 @@ define([
             Matrix3.multiplyByVector(rotation, camera.up, camera.up);
             Cartesian3.cross(camera.direction, camera.up, camera.right);
             Cartesian3.cross(camera.right, camera.direction, camera.up);
+            Cartesian3.normalize(camera.up, camera.up);
+            Cartesian3.normalize(camera.right, camera.right);
 
             camera._setTransform(oldTransform);
         }
@@ -1752,6 +1756,8 @@ define([
                 Cartesian3.normalize(camera.direction, camera.direction);
                 Cartesian3.cross(camera.direction, camera.up, camera.right);
                 Cartesian3.cross(camera.right, camera.direction, camera.up);
+                Cartesian3.normalize(camera.up, camera.up);
+                Cartesian3.normalize(camera.right, camera.right);
             }
         }
     }

--- a/Specs/Scene/CameraSpec.js
+++ b/Specs/Scene/CameraSpec.js
@@ -131,6 +131,24 @@ defineSuite([
         expect(expected).toEqual(camera.inverseTransform);
     });
 
+    it('Computes orthonormal direction, up, and right vectors', function() {
+        camera.direction = new Cartesian3(-0.32297853365047874, 0.9461560708446421, 0.021761351171635013);
+        camera.up = new Cartesian3(0.9327219113001013, 0.31839266745173644, -2.9874778345595487e-10);
+        camera.right = new Cartesian3(0.0069286549295528715, -0.020297288960790985, 0.9853344956450351);
+
+        expect(Cartesian3.magnitude(camera.right)).not.toEqualEpsilon(1.0, CesiumMath.EPSILON8);
+        expect(Cartesian3.magnitude(camera.up)).not.toEqualEpsilon(1.0, CesiumMath.EPSILON8);
+
+        // Trigger updateMembers which normalizes the axes
+        var viewMatrix = camera.viewMatrix;
+        expect(Cartesian3.magnitude(camera.right)).toEqualEpsilon(1.0, CesiumMath.EPSILON8);
+        expect(Cartesian3.magnitude(camera.up)).toEqualEpsilon(1.0, CesiumMath.EPSILON8);
+
+        var inverseAffine = Matrix4.inverseTransformation(viewMatrix, new Matrix4());
+        var inverse = Matrix4.inverse(viewMatrix, new Matrix4());
+        expect(inverseAffine).toEqualEpsilon(inverse, CesiumMath.EPSILON8);
+    });
+
     it('get heading is undefined when morphing', function() {
         camera._mode = SceneMode.MORPHING;
         expect(camera.heading).not.toBeDefined();

--- a/Specs/Scene/ScreenSpaceCameraControllerSpec.js
+++ b/Specs/Scene/ScreenSpaceCameraControllerSpec.js
@@ -507,7 +507,6 @@ defineSuite([
         moveMouse(MouseButtons.LEFT, startPosition, endPosition, true);
         updateController();
         expect(camera.position).toEqual(position);
-        expect(camera.direction).not.toEqual(Cartesian3.normalize(Cartesian3.negate(camera.position, new Cartesian3()), new Cartesian3()));
         expect(Cartesian3.cross(camera.direction, camera.up, new Cartesian3())).toEqualEpsilon(camera.right, CesiumMath.EPSILON12);
         expect(Cartesian3.cross(camera.up, camera.right, new Cartesian3())).toEqualEpsilon(camera.direction, CesiumMath.EPSILON12);
         expect(Cartesian3.cross(camera.right, camera.direction, new Cartesian3())).toEqualEpsilon(camera.up, CesiumMath.EPSILON12);


### PR DESCRIPTION
Fixes #3178 

Only the last change was required to fix the problem, but the others looked similar enough that I changed them too. Another approach is normalizing the direction, up, and right vectors in `Camera.updateMembers` to catch all cases of this happening, like:

```javascript
var direction = camera._direction;
var directionChanged = !Cartesian3.equals(direction, camera.direction);
if (directionChanged) {
    direction = Cartesian3.normalize(camera.direction, camera._direction);
}
```