### PR TITLE
Updated Julian date doc

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -33,6 +33,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to Cesiu
    * [Rob Taglang](https://github.com/lasalvavida)
    * [Todd Smith] (https://github.com/tsmith717)
    * [Josh Becker] (https://github.com/JoshuaStorm)
+   * [Kangning Li] (https://github.com/likangning93)
 * [NICTA](http://www.nicta.com.au/)
    * [Chris Cooper](https://github.com/chris-cooper)
    * [Kevin Ring](https://github.com/kring)

--- a/Source/Core/JulianDate.js
+++ b/Source/Core/JulianDate.js
@@ -170,8 +170,8 @@ define([
      * @alias JulianDate
      * @constructor
      *
-     * @param {Number} julianDayNumber The Julian Day Number representing the number of whole days.  Fractional days will also be handled correctly.
-     * @param {Number} secondsOfDay The number of seconds into the current Julian Day Number.  Fractional seconds, negative seconds and seconds greater than a day will be handled correctly.
+     * @param {Number} [julianDayNumber=0.0] The Julian Day Number representing the number of whole days.  Fractional days will also be handled correctly.
+     * @param {Number} [secondsOfDay=0.0] The number of seconds into the current Julian Day Number.  Fractional seconds, negative seconds and seconds greater than a day will be handled correctly.
      * @param {TimeStandard} [timeStandard=TimeStandard.UTC] The time standard in which the first two parameters are defined.
      */
     function JulianDate(julianDayNumber, secondsOfDay, timeStandard) {


### PR DESCRIPTION
Fixes #3944 

Made `JulianDate` constructor arguments `julianDayNumber` and  `secondsOfDay` optional in the documentation.