### PR TITLE
Fix models in 2D near the IDL.

### DIFF
--- a/Source/Scene/Model.js
+++ b/Source/Scene/Model.js
@@ -3161,8 +3161,6 @@ define([
 
     ///////////////////////////////////////////////////////////////////////////
 
-    var scratchCartographic = new Cartographic();
-
     function getUpdateHeightCallback(model, ellipsoid, cartoPosition) {
         return function (clampedPosition) {
             if (model.heightReference === HeightReference.RELATIVE_TO_GROUND) {

--- a/Specs/Scene/ModelSpec.js
+++ b/Specs/Scene/ModelSpec.js
@@ -226,6 +226,14 @@ defineSuite([
         verifyRender(texturedBoxModel);
     });
 
+    it('renders in 2D over the IDL', function() {
+        return when(loadModel(texturedBoxUrl)).then(function(model) {
+            model.modelMatrix = Transforms.eastNorthUpToFixedFrame(Cartesian3.fromDegrees(180.0, 0.0, 100.0));
+            scene.morphTo2D(0.0);
+            verifyRender(model);
+        });
+    });
+
     it('resolves readyPromise', function() {
         return texturedBoxModel.readyPromise.then(function(model) {
             verifyRender(model);


### PR DESCRIPTION
Adds another command to each node (when not `scene3DOnly`). Updates that command to position it on the opposite side of the map. Adds the command only if the bounding sphere intersects the IDL.