### PR TITLE
Tweak WebStorm auto-formatter

### DIFF
--- a/.idea/codeStyleSettings.xml
+++ b/.idea/codeStyleSettings.xml
@@ -12,7 +12,6 @@
         </XML>
         <codeStyleSettings language="JavaScript">
           <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
-          <option name="ALIGN_MULTILINE_PARAMETERS_IN_CALLS" value="true" />
           <option name="ALIGN_MULTILINE_BINARY_OPERATION" value="true" />
           <option name="ALIGN_MULTILINE_TERNARY_OPERATION" value="true" />
           <option name="ALIGN_MULTILINE_ARRAY_INITIALIZER_EXPRESSION" value="true" />


### PR DESCRIPTION
We had `ALIGN_MULTILINE_PARAMETERS_IN_CALLS` enabled in WebStorm's formatter (it's not the default) because it was believed to match the existing Cesium formatting better, but it turns out it's just annoying and ends up adding a ton of whitespace.