### PR TITLE
Cesium3DTileSet boundingVolume getter

### DIFF
--- a/Apps/Sandcastle/gallery/3D Tiles.html
+++ b/Apps/Sandcastle/gallery/3D Tiles.html
@@ -58,7 +58,7 @@ function loadTileset(url) {
     }));
 
     return Cesium.when(tileset.readyPromise).then(function(tileset) {
-        var boundingBox = tileset._root._boundingVolume;
+        var boundingBox = tileset.boundingVolume;
         var center = Cesium.Rectangle.center(boundingBox.rectangle);
         var height = boundingBox.maximumHeight + 500.0;
         viewer.camera.setView({

--- a/Source/Scene/Cesium3DTileset.js
+++ b/Source/Scene/Cesium3DTileset.js
@@ -572,6 +572,21 @@ define([
         },
 
         /**
+         *
+         */
+        boundingVolume : {
+            get : function() {
+                //>>includeStart('debug', pragmas.debug);
+                if (!this.ready) {
+                    throw new DeveloperError('The tileset is not loaded.  Use Cesium3DTileset.readyPromise or wait for Cesium3DTileset.ready to be true.');
+                }
+                //>>includeEnd('debug');
+                
+                return this._root.contentBoundingVolume;
+            }
+        },
+
+        /**
          * @private
          */
         styleEngine : {

--- a/Source/Scene/Cesium3DTileset.js
+++ b/Source/Scene/Cesium3DTileset.js
@@ -572,7 +572,17 @@ define([
         },
 
         /**
+         * The tileset's bounding volume. As previously accessed by tileset._root.contentBoundingVolume.
          *
+         * @memberof Cesium3DTileset.prototype
+         *
+         * @type {TileBoundingVolume}
+         * @readonly
+         *
+         * @exception {DeveloperError} The tileset is not loaded.  Use Cesium3DTileset.readyPromise or wait for Cesium3DTileset.ready to be true.
+         *
+         * @example
+         * console.log('Bounding volume of tileset: ' + tileset.boundingVolume);
          */
         boundingVolume : {
             get : function() {

--- a/Source/Scene/Cesium3DTileset.js
+++ b/Source/Scene/Cesium3DTileset.js
@@ -572,7 +572,7 @@ define([
         },
 
         /**
-         * The tileset's bounding volume. As previously accessed by tileset._root.contentBoundingVolume.
+         * The tileset's bounding volume.
          *
          * @memberof Cesium3DTileset.prototype
          *
@@ -580,9 +580,6 @@ define([
          * @readonly
          *
          * @exception {DeveloperError} The tileset is not loaded.  Use Cesium3DTileset.readyPromise or wait for Cesium3DTileset.ready to be true.
-         *
-         * @example
-         * console.log('Bounding volume of tileset: ' + tileset.boundingVolume);
          */
         boundingVolume : {
             get : function() {
@@ -592,7 +589,7 @@ define([
                 }
                 //>>includeEnd('debug');
                 
-                return this._root.contentBoundingVolume;
+                return this._root._boundingVolume;
             }
         },
 


### PR DESCRIPTION
Corrects #3138
Added getter in for boundingVolume in Cesium3DTileset. Update 3D Tiles Sandcastle accordingly.

Replaced `var bb = tileset._root._tileBoundingBox;`
with `tileset.boundingVolume`