### PR TITLE
Fix model 2D z-fighting

### DIFF
--- a/Apps/Sandcastle/gallery/3D Models.html
+++ b/Apps/Sandcastle/gallery/3D Models.html
@@ -55,7 +55,7 @@ function createModel(url, height) {
     viewer.trackedEntity = entity;
 }
 
-var options = [/*{
+var options = [{
     text : 'Aircraft',
     onselect : function() {
         createModel('../../SampleData/models/CesiumAir/Cesium_Air.glb', 5000.0);
@@ -70,7 +70,7 @@ var options = [/*{
     onselect : function() {
         createModel('../../SampleData/models/CesiumMilkTruck/CesiumMilkTruck-kmc.glb', 0);
     }
-},*/ {
+}, {
     text : 'Skinned character',
     onselect : function() {
         createModel('../../SampleData/models/CesiumMan/Cesium_Man.glb', 0);

--- a/Apps/Sandcastle/gallery/3D Models.html
+++ b/Apps/Sandcastle/gallery/3D Models.html
@@ -29,8 +29,7 @@ function startup(Cesium) {
 //Sandcastle_Begin
 var viewer = new Cesium.Viewer('cesiumContainer', {
     infoBox : false,
-    selectionIndicator : false,
-    sceneMode : Cesium.SceneMode.SCENE2D
+    selectionIndicator : false
 });
 
 function createModel(url, height) {

--- a/Apps/Sandcastle/gallery/3D Models.html
+++ b/Apps/Sandcastle/gallery/3D Models.html
@@ -29,7 +29,8 @@ function startup(Cesium) {
 //Sandcastle_Begin
 var viewer = new Cesium.Viewer('cesiumContainer', {
     infoBox : false,
-    selectionIndicator : false
+    selectionIndicator : false,
+    sceneMode : Cesium.SceneMode.SCENE2D
 });
 
 function createModel(url, height) {
@@ -54,7 +55,7 @@ function createModel(url, height) {
     viewer.trackedEntity = entity;
 }
 
-var options = [{
+var options = [/*{
     text : 'Aircraft',
     onselect : function() {
         createModel('../../SampleData/models/CesiumAir/Cesium_Air.glb', 5000.0);
@@ -69,7 +70,7 @@ var options = [{
     onselect : function() {
         createModel('../../SampleData/models/CesiumMilkTruck/CesiumMilkTruck-kmc.glb', 0);
     }
-}, {
+},*/ {
     text : 'Skinned character',
     onselect : function() {
         createModel('../../SampleData/models/CesiumMan/Cesium_Man.glb', 0);

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,7 @@ Change Log
 * Fixed a bug that was causing errors to be thrown when picking and terrain was enabled. [#3779](https://github.com/AnalyticalGraphicsInc/cesium/issues/3779)
 * Fixed issue where labels were disappearing. [3730](https://github.com/AnalyticalGraphicsInc/cesium/issues/3730)
 * Added `CullingVolume.fromBoundingSphere`.
+* Added `Scene.nearToFarDistance2D` that determines the size of each frustum of the multifrustum in 2D.
 
 ### 1.21 - 2016-05-02
 

--- a/Source/Scene/Scene.js
+++ b/Source/Scene/Scene.js
@@ -1274,6 +1274,8 @@ define([
         if (!is2D) {
             numFrustums = Math.ceil(Math.log(far / near) / Math.log(farToNearRatio));
         } else {
+            far = Math.min(far, camera.position.z + scene.frustumSize2D);
+            near = Math.min(near, far);
             numFrustums = Math.ceil(Math.max(1.0, far - near) / scene.frustumSize2D);
         }
 

--- a/Source/Scene/Scene.js
+++ b/Source/Scene/Scene.js
@@ -400,6 +400,7 @@ define([
          * @default 1000.0
          */
         this.farToNearRatio = 1000.0;
+
         /**
          * Determines the uniform depth size in meters of each frustum of the multifrustum in 2D. If a primitive or model close
          * to the surface shows z-fighting, decreasing this will eliminate the artifact, but decrease performance. On the


### PR DESCRIPTION
Uniformly divides the camera frustum in 2D. The default depth for each frustum is `1.75e6` which divides the camera frustum up to 9 times. Increasing `Scene.frustumSize2D` will increase performance by decreasing the number of frustums but may cause some z-fighting.