### PR TITLE
Throw with PolygonGeometry perPositionHeight and height

### DIFF
--- a/Source/Core/PolygonGeometry.js
+++ b/Source/Core/PolygonGeometry.js
@@ -493,7 +493,6 @@ define([
         var height = defaultValue(options.height, 0.0);
         var perPositionHeight = defaultValue(options.perPositionHeight, false);
 
-
         var extrudedHeight = options.extrudedHeight;
         var extrude = defined(extrudedHeight);
 

--- a/Source/Core/PolygonGeometry.js
+++ b/Source/Core/PolygonGeometry.js
@@ -480,6 +480,9 @@ define([
         if (!defined(options) || !defined(options.polygonHierarchy)) {
             throw new DeveloperError('options.polygonHierarchy is required.');
         }
+        if (defined(options.perPositionHeight) && options.perPositionHeight && defined(options.height)) {
+            throw new DeveloperError('Cannot use both options.perPositionHeight and options.height');
+        }
         //>>includeEnd('debug');
 
         var polygonHierarchy = options.polygonHierarchy;
@@ -489,6 +492,7 @@ define([
         var stRotation = defaultValue(options.stRotation, 0.0);
         var height = defaultValue(options.height, 0.0);
         var perPositionHeight = defaultValue(options.perPositionHeight, false);
+
 
         var extrudedHeight = options.extrudedHeight;
         var extrude = defined(extrudedHeight);

--- a/Source/Core/PolygonOutlineGeometry.js
+++ b/Source/Core/PolygonOutlineGeometry.js
@@ -289,6 +289,9 @@ define([
         if (!defined(options) || !defined(options.polygonHierarchy)) {
             throw new DeveloperError('options.polygonHierarchy is required.');
         }
+        if (defined(options.perPositionHeight) && options.perPositionHeight && defined(options.height)) {
+            throw new DeveloperError('Cannot use both options.perPositionHeight and options.height');
+        }
         //>>includeEnd('debug');
 
         var polygonHierarchy = options.polygonHierarchy;

--- a/Specs/Core/PolygonGeometrySpec.js
+++ b/Specs/Core/PolygonGeometrySpec.js
@@ -23,6 +23,15 @@ defineSuite([
         }).toThrowDeveloperError();
     });
 
+    it('throws with height when perPositionHeight is true', function() {
+        expect(function() {
+            return new PolygonGeometry({
+                height: 30,
+                perPositionHeight: true
+            });
+        }).toThrowDeveloperError();
+    });
+
     it('throws without positions', function() {
         expect(function() {
             return PolygonGeometry.fromPositions();

--- a/Specs/Core/PolygonOutlineGeometrySpec.js
+++ b/Specs/Core/PolygonOutlineGeometrySpec.js
@@ -21,6 +21,15 @@ defineSuite([
         }).toThrowDeveloperError();
     });
 
+    it('throws with height when perPositionHeight is true', function() {
+        expect(function() {
+            return new PolygonOutlineGeometry({
+                height: 30,
+                perPositionHeight: true
+            });
+        }).toThrowDeveloperError();
+    });
+
     it('throws without positions', function() {
         expect(function() {
             return PolygonOutlineGeometry.fromPositions();

--- a/Specs/DataSources/PolygonGeometryUpdaterSpec.js
+++ b/Specs/DataSources/PolygonGeometryUpdaterSpec.js
@@ -289,7 +289,7 @@ defineSuite([
             fill : true,
             outline : true,
             outlineColor : Color.BLUE,
-            perPositionHeight : true,
+            perPositionHeight : false,
             closeTop: true,
             closeBottom: false
         });


### PR DESCRIPTION
In `PolygonGeometry` `options.perPositionHeight` was not designed to be used in conjunction with the `options.height` property.  When trying to use both, you could run into unexpected side effects (like incorrect normals)
This throws a `DeveloperError` if `perPositionHeight === true` and `height !== undefined`

@mramato 