### PR TITLE
Create a culling volume from a bounding sphere

### DIFF
--- a/Source/Scene/CullingVolume.js
+++ b/Source/Scene/CullingVolume.js
@@ -1,6 +1,7 @@
 /*global define*/
 define([
         '../Core/Cartesian3',
+        '../Core/Cartesian4',
         '../Core/defaultValue',
         '../Core/defined',
         '../Core/DeveloperError',
@@ -8,6 +9,7 @@ define([
         '../Core/Plane'
     ], function(
         Cartesian3,
+        Cartesian4,
         defaultValue,
         defined,
         DeveloperError,
@@ -21,7 +23,7 @@ define([
      * @alias CullingVolume
      * @constructor
      *
-     * @param {Cartesian4[]} planes An array of clipping planes.
+     * @param {Cartesian4[]} [planes] An array of clipping planes.
      */
     function CullingVolume(planes) {
         /**
@@ -34,7 +36,78 @@ define([
         this.planes = defaultValue(planes, []);
     }
 
+    var faces = [new Cartesian3(), new Cartesian3(), new Cartesian3()];
+    Cartesian3.clone(Cartesian3.UNIT_X, faces[0]);
+    Cartesian3.clone(Cartesian3.UNIT_Y, faces[1]);
+    Cartesian3.clone(Cartesian3.UNIT_Z, faces[2]);
+
+    var scratchPlaneCenter = new Cartesian3();
+    var scratchPlaneNormal = new Cartesian3();
     var scratchPlane = new Plane(new Cartesian3(), 0.0);
+
+    /**
+     * Constructs a culling volume from a bounding sphere. Creates six planes that create a box containing the sphere.
+     * The planes are aligned to the x, y, and z axes in world coordinates.
+     *
+     * @param {BoundingSphere} boundingSphere The bounding sphere used to create the culling volume.
+     * @param {CullingVolume} [result] The object onto which to store the result.
+     * @returns {CullingVolume} The culling volume created from the bounding sphere.
+     */
+    CullingVolume.fromBoundingSphere = function(boundingSphere, result) {
+        //>>includeStart('debug', pragmas.debug);
+        if (!defined(boundingSphere)) {
+            throw new DeveloperError('boundingSphere is required.');
+        }
+        //>>includeEnd('debug');
+
+        if (!defined(result)) {
+            result = new CullingVolume();
+        }
+
+        var length = faces.length;
+        var planes = result.planes;
+        planes.length = 2 * length;
+
+        var center = boundingSphere.center;
+        var radius = boundingSphere.radius;
+
+        var planeIndex = 0;
+
+        for (var i = 0; i < length; ++i) {
+            var faceNormal = faces[i];
+
+            var plane0 = planes[planeIndex];
+            var plane1 = planes[planeIndex + 1];
+
+            if (!defined(plane0)) {
+                plane0 = planes[planeIndex] = new Cartesian4();
+            }
+            if (!defined(plane1)) {
+                plane1 = planes[planeIndex + 1] = new Cartesian4();
+            }
+
+            Cartesian3.multiplyByScalar(faceNormal, -radius, scratchPlaneCenter);
+            Cartesian3.add(center, scratchPlaneCenter, scratchPlaneCenter);
+
+            plane0.x = faceNormal.x;
+            plane0.y = faceNormal.y;
+            plane0.z = faceNormal.z;
+            plane0.w = -Cartesian3.dot(faceNormal, scratchPlaneCenter);
+
+            Cartesian3.multiplyByScalar(faceNormal, radius, scratchPlaneCenter);
+            Cartesian3.add(center, scratchPlaneCenter, scratchPlaneCenter);
+
+            plane1.x = -faceNormal.x;
+            plane1.y = -faceNormal.y;
+            plane1.z = -faceNormal.z;
+            plane1.w = -Cartesian3.dot(Cartesian3.negate(faceNormal, scratchPlaneNormal), scratchPlaneCenter);
+
+            planeIndex += 2;
+        }
+
+        return result;
+    };
+
     /**
      * Determines whether a bounding volume intersects the culling volume.
      *

--- a/Specs/Scene/CullingVolumeSpec.js
+++ b/Specs/Scene/CullingVolumeSpec.js
@@ -58,15 +58,16 @@ defineSuite([
         }
         expect(culling.computeVisibilityWithPlaneMask(bound, mask)).toEqual(mask);
     }
+
     describe('box intersections', function() {
 
         it('can contain an axis aligned bounding box', function() {
             var box1 = AxisAlignedBoundingBox.fromPoints([
-                                                   new Cartesian3(-0.5, 0, -1.25),
-                                                   new Cartesian3(0.5, 0, -1.25),
-                                                   new Cartesian3(-0.5, 0, -1.75),
-                                                   new Cartesian3(0.5, 0, -1.75)
-                                                  ]);
+                new Cartesian3(-0.5, 0, -1.25),
+                new Cartesian3(0.5, 0, -1.25),
+                new Cartesian3(-0.5, 0, -1.75),
+                new Cartesian3(0.5, 0, -1.75)
+            ]);
             testWithAndWithoutPlaneMask(cullingVolume, box1, Intersect.INSIDE);
         });
 
@@ -74,61 +75,61 @@ defineSuite([
 
             it('on the far plane', function() {
                 var box2 = AxisAlignedBoundingBox.fromPoints([
-                                                       new Cartesian3(-0.5, 0, -1.5),
-                                                       new Cartesian3(0.5, 0, -1.5),
-                                                       new Cartesian3(-0.5, 0, -2.5),
-                                                       new Cartesian3(0.5, 0, -2.5)
-                                                      ]);
+                    new Cartesian3(-0.5, 0, -1.5),
+                    new Cartesian3(0.5, 0, -1.5),
+                    new Cartesian3(-0.5, 0, -2.5),
+                    new Cartesian3(0.5, 0, -2.5)
+                ]);
                 testWithAndWithoutPlaneMask(cullingVolume, box2, Intersect.INTERSECTING);
             });
 
             it('on the near plane', function() {
                 var box3 = AxisAlignedBoundingBox.fromPoints([
-                                                       new Cartesian3(-0.5, 0, -0.5),
-                                                       new Cartesian3(0.5, 0, -0.5),
-                                                       new Cartesian3(-0.5, 0, -1.5),
-                                                       new Cartesian3(0.5, 0, -1.5)
-                                                      ]);
+                    new Cartesian3(-0.5, 0, -0.5),
+                    new Cartesian3(0.5, 0, -0.5),
+                    new Cartesian3(-0.5, 0, -1.5),
+                    new Cartesian3(0.5, 0, -1.5)
+                ]);
                 testWithAndWithoutPlaneMask(cullingVolume, box3, Intersect.INTERSECTING);
             });
 
             it('on the left plane', function() {
                 var box4 = AxisAlignedBoundingBox.fromPoints([
-                                                       new Cartesian3(-1.5, 0, -1.25),
-                                                       new Cartesian3(0, 0, -1.25),
-                                                       new Cartesian3(-1.5, 0, -1.5),
-                                                       new Cartesian3(0, 0, -1.5)
-                                                      ]);
+                    new Cartesian3(-1.5, 0, -1.25),
+                    new Cartesian3(0, 0, -1.25),
+                    new Cartesian3(-1.5, 0, -1.5),
+                    new Cartesian3(0, 0, -1.5)
+                ]);
                 testWithAndWithoutPlaneMask(cullingVolume, box4, Intersect.INTERSECTING);
             });
 
             it('on the right plane', function() {
                 var box5 = AxisAlignedBoundingBox.fromPoints([
-                                                       new Cartesian3(0, 0, -1.25),
-                                                       new Cartesian3(1.5, 0, -1.25),
-                                                       new Cartesian3(0, 0, -1.5),
-                                                       new Cartesian3(1.5, 0, -1.5)
-                                                      ]);
+                    new Cartesian3(0, 0, -1.25),
+                    new Cartesian3(1.5, 0, -1.25),
+                    new Cartesian3(0, 0, -1.5),
+                    new Cartesian3(1.5, 0, -1.5)
+                ]);
                 testWithAndWithoutPlaneMask(cullingVolume, box5, Intersect.INTERSECTING);
             });
 
             it('on the top plane', function() {
                 var box6 = AxisAlignedBoundingBox.fromPoints([
-                                                       new Cartesian3(-0.5, 0, -1.25),
-                                                       new Cartesian3(0.5, 0, -1.25),
-                                                       new Cartesian3(-0.5, 2.0, -1.75),
-                                                       new Cartesian3(0.5, 2.0, -1.75)
-                                                      ]);
+                    new Cartesian3(-0.5, 0, -1.25),
+                    new Cartesian3(0.5, 0, -1.25),
+                    new Cartesian3(-0.5, 2.0, -1.75),
+                    new Cartesian3(0.5, 2.0, -1.75)
+                ]);
                 testWithAndWithoutPlaneMask(cullingVolume, box6, Intersect.INTERSECTING);
             });
 
             it('on the bottom plane', function() {
                 var box7 = AxisAlignedBoundingBox.fromPoints([
-                                                       new Cartesian3(-0.5, -2.0, -1.25),
-                                                       new Cartesian3(0.5, 0, -1.25),
-                                                       new Cartesian3(-0.5, -2.0, -1.5),
-                                                       new Cartesian3(0.5, 0, -1.5)
-                                                      ]);
+                    new Cartesian3(-0.5, -2.0, -1.25),
+                    new Cartesian3(0.5, 0, -1.25),
+                    new Cartesian3(-0.5, -2.0, -1.5),
+                    new Cartesian3(0.5, 0, -1.5)
+                ]);
                 testWithAndWithoutPlaneMask(cullingVolume, box7, Intersect.INTERSECTING);
             });
         });
@@ -137,61 +138,61 @@ defineSuite([
 
             it('past the far plane', function() {
                 var box8 = AxisAlignedBoundingBox.fromPoints([
-                                                       new Cartesian3(-0.5, 0, -2.25),
-                                                       new Cartesian3(0.5, 0, -2.25),
-                                                       new Cartesian3(-0.5, 0, -2.75),
-                                                       new Cartesian3(0.5, 0, -2.75)
-                                                      ]);
+                    new Cartesian3(-0.5, 0, -2.25),
+                    new Cartesian3(0.5, 0, -2.25),
+                    new Cartesian3(-0.5, 0, -2.75),
+                    new Cartesian3(0.5, 0, -2.75)
+                ]);
                 testWithAndWithoutPlaneMask(cullingVolume, box8, Intersect.OUTSIDE);
             });
 
             it('before the near plane', function() {
                 var box9 = AxisAlignedBoundingBox.fromPoints([
-                                                       new Cartesian3(-0.5, 0, -0.25),
-                                                       new Cartesian3(0.5, 0, -0.25),
-                                                       new Cartesian3(-0.5, 0, -0.75),
-                                                       new Cartesian3(0.5, 0, -0.75)
-                                                      ]);
+                    new Cartesian3(-0.5, 0, -0.25),
+                    new Cartesian3(0.5, 0, -0.25),
+                    new Cartesian3(-0.5, 0, -0.75),
+                    new Cartesian3(0.5, 0, -0.75)
+                ]);
                 testWithAndWithoutPlaneMask(cullingVolume, box9, Intersect.OUTSIDE);
             });
 
             it('past the left plane', function() {
                 var box10 = AxisAlignedBoundingBox.fromPoints([
-                                                        new Cartesian3(-5, 0, -1.25),
-                                                        new Cartesian3(-3, 0, -1.25),
-                                                        new Cartesian3(-5, 0, -1.75),
-                                                        new Cartesian3(-3, 0, -1.75)
-                                                       ]);
+                    new Cartesian3(-5, 0, -1.25),
+                    new Cartesian3(-3, 0, -1.25),
+                    new Cartesian3(-5, 0, -1.75),
+                    new Cartesian3(-3, 0, -1.75)
+                ]);
                 testWithAndWithoutPlaneMask(cullingVolume, box10, Intersect.OUTSIDE);
             });
 
             it('past the right plane', function() {
                 var box11 = AxisAlignedBoundingBox.fromPoints([
-                                                        new Cartesian3(3, 0, -1.25),
-                                                        new Cartesian3(5, 0, -1.25),
-                                                        new Cartesian3(3, 0, -1.75),
-                                                        new Cartesian3(5, 0, -1.75)
-                                                       ]);
+                    new Cartesian3(3, 0, -1.25),
+                    new Cartesian3(5, 0, -1.25),
+                    new Cartesian3(3, 0, -1.75),
+                    new Cartesian3(5, 0, -1.75)
+                ]);
                 testWithAndWithoutPlaneMask(cullingVolume, box11, Intersect.OUTSIDE);
             });
 
             it('past the top plane', function() {
                 var box12 = AxisAlignedBoundingBox.fromPoints([
-                                                        new Cartesian3(-0.5, 3, -1.25),
-                                                        new Cartesian3(0.5, 3, -1.25),
-                                                        new Cartesian3(-0.5, 5, -1.75),
-                                                        new Cartesian3(0.5, 5, -1.75)
-                                                       ]);
+                    new Cartesian3(-0.5, 3, -1.25),
+                    new Cartesian3(0.5, 3, -1.25),
+                    new Cartesian3(-0.5, 5, -1.75),
+                    new Cartesian3(0.5, 5, -1.75)
+                ]);
                 testWithAndWithoutPlaneMask(cullingVolume, box12, Intersect.OUTSIDE);
             });
 
             it('past the bottom plane', function() {
                 var box13 = AxisAlignedBoundingBox.fromPoints([
-                                                        new Cartesian3(-0.5, -3, -1.25),
-                                                        new Cartesian3(0.5, -3, -1.25),
-                                                        new Cartesian3(-0.5, -5, -1.75),
-                                                        new Cartesian3(0.5, -5, -1.75)
-                                                       ]);
+                    new Cartesian3(-0.5, -3, -1.25),
+                    new Cartesian3(0.5, -3, -1.25),
+                    new Cartesian3(-0.5, -5, -1.75),
+                    new Cartesian3(0.5, -5, -1.75)
+                ]);
                 testWithAndWithoutPlaneMask(cullingVolume, box13, Intersect.OUTSIDE);
             });
 
@@ -267,6 +268,131 @@ defineSuite([
 
             it('past the bottom plane', function() {
                 var sphere13 = BoundingSphere.fromPoints([new Cartesian3(-0.5, -4.5, -1.25), new Cartesian3(-0.5, -5, -1.25)]);
+                testWithAndWithoutPlaneMask(cullingVolume, sphere13, Intersect.OUTSIDE);
+            });
+        });
+    });
+
+    describe('construct from bounding sphere', function() {
+        var boundingSphereCullingVolume = new BoundingSphere(new Cartesian3(1000.0, 2000.0, 3000.0), 100.0);
+        var cullingVolume = CullingVolume.fromBoundingSphere(boundingSphereCullingVolume);
+
+        it('can contain a volume', function() {
+            var sphere1 = BoundingSphere.clone(boundingSphereCullingVolume);
+            sphere1.radius *= 0.5;
+            testWithAndWithoutPlaneMask(cullingVolume, sphere1, Intersect.INSIDE);
+        });
+
+        describe('can partially contain a volume', function() {
+
+            it('on the far plane', function() {
+                var offset = new Cartesian3(0.0, 0.0, boundingSphereCullingVolume.radius * 1.5);
+                var center = Cartesian3.add(boundingSphereCullingVolume.center, offset, new Cartesian3());
+                var radius = boundingSphereCullingVolume.radius * 0.5;
+                var sphere2 = new BoundingSphere(center, radius);
+
+                testWithAndWithoutPlaneMask(cullingVolume, sphere2, Intersect.INTERSECTING);
+            });
+
+            it('on the near plane', function() {
+                var offset = new Cartesian3(0.0, 0.0, -boundingSphereCullingVolume.radius * 1.5);
+                var center = Cartesian3.add(boundingSphereCullingVolume.center, offset, new Cartesian3());
+                var radius = boundingSphereCullingVolume.radius * 0.5;
+                var sphere3 = new BoundingSphere(center, radius);
+
+                testWithAndWithoutPlaneMask(cullingVolume, sphere3, Intersect.INTERSECTING);
+            });
+
+            it('on the left plane', function() {
+                var offset = new Cartesian3(-boundingSphereCullingVolume.radius * 1.5, 0.0, 0.0);
+                var center = Cartesian3.add(boundingSphereCullingVolume.center, offset, new Cartesian3());
+                var radius = boundingSphereCullingVolume.radius * 0.5;
+                var sphere4 = new BoundingSphere(center, radius);
+
+                testWithAndWithoutPlaneMask(cullingVolume, sphere4, Intersect.INTERSECTING);
+            });
+
+            it('on the right plane', function() {
+                var offset = new Cartesian3(boundingSphereCullingVolume.radius * 1.5, 0.0, 0.0);
+                var center = Cartesian3.add(boundingSphereCullingVolume.center, offset, new Cartesian3());
+                var radius = boundingSphereCullingVolume.radius * 0.5;
+                var sphere5 = new BoundingSphere(center, radius);
+
+                testWithAndWithoutPlaneMask(cullingVolume, sphere5, Intersect.INTERSECTING);
+            });
+
+            it('on the top plane', function() {
+                var offset = new Cartesian3(0.0, boundingSphereCullingVolume.radius * 1.5, 0.0);
+                var center = Cartesian3.add(boundingSphereCullingVolume.center, offset, new Cartesian3());
+                var radius = boundingSphereCullingVolume.radius * 0.5;
+                var sphere6 = new BoundingSphere(center, radius);
+
+                testWithAndWithoutPlaneMask(cullingVolume, sphere6, Intersect.INTERSECTING);
+            });
+
+            it('on the bottom plane', function() {
+                var offset = new Cartesian3(0.0, -boundingSphereCullingVolume.radius * 1.5, 0.0);
+                var center = Cartesian3.add(boundingSphereCullingVolume.center, offset, new Cartesian3());
+                var radius = boundingSphereCullingVolume.radius * 0.5;
+                var sphere7 = new BoundingSphere(center, radius);
+
+                testWithAndWithoutPlaneMask(cullingVolume, sphere7, Intersect.INTERSECTING);
+            });
+        });
+
+        describe('can not contain a volume', function() {
+
+            it('past the far plane', function() {
+                var offset = new Cartesian3(0.0, 0.0, boundingSphereCullingVolume.radius * 2.0);
+                var center = Cartesian3.add(boundingSphereCullingVolume.center, offset, new Cartesian3());
+                var radius = boundingSphereCullingVolume.radius * 0.5;
+                var sphere8 = new BoundingSphere(center, radius);
+
+                testWithAndWithoutPlaneMask(cullingVolume, sphere8, Intersect.OUTSIDE);
+            });
+
+            it('before the near plane', function() {
+                var offset = new Cartesian3(0.0, 0.0, -boundingSphereCullingVolume.radius * 2.0);
+                var center = Cartesian3.add(boundingSphereCullingVolume.center, offset, new Cartesian3());
+                var radius = boundingSphereCullingVolume.radius * 0.5;
+                var sphere9 = new BoundingSphere(center, radius);
+
+                testWithAndWithoutPlaneMask(cullingVolume, sphere9, Intersect.OUTSIDE);
+            });
+
+            it('past the left plane', function() {
+                var offset = new Cartesian3(-boundingSphereCullingVolume.radius * 2.0, 0.0, 0.0);
+                var center = Cartesian3.add(boundingSphereCullingVolume.center, offset, new Cartesian3());
+                var radius = boundingSphereCullingVolume.radius * 0.5;
+                var sphere10 = new BoundingSphere(center, radius);
+
+                testWithAndWithoutPlaneMask(cullingVolume, sphere10, Intersect.OUTSIDE);
+            });
+
+            it('past the right plane', function() {
+                var offset = new Cartesian3(boundingSphereCullingVolume.radius * 2.0, 0.0, 0.0);
+                var center = Cartesian3.add(boundingSphereCullingVolume.center, offset, new Cartesian3());
+                var radius = boundingSphereCullingVolume.radius * 0.5;
+                var sphere11 = new BoundingSphere(center, radius);
+
+                testWithAndWithoutPlaneMask(cullingVolume, sphere11, Intersect.OUTSIDE);
+            });
+
+            it('past the top plane', function() {
+                var offset = new Cartesian3(0.0, boundingSphereCullingVolume.radius * 2.0, 0.0);
+                var center = Cartesian3.add(boundingSphereCullingVolume.center, offset, new Cartesian3());
+                var radius = boundingSphereCullingVolume.radius * 0.5;
+                var sphere12 = new BoundingSphere(center, radius);
+
+                testWithAndWithoutPlaneMask(cullingVolume, sphere12, Intersect.OUTSIDE);
+            });
+
+            it('past the bottom plane', function() {
+                var offset = new Cartesian3(0.0, -boundingSphereCullingVolume.radius * 2.0, 0.0);
+                var center = Cartesian3.add(boundingSphereCullingVolume.center, offset, new Cartesian3());
+                var radius = boundingSphereCullingVolume.radius * 0.5;
+                var sphere13 = new BoundingSphere(center, radius);
+
                 testWithAndWithoutPlaneMask(cullingVolume, sphere13, Intersect.OUTSIDE);
             });
         });


### PR DESCRIPTION
Construct culling volumes from bounding spheres to avoid creating intersection tests for bounding spheres with every other type of bounding volume. This will be used for culling primitives for point lights.

This method for intersection testing can be used for all bounding volumes to avoid adding many intersection tests and having to determine which intersection test to use. The downside is that it is potentially slow. For example, finding if a sphere intersects an OBB can be faster than testing the OBB against 6 planes. Also, the culling volume  planes aren't limited to 6, so we could use this for something like k-DOP intersections.