### PR TITLE
Shadows - Fix IE test failures

### DIFF
--- a/Apps/Sandcastle/gallery/development/Shadows.html
+++ b/Apps/Sandcastle/gallery/development/Shadows.html
@@ -374,7 +374,7 @@ function updateSettings() {
     for (var i = 0; i < viewModel.biasModes.length; ++i) {
         var biasMode = viewModel.biasModes[i];
         var bias = shadowMap['_' + biasMode.type + 'Bias'];
-        bias.polygonOffset = biasMode.polygonOffset();
+        bias.polygonOffset = shadowMap._polygonOffsetSupported && biasMode.polygonOffset();
         bias.polygonOffsetFactor = biasMode.polygonOffsetFactor();
         bias.polygonOffsetUnits = biasMode.polygonOffsetUnits();
         bias.normalOffset = biasMode.normalOffset();

--- a/Apps/Sandcastle/gallery/development/Shadows.html
+++ b/Apps/Sandcastle/gallery/development/Shadows.html
@@ -374,7 +374,7 @@ function updateSettings() {
     for (var i = 0; i < viewModel.biasModes.length; ++i) {
         var biasMode = viewModel.biasModes[i];
         var bias = shadowMap['_' + biasMode.type + 'Bias'];
-        bias.polygonOffset = shadowMap._polygonOffsetSupported && biasMode.polygonOffset();
+        bias.polygonOffset = !shadowMap._isPointLight && shadowMap._polygonOffsetSupported && biasMode.polygonOffset();
         bias.polygonOffsetFactor = biasMode.polygonOffsetFactor();
         bias.polygonOffsetUnits = biasMode.polygonOffsetUnits();
         bias.normalOffset = biasMode.normalOffset();

--- a/Source/Scene/ShadowMap.js
+++ b/Source/Scene/ShadowMap.js
@@ -211,7 +211,7 @@ define([
         };
 
         this._pointBias = {
-            polygonOffset : polygonOffsetSupported,
+            polygonOffset : false,
             polygonOffsetFactor : 1.1,
             polygonOffsetUnits : 4.0,
             normalOffset : false,

--- a/Source/Scene/ShadowMap.js
+++ b/Source/Scene/ShadowMap.js
@@ -182,7 +182,6 @@ define([
 
         // In IE11 and Edge polygon offset is not functional.
         var polygonOffsetSupported = true;
-        // TODO : check for Edge too
         if (FeatureDetection.isInternetExplorer) {
             polygonOffsetSupported = false;
         }

--- a/Source/Scene/ShadowMap.js
+++ b/Source/Scene/ShadowMap.js
@@ -17,6 +17,7 @@ define([
         '../Core/defineProperties',
         '../Core/destroyObject',
         '../Core/DeveloperError',
+        '../Core/FeatureDetection',
         '../Core/Geometry',
         '../Core/GeometryAttribute',
         '../Core/GeometryAttributes',
@@ -73,6 +74,7 @@ define([
         defineProperties,
         destroyObject,
         DeveloperError,
+        FeatureDetection,
         Geometry,
         GeometryAttribute,
         GeometryAttributes,
@@ -178,8 +180,16 @@ define([
         this._outOfViewPrevious = false;
         this._needsUpdate = true;
 
+        // In IE11 and Edge polygon offset is not functional.
+        var polygonOffsetSupported = true;
+        // TODO : check for Edge too
+        if (FeatureDetection.isInternetExplorer) {
+            polygonOffsetSupported = false;
+        }
+        this._polygonOffsetSupported = polygonOffsetSupported;
+
         this._terrainBias = {
-            polygonOffset : true,
+            polygonOffset : polygonOffsetSupported,
             polygonOffsetFactor : 1.1,
             polygonOffsetUnits : 4.0,
             normalOffset : true,
@@ -190,7 +200,7 @@ define([
         };
 
         this._primitiveBias = {
-            polygonOffset : true,
+            polygonOffset : polygonOffsetSupported,
             polygonOffsetFactor : 1.1,
             polygonOffsetUnits : 4.0,
             normalOffset : true,
@@ -201,7 +211,7 @@ define([
         };
 
         this._pointBias = {
-            polygonOffset : false,
+            polygonOffset : polygonOffsetSupported,
             polygonOffsetFactor : 1.1,
             polygonOffsetUnits : 4.0,
             normalOffset : false,


### PR DESCRIPTION
For #2594 

This fixes the tests failures I was seeing in IE. This isn't completely ready because I need to update `FeatureDetection` to check for Edge and test it on Windows 10.

The problem was rendering any commands into the shadow map with polygon offset enabled was causing the test to completely fail, even if the test wasn't checking shadows.