### PR TITLE
Added heightReference to models

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,7 @@ Change Log
 * Fixed issue where a repeating model animation doesn't play when the clock is set to a time before the model was created. [3932](https://github.com/AnalyticalGraphicsInc/cesium/issues/3932)
 * Fixed issue where billboards on terrain didn't always update when the terrain provider was changed. [3921](https://github.com/AnalyticalGraphicsInc/cesium/issues/3921)
 * Added `heightReference` to models so they can be drawn on terrain.
+* Added `terrainProviderChanged` event to `Scene` and `Globe`
 * Added `CullingVolume.fromBoundingSphere`.
 * Added `debugShowShadowVolume` to `GroundPrimitive`.
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,8 @@ Change Log
 * Fixed a bug that was causing errors to be thrown when picking and terrain was enabled. [#3779](https://github.com/AnalyticalGraphicsInc/cesium/issues/3779)
 * Fixed issue where labels were disappearing. [3730](https://github.com/AnalyticalGraphicsInc/cesium/issues/3730)
 * Fixed issue where a repeating model animation doesn't play when the clock is set to a time before the model was created. [3932](https://github.com/AnalyticalGraphicsInc/cesium/issues/3932)
+* Fixed issue where billboards on terrain didn't always update when the terrain provider was changed. [3921](https://github.com/AnalyticalGraphicsInc/cesium/issues/3921)
+* Added `heightReference` to models so they can be drawn on terrain.
 * Added `CullingVolume.fromBoundingSphere`.
 * Added `debugShowShadowVolume` to `GroundPrimitive`.
 

--- a/Source/Scene/Billboard.js
+++ b/Source/Scene/Billboard.js
@@ -152,6 +152,13 @@ define([
         this._mode = SceneMode.SCENE3D;
 
         this._updateClamping();
+
+        var scene = this._billboardCollection._scene;
+        if (defined(scene)) {
+            scene.terrainProviderChanged.addEventListener(function() {
+                this._updateClamping();
+            }, this);
+        }
     }
 
     var SHOW_INDEX = Billboard.SHOW_INDEX = 0;

--- a/Source/Scene/Billboard.js
+++ b/Source/Scene/Billboard.js
@@ -152,13 +152,6 @@ define([
         this._mode = SceneMode.SCENE3D;
 
         this._updateClamping();
-
-        var scene = this._billboardCollection._scene;
-        if (defined(scene)) {
-            scene.terrainProviderChanged.addEventListener(function() {
-                this._updateClamping();
-            }, this);
-        }
     }
 
     var SHOW_INDEX = Billboard.SHOW_INDEX = 0;
@@ -853,9 +846,11 @@ define([
     Billboard._updateClamping = function(collection, owner) {
         var scene = collection._scene;
         if (!defined(scene)) {
+            //>>includeStart('debug', pragmas.debug);
             if (owner._heightReference !== HeightReference.NONE) {
-                throw new DeveloperError('Height reference is not supported.');
+                throw new DeveloperError('Height reference is not supported without a scene.');
             }
+            //>>includeEnd('debug');
             return;
         }
 

--- a/Source/Scene/BillboardCollection.js
+++ b/Source/Scene/BillboardCollection.js
@@ -281,6 +281,17 @@ define([
                 return that._textureAtlas.texture;
             }
         };
+
+        var scene = this._scene;
+        if (defined(scene)) {
+            scene.terrainProviderChanged.addEventListener(function() {
+                var billboards = this._billboards;
+                var length = billboards.length;
+                for (var i=0;i<length;++i) {
+                    billboards[i]._updateClamping();
+                }
+            }, this);
+        }
     }
 
     defineProperties(BillboardCollection.prototype, {

--- a/Source/Scene/Globe.js
+++ b/Source/Scene/Globe.js
@@ -11,6 +11,7 @@ define([
         '../Core/DeveloperError',
         '../Core/Ellipsoid',
         '../Core/EllipsoidTerrainProvider',
+        '../Core/Event',
         '../Core/GeographicProjection',
         '../Core/IntersectionTests',
         '../Core/loadImage',
@@ -39,6 +40,7 @@ define([
         DeveloperError,
         Ellipsoid,
         EllipsoidTerrainProvider,
+        Event,
         GeographicProjection,
         IntersectionTests,
         loadImage,
@@ -95,11 +97,8 @@ define([
             })
         });
 
-        /**
-         * The terrain provider providing surface geometry for this globe.
-         * @type {TerrainProvider}
-         */
-        this.terrainProvider = terrainProvider;
+        this._terrainProvider = terrainProvider;
+        this._terrainProviderChanged = new Event();
 
         /**
          * Determines if the globe will be shown.
@@ -224,6 +223,37 @@ define([
             },
             set : function(value) {
                 this._surface.tileProvider.baseColor = value;
+            }
+        },
+        /**
+         * The terrain provider providing surface geometry for this globe.
+         * @type {TerrainProvider}
+         *
+         * @memberof Globe.prototype
+         * @type {TerrainProvider}
+         *
+         */
+        terrainProvider : {
+            get : function() {
+                return this._terrainProvider;
+            },
+            set : function(value) {
+                if (value !== this._terrainProvider) {
+                    this._terrainProvider = value;
+                    this._terrainProviderChanged.raiseEvent(value);
+                }
+            }
+        },
+        /**
+         * Gets an event that's raised when the terrain provider is changed
+         *
+         * @memberof Globe.prototype
+         * @type {Event}
+         * @readonly
+         */
+        terrainProviderChanged : {
+            get: function() {
+                return this._terrainProviderChanged;
             }
         },
         /**

--- a/Source/Scene/Model.js
+++ b/Source/Scene/Model.js
@@ -4,6 +4,7 @@ define([
         '../Core/Cartesian2',
         '../Core/Cartesian3',
         '../Core/Cartesian4',
+        '../Core/Cartographic',
         '../Core/clone',
         '../Core/combine',
         '../Core/ComponentDatatype',
@@ -46,6 +47,7 @@ define([
         '../ThirdParty/Uri',
         '../ThirdParty/when',
         './getModelAccessor',
+        './HeightReference',
         './ModelAnimationCache',
         './ModelAnimationCollection',
         './ModelMaterial',
@@ -59,6 +61,7 @@ define([
         Cartesian2,
         Cartesian3,
         Cartesian4,
+        Cartographic,
         clone,
         combine,
         ComponentDatatype,
@@ -101,6 +104,7 @@ define([
         Uri,
         when,
         getModelAccessor,
+        HeightReference,
         ModelAnimationCache,
         ModelAnimationCollection,
         ModelMaterial,
@@ -307,6 +311,8 @@ define([
      * @param {Boolean} [options.asynchronous=true] Determines if model WebGL resource creation will be spread out over several frames or block until completion once all glTF files are loaded.
      * @param {Boolean} [options.debugShowBoundingVolume=false] For debugging only. Draws the bounding sphere for each draw command in the model.
      * @param {Boolean} [options.debugWireframe=false] For debugging only. Draws the model in wireframe.
+     * @param {HeightReference} [options.heightReference] Determines how the model is drawn relative to terrain.
+     * @param {Scene} [options.scene] Must be passed in for models that use the height reference property.
      *
      * @exception {DeveloperError} bgltf is not a valid Binary glTF file.
      * @exception {DeveloperError} Only glTF Binary version 1 is supported.
@@ -400,6 +406,7 @@ define([
          */
         this.modelMatrix = Matrix4.clone(defaultValue(options.modelMatrix, Matrix4.IDENTITY));
         this._modelMatrix = Matrix4.clone(this.modelMatrix);
+        this._clampedModelMatrix = undefined;
 
         /**
          * A uniform scale applied to this model before the {@link Model#modelMatrix}.
@@ -446,6 +453,21 @@ define([
          */
         this.id = options.id;
         this._id = options.id;
+
+        /**
+         * Returns the height reference of the model
+         *
+         * @memberof Model.prototype
+         *
+         * @type {HeightReference}
+         *
+         * @default HeightReference.NONE
+         */
+        this.heightReference = defaultValue(options.heightReference, HeightReference.NONE);
+        this._heightReference = this.heightReference;
+        this._heightChanged = false;
+        this._removeUpdateHeightCallback = undefined;
+        this._scene = options.scene;
 
         /**
          * Used for picking primitives that wrap a model.
@@ -666,7 +688,12 @@ define([
                 }
                 //>>includeEnd('debug');
 
-                var nonUniformScale = Matrix4.getScale(this.modelMatrix, boundingSphereCartesian3Scratch);
+                var modelMatrix = this.modelMatrix;
+                if ((this.heightReference !== HeightReference.NONE) && this._clampedModelMatrix) {
+                    modelMatrix = this._clampedModelMatrix;
+                }
+
+                var nonUniformScale = Matrix4.getScale(modelMatrix, boundingSphereCartesian3Scratch);
                 var scale = defined(this.maximumScale) ? Math.min(this.maximumScale, this.scale) : this.scale;
                 Cartesian3.multiplyByScalar(nonUniformScale, scale, nonUniformScale);
 
@@ -3077,6 +3104,32 @@ define([
 
     ///////////////////////////////////////////////////////////////////////////
 
+    var scratchCartographic = new Cartographic();
+
+    function getUpdateHeightCallback(model, ellipsoid, cartoPosition) {
+        return function (clampedPosition) {
+            if (model.heightReference === HeightReference.RELATIVE_TO_GROUND) {
+                var clampedCart = ellipsoid.cartesianToCartographic(clampedPosition, scratchCartographic);
+                clampedCart.height += cartoPosition.height;
+                ellipsoid.cartographicToCartesian(clampedCart, clampedPosition);
+            }
+
+            var clampedModelMatrix = model._clampedModelMatrix;
+            if (!defined(clampedModelMatrix)) {
+                clampedModelMatrix = new Matrix4();
+                model._clampedModelMatrix = clampedModelMatrix;
+            }
+
+            // Modify clamped model matrix to use new height
+            Matrix4.clone(model.modelMatrix, clampedModelMatrix);
+            clampedModelMatrix[12] = clampedPosition.x;
+            clampedModelMatrix[13] = clampedPosition.y;
+            clampedModelMatrix[14] = clampedPosition.z;
+
+            model._heightChanged = true;
+        };
+    }
+
     /**
      * Called when {@link Viewer} or {@link CesiumWidget} render the scene to
      * get the draw commands needed to render this primitive.
@@ -3199,22 +3252,52 @@ define([
             var animated = this.activeAnimations.update(frameState) || this._cesiumAnimationsDirty;
             this._cesiumAnimationsDirty = false;
             this._dirty = false;
+            var modelMatrix = this.modelMatrix;
 
             // Model's model matrix needs to be updated
-            var modelTransformChanged = !Matrix4.equals(this._modelMatrix, this.modelMatrix) ||
+            var modelTransformChanged = !Matrix4.equals(this._modelMatrix, modelMatrix) ||
                 (this._scale !== this.scale) ||
                 (this._minimumPixelSize !== this.minimumPixelSize) || (this.minimumPixelSize !== 0.0) || // Minimum pixel size changed or is enabled
-                (this._maximumScale !== this.maximumScale);
+                (this._maximumScale !== this.maximumScale) || (this._heightReference !== this.heightReference) ||
+                this._heightChanged;
 
             if (modelTransformChanged || justLoaded) {
-                Matrix4.clone(this.modelMatrix, this._modelMatrix);
+                Matrix4.clone(modelMatrix, this._modelMatrix);
+
+                if (defined(this._removeUpdateHeightCallback)) {
+                    this._removeUpdateHeightCallback();
+                    this._removeUpdateHeightCallback = undefined;
+                }
+
+                // If it's on terrain use the clampedModelMatrix if we have it
+                var scene = this._scene;
+                if ((this.heightReference !== HeightReference.NONE) && defined(scene)) {
+                    var globe = scene.globe;
+                    var ellipsoid = globe.ellipsoid;
+
+                    // Compute cartographic position so we don't recompute every update
+                    scratchPosition.x = modelMatrix[12];
+                    scratchPosition.y = modelMatrix[13];
+                    scratchPosition.z = modelMatrix[14];
+                    var cartoPosition = ellipsoid.cartesianToCartographic(scratchPosition);
+
+                    var surface = globe._surface;
+                    this._removeUpdateHeightCallback = surface.updateHeight(cartoPosition, getUpdateHeightCallback(this, ellipsoid, cartoPosition));
+
+                    if (defined(this._clampedModelMatrix)) {
+                        modelMatrix = this._clampedModelMatrix;
+                    }
+                }
+
                 this._scale = this.scale;
                 this._minimumPixelSize = this.minimumPixelSize;
                 this._maximumScale = this.maximumScale;
+                this._heightReference = this.heightReference;
+                this._heightChanged = false;
 
                 var scale = getScale(this, frameState);
                 var computedModelMatrix = this._computedModelMatrix;
-                Matrix4.multiplyByUniformScale(this.modelMatrix, scale, computedModelMatrix);
+                Matrix4.multiplyByUniformScale(modelMatrix, scale, computedModelMatrix);
                 Matrix4.multiplyTransformation(computedModelMatrix, yUpToZUp, computedModelMatrix);
             }
 

--- a/Source/Scene/Model.js
+++ b/Source/Scene/Model.js
@@ -3153,7 +3153,6 @@ define([
             return;
         }
 
-        // If it's on terrain use the clampedModelMatrix if we have it
         var globe = scene.globe;
         var ellipsoid = globe.ellipsoid;
 
@@ -3164,8 +3163,22 @@ define([
         scratchPosition.z = modelMatrix[14];
         var cartoPosition = ellipsoid.cartesianToCartographic(scratchPosition);
 
+        // Install callback to handle updating of terrain tiles
         var surface = globe._surface;
         model._removeUpdateHeightCallback = surface.updateHeight(cartoPosition, getUpdateHeightCallback(model, ellipsoid, cartoPosition));
+
+        // Set the correct height now
+        var height = globe.getHeight(cartoPosition);
+        if (defined(height)) {
+            // Get callback with cartoPosition being the non-clamped position
+            var cb = getUpdateHeightCallback(model, ellipsoid, cartoPosition);
+
+            // Compute the clamped cartesian and call updateHeight callback
+            Cartographic.clone(cartoPosition, scratchCartographic);
+            scratchCartographic.height = height;
+            ellipsoid.cartographicToCartesian(scratchCartographic, scratchPosition);
+            cb(scratchPosition);
+        }
     }
 
     /**

--- a/Source/Scene/Scene.js
+++ b/Source/Scene/Scene.js
@@ -822,6 +822,19 @@ define([
         },
 
         /**
+         * Gets an event that's raised when the terrain provider is changed
+         * @memberof Scene.prototype
+         *
+         * @type {Event}
+         * @readonly
+         */
+        terrainProviderChanged : {
+            get : function() {
+                return this.globe.terrainProviderChanged;
+            }
+        },
+
+        /**
          * Gets the event that will be raised when an error is thrown inside the <code>render</code> function.
          * The Scene instance and the thrown error are the only two parameters passed to the event handler.
          * By default, errors are not rethrown after this event is raised, but that can be changed by setting

--- a/Specs/Scene/BillboardCollectionSpec.js
+++ b/Specs/Scene/BillboardCollectionSpec.js
@@ -8,6 +8,7 @@ defineSuite([
         'Core/Color',
         'Core/defined',
         'Core/Ellipsoid',
+        'Core/Event',
         'Core/loadImage',
         'Core/Math',
         'Core/NearFarScalar',
@@ -30,6 +31,7 @@ defineSuite([
         Color,
         defined,
         Ellipsoid,
+        Event,
         loadImage,
         CesiumMath,
         NearFarScalar,
@@ -1575,6 +1577,8 @@ defineSuite([
                 _surface : {},
                 destroy : function() {}
             };
+
+            globe.terrainProviderChanged = new Event();
 
             globe._surface.updateHeight = function(position, callback) {
                 globe.callback = callback;

--- a/Specs/Scene/BillboardCollectionSpec.js
+++ b/Specs/Scene/BillboardCollectionSpec.js
@@ -54,53 +54,12 @@ defineSuite([
     var scene;
     var context;
     var camera;
-    var globe;
     var billboards;
-    var billboardsWithHeight;
 
     var greenImage;
     var blueImage;
     var whiteImage;
     var largeBlueImage;
-
-    function createMockGlobe() {
-        var globe = {
-            callback : undefined,
-            removedCallback : false,
-            ellipsoid : Ellipsoid.WGS84,
-            update : function() {},
-            getHeight : function() {
-                return 0.0;
-            },
-            _surface : {},
-            destroy : function() {}
-        };
-
-        globe.beginFrame = function() {
-        };
-
-        globe.endFrame = function() {
-        };
-
-        globe.terrainProviderChanged = new Event();
-        defineProperties(globe, {
-            terrainProvider : {
-                set : function(value) {
-                    this.terrainProviderChanged.raiseEvent(value);
-                }
-            }
-        });
-
-        globe._surface.updateHeight = function(position, callback) {
-            globe.callback = callback;
-            return function() {
-                globe.removedCallback = true;
-                globe.callback = undefined;
-            };
-        };
-
-        return globe;
-    }
 
     beforeAll(function() {
         scene = createScene();
@@ -135,14 +94,6 @@ defineSuite([
 
         billboards = new BillboardCollection();
         scene.primitives.add(billboards);
-
-        globe = createMockGlobe();
-        scene.globe = globe;
-        billboardsWithHeight = new BillboardCollection({
-            scene : scene
-        });
-        scene.primitives.add(billboardsWithHeight);
-        scene.globe = undefined;
     });
 
     afterEach(function() {
@@ -1612,8 +1563,55 @@ defineSuite([
     });
 
     describe('height referenced billboards', function() {
+        function createMockGlobe() {
+            var globe = {
+                callback : undefined,
+                removedCallback : false,
+                ellipsoid : Ellipsoid.WGS84,
+                update : function() {},
+                getHeight : function() {
+                    return 0.0;
+                },
+                _surface : {},
+                destroy : function() {}
+            };
+
+            globe.beginFrame = function() {
+            };
+
+            globe.endFrame = function() {
+            };
+
+            globe.terrainProviderChanged = new Event();
+            defineProperties(globe, {
+                terrainProvider : {
+                    set : function(value) {
+                        this.terrainProviderChanged.raiseEvent(value);
+                    }
+                }
+            });
+
+            globe._surface.updateHeight = function(position, callback) {
+                globe.callback = callback;
+                return function() {
+                    globe.removedCallback = true;
+                    globe.callback = undefined;
+                };
+            };
+
+            return globe;
+        }
+
+        var billboardsWithHeight;
+        beforeEach(function() {
+            scene.globe = createMockGlobe();
+            billboardsWithHeight = new BillboardCollection({
+                scene : scene
+            });
+            scene.primitives.add(billboardsWithHeight);
+        });
+
         it('explicitly constructs a billboard with height reference', function() {
-            scene.globe = globe;
             var b = billboardsWithHeight.add({
                 heightReference : HeightReference.CLAMP_TO_GROUND
             });
@@ -1622,7 +1620,6 @@ defineSuite([
         });
 
         it('set billboard height reference property', function() {
-            scene.globe = globe;
             var b = billboardsWithHeight.add();
             b.heightReference = HeightReference.CLAMP_TO_GROUND;
 
@@ -1630,7 +1627,6 @@ defineSuite([
         });
 
         it('creating with a height reference creates a height update callback', function() {
-            scene.globe = globe;
             billboardsWithHeight.add({
                 heightReference : HeightReference.CLAMP_TO_GROUND,
                 position : Cartesian3.fromDegrees(-72.0, 40.0)
@@ -1639,7 +1635,6 @@ defineSuite([
         });
 
         it('set height reference property creates a height update callback', function() {
-            scene.globe = globe;
             var b = billboardsWithHeight.add({
                 position : Cartesian3.fromDegrees(-72.0, 40.0)
             });
@@ -1648,7 +1643,6 @@ defineSuite([
         });
 
         it('updates the callback when the height reference changes', function() {
-            scene.globe = globe;
             var b = billboardsWithHeight.add({
                 heightReference : HeightReference.CLAMP_TO_GROUND,
                 position : Cartesian3.fromDegrees(-72.0, 40.0)
@@ -1666,7 +1660,6 @@ defineSuite([
         });
 
         it('changing the position updates the callback', function() {
-            scene.globe = globe;
             var b = billboardsWithHeight.add({
                 heightReference : HeightReference.CLAMP_TO_GROUND,
                 position : Cartesian3.fromDegrees(-72.0, 40.0)
@@ -1679,7 +1672,6 @@ defineSuite([
         });
 
         it('callback updates the position', function() {
-            scene.globe = globe;
             var b = billboardsWithHeight.add({
                 heightReference : HeightReference.CLAMP_TO_GROUND,
                 position : Cartesian3.fromDegrees(-72.0, 40.0)
@@ -1695,7 +1687,6 @@ defineSuite([
         });
 
         it('changing the terrain provider', function() {
-            scene.globe = globe;
             var b = billboardsWithHeight.add({
                 heightReference : HeightReference.CLAMP_TO_GROUND,
                 position : Cartesian3.fromDegrees(-72.0, 40.0)
@@ -1715,7 +1706,6 @@ defineSuite([
         });
 
         it('height reference without a scene rejects', function() {
-            scene.globe = globe;
             expect(function() {
                 return billboards.add({
                     heightReference : HeightReference.CLAMP_TO_GROUND,
@@ -1725,7 +1715,6 @@ defineSuite([
         });
 
         it('changing height reference without a scene throws DeveloperError', function() {
-            scene.globe = globe;
             var b = billboards.add({
                 position : Cartesian3.fromDegrees(-72.0, 40.0)
             });

--- a/Specs/Scene/BillboardCollectionSpec.js
+++ b/Specs/Scene/BillboardCollectionSpec.js
@@ -5,8 +5,10 @@ defineSuite([
         'Core/BoundingSphere',
         'Core/Cartesian2',
         'Core/Cartesian3',
+        'Core/CesiumTerrainProvider',
         'Core/Color',
         'Core/defined',
+        'Core/defineProperties',
         'Core/Ellipsoid',
         'Core/Event',
         'Core/loadImage',
@@ -28,8 +30,10 @@ defineSuite([
         BoundingSphere,
         Cartesian2,
         Cartesian3,
+        CesiumTerrainProvider,
         Color,
         defined,
+        defineProperties,
         Ellipsoid,
         Event,
         loadImage,
@@ -1579,6 +1583,13 @@ defineSuite([
             };
 
             globe.terrainProviderChanged = new Event();
+            defineProperties(globe, {
+                terrainProvider : {
+                    set : function(value) {
+                        this.terrainProviderChanged.raiseEvent(value);
+                    }
+                }
+            });
 
             globe._surface.updateHeight = function(position, callback) {
                 globe.callback = callback;
@@ -1671,6 +1682,26 @@ defineSuite([
             scene.globe.callback(Cartesian3.fromDegrees(-72.0, 40.0, 100.0));
             cartographic = scene.globe.ellipsoid.cartesianToCartographic(b._clampedPosition);
             expect(cartographic.height).toEqualEpsilon(100.0, CesiumMath.EPSILON9);
+        });
+
+        it('changing the terrain provider', function() {
+            scene.globe = createMockGlobe();
+            var b = billboardsWithHeight.add({
+                heightReference : HeightReference.CLAMP_TO_GROUND,
+                position : Cartesian3.fromDegrees(-72.0, 40.0)
+            });
+            expect(scene.globe.callback).toBeDefined();
+
+            spyOn(b, '_updateClamping').and.callThrough();
+
+            var terrainProvider = new CesiumTerrainProvider({
+                url : 'made/up/url',
+                requestVertexNormals : true
+            });
+
+            scene.terrainProvider = terrainProvider;
+
+            expect(b._updateClamping).toHaveBeenCalled();
         });
     });
 }, 'WebGL');

--- a/Specs/Scene/GlobeSpec.js
+++ b/Specs/Scene/GlobeSpec.js
@@ -106,6 +106,20 @@ defineSuite([
         });
     });
 
+    it('terrainProviderChanged event fires', function() {
+        var terrainProvider = new CesiumTerrainProvider({
+            url : 'made/up/url',
+            requestVertexNormals : true
+        });
+
+        var spyListener = jasmine.createSpy('listener');
+        globe.terrainProviderChanged.addEventListener(spyListener);
+
+        globe.terrainProvider = terrainProvider;
+
+        expect(spyListener).toHaveBeenCalledWith(terrainProvider);
+    });
+
     it('renders terrain with enableLighting', function() {
         globe.enableLighting = true;
 

--- a/Specs/Scene/ModelSpec.js
+++ b/Specs/Scene/ModelSpec.js
@@ -8,6 +8,8 @@ defineSuite([
         'Core/combine',
         'Core/defaultValue',
         'Core/defined',
+        'Core/Ellipsoid',
+        'Core/Event',
         'Core/FeatureDetection',
         'Core/HeadingPitchRange',
         'Core/JulianDate',
@@ -20,6 +22,7 @@ defineSuite([
         'Renderer/RenderState',
         'Renderer/ShaderSource',
         'Renderer/WebGLConstants',
+        'Scene/HeightReference',
         'Scene/ModelAnimationLoop',
         'Specs/createScene',
         'Specs/pollToPromise',
@@ -33,6 +36,8 @@ defineSuite([
         combine,
         defaultValue,
         defined,
+        Ellipsoid,
+        Event,
         FeatureDetection,
         HeadingPitchRange,
         JulianDate,
@@ -45,6 +50,7 @@ defineSuite([
         RenderState,
         ShaderSource,
         WebGLConstants,
+        HeightReference,
         ModelAnimationLoop,
         createScene,
         pollToPromise,
@@ -1690,6 +1696,161 @@ defineSuite([
 
             m.show = false;
             primitives.remove(m);
+        });
+    });
+
+    describe('height referenced model', function() {
+        function createMockGlobe() {
+            var globe = {
+                callback : undefined,
+                removedCallback : false,
+                ellipsoid : Ellipsoid.WGS84,
+                update : function() {},
+                getHeight : function() {
+                    return 0.0;
+                },
+                _surface : {},
+                destroy : function() {}
+            };
+
+            globe.beginFrame = function() {
+            };
+
+            globe.endFrame = function() {
+            };
+
+            globe.terrainProviderChanged = new Event();
+
+            globe._surface.updateHeight = function(position, callback) {
+                globe.callback = callback;
+                return function() {
+                    globe.removedCallback = true;
+                    globe.callback = undefined;
+                };
+            };
+
+            return globe;
+        }
+
+        it('explicitly constructs a model with height reference', function() {
+            scene.globe = createMockGlobe();
+            return loadModelJson(texturedBoxModel.gltf, {
+                heightReference : HeightReference.CLAMP_TO_GROUND,
+                scene : scene
+            }).then(function(model) {
+                expect(model.heightReference).toEqual(HeightReference.CLAMP_TO_GROUND);
+                primitives.remove(model);
+            });
+        });
+
+        it('set model height reference property', function() {
+            scene.globe = createMockGlobe();
+            return loadModelJson(texturedBoxModel.gltf, {
+                scene : scene
+            }).then(function(model) {
+                model.heightReference = HeightReference.CLAMP_TO_GROUND;
+                expect(model.heightReference).toEqual(HeightReference.CLAMP_TO_GROUND);
+                primitives.remove(model);
+            });
+        });
+
+        it('creating with a height reference creates a height update callback', function() {
+            scene.globe = createMockGlobe();
+            return loadModelJson(texturedBoxModel.gltf, {
+                heightReference : HeightReference.CLAMP_TO_GROUND,
+                position : Cartesian3.fromDegrees(-72.0, 40.0),
+                scene : scene
+            }).then(function(model) {
+                expect(scene.globe.callback).toBeDefined();
+                primitives.remove(model);
+            });
+        });
+
+        it('set height reference property creates a height update callback', function() {
+            scene.globe = createMockGlobe();
+            return loadModelJson(texturedBoxModel.gltf, {
+                position : Cartesian3.fromDegrees(-72.0, 40.0),
+                scene : scene,
+                show : true
+            }).then(function(model) {
+                model.heightReference = HeightReference.CLAMP_TO_GROUND;
+                expect(model.heightReference).toEqual(HeightReference.CLAMP_TO_GROUND);
+                scene.renderForSpecs();
+                expect(scene.globe.callback).toBeDefined();
+                primitives.remove(model);
+            });
+        });
+
+        it('updates the callback when the height reference changes', function() {
+            scene.globe = createMockGlobe();
+            return loadModelJson(texturedBoxModel.gltf, {
+                heightReference : HeightReference.CLAMP_TO_GROUND,
+                position : Cartesian3.fromDegrees(-72.0, 40.0),
+                scene : scene,
+                show : true
+            }).then(function(model) {
+                expect(scene.globe.callback).toBeDefined();
+
+                model.heightReference = HeightReference.RELATIVE_TO_GROUND;
+                scene.renderForSpecs();
+                expect(scene.globe.removedCallback).toEqual(true);
+                expect(scene.globe.callback).toBeDefined();
+
+                scene.globe.removedCallback = false;
+                model.heightReference = HeightReference.NONE;
+                scene.renderForSpecs();
+                expect(scene.globe.removedCallback).toEqual(true);
+                expect(scene.globe.callback).not.toBeDefined();
+                
+                primitives.remove(model);
+            });
+        });
+
+        it('changing the position updates the callback', function() {
+            scene.globe = createMockGlobe();
+            return loadModelJson(texturedBoxModel.gltf, {
+                heightReference : HeightReference.CLAMP_TO_GROUND,
+                position : Cartesian3.fromDegrees(-72.0, 40.0),
+                scene : scene,
+                show : true
+            }).then(function(model) {
+                expect(scene.globe.callback).toBeDefined();
+
+                var matrix = Matrix4.clone(model.modelMatrix);
+                var position = Cartesian3.fromDegrees(-73.0, 40.0);
+                matrix[12] = position.x;
+                matrix[13] = position.y;
+                matrix[14] = position.z;
+
+                model.modelMatrix = matrix;
+                scene.renderForSpecs();
+
+                expect(scene.globe.removedCallback).toEqual(true);
+                expect(scene.globe.callback).toBeDefined();
+
+                primitives.remove(model);
+            });
+        });
+
+        it('callback updates the position', function() {
+            scene.globe = createMockGlobe();
+            return loadModelJson(texturedBoxModel.gltf, {
+                heightReference : HeightReference.CLAMP_TO_GROUND,
+                position : Cartesian3.fromDegrees(-72.0, 40.0),
+                scene : scene,
+                show : true
+            }).then(function(model) {
+                expect(scene.globe.callback).toBeDefined();
+                scene.renderForSpecs();
+
+                scene.globe.callback(Cartesian3.fromDegrees(-72.0, 40.0, 100.0));
+                var matrix = model._clampedModelMatrix;
+                var clampedPosition = new Cartesian3(matrix[12], matrix[13], matrix[14]);
+                var cartographic = scene.globe.ellipsoid.cartesianToCartographic(clampedPosition);
+                expect(cartographic.height).toEqualEpsilon(100.0, CesiumMath.EPSILON9);
+
+                primitives.remove(model);
+            });
         });
     });
 

--- a/Specs/Scene/ModelSpec.js
+++ b/Specs/Scene/ModelSpec.js
@@ -4,10 +4,12 @@ defineSuite([
         'Core/Cartesian2',
         'Core/Cartesian3',
         'Core/Cartesian4',
+        'Core/CesiumTerrainProvider',
         'Core/clone',
         'Core/combine',
         'Core/defaultValue',
         'Core/defined',
+        'Core/defineProperties',
         'Core/Ellipsoid',
         'Core/Event',
         'Core/FeatureDetection',
@@ -32,10 +34,12 @@ defineSuite([
         Cartesian2,
         Cartesian3,
         Cartesian4,
+        CesiumTerrainProvider,
         clone,
         combine,
         defaultValue,
         defined,
+        defineProperties,
         Ellipsoid,
         Event,
         FeatureDetection,
@@ -1720,6 +1724,13 @@ defineSuite([
             };
 
             globe.terrainProviderChanged = new Event();
+            defineProperties(globe, {
+                terrainProvider : {
+                    set : function(value) {
+                        this.terrainProviderChanged.raiseEvent(value);
+                    }
+                }
+            });
 
             globe._surface.updateHeight = function(position, callback) {
                 globe.callback = callback;
@@ -1850,6 +1861,26 @@ defineSuite([
                 expect(cartographic.height).toEqualEpsilon(100.0, CesiumMath.EPSILON9);
 
                 primitives.remove(model);
+            });
+        });
+
+        it('changing the terrain provider', function() {
+            scene.globe = createMockGlobe();
+            return loadModelJson(texturedBoxModel.gltf, {
+                heightReference : HeightReference.CLAMP_TO_GROUND,
+                position : Cartesian3.fromDegrees(-72.0, 40.0),
+                scene : scene
+            }).then(function(model) {
+                expect(model._heightChanged).toBe(false);
+
+                var terrainProvider = new CesiumTerrainProvider({
+                    url : 'made/up/url',
+                    requestVertexNormals : true
+                });
+
+                scene.terrainProvider = terrainProvider;
+
+                expect(model._heightChanged).toBe(true);
             });
         });
     });

--- a/Specs/Scene/ModelSpec.js
+++ b/Specs/Scene/ModelSpec.js
@@ -1883,6 +1883,31 @@ defineSuite([
                 expect(model._heightChanged).toBe(true);
             });
         });
+
+        it('height reference without a scene rejects', function() {
+            scene.globe = createMockGlobe();
+            return loadModelJson(texturedBoxModel.gltf, {
+                heightReference : HeightReference.CLAMP_TO_GROUND,
+                position : Cartesian3.fromDegrees(-72.0, 40.0),
+                show : true
+            }).otherwise(function(error) {
+                expect(error.message).toEqual('Height reference is not supported without a scene.');
+            });
+        });
+
+        it('changing height reference without a scene throws DeveloperError', function() {
+            scene.globe = createMockGlobe();
+            return loadModelJson(texturedBoxModel.gltf, {
+                position : Cartesian3.fromDegrees(-72.0, 40.0),
+                show : true
+            }).then(function(model) {
+                model.heightReference = HeightReference.CLAMP_TO_GROUND;
+
+                expect(function () {
+                    return scene.renderForSpecs();
+                }).toThrowDeveloperError();
+            });
+        });
     });
 
 }, 'WebGL');


### PR DESCRIPTION
Adds a heightReference property for models. If you use it `scene` is also required. This will render models on terrain (or relative to it). Tests were also added in `ModelSpec.js`.

In order to get this working properly #3921 was fixed. The issue was that the `QuadTreePrimitive` removes the `updateHeight` callback once we get to the highest resolution tile. If we changed terrain providers we never add the callback again. I added a `terrainProviderChanged` event to `Globe` and `Scene` and hooked them up to the `Billboard` and `Model` so it updates the clamped positions when the provider is changed.

Tests were added to `Globe` to make sure the event fires and to `BillboardCollection` and `Model` to make sure it gets the event when the provider is changed.

`CHANGES.md` was also updated.
