### PR TITLE
Fixed CV issue where it would start in 2D view. 

### DIFF
--- a/Source/Scene/SceneTransitioner.js
+++ b/Source/Scene/SceneTransitioner.js
@@ -129,12 +129,15 @@ define([
         var up = scratchToCVUp;
 
         if (duration > 0.0) {
+            var maxRadii = ellipsoid.maximumRadius;
             position.x = 0.0;
-            position.y = 0.0;
-            position.z = 5.0 * ellipsoid.maximumRadius;
+            position.y = -1.0;
+            position.z = 1.0;
 
-            Cartesian3.negate(Cartesian3.UNIT_Z, direction);
-            Cartesian3.clone(Cartesian3.UNIT_Y, up);
+            position = Cartesian3.multiplyByScalar(Cartesian3.normalize(position, position), 5.0 * maxRadii, position);
+
+            Cartesian3.negate(Cartesian3.normalize(position, direction), direction);
+            Cartesian3.cross(Cartesian3.UNIT_X, direction, up);
         } else {
             var camera = scene.camera;
             if (this._previousMode === SceneMode.SCENE2D) {
@@ -688,7 +691,7 @@ define([
             update : update,
             complete : function() {
                 scene._mode = SceneMode.MORPHING;
-                morphOrthographicToPerspective(transitioner, duration, cameraCV, complete);
+                morphOrthographicToPerspective(transitioner, 0.0, cameraCV, complete);
             }
         });
         transitioner._currentTweens.push(tween);


### PR DESCRIPTION
Fixes #3878

Transition between 2D and CV views has a bit of a jump due to leaving orthographic view, similar to the jerkiness of 2D view entering orthographic view. I will look into fixing that as well, but that may be worth a separate PR.