### PR TITLE
Fix 2D in IE/Edge

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,7 @@ Change Log
 * Fixed issue causing the fog to go dark and the atmosphere to flicker when the camera clips the globe. [#3178](https://github.com/AnalyticalGraphicsInc/cesium/issues/3178)
 * Fixed a bug that caused an exception and rendering to stop when using `ArcGisMapServerImageryProvider` to connect to a MapServer specifying the Web Mercator projection and a fullExtent bigger than the valid extent of the projection. [#3854](https://github.com/AnalyticalGraphicsInc/cesium/pull/3854)
 * Fixed issue causing an exception when switching scene modes with an active KML network link. [#3865](https://github.com/AnalyticalGraphicsInc/cesium/issues/3865)
+* Fixed infinite horizontal 2D scrolling in IE/Edge. [#3893](https://github.com/AnalyticalGraphicsInc/cesium/issues/3893)
 
 ### 1.20 - 2016-04-01
 

--- a/Source/Scene/Scene.js
+++ b/Source/Scene/Scene.js
@@ -1768,32 +1768,32 @@ define([
             executeCommandsInViewport(true, scene, passState, backgroundColor, picking);
 
             viewport.x += windowCoordinates.x;
+            viewport.width = context.drawingBufferWidth - windowCoordinates.x;
 
             camera.position.x = -camera.position.x;
 
-            var right = camera.frustum.right;
-            camera.frustum.right = -camera.frustum.left;
-            camera.frustum.left = -right;
+            camera.frustum.left = -camera.frustum.right;
+            camera.frustum.right = camera.frustum.left + x;
 
             frameState.cullingVolume = camera.frustum.computeCullingVolume(camera.positionWC, camera.directionWC, camera.upWC);
             context.uniformState.update(frameState);
 
             executeCommandsInViewport(false, scene, passState, backgroundColor, picking);
         } else {
-            viewport.x += windowCoordinates.x;
-            viewport.width -= windowCoordinates.x;
+            viewport.x = windowCoordinates.x;
+            viewport.width = context.drawingBufferWidth - windowCoordinates.x;
 
             camera.frustum.left = -maxCoord.x - x;
 
             executeCommandsInViewport(true, scene, passState, backgroundColor, picking);
 
-            viewport.x = viewport.x - viewport.width;
+            viewport.x = 0;
+            viewport.width = windowCoordinates.x;
 
             camera.position.x = -camera.position.x;
 
-            var left = camera.frustum.left;
-            camera.frustum.left = -camera.frustum.right;
-            camera.frustum.right = -left;
+            camera.frustum.right = -camera.frustum.left;
+            camera.frustum.left = camera.frustum.right + x;
 
             frameState.cullingVolume = camera.frustum.computeCullingVolume(camera.positionWC, camera.directionWC, camera.upWC);
             context.uniformState.update(frameState);

--- a/Source/Scene/Scene.js
+++ b/Source/Scene/Scene.js
@@ -1763,6 +1763,7 @@ define([
         } else if (windowCoordinates.x > context.drawingBufferWidth * 0.5) {
             viewport.width = windowCoordinates.x;
 
+            var right = camera.frustum.right;
             camera.frustum.right = maxCoord.x - x;
 
             executeCommandsInViewport(true, scene, passState, backgroundColor, picking);
@@ -1773,7 +1774,7 @@ define([
             camera.position.x = -camera.position.x;
 
             camera.frustum.left = -camera.frustum.right;
-            camera.frustum.right = camera.frustum.left + x;
+            camera.frustum.right = camera.frustum.left + (right - camera.frustum.right);
 
             frameState.cullingVolume = camera.frustum.computeCullingVolume(camera.positionWC, camera.directionWC, camera.upWC);
             context.uniformState.update(frameState);
@@ -1783,6 +1784,7 @@ define([
             viewport.x = windowCoordinates.x;
             viewport.width = context.drawingBufferWidth - windowCoordinates.x;
 
+            var left = camera.frustum.left;
             camera.frustum.left = -maxCoord.x - x;
 
             executeCommandsInViewport(true, scene, passState, backgroundColor, picking);
@@ -1793,7 +1795,8 @@ define([
             camera.position.x = -camera.position.x;
 
             camera.frustum.right = -camera.frustum.left;
-            camera.frustum.left = camera.frustum.right + x;
+            camera.frustum.left = camera.frustum.right + (left - camera.frustum.left);
+
 
             frameState.cullingVolume = camera.frustum.computeCullingVolume(camera.positionWC, camera.directionWC, camera.upWC);
             context.uniformState.update(frameState);


### PR DESCRIPTION
Fixes #3893.

2D is rendered with multiple viewports and part of those viewports were off screen. IE/Edge was clamping the viewports so that they fit the size of the drawing buffer. I'm not sure if that's a bug in IE/Edge or not, but we shouldn't be drawing off screen anyway.

@mramato Can you test with Edge?