### PR TITLE
Constrain ArcGIS rectangle to the tiling scheme's rectangle.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@ Change Log
 * Added ability to import and export Sandcastle example using GitHub Gists. [#3795](https://github.com/AnalyticalGraphicsInc/cesium/pull/3795)
 * Fixed issue where `Camera.flyTo` does not go to the rectangle. [#3688](https://github.com/AnalyticalGraphicsInc/cesium/issues/3688)
 * Fixed issue causing the fog to go dark and the atmosphere to flicker when the camera clips the globe. [#3178](https://github.com/AnalyticalGraphicsInc/cesium/issues/3178)
+* Fixed a bug that caused an exception and rendering to stop when using `ArcGisMapServerImageryProvider` to connect to a MapServer specifying the Web Mercator projection and a fullExtent bigger than the valid extent of the projection. [#3854](https://github.com/AnalyticalGraphicsInc/cesium/pull/3854)
 
 ### 1.20 - 2016-04-01
 

--- a/Source/Scene/ArcGisMapServerImageryProvider.js
+++ b/Source/Scene/ArcGisMapServerImageryProvider.js
@@ -179,8 +179,9 @@ define([
                             data.fullExtent.spatialReference.wkid === 102113) {
 
                             var projection = new WebMercatorProjection();
-                            var sw = projection.unproject(new Cartesian2(data.fullExtent.xmin, data.fullExtent.ymin));
-                            var ne = projection.unproject(new Cartesian2(data.fullExtent.xmax, data.fullExtent.ymax));
+                            var extent = data.fullExtent;
+                            var sw = projection.unproject(new Cartesian3(Math.max(extent.xmin, -that._tilingScheme.ellipsoid.maximumRadius * Math.PI), Math.max(extent.ymin, -that._tilingScheme.ellipsoid.maximumRadius * Math.PI), 0.0));
+                            var ne = projection.unproject(new Cartesian3(Math.min(extent.xmax, that._tilingScheme.ellipsoid.maximumRadius * Math.PI), Math.min(extent.ymax, that._tilingScheme.ellipsoid.maximumRadius * Math.PI), 0.0));
                             that._rectangle = new Rectangle(sw.longitude, sw.latitude, ne.longitude, ne.latitude);
                         } else if (data.fullExtent.spatialReference.wkid === 4326) {
                             that._rectangle = Rectangle.fromDegrees(data.fullExtent.xmin, data.fullExtent.ymin, data.fullExtent.xmax, data.fullExtent.ymax);

--- a/Specs/Scene/ArcGisMapServerImageryProviderSpec.js
+++ b/Specs/Scene/ArcGisMapServerImageryProviderSpec.js
@@ -695,6 +695,65 @@ defineSuite([
         });
     });
 
+    it('constrains extent to the tiling scheme\'s rectangle', function() {
+        var baseUrl = '//tiledArcGisMapServer.invalid';
+
+        var webMercatorOutsideBoundsResult = {
+            "currentVersion" : 10.01,
+            "copyrightText" : "Test copyright text",
+            "tileInfo" : {
+                "rows" : 128,
+                "cols" : 256,
+                "origin" : {
+                    "x" : -20037508.342787,
+                    "y" : 20037508.342787
+                },
+                "spatialReference" : {
+                    "wkid" : 102100
+                },
+                "lods" : [{
+                    "level" : 0,
+                    "resolution" : 156543.033928,
+                    "scale" : 591657527.591555
+                }, {
+                    "level" : 1,
+                    "resolution" : 78271.5169639999,
+                    "scale" : 295828763.795777
+                }, {
+                    "level" : 2,
+                    "resolution" : 39135.7584820001,
+                    "scale" : 147914381.897889
+                }]
+            },
+            fullExtent : {
+                "xmin" :  -2.0037507067161843E7,
+                "ymin" : -1.4745615008589065E7,
+                "xmax" : 2.0037507067161843E7,
+                "ymax" : 3.0240971958386205E7,
+                "spatialReference" : {
+                    "wkid" : 102100
+                }
+            }
+        };
+
+        stubJSONPCall(baseUrl, webMercatorOutsideBoundsResult);
+
+        var provider = new ArcGisMapServerImageryProvider({
+            url : baseUrl
+        });
+
+        expect(provider.url).toEqual(baseUrl);
+
+        return pollToPromise(function() {
+            return provider.ready;
+        }).then(function() {
+            expect(provider.rectangle.west >= -Math.PI).toBe(true);
+            expect(provider.rectangle.east <= Math.PI).toBe(true);
+            expect(provider.rectangle.south >= -WebMercatorProjection.MaximumLatitude).toBe(true);
+            expect(provider.rectangle.north <= WebMercatorProjection.MaximumLatitude).toBe(true);
+        });
+    });
+
     it('honors fullExtent of tiled server with geographic projection', function() {
         var baseUrl = '//tiledArcGisMapServer.invalid';
 


### PR DESCRIPTION
This fixes the issue described on the forum:
https://groups.google.com/d/topic/cesium-dev/BE_LnRc9VOY/discussion

The problem is that the ArcGIS Server described in the forum post indicates an extent that is bigger than the valid extent of the Web Mercator projection.  I've seen this with other ArcGIS servers in the past, too.