### PR TITLE
Removed deprecation warnings in KmlDataSource

### DIFF
--- a/Apps/CesiumViewer/CesiumViewer.js
+++ b/Apps/CesiumViewer/CesiumViewer.js
@@ -104,7 +104,10 @@ define([
         } else if (/\.geojson$/i.test(source) || /\.json$/i.test(source) || /\.topojson$/i.test(source)) {
             loadPromise = GeoJsonDataSource.load(source);
         } else if (/\.kml$/i.test(source) || /\.kmz$/i.test(source)) {
-            loadPromise = KmlDataSource.load(source);
+            loadPromise = KmlDataSource.load(source, {
+                camera: scene.camera,
+                canvas: scene.canvas
+            });
         } else {
             showLoadError(source, 'Unknown format.');
         }

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,8 @@ Change Log
 
 ### 1.22 - 2016-06-01
 
+* Breaking changes
+    * `KmlDataSource` now requires `options.camera` and `options.canvas`.
 * Added shadows
     * See the Sandcastle demo: [Shadows](http://cesiumjs.org/Cesium/Apps/Sandcastle/index.html?src=Shadows.html&label=Showcases).
     * Added `Viewer.shadows` and `Viewer.terrainShadows`. Both are off by default.

--- a/Source/DataSources/KmlDataSource.js
+++ b/Source/DataSources/KmlDataSource.js
@@ -12,7 +12,6 @@ define([
         '../Core/defaultValue',
         '../Core/defined',
         '../Core/defineProperties',
-        '../Core/deprecationWarning',
         '../Core/DeveloperError',
         '../Core/Ellipsoid',
         '../Core/Event',
@@ -70,7 +69,6 @@ define([
         defaultValue,
         defined,
         defineProperties,
-        deprecationWarning,
         DeveloperError,
         Ellipsoid,
         Event,
@@ -2129,22 +2127,19 @@ define([
      *      });
      */
     function KmlDataSource(options) {
-        var showWarning = false;
         options = defaultValue(options, {});
-        if (defined(options.getURL)) {
-            showWarning = true;
-            var proxy = options;
-            options = {
-                proxy: proxy
-            };
-        } else if (!defined(options.camera) || !defined(options.canvas)) {
-            showWarning = true;
-        }
+        var camera = options.camera;
+        var canvas = options.canvas;
 
-        if (showWarning) {
-            deprecationWarning('KmlDataSource', 'KmlDataSource now longer takes a proxy object. It takes an options object with camera and canvas as required properties. This will throw in Cesium 1.22.');
+        //>>includeStart('debug', pragmas.debug);
+        if (!defined(camera)) {
+            throw new DeveloperError('camera is required.');
         }
-
+        if (!defined(canvas)) {
+            throw new DeveloperError('canvas is required.');
+        }
+        //>>includeEnd('debug');
+        
         this._changed = new Event();
         this._error = new Event();
         this._loading = new Event();
@@ -2157,9 +2152,6 @@ define([
         this._pinBuilder = new PinBuilder();
         this._promises = [];
         this._networkLinks = new AssociativeArray();
-
-        var camera = options.camera;
-        var canvas = options.canvas;
 
         this._canvas = canvas;
         this._camera = camera;

--- a/Source/DataSources/KmlDataSource.js
+++ b/Source/DataSources/KmlDataSource.js
@@ -2133,13 +2133,13 @@ define([
 
         //>>includeStart('debug', pragmas.debug);
         if (!defined(camera)) {
-            throw new DeveloperError('camera is required.');
+            throw new DeveloperError('options.camera is required.');
         }
         if (!defined(canvas)) {
-            throw new DeveloperError('canvas is required.');
+            throw new DeveloperError('options.canvas is required.');
         }
         //>>includeEnd('debug');
-        
+
         this._changed = new Event();
         this._error = new Event();
         this._loading = new Event();

--- a/Specs/DataSources/KmlDataSourceSpec.js
+++ b/Specs/DataSources/KmlDataSourceSpec.js
@@ -147,7 +147,7 @@ defineSuite([
     });
 
     it('show sets underlying entity collection show.', function() {
-        var dataSource = new KmlDataSource();
+        var dataSource = new KmlDataSource(options);
 
         dataSource.show = false;
         expect(dataSource.show).toBe(false);


### PR DESCRIPTION
We now throw if we are missing `camera` or `canvas`. This fixes #3866.

@hpinkos can you review this?