### PR TITLE
Set Model position attribute to the 0th index

### DIFF
--- a/Source/Scene/Model.js
+++ b/Source/Scene/Model.js
@@ -1504,6 +1504,7 @@ define([
             if (attribute.toLowerCase().indexOf('position') > -1) {
                 attributes[i] = attributes[0];
                 attributes[0] = attribute;
+                break;
             }
         }
 

--- a/Source/Scene/Model.js
+++ b/Source/Scene/Model.js
@@ -1493,9 +1493,39 @@ define([
         }
     }
 
-    function createAttributeLocations(attributes) {
+    function getPositionAttribute(model) {
+        var techniques = model.gltf.techniques;
+        for (var techniqueId in techniques) {
+            if (techniques.hasOwnProperty(techniqueId)) {
+                var technique = techniques[techniqueId];
+                var attributes = technique.attributes;
+                for (var attributeId in attributes) {
+                    if (attributes.hasOwnProperty(attributeId)) {
+                        var attribute = attributes[attributeId];
+                        var semantic = technique.parameters[attribute].semantic;
+                        if (defined(semantic) && semantic === 'POSITION') {
+                            return attributeId;
+                        }
+                    }
+                }
+            }
+        }
+        return undefined;
+    }
+
+    function createAttributeLocations(model, attributes) {
         var attributeLocations = {};
         var length = attributes.length;
+
+        // Set the position attribute to the 0th index
+        var positionAttribute = getPositionAttribute(model);
+        if (defined(positionAttribute)) {
+            var index = attributes.indexOf(positionAttribute);
+            if (index > 0) {
+                attributes[index] = attributes[0];
+                attributes[0] = positionAttribute;
+            }
+        }
 
         for (var i = 0; i < length; ++i) {
             attributeLocations[attributes[i]] = i;
@@ -1528,7 +1558,7 @@ define([
         var shaders = model._loadResources.shaders;
         var program = programs[id];
 
-        var attributeLocations = createAttributeLocations(program.attributes);
+        var attributeLocations = createAttributeLocations(model, program.attributes);
         var vs = getShaderSource(model, shaders[program.vertexShader]);
         var fs = getShaderSource(model, shaders[program.fragmentShader]);
 

--- a/Source/Scene/Model.js
+++ b/Source/Scene/Model.js
@@ -1498,10 +1498,13 @@ define([
         var length = attributes.length;
         var i;
 
-        // Set the position attribute to the 0th index
+        // Set the position attribute to the 0th index. In some WebGL implementations the shader
+        // will not work correctly if the 0th attribute is not active. For example, some glTF models
+        // list the normal attribute first but derived shaders like the cast-shadows shader do not use
+        // the normal attribute.
         for (i = 1; i < length; ++i) {
             var attribute = attributes[i];
-            if (attribute.toLowerCase().indexOf('position') > -1) {
+            if (/position/i.test(attribute)) {
                 attributes[i] = attributes[0];
                 attributes[0] = attribute;
                 break;

--- a/Source/Scene/Model.js
+++ b/Source/Scene/Model.js
@@ -1493,41 +1493,21 @@ define([
         }
     }
 
-    function getPositionAttribute(model) {
-        var techniques = model.gltf.techniques;
-        for (var techniqueId in techniques) {
-            if (techniques.hasOwnProperty(techniqueId)) {
-                var technique = techniques[techniqueId];
-                var attributes = technique.attributes;
-                for (var attributeId in attributes) {
-                    if (attributes.hasOwnProperty(attributeId)) {
-                        var attribute = attributes[attributeId];
-                        var semantic = technique.parameters[attribute].semantic;
-                        if (defined(semantic) && semantic === 'POSITION') {
-                            return attributeId;
-                        }
-                    }
-                }
-            }
-        }
-        return undefined;
-    }
-
     function createAttributeLocations(model, attributes) {
         var attributeLocations = {};
         var length = attributes.length;
+        var i;
 
         // Set the position attribute to the 0th index
-        var positionAttribute = getPositionAttribute(model);
-        if (defined(positionAttribute)) {
-            var index = attributes.indexOf(positionAttribute);
-            if (index > 0) {
-                attributes[index] = attributes[0];
-                attributes[0] = positionAttribute;
+        for (i = 1; i < length; ++i) {
+            var attribute = attributes[i];
+            if (attribute.toLowerCase().indexOf('position') > -1) {
+                attributes[i] = attributes[0];
+                attributes[0] = attribute;
             }
         }
 
-        for (var i = 0; i < length; ++i) {
+        for (i = 0; i < length; ++i) {
             attributeLocations[attributes[i]] = i;
         }
 


### PR DESCRIPTION
This fixes a bug with shadow-casting on linux where the normal attribute is the first attribute in the glTF file but is compiled out of the shadow-cast shader, and so no attributes are bound to the 0th index causing the model shadows to be broken. This fix forces the position attribute to be the 0th index. It's a little weird though, because the `program` node only  lists attribute names and not semantics, so I had to search through the techniques to find the attribute name that is tied to the POSITION semantic.