### PR TITLE
add support for invalid but common URL tag inside of NetworkLink KML

### DIFF
--- a/Source/DataSources/KmlDataSource.js
+++ b/Source/DataSources/KmlDataSource.js
@@ -835,7 +835,7 @@ define([
                 }
                 id = uri + '#' + tokens[1];
             }
-            
+
             styleEntity = styleCollection.getById(id);
             if (!defined(styleEntity)) {
                 styleEntity = styleCollection.getById('#' + id);
@@ -1827,6 +1827,10 @@ define([
         var networkEntity = r.entity;
 
         var link = queryFirstNode(node, 'Link', namespaces.kml);
+
+        if(!defined(link)){
+            link = queryFirstNode(node, 'Url', namespaces.kml);
+        }
         if (defined(link)) {
             var href = queryStringValue(link, 'href', namespaces.kml);
             if (defined(href)) {

--- a/Specs/DataSources/KmlDataSourceSpec.js
+++ b/Specs/DataSources/KmlDataSourceSpec.js
@@ -3116,6 +3116,27 @@ defineSuite([
         });
     });
 
+    it('NetworkLink can accept invalid but common URL tag instead of Link', function(){
+        var kml = '<?xml version="1.0" encoding="UTF-8"?>\
+          <NetworkLink id="link">\
+            <Url>\
+              <href>./Data/KML/refresh.kml</href>\
+            </Url>\
+          </NetworkLink>';
+
+        var requestNetworkLink = when.defer();
+        spyOn(loadWithXhr, 'load').and.callFake(function(url, responseType, method, data, headers, deferred, overrideMimeType) {
+            requestNetworkLink.resolve(url);
+            deferred.reject();
+        });
+
+        KmlDataSource.load(parser.parseFromString(kml, "text/xml"), options);
+
+        return requestNetworkLink.promise.then(function(url) {
+            expect(url).toEqual('./Data/KML/refresh.kml');
+        });
+    });
+
     it('NetworkLink: Url is correct on initial load with onStop defaults', function() {
         var kml = '<?xml version="1.0" encoding="UTF-8"?>\
           <NetworkLink id="link">\


### PR DESCRIPTION
When exploring KML support in Cesium, we keep running across invalid KML in the 'wild' which uses a `Url` tag name instead of the standard `link`.   Google Earth accepts this invalid KML as well.  
    
     <NetworkLink id="link">\
        <Url>\  <!-- instead of Link --> 
          <href>./Data/KML/refresh.kml</href>\
        </Url>\
      </NetworkLink>

This is a fix that will allow those types of KML to be parsed.  It should expand the range of KML that Cesium can accept.  