### PR TITLE
Fix failing sun tests with WebGL validation on.

### DIFF
--- a/Source/Scene/Sun.js
+++ b/Source/Scene/Sun.js
@@ -178,7 +178,7 @@ define([
             this._glowFactorDirty = false;
 
             var size = Math.max(drawingBufferWidth, drawingBufferHeight);
-            size = Math.pow(2.0, Math.ceil(Math.log(size) / Math.log(2.0)) - 2.0);
+            size = Math.max(1.0, Math.pow(2.0, Math.ceil(Math.log(size) / Math.log(2.0)) - 2.0));
 
             this._texture = new Texture({
                 context : context,

--- a/Source/Scene/SunPostProcess.js
+++ b/Source/Scene/SunPostProcess.js
@@ -215,7 +215,7 @@ define([
 
         var downSampleWidth = Math.pow(2.0, Math.ceil(Math.log(width) / Math.log(2)) - 2.0);
         var downSampleHeight = Math.pow(2.0, Math.ceil(Math.log(height) / Math.log(2)) - 2.0);
-        var downSampleSize = Math.max(downSampleWidth, downSampleHeight);
+        var downSampleSize = Math.max(1.0, Math.max(downSampleWidth, downSampleHeight));
 
         var downSampleViewport = downSampleViewportBoundingRectangle;
         downSampleViewport.width = downSampleSize;


### PR DESCRIPTION
For #2771.

The framebuffer was incomplete because we render the sun to a texture that is a fraction of the drawing buffer size. For the tests, the size is between 0 and 1. In practice, this will never happen, but I capped the minimum size to 1 for the tests. Since this never failed before, maybe there was an update where the texture width and height must be greater than or equal to 1?