### PR TITLE
Add ability to create open extruded PolygonGeometry

### DIFF
--- a/Apps/Sandcastle/gallery/CZML Polygon.html
+++ b/Apps/Sandcastle/gallery/CZML Polygon.html
@@ -72,7 +72,8 @@ var czml = [
           }
         }
       },
-      "extrudedHeight" : 500000.0
+      "extrudedHeight" : 500000.0,
+      "open" : true
     }
   }, {
     "id" : "orangePolygon",

--- a/Apps/Sandcastle/gallery/Polygon.html
+++ b/Apps/Sandcastle/gallery/Polygon.html
@@ -48,7 +48,8 @@ var greenPolygon = viewer.entities.add({
                                                         -100.0, 42.0,
                                                         -104.0, 40.0]),
         extrudedHeight: 500000.0,
-        material : Cesium.Color.GREEN
+        material : Cesium.Color.GREEN,
+        open : true
     }
 });
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@ Change Log
   *
 * Fixed issue causing the sun not to render. [#3801](https://github.com/AnalyticalGraphicsInc/cesium/pull/3801)
 * Added ability to import and export Sandcastle example using GitHub Gists. [#3795](https://github.com/AnalyticalGraphicsInc/cesium/pull/3795)
+* Added `PolygonGraphics.open` and `PolygonGeometry` option for creating an extruded polygon without a top and bottom.
 * Fixed issue where `Camera.flyTo` does not go to the rectangle. [#3688](https://github.com/AnalyticalGraphicsInc/cesium/issues/3688)
 * Fixed issue causing the fog to go dark and the atmosphere to flicker when the camera clips the globe. [#3178](https://github.com/AnalyticalGraphicsInc/cesium/issues/3178)
 * Fixed a bug that caused an exception and rendering to stop when using `ArcGisMapServerImageryProvider` to connect to a MapServer specifying the Web Mercator projection and a fullExtent bigger than the valid extent of the projection. [#3854](https://github.com/AnalyticalGraphicsInc/cesium/pull/3854)

--- a/Source/DataSources/CzmlDataSource.js
+++ b/Source/DataSources/CzmlDataSource.js
@@ -1319,6 +1319,7 @@ define([
         processPacketData(Color, polygon, 'outlineColor', polygonData.outlineColor, interval, sourceUri, entityCollection);
         processPacketData(Number, polygon, 'outlineWidth', polygonData.outlineWidth, interval, sourceUri, entityCollection);
         processPacketData(Boolean, polygon, 'perPositionHeight', polygonData.perPositionHeight, interval, sourceUri, entityCollection);
+        processPacketData(Boolean, polygon, 'open', polygonData.open, interval, sourceUri, entityCollection);
         processPositions(polygon, 'hierarchy', polygonData.positions, entityCollection);
     }
 

--- a/Source/DataSources/PolygonGeometryUpdater.js
+++ b/Source/DataSources/PolygonGeometryUpdater.js
@@ -61,6 +61,7 @@ define([
         this.vertexFormat = undefined;
         this.polygonHierarchy = undefined;
         this.perPositionHeight = undefined;
+        this.open = undefined;
         this.height = undefined;
         this.extrudedHeight = undefined;
         this.granularity = undefined;
@@ -453,6 +454,7 @@ define([
         var stRotation = polygon.stRotation;
         var outlineWidth = polygon.outlineWidth;
         var perPositionHeight = polygon.perPositionHeight;
+        var open = polygon.open;
 
         this._fillEnabled = fillEnabled;
         this._outlineEnabled = outlineEnabled;
@@ -463,7 +465,8 @@ define([
             !Property.isConstant(granularity) || //
             !Property.isConstant(stRotation) || //
             !Property.isConstant(outlineWidth) || //
-            !Property.isConstant(perPositionHeight)) {
+            !Property.isConstant(perPositionHeight) || //
+            !Property.isConstant(open)) {
             if (!this._dynamic) {
                 this._dynamic = true;
                 this._geometryChanged.raiseEvent(this);
@@ -477,17 +480,19 @@ define([
                 hierarchyValue = new PolygonHierarchy(hierarchyValue);
             }
 
-            var heightValue = defined(height) ? height.getValue(Iso8601.MINIMUM_VALUE) : undefined;
-            var extrudedHeightValue = defined(extrudedHeight) ? extrudedHeight.getValue(Iso8601.MINIMUM_VALUE) : undefined;
+            var heightValue = Property.getValueOrUndefined(height, Iso8601.MINIMUM_VALUE);
+            var isOpen = Property.getValueOrUndefined(open, Iso8601.MINIMUM_VALUE);
+            var extrudedHeightValue = Property.getValueOrUndefined(extrudedHeight, Iso8601.MINIMUM_VALUE);
 
             options.polygonHierarchy = hierarchyValue;
             options.height = heightValue;
             options.extrudedHeight = extrudedHeightValue;
-            options.granularity = defined(granularity) ? granularity.getValue(Iso8601.MINIMUM_VALUE) : undefined;
-            options.stRotation = defined(stRotation) ? stRotation.getValue(Iso8601.MINIMUM_VALUE) : undefined;
-            options.perPositionHeight = defined(perPositionHeight) ? perPositionHeight.getValue(Iso8601.MINIMUM_VALUE) : undefined;
-            this._outlineWidth = defined(outlineWidth) ? outlineWidth.getValue(Iso8601.MINIMUM_VALUE) : 1.0;
-            this._isClosed = defined(extrudedHeightValue) && extrudedHeightValue !== heightValue;
+            options.granularity = Property.getValueOrUndefined(granularity, Iso8601.MINIMUM_VALUE);
+            options.stRotation = Property.getValueOrUndefined(stRotation, Iso8601.MINIMUM_VALUE);
+            options.perPositionHeight = Property.getValueOrUndefined(perPositionHeight, Iso8601.MINIMUM_VALUE);
+            options.open = isOpen;
+            this._outlineWidth = Property.getValueOrDefault(outlineWidth, Iso8601.MINIMUM_VALUE, 1.0);
+            this._isClosed = defined(extrudedHeightValue) && extrudedHeightValue !== heightValue && !isOpen;
             this._dynamic = false;
             this._geometryChanged.raiseEvent(this);
         }
@@ -562,6 +567,7 @@ define([
         options.granularity = Property.getValueOrUndefined(polygon.granularity, time);
         options.stRotation = Property.getValueOrUndefined(polygon.stRotation, time);
         options.perPositionHeight = Property.getValueOrUndefined(polygon.perPositionHeight, time);
+        options.open = Property.getValueOrUndefined(polygon.open, time);
 
         if (Property.getValueOrDefault(polygon.fill, time, true)) {
             var material = MaterialProperty.getValue(time, geometryUpdater.fillMaterialProperty, this._material);

--- a/Source/DataSources/PolygonGraphics.js
+++ b/Source/DataSources/PolygonGraphics.js
@@ -38,6 +38,7 @@ define([
      * @param {Property} [options.stRotation=0.0] A numeric property specifying the rotation of the polygon texture counter-clockwise from north.
      * @param {Property} [options.granularity=Cesium.Math.RADIANS_PER_DEGREE] A numeric Property specifying the angular distance between each latitude and longitude point.
      * @param {Property} [options.perPositionHeight=false] A boolean specifying whether or not the the height of each position is used.
+     * @param {Property} [options.open=false] When true, leaves off the top and bottom of an extruded polygon.
      *
      * @see Entity
      * @demo {@link http://cesiumjs.org/Cesium/Apps/Sandcastle/index.html?src=Polygon.html|Cesium Sandcastle Polygon Demo}
@@ -68,6 +69,8 @@ define([
         this._definitionChanged = new Event();
         this._fill = undefined;
         this._fillSubscription = undefined;
+        this._open = undefined;
+        this._openSubscription = undefined;
 
         this.merge(defaultValue(options, defaultValue.EMPTY_OBJECT));
     }
@@ -181,7 +184,14 @@ define([
          * @memberof PolygonGraphics.prototype
          * @type {Property}
          */
-        perPositionHeight : createPropertyDescriptor('perPositionHeight')
+        perPositionHeight : createPropertyDescriptor('perPositionHeight'),
+
+        /**
+         * Gets or sets the boolean specifying whether or not the the top and bottom an extruded polygon are included.
+         * @memberof PolygonGraphics.prototype
+         * @type {Property}
+         */
+        open : createPropertyDescriptor('open')
     });
 
     /**
@@ -206,6 +216,7 @@ define([
         result.outlineColor = this.outlineColor;
         result.outlineWidth = this.outlineWidth;
         result.perPositionHeight = this.perPositionHeight;
+        result.open = this.open;
         return result;
     };
 
@@ -234,6 +245,7 @@ define([
         this.outlineColor = defaultValue(this.outlineColor, source.outlineColor);
         this.outlineWidth = defaultValue(this.outlineWidth, source.outlineWidth);
         this.perPositionHeight = defaultValue(this.perPositionHeight, source.perPositionHeight);
+        this.open = defaultValue(this.open, source.open);
     };
 
     return PolygonGraphics;

--- a/Specs/Core/PolygonGeometrySpec.js
+++ b/Specs/Core/PolygonGeometrySpec.js
@@ -378,6 +378,25 @@ defineSuite([
         expect(p.indices.length).toEqual(numTriangles * 3);
     });
 
+    it('computes positions extruded and open', function() {
+        var p = PolygonGeometry.createGeometry(PolygonGeometry.fromPositions({
+             vertexFormat : VertexFormat.POSITION_ONLY,
+             positions : Cartesian3.fromDegreesArray([
+                                                         -1.0, -1.0,
+                                                         1.0, -1.0,
+                                                         1.0, 1.0,
+                                                         -1.0, 1.0
+                                                     ]),
+             extrudedHeight: 30000,
+             open: true
+         }));
+
+        var numVertices = 24; // 8 top edge + 8 bottom edge + 4 top corner + 4 bottom corner
+        var numTriangles = 16; // 2 triangles * 4 sides
+        expect(p.attributes.position.values.length).toEqual(numVertices * 3);
+        expect(p.indices.length).toEqual(numTriangles * 3);
+    });
+
     it('removes duplicates extruded', function() {
         var p = PolygonGeometry.createGeometry(PolygonGeometry.fromPositions({
             vertexFormat : VertexFormat.POSITION_ONLY,
@@ -574,6 +593,6 @@ defineSuite([
     packedInstance.push(3.0, 0.0);
     addPositions(packedInstance, holePositions1);
     packedInstance.push(Ellipsoid.WGS84.radii.x, Ellipsoid.WGS84.radii.y, Ellipsoid.WGS84.radii.z);
-    packedInstance.push(1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, CesiumMath.PI_OVER_THREE, 0.0, 0.0, 1.0, 49);
+    packedInstance.push(1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, CesiumMath.PI_OVER_THREE, 0.0, 0.0, 1.0, 0, 50);
     createPackableSpecs(PolygonGeometry, polygon, packedInstance);
 });

--- a/Specs/Core/PolygonGeometrySpec.js
+++ b/Specs/Core/PolygonGeometrySpec.js
@@ -399,16 +399,16 @@ defineSuite([
 
     it('computes positions extruded and not closeBottom', function() {
         var p = PolygonGeometry.createGeometry(PolygonGeometry.fromPositions({
-                                                                                 vertexFormat : VertexFormat.POSITION_ONLY,
-                                                                                 positions : Cartesian3.fromDegreesArray([
-                                                                                                                             -1.0, -1.0,
-                                                                                                                             1.0, -1.0,
-                                                                                                                             1.0, 1.0,
-                                                                                                                             -1.0, 1.0
-                                                                                                                         ]),
-                                                                                 extrudedHeight: 30000,
-                                                                                 closeBottom: false
-                                                                             }));
+             vertexFormat : VertexFormat.POSITION_ONLY,
+             positions : Cartesian3.fromDegreesArray([
+                                                         -1.0, -1.0,
+                                                         1.0, -1.0,
+                                                         1.0, 1.0,
+                                                         -1.0, 1.0
+                                                     ]),
+             extrudedHeight: 30000,
+             closeBottom: false
+         }));
 
         var numVertices = 37; // 13 top + 8 top edge + 8 bottom edge + 4 top corner + 4 bottom corner
         var numTriangles = 32; // 16 top fill + 2 triangles * 4 sides

--- a/Specs/DataSources/CzmlDataSourceSpec.js
+++ b/Specs/DataSources/CzmlDataSourceSpec.js
@@ -1403,7 +1403,8 @@ defineSuite([
                 outlineColor : {
                     rgbaf : [0.2, 0.2, 0.2, 0.2]
                 },
-                outlineWidth : 6
+                outlineWidth : 6,
+                open : true
             }
         };
 
@@ -1421,6 +1422,7 @@ defineSuite([
         expect(entity.polygon.outline.getValue(Iso8601.MINIMUM_VALUE)).toEqual(true);
         expect(entity.polygon.outlineColor.getValue(Iso8601.MINIMUM_VALUE)).toEqual(new Color(0.2, 0.2, 0.2, 0.2));
         expect(entity.polygon.outlineWidth.getValue(Iso8601.MINIMUM_VALUE)).toEqual(6);
+        expect(entity.polygon.open.getValue(Iso8601.MINIMUM_VALUE)).toEqual(true);
     });
 
     it('CZML adds data for constrained polygon.', function() {

--- a/Specs/DataSources/PolygonGeometryUpdaterSpec.js
+++ b/Specs/DataSources/PolygonGeometryUpdaterSpec.js
@@ -143,6 +143,14 @@ defineSuite([
         expect(updater.isClosed).toBe(true);
     });
 
+    it('Settings extrudedHeight and open causes geometry to be open.', function() {
+        var entity = createBasicPolygon();
+        var updater = new PolygonGeometryUpdater(entity, scene);
+        entity.polygon.extrudedHeight = new ConstantProperty(1000);
+        entity.polygon.open = true;
+        expect(updater.isClosed).toBe(false);
+    });
+
     it('A time-varying outlineWidth causes geometry to be dynamic', function() {
         var entity = createBasicPolygon();
         var updater = new PolygonGeometryUpdater(entity, scene);
@@ -216,6 +224,7 @@ defineSuite([
         polygon.outline = new ConstantProperty(options.outline);
         polygon.outlineColor = new ConstantProperty(options.outlineColor);
         polygon.perPositionHeight = new ConstantProperty(options.perPositionHeight);
+        polygon.open = new ConstantProperty(options.open);
 
         polygon.stRotation = new ConstantProperty(options.stRotation);
         polygon.height = new ConstantProperty(options.height);
@@ -234,6 +243,7 @@ defineSuite([
             expect(geometry._height).toEqual(options.height);
             expect(geometry._granularity).toEqual(options.granularity);
             expect(geometry._extrudedHeight).toEqual(options.extrudedHeight);
+            expect(geometry._open).toEqual(options.open);
 
             attributes = instance.attributes;
             if (options.material instanceof ColorMaterialProperty) {
@@ -269,7 +279,8 @@ defineSuite([
             fill : true,
             outline : true,
             outlineColor : Color.BLUE,
-            perPositionHeight : true
+            perPositionHeight : true,
+            open: false
         });
     });
 
@@ -284,7 +295,8 @@ defineSuite([
             fill : true,
             outline : true,
             outlineColor : Color.BLUE,
-            perPositionHeight : false
+            perPositionHeight : false,
+            open : true
         });
     });
 
@@ -392,6 +404,7 @@ defineSuite([
         polygon.perPositionHeight = createDynamicProperty(false);
         polygon.granularity = createDynamicProperty(2);
         polygon.stRotation = createDynamicProperty(1);
+        polygon.open = createDynamicProperty(true);
 
         var entity = new Entity();
         entity.polygon = polygon;
@@ -413,6 +426,7 @@ defineSuite([
         expect(options.perPositionHeight).toEqual(polygon.perPositionHeight.getValue());
         expect(options.granularity).toEqual(polygon.granularity.getValue());
         expect(options.stRotation).toEqual(polygon.stRotation.getValue());
+        expect(options.open).toEqual(polygon.open.getValue());
 
         entity.show = false;
         dynamicUpdater.update(JulianDate.now());

--- a/Specs/DataSources/PolygonGraphicsSpec.js
+++ b/Specs/DataSources/PolygonGraphicsSpec.js
@@ -30,7 +30,8 @@ defineSuite([
             fill : false,
             outline : false,
             outlineColor : Color.RED,
-            outlineWidth : 7
+            outlineWidth : 7,
+            open : true
         };
 
         var polygon = new PolygonGraphics(options);
@@ -46,6 +47,7 @@ defineSuite([
         expect(polygon.outline).toBeInstanceOf(ConstantProperty);
         expect(polygon.outlineColor).toBeInstanceOf(ConstantProperty);
         expect(polygon.outlineWidth).toBeInstanceOf(ConstantProperty);
+        expect(polygon.open).toBeInstanceOf(ConstantProperty);
 
         expect(polygon.material.color.getValue()).toEqual(options.material);
         expect(polygon.show.getValue()).toEqual(options.show);
@@ -59,6 +61,7 @@ defineSuite([
         expect(polygon.outline.getValue()).toEqual(options.outline);
         expect(polygon.outlineColor.getValue()).toEqual(options.outlineColor);
         expect(polygon.outlineWidth.getValue()).toEqual(options.outlineWidth);
+        expect(polygon.open.getValue()).toEqual(options.open);
     });
 
     it('merge assigns unassigned properties', function() {
@@ -75,6 +78,7 @@ defineSuite([
         source.outlineColor = new ConstantProperty();
         source.outlineWidth = new ConstantProperty();
         source.perPositionHeight = new ConstantProperty();
+        source.open = new ConstantProperty();
 
         var target = new PolygonGraphics();
         target.merge(source);
@@ -91,6 +95,7 @@ defineSuite([
         expect(target.outlineColor).toBe(source.outlineColor);
         expect(target.outlineWidth).toBe(source.outlineWidth);
         expect(target.perPositionHeight).toBe(source.perPositionHeight);
+        expect(target.open).toBe(source.open);
     });
 
     it('merge does not assign assigned properties', function() {
@@ -108,6 +113,7 @@ defineSuite([
         var outlineColor = new ConstantProperty();
         var outlineWidth = new ConstantProperty();
         var perPositionHeight = new ConstantProperty();
+        var open = new ConstantProperty();
 
         var target = new PolygonGraphics();
         target.material = material;
@@ -122,6 +128,7 @@ defineSuite([
         target.outlineColor = outlineColor;
         target.outlineWidth = outlineWidth;
         target.perPositionHeight = perPositionHeight;
+        target.open = open;
 
         target.merge(source);
 
@@ -137,6 +144,7 @@ defineSuite([
         expect(target.outlineColor).toBe(outlineColor);
         expect(target.outlineWidth).toBe(outlineWidth);
         expect(target.perPositionHeight).toBe(perPositionHeight);
+        expect(target.open).toBe(open);
     });
 
     it('clone works', function() {
@@ -153,6 +161,7 @@ defineSuite([
         source.outlineColor = new ConstantProperty();
         source.outlineWidth = new ConstantProperty();
         source.perPositionHeight = new ConstantProperty();
+        source.open = new ConstantProperty();
 
         var result = source.clone();
         expect(result.material).toBe(source.material);
@@ -167,6 +176,7 @@ defineSuite([
         expect(result.outlineColor).toBe(source.outlineColor);
         expect(result.outlineWidth).toBe(source.outlineWidth);
         expect(result.perPositionHeight).toBe(source.perPositionHeight);
+        expect(result.open).toBe(source.open);
     });
 
     it('merge throws if source undefined', function() {
@@ -190,5 +200,6 @@ defineSuite([
         testDefinitionChanged(property, 'outlineColor', Color.RED, Color.BLUE);
         testDefinitionChanged(property, 'outlineWidth', 2, 3);
         testDefinitionChanged(property, 'perPositionHeight', false, true);
+        testDefinitionChanged(property, 'open', true, false);
     });
 });


### PR DESCRIPTION
While working on the NYC 3D Tiles demo, I needed to create open Polygon geometry (for example, a building with a different color roof). Having a top and bottom on the polygon was inefficient and also caused z-fighting.)

Also added feature to CZML and Entity API as well as tweaked Sandcastle examples to show it.

This also makes it easier for users who want to create a polygon with different top/bottonm materials, which is often asked about on the mailing list (and doesn't work with walls because of interpolation).