### PR TITLE
Shadows - Viewer Change

### DIFF
--- a/Source/Scene/Globe.js
+++ b/Source/Scene/Globe.js
@@ -189,7 +189,7 @@ define([
         this.depthTestAgainstTerrain = false;
 
         /**
-         * Determines whether the globe will cast shadows from each light source. Any primitive that has
+         * Determines whether the globe casts shadows from each light source. Any primitive that has
          * <code>receiveShadows</code> set to <code>true</code> will receive shadows that are casted by
          * the globe. This may impact performance since the terrain is rendered again from the light's
          * perspective, which will also load terrain tiles that are potentially out of view.
@@ -200,7 +200,7 @@ define([
         this.castShadows = false;
 
         /**
-         * Determines whether the globe will receive shadows from any shadow casters in the scene.
+         * Determines whether the globe receives shadows from shadow casters in the scene.
          *
          * @type {Boolean}
          * @default true

--- a/Source/Scene/Primitive.js
+++ b/Source/Scene/Primitive.js
@@ -108,8 +108,8 @@ define([
      * @param {Boolean} [options.cull=true] When <code>true</code>, the renderer frustum culls and horizon culls the primitive's commands based on their bounding volume.  Set this to <code>false</code> for a small performance gain if you are manually culling the primitive.
      * @param {Boolean} [options.asynchronous=true] Determines if the primitive will be created asynchronously or block until ready.
      * @param {Boolean} [options.debugShowBoundingVolume=false] For debugging only. Determines if this primitive's commands' bounding spheres are shown.
-     * @param {Boolean} [options.castShadows=false] Determines whether this primitive will cast shadows from each light source.
-     * @param {Boolean} [options.receiveShadows=false] Determines whether this primitive will receive shadows from any shadow casters in the scene.
+     * @param {Boolean} [options.castShadows=false] Determines whether this primitive casts shadows from each light source.
+     * @param {Boolean} [options.receiveShadows=false] Determines whether this primitive receives shadows from shadow casters in the scene.
      *
      * @example
      * // 1. Draw a translucent ellipse on the surface with a checkerboard pattern
@@ -284,7 +284,7 @@ define([
         //>>includeEnd('debug');
 
         /**
-         * Determines whether this primitive will cast shadows from each light source.
+         * Determines whether this primitive casts shadows from each light source.
          *
          * @type {Boolean}
          *
@@ -293,7 +293,7 @@ define([
         this.castShadows = defaultValue(options.castShadows, false);
 
         /**
-         * Determines whether this primitive will receive shadows from any shadow casters in the scene.
+         * Determines whether this primitive receives shadows from shadow casters in the scene.
          *
          * @type {Boolean}
          *

--- a/Source/Widgets/CesiumWidget/CesiumWidget.js
+++ b/Source/Widgets/CesiumWidget/CesiumWidget.js
@@ -160,7 +160,8 @@ define([
      *        to the bottom of the widget itself.
      * @param {Number} [options.terrainExaggeration=1.0] A scalar used to exaggerate the terrain. Note that terrain exaggeration will not modify any other primitive as they are positioned relative to the ellipsoid.
      * @param {Boolean} [options.shadows=false] Determines if shadows are cast by the sun.
-     *     
+     * @param {Boolean} [options.terrainShadows=false] Determines if the terrain casts shadows from the sun.
+     *
      * @exception {DeveloperError} Element with id "container" does not exist in the document.
      *
      * @demo {@link http://cesiumjs.org/Cesium/Apps/Sandcastle/index.html?src=Cesium%20Widget.html|Cesium Sandcastle Cesium Widget Demo}
@@ -277,6 +278,7 @@ define([
             }
             if (globe !== false) {
                 scene.globe = globe;
+                scene.globe.castShadows = defaultValue(options.terrainShadows, false);
             }
 
             var skyBox = options.skyBox;

--- a/Source/Widgets/Viewer/Viewer.js
+++ b/Source/Widgets/Viewer/Viewer.js
@@ -277,6 +277,7 @@ define([
      *                               the instance is assumed to be owned by the caller and will not be destroyed when the viewer is destroyed.
      * @param {Number} [options.terrainExaggeration=1.0] A scalar used to exaggerate the terrain. Note that terrain exaggeration will not modify any other primitive as they are positioned relative to the ellipsoid.
      * @param {Boolean} [options.shadows=false] Determines if shadows are cast by the sun.
+     * @param {Boolean} [options.terrainShadows=false] Determines if the terrain casts shadows from the sun.
      *
      * @exception {DeveloperError} Element with id "container" does not exist in the document.
      * @exception {DeveloperError} options.imageryProvider is not available when using the BaseLayerPicker widget, specify options.selectedImageryProviderViewModel instead.
@@ -410,7 +411,8 @@ Either specify options.terrainProvider instead or set options.baseLayerPicker to
             creditContainer : defined(options.creditContainer) ? options.creditContainer : bottomContainer,
             scene3DOnly : scene3DOnly,
             terrainExaggeration : options.terrainExaggeration,
-            shadows : options.shadows
+            shadows : options.shadows,
+            terrainShadows : options.terrainShadows
         });
 
         var dataSourceCollection = options.dataSources;
@@ -948,7 +950,6 @@ Either specify options.terrainProvider instead or set options.baseLayerPicker to
          * Determines if shadows are cast by the sun.
          * @memberof Viewer.prototype
          * @type {Boolean}
-         * @readonly
          */
         shadows : {
             get : function() {
@@ -956,6 +957,20 @@ Either specify options.terrainProvider instead or set options.baseLayerPicker to
             },
             set : function(value) {
                 this.scene.shadowMap.enabled = value;
+            }
+        },
+
+        /**
+         * Determines if the terrain casts shadows from the sun.
+         * @memberof Viewer.prototype
+         * @type {Boolean}
+         */
+        terrainShadows : {
+            get : function() {
+                return this.scene.globe.castShadows;
+            },
+            set : function(value) {
+                this.scene.globe.castShadows = value;
             }
         },
 

--- a/Specs/Widgets/Viewer/ViewerSpec.js
+++ b/Specs/Widgets/Viewer/ViewerSpec.js
@@ -361,6 +361,13 @@ defineSuite([
         expect(viewer.shadows).toBe(true);
     });
 
+    it('can set terrain shadows', function() {
+        viewer = createViewer(container, {
+            terrainShadows : true
+        });
+        expect(viewer.terrainShadows).toBe(true);
+    });
+
     it('can set terrainProvider', function() {
         var provider = new EllipsoidTerrainProvider();
 


### PR DESCRIPTION
For #2594 

Separated this code from #3928.

> I also added the property Viewer.terrainShadows which controls whether the terrain casts shadows. I considered having two properties for cast and receive, but in most cases the user won't be playing around with receive. It seems clearer this way.