### PR TITLE
Fix PolygonGeometry when height equals extrudedHeight

### DIFF
--- a/Source/Core/PolygonGeometry.js
+++ b/Source/Core/PolygonGeometry.js
@@ -473,16 +473,16 @@ define([
         var extrudedHeight = options.extrudedHeight;
         var extrude = defined(extrudedHeight);
 
-        //Ignore extrudedHeight if it matches height
-        if (extrude && CesiumMath.equalsEpsilon(height, extrudedHeight, CesiumMath.EPSILON10)) {
-            extrudedHeight = undefined;
-            extrude = false;
-        }
-
-        if (extrude && !perPositionHeight) {
-            var h = extrudedHeight;
-            extrudedHeight = Math.min(h, height);
-            height = Math.max(h, height);
+        if (!perPositionHeight && extrude) {
+            //Ignore extrudedHeight if it matches height
+            if (CesiumMath.equalsEpsilon(height, extrudedHeight, CesiumMath.EPSILON10)) {
+                extrudedHeight = undefined;
+                extrude = false;
+            } else {
+                var h = extrudedHeight;
+                extrudedHeight = Math.min(h, height);
+                height = Math.max(h, height);
+            }
         }
 
         this._vertexFormat = VertexFormat.clone(vertexFormat);

--- a/Source/Core/PolygonGeometry.js
+++ b/Source/Core/PolygonGeometry.js
@@ -472,6 +472,13 @@ define([
 
         var extrudedHeight = options.extrudedHeight;
         var extrude = defined(extrudedHeight);
+
+        //Ignore extrudedHeight if it matches height
+        if (extrude && CesiumMath.equalsEpsilon(height, extrudedHeight, CesiumMath.EPSILON10)) {
+            extrudedHeight = undefined;
+            extrude = false;
+        }
+
         if (extrude && !perPositionHeight) {
             var h = extrudedHeight;
             extrudedHeight = Math.min(h, height);

--- a/Specs/Core/PolygonGeometrySpec.js
+++ b/Specs/Core/PolygonGeometrySpec.js
@@ -1,4 +1,3 @@
-
 /*global defineSuite*/
 defineSuite([
         'Core/PolygonGeometry',
@@ -394,6 +393,23 @@ defineSuite([
 
         expect(p.attributes.position.values.length).toEqual(50 * 3);
         expect(p.indices.length).toEqual(48 * 3);
+    });
+
+    it('Ignores extrudedHeight if it equals height.', function() {
+        var p = PolygonGeometry.createGeometry(PolygonGeometry.fromPositions({
+             vertexFormat : VertexFormat.POSITION_ONLY,
+             positions : Cartesian3.fromDegreesArray([
+                                                         -1.0, -1.0,
+                                                         1.0, -1.0,
+                                                         1.0, 1.0,
+                                                         -1.0, 1.0
+                                                     ]),
+            height: 0,
+            extrudedHeight: CesiumMath.EPSILON10
+         }));
+
+        expect(p.attributes.position.values.length).toEqual(13 * 3);
+        expect(p.indices.length).toEqual(16 * 3);
     });
 
     it('computes all attributes extruded', function() {


### PR DESCRIPTION
We were trying to create an extrusion of height 0; which produced NaNs in the normals (because normalize calls were producing NaN). Now we just compare them and consider them equal at epsilon 10, which was determined experimentally.