### PR TITLE
Avoid JS errors in Eclipse by ignoring gulpfile.js.

### DIFF
--- a/.settings/.jsdtscope
+++ b/.settings/.jsdtscope
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry excluding="Source/ThirdParty/|Source/Workers/cesiumWorkerBootstrapper.js|ThirdParty/|Tools/build.js" kind="src" path=""/>
+	<classpathentry excluding="Source/ThirdParty/|Source/Workers/cesiumWorkerBootstrapper.js|ThirdParty/|gulpfile.js" kind="src" path=""/>
 	<classpathentry kind="con" path="org.eclipse.wst.jsdt.launching.JRE_CONTAINER"/>
 	<classpathentry kind="con" path="org.eclipse.wst.jsdt.launching.baseBrowserLibrary/StandardBrowser/html5"/>
 	<classpathentry kind="output" path=""/>


### PR DESCRIPTION
Fixes #3786.