### PR TITLE
Do not attempt to deploy pull requests to s3.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -308,7 +308,16 @@ gulp.task('minifyRelease', ['generateStubs'], function() {
     });
 });
 
+function isTravisPullRequest() {
+    return process.env.TRAVIS_PULL_REQUEST !== undefined && process.env.TRAVIS_PULL_REQUEST !== 'false';
+}
+
 gulp.task('deploy-s3', function(done) {
+    if (isTravisPullRequest()) {
+        console.log('Skipping deployment for non-pull request.');
+        return;
+    }
+
     var argv = yargs.usage('Usage: delpoy -b [Bucket Name] -d [Upload Directory]')
         .demand(['b', 'd']).argv;
 
@@ -558,6 +567,11 @@ gulp.task('deploy-set-version', function() {
 });
 
 gulp.task('deploy-status', function() {
+    if (isTravisPullRequest()) {
+        console.log('Skipping deployment status for non-pull request.');
+        return;
+    }
+
     var status = yargs.argv.status;
     var message = yargs.argv.message;
 


### PR DESCRIPTION
For a pull request, the `TRAVIS_BRANCH` variable is always `master` this causes deployment to deploy to the master branch instead of the branch name (which is unavailable for pull requests). Even if the branch name were available, forks that open pull requests could have name conflicts with branches in the primary repository, so we wouldn't be able to deploy them anyway.

I'm fairly certain this is the right approach, but we'll have to actually merge it and keep an eye on things to see.

Fixes #3937