### PR TITLE
Fix exception when enabling cardboard demo.

### DIFF
--- a/Source/Scene/DeviceOrientationCameraController.js
+++ b/Source/Scene/DeviceOrientationCameraController.js
@@ -38,10 +38,19 @@ define([
         this._gamma = undefined;
 
         var that = this;
+
         function callback(e) {
-            that._alpha = CesiumMath.toRadians(defaultValue(e.alpha, 0.0));
-            that._beta = CesiumMath.toRadians(defaultValue(e.beta, 0.0));
-            that._gamma = CesiumMath.toRadians(defaultValue(e.gamma, 0.0));
+            var alpha = e.alpha;
+            if (!defined(alpha)) {
+                that._alpha = undefined;
+                that._beta = undefined;
+                that._gamma = undefined;
+                return;
+            }
+
+            that._alpha = CesiumMath.toRadians(alpha);
+            that._beta = CesiumMath.toRadians(e.beta);
+            that._gamma = CesiumMath.toRadians(e.gamma);
         }
 
         window.addEventListener('deviceorientation', callback, false);


### PR DESCRIPTION
Enabling cardboard (at least on the desktop) would cause an exception because the orientation parameters were `null` instead of `undefined` and we were incorrectly using `defaultValue` (which doesn't handle null).

We should probably get this in for 1.21.