### PR TITLE
Naive fix for #3796

### DIFF
--- a/Source/Core/EllipseGeometry.js
+++ b/Source/Core/EllipseGeometry.js
@@ -819,7 +819,7 @@ define([
             return;
         }
 
-        ellipseGeometry._center = ellipseGeometry._ellipsoid.scaleToGeodeticSurface(ellipseGeometry._center, ellipseGeometry._center);
+        ellipseGeometry._center = ellipseGeometry._ellipsoid.scaleToGeocentricSurface(ellipseGeometry._center, ellipseGeometry._center);
         var options = {
             center : ellipseGeometry._center,
             semiMajorAxis : ellipseGeometry._semiMajorAxis,

--- a/Source/DataSources/EllipseGeometryUpdater.js
+++ b/Source/DataSources/EllipseGeometryUpdater.js
@@ -1,5 +1,6 @@
 /*global define*/
 define([
+        '../Core/Cartesian3',
         '../Core/Color',
         '../Core/ColorGeometryInstanceAttribute',
         '../Core/defaultValue',
@@ -22,6 +23,7 @@ define([
         './MaterialProperty',
         './Property'
     ], function(
+        Cartesian3,
         Color,
         ColorGeometryInstanceAttribute,
         defaultValue,
@@ -478,6 +480,7 @@ define([
             var options = this._options;
             options.vertexFormat = isColorMaterial ? PerInstanceColorAppearance.VERTEX_FORMAT : MaterialAppearance.MaterialSupport.TEXTURED.vertexFormat;
             options.center = position.getValue(Iso8601.MINIMUM_VALUE, options.center);
+            options.center = options.center ? options.center : new Cartesian3();
             options.semiMajorAxis = semiMajorAxis.getValue(Iso8601.MINIMUM_VALUE, options.semiMajorAxis);
             options.semiMinorAxis = semiMinorAxis.getValue(Iso8601.MINIMUM_VALUE, options.semiMinorAxis);
             options.rotation = defined(rotation) ? rotation.getValue(Iso8601.MINIMUM_VALUE) : undefined;


### PR DESCRIPTION
In reference to #3796. I think the reason why ellipses throw an exception here is because currently they get scaled along the geodetic surface normal, so defaulting the center to zero causes problems later. You could default the value to zero and then use ```scaleToGeocentricSurface``` instead, but I don't know if doing that has any broader implications.