### PR TITLE
Fix camera on IDL in 2D

### DIFF
--- a/Source/Scene/Scene.js
+++ b/Source/Scene/Scene.js
@@ -1773,7 +1773,7 @@ define([
 
         if (x === 0.0 || windowCoordinates.x <= 0.0 || windowCoordinates.x >= context.drawingBufferWidth) {
             executeCommandsInViewport(true, scene, passState, backgroundColor, picking);
-        } else if (windowCoordinates.x === Math.floor(context.drawingBufferWidth * 0.5)) {
+        } else if (Math.abs(context.drawingBufferWidth * 0.5 - windowCoordinates.x) < 1.0) {
             viewport.width = windowCoordinates.x;
 
             camera.position.x *= CesiumMath.sign(camera.position.x);

--- a/Source/Scene/Scene.js
+++ b/Source/Scene/Scene.js
@@ -1773,11 +1773,37 @@ define([
 
         if (x === 0.0 || windowCoordinates.x <= 0.0 || windowCoordinates.x >= context.drawingBufferWidth) {
             executeCommandsInViewport(true, scene, passState, backgroundColor, picking);
+        } else if (windowCoordinates.x === Math.floor(context.drawingBufferWidth * 0.5)) {
+            viewport.width = windowCoordinates.x;
+
+            camera.position.x *= CesiumMath.sign(camera.position.x);
+
+            camera.frustum.right = 0.0;
+
+            frameState.cullingVolume = camera.frustum.computeCullingVolume(camera.positionWC, camera.directionWC, camera.upWC);
+            context.uniformState.update(frameState);
+
+            executeCommandsInViewport(true, scene, passState, backgroundColor, picking);
+
+            viewport.x = viewport.width;
+
+            camera.position.x = -camera.position.x;
+
+            camera.frustum.right = -camera.frustum.left;
+            camera.frustum.left = 0.0;
+
+            frameState.cullingVolume = camera.frustum.computeCullingVolume(camera.positionWC, camera.directionWC, camera.upWC);
+            context.uniformState.update(frameState);
+
+            executeCommandsInViewport(false, scene, passState, backgroundColor, picking);
         } else if (windowCoordinates.x > context.drawingBufferWidth * 0.5) {
             viewport.width = windowCoordinates.x;
 
             var right = camera.frustum.right;
             camera.frustum.right = maxCoord.x - x;
+
+            frameState.cullingVolume = camera.frustum.computeCullingVolume(camera.positionWC, camera.directionWC, camera.upWC);
+            context.uniformState.update(frameState);
 
             executeCommandsInViewport(true, scene, passState, backgroundColor, picking);
 
@@ -1787,7 +1813,7 @@ define([
             camera.position.x = -camera.position.x;
 
             camera.frustum.left = -camera.frustum.right;
-            camera.frustum.right = camera.frustum.left + (right - camera.frustum.right);
+            camera.frustum.right = right - camera.frustum.right * 2.0;
 
             frameState.cullingVolume = camera.frustum.computeCullingVolume(camera.positionWC, camera.directionWC, camera.upWC);
             context.uniformState.update(frameState);
@@ -1800,6 +1826,9 @@ define([
             var left = camera.frustum.left;
             camera.frustum.left = -maxCoord.x - x;
 
+            frameState.cullingVolume = camera.frustum.computeCullingVolume(camera.positionWC, camera.directionWC, camera.upWC);
+            context.uniformState.update(frameState);
+
             executeCommandsInViewport(true, scene, passState, backgroundColor, picking);
 
             viewport.x = 0;
@@ -1808,8 +1837,7 @@ define([
             camera.position.x = -camera.position.x;
 
             camera.frustum.right = -camera.frustum.left;
-            camera.frustum.left = camera.frustum.right + (left - camera.frustum.left);
-
+            camera.frustum.left = left - camera.frustum.left * 2.0;
 
             frameState.cullingVolume = camera.frustum.computeCullingVolume(camera.positionWC, camera.directionWC, camera.upWC);
             context.uniformState.update(frameState);

--- a/Specs/Scene/SceneSpec.js
+++ b/Specs/Scene/SceneSpec.js
@@ -29,6 +29,7 @@ defineSuite([
         'Scene/Scene',
         'Scene/ScreenSpaceCameraController',
         'Scene/TweenCollection',
+        'Specs/createCanvas',
         'Specs/createScene',
         'Specs/equals',
         'Specs/pollToPromise',
@@ -63,6 +64,7 @@ defineSuite([
         Scene,
         ScreenSpaceCameraController,
         TweenCollection,
+        createCanvas,
         createScene,
         equals,
         pollToPromise,
@@ -558,6 +560,33 @@ defineSuite([
         expect(pixels[0]).not.toEqual(0);
         expect(pixels[1]).toEqual(0);
         expect(pixels[2]).toEqual(0);
+    });
+
+    it('renders map when the camera is on the IDL in 2D', function() {
+        var s = createScene({
+            canvas : createCanvas(5, 5)
+        });
+        s.morphTo2D(0.0);
+
+        var rectangle = Rectangle.fromDegrees(-180.0, -90.0, 180.0, 90.0);
+
+        var rectanglePrimitive1 = createRectangle(rectangle, 0.0);
+        rectanglePrimitive1.appearance.material.uniforms.color = new Color(1.0, 0.0, 0.0, 1.0);
+
+        var primitives = s.primitives;
+        primitives.add(rectanglePrimitive1);
+
+        s.camera.setView({
+            destination : new Cartesian3(Ellipsoid.WGS84.maximumRadius * Math.PI, 0.0, 10.0),
+            convert : false
+        });
+
+        var pixels = s.renderForSpecs();
+        expect(pixels[0]).not.toEqual(0);
+        expect(pixels[1]).toEqual(0);
+        expect(pixels[2]).toEqual(0);
+
+        s.destroyForSpecs();
     });
 
     it('copies the globe depth', function() {


### PR DESCRIPTION
Fixes #3951.

Adds a special case for when the camera is on the IDL. The test fails in master with the same error mentioned in https://github.com/AnalyticalGraphicsInc/cesium/pull/3936#issuecomment-22112904 and passes in this branch.