### PR TITLE
minimumPixelSize incorrect if model is clamped to terrain

### DIFF
--- a/Source/Scene/Model.js
+++ b/Source/Scene/Model.js
@@ -3015,7 +3015,7 @@ define([
             // Compute size of bounding sphere in pixels
             var context = frameState.context;
             var maxPixelSize = Math.max(context.drawingBufferWidth, context.drawingBufferHeight);
-            var m = model.modelMatrix;
+            var m = defined(model._clampedModelMatrix) ? model._clampedModelMatrix : model.modelMatrix;
             scratchPosition.x = m[12];
             scratchPosition.y = m[13];
             scratchPosition.z = m[14];


### PR DESCRIPTION
Fixed small issue where minimumPixelSize was computed from the given position, not the clamped position.

If you load the `development/3d Models` Sandcastle example and replace the `createModel` function with this

```
function createModel(url, height, heading, pitch, roll) {
    height = Cesium.defaultValue(height, 0.0);
    heading = Cesium.defaultValue(heading, 0.0);
    pitch = Cesium.defaultValue(pitch, 0.0);
    roll = Cesium.defaultValue(roll, 0.0);

    var origin = Cesium.Cartesian3.fromDegrees(-123.0744619, 44.0503706, height);
    var modelMatrix = Cesium.Transforms.headingPitchRollToFixedFrame(origin, heading, pitch, roll);

    scene.primitives.removeAll(); // Remove previous model
    var model = scene.primitives.add(Cesium.Model.fromGltf({
        url : url,
        modelMatrix : modelMatrix,
        minimumPixelSize : 128,
        scene : scene,
        heightReference:Cesium.HeightReference.RELATIVE_TO_GROUND
    }));

    model.readyPromise.then(function(model) {
        // Play and loop all animations at half-speed
        model.activeAnimations.addAll({
            speedup : 0.5,
            loop : Cesium.ModelAnimationLoop.REPEAT
        });
        
        var camera = viewer.camera;
        
        // Zoom to model
        var controller = scene.screenSpaceCameraController;
        var r = 2.0 * Math.max(model.boundingSphere.radius, camera.frustum.near);
        controller.minimumZoomDistance = r * 0.5;
        
        var center = Cesium.Matrix4.multiplyByPoint(model.modelMatrix, model.boundingSphere.center, new Cesium.Cartesian3());
        var heading = Cesium.Math.toRadians(230.0);
        var pitch = Cesium.Math.toRadians(-20.0);
        camera.lookAt(center, new Cesium.HeadingPitchRange(heading, pitch, r * 2.0));
        camera.lookAtTransform(Cesium.Matrix4.IDENTITY);
    }).otherwise(function(error){
        window.alert(error);
    });
}
```

When you load the ground vehicle and rotate around it, you'll see it growing/shrinking when it shouldn't. @bagnell I'm not sure how to automate a test for this. Any suggestions?