### PR TITLE
Fix missing tiles on Linux after switching to 3D from 2D

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -33,6 +33,7 @@ Change Log
 * Added `Matrix4.computeView`.
 * Added `CullingVolume.fromBoundingSphere`.
 * Added `debugShowShadowVolume` to `GroundPrimitive`.
+* Fix issue with disappearing tiles on Linux. [#3889](https://github.com/AnalyticalGraphicsInc/cesium/issues/3889)
 
 ### 1.21 - 2016-05-02
 

--- a/Source/Scene/GlobeSurfaceShaderSet.js
+++ b/Source/Scene/GlobeSurfaceShaderSet.js
@@ -35,8 +35,7 @@ define([
 
     function getPositionMode(sceneMode) {
         var getPosition3DMode = 'vec4 getPosition(vec3 position, float height, vec2 textureCoordinates) { return getPosition3DMode(position, height, textureCoordinates); }';
-        var getPosition2DMode = 'vec4 getPosition(vec3 position, float height, vec2 textureCoordinates) { return getPosition2DMode(position, height, textureCoordinates); }';
-        var getPositionColumbusViewMode = 'vec4 getPosition(vec3 position, float height, vec2 textureCoordinates) { return getPositionColumbusViewMode(position, height, textureCoordinates); }';
+        var getPositionColumbusViewAnd2DMode = 'vec4 getPosition(vec3 position, float height, vec2 textureCoordinates) { return getPositionColumbusViewMode(position, height, textureCoordinates); }';
         var getPositionMorphingMode = 'vec4 getPosition(vec3 position, float height, vec2 textureCoordinates) { return getPositionMorphingMode(position, height, textureCoordinates); }';
 
         var positionMode;
@@ -46,10 +45,8 @@ define([
             positionMode = getPosition3DMode;
             break;
         case SceneMode.SCENE2D:
-            positionMode = getPosition2DMode;
-            break;
         case SceneMode.COLUMBUS_VIEW:
-            positionMode = getPositionColumbusViewMode;
+            positionMode = getPositionColumbusViewAnd2DMode;
             break;
         case SceneMode.MORPHING:
             positionMode = getPositionMorphingMode;


### PR DESCRIPTION
Use the attribute at index zero when in 2D. This draws the terrain at height instead of at always at zero height.

Fixes #3889.