### PR TITLE
Fix documentation error in Matrix4.js

### DIFF
--- a/Source/Core/Matrix4.js
+++ b/Source/Core/Matrix4.js
@@ -841,7 +841,6 @@ define([
      * @param {Number} bottom The number of meters below of the camera that will be in view.
      * @param {Number} top The number of meters above of the camera that will be in view.
      * @param {Number} near The distance to the near plane in meters.
-     * @param {Number} far The distance to the far plane in meters.
      * @param {Matrix4} result The object in which the result will be stored.
      * @returns {Matrix4} The modified result parameter.
      */


### PR DESCRIPTION
Removed a non-existing parameter from the jsdoc