### PR TITLE
Fix viewer.zoomTo/flyTo for certain arguments.

### DIFF
--- a/Source/Widgets/Viewer/Viewer.js
+++ b/Source/Widgets/Viewer/Viewer.js
@@ -1710,10 +1710,16 @@ Either specify options.terrainProvider instead or set options.baseLayerPicker to
                 return;
             }
 
-            //zoomTarget is now an EntityCollection, this will retrieve the array
+            //Zoom target is already an array, just copy it and return.
+            if (isArray(zoomTarget)) {
+                that._zoomTarget = zoomTarget.slice(0);
+                return;
+            }
+
+            //If zoomTarget is an EntityCollection, this will retrieve the array
             zoomTarget = defaultValue(zoomTarget.values, zoomTarget);
 
-            //If zoomTarget is a DataSource, this will retrieve the EntityCollection.
+            //If zoomTarget is a DataSource, this will retrieve the array.
             if (defined(zoomTarget.entities)) {
                 zoomTarget = zoomTarget.entities.values;
             }


### PR DESCRIPTION
ES6 (Chrome 51 and Firefox 48) now expose an `Array.values` function. This broke existing code in Viewer that was relying on duck-typing to detect if an object was an EntityCollection or not.  Added logic to detect if the zoomTarget was already an array for early return.

Fixes #3980, see that issue for more details.