### PR TITLE
Shadows for Primitive entities

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,9 +2,13 @@ Change Log
 ==========
 
 ### Shadows TODO
-* Added `castShadows` and `receiveShadows` properties to `Primitive`, and options to the `Primitive` constructor.
-* Added `castShadows` and `receiveShadows` properties to `Model`, and options to the `Model` constructor and `Model.fromGltf`.
-* Added `castShadows` and `receiveShadows` properties to `Globe`.
+* Added shadows
+    * Added `ShadowMap` class which supports cascaded shadow maps, directional lights, point lights, and spot lights.
+    * Added `Viewer.shadows` and `Viewer.terrainShadows`. Shadows are disabled by default.
+    * Added `castShadows` and `receiveShadows` properties to the entity API for models, boxes, corridors, cylinders, ellipses, ellipsoids, polygons, polylines, polyline volumes, rectangles, and walls.
+    * Added `castShadows` and `receiveShadows` properties to `Primitive`, and options to the `Primitive` constructor.
+    * Added `castShadows` and `receiveShadows` properties to `Model`, and options to the `Model` constructor and `Model.fromGltf`.
+    * Added `castShadows` and `receiveShadows` properties to `Globe`.
 * Added `Matrix4.computeView`.
 
 ### 1.22 - 2016-06-01

--- a/Source/DataSources/BoxGeometryUpdater.js
+++ b/Source/DataSources/BoxGeometryUpdater.js
@@ -50,6 +50,8 @@ define([
     var defaultFill = new ConstantProperty(true);
     var defaultOutline = new ConstantProperty(false);
     var defaultOutlineColor = new ConstantProperty(Color.BLACK);
+    var defaultCastShadows = new ConstantProperty(false);
+    var defaultReceiveShadows = new ConstantProperty(false);
     var scratchColor = new Color();
 
     function GeometryOptions(entity) {
@@ -90,6 +92,8 @@ define([
         this._showOutlineProperty = undefined;
         this._outlineColorProperty = undefined;
         this._outlineWidth = 1.0;
+        this._castShadowsProperty = undefined;
+        this._receiveShadowsProperty = undefined;
         this._options = new GeometryOptions(entity);
         this._onEntityPropertyChanged(entity, 'box', entity.box, undefined);
     }
@@ -215,6 +219,32 @@ define([
         outlineWidth : {
             get : function() {
                 return this._outlineWidth;
+            }
+        },
+        /**
+         * Gets the boolean property specifying whether the geometry
+         * casts shadows from each light source.
+         * @memberof BoxGeometryUpdater.prototype
+         * 
+         * @type {Property}
+         * @readonly
+         */
+        castShadowsProperty : {
+            get : function() {
+                return this._castShadowsProperty;
+            }
+        },
+        /**
+         * Gets the boolean Property specifying whether the geometry
+         * receives shadows from shadow casters in the scene.
+         * @memberof BoxGeometryUpdater.prototype
+         * 
+         * @type {Property}
+         * @readonly
+         */
+        receiveShadowsProperty : {
+            get : function() {
+                return this._receiveShadowsProperty;
             }
         },
         /**
@@ -436,6 +466,8 @@ define([
         this._showProperty = defaultValue(show, defaultShow);
         this._showOutlineProperty = defaultValue(box.outline, defaultOutline);
         this._outlineColorProperty = outlineEnabled ? defaultValue(box.outlineColor, defaultOutlineColor) : undefined;
+        this._castShadowsProperty = defaultValue(box.castShadows, defaultCastShadows);
+        this._receiveShadowsProperty = defaultValue(box.receiveShadows, defaultReceiveShadows);
 
         var outlineWidth = box.outlineWidth;
 
@@ -521,6 +553,9 @@ define([
 
         options.dimensions = dimensions;
 
+        var castShadows = this._geometryUpdater.castShadowsProperty.getValue(time);
+        var receiveShadows = this._geometryUpdater.receiveShadowsProperty.getValue(time);
+
         if (Property.getValueOrDefault(box.fill, time, true)) {
             var material = MaterialProperty.getValue(time, geometryUpdater.fillMaterialProperty, this._material);
             this._material = material;
@@ -539,7 +574,9 @@ define([
                     modelMatrix : modelMatrix
                 }),
                 appearance : appearance,
-                asynchronous : false
+                asynchronous : false,
+                castShadows : castShadows,
+                receiveShadows : receiveShadows
             }));
         }
 
@@ -566,7 +603,9 @@ define([
                         lineWidth : geometryUpdater._scene.clampLineWidth(outlineWidth)
                     }
                 }),
-                asynchronous : false
+                asynchronous : false,
+                castShadows : castShadows,
+                receiveShadows : receiveShadows
             }));
         }
     };

--- a/Source/DataSources/BoxGraphics.js
+++ b/Source/DataSources/BoxGraphics.js
@@ -31,6 +31,8 @@ define([
      * @param {Property} [options.outline=false] A boolean Property specifying whether the box is outlined.
      * @param {Property} [options.outlineColor=Color.BLACK] A Property specifying the {@link Color} of the outline.
      * @param {Property} [options.outlineWidth=1.0] A numeric Property specifying the width of the outline.
+     * @param {Property} [options.castShadows=false] A boolean Property specifying whether the box casts shadows from each light source.
+     * @param {Property} [options.receiveShadows=false] A boolean Property specifying whether the box receives shadows from shadow casters in the scene.
      *
      * @demo {@link http://cesiumjs.org/Cesium/Apps/Sandcastle/index.html?src=Box.html|Cesium Sandcastle Box Demo}
      */
@@ -49,6 +51,10 @@ define([
         this._outlineColorSubscription = undefined;
         this._outlineWidth = undefined;
         this._outlineWidthSubscription = undefined;
+        this._castShadows = undefined;
+        this._castShadowsSubscription = undefined;
+        this._receiveShadows = undefined;
+        this._receiveShadowsSubscription = undefined;
         this._definitionChanged = new Event();
 
         this.merge(defaultValue(options, defaultValue.EMPTY_OBJECT));
@@ -120,7 +126,25 @@ define([
          * @type {Property}
          * @default 1.0
          */
-        outlineWidth : createPropertyDescriptor('outlineWidth')
+        outlineWidth : createPropertyDescriptor('outlineWidth'),
+
+        /**
+         * Get or sets the boolean Property specifying whether the box
+         * casts shadows from each light source.
+         * @memberof BoxGraphics.prototype
+         * @type {Property}
+         * @default false
+         */
+        castShadows : createPropertyDescriptor('castShadows'),
+
+        /**
+         * Get or sets the boolean Property specifying whether the box
+         * receives shadows from shadow casters in the scene.
+         * @memberof BoxGraphics.prototype
+         * @type {Property}
+         * @default false
+         */
+        receiveShadows : createPropertyDescriptor('receiveShadows')
     });
 
     /**
@@ -140,6 +164,8 @@ define([
         result.outline = this.outline;
         result.outlineColor = this.outlineColor;
         result.outlineWidth = this.outlineWidth;
+        result.castShadows = this.castShadows;
+        result.receiveShadows = this.receiveShadows;
         return result;
     };
 
@@ -163,6 +189,8 @@ define([
         this.outline = defaultValue(this.outline, source.outline);
         this.outlineColor = defaultValue(this.outlineColor, source.outlineColor);
         this.outlineWidth = defaultValue(this.outlineWidth, source.outlineWidth);
+        this.castShadows = defaultValue(this.castShadows, source.castShadows);
+        this.receiveShadows = defaultValue(this.receiveShadows, source.receiveShadows);
     };
 
     return BoxGraphics;

--- a/Source/DataSources/CorridorGeometryUpdater.js
+++ b/Source/DataSources/CorridorGeometryUpdater.js
@@ -50,6 +50,8 @@ define([
     var defaultFill = new ConstantProperty(true);
     var defaultOutline = new ConstantProperty(false);
     var defaultOutlineColor = new ConstantProperty(Color.BLACK);
+    var defaultCastShadows = new ConstantProperty(false);
+    var defaultReceiveShadows = new ConstantProperty(false);
     var scratchColor = new Color();
 
     function GeometryOptions(entity) {
@@ -96,6 +98,8 @@ define([
         this._showOutlineProperty = undefined;
         this._outlineColorProperty = undefined;
         this._outlineWidth = 1.0;
+        this._castShadowsProperty = undefined;
+        this._receiveShadowsProperty = undefined;
         this._options = new GeometryOptions(entity);
         this._onEntityPropertyChanged(entity, 'corridor', entity.corridor, undefined);
     }
@@ -221,6 +225,32 @@ define([
         outlineWidth : {
             get : function() {
                 return this._outlineWidth;
+            }
+        },
+        /**
+         * Gets the boolean property specifying whether the geometry
+         * casts shadows from each light source.
+         * @memberof CorridorGeometryUpdater.prototype
+         * 
+         * @type {Property}
+         * @readonly
+         */
+        castShadowsProperty : {
+            get : function() {
+                return this._castShadowsProperty;
+            }
+        },
+        /**
+         * Gets the boolean Property specifying whether the geometry
+         * receives shadows from shadow casters in the scene.
+         * @memberof CorridorGeometryUpdater.prototype
+         * 
+         * @type {Property}
+         * @readonly
+         */
+        receiveShadowsProperty : {
+            get : function() {
+                return this._receiveShadowsProperty;
             }
         },
         /**
@@ -442,6 +472,8 @@ define([
         this._showProperty = defaultValue(show, defaultShow);
         this._showOutlineProperty = defaultValue(corridor.outline, defaultOutline);
         this._outlineColorProperty = outlineEnabled ? defaultValue(corridor.outlineColor, defaultOutlineColor) : undefined;
+        this._castShadowsProperty = defaultValue(corridor.castShadows, defaultCastShadows);
+        this._receiveShadowsProperty = defaultValue(corridor.receiveShadows, defaultReceiveShadows);
 
         var height = corridor.height;
         var extrudedHeight = corridor.extrudedHeight;
@@ -546,6 +578,9 @@ define([
         options.granularity = Property.getValueOrUndefined(corridor.granularity, time);
         options.cornerType = Property.getValueOrUndefined(corridor.cornerType, time);
 
+        var castShadows = this._geometryUpdater.castShadowsProperty.getValue(time);
+        var receiveShadows = this._geometryUpdater.receiveShadowsProperty.getValue(time);
+
         if (!defined(corridor.fill) || corridor.fill.getValue(time)) {
             var material = MaterialProperty.getValue(time, geometryUpdater.fillMaterialProperty, this._material);
             this._material = material;
@@ -563,7 +598,9 @@ define([
                     geometry : new CorridorGeometry(options)
                 }),
                 appearance : appearance,
-                asynchronous : false
+                asynchronous : false,
+                castShadows : castShadows,
+                receiveShadows : receiveShadows
             }));
         }
 
@@ -589,7 +626,9 @@ define([
                         lineWidth : geometryUpdater._scene.clampLineWidth(outlineWidth)
                     }
                 }),
-                asynchronous : false
+                asynchronous : false,
+                castShadows : castShadows,
+                receiveShadows : receiveShadows
             }));
         }
     };

--- a/Source/DataSources/CorridorGraphics.js
+++ b/Source/DataSources/CorridorGraphics.js
@@ -38,6 +38,8 @@ define([
      * @param {Property} [options.outlineColor=Color.BLACK] A Property specifying the {@link Color} of the outline.
      * @param {Property} [options.outlineWidth=1.0] A numeric Property specifying the width of the outline.
      * @param {Property} [options.granularity=Cesium.Math.RADIANS_PER_DEGREE] A numeric Property specifying the distance between each latitude and longitude.
+     * @param {Property} [options.castShadows=false] A boolean Property specifying whether the corridor casts shadows from each light source.
+     * @param {Property} [options.receiveShadows=false] A boolean Property specifying whether the corridor receives shadows from shadow casters in the scene.
      *
      * @see Entity
      * @demo {@link http://cesiumjs.org/Cesium/Apps/Sandcastle/index.html?src=Corridor.html|Cesium Sandcastle Corridor Demo}
@@ -67,6 +69,10 @@ define([
         this._outlineColorSubscription = undefined;
         this._outlineWidth = undefined;
         this._outlineWidthSubscription = undefined;
+        this._castShadows = undefined;
+        this._castShadowsSubscription = undefined;
+        this._receiveShadows = undefined;
+        this._receiveShadowsSubscription = undefined;
         this._definitionChanged = new Event();
 
         this.merge(defaultValue(options, defaultValue.EMPTY_OBJECT));
@@ -178,7 +184,25 @@ define([
          * @type {Property}
          * @default CornerType.ROUNDED
          */
-        cornerType : createPropertyDescriptor('cornerType')
+        cornerType : createPropertyDescriptor('cornerType'),
+        
+        /**
+         * Get or sets the boolean Property specifying whether the corridor
+         * casts shadows from each light source.
+         * @memberof CorridorGraphics.prototype
+         * @type {Property}
+         * @default false
+         */
+        castShadows : createPropertyDescriptor('castShadows'),
+
+        /**
+         * Get or sets the boolean Property specifying whether the corridor
+         * receives shadows from shadow casters in the scene.
+         * @memberof CorridorGraphics.prototype
+         * @type {Property}
+         * @default false
+         */
+        receiveShadows : createPropertyDescriptor('receiveShadows')
     });
 
     /**
@@ -203,6 +227,8 @@ define([
         result.outlineColor = this.outlineColor;
         result.outlineWidth = this.outlineWidth;
         result.cornerType = this.cornerType;
+        result.castShadows = this.castShadows;
+        result.receiveShadows = this.receiveShadows;
         return result;
     };
 
@@ -231,6 +257,8 @@ define([
         this.outlineColor = defaultValue(this.outlineColor, source.outlineColor);
         this.outlineWidth = defaultValue(this.outlineWidth, source.outlineWidth);
         this.cornerType = defaultValue(this.cornerType, source.cornerType);
+        this.castShadows = defaultValue(this.castShadows, source.castShadows);
+        this.receiveShadows = defaultValue(this.receiveShadows, source.receiveShadows);
     };
 
     return CorridorGraphics;

--- a/Source/DataSources/CylinderGeometryUpdater.js
+++ b/Source/DataSources/CylinderGeometryUpdater.js
@@ -52,6 +52,8 @@ define([
     var defaultFill = new ConstantProperty(true);
     var defaultOutline = new ConstantProperty(false);
     var defaultOutlineColor = new ConstantProperty(Color.BLACK);
+    var defaultCastShadows = new ConstantProperty(false);
+    var defaultReceiveShadows = new ConstantProperty(false);
 
     var scratchColor = new Color();
 
@@ -97,6 +99,8 @@ define([
         this._showOutlineProperty = undefined;
         this._outlineColorProperty = undefined;
         this._outlineWidth = 1.0;
+        this._castShadowsProperty = undefined;
+        this._receiveShadowsProperty = undefined;
         this._options = new GeometryOptions(entity);
         this._onEntityPropertyChanged(entity, 'cylinder', entity.cylinder, undefined);
     }
@@ -222,6 +226,32 @@ define([
         outlineWidth : {
             get : function() {
                 return this._outlineWidth;
+            }
+        },
+        /**
+         * Gets the boolean property specifying whether the geometry
+         * casts shadows from each light source.
+         * @memberof CylinderGeometryUpdater.prototype
+         * 
+         * @type {Property}
+         * @readonly
+         */
+        castShadowsProperty : {
+            get : function() {
+                return this._castShadowsProperty;
+            }
+        },
+        /**
+         * Gets the boolean Property specifying whether the geometry
+         * receives shadows from shadow casters in the scene.
+         * @memberof CylinderGeometryUpdater.prototype
+         * 
+         * @type {Property}
+         * @readonly
+         */
+        receiveShadowsProperty : {
+            get : function() {
+                return this._receiveShadowsProperty;
             }
         },
         /**
@@ -446,6 +476,8 @@ define([
         this._showProperty = defaultValue(show, defaultShow);
         this._showOutlineProperty = defaultValue(cylinder.outline, defaultOutline);
         this._outlineColorProperty = outlineEnabled ? defaultValue(cylinder.outlineColor, defaultOutlineColor) : undefined;
+        this._castShadowsProperty = defaultValue(cylinder.castShadows, defaultCastShadows);
+        this._receiveShadowsProperty = defaultValue(cylinder.receiveShadows, defaultReceiveShadows);
 
         var slices = cylinder.slices;
         var outlineWidth = cylinder.outlineWidth;
@@ -547,6 +579,9 @@ define([
         options.slices = Property.getValueOrUndefined(cylinder.slices, time);
         options.numberOfVerticalLines = Property.getValueOrUndefined(cylinder.numberOfVerticalLines, time);
 
+        var castShadows = this._geometryUpdater.castShadowsProperty.getValue(time);
+        var receiveShadows = this._geometryUpdater.receiveShadowsProperty.getValue(time);
+        
         if (Property.getValueOrDefault(cylinder.fill, time, true)) {
             var material = MaterialProperty.getValue(time, geometryUpdater.fillMaterialProperty, this._material);
             this._material = material;
@@ -565,7 +600,9 @@ define([
                     modelMatrix : modelMatrix
                 }),
                 appearance : appearance,
-                asynchronous : false
+                asynchronous : false,
+                castShadows : castShadows,
+                receiveShadows : receiveShadows
             }));
         }
 
@@ -592,7 +629,9 @@ define([
                         lineWidth : geometryUpdater._scene.clampLineWidth(outlineWidth)
                     }
                 }),
-                asynchronous : false
+                asynchronous : false,
+                castShadows : castShadows,
+                receiveShadows : receiveShadows
             }));
         }
     };

--- a/Source/DataSources/CylinderGraphics.js
+++ b/Source/DataSources/CylinderGraphics.js
@@ -36,6 +36,8 @@ define([
      * @param {Property} [options.outlineWidth=1.0] A numeric Property specifying the width of the outline.
      * @param {Property} [options.numberOfVerticalLines=16] A numeric Property specifying the number of vertical lines to draw along the perimeter for the outline.
      * @param {Property} [options.slices=128] The number of edges around perimeter of the cylinder.
+     * @param {Property} [options.castShadows=false] A boolean Property specifying whether the cylinder casts shadows from each light source.
+     * @param {Property} [options.receiveShadows=false] A boolean Property specifying whether the cylinder receives shadows from shadow casters in the scene.
      *
      */
     function CylinderGraphics(options) {
@@ -61,6 +63,10 @@ define([
         this._outlineColorSubscription = undefined;
         this._outlineWidth = undefined;
         this._outlineWidthSubscription = undefined;
+        this._castShadows = undefined;
+        this._castShadowsSubscription = undefined;
+        this._receiveShadows = undefined;
+        this._receiveShadowsSubscription = undefined;
         this._definitionChanged = new Event();
 
         this.merge(defaultValue(options, defaultValue.EMPTY_OBJECT));
@@ -165,7 +171,25 @@ define([
          * @type {Property}
          * @default 1.0
          */
-        outlineWidth : createPropertyDescriptor('outlineWidth')
+        outlineWidth : createPropertyDescriptor('outlineWidth'),
+
+        /**
+         * Get or sets the boolean Property specifying whether the cylinder
+         * casts shadows from each light source.
+         * @memberof CylinderGraphics.prototype
+         * @type {Property}
+         * @default false
+         */
+        castShadows : createPropertyDescriptor('castShadows'),
+
+        /**
+         * Get or sets the boolean Property specifying whether the cylinder
+         * receives shadows from shadow casters in the scene.
+         * @memberof CylinderGraphics.prototype
+         * @type {Property}
+         * @default false
+         */
+        receiveShadows : createPropertyDescriptor('receiveShadows')
     });
 
     /**
@@ -189,6 +213,8 @@ define([
         result.outline = this.outline;
         result.outlineColor = this.outlineColor;
         result.outlineWidth = this.outlineWidth;
+        result.castShadows = this.castShadows;
+        result.receiveShadows = this.receiveShadows;
         return result;
     };
 
@@ -216,6 +242,8 @@ define([
         this.outline = defaultValue(this.outline, source.outline);
         this.outlineColor = defaultValue(this.outlineColor, source.outlineColor);
         this.outlineWidth = defaultValue(this.outlineWidth, source.outlineWidth);
+        this.castShadows = defaultValue(this.castShadows, source.castShadows);
+        this.receiveShadows = defaultValue(this.receiveShadows, source.receiveShadows);
     };
 
     return CylinderGraphics;

--- a/Source/DataSources/CzmlDataSource.js
+++ b/Source/DataSources/CzmlDataSource.js
@@ -1102,6 +1102,8 @@ define([
         processPacketData(Color, ellipse, 'outlineColor', ellipseData.outlineColor, interval, sourceUri, entityCollection);
         processPacketData(Number, ellipse, 'outlineWidth', ellipseData.outlineWidth, interval, sourceUri, entityCollection);
         processPacketData(Number, ellipse, 'numberOfVerticalLines', ellipseData.numberOfVerticalLines, interval, sourceUri, entityCollection);
+        processPacketData(Boolean, ellipse, 'castShadows', ellipseData.castShadows, interval, sourceUri, entityCollection);
+        processPacketData(Boolean, ellipse, 'receiveShadows', ellipseData.receiveShadows, interval, sourceUri, entityCollection);
     }
 
     function processEllipsoid(entity, packet, entityCollection, sourceUri) {
@@ -1129,6 +1131,8 @@ define([
         processPacketData(Boolean, ellipsoid, 'outline', ellipsoidData.outline, interval, sourceUri, entityCollection);
         processPacketData(Color, ellipsoid, 'outlineColor', ellipsoidData.outlineColor, interval, sourceUri, entityCollection);
         processPacketData(Number, ellipsoid, 'outlineWidth', ellipsoidData.outlineWidth, interval, sourceUri, entityCollection);
+        processPacketData(Boolean, ellipsoid, 'castShadows', ellipsoidData.castShadows, interval, sourceUri, entityCollection);
+        processPacketData(Boolean, ellipsoid, 'receiveShadows', ellipsoidData.receiveShadows, interval, sourceUri, entityCollection);
     }
 
     function processLabel(entity, packet, entityCollection, sourceUri) {
@@ -1331,6 +1335,8 @@ define([
         processPacketData(Boolean, polygon, 'perPositionHeight', polygonData.perPositionHeight, interval, sourceUri, entityCollection);
         processPacketData(Boolean, polygon, 'closeTop', polygonData.closeTop, interval, sourceUri, entityCollection);
         processPacketData(Boolean, polygon, 'closeBottom', polygonData.closeBottom, interval, sourceUri, entityCollection);
+        processPacketData(Boolean, polygon, 'castShadows', polygonData.castShadows, interval, sourceUri, entityCollection);
+        processPacketData(Boolean, polygon, 'receiveShadows', polygonData.receiveShadows, interval, sourceUri, entityCollection);
         processPositions(polygon, 'hierarchy', polygonData.positions, entityCollection);
     }
 
@@ -1366,6 +1372,8 @@ define([
         processPacketData(Number, rectangle, 'outlineWidth', rectangleData.outlineWidth, interval, sourceUri, entityCollection);
         processPacketData(Boolean, rectangle, 'closeBottom', rectangleData.closeBottom, interval, sourceUri, entityCollection);
         processPacketData(Boolean, rectangle, 'closeTop', rectangleData.closeTop, interval, sourceUri, entityCollection);
+        processPacketData(Boolean, rectangle, 'castShadows', rectangleData.castShadows, interval, sourceUri, entityCollection);
+        processPacketData(Boolean, rectangle, 'receiveShadows', rectangleData.receiveShadows, interval, sourceUri, entityCollection);
     }
 
     function processWall(entity, packet, entityCollection, sourceUri) {
@@ -1395,6 +1403,8 @@ define([
         processPacketData(Boolean, wall, 'outline', wallData.outline, interval, sourceUri, entityCollection);
         processPacketData(Color, wall, 'outlineColor', wallData.outlineColor, interval, sourceUri, entityCollection);
         processPacketData(Number, wall, 'outlineWidth', wallData.outlineWidth, interval, sourceUri, entityCollection);
+        processPacketData(Boolean, wall, 'castShadows', wallData.castShadows, interval, sourceUri, entityCollection);
+        processPacketData(Boolean, wall, 'receiveShadows', wallData.receiveShadows, interval, sourceUri, entityCollection);
         processPositions(wall, 'positions', wallData.positions, entityCollection);
     }
 
@@ -1421,6 +1431,8 @@ define([
         processMaterialPacketData(polyline, 'material', polylineData.material, interval, sourceUri, entityCollection);
         processPacketData(Boolean, polyline, 'followSurface', polylineData.followSurface, interval, sourceUri, entityCollection);
         processPacketData(Number, polyline, 'granularity', polylineData.granularity, interval, sourceUri, entityCollection);
+        processPacketData(Boolean, polyline, 'castShadows', polylineData.castShadows, interval, sourceUri, entityCollection);
+        processPacketData(Boolean, polyline, 'receiveShadows', polylineData.receiveShadows, interval, sourceUri, entityCollection);
         processPositions(polyline, 'positions', polylineData.positions, entityCollection);
     }
 

--- a/Source/DataSources/EllipseGeometryUpdater.js
+++ b/Source/DataSources/EllipseGeometryUpdater.js
@@ -50,6 +50,8 @@ define([
     var defaultFill = new ConstantProperty(true);
     var defaultOutline = new ConstantProperty(false);
     var defaultOutlineColor = new ConstantProperty(Color.BLACK);
+    var defaultCastShadows = new ConstantProperty(false);
+    var defaultReceiveShadows = new ConstantProperty(false);
     var scratchColor = new Color();
 
     function GeometryOptions(entity) {
@@ -99,6 +101,8 @@ define([
         this._showOutlineProperty = undefined;
         this._outlineColorProperty = undefined;
         this._outlineWidth = 1.0;
+        this._castShadowsProperty = undefined;
+        this._receiveShadowsProperty = undefined;
         this._options = new GeometryOptions(entity);
         this._onEntityPropertyChanged(entity, 'ellipse', entity.ellipse, undefined);
     }
@@ -224,6 +228,32 @@ define([
         outlineWidth : {
             get : function() {
                 return this._outlineWidth;
+            }
+        },
+        /**
+         * Gets the boolean property specifying whether the geometry
+         * casts shadows from each light source.
+         * @memberof EllipseGeometryUpdater.prototype
+         * 
+         * @type {Property}
+         * @readonly
+         */
+        castShadowsProperty : {
+            get : function() {
+                return this._castShadowsProperty;
+            }
+        },
+        /**
+         * Gets the boolean Property specifying whether the geometry
+         * receives shadows from shadow casters in the scene.
+         * @memberof EllipseGeometryUpdater.prototype
+         * 
+         * @type {Property}
+         * @readonly
+         */
+        receiveShadowsProperty : {
+            get : function() {
+                return this._receiveShadowsProperty;
             }
         },
         /**
@@ -447,6 +477,8 @@ define([
         this._showProperty = defaultValue(show, defaultShow);
         this._showOutlineProperty = defaultValue(ellipse.outline, defaultOutline);
         this._outlineColorProperty = outlineEnabled ? defaultValue(ellipse.outlineColor, defaultOutlineColor) : undefined;
+        this._castShadowsProperty = defaultValue(ellipse.castShadows, defaultCastShadows);
+        this._receiveShadowsProperty = defaultValue(ellipse.receiveShadows, defaultReceiveShadows);
 
         var rotation = ellipse.rotation;
         var height = ellipse.height;
@@ -562,6 +594,9 @@ define([
         options.stRotation = Property.getValueOrUndefined(ellipse.stRotation, time);
         options.numberOfVerticalLines = Property.getValueOrUndefined(ellipse.numberOfVerticalLines, time);
 
+        var castShadows = this._geometryUpdater.castShadowsProperty.getValue(time);
+        var receiveShadows = this._geometryUpdater.receiveShadowsProperty.getValue(time);
+
         if (Property.getValueOrDefault(ellipse.fill, time, true)) {
             var material = MaterialProperty.getValue(time, geometryUpdater.fillMaterialProperty, this._material);
             this._material = material;
@@ -579,7 +614,9 @@ define([
                     geometry : new EllipseGeometry(options)
                 }),
                 appearance : appearance,
-                asynchronous : false
+                asynchronous : false,
+                castShadows : castShadows,
+                receiveShadows : receiveShadows
             }));
         }
 
@@ -605,7 +642,9 @@ define([
                         lineWidth : geometryUpdater._scene.clampLineWidth(outlineWidth)
                     }
                 }),
-                asynchronous : false
+                asynchronous : false,
+                castShadows : castShadows,
+                receiveShadows : receiveShadows
             }));
         }
     };

--- a/Source/DataSources/EllipseGraphics.js
+++ b/Source/DataSources/EllipseGraphics.js
@@ -41,6 +41,8 @@ define([
      * @param {Property} [options.rotation=0.0] A numeric property specifying the rotation of the ellipse counter-clockwise from north.
      * @param {Property} [options.stRotation=0.0] A numeric property specifying the rotation of the ellipse texture counter-clockwise from north.
      * @param {Property} [options.granularity=Cesium.Math.RADIANS_PER_DEGREE] A numeric Property specifying the angular distance between points on the ellipse.
+     * @param {Property} [options.castShadows=false] A boolean Property specifying whether the ellipse casts shadows from each light source.
+     * @param {Property} [options.receiveShadows=false] A boolean Property specifying whether the ellipse receives shadows from shadow casters in the scene.
      *
      * @demo {@link http://cesiumjs.org/Cesium/Apps/Sandcastle/index.html?src=Circles and Ellipses.html|Cesium Sandcastle Circles and Ellipses Demo}
      */
@@ -73,6 +75,10 @@ define([
         this._outlineWidthSubscription = undefined;
         this._numberOfVerticalLines = undefined;
         this._numberOfVerticalLinesSubscription = undefined;
+        this._castShadows = undefined;
+        this._castShadowsSubscription = undefined;
+        this._receiveShadows = undefined;
+        this._receiveShadowsSubscription = undefined;
         this._definitionChanged = new Event();
 
         this.merge(defaultValue(options, defaultValue.EMPTY_OBJECT));
@@ -200,7 +206,25 @@ define([
          * @type {Property}
          * @default 16
          */
-        numberOfVerticalLines : createPropertyDescriptor('numberOfVerticalLines')
+        numberOfVerticalLines : createPropertyDescriptor('numberOfVerticalLines'),
+        
+        /**
+         * Get or sets the boolean Property specifying whether the ellipse
+         * casts shadows from each light source.
+         * @memberof EllipseGraphics.prototype
+         * @type {Property}
+         * @default false
+         */
+        castShadows : createPropertyDescriptor('castShadows'),
+
+        /**
+         * Get or sets the boolean Property specifying whether the ellipse
+         * receives shadows from shadow casters in the scene.
+         * @memberof EllipseGraphics.prototype
+         * @type {Property}
+         * @default false
+         */
+        receiveShadows : createPropertyDescriptor('receiveShadows')
     });
 
     /**
@@ -227,6 +251,8 @@ define([
         result.outlineColor = this.outlineColor;
         result.outlineWidth = this.outlineWidth;
         result.numberOfVerticalLines = this.numberOfVerticalLines;
+        result.castShadows = this.castShadows;
+        result.receiveShadows = this.receiveShadows;
         return result;
     };
 
@@ -257,6 +283,8 @@ define([
         this.outlineColor = defaultValue(this.outlineColor, source.outlineColor);
         this.outlineWidth = defaultValue(this.outlineWidth, source.outlineWidth);
         this.numberOfVerticalLines = defaultValue(this.numberOfVerticalLines, source.numberOfVerticalLines);
+        this.castShadows = defaultValue(this.castShadows, source.castShadows);
+        this.receiveShadows = defaultValue(this.receiveShadows, source.receiveShadows);
     };
 
     return EllipseGraphics;

--- a/Source/DataSources/EllipsoidGeometryUpdater.js
+++ b/Source/DataSources/EllipsoidGeometryUpdater.js
@@ -56,6 +56,8 @@ define([
     var defaultFill = new ConstantProperty(true);
     var defaultOutline = new ConstantProperty(false);
     var defaultOutlineColor = new ConstantProperty(Color.BLACK);
+    var defaultCastShadows = new ConstantProperty(false);
+    var defaultReceiveShadows = new ConstantProperty(false);
 
     var radiiScratch = new Cartesian3();
     var scratchColor = new Color();
@@ -102,6 +104,8 @@ define([
         this._showOutlineProperty = undefined;
         this._outlineColorProperty = undefined;
         this._outlineWidth = 1.0;
+        this._castShadowsProperty = undefined;
+        this._receiveShadowsProperty = undefined;
         this._options = new GeometryOptions(entity);
         this._onEntityPropertyChanged(entity, 'ellipsoid', entity.ellipsoid, undefined);
     }
@@ -227,6 +231,32 @@ define([
         outlineWidth : {
             get : function() {
                 return this._outlineWidth;
+            }
+        },
+        /**
+         * Gets the boolean property specifying whether the geometry
+         * casts shadows from each light source.
+         * @memberof EllipsoidGeometryUpdater.prototype
+         * 
+         * @type {Property}
+         * @readonly
+         */
+        castShadowsProperty : {
+            get : function() {
+                return this._castShadowsProperty;
+            }
+        },
+        /**
+         * Gets the boolean Property specifying whether the geometry
+         * receives shadows from shadow casters in the scene.
+         * @memberof EllipsoidGeometryUpdater.prototype
+         * 
+         * @type {Property}
+         * @readonly
+         */
+        receiveShadowsProperty : {
+            get : function() {
+                return this._receiveShadowsProperty;
             }
         },
         /**
@@ -450,6 +480,9 @@ define([
         this._showProperty = defaultValue(show, defaultShow);
         this._showOutlineProperty = defaultValue(ellipsoid.outline, defaultOutline);
         this._outlineColorProperty = outlineEnabled ? defaultValue(ellipsoid.outlineColor, defaultOutlineColor) : undefined;
+        this._castShadowsProperty = defaultValue(ellipsoid.castShadows, defaultCastShadows);
+        this._receiveShadowsProperty = defaultValue(ellipsoid.receiveShadows, defaultReceiveShadows);
+        
         this._fillEnabled = fillEnabled;
         this._outlineEnabled = outlineEnabled;
 
@@ -577,6 +610,10 @@ define([
         var in3D = sceneMode === SceneMode.SCENE3D;
 
         var options = this._options;
+        
+        var castShadows = this._geometryUpdater.castShadows;
+        var receiveShadows = this._geometryUpdater.receiveShadows;
+        
         //We only rebuild the primitive if something other than the radii has changed
         //For the radii, we use unit sphere and then deform it with a scale matrix.
         var rebuildPrimitives = !in3D || this._lastSceneMode !== sceneMode || !defined(this._primitive) || //
@@ -614,7 +651,9 @@ define([
                     }
                 }),
                 appearance : appearance,
-                asynchronous : false
+                asynchronous : false,
+                castShadows : castShadows,
+                receiveShadows : receiveShadows
             }));
 
             options.vertexFormat = PerInstanceColorAppearance.VERTEX_FORMAT;
@@ -636,7 +675,9 @@ define([
                         lineWidth : this._geometryUpdater._scene.clampLineWidth(outlineWidth)
                     }
                 }),
-                asynchronous : false
+                asynchronous : false,
+                castShadows : castShadows,
+                receiveShadows : receiveShadows
             }));
 
             this._lastShow = showFill;

--- a/Source/DataSources/EllipsoidGraphics.js
+++ b/Source/DataSources/EllipsoidGraphics.js
@@ -34,6 +34,8 @@ define([
      * @param {Property} [options.subdivisions=128] A Property specifying the number of samples per outline ring, determining the granularity of the curvature.
      * @param {Property} [options.stackPartitions=64] A Property specifying the number of stacks.
      * @param {Property} [options.slicePartitions=64] A Property specifying the number of radial slices.
+     * @param {Property} [options.castShadows=false] A boolean Property specifying whether the ellipsoid casts shadows from each light source.
+     * @param {Property} [options.receiveShadows=false] A boolean Property specifying whether the ellipsoid receives shadows from shadow casters in the scene.
      *
      * @demo {@link http://cesiumjs.org/Cesium/Apps/Sandcastle/index.html?src=Spheres%20and%20Ellipsoids.html|Cesium Sandcastle Spheres and Ellipsoids Demo}
      */
@@ -58,6 +60,10 @@ define([
         this._outlineColorSubscription = undefined;
         this._outlineWidth = undefined;
         this._outlineWidthSubscription = undefined;
+        this._castShadows = undefined;
+        this._castShadowsSubscription = undefined;
+        this._receiveShadows = undefined;
+        this._receiveShadowsSubscription = undefined;
         this._definitionChanged = new Event();
 
         this.merge(defaultValue(options, defaultValue.EMPTY_OBJECT));
@@ -154,7 +160,25 @@ define([
          * @type {Property}
          * @default 128
          */
-        subdivisions : createPropertyDescriptor('subdivisions')
+        subdivisions : createPropertyDescriptor('subdivisions'),
+
+        /**
+         * Get or sets the boolean Property specifying whether the ellipsoid
+         * casts shadows from each light source.
+         * @memberof EllipsoidGraphics.prototype
+         * @type {Property}
+         * @default false
+         */
+        castShadows : createPropertyDescriptor('castShadows'),
+
+        /**
+         * Get or sets the boolean Property specifying whether the ellipsoid
+         * receives shadows from shadow casters in the scene.
+         * @memberof EllipsoidGraphics.prototype
+         * @type {Property}
+         * @default false
+         */
+        receiveShadows : createPropertyDescriptor('receiveShadows')
     });
 
     /**
@@ -177,6 +201,8 @@ define([
         result.stackPartitions = this.stackPartitions;
         result.slicePartitions = this.slicePartitions;
         result.subdivisions = this.subdivisions;
+        result.castShadows = this.castShadows;
+        result.receiveShadows = this.receiveShadows;
 
         return result;
     };
@@ -204,6 +230,8 @@ define([
         this.stackPartitions = defaultValue(this.stackPartitions, source.stackPartitions);
         this.slicePartitions = defaultValue(this.slicePartitions, source.slicePartitions);
         this.subdivisions = defaultValue(this.subdivisions, source.subdivisions);
+        this.castShadows = defaultValue(this.castShadows, source.castShadows);
+        this.receiveShadows = defaultValue(this.receiveShadows, source.receiveShadows);
     };
 
     return EllipsoidGraphics;

--- a/Source/DataSources/ModelGraphics.js
+++ b/Source/DataSources/ModelGraphics.js
@@ -45,8 +45,8 @@ define([
      * @param {Property} [options.minimumPixelSize=0.0] A numeric Property specifying the approximate minimum pixel size of the model regardless of zoom.
      * @param {Property} [options.maximumScale] The maximum scale size of a model. An upper limit for minimumPixelSize.
      * @param {Property} [options.incrementallyLoadTextures=true] Determine if textures may continue to stream in after the model is loaded.
-     * @param {Property} [options.castShadows=true] A boolean Property specifying whether the model casts shadows from each light source.
-     * @param {Property} [options.receiveShadows=true] A boolean Property specifying whether the model receives shadows from shadow casters in the scene.
+     * @param {Property} [options.castShadows=false] A boolean Property specifying whether the model casts shadows from each light source.
+     * @param {Property} [options.receiveShadows=false] A boolean Property specifying whether the model receives shadows from shadow casters in the scene.
      * @param {Property} [options.runAnimations=true] A boolean Property specifying if glTF animations specified in the model should be started.
      * @param {Property} [options.nodeTransformations] An object, where keys are names of nodes, and values are {@link TranslationRotationScale} Properties describing the transformation to apply to that node.
      *
@@ -143,6 +143,7 @@ define([
          * casts shadows from each light source.
          * @memberof ModelGraphics.prototype
          * @type {Property}
+         * @default false
          */
         castShadows : createPropertyDescriptor('castShadows'),
 
@@ -151,6 +152,7 @@ define([
          * receives shadows from shadow casters in the scene.
          * @memberof ModelGraphics.prototype
          * @type {Property}
+         * @default false
          */
         receiveShadows : createPropertyDescriptor('receiveShadows'),
 

--- a/Source/DataSources/ModelGraphics.js
+++ b/Source/DataSources/ModelGraphics.js
@@ -45,8 +45,8 @@ define([
      * @param {Property} [options.minimumPixelSize=0.0] A numeric Property specifying the approximate minimum pixel size of the model regardless of zoom.
      * @param {Property} [options.maximumScale] The maximum scale size of a model. An upper limit for minimumPixelSize.
      * @param {Property} [options.incrementallyLoadTextures=true] Determine if textures may continue to stream in after the model is loaded.
-     * @param {Property} [options.castShadows=false] A boolean Property specifying whether the model casts shadows from each light source.
-     * @param {Property} [options.receiveShadows=false] A boolean Property specifying whether the model receives shadows from shadow casters in the scene.
+     * @param {Property} [options.castShadows=true] A boolean Property specifying whether the model casts shadows from each light source.
+     * @param {Property} [options.receiveShadows=true] A boolean Property specifying whether the model receives shadows from shadow casters in the scene.
      * @param {Property} [options.runAnimations=true] A boolean Property specifying if glTF animations specified in the model should be started.
      * @param {Property} [options.nodeTransformations] An object, where keys are names of nodes, and values are {@link TranslationRotationScale} Properties describing the transformation to apply to that node.
      *
@@ -143,7 +143,7 @@ define([
          * casts shadows from each light source.
          * @memberof ModelGraphics.prototype
          * @type {Property}
-         * @default false
+         * @default true
          */
         castShadows : createPropertyDescriptor('castShadows'),
 
@@ -152,7 +152,7 @@ define([
          * receives shadows from shadow casters in the scene.
          * @memberof ModelGraphics.prototype
          * @type {Property}
-         * @default false
+         * @default true
          */
         receiveShadows : createPropertyDescriptor('receiveShadows'),
 

--- a/Source/DataSources/PolygonGeometryUpdater.js
+++ b/Source/DataSources/PolygonGeometryUpdater.js
@@ -54,6 +54,8 @@ define([
     var defaultFill = new ConstantProperty(true);
     var defaultOutline = new ConstantProperty(false);
     var defaultOutlineColor = new ConstantProperty(Color.BLACK);
+    var defaultCastShadows = new ConstantProperty(false);
+    var defaultReceiveShadows = new ConstantProperty(false);
     var scratchColor = new Color();
 
     function GeometryOptions(entity) {
@@ -102,6 +104,8 @@ define([
         this._showOutlineProperty = undefined;
         this._outlineColorProperty = undefined;
         this._outlineWidth = 1.0;
+        this._castShadowsProperty = undefined;
+        this._receiveShadowsProperty = undefined;
         this._options = new GeometryOptions(entity);
         this._onEntityPropertyChanged(entity, 'polygon', entity.polygon, undefined);
     }
@@ -227,6 +231,32 @@ define([
         outlineWidth : {
             get : function() {
                 return this._outlineWidth;
+            }
+        },
+        /**
+         * Gets the boolean property specifying whether the geometry
+         * casts shadows from each light source.
+         * @memberof PolygonGeometryUpdater.prototype
+         * 
+         * @type {Property}
+         * @readonly
+         */
+        castShadowsProperty : {
+            get : function() {
+                return this._castShadowsProperty;
+            }
+        },
+        /**
+         * Gets the boolean Property specifying whether the geometry
+         * receives shadows from shadow casters in the scene.
+         * @memberof PolygonGeometryUpdater.prototype
+         * 
+         * @type {Property}
+         * @readonly
+         */
+        receiveShadowsProperty : {
+            get : function() {
+                return this._receiveShadowsProperty;
             }
         },
         /**
@@ -448,6 +478,8 @@ define([
         this._showProperty = defaultValue(show, defaultShow);
         this._showOutlineProperty = defaultValue(polygon.outline, defaultOutline);
         this._outlineColorProperty = outlineEnabled ? defaultValue(polygon.outlineColor, defaultOutlineColor) : undefined;
+        this._castShadowsProperty = defaultValue(polygon.castShadows, defaultCastShadows);
+        this._receiveShadowsProperty = defaultValue(polygon.receiveShadows, defaultReceiveShadows);
 
         var height = polygon.height;
         var extrudedHeight = polygon.extrudedHeight;
@@ -579,6 +611,9 @@ define([
         options.closeTop = closeTopValue;
         options.closeBottom = closeBottomValue;
 
+        var castShadows = this._geometryUpdater.castShadowsProperty.getValue(time);
+        var receiveShadows = this._geometryUpdater.receiveShadowsProperty.getValue(time);
+        
         if (Property.getValueOrDefault(polygon.fill, time, true)) {
             var material = MaterialProperty.getValue(time, geometryUpdater.fillMaterialProperty, this._material);
             this._material = material;
@@ -596,7 +631,9 @@ define([
                     geometry : new PolygonGeometry(options)
                 }),
                 appearance : appearance,
-                asynchronous : false
+                asynchronous : false,
+                castShadows : castShadows,
+                receiveShadows : receiveShadows
             }));
         }
 
@@ -622,7 +659,9 @@ define([
                         lineWidth : geometryUpdater._scene.clampLineWidth(outlineWidth)
                     }
                 }),
-                asynchronous : false
+                asynchronous : false,
+                castShadows : castShadows,
+                receiveShadows : receiveShadows
             }));
         }
     };

--- a/Source/DataSources/PolygonGraphics.js
+++ b/Source/DataSources/PolygonGraphics.js
@@ -40,6 +40,8 @@ define([
      * @param {Property} [options.perPositionHeight=false] A boolean specifying whether or not the the height of each position is used.
      * @param {Boolean} [options.closeTop=true] When false, leaves off the top of an extruded polygon open.
      * @param {Boolean} [options.closeBottom=true] When false, leaves off the bottom of an extruded polygon open.
+     * @param {Property} [options.castShadows=false] A boolean Property specifying whether the polygon casts shadows from each light source.
+     * @param {Property} [options.receiveShadows=false] A boolean Property specifying whether the polygon receives shadows from shadow casters in the scene.
      *
      * @see Entity
      * @demo {@link http://cesiumjs.org/Cesium/Apps/Sandcastle/index.html?src=Polygon.html|Cesium Sandcastle Polygon Demo}
@@ -74,6 +76,10 @@ define([
         this._closeTopSubscription = undefined;
         this._closeBottom = undefined;
         this._closeBottomSubscription = undefined;
+        this._castShadows = undefined;
+        this._castShadowsSubscription = undefined;
+        this._receiveShadows = undefined;
+        this._receiveShadowsSubscription = undefined;
 
         this.merge(defaultValue(options, defaultValue.EMPTY_OBJECT));
     }
@@ -201,7 +207,25 @@ define([
          * @memberof PolygonGraphics.prototype
          * @type {Property}
          */
-        closeBottom : createPropertyDescriptor('closeBottom')
+        closeBottom : createPropertyDescriptor('closeBottom'),
+
+        /**
+         * Get or sets the boolean Property specifying whether the polygon
+         * casts shadows from each light source.
+         * @memberof PolygonGraphics.prototype
+         * @type {Property}
+         * @default false
+         */
+        castShadows : createPropertyDescriptor('castShadows'),
+
+        /**
+         * Get or sets the boolean Property specifying whether the polygon
+         * receives shadows from shadow casters in the scene.
+         * @memberof PolygonGraphics.prototype
+         * @type {Property}
+         * @default false
+         */
+        receiveShadows : createPropertyDescriptor('receiveShadows')
     });
 
     /**
@@ -228,6 +252,8 @@ define([
         result.perPositionHeight = this.perPositionHeight;
         result.closeTop = this.closeTop;
         result.closeBottom = this.closeBottom;
+        result.castShadows = this.castShadows;
+        result.receiveShadows = this.receiveShadows;
         return result;
     };
 
@@ -258,6 +284,8 @@ define([
         this.perPositionHeight = defaultValue(this.perPositionHeight, source.perPositionHeight);
         this.closeTop = defaultValue(this.closeTop, source.closeTop);
         this.closeBottom = defaultValue(this.closeBottom, source.closeBottom);
+        this.castShadows = defaultValue(this.castShadows, source.castShadows);
+        this.receiveShadows = defaultValue(this.receiveShadows, source.receiveShadows);
     };
 
     return PolygonGraphics;

--- a/Source/DataSources/PolylineGeometryUpdater.js
+++ b/Source/DataSources/PolylineGeometryUpdater.js
@@ -54,6 +54,8 @@ define([
 
     var defaultMaterial = new ColorMaterialProperty(Color.WHITE);
     var defaultShow = new ConstantProperty(true);
+    var defaultCastShadows = new ConstantProperty(false);
+    var defaultReceiveShadows = new ConstantProperty(false);
 
     function GeometryOptions(entity) {
         this.id = entity;
@@ -91,6 +93,8 @@ define([
         this._geometryChanged = new Event();
         this._showProperty = undefined;
         this._materialProperty = undefined;
+        this._castShadowsProperty = undefined;
+        this._receiveShadowsProperty = undefined;
         this._options = new GeometryOptions(entity);
         this._onEntityPropertyChanged(entity, 'polyline', entity.polyline, undefined);
     }
@@ -194,6 +198,32 @@ define([
             value : undefined
         },
         /**
+         * Gets the boolean property specifying whether the geometry
+         * casts shadows from each light source.
+         * @memberof PolylineGeometryUpdater.prototype
+         * 
+         * @type {Property}
+         * @readonly
+         */
+        castShadowsProperty : {
+            get : function() {
+                return this._castShadowsProperty;
+            }
+        },
+        /**
+         * Gets the boolean Property specifying whether the geometry
+         * receives shadows from shadow casters in the scene.
+         * @memberof PolylineGeometryUpdater.prototype
+         * 
+         * @type {Property}
+         * @readonly
+         */
+        receiveShadowsProperty : {
+            get : function() {
+                return this._receiveShadowsProperty;
+            }
+        },
+        /**
          * Gets a value indicating if the geometry is time-varying.
          * If true, all visualization is delegated to the {@link DynamicGeometryUpdater}
          * returned by GeometryUpdater#createDynamicUpdater.
@@ -202,6 +232,7 @@ define([
          * @type {Boolean}
          * @readonly
          */
+        
         isDynamic : {
             get : function() {
                 return this._dynamic;
@@ -366,6 +397,8 @@ define([
         var isColorMaterial = material instanceof ColorMaterialProperty;
         this._materialProperty = material;
         this._showProperty = defaultValue(show, defaultShow);
+        this._castShadowsProperty = defaultValue(polyline.castShadows, defaultCastShadows);
+        this._receiveShadowsProperty = defaultValue(polyline.receiveShadows, defaultReceiveShadows);
         this._fillEnabled = true;
 
         var width = polyline.width;

--- a/Source/DataSources/PolylineGraphics.js
+++ b/Source/DataSources/PolylineGraphics.js
@@ -32,6 +32,8 @@ define([
      * @param {Property} [options.show=true] A boolean Property specifying the visibility of the polyline.
      * @param {MaterialProperty} [options.material=Color.WHITE] A Property specifying the material used to draw the polyline.
      * @param {Property} [options.granularity=Cesium.Math.RADIANS_PER_DEGREE] A numeric Property specifying the angular distance between each latitude and longitude if followSurface is true.
+     * @param {Property} [options.castShadows=false] A boolean Property specifying whether the polyline casts shadows from each light source.
+     * @param {Property} [options.receiveShadows=false] A boolean Property specifying whether the polyline receives shadows from shadow casters in the scene.
      *
      * @see Entity
      * @demo {@link http://cesiumjs.org/Cesium/Apps/Sandcastle/index.html?src=Polyline.html|Cesium Sandcastle Polyline Demo}
@@ -50,6 +52,10 @@ define([
         this._widthSubscription = undefined;
         this._width = undefined;
         this._widthSubscription = undefined;
+        this._castShadows = undefined;
+        this._castShadowsSubscription = undefined;
+        this._receiveShadows = undefined;
+        this._receiveShadowsSubscription = undefined;
         this._definitionChanged = new Event();
 
         this.merge(defaultValue(options, defaultValue.EMPTY_OBJECT));
@@ -116,7 +122,25 @@ define([
          * @type {Property}
          * @default Cesium.Math.RADIANS_PER_DEGREE
          */
-        granularity : createPropertyDescriptor('granularity')
+        granularity : createPropertyDescriptor('granularity'),
+        
+        /**
+         * Get or sets the boolean Property specifying whether the polyline
+         * casts shadows from each light source.
+         * @memberof PolylineGraphics.prototype
+         * @type {Property}
+         * @default false
+         */
+        castShadows : createPropertyDescriptor('castShadows'),
+
+        /**
+         * Get or sets the boolean Property specifying whether the polyline
+         * receives shadows from shadow casters in the scene.
+         * @memberof PolylineGraphics.prototype
+         * @type {Property}
+         * @default false
+         */
+        receiveShadows : createPropertyDescriptor('receiveShadows')
     });
 
     /**
@@ -135,6 +159,8 @@ define([
         result.width = this.width;
         result.followSurface = this.followSurface;
         result.granularity = this.granularity;
+        result.castShadows = this.castShadows;
+        result.receiveShadows = this.receiveShadows;
         return result;
     };
 
@@ -157,6 +183,8 @@ define([
         this.width = defaultValue(this.width, source.width);
         this.followSurface = defaultValue(this.followSurface, source.followSurface);
         this.granularity = defaultValue(this.granularity, source.granularity);
+        this.castShadows = defaultValue(this.castShadows, source.castShadows);
+        this.receiveShadows = defaultValue(this.receiveShadows, source.receiveShadows);
     };
 
     return PolylineGraphics;

--- a/Source/DataSources/PolylineVolumeGeometryUpdater.js
+++ b/Source/DataSources/PolylineVolumeGeometryUpdater.js
@@ -50,6 +50,8 @@ define([
     var defaultFill = new ConstantProperty(true);
     var defaultOutline = new ConstantProperty(false);
     var defaultOutlineColor = new ConstantProperty(Color.BLACK);
+    var defaultCastShadows = new ConstantProperty(false);
+    var defaultReceiveShadows = new ConstantProperty(false);
     var scratchColor = new Color();
 
     function GeometryOptions(entity) {
@@ -93,6 +95,8 @@ define([
         this._showOutlineProperty = undefined;
         this._outlineColorProperty = undefined;
         this._outlineWidth = 1.0;
+        this._castShadowsProperty = undefined;
+        this._receiveShadowsProperty = undefined;
         this._options = new GeometryOptions(entity);
         this._onEntityPropertyChanged(entity, 'polylineVolume', entity.polylineVolume, undefined);
     }
@@ -218,6 +222,32 @@ define([
         outlineWidth : {
             get : function() {
                 return this._outlineWidth;
+            }
+        },
+        /**
+         * Gets the boolean property specifying whether the geometry
+         * casts shadows from each light source.
+         * @memberof PolylineVolumeGeometryUpdater.prototype
+         * 
+         * @type {Property}
+         * @readonly
+         */
+        castShadowsProperty : {
+            get : function() {
+                return this._castShadowsProperty;
+            }
+        },
+        /**
+         * Gets the boolean Property specifying whether the geometry
+         * receives shadows from shadow casters in the scene.
+         * @memberof PolylineVolumeGeometryUpdater.prototype
+         * 
+         * @type {Property}
+         * @readonly
+         */
+        receiveShadowsProperty : {
+            get : function() {
+                return this._receiveShadowsProperty;
             }
         },
         /**
@@ -437,6 +467,8 @@ define([
         this._showProperty = defaultValue(show, defaultShow);
         this._showOutlineProperty = defaultValue(polylineVolume.outline, defaultOutline);
         this._outlineColorProperty = outlineEnabled ? defaultValue(polylineVolume.outlineColor, defaultOutlineColor) : undefined;
+        this._castShadowsProperty = defaultValue(polylineVolume.castShadows, defaultCastShadows);
+        this._receiveShadowsProperty = defaultValue(polylineVolume.receiveShadows, defaultReceiveShadows);
 
         var granularity = polylineVolume.granularity;
         var outlineWidth = polylineVolume.outlineWidth;
@@ -531,6 +563,9 @@ define([
         options.granularity = Property.getValueOrUndefined(polylineVolume.granularity, time);
         options.cornerType = Property.getValueOrUndefined(polylineVolume.cornerType, time);
 
+        var castShadows = this._geometryUpdater.castShadowsProperty.getValue(time);
+        var receiveShadows = this._geometryUpdater.receiveShadowsProperty.getValue(time);
+
         if (!defined(polylineVolume.fill) || polylineVolume.fill.getValue(time)) {
             var material = MaterialProperty.getValue(time, geometryUpdater.fillMaterialProperty, this._material);
             this._material = material;
@@ -548,7 +583,9 @@ define([
                     geometry : new PolylineVolumeGeometry(options)
                 }),
                 appearance : appearance,
-                asynchronous : false
+                asynchronous : false,
+                castShadows : castShadows,
+                receiveShadows : receiveShadows
             }));
         }
 
@@ -574,7 +611,9 @@ define([
                         lineWidth : geometryUpdater._scene.clampLineWidth(outlineWidth)
                     }
                 }),
-                asynchronous : false
+                asynchronous : false,
+                castShadows : castShadows,
+                receiveShadows : receiveShadows
             }));
         }
     };

--- a/Source/DataSources/PolylineVolumeGraphics.js
+++ b/Source/DataSources/PolylineVolumeGraphics.js
@@ -35,6 +35,8 @@ define([
      * @param {Property} [options.outlineColor=Color.BLACK] A Property specifying the {@link Color} of the outline.
      * @param {Property} [options.outlineWidth=1.0] A numeric Property specifying the width of the outline.
      * @param {Property} [options.granularity=Cesium.Math.RADIANS_PER_DEGREE] A numeric Property specifying the angular distance between each latitude and longitude point.
+     * @param {Property} [options.castShadows=false] A boolean Property specifying whether the volume casts shadows from each light source.
+     * @param {Property} [options.receiveShadows=false] A boolean Property specifying whether the volume receives shadows from shadow casters in the scene.
      *
      * @see Entity
      * @demo {@link http://cesiumjs.org/Cesium/Apps/Sandcastle/index.html?src=Polyline%20Volume.html|Cesium Sandcastle Polyline Volume Demo}
@@ -60,6 +62,10 @@ define([
         this._outlineColorSubscription = undefined;
         this._outlineWidth = undefined;
         this._outlineWidthSubscription = undefined;
+        this._castShadows = undefined;
+        this._castShadowsSubscription = undefined;
+        this._receiveShadows = undefined;
+        this._receiveShadowsSubscription = undefined;
         this._definitionChanged = new Event();
 
         this.merge(defaultValue(options, defaultValue.EMPTY_OBJECT));
@@ -155,7 +161,25 @@ define([
          * @type {Property}
          * @default CornerType.ROUNDED
          */
-        cornerType : createPropertyDescriptor('cornerType')
+        cornerType : createPropertyDescriptor('cornerType'),
+
+        /**
+         * Get or sets the boolean Property specifying whether the volume
+         * casts shadows from each light source.
+         * @memberof PolylineVolumeGraphics.prototype
+         * @type {Property}
+         * @default false
+         */
+        castShadows : createPropertyDescriptor('castShadows'),
+
+        /**
+         * Get or sets the boolean Property specifying whether the volume
+         * receives shadows from shadow casters in the scene.
+         * @memberof PolylineVolumeGraphics.prototype
+         * @type {Property}
+         * @default false
+         */
+        receiveShadows : createPropertyDescriptor('receiveShadows')
     });
 
     /**
@@ -178,6 +202,8 @@ define([
         result.outlineColor = this.outlineColor;
         result.outlineWidth = this.outlineWidth;
         result.cornerType = this.cornerType;
+        result.castShadows = this.castShadows;
+        result.receiveShadows = this.receiveShadows;
         return result;
     };
 
@@ -204,6 +230,8 @@ define([
         this.outlineColor = defaultValue(this.outlineColor, source.outlineColor);
         this.outlineWidth = defaultValue(this.outlineWidth, source.outlineWidth);
         this.cornerType = defaultValue(this.cornerType, source.cornerType);
+        this.castShadows = defaultValue(this.castShadows, source.castShadows);
+        this.receiveShadows = defaultValue(this.receiveShadows, source.receiveShadows);
     };
 
     return PolylineVolumeGraphics;

--- a/Source/DataSources/RectangleGeometryUpdater.js
+++ b/Source/DataSources/RectangleGeometryUpdater.js
@@ -50,6 +50,8 @@ define([
     var defaultFill = new ConstantProperty(true);
     var defaultOutline = new ConstantProperty(false);
     var defaultOutlineColor = new ConstantProperty(Color.BLACK);
+    var defaultCastShadows = new ConstantProperty(false);
+    var defaultReceiveShadows = new ConstantProperty(false);
     var scratchColor = new Color();
 
     function GeometryOptions(entity) {
@@ -98,6 +100,8 @@ define([
         this._showOutlineProperty = undefined;
         this._outlineColorProperty = undefined;
         this._outlineWidth = 1.0;
+        this._castShadowsProperty = undefined;
+        this._receiveShadowsProperty = undefined;
         this._options = new GeometryOptions(entity);
         this._onEntityPropertyChanged(entity, 'rectangle', entity.rectangle, undefined);
     }
@@ -223,6 +227,32 @@ define([
         outlineWidth : {
             get : function() {
                 return this._outlineWidth;
+            }
+        },
+        /**
+         * Gets the boolean property specifying whether the geometry
+         * casts shadows from each light source.
+         * @memberof RectangleGeometryUpdater.prototype
+         * 
+         * @type {Property}
+         * @readonly
+         */
+        castShadowsProperty : {
+            get : function() {
+                return this._castShadowsProperty;
+            }
+        },
+        /**
+         * Gets the boolean Property specifying whether the geometry
+         * receives shadows from shadow casters in the scene.
+         * @memberof RectangleGeometryUpdater.prototype
+         * 
+         * @type {Property}
+         * @readonly
+         */
+        receiveShadowsProperty : {
+            get : function() {
+                return this._receiveShadowsProperty;
             }
         },
         /**
@@ -444,6 +474,8 @@ define([
         this._showProperty = defaultValue(show, defaultShow);
         this._showOutlineProperty = defaultValue(rectangle.outline, defaultOutline);
         this._outlineColorProperty = outlineEnabled ? defaultValue(rectangle.outlineColor, defaultOutlineColor) : undefined;
+        this._castShadowsProperty = defaultValue(rectangle.castShadows, defaultCastShadows);
+        this._receiveShadowsProperty = defaultValue(rectangle.receiveShadows, defaultReceiveShadows);
 
         var height = rectangle.height;
         var extrudedHeight = rectangle.extrudedHeight;
@@ -555,6 +587,9 @@ define([
         options.closeBottom = Property.getValueOrUndefined(rectangle.closeBottom, time);
         options.closeTop = Property.getValueOrUndefined(rectangle.closeTop, time);
 
+        var castShadows = this._geometryUpdater.castShadowsProperty.getValue(time);
+        var receiveShadows = this._geometryUpdater.receiveShadowsProperty.getValue(time);
+
         if (Property.getValueOrDefault(rectangle.fill, time, true)) {
             var material = MaterialProperty.getValue(time, geometryUpdater.fillMaterialProperty, this._material);
             this._material = material;
@@ -572,7 +607,9 @@ define([
                     geometry : new RectangleGeometry(options)
                 }),
                 appearance : appearance,
-                asynchronous : false
+                asynchronous : false,
+                castShadows : castShadows,
+                receiveShadows : receiveShadows
             }));
         }
 
@@ -598,7 +635,9 @@ define([
                         lineWidth : geometryUpdater._scene.clampLineWidth(outlineWidth)
                     }
                 }),
-                asynchronous : false
+                asynchronous : false,
+                castShadows : castShadows,
+                receiveShadows : receiveShadows
             }));
         }
     };

--- a/Source/DataSources/RectangleGraphics.js
+++ b/Source/DataSources/RectangleGraphics.js
@@ -40,6 +40,8 @@ define([
      * @param {Property} [options.rotation=0.0] A numeric property specifying the rotation of the rectangle clockwise from north.
      * @param {Property} [options.stRotation=0.0] A numeric property specifying the rotation of the rectangle texture counter-clockwise from north.
      * @param {Property} [options.granularity=Cesium.Math.RADIANS_PER_DEGREE] A numeric Property specifying the angular distance between points on the rectangle.
+     * @param {Property} [options.castShadows=false] A boolean Property specifying whether the rectangle casts shadows from each light source.
+     * @param {Property} [options.receiveShadows=false] A boolean Property specifying whether the rectangle receives shadows from shadow casters in the scene.
      *
      * @see Entity
      * @demo {@link http://cesiumjs.org/Cesium/Apps/Sandcastle/index.html?src=Rectangle.html|Cesium Sandcastle Rectangle Demo}
@@ -73,6 +75,10 @@ define([
         this._outlineColorSubscription = undefined;
         this._outlineWidth = undefined;
         this._outlineWidthSubscription = undefined;
+        this._castShadows = undefined;
+        this._castShadowsSubscription = undefined;
+        this._receiveShadows = undefined;
+        this._receiveShadowsSubscription = undefined;
         this._definitionChanged = new Event();
 
         this.merge(defaultValue(options, defaultValue.EMPTY_OBJECT));
@@ -201,7 +207,25 @@ define([
          * @type {Property}
          * @default true
          */
-        closeBottom : createPropertyDescriptor('closeBottom')
+        closeBottom : createPropertyDescriptor('closeBottom'),
+
+        /**
+         * Get or sets the boolean Property specifying whether the rectangle
+         * casts shadows from each light source.
+         * @memberof RectangleGraphics.prototype
+         * @type {Property}
+         * @default false
+         */
+        castShadows : createPropertyDescriptor('castShadows'),
+
+        /**
+         * Get or sets the boolean Property specifying whether the rectangle
+         * receives shadows from shadow casters in the scene.
+         * @memberof RectangleGraphics.prototype
+         * @type {Property}
+         * @default false
+         */
+        receiveShadows : createPropertyDescriptor('receiveShadows')
     });
 
     /**
@@ -228,6 +252,8 @@ define([
         result.outlineWidth = this.outlineWidth;
         result.closeTop = this.closeTop;
         result.closeBottom = this.closeBottom;
+        result.castShadows = this.castShadows;
+        result.receiveShadows = this.receiveShadows;
         return result;
     };
 
@@ -258,6 +284,8 @@ define([
         this.outlineWidth = defaultValue(this.outlineWidth, source.outlineWidth);
         this.closeTop = defaultValue(this.closeTop, source.closeTop);
         this.closeBottom = defaultValue(this.closeBottom, source.closeBottom);
+        this.castShadows = defaultValue(this.castShadows, source.castShadows);
+        this.receiveShadows = defaultValue(this.receiveShadows, source.receiveShadows);
     };
 
     return RectangleGraphics;

--- a/Source/DataSources/StaticGeometryColorBatch.js
+++ b/Source/DataSources/StaticGeometryColorBatch.js
@@ -19,10 +19,12 @@ define([
 
     var colorScratch = new Color();
 
-    function Batch(primitives, translucent, appearanceType, closed) {
+    function Batch(primitives, translucent, appearanceType, closed, castShadows, receiveShadows) {
         this.translucent = translucent;
         this.appearanceType = appearanceType;
         this.closed = closed;
+        this.castShadows = castShadows;
+        this.receiveShadows = receiveShadows;
         this.primitives = primitives;
         this.createPrimitive = false;
         this.waitingOnCreate = false;
@@ -107,7 +109,9 @@ define([
                     appearance : new this.appearanceType({
                         translucent : this.translucent,
                         closed : this.closed
-                    })
+                    }),
+                    castShadows : this.castShadows,
+                    receiveShadows : this.receiveShadows
                 });
                 primitives.add(primitive);
                 isUpdated = false;
@@ -234,9 +238,9 @@ define([
     /**
      * @private
      */
-    function StaticGeometryColorBatch(primitives, appearanceType, closed) {
-        this._solidBatch = new Batch(primitives, false, appearanceType, closed);
-        this._translucentBatch = new Batch(primitives, true, appearanceType, closed);
+    function StaticGeometryColorBatch(primitives, appearanceType, closed, castShadows, receiveShadows) {
+        this._solidBatch = new Batch(primitives, false, appearanceType, closed, castShadows, receiveShadows);
+        this._translucentBatch = new Batch(primitives, true, appearanceType, closed, castShadows, receiveShadows);
     }
     StaticGeometryColorBatch.prototype.add = function(time, updater) {
         var instance = updater.createFillGeometryInstance(time);

--- a/Source/DataSources/StaticGeometryPerMaterialBatch.js
+++ b/Source/DataSources/StaticGeometryPerMaterialBatch.js
@@ -15,11 +15,13 @@ define([
         MaterialProperty) {
     'use strict';
 
-    function Batch(primitives, appearanceType, materialProperty, closed) {
+    function Batch(primitives, appearanceType, materialProperty, closed, castShadows, receiveShadows) {
         this.primitives = primitives;
         this.appearanceType = appearanceType;
         this.materialProperty = materialProperty;
         this.closed = closed;
+        this.castShadows = castShadows;
+        this.receiveShadows = receiveShadows;
         this.updaters = new AssociativeArray();
         this.createPrimitive = true;
         this.primitive = undefined;
@@ -125,7 +127,9 @@ define([
                         material : this.material,
                         translucent : this.material.isTranslucent(),
                         closed : this.closed
-                    })
+                    }),
+                    castShadows : this.castShadows,
+                    receiveShadows : this.receiveShadows
                 });
 
                 primitives.add(primitive);
@@ -238,11 +242,13 @@ define([
     /**
      * @private
      */
-    function StaticGeometryPerMaterialBatch(primitives, appearanceType, closed) {
+    function StaticGeometryPerMaterialBatch(primitives, appearanceType, closed, castShadows, receiveShadows) {
         this._items = [];
         this._primitives = primitives;
         this._appearanceType = appearanceType;
         this._closed = closed;
+        this._castShadows = castShadows;
+        this._receiveShadows = receiveShadows;
     }
     StaticGeometryPerMaterialBatch.prototype.add = function(time, updater) {
         var items = this._items;
@@ -254,7 +260,7 @@ define([
                 return;
             }
         }
-        var batch = new Batch(this._primitives, this._appearanceType, updater.fillMaterialProperty, this._closed);
+        var batch = new Batch(this._primitives, this._appearanceType, updater.fillMaterialProperty, this._closed, this._castShadows, this._receiveShadows);
         batch.add(time, updater);
         items.push(batch);
     };

--- a/Source/DataSources/StaticOutlineGeometryBatch.js
+++ b/Source/DataSources/StaticOutlineGeometryBatch.js
@@ -19,8 +19,11 @@ define([
         BoundingSphereState) {
     'use strict';
 
-    function Batch(primitives, translucent, width) {
+    function Batch(primitives, translucent, width, castShadows, receiveShadows) {
         this.translucent = translucent;
+        this.width = width;
+        this.castShadows = castShadows;
+        this.receiveShadows = receiveShadows;
         this.primitives = primitives;
         this.createPrimitive = false;
         this.waitingOnCreate = false;
@@ -31,7 +34,6 @@ define([
         this.updatersWithAttributes = new AssociativeArray();
         this.attributes = new AssociativeArray();
         this.itemsToRemove = [];
-        this.width = width;
         this.subscriptions = new AssociativeArray();
         this.showsUpdated = new AssociativeArray();
     }
@@ -110,7 +112,9 @@ define([
                         renderState : {
                             lineWidth : this.width
                         }
-                    })
+                    }),
+                    castShadows : this.castShadows,
+                    receiveShadows : this.receiveShadows
                 });
 
                 primitives.add(primitive);
@@ -240,9 +244,11 @@ define([
     /**
      * @private
      */
-    function StaticOutlineGeometryBatch(primitives, scene) {
+    function StaticOutlineGeometryBatch(primitives, scene, castShadows, receiveShadows) {
         this._primitives = primitives;
         this._scene = scene;
+        this._castShadows = castShadows;
+        this._receiveShadows = receiveShadows;
         this._solidBatches = new AssociativeArray();
         this._translucentBatches = new AssociativeArray();
     }
@@ -255,7 +261,7 @@ define([
             batches = this._solidBatches;
             batch = batches.get(width);
             if (!defined(batch)) {
-                batch = new Batch(this._primitives, false, width);
+                batch = new Batch(this._primitives, false, width, this._castShadows, this._receiveShadows);
                 batches.set(width, batch);
             }
             batch.add(updater, instance);
@@ -263,7 +269,7 @@ define([
             batches = this._translucentBatches;
             batch = batches.get(width);
             if (!defined(batch)) {
-                batch = new Batch(this._primitives, true, width);
+                batch = new Batch(this._primitives, true, width, this._castShadows, this._receiveShadows);
                 batches.set(width, batch);
             }
             batch.add(updater, instance);

--- a/Source/DataSources/WallGeometryUpdater.js
+++ b/Source/DataSources/WallGeometryUpdater.js
@@ -50,6 +50,8 @@ define([
     var defaultFill = new ConstantProperty(true);
     var defaultOutline = new ConstantProperty(false);
     var defaultOutlineColor = new ConstantProperty(Color.BLACK);
+    var defaultCastShadows = new ConstantProperty(false);
+    var defaultReceiveShadows = new ConstantProperty(false);
     var scratchColor = new Color();
 
     function GeometryOptions(entity) {
@@ -93,6 +95,8 @@ define([
         this._showOutlineProperty = undefined;
         this._outlineColorProperty = undefined;
         this._outlineWidth = 1.0;
+        this._castShadowsProperty = undefined;
+        this._receiveShadowsProperty = undefined;
         this._options = new GeometryOptions(entity);
         this._onEntityPropertyChanged(entity, 'wall', entity.wall, undefined);
     }
@@ -218,6 +222,32 @@ define([
         outlineWidth : {
             get : function() {
                 return this._outlineWidth;
+            }
+        },
+        /**
+         * Gets the boolean property specifying whether the geometry
+         * casts shadows from each light source.
+         * @memberof WallGeometryUpdater.prototype
+         *
+         * @type {Property}
+         * @readonly
+         */
+        castShadowsProperty : {
+            get : function() {
+                return this._castShadowsProperty;
+            }
+        },
+        /**
+         * Gets the boolean Property specifying whether the geometry
+         * receives shadows from shadow casters in the scene.
+         * @memberof WallGeometryUpdater.prototype
+         *
+         * @type {Property}
+         * @readonly
+         */
+        receiveShadowsProperty : {
+            get : function() {
+                return this._receiveShadowsProperty;
             }
         },
         /**
@@ -439,6 +469,8 @@ define([
         this._showProperty = defaultValue(show, defaultShow);
         this._showOutlineProperty = defaultValue(wall.outline, defaultOutline);
         this._outlineColorProperty = outlineEnabled ? defaultValue(wall.outlineColor, defaultOutlineColor) : undefined;
+        this._castShadowsProperty = defaultValue(wall.castShadows, defaultCastShadows);
+        this._receiveShadowsProperty = defaultValue(wall.receiveShadows, defaultReceiveShadows);
 
         var minimumHeights = wall.minimumHeights;
         var maximumHeights = wall.maximumHeights;
@@ -533,6 +565,9 @@ define([
         options.maximumHeights = Property.getValueOrUndefined(wall.maximumHeights, time, options.maximumHeights);
         options.granularity = Property.getValueOrUndefined(wall.granularity, time);
 
+        var castShadows = this._geometryUpdater.castShadowsProperty.getValue(time);
+        var receiveShadows = this._geometryUpdater.receiveShadowsProperty.getValue(time);
+
         if (Property.getValueOrDefault(wall.fill, time, true)) {
             var material = MaterialProperty.getValue(time, geometryUpdater.fillMaterialProperty, this._material);
             this._material = material;
@@ -550,7 +585,9 @@ define([
                     geometry : new WallGeometry(options)
                 }),
                 appearance : appearance,
-                asynchronous : false
+                asynchronous : false,
+                castShadows : castShadows,
+                receiveShadows : receiveShadows
             }));
         }
 
@@ -576,7 +613,9 @@ define([
                         lineWidth : geometryUpdater._scene.clampLineWidth(outlineWidth)
                     }
                 }),
-                asynchronous : false
+                asynchronous : false,
+                castShadows : castShadows,
+                receiveShadows : receiveShadows
             }));
         }
     };

--- a/Source/DataSources/WallGraphics.js
+++ b/Source/DataSources/WallGraphics.js
@@ -35,6 +35,8 @@ define([
      * @param {Property} [options.outlineColor=Color.BLACK] A Property specifying the {@link Color} of the outline.
      * @param {Property} [options.outlineWidth=1.0] A numeric Property specifying the width of the outline.
      * @param {Property} [options.granularity=Cesium.Math.RADIANS_PER_DEGREE] A numeric Property specifying the angular distance between each latitude and longitude point.
+     * @param {Property} [options.castShadows=false] A boolean Property specifying whether the wall casts shadows from each light source.
+     * @param {Property} [options.receiveShadows=false] A boolean Property specifying whether the wall receives shadows from shadow casters in the scene.
      *
      * @see Entity
      * @demo {@link http://cesiumjs.org/Cesium/Apps/Sandcastle/index.html?src=Wall.html|Cesium Sandcastle Wall Demo}
@@ -60,6 +62,10 @@ define([
         this._outlineColorSubscription = undefined;
         this._outlineWidth = undefined;
         this._outlineWidthSubscription = undefined;
+        this._castShadows = undefined;
+        this._castShadowsSubscription = undefined;
+        this._receiveShadows = undefined;
+        this._receiveShadowsSubscription = undefined;
         this._definitionChanged = new Event();
 
         this.merge(defaultValue(options, defaultValue.EMPTY_OBJECT));
@@ -156,7 +162,25 @@ define([
          * @type {Property}
          * @default 1.0
          */
-        outlineWidth : createPropertyDescriptor('outlineWidth')
+        outlineWidth : createPropertyDescriptor('outlineWidth'),
+        
+        /**
+         * Get or sets the boolean Property specifying whether the wall
+         * casts shadows from each light source.
+         * @memberof WallGraphics.prototype
+         * @type {Property}
+         * @default false
+         */
+        castShadows : createPropertyDescriptor('castShadows'),
+
+        /**
+         * Get or sets the boolean Property specifying whether the wall
+         * receives shadows from shadow casters in the scene.
+         * @memberof WallGraphics.prototype
+         * @type {Property}
+         * @default false
+         */
+        receiveShadows : createPropertyDescriptor('receiveShadows')
     });
 
     /**
@@ -179,6 +203,8 @@ define([
         result.outline = this.outline;
         result.outlineColor = this.outlineColor;
         result.outlineWidth = this.outlineWidth;
+        result.castShadows = this.castShadows;
+        result.receiveShadows = this.receiveShadows;
         return result;
     };
 
@@ -205,6 +231,8 @@ define([
         this.outline = defaultValue(this.outline, source.outline);
         this.outlineColor = defaultValue(this.outlineColor, source.outlineColor);
         this.outlineWidth = defaultValue(this.outlineWidth, source.outlineWidth);
+        this.castShadows = defaultValue(this.castShadows, source.castShadows);
+        this.receiveShadows = defaultValue(this.receiveShadows, source.receiveShadows);
     };
 
     return WallGraphics;

--- a/Source/Scene/Globe.js
+++ b/Source/Scene/Globe.js
@@ -189,7 +189,7 @@ define([
         this.depthTestAgainstTerrain = false;
 
         /**
-         * Determines whether the globe casts shadows from each light source. Any primitive that has
+         * Determines whether the globe will cast shadows from each light source. Any primitive that has
          * <code>receiveShadows</code> set to <code>true</code> will receive shadows that are casted by
          * the globe. This may impact performance since the terrain is rendered again from the light's
          * perspective, which will also load terrain tiles that are potentially out of view.
@@ -200,7 +200,7 @@ define([
         this.castShadows = false;
 
         /**
-         * Determines whether the globe receives shadows from shadow casters in the scene.
+         * Determines whether the globe will receive shadows from any shadow casters in the scene.
          *
          * @type {Boolean}
          * @default true

--- a/Source/Scene/Primitive.js
+++ b/Source/Scene/Primitive.js
@@ -108,8 +108,8 @@ define([
      * @param {Boolean} [options.cull=true] When <code>true</code>, the renderer frustum culls and horizon culls the primitive's commands based on their bounding volume.  Set this to <code>false</code> for a small performance gain if you are manually culling the primitive.
      * @param {Boolean} [options.asynchronous=true] Determines if the primitive will be created asynchronously or block until ready.
      * @param {Boolean} [options.debugShowBoundingVolume=false] For debugging only. Determines if this primitive's commands' bounding spheres are shown.
-     * @param {Boolean} [options.castShadows=false] Determines whether this primitive casts shadows from each light source.
-     * @param {Boolean} [options.receiveShadows=false] Determines whether this primitive receives shadows from shadow casters in the scene.
+     * @param {Boolean} [options.castShadows=false] Determines whether this primitive will cast shadows from each light source.
+     * @param {Boolean} [options.receiveShadows=false] Determines whether this primitive will receive shadows from any shadow casters in the scene.
      *
      * @example
      * // 1. Draw a translucent ellipse on the surface with a checkerboard pattern
@@ -284,7 +284,7 @@ define([
         //>>includeEnd('debug');
 
         /**
-         * Determines whether this primitive casts shadows from each light source.
+         * Determines whether this primitive will cast shadows from each light source.
          *
          * @type {Boolean}
          *
@@ -293,7 +293,7 @@ define([
         this.castShadows = defaultValue(options.castShadows, false);
 
         /**
-         * Determines whether this primitive receives shadows from shadow casters in the scene.
+         * Determines whether this primitive will receive shadows from any shadow casters in the scene.
          *
          * @type {Boolean}
          *

--- a/Source/Widgets/CesiumWidget/CesiumWidget.js
+++ b/Source/Widgets/CesiumWidget/CesiumWidget.js
@@ -160,8 +160,7 @@ define([
      *        to the bottom of the widget itself.
      * @param {Number} [options.terrainExaggeration=1.0] A scalar used to exaggerate the terrain. Note that terrain exaggeration will not modify any other primitive as they are positioned relative to the ellipsoid.
      * @param {Boolean} [options.shadows=false] Determines if shadows are cast by the sun.
-     * @param {Boolean} [options.terrainShadows=false] Determines if the terrain casts shadows from the sun.
-     *
+     *     
      * @exception {DeveloperError} Element with id "container" does not exist in the document.
      *
      * @demo {@link http://cesiumjs.org/Cesium/Apps/Sandcastle/index.html?src=Cesium%20Widget.html|Cesium Sandcastle Cesium Widget Demo}
@@ -278,7 +277,6 @@ define([
             }
             if (globe !== false) {
                 scene.globe = globe;
-                scene.globe.castShadows = defaultValue(options.terrainShadows, false);
             }
 
             var skyBox = options.skyBox;

--- a/Source/Widgets/Viewer/Viewer.js
+++ b/Source/Widgets/Viewer/Viewer.js
@@ -277,7 +277,6 @@ define([
      *                               the instance is assumed to be owned by the caller and will not be destroyed when the viewer is destroyed.
      * @param {Number} [options.terrainExaggeration=1.0] A scalar used to exaggerate the terrain. Note that terrain exaggeration will not modify any other primitive as they are positioned relative to the ellipsoid.
      * @param {Boolean} [options.shadows=false] Determines if shadows are cast by the sun.
-     * @param {Boolean} [options.terrainShadows=false] Determines if the terrain casts shadows from the sun.
      *
      * @exception {DeveloperError} Element with id "container" does not exist in the document.
      * @exception {DeveloperError} options.imageryProvider is not available when using the BaseLayerPicker widget, specify options.selectedImageryProviderViewModel instead.
@@ -411,8 +410,7 @@ Either specify options.terrainProvider instead or set options.baseLayerPicker to
             creditContainer : defined(options.creditContainer) ? options.creditContainer : bottomContainer,
             scene3DOnly : scene3DOnly,
             terrainExaggeration : options.terrainExaggeration,
-            shadows : options.shadows,
-            terrainShadows : options.terrainShadows
+            shadows : options.shadows
         });
 
         var dataSourceCollection = options.dataSources;
@@ -950,6 +948,7 @@ Either specify options.terrainProvider instead or set options.baseLayerPicker to
          * Determines if shadows are cast by the sun.
          * @memberof Viewer.prototype
          * @type {Boolean}
+         * @readonly
          */
         shadows : {
             get : function() {
@@ -957,20 +956,6 @@ Either specify options.terrainProvider instead or set options.baseLayerPicker to
             },
             set : function(value) {
                 this.scene.shadowMap.enabled = value;
-            }
-        },
-
-        /**
-         * Determines if the terrain casts shadows from the sun.
-         * @memberof Viewer.prototype
-         * @type {Boolean}
-         */
-        terrainShadows : {
-            get : function() {
-                return this.scene.globe.castShadows;
-            },
-            set : function(value) {
-                this.scene.globe.castShadows = value;
             }
         },
 

--- a/Specs/DataSources/BoxGeometryUpdaterSpec.js
+++ b/Specs/DataSources/BoxGeometryUpdaterSpec.js
@@ -78,6 +78,8 @@ defineSuite([
         expect(updater.hasConstantOutline).toBe(true);
         expect(updater.outlineColorProperty).toBe(undefined);
         expect(updater.outlineWidth).toBe(1.0);
+        expect(updater.castShadowsProperty).toBe(undefined);
+        expect(updater.receiveShadowsProperty).toBe(undefined);
         expect(updater.isDynamic).toBe(false);
         expect(updater.isOutlineVisible(time)).toBe(false);
         expect(updater.isFilled(time)).toBe(false);
@@ -118,6 +120,8 @@ defineSuite([
         expect(updater.hasConstantOutline).toBe(true);
         expect(updater.outlineColorProperty).toBe(undefined);
         expect(updater.outlineWidth).toBe(1.0);
+        expect(updater.castShadowsProperty).toEqual(new ConstantProperty(false));
+        expect(updater.receiveShadowsProperty).toEqual(new ConstantProperty(false));
         expect(updater.isDynamic).toBe(false);
     });
 

--- a/Specs/DataSources/BoxGraphicsSpec.js
+++ b/Specs/DataSources/BoxGraphicsSpec.js
@@ -25,7 +25,9 @@ defineSuite([
             outline : false,
             outlineColor : Color.RED,
             outlineWidth : 1,
-            dimensions : new Cartesian3(2, 3, 4)
+            dimensions : new Cartesian3(2, 3, 4),
+            castShadows : false,
+            receiveShadows : false
         };
 
         var box = new BoxGraphics(options);
@@ -36,6 +38,8 @@ defineSuite([
         expect(box.outlineColor).toBeInstanceOf(ConstantProperty);
         expect(box.outlineWidth).toBeInstanceOf(ConstantProperty);
         expect(box.dimensions).toBeInstanceOf(ConstantProperty);
+        expect(box.castShadows).toBeInstanceOf(ConstantProperty);
+        expect(box.receiveShadows).toBeInstanceOf(ConstantProperty);
 
         expect(box.material.color.getValue()).toEqual(options.material);
         expect(box.show.getValue()).toEqual(options.show);
@@ -44,6 +48,8 @@ defineSuite([
         expect(box.outlineColor.getValue()).toEqual(options.outlineColor);
         expect(box.outlineWidth.getValue()).toEqual(options.outlineWidth);
         expect(box.dimensions.getValue()).toEqual(options.dimensions);
+        expect(box.castShadows.getValue()).toEqual(options.castShadows);
+        expect(box.receiveShadows.getValue()).toEqual(options.receiveShadows);
     });
 
     it('merge assigns unassigned properties', function() {
@@ -55,6 +61,8 @@ defineSuite([
         source.outlineColor = new ConstantProperty();
         source.outlineWidth = new ConstantProperty();
         source.dimensions = new ConstantProperty();
+        source.castShadows = new ConstantProperty(true);
+        source.receiveShadows = new ConstantProperty(true);
 
         var target = new BoxGraphics();
         target.merge(source);
@@ -66,6 +74,8 @@ defineSuite([
         expect(target.outlineColor).toBe(source.outlineColor);
         expect(target.outlineWidth).toBe(source.outlineWidth);
         expect(target.dimensions).toBe(source.dimensions);
+        expect(target.castShadows).toBe(source.castShadows);
+        expect(target.receiveShadows).toBe(source.receiveShadows);
     });
 
     it('merge does not assign assigned properties', function() {
@@ -78,6 +88,8 @@ defineSuite([
         var outlineColor = new ConstantProperty();
         var outlineWidth = new ConstantProperty();
         var dimensions = new ConstantProperty();
+        var castShadows = new ConstantProperty();
+        var receiveShadows = new ConstantProperty();
 
         var target = new BoxGraphics();
         target.material = material;
@@ -87,6 +99,8 @@ defineSuite([
         target.outlineColor = outlineColor;
         target.outlineWidth = outlineWidth;
         target.dimensions = dimensions;
+        target.castShadows = castShadows;
+        target.receiveShadows = receiveShadows;
 
         target.merge(source);
 
@@ -97,6 +111,8 @@ defineSuite([
         expect(target.outlineColor).toBe(outlineColor);
         expect(target.outlineWidth).toBe(outlineWidth);
         expect(target.dimensions).toBe(dimensions);
+        expect(target.castShadows).toBe(castShadows);
+        expect(target.receiveShadows).toBe(receiveShadows);
     });
 
     it('clone works', function() {
@@ -108,6 +124,8 @@ defineSuite([
         source.outlineColor = new ConstantProperty();
         source.outlineWidth = new ConstantProperty();
         source.dimensions = new ConstantProperty();
+        source.castShadows = new ConstantProperty();
+        source.receiveShadows = new ConstantProperty();
 
         var result = source.clone();
         expect(result.material).toBe(source.material);
@@ -117,6 +135,8 @@ defineSuite([
         expect(result.outlineColor).toBe(source.outlineColor);
         expect(result.outlineWidth).toBe(source.outlineWidth);
         expect(result.dimensions).toBe(source.dimensions);
+        expect(result.castShadows).toBe(source.castShadows);
+        expect(result.receiveShadows).toBe(source.receiveShadows);
     });
 
     it('merge throws if source undefined', function() {
@@ -135,5 +155,7 @@ defineSuite([
         testDefinitionChanged(property, 'outlineColor', Color.RED, Color.BLUE);
         testDefinitionChanged(property, 'outlineWidth', 2, 3);
         testDefinitionChanged(property, 'dimensions', new Cartesian3(0, 0, 0), new Cartesian3(1, 1, 1));
+        testDefinitionChanged(property, 'castShadows', true, false);
+        testDefinitionChanged(property, 'receiveShadows', true, false);
     });
 });

--- a/Specs/DataSources/CorridorGeometryUpdaterSpec.js
+++ b/Specs/DataSources/CorridorGeometryUpdaterSpec.js
@@ -87,6 +87,8 @@ defineSuite([
         expect(updater.hasConstantOutline).toBe(true);
         expect(updater.outlineColorProperty).toBe(undefined);
         expect(updater.outlineWidth).toBe(1.0);
+        expect(updater.castShadowsProperty).toBe(undefined);
+        expect(updater.receiveShadowsProperty).toBe(undefined);
         expect(updater.isDynamic).toBe(false);
         expect(updater.isOutlineVisible(time)).toBe(false);
         expect(updater.isFilled(time)).toBe(false);
@@ -127,6 +129,8 @@ defineSuite([
         expect(updater.hasConstantOutline).toBe(true);
         expect(updater.outlineColorProperty).toBe(undefined);
         expect(updater.outlineWidth).toBe(1.0);
+        expect(updater.castShadowsProperty).toEqual(new ConstantProperty(false));
+        expect(updater.receiveShadowsProperty).toEqual(new ConstantProperty(false));
         expect(updater.isDynamic).toBe(false);
     });
 

--- a/Specs/DataSources/CorridorGraphicsSpec.js
+++ b/Specs/DataSources/CorridorGraphicsSpec.js
@@ -30,7 +30,9 @@ defineSuite([
             outline : false,
             outlineColor : Color.RED,
             outlineWidth : 5,
-            cornerType : CornerType.BEVELED
+            cornerType : CornerType.BEVELED,
+            castShadows : false,
+            receiveShadows : false
         };
 
         var corridor = new CorridorGraphics(options);
@@ -46,6 +48,8 @@ defineSuite([
         expect(corridor.outlineColor).toBeInstanceOf(ConstantProperty);
         expect(corridor.outlineWidth).toBeInstanceOf(ConstantProperty);
         expect(corridor.cornerType).toBeInstanceOf(ConstantProperty);
+        expect(corridor.castShadows).toBeInstanceOf(ConstantProperty);
+        expect(corridor.receiveShadows).toBeInstanceOf(ConstantProperty);
 
         expect(corridor.material.color.getValue()).toEqual(options.material);
         expect(corridor.positions.getValue()).toEqual(options.positions);
@@ -59,6 +63,8 @@ defineSuite([
         expect(corridor.outlineColor.getValue()).toEqual(options.outlineColor);
         expect(corridor.outlineWidth.getValue()).toEqual(options.outlineWidth);
         expect(corridor.cornerType.getValue()).toEqual(options.cornerType);
+        expect(corridor.castShadows.getValue()).toEqual(options.castShadows);
+        expect(corridor.receiveShadows.getValue()).toEqual(options.receiveShadows);
     });
 
     it('merge assigns unassigned properties', function() {
@@ -75,6 +81,8 @@ defineSuite([
         source.outlineColor = new ConstantProperty();
         source.outlineWidth = new ConstantProperty();
         source.cornerType = new ConstantProperty();
+        source.castShadows = new ConstantProperty(true);
+        source.receiveShadows = new ConstantProperty(true);
 
         var target = new CorridorGraphics();
         target.merge(source);
@@ -91,6 +99,8 @@ defineSuite([
         expect(target.outlineColor).toBe(source.outlineColor);
         expect(target.outlineWidth).toBe(source.outlineWidth);
         expect(target.cornerType).toBe(source.cornerType);
+        expect(target.castShadows).toBe(source.castShadows);
+        expect(target.receiveShadows).toBe(source.receiveShadows);
     });
 
     it('merge does not assign assigned properties', function() {
@@ -108,6 +118,8 @@ defineSuite([
         var outlineColor = new ConstantProperty();
         var outlineWidth = new ConstantProperty();
         var cornerType = new ConstantProperty();
+        var castShadows = new ConstantProperty();
+        var receiveShadows = new ConstantProperty();
 
         var target = new CorridorGraphics();
         target.material = material;
@@ -122,6 +134,8 @@ defineSuite([
         target.outlineColor = outlineColor;
         target.outlineWidth = outlineWidth;
         target.cornerType = cornerType;
+        target.castShadows = castShadows;
+        target.receiveShadows = receiveShadows;
 
         target.merge(source);
 
@@ -137,6 +151,8 @@ defineSuite([
         expect(target.outlineColor).toBe(outlineColor);
         expect(target.outlineWidth).toBe(outlineWidth);
         expect(target.cornerType).toBe(cornerType);
+        expect(target.castShadows).toBe(castShadows);
+        expect(target.receiveShadows).toBe(receiveShadows);
     });
 
     it('clone works', function() {
@@ -153,6 +169,8 @@ defineSuite([
         source.outlineColor = new ConstantProperty();
         source.outlineWidth = new ConstantProperty();
         source.cornerType = new ConstantProperty();
+        source.castShadows = new ConstantProperty();
+        source.receiveShadows = new ConstantProperty();
 
         var result = source.clone();
         expect(result.material).toBe(source.material);
@@ -167,6 +185,8 @@ defineSuite([
         expect(result.outlineColor).toBe(source.outlineColor);
         expect(result.outlineWidth).toBe(source.outlineWidth);
         expect(result.cornerType).toBe(source.cornerType);
+        expect(result.castShadows).toBe(source.castShadows);
+        expect(result.receiveShadows).toBe(source.receiveShadows);
     });
 
     it('merge throws if source undefined', function() {
@@ -190,5 +210,7 @@ defineSuite([
         testDefinitionChanged(property, 'outlineColor', Color.RED, Color.BLUE);
         testDefinitionChanged(property, 'outlineWidth', 2, 3);
         testDefinitionChanged(property, 'cornerType', CornerType.BEVELED, CornerType.MITERED);
+        testDefinitionChanged(property, 'castShadows', true, false);
+        testDefinitionChanged(property, 'receiveShadows', true, false);
     });
 });

--- a/Specs/DataSources/CylinderGeometryUpdaterSpec.js
+++ b/Specs/DataSources/CylinderGeometryUpdaterSpec.js
@@ -85,6 +85,8 @@ defineSuite([
         expect(updater.hasConstantOutline).toBe(true);
         expect(updater.outlineColorProperty).toBe(undefined);
         expect(updater.outlineWidth).toBe(1.0);
+        expect(updater.castShadowsProperty).toBe(undefined);
+        expect(updater.receiveShadowsProperty).toBe(undefined);
         expect(updater.isDynamic).toBe(false);
         expect(updater.isOutlineVisible(time)).toBe(false);
         expect(updater.isFilled(time)).toBe(false);
@@ -145,6 +147,8 @@ defineSuite([
         expect(updater.hasConstantOutline).toBe(true);
         expect(updater.outlineColorProperty).toBe(undefined);
         expect(updater.outlineWidth).toBe(1.0);
+        expect(updater.castShadowsProperty).toEqual(new ConstantProperty(false));
+        expect(updater.receiveShadowsProperty).toEqual(new ConstantProperty(false));
         expect(updater.isDynamic).toBe(false);
     });
 

--- a/Specs/DataSources/CylinderGraphicsSpec.js
+++ b/Specs/DataSources/CylinderGraphicsSpec.js
@@ -27,7 +27,9 @@ defineSuite([
             fill : false,
             outline : false,
             outlineColor : Color.RED,
-            outlineWidth : 6
+            outlineWidth : 6,
+            castShadows : false,
+            receiveShadows : false
         };
 
         var cylinder = new CylinderGraphics(options);
@@ -42,6 +44,8 @@ defineSuite([
         expect(cylinder.outline).toBeInstanceOf(ConstantProperty);
         expect(cylinder.outlineColor).toBeInstanceOf(ConstantProperty);
         expect(cylinder.outlineWidth).toBeInstanceOf(ConstantProperty);
+        expect(cylinder.castShadows).toBeInstanceOf(ConstantProperty);
+        expect(cylinder.receiveShadows).toBeInstanceOf(ConstantProperty);
 
         expect(cylinder.material.color.getValue()).toEqual(options.material);
         expect(cylinder.show.getValue()).toEqual(options.show);
@@ -54,6 +58,8 @@ defineSuite([
         expect(cylinder.outline.getValue()).toEqual(options.outline);
         expect(cylinder.outlineColor.getValue()).toEqual(options.outlineColor);
         expect(cylinder.outlineWidth.getValue()).toEqual(options.outlineWidth);
+        expect(cylinder.castShadows.getValue()).toEqual(options.castShadows);
+        expect(cylinder.receiveShadows.getValue()).toEqual(options.receiveShadows);
     });
 
     it('merge assigns unassigned properties', function() {
@@ -68,6 +74,8 @@ defineSuite([
         source.outline = new ConstantProperty();
         source.outlineColor = new ConstantProperty();
         source.outlineWidth = new ConstantProperty();
+        source.castShadows = new ConstantProperty(true);
+        source.receiveShadows = new ConstantProperty(true);
 
         var target = new CylinderGraphics();
         target.merge(source);
@@ -82,6 +90,8 @@ defineSuite([
         expect(target.outline).toBe(source.outline);
         expect(target.outlineColor).toBe(source.outlineColor);
         expect(target.outlineWidth).toBe(source.outlineWidth);
+        expect(target.castShadows).toBe(source.castShadows);
+        expect(target.receiveShadows).toBe(source.receiveShadows);
     });
 
     it('merge does not assign assigned properties', function() {
@@ -97,6 +107,8 @@ defineSuite([
         var outline = new ConstantProperty();
         var outlineColor = new ConstantProperty();
         var outlineWidth = new ConstantProperty();
+        var castShadows = new ConstantProperty();
+        var receiveShadows = new ConstantProperty();
 
         var target = new CylinderGraphics();
         target.material = material;
@@ -109,6 +121,8 @@ defineSuite([
         target.outline = outline;
         target.outlineColor = outlineColor;
         target.outlineWidth = outlineWidth;
+        target.castShadows = castShadows;
+        target.receiveShadows = receiveShadows;
 
         target.merge(source);
 
@@ -122,6 +136,8 @@ defineSuite([
         expect(target.outline).toBe(outline);
         expect(target.outlineColor).toBe(outlineColor);
         expect(target.outlineWidth).toBe(outlineWidth);
+        expect(target.castShadows).toBe(castShadows);
+        expect(target.receiveShadows).toBe(receiveShadows);
     });
 
     it('clone works', function() {
@@ -136,6 +152,8 @@ defineSuite([
         source.outline = new ConstantProperty();
         source.outlineColor = new ConstantProperty();
         source.outlineWidth = new ConstantProperty();
+        source.castShadows = new ConstantProperty();
+        source.receiveShadows = new ConstantProperty();
 
         var result = source.clone();
         expect(result.material).toBe(source.material);
@@ -148,6 +166,8 @@ defineSuite([
         expect(result.outline).toBe(source.outline);
         expect(result.outlineColor).toBe(source.outlineColor);
         expect(result.outlineWidth).toBe(source.outlineWidth);
+        expect(result.castShadows).toBe(source.castShadows);
+        expect(result.receiveShadows).toBe(source.receiveShadows);
     });
 
     it('merge throws if source undefined', function() {
@@ -169,5 +189,7 @@ defineSuite([
         testDefinitionChanged(property, 'outline', true, false);
         testDefinitionChanged(property, 'outlineColor', Color.RED, Color.BLUE);
         testDefinitionChanged(property, 'outlineWidth', 2, 3);
+        testDefinitionChanged(property, 'castShadows', true, false);
+        testDefinitionChanged(property, 'receiveShadows', true, false);
     });
 });

--- a/Specs/DataSources/CzmlDataSourceSpec.js
+++ b/Specs/DataSources/CzmlDataSourceSpec.js
@@ -770,7 +770,9 @@ defineSuite([
                 outlineColor : {
                     rgbaf : [0.2, 0.2, 0.2, 0.2]
                 },
-                outlineWidth : 6
+                outlineWidth : 6,
+                castShadows : true,
+                receiveShadows : true
             }
         };
 
@@ -785,6 +787,8 @@ defineSuite([
         expect(entity.ellipse.outline.getValue(Iso8601.MINIMUM_VALUE)).toEqual(true);
         expect(entity.ellipse.outlineColor.getValue(Iso8601.MINIMUM_VALUE)).toEqual(new Color(0.2, 0.2, 0.2, 0.2));
         expect(entity.ellipse.outlineWidth.getValue(Iso8601.MINIMUM_VALUE)).toEqual(6);
+        expect(entity.ellipse.castShadows.getValue(Iso8601.MINIMUM_VALUE)).toEqual(true);
+        expect(entity.ellipse.receiveShadows.getValue(Iso8601.MINIMUM_VALUE)).toEqual(true);
     });
 
     it('CZML adds data for constrained ellipse.', function() {
@@ -793,7 +797,9 @@ defineSuite([
                 interval : '2000-01-01/2001-01-01',
                 semiMajorAxis : 10,
                 semiMinorAxis : 20,
-                rotation : 1.0
+                rotation : 1.0,
+                castShadows : true,
+                receiveShadows : true
             }
         };
 
@@ -810,10 +816,14 @@ defineSuite([
         expect(entity.ellipse.semiMajorAxis.getValue(validTime)).toEqual(ellipsePacketInterval.ellipse.semiMajorAxis);
         expect(entity.ellipse.semiMinorAxis.getValue(validTime)).toEqual(ellipsePacketInterval.ellipse.semiMinorAxis);
         expect(entity.ellipse.rotation.getValue(validTime)).toEqual(ellipsePacketInterval.ellipse.rotation);
+        expect(entity.ellipse.castShadows.getValue(validTime)).toEqual(true);
+        expect(entity.ellipse.receiveShadows.getValue(validTime)).toEqual(true);
 
         expect(entity.ellipse.semiMajorAxis.getValue(invalidTime)).toBeUndefined();
         expect(entity.ellipse.semiMinorAxis.getValue(invalidTime)).toBeUndefined();
         expect(entity.ellipse.rotation.getValue(invalidTime)).toBeUndefined();
+        expect(entity.ellipse.castShadows.getValue(invalidTime)).toBeUndefined();
+        expect(entity.ellipse.receiveShadows.getValue(invalidTime)).toBeUndefined();
     });
 
     it('CZML adds data for infinite ellipsoid.', function() {
@@ -836,7 +846,9 @@ defineSuite([
                 outlineColor : {
                     rgbaf : [0.2, 0.2, 0.2, 0.2]
                 },
-                outlineWidth : 6
+                outlineWidth : 6,
+                castShadows : true,
+                receiveShadows : true
             }
         };
 
@@ -851,6 +863,8 @@ defineSuite([
         expect(entity.ellipsoid.outline.getValue(Iso8601.MINIMUM_VALUE)).toEqual(true);
         expect(entity.ellipsoid.outlineColor.getValue(Iso8601.MINIMUM_VALUE)).toEqual(new Color(0.2, 0.2, 0.2, 0.2));
         expect(entity.ellipsoid.outlineWidth.getValue(Iso8601.MINIMUM_VALUE)).toEqual(6);
+        expect(entity.ellipsoid.castShadows.getValue(Iso8601.MINIMUM_VALUE)).toEqual(true);
+        expect(entity.ellipsoid.receiveShadows.getValue(Iso8601.MINIMUM_VALUE)).toEqual(true);
     });
 
     it('CZML adds data for constrained ellipsoid.', function() {
@@ -869,7 +883,9 @@ defineSuite([
                             rgbaf : [0.1, 0.1, 0.1, 0.1]
                         }
                     }
-                }
+                },
+                castShadows : true,
+                receiveShadows : true
             }
         };
 
@@ -886,10 +902,14 @@ defineSuite([
         expect(entity.ellipsoid.radii.getValue(validTime)).toEqual(expectedRadii);
         expect(entity.ellipsoid.show.getValue(validTime)).toEqual(ellipsoidPacketInterval.ellipsoid.show);
         expect(entity.ellipsoid.material.getValue(validTime).color).toEqual(new Color(0.1, 0.1, 0.1, 0.1));
+        expect(entity.ellipsoid.castShadows.getValue(validTime)).toEqual(true);
+        expect(entity.ellipsoid.receiveShadows.getValue(validTime)).toEqual(true);
 
         expect(entity.ellipsoid.radii.getValue(invalidTime)).toBeUndefined();
         expect(entity.ellipsoid.show.getValue(invalidTime)).toBeUndefined();
         expect(entity.ellipsoid.material.getValue(invalidTime)).toBeUndefined();
+        expect(entity.ellipsoid.castShadows.getValue(invalidTime)).toBeUndefined();
+        expect(entity.ellipsoid.receiveShadows.getValue(invalidTime)).toBeUndefined();
     });
 
     it('CZML adds data for infinite label.', function() {
@@ -1405,7 +1425,9 @@ defineSuite([
                 },
                 outlineWidth : 6,
                 closeTop : false,
-                closeBottom : false
+                closeBottom : false,
+                castShadows : true,
+                receiveShadows : true
             }
         };
 
@@ -1425,6 +1447,8 @@ defineSuite([
         expect(entity.polygon.outlineWidth.getValue(Iso8601.MINIMUM_VALUE)).toEqual(6);
         expect(entity.polygon.closeTop.getValue(Iso8601.MINIMUM_VALUE)).toEqual(false);
         expect(entity.polygon.closeBottom.getValue(Iso8601.MINIMUM_VALUE)).toEqual(false);
+        expect(entity.polygon.castShadows.getValue(Iso8601.MINIMUM_VALUE)).toEqual(true);
+        expect(entity.polygon.receiveShadows.getValue(Iso8601.MINIMUM_VALUE)).toEqual(true);
     });
 
     it('CZML adds data for constrained polygon.', function() {
@@ -1438,7 +1462,9 @@ defineSuite([
                         }
                     }
                 },
-                show : true
+                show : true,
+                castShadows : true,
+                receiveShadows : true
             }
         };
 
@@ -1454,9 +1480,14 @@ defineSuite([
         expect(entity.polygon).toBeDefined();
         expect(entity.polygon.material.getValue(validTime).color).toEqual(new Color(0.1, 0.1, 0.1, 0.1));
         expect(entity.polygon.show.getValue(validTime)).toEqual(true);
+        expect(entity.polygon.castShadows.getValue(validTime)).toEqual(true);
+        expect(entity.polygon.receiveShadows.getValue(validTime)).toEqual(true);
 
         expect(entity.polygon.material.getValue(invalidTime)).toBeUndefined();
         expect(entity.polygon.show.getValue(invalidTime)).toBeUndefined();
+        expect(entity.polygon.castShadows.getValue(invalidTime)).toBeUndefined();
+        expect(entity.polygon.receiveShadows.getValue(invalidTime)).toBeUndefined();
+
     });
 
     it('CZML adds data for infinite polyline.', function() {
@@ -1474,7 +1505,9 @@ defineSuite([
                     }
                 },
                 width : 1.0,
-                show : true
+                show : true,
+                castShadows : true,
+                receiveShadows : true
             }
         };
 
@@ -1488,6 +1521,8 @@ defineSuite([
         expect(entity.polyline.material.outlineColor.getValue(Iso8601.MINIMUM_VALUE)).toEqual(new Color(0.2, 0.2, 0.2, 0.2));
         expect(entity.polyline.material.outlineWidth.getValue(Iso8601.MINIMUM_VALUE)).toEqual(1.0);
         expect(entity.polyline.show.getValue(Iso8601.MINIMUM_VALUE)).toEqual(true);
+        expect(entity.polyline.castShadows.getValue(Iso8601.MINIMUM_VALUE)).toEqual(true);
+        expect(entity.polyline.receiveShadows.getValue(Iso8601.MINIMUM_VALUE)).toEqual(true);
     });
 
     it('CZML adds data for constrained polyline.', function() {
@@ -1506,7 +1541,9 @@ defineSuite([
                     }
                 },
                 width : 1.0,
-                show : true
+                show : true,
+                castShadows : true,
+                receiveShadows : true
             }
         };
 
@@ -1525,10 +1562,15 @@ defineSuite([
         expect(entity.polyline.material.getValue(validTime).outlineColor).toEqual(new Color(0.2, 0.2, 0.2, 0.2));
         expect(entity.polyline.material.getValue(validTime).outlineWidth).toEqual(1.0);
         expect(entity.polyline.show.getValue(validTime)).toEqual(true);
+        expect(entity.polyline.castShadows.getValue(validTime)).toEqual(true);
+        expect(entity.polyline.receiveShadows.getValue(validTime)).toEqual(true);
 
         expect(entity.polyline.material.getValue(invalidTime)).toBeUndefined();
         expect(entity.polyline.width.getValue(invalidTime)).toBeUndefined();
         expect(entity.polyline.show.getValue(invalidTime)).toBeUndefined();
+        expect(entity.polyline.castShadows.getValue(invalidTime)).toBeUndefined();
+        expect(entity.polyline.receiveShadows.getValue(invalidTime)).toBeUndefined();
+
     });
 
     it('CZML adds data for infinite model.', function() {
@@ -1868,7 +1910,9 @@ defineSuite([
                 outlineColor : {
                     rgbaf : [0.2, 0.2, 0.2, 0.2]
                 },
-                outlineWidth : 6
+                outlineWidth : 6,
+                castShadows : true,
+                receiveShadows : true
             }
         };
 
@@ -1892,6 +1936,8 @@ defineSuite([
         expect(entity.rectangle.outline.getValue(Iso8601.MINIMUM_VALUE)).toEqual(true);
         expect(entity.rectangle.outlineColor.getValue(Iso8601.MINIMUM_VALUE)).toEqual(new Color(0.2, 0.2, 0.2, 0.2));
         expect(entity.rectangle.outlineWidth.getValue(Iso8601.MINIMUM_VALUE)).toEqual(6);
+        expect(entity.rectangle.castShadows.getValue(Iso8601.MINIMUM_VALUE)).toEqual(true);
+        expect(entity.rectangle.receiveShadows.getValue(Iso8601.MINIMUM_VALUE)).toEqual(true);
     });
 
     it('CZML adds data for rectangle in degrees.', function() {
@@ -1931,7 +1977,9 @@ defineSuite([
                 outlineColor : {
                     rgbaf : [0.2, 0.2, 0.2, 0.2]
                 },
-                outlineWidth : 6
+                outlineWidth : 6,
+                castShadows : true,
+                receiveShadows : true
             }
         };
 
@@ -1950,6 +1998,8 @@ defineSuite([
         expect(entity.wall.outline.getValue(Iso8601.MINIMUM_VALUE)).toEqual(true);
         expect(entity.wall.outlineColor.getValue(Iso8601.MINIMUM_VALUE)).toEqual(new Color(0.2, 0.2, 0.2, 0.2));
         expect(entity.wall.outlineWidth.getValue(Iso8601.MINIMUM_VALUE)).toEqual(6);
+        expect(entity.wall.castShadows.getValue(Iso8601.MINIMUM_VALUE)).toEqual(true);
+        expect(entity.wall.receiveShadows.getValue(Iso8601.MINIMUM_VALUE)).toEqual(true);
     });
 
     it('Has entity collection with link to data source', function() {

--- a/Specs/DataSources/EllipseGeometryUpdaterSpec.js
+++ b/Specs/DataSources/EllipseGeometryUpdaterSpec.js
@@ -85,6 +85,8 @@ defineSuite([
         expect(updater.isDynamic).toBe(false);
         expect(updater.isOutlineVisible(time)).toBe(false);
         expect(updater.isFilled(time)).toBe(false);
+        expect(updater.castShadowsProperty).toBe(undefined);
+        expect(updater.receiveShadowsProperty).toBe(undefined);
         updater.destroy();
         expect(updater.isDestroyed()).toBe(true);
     });
@@ -143,6 +145,8 @@ defineSuite([
         expect(updater.outlineColorProperty).toBe(undefined);
         expect(updater.outlineWidth).toBe(1.0);
         expect(updater.isDynamic).toBe(false);
+        expect(updater.castShadowsProperty).toEqual(new ConstantProperty(false));
+        expect(updater.receiveShadowsProperty).toEqual(new ConstantProperty(false));
     });
 
     it('Ellipse material is correctly exposed.', function() {

--- a/Specs/DataSources/EllipseGraphicsSpec.js
+++ b/Specs/DataSources/EllipseGraphicsSpec.js
@@ -30,7 +30,9 @@ defineSuite([
             fill : false,
             outline : false,
             outlineColor : Color.RED,
-            outlineWidth : 9
+            outlineWidth : 9,
+            castShadows : false,
+            receiveShadows : false
         };
 
         var ellipse = new EllipseGraphics(options);
@@ -48,6 +50,8 @@ defineSuite([
         expect(ellipse.outline).toBeInstanceOf(ConstantProperty);
         expect(ellipse.outlineColor).toBeInstanceOf(ConstantProperty);
         expect(ellipse.outlineWidth).toBeInstanceOf(ConstantProperty);
+        expect(ellipse.castShadows).toBeInstanceOf(ConstantProperty);
+        expect(ellipse.receiveShadows).toBeInstanceOf(ConstantProperty);
 
         expect(ellipse.material.color.getValue()).toEqual(options.material);
         expect(ellipse.show.getValue()).toEqual(options.show);
@@ -63,6 +67,8 @@ defineSuite([
         expect(ellipse.outline.getValue()).toEqual(options.outline);
         expect(ellipse.outlineColor.getValue()).toEqual(options.outlineColor);
         expect(ellipse.outlineWidth.getValue()).toEqual(options.outlineWidth);
+        expect(ellipse.castShadows.getValue()).toEqual(options.castShadows);
+        expect(ellipse.receiveShadows.getValue()).toEqual(options.receiveShadows);
     });
 
     it('merge assigns unassigned properties', function() {
@@ -81,6 +87,8 @@ defineSuite([
         source.outlineColor = new ConstantProperty();
         source.outlineWidth = new ConstantProperty();
         source.numberOfVerticalLines = new ConstantProperty();
+        source.castShadows = new ConstantProperty(true);
+        source.receiveShadows = new ConstantProperty(true);
 
         var target = new EllipseGraphics();
         target.merge(source);
@@ -99,6 +107,8 @@ defineSuite([
         expect(target.outlineColor).toBe(source.outlineColor);
         expect(target.outlineWidth).toBe(source.outlineWidth);
         expect(target.numberOfVerticalLines).toBe(source.numberOfVerticalLines);
+        expect(target.castShadows).toBe(source.castShadows);
+        expect(target.receiveShadows).toBe(source.receiveShadows);
     });
 
     it('merge does not assign assigned properties', function() {
@@ -118,6 +128,8 @@ defineSuite([
         var outlineColor = new ConstantProperty();
         var outlineWidth = new ConstantProperty();
         var numberOfVerticalLines = new ConstantProperty();
+        var castShadows = new ConstantProperty();
+        var receiveShadows = new ConstantProperty();
 
         var target = new EllipseGraphics();
         target.material = material;
@@ -134,6 +146,8 @@ defineSuite([
         target.outlineColor = outlineColor;
         target.outlineWidth = outlineWidth;
         target.numberOfVerticalLines = numberOfVerticalLines;
+        target.castShadows = castShadows;
+        target.receiveShadows = receiveShadows;
 
         target.merge(source);
 
@@ -151,6 +165,8 @@ defineSuite([
         expect(target.outlineColor).toBe(outlineColor);
         expect(target.outlineWidth).toBe(outlineWidth);
         expect(target.numberOfVerticalLines).toBe(numberOfVerticalLines);
+        expect(target.castShadows).toBe(castShadows);
+        expect(target.receiveShadows).toBe(receiveShadows);
     });
 
     it('clone works', function() {
@@ -169,6 +185,8 @@ defineSuite([
         source.outlineColor = new ConstantProperty();
         source.outlineWidth = new ConstantProperty();
         source.numberOfVerticalLines = new ConstantProperty();
+        source.castShadows = new ConstantProperty();
+        source.receiveShadows = new ConstantProperty();
 
         var result = source.clone();
         expect(result.material).toBe(source.material);
@@ -185,6 +203,8 @@ defineSuite([
         expect(result.outlineColor).toBe(source.outlineColor);
         expect(result.outlineWidth).toBe(source.outlineWidth);
         expect(result.numberOfVerticalLines).toBe(source.numberOfVerticalLines);
+        expect(result.castShadows).toBe(source.castShadows);
+        expect(result.receiveShadows).toBe(source.receiveShadows);
     });
 
     it('merge throws if source undefined', function() {
@@ -210,5 +230,7 @@ defineSuite([
         testDefinitionChanged(property, 'outlineColor', Color.RED, Color.BLUE);
         testDefinitionChanged(property, 'outlineWidth', 2, 3);
         testDefinitionChanged(property, 'numberOfVerticalLines', 16, 32);
+        testDefinitionChanged(property, 'castShadows', true, false);
+        testDefinitionChanged(property, 'receiveShadows', true, false);
     });
 });

--- a/Specs/DataSources/EllipsoidGeometryUpdaterSpec.js
+++ b/Specs/DataSources/EllipsoidGeometryUpdaterSpec.js
@@ -82,6 +82,8 @@ defineSuite([
         expect(updater.hasConstantOutline).toBe(true);
         expect(updater.outlineColorProperty).toBe(undefined);
         expect(updater.outlineWidth).toBe(1.0);
+        expect(updater.castShadowsProperty).toBe(undefined);
+        expect(updater.receiveShadowsProperty).toBe(undefined);
         expect(updater.isDynamic).toBe(false);
         expect(updater.isOutlineVisible(time)).toBe(false);
         expect(updater.isFilled(time)).toBe(false);
@@ -131,6 +133,8 @@ defineSuite([
         expect(updater.hasConstantOutline).toBe(true);
         expect(updater.outlineColorProperty).toBe(undefined);
         expect(updater.outlineWidth).toBe(1.0);
+        expect(updater.castShadowsProperty).toEqual(new ConstantProperty(false));
+        expect(updater.receiveShadowsProperty).toEqual(new ConstantProperty(false));
         expect(updater.isDynamic).toBe(false);
     });
 

--- a/Specs/DataSources/EllipsoidGraphicsSpec.js
+++ b/Specs/DataSources/EllipsoidGraphicsSpec.js
@@ -27,7 +27,9 @@ defineSuite([
             fill : false,
             outline : false,
             outlineColor : Color.RED,
-            outlineWidth : 4
+            outlineWidth : 4,
+            castShadows : false,
+            receiveShadows : false
         };
 
         var ellipsoid = new EllipsoidGraphics(options);
@@ -40,6 +42,8 @@ defineSuite([
         expect(ellipsoid.outline).toBeInstanceOf(ConstantProperty);
         expect(ellipsoid.outlineColor).toBeInstanceOf(ConstantProperty);
         expect(ellipsoid.outlineWidth).toBeInstanceOf(ConstantProperty);
+        expect(ellipsoid.castShadows).toBeInstanceOf(ConstantProperty);
+        expect(ellipsoid.receiveShadows).toBeInstanceOf(ConstantProperty);
 
         expect(ellipsoid.material.color.getValue()).toEqual(options.material);
         expect(ellipsoid.show.getValue()).toEqual(options.show);
@@ -50,6 +54,8 @@ defineSuite([
         expect(ellipsoid.outline.getValue()).toEqual(options.outline);
         expect(ellipsoid.outlineColor.getValue()).toEqual(options.outlineColor);
         expect(ellipsoid.outlineWidth.getValue()).toEqual(options.outlineWidth);
+        expect(ellipsoid.castShadows.getValue()).toEqual(options.castShadows);
+        expect(ellipsoid.receiveShadows.getValue()).toEqual(options.receiveShadows);
     });
 
     it('merge assigns unassigned properties', function() {
@@ -64,6 +70,8 @@ defineSuite([
         source.outline = new ConstantProperty();
         source.outlineColor = new ConstantProperty();
         source.outlineWidth = new ConstantProperty();
+        source.castShadows = new ConstantProperty(true);
+        source.receiveShadows = new ConstantProperty(true);
 
         var target = new EllipsoidGraphics();
         target.merge(source);
@@ -78,6 +86,8 @@ defineSuite([
         expect(target.outline).toBe(source.outline);
         expect(target.outlineColor).toBe(source.outlineColor);
         expect(target.outlineWidth).toBe(source.outlineWidth);
+        expect(target.castShadows).toBe(source.castShadows);
+        expect(target.receiveShadows).toBe(source.receiveShadows);
     });
 
     it('merge does not assign assigned properties', function() {
@@ -93,6 +103,8 @@ defineSuite([
         var outline = new ConstantProperty();
         var outlineColor = new ConstantProperty();
         var outlineWidth = new ConstantProperty();
+        var castShadows = new ConstantProperty();
+        var receiveShadows = new ConstantProperty();
 
         var target = new EllipsoidGraphics();
         target.material = material;
@@ -101,6 +113,9 @@ defineSuite([
         target.stackPartitions = stackPartitions;
         target.slicePartitions = slicePartitions;
         target.subdivisions = subdivisions;
+        target.castShadows = castShadows;
+        target.receiveShadows = receiveShadows;
+
         source.fill = fill;
         source.outline = outline;
         source.outlineColor = outlineColor;
@@ -118,6 +133,8 @@ defineSuite([
         expect(target.outline).toBe(outline);
         expect(target.outlineColor).toBe(outlineColor);
         expect(target.outlineWidth).toBe(outlineWidth);
+        expect(target.castShadows).toBe(castShadows);
+        expect(target.receiveShadows).toBe(receiveShadows);
     });
 
     it('clone works', function() {
@@ -132,6 +149,8 @@ defineSuite([
         source.outline = new ConstantProperty();
         source.outlineColor = new ConstantProperty();
         source.outlineWidth = new ConstantProperty();
+        source.castShadows = new ConstantProperty();
+        source.receiveShadows = new ConstantProperty();
 
         var result = source.clone();
         expect(result.material).toBe(source.material);
@@ -144,6 +163,8 @@ defineSuite([
         expect(result.outline).toBe(source.outline);
         expect(result.outlineColor).toBe(source.outlineColor);
         expect(result.outlineWidth).toBe(source.outlineWidth);
+        expect(result.castShadows).toBe(source.castShadows);
+        expect(result.receiveShadows).toBe(source.receiveShadows);
     });
 
     it('merge throws if source undefined', function() {
@@ -165,5 +186,7 @@ defineSuite([
         testDefinitionChanged(property, 'outline', true, false);
         testDefinitionChanged(property, 'outlineColor', Color.RED, Color.BLUE);
         testDefinitionChanged(property, 'outlineWidth', 2, 3);
+        testDefinitionChanged(property, 'castShadows', true, false);
+        testDefinitionChanged(property, 'receiveShadows', true, false);
     });
 });

--- a/Specs/DataSources/GeometryVisualizerSpec.js
+++ b/Specs/DataSources/GeometryVisualizerSpec.js
@@ -280,6 +280,52 @@ defineSuite([
         });
     });
 
+    function createAndRemoveGeometryWithShadows(castShadows, receiveShadows) {
+        var objects = new EntityCollection();
+        var visualizer = new GeometryVisualizer(EllipseGeometryUpdater, scene, objects);
+
+        var ellipse = new EllipseGraphics();
+        ellipse.semiMajorAxis = new ConstantProperty(2);
+        ellipse.semiMinorAxis = new ConstantProperty(1);
+        ellipse.material = new ColorMaterialProperty();
+        ellipse.castShadows = new ConstantProperty(castShadows);
+        ellipse.receiveShadows = new ConstantProperty(receiveShadows);
+
+        var entity = new Entity();
+        entity.position = new ConstantPositionProperty(new Cartesian3(1234, 5678, 9101112));
+        entity.ellipse = ellipse;
+        objects.add(entity);
+
+        return pollToPromise(function() {
+            scene.initializeFrame();
+            var isUpdated = visualizer.update(time);
+            scene.render(time);
+            return isUpdated;
+        }).then(function() {
+            var primitive = scene.primitives.get(0);
+            expect(primitive.castShadows).toBe(castShadows);
+            expect(primitive.receiveShadows).toBe(receiveShadows);
+
+            objects.remove(entity);
+
+            return pollToPromise(function() {
+                scene.initializeFrame();
+                expect(visualizer.update(time)).toBe(true);
+                scene.render(time);
+                return scene.primitives.length === 0;
+            }).then(function(){
+                visualizer.destroy();
+            });
+        });
+    }
+
+    it('Creates and removes geometry with shadows', function() {
+        createAndRemoveGeometryWithShadows(true, true);
+        createAndRemoveGeometryWithShadows(true, false);
+        createAndRemoveGeometryWithShadows(false, true);
+        createAndRemoveGeometryWithShadows(false, false);
+    });
+
     it('Correctly handles geometry changing batches', function() {
         var objects = new EntityCollection();
         var visualizer = new GeometryVisualizer(EllipseGeometryUpdater, scene, objects);
@@ -697,7 +743,7 @@ defineSuite([
         });
     });
 
-    it('Sets static geometry  primitive show attribute when using dynamic fill color', function() {
+    it('Sets static geometry primitive show attribute when using dynamic fill color', function() {
         var entities = new EntityCollection();
         var visualizer = new GeometryVisualizer(EllipseGeometryUpdater, scene, entities);
 
@@ -740,7 +786,7 @@ defineSuite([
         });
     });
 
-    it('Sets static geometry  primitive show attribute when using dynamic outline color', function() {
+    it('Sets static geometry primitive show attribute when using dynamic outline color', function() {
         var entities = new EntityCollection();
         var visualizer = new GeometryVisualizer(EllipseGeometryUpdater, scene, entities);
 

--- a/Specs/DataSources/PolygonGeometryUpdaterSpec.js
+++ b/Specs/DataSources/PolygonGeometryUpdaterSpec.js
@@ -86,6 +86,8 @@ defineSuite([
         expect(updater.hasConstantOutline).toBe(true);
         expect(updater.outlineColorProperty).toBe(undefined);
         expect(updater.outlineWidth).toBe(1.0);
+        expect(updater.castShadowsProperty).toBe(undefined);
+        expect(updater.receiveShadowsProperty).toBe(undefined);
         expect(updater.isDynamic).toBe(false);
         expect(updater.isOutlineVisible(time)).toBe(false);
         expect(updater.isFilled(time)).toBe(false);
@@ -126,6 +128,8 @@ defineSuite([
         expect(updater.hasConstantOutline).toBe(true);
         expect(updater.outlineColorProperty).toBe(undefined);
         expect(updater.outlineWidth).toBe(1.0);
+        expect(updater.castShadowsProperty).toEqual(new ConstantProperty(false));
+        expect(updater.receiveShadowsProperty).toEqual(new ConstantProperty(false));
         expect(updater.isDynamic).toBe(false);
     });
 

--- a/Specs/DataSources/PolygonGraphicsSpec.js
+++ b/Specs/DataSources/PolygonGraphicsSpec.js
@@ -32,7 +32,9 @@ defineSuite([
             outlineColor : Color.RED,
             outlineWidth : 7,
             closeTop : true,
-            closeBottom : true
+            closeBottom : true,
+            castShadows : false,
+            receiveShadows : false
         };
 
         var polygon = new PolygonGraphics(options);
@@ -50,6 +52,8 @@ defineSuite([
         expect(polygon.outlineWidth).toBeInstanceOf(ConstantProperty);
         expect(polygon.closeTop).toBeInstanceOf(ConstantProperty);
         expect(polygon.closeBottom).toBeInstanceOf(ConstantProperty);
+        expect(polygon.castShadows).toBeInstanceOf(ConstantProperty);
+        expect(polygon.receiveShadows).toBeInstanceOf(ConstantProperty);
 
         expect(polygon.material.color.getValue()).toEqual(options.material);
         expect(polygon.show.getValue()).toEqual(options.show);
@@ -65,6 +69,8 @@ defineSuite([
         expect(polygon.outlineWidth.getValue()).toEqual(options.outlineWidth);
         expect(polygon.closeTop.getValue()).toEqual(options.closeTop);
         expect(polygon.closeBottom.getValue()).toEqual(options.closeBottom);
+        expect(polygon.castShadows.getValue()).toEqual(options.castShadows);
+        expect(polygon.receiveShadows.getValue()).toEqual(options.receiveShadows);
     });
 
     it('merge assigns unassigned properties', function() {
@@ -83,6 +89,8 @@ defineSuite([
         source.perPositionHeight = new ConstantProperty();
         source.closeTop = new ConstantProperty();
         source.closeBottom = new ConstantProperty();
+        source.castShadows = new ConstantProperty(true);
+        source.receiveShadows = new ConstantProperty(true);
 
         var target = new PolygonGraphics();
         target.merge(source);
@@ -101,6 +109,8 @@ defineSuite([
         expect(target.perPositionHeight).toBe(source.perPositionHeight);
         expect(target.closeTop).toBe(source.closeTop);
         expect(target.closeBottom).toBe(source.closeBottom);
+        expect(target.castShadows).toBe(source.castShadows);
+        expect(target.receiveShadows).toBe(source.receiveShadows);
     });
 
     it('merge does not assign assigned properties', function() {
@@ -120,6 +130,8 @@ defineSuite([
         var perPositionHeight = new ConstantProperty();
         var closeTop = new ConstantProperty();
         var closeBottom = new ConstantProperty();
+        var castShadows = new ConstantProperty();
+        var receiveShadows = new ConstantProperty();
 
         var target = new PolygonGraphics();
         target.material = material;
@@ -136,6 +148,8 @@ defineSuite([
         target.perPositionHeight = perPositionHeight;
         target.closeTop = closeTop;
         target.closeBottom = closeBottom;
+        target.castShadows = castShadows;
+        target.receiveShadows = receiveShadows;
 
         target.merge(source);
 
@@ -153,6 +167,8 @@ defineSuite([
         expect(target.perPositionHeight).toBe(perPositionHeight);
         expect(target.closeTop).toBe(closeTop);
         expect(target.closeBottom).toBe(closeBottom);
+        expect(target.castShadows).toBe(castShadows);
+        expect(target.receiveShadows).toBe(receiveShadows);
     });
 
     it('clone works', function() {
@@ -171,6 +187,8 @@ defineSuite([
         source.perPositionHeight = new ConstantProperty();
         source.closeTop = new ConstantProperty();
         source.closeBottom = new ConstantProperty();
+        source.castShadows = new ConstantProperty();
+        source.receiveShadows = new ConstantProperty();
 
         var result = source.clone();
         expect(result.material).toBe(source.material);
@@ -187,6 +205,8 @@ defineSuite([
         expect(result.perPositionHeight).toBe(source.perPositionHeight);
         expect(result.closeTop).toBe(source.closeTop);
         expect(result.closeBottom).toBe(source.closeBottom);
+        expect(result.castShadows).toBe(source.castShadows);
+        expect(result.receiveShadows).toBe(source.receiveShadows);
     });
 
     it('merge throws if source undefined', function() {
@@ -212,5 +232,7 @@ defineSuite([
         testDefinitionChanged(property, 'perPositionHeight', false, true);
         testDefinitionChanged(property, 'closeTop', true, false);
         testDefinitionChanged(property, 'closeBottom', true, false);
+        testDefinitionChanged(property, 'castShadows', true, false);
+        testDefinitionChanged(property, 'receiveShadows', true, false);
     });
 });

--- a/Specs/DataSources/PolylineGeometryUpdaterSpec.js
+++ b/Specs/DataSources/PolylineGeometryUpdaterSpec.js
@@ -91,6 +91,8 @@ defineSuite([
         expect(updater.hasConstantFill).toBe(true);
         expect(updater.hasConstantOutline).toBe(true);
         expect(updater.outlineColorProperty).toBe(undefined);
+        expect(updater.castShadowsProperty).toBe(undefined);
+        expect(updater.receiveShadowsProperty).toBe(undefined);
         expect(updater.isDynamic).toBe(false);
         expect(updater.isOutlineVisible(time)).toBe(false);
         expect(updater.isFilled(time)).toBe(false);
@@ -129,6 +131,8 @@ defineSuite([
         expect(updater.hasConstantFill).toBe(true);
         expect(updater.hasConstantOutline).toBe(true);
         expect(updater.outlineColorProperty).toBe(undefined);
+        expect(updater.castShadowsProperty).toEqual(new ConstantProperty(false));
+        expect(updater.receiveShadowsProperty).toEqual(new ConstantProperty(false));
         expect(updater.isDynamic).toBe(false);
     });
 

--- a/Specs/DataSources/PolylineGraphicsSpec.js
+++ b/Specs/DataSources/PolylineGraphicsSpec.js
@@ -22,7 +22,9 @@ defineSuite([
             show : true,
             width : 1,
             followSurface : false,
-            granularity : 2
+            granularity : 2,
+            castShadows : false,
+            receiveShadows : false
         };
 
         var polyline = new PolylineGraphics(options);
@@ -32,6 +34,8 @@ defineSuite([
         expect(polyline.width).toBeInstanceOf(ConstantProperty);
         expect(polyline.followSurface).toBeInstanceOf(ConstantProperty);
         expect(polyline.granularity).toBeInstanceOf(ConstantProperty);
+        expect(polyline.castShadows).toBeInstanceOf(ConstantProperty);
+        expect(polyline.receiveShadows).toBeInstanceOf(ConstantProperty);
 
         expect(polyline.material.color.getValue()).toEqual(options.material);
         expect(polyline.positions.getValue()).toEqual(options.positions);
@@ -39,6 +43,8 @@ defineSuite([
         expect(polyline.width.getValue()).toEqual(options.width);
         expect(polyline.followSurface.getValue()).toEqual(options.followSurface);
         expect(polyline.granularity.getValue()).toEqual(options.granularity);
+        expect(polyline.castShadows.getValue()).toEqual(options.castShadows);
+        expect(polyline.receiveShadows.getValue()).toEqual(options.receiveShadows);
     });
 
     it('merge assigns unassigned properties', function() {
@@ -49,6 +55,8 @@ defineSuite([
         source.show = new ConstantProperty();
         source.followSurface = new ConstantProperty();
         source.granularity = new ConstantProperty();
+        source.castShadows = new ConstantProperty(true);
+        source.receiveShadows = new ConstantProperty(true);
 
         var target = new PolylineGraphics();
         target.merge(source);
@@ -58,6 +66,8 @@ defineSuite([
         expect(target.show).toBe(source.show);
         expect(target.followSurface).toBe(source.followSurface);
         expect(target.granularity).toBe(source.granularity);
+        expect(target.castShadows).toBe(source.castShadows);
+        expect(target.receiveShadows).toBe(source.receiveShadows);
     });
 
     it('merge does not assign assigned properties', function() {
@@ -68,6 +78,8 @@ defineSuite([
         source.show = new ConstantProperty();
         source.followSurface = new ConstantProperty();
         source.granularity = new ConstantProperty();
+        source.castShadows = new ConstantProperty();
+        source.receiveShadows = new ConstantProperty();
 
         var color = new ColorMaterialProperty();
         var positions = new ConstantProperty();
@@ -75,6 +87,8 @@ defineSuite([
         var show = new ConstantProperty();
         var followSurface = new ConstantProperty();
         var granularity = new ConstantProperty();
+        var castShadows = new ConstantProperty();
+        var receiveShadows = new ConstantProperty();
 
         var target = new PolylineGraphics();
         target.material = color;
@@ -83,6 +97,8 @@ defineSuite([
         target.show = show;
         target.followSurface = followSurface;
         target.granularity = granularity;
+        target.castShadows = castShadows;
+        target.receiveShadows = receiveShadows;
 
         target.merge(source);
         expect(target.material).toBe(color);
@@ -91,6 +107,8 @@ defineSuite([
         expect(target.show).toBe(show);
         expect(target.followSurface).toBe(followSurface);
         expect(target.granularity).toBe(granularity);
+        expect(target.castShadows).toBe(castShadows);
+        expect(target.receiveShadows).toBe(receiveShadows);
     });
 
     it('clone works', function() {
@@ -101,6 +119,8 @@ defineSuite([
         source.show = new ConstantProperty();
         source.followSurface = new ConstantProperty();
         source.granularity = new ConstantProperty();
+        source.castShadows = new ConstantProperty();
+        source.receiveShadows = new ConstantProperty();
 
         var result = source.clone();
         expect(result.material).toBe(source.material);
@@ -109,6 +129,8 @@ defineSuite([
         expect(result.show).toBe(source.show);
         expect(result.followSurface).toBe(source.followSurface);
         expect(result.granularity).toBe(source.granularity);
+        expect(result.castShadows).toBe(source.castShadows);
+        expect(result.receiveShadows).toBe(source.receiveShadows);
     });
 
     it('merge throws if source undefined', function() {
@@ -126,5 +148,7 @@ defineSuite([
         testDefinitionChanged(property, 'width', 3, 4);
         testDefinitionChanged(property, 'followSurface', false, true);
         testDefinitionChanged(property, 'granularity', 2, 1);
+        testDefinitionChanged(property, 'castShadows', true, false);
+        testDefinitionChanged(property, 'receiveShadows', true, false);
     });
 });

--- a/Specs/DataSources/PolylineVolumeGeometryUpdaterSpec.js
+++ b/Specs/DataSources/PolylineVolumeGeometryUpdaterSpec.js
@@ -89,6 +89,8 @@ defineSuite([
         expect(updater.hasConstantOutline).toBe(true);
         expect(updater.outlineColorProperty).toBe(undefined);
         expect(updater.outlineWidth).toBe(1.0);
+        expect(updater.castShadowsProperty).toBe(undefined);
+        expect(updater.receiveShadowsProperty).toBe(undefined);
         expect(updater.isDynamic).toBe(false);
         expect(updater.isOutlineVisible(time)).toBe(false);
         expect(updater.isFilled(time)).toBe(false);
@@ -128,6 +130,8 @@ defineSuite([
         expect(updater.hasConstantOutline).toBe(true);
         expect(updater.outlineColorProperty).toBe(undefined);
         expect(updater.outlineWidth).toBe(1.0);
+        expect(updater.castShadowsProperty).toEqual(new ConstantProperty(false));
+        expect(updater.receiveShadowsProperty).toEqual(new ConstantProperty(false));
         expect(updater.isDynamic).toBe(false);
     });
 

--- a/Specs/DataSources/PolylineVolumeGraphicsSpec.js
+++ b/Specs/DataSources/PolylineVolumeGraphicsSpec.js
@@ -28,7 +28,9 @@ defineSuite([
             outline : false,
             outlineColor : Color.RED,
             outlineWidth : 2,
-            cornerType : CornerType.BEVELED
+            cornerType : CornerType.BEVELED,
+            castShadows : false,
+            receiveShadows : false
         };
 
         var polylineVolume = new PolylineVolumeGraphics(options);
@@ -42,6 +44,8 @@ defineSuite([
         expect(polylineVolume.outlineColor).toBeInstanceOf(ConstantProperty);
         expect(polylineVolume.outlineWidth).toBeInstanceOf(ConstantProperty);
         expect(polylineVolume.cornerType).toBeInstanceOf(ConstantProperty);
+        expect(polylineVolume.castShadows).toBeInstanceOf(ConstantProperty);
+        expect(polylineVolume.receiveShadows).toBeInstanceOf(ConstantProperty);
 
         expect(polylineVolume.material.color.getValue()).toEqual(options.material);
         expect(polylineVolume.positions.getValue()).toEqual(options.positions);
@@ -53,6 +57,8 @@ defineSuite([
         expect(polylineVolume.outlineColor.getValue()).toEqual(options.outlineColor);
         expect(polylineVolume.outlineWidth.getValue()).toEqual(options.outlineWidth);
         expect(polylineVolume.cornerType.getValue()).toEqual(options.cornerType);
+        expect(polylineVolume.castShadows.getValue()).toEqual(options.castShadows);
+        expect(polylineVolume.receiveShadows.getValue()).toEqual(options.receiveShadows);
     });
 
     it('merge assigns unassigned properties', function() {
@@ -67,6 +73,8 @@ defineSuite([
         source.outlineColor = new ConstantProperty();
         source.outlineWidth = new ConstantProperty();
         source.cornerType = new ConstantProperty();
+        source.castShadows = new ConstantProperty(true);
+        source.receiveShadows = new ConstantProperty(true);
 
         var target = new PolylineVolumeGraphics();
         target.merge(source);
@@ -81,6 +89,8 @@ defineSuite([
         expect(target.outlineColor).toBe(source.outlineColor);
         expect(target.outlineWidth).toBe(source.outlineWidth);
         expect(target.cornerType).toBe(source.cornerType);
+        expect(target.castShadows).toBe(source.castShadows);
+        expect(target.receiveShadows).toBe(source.receiveShadows);
     });
 
     it('merge does not assign assigned properties', function() {
@@ -96,6 +106,8 @@ defineSuite([
         var outlineColor = new ConstantProperty();
         var outlineWidth = new ConstantProperty();
         var cornerType = new ConstantProperty();
+        var castShadows = new ConstantProperty();
+        var receiveShadows = new ConstantProperty();
 
         var target = new PolylineVolumeGraphics();
         target.material = material;
@@ -108,6 +120,8 @@ defineSuite([
         target.outlineColor = outlineColor;
         target.outlineWidth = outlineWidth;
         target.cornerType = cornerType;
+        target.castShadows = castShadows;
+        target.receiveShadows = receiveShadows;
 
         target.merge(source);
 
@@ -121,6 +135,8 @@ defineSuite([
         expect(target.outlineColor).toBe(outlineColor);
         expect(target.outlineWidth).toBe(outlineWidth);
         expect(target.cornerType).toBe(cornerType);
+        expect(target.castShadows).toBe(castShadows);
+        expect(target.receiveShadows).toBe(receiveShadows);
     });
 
     it('clone works', function() {
@@ -135,6 +151,8 @@ defineSuite([
         source.outlineColor = new ConstantProperty();
         source.outlineWidth = new ConstantProperty();
         source.cornerType = new ConstantProperty();
+        source.castShadows = new ConstantProperty();
+        source.receiveShadows = new ConstantProperty();
 
         var result = source.clone();
         expect(result.material).toBe(source.material);
@@ -147,6 +165,8 @@ defineSuite([
         expect(result.outlineColor).toBe(source.outlineColor);
         expect(result.outlineWidth).toBe(source.outlineWidth);
         expect(result.cornerType).toBe(source.cornerType);
+        expect(result.castShadows).toBe(source.castShadows);
+        expect(result.receiveShadows).toBe(source.receiveShadows);
     });
 
     it('merge throws if source undefined', function() {
@@ -168,5 +188,7 @@ defineSuite([
         testDefinitionChanged(property, 'outlineColor', Color.RED, Color.BLUE);
         testDefinitionChanged(property, 'outlineWidth', 2, 3);
         testDefinitionChanged(property, 'cornerType', CornerType.BEVELED, CornerType.MITERED);
+        testDefinitionChanged(property, 'castShadows', true, false);
+        testDefinitionChanged(property, 'receiveShadows', true, false);
     });
 });

--- a/Specs/DataSources/RectangleGeometryUpdaterSpec.js
+++ b/Specs/DataSources/RectangleGeometryUpdaterSpec.js
@@ -81,6 +81,8 @@ defineSuite([
         expect(updater.hasConstantOutline).toBe(true);
         expect(updater.outlineColorProperty).toBe(undefined);
         expect(updater.outlineWidth).toBe(1.0);
+        expect(updater.castShadowsProperty).toBe(undefined);
+        expect(updater.receiveShadowsProperty).toBe(undefined);
         expect(updater.isDynamic).toBe(false);
         expect(updater.isOutlineVisible(time)).toBe(false);
         expect(updater.isFilled(time)).toBe(false);
@@ -121,6 +123,8 @@ defineSuite([
         expect(updater.hasConstantOutline).toBe(true);
         expect(updater.outlineColorProperty).toBe(undefined);
         expect(updater.outlineWidth).toBe(1.0);
+        expect(updater.castShadowsProperty).toEqual(new ConstantProperty(false));
+        expect(updater.receiveShadowsProperty).toEqual(new ConstantProperty(false));
         expect(updater.isDynamic).toBe(false);
     });
 

--- a/Specs/DataSources/RectangleGraphicsSpec.js
+++ b/Specs/DataSources/RectangleGraphicsSpec.js
@@ -32,7 +32,9 @@ defineSuite([
             outlineColor : Color.RED,
             outlineWidth : 10,
             closeTop : false,
-            closeBottom : false
+            closeBottom : false,
+            castShadows : false,
+            receiveShadows : false
         };
 
         var ellipse = new RectangleGraphics(options);
@@ -50,7 +52,9 @@ defineSuite([
         expect(ellipse.outlineWidth).toBeInstanceOf(ConstantProperty);
         expect(ellipse.closeTop).toBeInstanceOf(ConstantProperty);
         expect(ellipse.closeBottom).toBeInstanceOf(ConstantProperty);
-
+        expect(ellipse.castShadows).toBeInstanceOf(ConstantProperty);
+        expect(ellipse.receiveShadows).toBeInstanceOf(ConstantProperty);
+        
         expect(ellipse.material.color.getValue()).toEqual(options.material);
         expect(ellipse.show.getValue()).toEqual(options.show);
         expect(ellipse.coordinates.getValue()).toEqual(options.coordinates);
@@ -65,6 +69,8 @@ defineSuite([
         expect(ellipse.outlineWidth.getValue()).toEqual(options.outlineWidth);
         expect(ellipse.closeTop.getValue()).toEqual(options.closeTop);
         expect(ellipse.closeBottom.getValue()).toEqual(options.closeBottom);
+        expect(ellipse.castShadows.getValue()).toEqual(options.castShadows);
+        expect(ellipse.receiveShadows.getValue()).toEqual(options.receiveShadows);
     });
 
     it('merge assigns unassigned properties', function() {
@@ -83,6 +89,8 @@ defineSuite([
         source.outlineWidth = new ConstantProperty();
         source.closeTop = new ConstantProperty();
         source.closeBottom = new ConstantProperty();
+        source.castShadows = new ConstantProperty(true);
+        source.receiveShadows = new ConstantProperty(true);
 
         var target = new RectangleGraphics();
         target.merge(source);
@@ -101,6 +109,8 @@ defineSuite([
         expect(target.outlineWidth).toBe(source.outlineWidth);
         expect(target.closeTop).toBe(source.closeTop);
         expect(target.closeBottom).toBe(source.closeBottom);
+        expect(target.castShadows).toBe(source.castShadows);
+        expect(target.receiveShadows).toBe(source.receiveShadows);
     });
 
     it('merge does not assign assigned properties', function() {
@@ -120,6 +130,8 @@ defineSuite([
         var outlineWidth = new ConstantProperty();
         var closeTop = new ConstantProperty();
         var closeBottom = new ConstantProperty();
+        var castShadows = new ConstantProperty();
+        var receiveShadows = new ConstantProperty();
 
         var target = new RectangleGraphics();
         target.material = material;
@@ -136,6 +148,8 @@ defineSuite([
         target.outlineWidth = outlineWidth;
         target.closeTop = closeTop;
         target.closeBottom = closeBottom;
+        target.castShadows = castShadows;
+        target.receiveShadows = receiveShadows;
 
         target.merge(source);
 
@@ -153,6 +167,8 @@ defineSuite([
         expect(target.outlineWidth).toBe(outlineWidth);
         expect(target.closeTop).toBe(closeTop);
         expect(target.closeBottom).toBe(closeBottom);
+        expect(target.castShadows).toBe(castShadows);
+        expect(target.receiveShadows).toBe(receiveShadows);
     });
 
     it('clone works', function() {
@@ -171,6 +187,8 @@ defineSuite([
         source.outlineWidth = new ConstantProperty();
         source.closeTop = new ConstantProperty();
         source.closeBottom = new ConstantProperty();
+        source.castShadows = new ConstantProperty();
+        source.receiveShadows = new ConstantProperty();
 
         var result = source.clone();
         expect(result.material).toBe(source.material);
@@ -187,6 +205,8 @@ defineSuite([
         expect(result.outlineWidth).toBe(source.outlineWidth);
         expect(result.closeTop).toBe(source.closeTop);
         expect(result.closeBottom).toBe(source.closeBottom);
+        expect(result.castShadows).toBe(source.castShadows);
+        expect(result.receiveShadows).toBe(source.receiveShadows);
     });
 
     it('merge throws if source undefined', function() {
@@ -212,5 +232,7 @@ defineSuite([
         testDefinitionChanged(property, 'outlineWidth', 2, 3);
         testDefinitionChanged(property, 'closeTop', false, true);
         testDefinitionChanged(property, 'closeBottom', false, true);
+        testDefinitionChanged(property, 'castShadows', true, false);
+        testDefinitionChanged(property, 'receiveShadows', true, false);
     });
 });

--- a/Specs/DataSources/WallGeometryUpdaterSpec.js
+++ b/Specs/DataSources/WallGeometryUpdaterSpec.js
@@ -88,6 +88,8 @@ defineSuite([
         expect(updater.hasConstantOutline).toBe(true);
         expect(updater.outlineColorProperty).toBe(undefined);
         expect(updater.outlineWidth).toBe(1.0);
+        expect(updater.castShadowsProperty).toBe(undefined);
+        expect(updater.receiveShadowsProperty).toBe(undefined);
         expect(updater.isDynamic).toBe(false);
         expect(updater.isOutlineVisible(time)).toBe(false);
         expect(updater.isFilled(time)).toBe(false);
@@ -128,6 +130,8 @@ defineSuite([
         expect(updater.hasConstantOutline).toBe(true);
         expect(updater.outlineColorProperty).toBe(undefined);
         expect(updater.outlineWidth).toBe(1.0);
+        expect(updater.castShadowsProperty).toEqual(new ConstantProperty(false));
+        expect(updater.receiveShadowsProperty).toEqual(new ConstantProperty(false));
         expect(updater.isDynamic).toBe(false);
     });
 

--- a/Specs/DataSources/WallGraphicsSpec.js
+++ b/Specs/DataSources/WallGraphicsSpec.js
@@ -26,7 +26,9 @@ defineSuite([
             outlineColor : Color.RED,
             outlineWidth : 2,
             minimumHeights : [3, 4, 5],
-            maximumHeights : [6, 7, 8]
+            maximumHeights : [6, 7, 8],
+            castShadows : false,
+            receiveShadows : false
         };
 
         var wall = new WallGraphics(options);
@@ -41,6 +43,8 @@ defineSuite([
         expect(wall.outlineWidth).toBeInstanceOf(ConstantProperty);
         expect(wall.minimumHeights).toBeInstanceOf(ConstantProperty);
         expect(wall.maximumHeights).toBeInstanceOf(ConstantProperty);
+        expect(wall.castShadows).toBeInstanceOf(ConstantProperty);
+        expect(wall.receiveShadows).toBeInstanceOf(ConstantProperty);
 
         expect(wall.material.color.getValue()).toEqual(options.material);
         expect(wall.positions.getValue()).toEqual(options.positions);
@@ -53,6 +57,8 @@ defineSuite([
         expect(wall.outlineWidth.getValue()).toEqual(options.outlineWidth);
         expect(wall.minimumHeights.getValue()).toEqual(options.minimumHeights);
         expect(wall.maximumHeights.getValue()).toEqual(options.maximumHeights);
+        expect(wall.castShadows.getValue()).toEqual(options.castShadows);
+        expect(wall.receiveShadows.getValue()).toEqual(options.receiveShadows);
     });
 
     it('merge assigns unassigned properties', function() {
@@ -67,6 +73,8 @@ defineSuite([
         source.outlineWidth = new ConstantProperty();
         source.minimumHeights = new ConstantProperty();
         source.maximumHeights = new ConstantProperty();
+        source.castShadows = new ConstantProperty(true);
+        source.receiveShadows = new ConstantProperty(true);
 
         var target = new WallGraphics();
         target.merge(source);
@@ -81,6 +89,8 @@ defineSuite([
         expect(target.outlineWidth).toBe(source.outlineWidth);
         expect(target.minimumHeights).toBe(source.minimumHeights);
         expect(target.maximumHeights).toBe(source.maximumHeights);
+        expect(target.castShadows).toBe(source.castShadows);
+        expect(target.receiveShadows).toBe(source.receiveShadows);
     });
 
     it('merge does not assign assigned properties', function() {
@@ -96,6 +106,8 @@ defineSuite([
         var outlineWidth = new ConstantProperty();
         var minimumHeights = new ConstantProperty();
         var maximumHeights = new ConstantProperty();
+        var castShadows = new ConstantProperty();
+        var receiveShadows = new ConstantProperty();
 
         var target = new WallGraphics();
         target.material = material;
@@ -108,6 +120,8 @@ defineSuite([
         target.outlineWidth = outlineWidth;
         target.minimumHeights = minimumHeights;
         target.maximumHeights = maximumHeights;
+        target.castShadows = castShadows;
+        target.receiveShadows = receiveShadows;
 
         target.merge(source);
 
@@ -121,6 +135,8 @@ defineSuite([
         expect(target.outlineWidth).toBe(outlineWidth);
         expect(target.minimumHeights).toBe(minimumHeights);
         expect(target.maximumHeights).toBe(maximumHeights);
+        expect(target.castShadows).toBe(castShadows);
+        expect(target.receiveShadows).toBe(receiveShadows);
     });
 
     it('clone works', function() {
@@ -135,6 +151,8 @@ defineSuite([
         source.outlineWidth = new ConstantProperty();
         source.minimumHeights = new ConstantProperty();
         source.maximumHeights = new ConstantProperty();
+        source.castShadows = new ConstantProperty();
+        source.receiveShadows = new ConstantProperty();
 
         var result = source.clone();
         expect(result.material).toBe(source.material);
@@ -147,6 +165,8 @@ defineSuite([
         expect(result.outlineWidth).toBe(source.outlineWidth);
         expect(result.minimumHeights).toBe(source.minimumHeights);
         expect(result.maximumHeights).toBe(source.maximumHeights);
+        expect(result.castShadows).toBe(source.castShadows);
+        expect(result.receiveShadows).toBe(source.receiveShadows);
     });
 
     it('merge throws if source undefined', function() {
@@ -168,5 +188,7 @@ defineSuite([
         testDefinitionChanged(property, 'outlineWidth', 2, 3);
         testDefinitionChanged(property, 'minimumHeights', [0, 1], [2, 3]);
         testDefinitionChanged(property, 'maximumHeights', [3, 5], [7, 8]);
+        testDefinitionChanged(property, 'castShadows', true, false);
+        testDefinitionChanged(property, 'receiveShadows', true, false);
     });
 });

--- a/Specs/Widgets/Viewer/ViewerSpec.js
+++ b/Specs/Widgets/Viewer/ViewerSpec.js
@@ -361,13 +361,6 @@ defineSuite([
         expect(viewer.shadows).toBe(true);
     });
 
-    it('can set terrain shadows', function() {
-        viewer = createViewer(container, {
-            terrainShadows : true
-        });
-        expect(viewer.terrainShadows).toBe(true);
-    });
-
     it('can set terrainProvider', function() {
         var provider = new EllipsoidTerrainProvider();
 


### PR DESCRIPTION
For #2594 

I added `castShadows` and `receiveShadows` properties to all the applicable entity types. It supports changing these properties at runtime. Batching based on shadows is handled in `GeometryVisualizer`. Each batch, besides the dynamic batch, is now an array of 4 batches (cast+receive, cast, receive, none). This was the cleanest solution for now, but could get unwieldy if we continue to add more bucket types. I tried and gave up on a unified solution for batching so that we wouldn't need `StaticOutlineGeometryBatch`, `StaticGeometryColorBatch`, and in `StaticGeometryPerMaterialBatch`. Maybe this is worth revisiting in a future rewrite.

I also added the property `Viewer.terrainShadows` which controls whether the terrain casts shadows. I considered having two properties for cast and receive, but in most cases the user won't be playing around with receive. It seems clearer this way.