### PR TITLE
Compute correct normals for PolygonGeometry using perPositionHeight

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,11 +6,13 @@ Change Log
 * Breaking changes
   * Removed `ImageryMaterialProperty.alpha`. Use `ImageryMaterialProperty.color.alpha` instead.
   * Removed `OpenStreetMapImageryProvider`. Use `createOpenStreetMapImageryProvider` instead.
+  * `PolygonGeometry` throws a `DeveloperError` when using `options.perPositionHeight === true` and `options.height !== undefined`.  Remove `options.height` to fix the error (it is not used in the polygon geometry calculation)
 * Deprecated
   *
 * Fixed issue causing the sun not to render. [#3801](https://github.com/AnalyticalGraphicsInc/cesium/pull/3801)
 * Added ability to import and export Sandcastle example using GitHub Gists. [#3795](https://github.com/AnalyticalGraphicsInc/cesium/pull/3795)
 * Added `PolygonGraphics.closeTop`, `PolygonGraphics.closeBottom`, and `PolygonGeometry` options for creating an extruded polygon without a top or bottom.
+* Fixed vertex normals for a `PolygonGeometry` using `options.perPositionHeight`
 * Fixed issue where `Camera.flyTo` does not go to the rectangle. [#3688](https://github.com/AnalyticalGraphicsInc/cesium/issues/3688)
 * Fixed issue causing the fog to go dark and the atmosphere to flicker when the camera clips the globe. [#3178](https://github.com/AnalyticalGraphicsInc/cesium/issues/3178)
 * Fixed a bug that caused an exception and rendering to stop when using `ArcGisMapServerImageryProvider` to connect to a MapServer specifying the Web Mercator projection and a fullExtent bigger than the valid extent of the projection. [#3854](https://github.com/AnalyticalGraphicsInc/cesium/pull/3854)

--- a/Source/Core/PolygonGeometry.js
+++ b/Source/Core/PolygonGeometry.js
@@ -4,6 +4,7 @@ define([
         './BoundingSphere',
         './Cartesian2',
         './Cartesian3',
+        './Cartographic',
         './ComponentDatatype',
         './defaultValue',
         './defined',
@@ -28,6 +29,7 @@ define([
         BoundingSphere,
         Cartesian2,
         Cartesian3,
+        Cartographic,
         ComponentDatatype,
         defaultValue,
         defined,
@@ -85,6 +87,20 @@ define([
         return result;
     }
 
+    var scratchCarto1 = new Cartographic();
+    var scratchCarto2 = new Cartographic();
+    function adjustPosHeightsForNormal(position, p1, p2, ellipsoid) {
+        var carto1 = ellipsoid.cartesianToCartographic(position, scratchCarto1);
+        var height = carto1.height;
+        var p1Carto = ellipsoid.cartesianToCartographic(p1, scratchCarto2);
+        p1Carto.height = height;
+        ellipsoid.cartographicToCartesian(p1Carto, p1);
+
+        var p2Carto = ellipsoid.cartesianToCartographic(p2, scratchCarto2);
+        p2Carto.height = height - 100;
+        ellipsoid.cartographicToCartesian(p2Carto, p2);
+    }
+
     var scratchBoundingRectangle = new BoundingRectangle();
     var scratchPosition = new Cartesian3();
     var scratchNormal = new Cartesian3();
@@ -92,6 +108,9 @@ define([
     var scratchBinormal = new Cartesian3();
     var p1Scratch = new Cartesian3();
     var p2Scratch = new Cartesian3();
+    var scratchPerPosNormal = new Cartesian3();
+    var scratchPerPosTangent = new Cartesian3();
+    var scratchPerPosBinormal = new Cartesian3();
 
     var appendTextureCoordinatesOrigin = new Cartesian2();
     var appendTextureCoordinatesCartesian2 = new Cartesian2();
@@ -109,8 +128,10 @@ define([
             var tangentPlane = options.tangentPlane;
             var ellipsoid = options.ellipsoid;
             var stRotation = options.stRotation;
-            var top = options.top || options.wall;
-            var bottom = options.bottom || options.wall;
+            var wall = options.wall;
+            var top = options.top || wall;
+            var bottom = options.bottom || wall;
+            var perPositionHeight = options.perPositionHeight;
 
             var origin = appendTextureCoordinatesOrigin;
             origin.x = boundingRectangle.x;
@@ -120,7 +141,14 @@ define([
             var length = flatPositions.length;
 
             var textureCoordinates = vertexFormat.st ? new Float32Array(2 * (length / 3)) : undefined;
-            var normals = vertexFormat.normal ? new Float32Array(length) : undefined;
+            var normals;
+            if (vertexFormat.normal) {
+                if (perPositionHeight && top && !wall) {
+                    normals = geometry.attributes.normal.values;
+                } else {
+                    normals = new Float32Array(length);
+                }
+            }
             var tangents = vertexFormat.tangent ? new Float32Array(length) : undefined;
             var binormals = vertexFormat.binormal ? new Float32Array(length) : undefined;
 
@@ -172,12 +200,15 @@ define([
                     var attrIndex1 = attrIndex + 1;
                     var attrIndex2 = attrIndex + 2;
 
-                    if (options.wall) {
+                    if (wall) {
                         if (i + 3 < length) {
                             var p1 = Cartesian3.fromArray(flatPositions, i + 3, p1Scratch);
 
                             if (recomputeNormal) {
                                 var p2 = Cartesian3.fromArray(flatPositions, i + length, p2Scratch);
+                                if (perPositionHeight) {
+                                    adjustPosHeightsForNormal(position, p1, p2, ellipsoid);
+                                }
                                 Cartesian3.subtract(p1, position, p1);
                                 Cartesian3.subtract(p2, position, p2);
                                 normal = Cartesian3.normalize(Cartesian3.cross(p2, p1, normal), normal);
@@ -198,6 +229,15 @@ define([
                     } else {
                         normal = ellipsoid.geodeticSurfaceNormal(position, normal);
                         if (vertexFormat.tangent || vertexFormat.binormal) {
+                            if (perPositionHeight) {
+                                scratchPerPosNormal = Cartesian3.fromArray(normals, attrIndex, scratchPerPosNormal);
+                                scratchPerPosTangent = Cartesian3.cross(Cartesian3.UNIT_Z, scratchPerPosNormal, scratchPerPosTangent);
+                                scratchPerPosTangent = Cartesian3.normalize(Matrix3.multiplyByVector(textureMatrix, scratchPerPosTangent, scratchPerPosTangent), scratchPerPosTangent);
+                                if (vertexFormat.binormal) {
+                                    scratchPerPosBinormal = Cartesian3.normalize(Cartesian3.cross(scratchPerPosNormal, scratchPerPosTangent, scratchPerPosBinormal), scratchPerPosBinormal);
+                                }
+                            }
+
                             tangent = Cartesian3.cross(Cartesian3.UNIT_Z, normal, tangent);
                             tangent = Cartesian3.normalize(Matrix3.multiplyByVector(textureMatrix, tangent, tangent), tangent);
                             if (vertexFormat.binormal) {
@@ -216,7 +256,8 @@ define([
                             normals[attrIndex1 + bottomOffset] = -normal.y;
                             normals[attrIndex2 + bottomOffset] = -normal.z;
                         }
-                        if (top) {
+
+                        if ((top && !perPositionHeight) || wall) {
                             normals[attrIndex] = normal.x;
                             normals[attrIndex1] = normal.y;
                             normals[attrIndex2] = normal.z;
@@ -235,9 +276,15 @@ define([
                         }
 
                         if(top) {
-                            tangents[attrIndex] = tangent.x;
-                            tangents[attrIndex1] = tangent.y;
-                            tangents[attrIndex2] = tangent.z;
+                            if (perPositionHeight) {
+                                tangents[attrIndex] = scratchPerPosTangent.x;
+                                tangents[attrIndex1] = scratchPerPosTangent.y;
+                                tangents[attrIndex2] = scratchPerPosTangent.z;
+                            } else {
+                                tangents[attrIndex] = tangent.x;
+                                tangents[attrIndex1] = tangent.y;
+                                tangents[attrIndex2] = tangent.z;
+                            }
                         }
                     }
 
@@ -248,9 +295,15 @@ define([
                             binormals[attrIndex2 + bottomOffset] = binormal.z;
                         }
                         if (top) {
-                            binormals[attrIndex] = binormal.x;
-                            binormals[attrIndex1] = binormal.y;
-                            binormals[attrIndex2] = binormal.z;
+                            if (perPositionHeight) {
+                                binormals[attrIndex] = scratchPerPosBinormal.x;
+                                binormals[attrIndex1] = scratchPerPosBinormal.y;
+                                binormals[attrIndex2] = scratchPerPosBinormal.z;
+                            } else {
+                                binormals[attrIndex] = binormal.x;
+                                binormals[attrIndex1] = binormal.y;
+                                binormals[attrIndex2] = binormal.z;
+                            }
                         }
                     }
                     attrIndex += 3;
@@ -330,6 +383,11 @@ define([
                 }
 
                 topGeo.attributes.position.values = topBottomPositions;
+                if (perPositionHeight) {
+                    var normals = topGeo.attributes.normal.values;
+                    topGeo.attributes.normal.values = new Float32Array(topBottomPositions.length);
+                    topGeo.attributes.normal.values.set(normals);
+                }
                 topGeo.indices = newIndices;
             } else if (closeBottom) {
                 numPositions = edgePoints.length / 3;
@@ -735,6 +793,7 @@ define([
         var geometries = [];
 
         var options = {
+            perPositionHeight: perPositionHeight,
             vertexFormat: vertexFormat,
             geometry: undefined,
             tangentPlane: tangentPlane,

--- a/Source/Core/PolygonGeometry.js
+++ b/Source/Core/PolygonGeometry.js
@@ -347,14 +347,14 @@ define([
 
     var createGeometryFromPositionsExtrudedPositions = [];
 
-    function createGeometryFromPositionsExtruded(ellipsoid, positions, granularity, hierarchy, perPositionHeight, closeTop, closeBottom) {
+    function createGeometryFromPositionsExtruded(ellipsoid, positions, granularity, hierarchy, perPositionHeight, closeTop, closeBottom, vertexFormat) {
         var geos = {
             walls : []
         };
         var i;
 
         if (closeTop || closeBottom) {
-            var topGeo = PolygonGeometryLibrary.createGeometryFromPositions(ellipsoid, positions, granularity, perPositionHeight);
+            var topGeo = PolygonGeometryLibrary.createGeometryFromPositions(ellipsoid, positions, granularity, perPositionHeight, vertexFormat);
 
             var edgePoints = topGeo.attributes.position.values;
             var indices = topGeo.indices;
@@ -808,7 +808,7 @@ define([
             options.top = closeTop;
             options.bottom = closeBottom;
             for (i = 0; i < polygons.length; i++) {
-                geometry = createGeometryFromPositionsExtruded(ellipsoid, polygons[i], granularity, hierarchy[i], perPositionHeight, closeTop, closeBottom);
+                geometry = createGeometryFromPositionsExtruded(ellipsoid, polygons[i], granularity, hierarchy[i], perPositionHeight, closeTop, closeBottom, vertexFormat);
                 if (closeTop && closeBottom) {
                     topAndBottom = geometry.topAndBottom;
                     options.geometry = PolygonGeometryLibrary.scaleToGeodeticHeightExtruded(topAndBottom.geometry, height, extrudedHeight, ellipsoid, perPositionHeight);
@@ -839,7 +839,7 @@ define([
         } else {
             for (i = 0; i < polygons.length; i++) {
                 geometry = new GeometryInstance({
-                    geometry : PolygonGeometryLibrary.createGeometryFromPositions(ellipsoid, polygons[i], granularity, perPositionHeight)
+                    geometry : PolygonGeometryLibrary.createGeometryFromPositions(ellipsoid, polygons[i], granularity, perPositionHeight, vertexFormat)
                 });
                 geometry.geometry.attributes.position.values = PolygonPipeline.scaleToGeodeticHeight(geometry.geometry.attributes.position.values, height, ellipsoid, !perPositionHeight);
                 options.geometry = geometry.geometry;

--- a/Source/Core/PolygonGeometryLibrary.js
+++ b/Source/Core/PolygonGeometryLibrary.js
@@ -10,6 +10,7 @@ define([
         './Geometry',
         './GeometryAttribute',
         './GeometryAttributes',
+        './GeometryPipeline',
         './IndexDatatype',
         './Math',
         './PolygonPipeline',
@@ -27,6 +28,7 @@ define([
         Geometry,
         GeometryAttribute,
         GeometryAttributes,
+        GeometryPipeline,
         IndexDatatype,
         CesiumMath,
         PolygonPipeline,
@@ -295,8 +297,7 @@ define([
                 flattenedPositions[index++] = p.y;
                 flattenedPositions[index++] = p.z;
             }
-
-            return new Geometry({
+            var geometry = new Geometry({
                 attributes : {
                     position : new GeometryAttribute({
                         componentDatatype : ComponentDatatype.DOUBLE,
@@ -307,6 +308,7 @@ define([
                 indices : indices,
                 primitiveType : PrimitiveType.TRIANGLES
             });
+            return GeometryPipeline.computeNormal(geometry);
         }
 
         return PolygonPipeline.computeSubdivision(ellipsoid, positions, indices, granularity);

--- a/Source/Core/PolygonGeometryLibrary.js
+++ b/Source/Core/PolygonGeometryLibrary.js
@@ -271,7 +271,7 @@ define([
 
     var createGeometryFromPositionsPositions = [];
 
-    PolygonGeometryLibrary.createGeometryFromPositions = function(ellipsoid, positions, granularity, perPositionHeight) {
+    PolygonGeometryLibrary.createGeometryFromPositions = function(ellipsoid, positions, granularity, perPositionHeight, vertexFormat) {
         var tangentPlane = EllipsoidTangentPlane.fromPoints(positions, ellipsoid);
         var positions2D = tangentPlane.projectPointsOntoPlane(positions, createGeometryFromPositionsPositions);
 
@@ -308,7 +308,12 @@ define([
                 indices : indices,
                 primitiveType : PrimitiveType.TRIANGLES
             });
-            return GeometryPipeline.computeNormal(geometry);
+
+            if (vertexFormat.normal) {
+                return GeometryPipeline.computeNormal(geometry);
+            }
+
+            return geometry;
         }
 
         return PolygonPipeline.computeSubdivision(ellipsoid, positions, indices, granularity);


### PR DESCRIPTION
We weren't actually computing the normals when `perPositonHeight === true`, instead we were just using the ellipsoid surface normal.
This uses `GeometryPipeline.computeNormal` to compute the normals for the top polygon (the perPositionHeight one) 
This also fixes the normals on the walls of an extruded perPositionHeight polygon if one of the positions has the same height as the extrusion