### PR TITLE
Don't let setView and flyTo set camera heading in 2D

### DIFF
--- a/Source/Scene/Camera.js
+++ b/Source/Scene/Camera.js
@@ -901,10 +901,7 @@ define([
         camera._setTransform(currentTransform);
     }
 
-    function setView2D(camera, position, heading, convert) {
-        var pitch = -CesiumMath.PI_OVER_TWO;
-        var roll = 0.0;
-
+    function setView2D(camera, position, convert) {
         var currentTransform = Matrix4.clone(camera.transform, scratchSetViewTransform1);
         camera._setTransform(Matrix4.IDENTITY);
 
@@ -929,12 +926,6 @@ define([
                 frustum.bottom = -frustum.top;
             }
         }
-
-        var rotQuat = Quaternion.fromHeadingPitchRoll(heading - CesiumMath.PI_OVER_TWO, pitch, roll, scratchSetViewQuaternion);
-        var rotMat = Matrix3.fromQuaternion(rotQuat, scratchSetViewMatrix3);
-
-        Matrix3.getColumn(rotMat, 2, camera.up);
-        Cartesian3.cross(camera.direction, camera.up, camera.right);
 
         camera._setTransform(currentTransform);
     }
@@ -984,8 +975,8 @@ define([
      * @param {Object} options Object with the following properties:
      * @param {Cartesian3|Rectangle} [options.destination] The final position of the camera in WGS84 (world) coordinates or a rectangle that would be visible from a top-down view.
      * @param {Object} [options.orientation] An object that contains either direction and up properties or heading, pith and roll properties. By default, the direction will point
-     * towards the center of the frame in 3D and in the negative z direction in Columbus view or 2D. The up direction will point towards local north in 3D and in the positive
-     * y direction in Columbus view or 2D.
+     * towards the center of the frame in 3D and in the negative z direction in Columbus view. The up direction will point towards local north in 3D and in the positive
+     * y direction in Columbus view. Orientation is not used in 2D.
      * @param {Matrix4} [options.endTransform] Transform matrix representing the reference frame of the camera.
      *
      * @example
@@ -1059,7 +1050,7 @@ define([
         if (mode === SceneMode.SCENE3D) {
             setView3D(this, destination, heading, pitch, roll);
         } else if (mode === SceneMode.SCENE2D) {
-            setView2D(this, destination, heading, convert);
+            setView2D(this, destination, convert);
         } else {
             setViewCV(this, destination, heading, pitch, roll, convert);
         }
@@ -2417,8 +2408,8 @@ define([
      * @param {Object} options Object with the following properties:
      * @param {Cartesian3|Rectangle} options.destination The final position of the camera in WGS84 (world) coordinates or a rectangle that would be visible from a top-down view.
      * @param {Object} [options.orientation] An object that contains either direction and up properties or heading, pith and roll properties. By default, the direction will point
-     * towards the center of the frame in 3D and in the negative z direction in Columbus view or 2D. The up direction will point towards local north in 3D and in the positive
-     * y direction in Columbus view or 2D.
+     * towards the center of the frame in 3D and in the negative z direction in Columbus view. The up direction will point towards local north in 3D and in the positive
+     * y direction in Columbus view.  Orientation is not used in 2D.
      * @param {Number} [options.duration] The duration of the flight in seconds. If omitted, Cesium attempts to calculate an ideal duration based on the distance to be traveled by the flight.
      * @param {Camera~FlightCompleteCallback} [options.complete] The function to execute when the flight is complete.
      * @param {Camera~FlightCancelledCallback} [options.cancel] The function to execute if the flight is cancelled.

--- a/Source/Scene/CameraFlightPath.js
+++ b/Source/Scene/CameraFlightPath.js
@@ -192,19 +192,12 @@ define([
         var camera = scene.camera;
 
         var start = Cartesian3.clone(camera.position, scratchStart);
-        var startHeading = adjustAngleForLERP(camera.heading, heading);
 
         var startHeight = camera.frustum.right - camera.frustum.left;
         var heightFunction = createHeightFunction(camera, destination, startHeight, destination.z, optionAltitude);
 
         function update(value) {
             var time = value.time / duration;
-
-            camera.setView({
-                orientation: {
-                    heading : CesiumMath.lerp(startHeading, heading, time)
-                }
-            });
 
             Cartesian2.lerp(start, destination, time, camera.position);
 

--- a/Specs/Scene/CameraSpec.js
+++ b/Specs/Scene/CameraSpec.js
@@ -218,7 +218,7 @@ defineSuite([
         expect(camera.right).toEqualEpsilon(right, CesiumMath.EPSILON8);
     });
 
-    it('set heading in 2D', function() {
+    it('does not set heading in 2D', function() {
         camera._mode = SceneMode.SCENE2D;
 
         var heading = camera.heading;
@@ -232,8 +232,7 @@ defineSuite([
         });
 
         expect(camera.positionCartographic).toEqual(positionCartographic);
-        expect(camera.heading).not.toEqual(heading);
-        expect(camera.heading).toEqualEpsilon(newHeading, CesiumMath.EPSILON14);
+        expect(camera.heading).toEqual(heading);
     });
 
     it('set heading in CV', function() {


### PR DESCRIPTION
We don't want to set the heading in 2D with the new infinite scrolling.  I removed the use of heading in the 2D functions for both `camera.setView` and `camera.flyTo` to fix this.