### PR TITLE
Fix GlobeSurfaceTileSpecs

### DIFF
--- a/Specs/Scene/GlobeSurfaceTileSpec.js
+++ b/Specs/Scene/GlobeSurfaceTileSpec.js
@@ -288,14 +288,16 @@ defineSuite([
                 expect(childTile.data.waterMaskTexture).toBeDefined();
                 var childWaterMaskTexture = childTile.data.waterMaskTexture;
                 var referenceCount = childWaterMaskTexture.referenceCount;
+                var vertexArraysToDestroy = [];
 
                 return pollToPromise(function() {
-                    GlobeSurfaceTile.processStateMachine(childTile, scene.frameState, realTerrainProvider, imageryLayerCollection, []);
+                    GlobeSurfaceTile.processStateMachine(childTile, scene.frameState, realTerrainProvider, imageryLayerCollection, vertexArraysToDestroy);
                     return childTile.state === QuadtreeTileLoadState.DONE;
                 }).then(function() {
                     expect(childTile.data.waterMaskTexture).toBeDefined();
                     expect(childTile.data.waterMaskTexture).not.toBe(childWaterMaskTexture);
                     expect(childWaterMaskTexture.referenceCount + 1).toBe(referenceCount);
+                    expect(vertexArraysToDestroy.length).toEqual(1);
                 });
             });
         });
@@ -333,13 +335,16 @@ defineSuite([
                     expect(grandchildTile.data.loadedTerrain).toBeUndefined();
                     expect(grandchildTile.data.upsampledTerrain).toBeUndefined();
 
+                    var vertexArraysToDestroy = [];
+
                     return pollToPromise(function() {
-                        GlobeSurfaceTile.processStateMachine(childTile, scene.frameState, realTerrainProvider, imageryLayerCollection, []);
+                        GlobeSurfaceTile.processStateMachine(childTile, scene.frameState, realTerrainProvider, imageryLayerCollection, vertexArraysToDestroy);
                         return childTile.state === QuadtreeTileLoadState.DONE;
                     }).then(function() {
                         expect(grandchildTile.state).toBe(QuadtreeTileLoadState.DONE);
                         expect(grandchildTile.data.loadedTerrain).toBeUndefined();
                         expect(grandchildTile.data.upsampledTerrain).toBeUndefined();
+                        expect(vertexArraysToDestroy.length).toEqual(1);
                     });
                 });
             });
@@ -368,15 +373,18 @@ defineSuite([
                     expect(greatGrandchildTile.data.loadedTerrain).toBeUndefined();
                     expect(greatGrandchildTile.data.upsampledTerrain).toBeUndefined();
 
+                    var vertexArraysToBeDestroyed = [];
+
                     return pollToPromise(function() {
-                        GlobeSurfaceTile.processStateMachine(childTile, scene.frameState, realTerrainProvider, imageryLayerCollection, []);
-                        GlobeSurfaceTile.processStateMachine(grandchildTile, scene.frameState, alwaysDeferTerrainProvider, imageryLayerCollection, []);
+                        GlobeSurfaceTile.processStateMachine(childTile, scene.frameState, realTerrainProvider, imageryLayerCollection, vertexArraysToBeDestroyed);
+                        GlobeSurfaceTile.processStateMachine(grandchildTile, scene.frameState, alwaysDeferTerrainProvider, imageryLayerCollection, vertexArraysToBeDestroyed);
                         return childTile.state === QuadtreeTileLoadState.DONE &&
                                !defined(grandchildTile.data.upsampledTerrain);
                     }).then(function() {
                         expect(greatGrandchildTile.state).toBe(QuadtreeTileLoadState.DONE);
                         expect(greatGrandchildTile.data.loadedTerrain).toBeUndefined();
                         expect(greatGrandchildTile.data.upsampledTerrain).toBeUndefined();
+                        expect(vertexArraysToBeDestroyed.length).toEqual(2);
                     });
                 });
             });

--- a/Specs/Scene/GlobeSurfaceTileSpec.js
+++ b/Specs/Scene/GlobeSurfaceTileSpec.js
@@ -123,12 +123,12 @@ defineSuite([
         });
 
         it('transitions to the LOADING state immediately', function() {
-            GlobeSurfaceTile.processStateMachine(rootTile, scene.frameState, alwaysDeferTerrainProvider, imageryLayerCollection);
+            GlobeSurfaceTile.processStateMachine(rootTile, scene.frameState, alwaysDeferTerrainProvider, imageryLayerCollection, []);
             expect(rootTile.state).toBe(QuadtreeTileLoadState.LOADING);
         });
 
         it('creates loadedTerrain but not upsampledTerrain for root tiles', function() {
-            GlobeSurfaceTile.processStateMachine(rootTile, scene.frameState, alwaysDeferTerrainProvider, imageryLayerCollection);
+            GlobeSurfaceTile.processStateMachine(rootTile, scene.frameState, alwaysDeferTerrainProvider, imageryLayerCollection, []);
             expect(rootTile.data.loadedTerrain).toBeDefined();
             expect(rootTile.data.upsampledTerrain).toBeUndefined();
         });
@@ -136,7 +136,7 @@ defineSuite([
         it('non-root tiles get neither loadedTerrain nor upsampledTerrain when their parent is not loaded nor upsampled', function() {
             var children = rootTile.children;
             for (var i = 0; i < children.length; ++i) {
-                GlobeSurfaceTile.processStateMachine(children[i], scene.frameState, alwaysDeferTerrainProvider, imageryLayerCollection);
+                GlobeSurfaceTile.processStateMachine(children[i], scene.frameState, alwaysDeferTerrainProvider, imageryLayerCollection, []);
                 expect(children[i].data.loadedTerrain).toBeUndefined();
                 expect(children[i].data.upsampledTerrain).toBeUndefined();
             }
@@ -144,12 +144,12 @@ defineSuite([
 
         it('once a root tile is loaded, its children get both loadedTerrain and upsampledTerrain', function() {
             return pollToPromise(function() {
-                GlobeSurfaceTile.processStateMachine(rootTile, scene.frameState, realTerrainProvider, imageryLayerCollection);
+                GlobeSurfaceTile.processStateMachine(rootTile, scene.frameState, realTerrainProvider, imageryLayerCollection, []);
                 return rootTile.state === QuadtreeTileLoadState.DONE;
             }).then(function() {
                 var children = rootTile.children;
                 for (var i = 0; i < children.length; ++i) {
-                    GlobeSurfaceTile.processStateMachine(children[i], scene.frameState, alwaysDeferTerrainProvider, imageryLayerCollection);
+                    GlobeSurfaceTile.processStateMachine(children[i], scene.frameState, alwaysDeferTerrainProvider, imageryLayerCollection, []);
                     expect(children[i].data.loadedTerrain).toBeDefined();
                     expect(children[i].data.upsampledTerrain).toBeDefined();
                 }
@@ -158,7 +158,7 @@ defineSuite([
 
         it('loaded terrainData is copied to the tile once it is available', function() {
             return pollToPromise(function() {
-                GlobeSurfaceTile.processStateMachine(rootTile, scene.frameState, realTerrainProvider, imageryLayerCollection);
+                GlobeSurfaceTile.processStateMachine(rootTile, scene.frameState, realTerrainProvider, imageryLayerCollection, []);
                 return rootTile.data.loadedTerrain.state >= TerrainState.RECEIVED;
             }).then(function() {
                 expect(rootTile.data.terrainData).toBeDefined();
@@ -167,12 +167,12 @@ defineSuite([
 
         it('upsampled terrainData is copied to the tile once it is available', function() {
             return pollToPromise(function() {
-                GlobeSurfaceTile.processStateMachine(rootTile, scene.frameState, realTerrainProvider, imageryLayerCollection);
+                GlobeSurfaceTile.processStateMachine(rootTile, scene.frameState, realTerrainProvider, imageryLayerCollection, []);
                 return rootTile.data.loadedTerrain.state >= TerrainState.RECEIVED;
             }).then(function() {
                 return pollToPromise(function() {
                     var childTile = rootTile.children[0];
-                    GlobeSurfaceTile.processStateMachine(childTile, scene.frameState, alwaysDeferTerrainProvider, imageryLayerCollection);
+                    GlobeSurfaceTile.processStateMachine(childTile, scene.frameState, alwaysDeferTerrainProvider, imageryLayerCollection, []);
                     return childTile.data.upsampledTerrain.state >= TerrainState.RECEIVED;
                 }).then(function() {
                     expect(rootTile.children[0].data.terrainData).toBeDefined();
@@ -184,20 +184,20 @@ defineSuite([
             var childTile = rootTile.children[0];
 
             return pollToPromise(function() {
-                GlobeSurfaceTile.processStateMachine(rootTile, scene.frameState, realTerrainProvider, imageryLayerCollection);
+                GlobeSurfaceTile.processStateMachine(rootTile, scene.frameState, realTerrainProvider, imageryLayerCollection, []);
                 return rootTile.data.loadedTerrain.state >= TerrainState.RECEIVED;
             }).then(function() {
                 var upsampledTerrainData;
 
                 return pollToPromise(function() {
-                    GlobeSurfaceTile.processStateMachine(childTile, scene.frameState, alwaysDeferTerrainProvider, imageryLayerCollection);
+                    GlobeSurfaceTile.processStateMachine(childTile, scene.frameState, alwaysDeferTerrainProvider, imageryLayerCollection, []);
                     return childTile.data.upsampledTerrain.state >= TerrainState.RECEIVED;
                 }).then(function() {
                     upsampledTerrainData = childTile.data.terrainData;
                     expect(upsampledTerrainData).toBeDefined();
 
                     return pollToPromise(function() {
-                        GlobeSurfaceTile.processStateMachine(childTile, scene.frameState, realTerrainProvider, imageryLayerCollection);
+                        GlobeSurfaceTile.processStateMachine(childTile, scene.frameState, realTerrainProvider, imageryLayerCollection, []);
                         return childTile.data.loadedTerrain.state >= TerrainState.RECEIVED;
                     }).then(function() {
                         expect(childTile.data.terrainData).not.toBe(upsampledTerrainData);
@@ -211,16 +211,16 @@ defineSuite([
             var grandchildTile = childTile.children[0];
 
             return pollToPromise(function() {
-                GlobeSurfaceTile.processStateMachine(rootTile, scene.frameState, realTerrainProvider, imageryLayerCollection);
+                GlobeSurfaceTile.processStateMachine(rootTile, scene.frameState, realTerrainProvider, imageryLayerCollection, []);
                 return rootTile.data.loadedTerrain.state >= TerrainState.RECEIVED;
             }).then(function() {
                 return pollToPromise(function() {
-                    GlobeSurfaceTile.processStateMachine(childTile, scene.frameState, alwaysDeferTerrainProvider, imageryLayerCollection);
+                    GlobeSurfaceTile.processStateMachine(childTile, scene.frameState, alwaysDeferTerrainProvider, imageryLayerCollection, []);
                     return childTile.data.upsampledTerrain.state >= TerrainState.RECEIVED;
                 });
             }).then(function() {
                 return pollToPromise(function() {
-                    GlobeSurfaceTile.processStateMachine(grandchildTile, scene.frameState, alwaysDeferTerrainProvider, imageryLayerCollection);
+                    GlobeSurfaceTile.processStateMachine(grandchildTile, scene.frameState, alwaysDeferTerrainProvider, imageryLayerCollection, []);
                     return grandchildTile.data.upsampledTerrain.state >= TerrainState.RECEIVED;
                 });
             }).then(function() {
@@ -228,7 +228,7 @@ defineSuite([
                 expect(grandchildTile.data.loadedTerrain).toBeUndefined();
 
                 return pollToPromise(function() {
-                    GlobeSurfaceTile.processStateMachine(childTile, scene.frameState, realTerrainProvider, imageryLayerCollection);
+                    GlobeSurfaceTile.processStateMachine(childTile, scene.frameState, realTerrainProvider, imageryLayerCollection, []);
                     return childTile.data.loadedTerrain.state >= TerrainState.RECEIVED;
                 }).then(function() {
                     expect(grandchildTile.data.upsampledTerrain).not.toBe(grandchildUpsampledTerrain);
@@ -243,32 +243,32 @@ defineSuite([
             var greatGrandchildTile = grandchildTile.children[0];
 
             return pollToPromise(function() {
-                GlobeSurfaceTile.processStateMachine(rootTile, scene.frameState, realTerrainProvider, imageryLayerCollection);
+                GlobeSurfaceTile.processStateMachine(rootTile, scene.frameState, realTerrainProvider, imageryLayerCollection, []);
                 return rootTile.data.loadedTerrain.state >= TerrainState.RECEIVED;
             }).then(function() {
                 return pollToPromise(function() {
-                    GlobeSurfaceTile.processStateMachine(childTile, scene.frameState, alwaysDeferTerrainProvider, imageryLayerCollection);
+                    GlobeSurfaceTile.processStateMachine(childTile, scene.frameState, alwaysDeferTerrainProvider, imageryLayerCollection, []);
                     return childTile.data.upsampledTerrain.state >= TerrainState.RECEIVED;
                 });
             }).then(function() {
                 return pollToPromise(function() {
-                    GlobeSurfaceTile.processStateMachine(grandchildTile, scene.frameState, alwaysDeferTerrainProvider, imageryLayerCollection);
+                    GlobeSurfaceTile.processStateMachine(grandchildTile, scene.frameState, alwaysDeferTerrainProvider, imageryLayerCollection, []);
                     return grandchildTile.data.upsampledTerrain.state >= TerrainState.RECEIVED;
                 });
             }).then(function() {
                 return pollToPromise(function() {
-                    GlobeSurfaceTile.processStateMachine(greatGrandchildTile, scene.frameState, alwaysDeferTerrainProvider, imageryLayerCollection);
+                    GlobeSurfaceTile.processStateMachine(greatGrandchildTile, scene.frameState, alwaysDeferTerrainProvider, imageryLayerCollection, []);
                     return greatGrandchildTile.data.upsampledTerrain.state >= TerrainState.RECEIVED;
                 });
             }).then(function() {
                return pollToPromise(function() {
-                   GlobeSurfaceTile.processStateMachine(childTile, scene.frameState, realTerrainProvider, imageryLayerCollection);
+                   GlobeSurfaceTile.processStateMachine(childTile, scene.frameState, realTerrainProvider, imageryLayerCollection, []);
                    return childTile.data.loadedTerrain.state >= TerrainState.RECEIVED;
                });
             }).then(function() {
                 var greatGrandchildUpsampledTerrain = grandchildTile.data.upsampledTerrain;
                 return pollToPromise(function() {
-                    GlobeSurfaceTile.processStateMachine(grandchildTile, scene.frameState, alwaysDeferTerrainProvider, imageryLayerCollection);
+                    GlobeSurfaceTile.processStateMachine(grandchildTile, scene.frameState, alwaysDeferTerrainProvider, imageryLayerCollection, []);
                     return grandchildTile.data.upsampledTerrain.state >= TerrainState.RECEIVED;
                 }).then(function() {
                     expect(greatGrandchildTile.data.upsampledTerrain).toBeDefined();
@@ -281,8 +281,8 @@ defineSuite([
             var childTile = rootTile.children[0];
 
             return pollToPromise(function() {
-                GlobeSurfaceTile.processStateMachine(rootTile, scene.frameState, realTerrainProvider, imageryLayerCollection);
-                GlobeSurfaceTile.processStateMachine(childTile, scene.frameState, alwaysDeferTerrainProvider, imageryLayerCollection);
+                GlobeSurfaceTile.processStateMachine(rootTile, scene.frameState, realTerrainProvider, imageryLayerCollection, []);
+                GlobeSurfaceTile.processStateMachine(childTile, scene.frameState, alwaysDeferTerrainProvider, imageryLayerCollection, []);
                 return rootTile.renderable && childTile.renderable;
             }).then(function() {
                 expect(childTile.data.waterMaskTexture).toBeDefined();
@@ -290,7 +290,7 @@ defineSuite([
                 var referenceCount = childWaterMaskTexture.referenceCount;
 
                 return pollToPromise(function() {
-                    GlobeSurfaceTile.processStateMachine(childTile, scene.frameState, realTerrainProvider, imageryLayerCollection);
+                    GlobeSurfaceTile.processStateMachine(childTile, scene.frameState, realTerrainProvider, imageryLayerCollection, []);
                     return childTile.state === QuadtreeTileLoadState.DONE;
                 }).then(function() {
                     expect(childTile.data.waterMaskTexture).toBeDefined();
@@ -304,8 +304,8 @@ defineSuite([
             var childTile = rootTile.children[0];
 
             return pollToPromise(function() {
-                GlobeSurfaceTile.processStateMachine(rootTile, scene.frameState, realTerrainProvider, imageryLayerCollection);
-                GlobeSurfaceTile.processStateMachine(childTile, scene.frameState, alwaysFailTerrainProvider, imageryLayerCollection);
+                GlobeSurfaceTile.processStateMachine(rootTile, scene.frameState, realTerrainProvider, imageryLayerCollection, []);
+                GlobeSurfaceTile.processStateMachine(childTile, scene.frameState, alwaysFailTerrainProvider, imageryLayerCollection, []);
                 return rootTile.renderable && childTile.renderable;
             }).then(function() {
                 expect(childTile.data.loadedTerrain).toBeUndefined();
@@ -318,8 +318,8 @@ defineSuite([
             var grandchildTile = childTile.children[0];
 
             return pollToPromise(function() {
-                GlobeSurfaceTile.processStateMachine(rootTile, scene.frameState, realTerrainProvider, imageryLayerCollection);
-                GlobeSurfaceTile.processStateMachine(childTile, scene.frameState, alwaysDeferTerrainProvider, imageryLayerCollection);
+                GlobeSurfaceTile.processStateMachine(rootTile, scene.frameState, realTerrainProvider, imageryLayerCollection, []);
+                GlobeSurfaceTile.processStateMachine(childTile, scene.frameState, alwaysDeferTerrainProvider, imageryLayerCollection, []);
                 return defined(rootTile.data.terrainData) && defined(rootTile.data.terrainData._mesh) &&
                        defined(childTile.data.terrainData);
             }).then(function() {
@@ -327,14 +327,14 @@ defineSuite([
                 childTile.data.terrainData._childTileMask = 15;
 
                 return pollToPromise(function() {
-                    GlobeSurfaceTile.processStateMachine(grandchildTile, scene.frameState, realTerrainProvider, imageryLayerCollection);
+                    GlobeSurfaceTile.processStateMachine(grandchildTile, scene.frameState, realTerrainProvider, imageryLayerCollection, []);
                     return grandchildTile.state === QuadtreeTileLoadState.DONE;
                 }).then(function() {
                     expect(grandchildTile.data.loadedTerrain).toBeUndefined();
                     expect(grandchildTile.data.upsampledTerrain).toBeUndefined();
 
                     return pollToPromise(function() {
-                        GlobeSurfaceTile.processStateMachine(childTile, scene.frameState, realTerrainProvider, imageryLayerCollection);
+                        GlobeSurfaceTile.processStateMachine(childTile, scene.frameState, realTerrainProvider, imageryLayerCollection, []);
                         return childTile.state === QuadtreeTileLoadState.DONE;
                     }).then(function() {
                         expect(grandchildTile.state).toBe(QuadtreeTileLoadState.DONE);
@@ -351,9 +351,9 @@ defineSuite([
             var greatGrandchildTile = grandchildTile.children[0];
 
             return pollToPromise(function() {
-                GlobeSurfaceTile.processStateMachine(rootTile, scene.frameState, realTerrainProvider, imageryLayerCollection);
-                GlobeSurfaceTile.processStateMachine(childTile, scene.frameState, alwaysDeferTerrainProvider, imageryLayerCollection);
-                GlobeSurfaceTile.processStateMachine(grandchildTile, scene.frameState, alwaysDeferTerrainProvider, imageryLayerCollection);
+                GlobeSurfaceTile.processStateMachine(rootTile, scene.frameState, realTerrainProvider, imageryLayerCollection, []);
+                GlobeSurfaceTile.processStateMachine(childTile, scene.frameState, alwaysDeferTerrainProvider, imageryLayerCollection, []);
+                GlobeSurfaceTile.processStateMachine(grandchildTile, scene.frameState, alwaysDeferTerrainProvider, imageryLayerCollection, []);
                 return defined(rootTile.data.terrainData) && defined(rootTile.data.terrainData._mesh) &&
                        defined(childTile.data.terrainData) && defined(childTile.data.terrainData._mesh) &&
                        defined(grandchildTile.data.terrainData);
@@ -362,15 +362,15 @@ defineSuite([
                 grandchildTile.data.terrainData._childTileMask = 15;
 
                 return pollToPromise(function() {
-                    GlobeSurfaceTile.processStateMachine(greatGrandchildTile, scene.frameState, realTerrainProvider, imageryLayerCollection);
+                    GlobeSurfaceTile.processStateMachine(greatGrandchildTile, scene.frameState, realTerrainProvider, imageryLayerCollection, []);
                     return greatGrandchildTile.state === QuadtreeTileLoadState.DONE;
                 }).then(function() {
                     expect(greatGrandchildTile.data.loadedTerrain).toBeUndefined();
                     expect(greatGrandchildTile.data.upsampledTerrain).toBeUndefined();
 
                     return pollToPromise(function() {
-                        GlobeSurfaceTile.processStateMachine(childTile, scene.frameState, realTerrainProvider, imageryLayerCollection);
-                        GlobeSurfaceTile.processStateMachine(grandchildTile, scene.frameState, alwaysDeferTerrainProvider, imageryLayerCollection);
+                        GlobeSurfaceTile.processStateMachine(childTile, scene.frameState, realTerrainProvider, imageryLayerCollection, []);
+                        GlobeSurfaceTile.processStateMachine(grandchildTile, scene.frameState, alwaysDeferTerrainProvider, imageryLayerCollection, []);
                         return childTile.state === QuadtreeTileLoadState.DONE &&
                                !defined(grandchildTile.data.upsampledTerrain);
                     }).then(function() {
@@ -386,8 +386,8 @@ defineSuite([
             var childTile = rootTile.children[0];
 
             return pollToPromise(function() {
-                GlobeSurfaceTile.processStateMachine(rootTile, scene.frameState, realTerrainProvider, imageryLayerCollection);
-                GlobeSurfaceTile.processStateMachine(childTile, scene.frameState, alwaysFailTerrainProvider, imageryLayerCollection);
+                GlobeSurfaceTile.processStateMachine(rootTile, scene.frameState, realTerrainProvider, imageryLayerCollection, []);
+                GlobeSurfaceTile.processStateMachine(childTile, scene.frameState, alwaysFailTerrainProvider, imageryLayerCollection, []);
                 return rootTile.state >= QuadtreeTileLoadState.DONE &&
                        childTile.state >= QuadtreeTileLoadState.DONE;
             }).then(function() {
@@ -422,10 +422,10 @@ defineSuite([
 
             return pollToPromise(function() {
                 if (rootTile.state !== QuadtreeTileLoadState.DONE) {
-                    GlobeSurfaceTile.processStateMachine(rootTile, scene.frameState, allWaterTerrainProvider, imageryLayerCollection);
+                    GlobeSurfaceTile.processStateMachine(rootTile, scene.frameState, allWaterTerrainProvider, imageryLayerCollection, []);
                     return false;
                 } else {
-                    GlobeSurfaceTile.processStateMachine(childTile, scene.frameState, allWaterTerrainProvider, imageryLayerCollection);
+                    GlobeSurfaceTile.processStateMachine(childTile, scene.frameState, allWaterTerrainProvider, imageryLayerCollection, []);
                     return childTile.state === QuadtreeTileLoadState.DONE;
                 }
             }).then(function() {
@@ -460,10 +460,10 @@ defineSuite([
 
             return pollToPromise(function() {
                 if (rootTile.state !== QuadtreeTileLoadState.DONE) {
-                    GlobeSurfaceTile.processStateMachine(rootTile, scene.frameState, allLandTerrainProvider, imageryLayerCollection);
+                    GlobeSurfaceTile.processStateMachine(rootTile, scene.frameState, allLandTerrainProvider, imageryLayerCollection, []);
                     return false;
                 } else {
-                    GlobeSurfaceTile.processStateMachine(childTile, scene.frameState, allLandTerrainProvider, imageryLayerCollection);
+                    GlobeSurfaceTile.processStateMachine(childTile, scene.frameState, allLandTerrainProvider, imageryLayerCollection, []);
                     return childTile.state === QuadtreeTileLoadState.DONE;
                 }
             }).then(function() {
@@ -481,7 +481,7 @@ defineSuite([
 
             var imageryLayerCollection = new ImageryLayerCollection();
 
-            GlobeSurfaceTile.processStateMachine(tile, scene.frameState, alwaysDeferTerrainProvider, imageryLayerCollection);
+            GlobeSurfaceTile.processStateMachine(tile, scene.frameState, alwaysDeferTerrainProvider, imageryLayerCollection, []);
 
             var layer = new ImageryLayer({
                 requestImage : function() {
@@ -494,7 +494,7 @@ defineSuite([
             expect(imagery.parent.state).toBe(ImageryState.UNLOADED);
 
             return pollToPromise(function() {
-                GlobeSurfaceTile.processStateMachine(tile, scene.frameState, alwaysDeferTerrainProvider, imageryLayerCollection);
+                GlobeSurfaceTile.processStateMachine(tile, scene.frameState, alwaysDeferTerrainProvider, imageryLayerCollection, []);
                 return imagery.parent.state !== ImageryState.UNLOADED;
             });
         });
@@ -531,7 +531,7 @@ defineSuite([
                     return false;
                 }
 
-                GlobeSurfaceTile.processStateMachine(tile, scene.frameState, terrainProvider, imageryLayerCollection);
+                GlobeSurfaceTile.processStateMachine(tile, scene.frameState, terrainProvider, imageryLayerCollection, []);
                 return tile.state === QuadtreeTileLoadState.DONE;
             }).then(function() {
                 var ray = new Ray(


### PR DESCRIPTION
As part of #3900, `vertexArraysToDestroy` was added as a parameter to `GlobeSurfaceTile.processStateMachine`, but none of the tests actually pass that parameter.  This happens to be OK in master because none of the tests end up using the parameter, but in the 3D Tiles branch, the parameter is required and merging in master results in failing tests.

Passing in an empty array fixes the issue (since we don't care about destroying the data in the specs), but we might possibly want to actually test that the parameter is being used correctly.

@bagnell any thoughts here?