### PR TITLE
Vanishing atmosphere when looking up #3347

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,6 +23,7 @@ Change Log
 * Added `debugShowShadowVolume` to `GroundPrimitive`.
 * Fixed issue where `Matrix4.fromCamera` was taking eye/target instead of position/direction. [#3927](https://github.com/AnalyticalGraphicsInc/cesium/issues/3927)
 * Fixed a bug that would cause a crash is the camera was on the IDL in 2D. [#3951](https://github.com/AnalyticalGraphicsInc/cesium/issues/3951)
+* Fixed a bug that was causing the atmosphere to disappear when only atmosphere is visible. [#3347](https://github.com/AnalyticalGraphicsInc/cesium/issues/3347) 
 
 ### 1.21 - 2016-05-02
 

--- a/Source/Scene/Scene.js
+++ b/Source/Scene/Scene.js
@@ -562,6 +562,7 @@ define([
 
             isSunVisible : false,
             isMoonVisible : false,
+            isReadyForAtmosphere : false,
             isSkyAtmosphereVisible : false,
 
             clearGlobeDepth : false,
@@ -1221,7 +1222,7 @@ define([
 
         // Determine visibility of celestial and terrestrial environment effects.
         var environmentState = scene._environmentState;
-        environmentState.isSkyAtmosphereVisible = defined(environmentState.skyAtmosphereCommand) && defined(scene.globe) && scene.globe._surface._tilesToRender.length > 0;
+        environmentState.isSkyAtmosphereVisible = defined(environmentState.skyAtmosphereCommand) && environmentState.isReadyForAtmosphere;
         environmentState.isSunVisible = isVisible(environmentState.sunDrawCommand, cullingVolume, occluder);
         environmentState.isMoonVisible = isVisible(environmentState.moonCommand, cullingVolume, occluder);
 
@@ -1876,6 +1877,7 @@ define([
         var environmentState = scene._environmentState;
         var renderPass = frameState.passes.render;
         environmentState.skyBoxCommand = (renderPass && defined(scene.skyBox)) ? scene.skyBox.update(frameState) : undefined;
+        environmentState.isReadyForAtmosphere = defined(scene.skyAtmosphere) && (environmentState.isReadyForAtmosphere || (defined(scene.globe) && scene.globe._surface._tilesToRender.length > 0));
         environmentState.skyAtmosphereCommand = (renderPass && defined(scene.skyAtmosphere)) ? scene.skyAtmosphere.update(frameState) : undefined;
         var sunCommands = (renderPass && defined(scene.sun)) ? scene.sun.update(scene) : undefined;
         environmentState.sunDrawCommand = defined(sunCommands) ? sunCommands.drawCommand : undefined;


### PR DESCRIPTION
Fixed #3347 

It seems like this problem was caused by commit 4cccade8135aea8070c1daba84fcec43fb892ec1. I think this was to prevent the atmosphere from rendering before tiles were ready, but the way it was handled caused the atmosphere to vanish if no tiles were being rendered (fully skyward view).

Also updated CHANGES.md.
<img width="954" alt="disappearing atmosphere snip" src="https://cloud.githubusercontent.com/assets/5395255/15584768/0625089a-234a-11e6-8451-9023547d4c39.PNG">
