### PR TITLE
Be more aggressive about releasing Entity references in visualizers

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@ Change Log
 * Deprecated
   *
 * Improved KML NetworkLink compatibility by supporting the `Url` tag. [#3895](https://github.com/AnalyticalGraphicsInc/cesium/pull/3895).
+* Improve memory management for entity billboard/label/point/path visualization.
 * Fixed exaggerated terrain tiles disappearing. [#3676](https://github.com/AnalyticalGraphicsInc/cesium/issues/3676)
 * Fixed infinite horizontal 2D scrolling in IE/Edge. [#3893](https://github.com/AnalyticalGraphicsInc/cesium/issues/3893)
 * Fixed a bug that could cause incorrect normals to be computed for exaggerated terrain, especially for low-detail tiles. [#3904](https://github.com/AnalyticalGraphicsInc/cesium/pull/3904)

--- a/Source/DataSources/BillboardVisualizer.js
+++ b/Source/DataSources/BillboardVisualizer.js
@@ -258,6 +258,7 @@ define([
             if (defined(billboard)) {
                 item.textureValue = undefined;
                 item.billboard = undefined;
+                billboard.id = undefined;
                 billboard.show = false;
                 billboard.image = undefined;
                 unusedIndexes.push(billboard._index);

--- a/Source/DataSources/LabelVisualizer.js
+++ b/Source/DataSources/LabelVisualizer.js
@@ -250,6 +250,7 @@ define([
             var label = item.label;
             if (defined(label)) {
                 unusedIndexes.push(item.index);
+                label.id = undefined;
                 label.show = false;
                 item.label = undefined;
                 item.index = -1;

--- a/Source/DataSources/PathVisualizer.js
+++ b/Source/DataSources/PathVisualizer.js
@@ -376,6 +376,7 @@ define([
             this._unusedIndexes.push(item.index);
             item.polyline = undefined;
             polyline.show = false;
+            polyline.id = undefined;
             item.index = undefined;
         }
     };

--- a/Source/DataSources/PointVisualizer.js
+++ b/Source/DataSources/PointVisualizer.js
@@ -221,6 +221,7 @@ define([
             var pointPrimitive = item.pointPrimitive;
             if (defined(pointPrimitive)) {
                 item.pointPrimitive = undefined;
+                pointPrimitive.id = undefined;
                 pointPrimitive.show = false;
                 unusedIndexes.push(pointPrimitive._index);
             }

--- a/Specs/DataSources/BillboardVisualizerSpec.js
+++ b/Specs/DataSources/BillboardVisualizerSpec.js
@@ -242,6 +242,7 @@ defineSuite([
             //internal cache used by the visualizer, instead it just hides it.
             entityCollection.removeAll();
             expect(bb.show).toEqual(false);
+            expect(bb.id).toBeUndefined();
         });
     });
 

--- a/Specs/DataSources/LabelVisualizerSpec.js
+++ b/Specs/DataSources/LabelVisualizerSpec.js
@@ -259,6 +259,7 @@ defineSuite([
         entityCollection.removeAll();
         visualizer.update(time);
         expect(l.show).toEqual(false);
+        expect(l.id).toBeUndefined();
     });
 
     it('Visualizer sets entity property.', function() {

--- a/Specs/DataSources/PathVisualizerSpec.js
+++ b/Specs/DataSources/PathVisualizerSpec.js
@@ -368,6 +368,7 @@ defineSuite([
         //internal cache used by the visualizer, instead it just hides it.
         entityCollection.removeAll();
         expect(primitive.show).toEqual(false);
+        expect(primitive.id).toBeUndefined();
     });
 
     it('Visualizer sets entity property.', function() {

--- a/Specs/DataSources/PointVisualizerSpec.js
+++ b/Specs/DataSources/PointVisualizerSpec.js
@@ -202,6 +202,7 @@ defineSuite([
         //internal cache used by the visualizer, instead it just hides it.
         entityCollection.removeAll();
         expect(bb.show).toEqual(false);
+        expect(bb.id).toBeUndefined();
     });
 
     it('Visualizer sets entity property.', function() {


### PR DESCRIPTION
Cached billboard/label/point/path primitives would still point to removed entity references, which in some cases prevents the browser form GCing them.

Fixes #3916

@tfili Please review/merge.