### PR TITLE
Maintain an array of KML nodes not yet supported by Cesium

### DIFF
--- a/Source/DataSources/KmlDataSource.js
+++ b/Source/DataSources/KmlDataSource.js
@@ -1654,7 +1654,7 @@ define([
     }
 
     function processUnsupported(dataSource, parent, node, entityCollection, styleCollection, sourceUri, uriResolver) {
-        dataSource._unsupportedNode.raiseEvent(dataSource, node);
+        dataSource._unsupportedNode.raiseEvent(dataSource, node, uriResolver);
         console.log('KML - Unsupported feature: ' + node.localName);
     }
 

--- a/Source/DataSources/KmlDataSource.js
+++ b/Source/DataSources/KmlDataSource.js
@@ -1654,7 +1654,7 @@ define([
     }
 
     function processUnsupported(dataSource, parent, node, entityCollection, styleCollection, sourceUri, uriResolver) {
-        dataSource._unsupportedNodes.push(node);
+        dataSource._unsupportedNode.raiseEvent(dataSource, node);
         console.log('KML - Unsupported feature: ' + node.localName);
     }
 
@@ -1937,6 +1937,7 @@ define([
         }
     }
 
+    // Ensure Specs/Data/KML/unsupported.kml is kept up to date with these supported types
     var featureTypes = {
         Document : processDocument,
         Folder : processFolder,
@@ -1953,7 +1954,7 @@ define([
         if (defined(featureProcessor)) {
             featureProcessor(dataSource, parent, node, entityCollection, styleCollection, sourceUri, uriResolver);
         } else {
-            dataSource._unsupportedNodes.push(node);
+            dataSource._unsupportedNode.raiseEvent(dataSource, node);
             console.log('KML - Unsupported feature node: ' + node.localName);
         }
     }
@@ -2146,6 +2147,8 @@ define([
         this._error = new Event();
         this._loading = new Event();
         this._refresh = new Event();
+        this._unsupportedNode = new Event();
+
         this._clock = undefined;
         this._entityCollection = new EntityCollection(this);
         this._name = undefined;
@@ -2154,7 +2157,6 @@ define([
         this._pinBuilder = new PinBuilder();
         this._promises = [];
         this._networkLinks = new AssociativeArray();
-        this._unsupportedNodes = [];
 
         this._canvas = canvas;
         this._camera = camera;
@@ -2219,16 +2221,6 @@ define([
             }
         },
         /**
-         * Gets the array of KML nodes that are not yet suported by Cesium.
-         * @memberof KmlDataSource.prototype
-         * @type {Array}
-         */
-        unsupportedNodes : {
-            get : function() {
-                return this._unsupportedNodes;
-            }
-        },
-        /**
          * Gets a value indicating if the data source is currently loading data.
          * @memberof KmlDataSource.prototype
          * @type {Boolean}
@@ -2276,6 +2268,16 @@ define([
         refreshEvent : {
             get : function() {
                 return this._refresh;
+            }
+        },
+        /**
+         * Gets an event that will be raised when the data source finds an unsupported node type.
+         * @memberof KmlDataSource.prototype
+         * @type {Event}
+         */
+        unsupportedNodeEvent : {
+            get : function() {
+                return this._unsupportedNode;
             }
         },
         /**

--- a/Source/DataSources/KmlDataSource.js
+++ b/Source/DataSources/KmlDataSource.js
@@ -1654,6 +1654,7 @@ define([
     }
 
     function processUnsupported(dataSource, parent, node, entityCollection, styleCollection, sourceUri, uriResolver) {
+        dataSource._unsupportedNodes.push(node);
         console.log('KML - Unsupported feature: ' + node.localName);
     }
 
@@ -1948,10 +1949,11 @@ define([
     };
 
     function processFeatureNode(dataSource, node, parent, entityCollection, styleCollection, sourceUri, uriResolver) {
-        var featureProocessor = featureTypes[node.localName];
-        if (defined(featureProocessor)) {
-            featureProocessor(dataSource, parent, node, entityCollection, styleCollection, sourceUri, uriResolver);
+        var featureProcessor = featureTypes[node.localName];
+        if (defined(featureProcessor)) {
+            featureProcessor(dataSource, parent, node, entityCollection, styleCollection, sourceUri, uriResolver);
         } else {
+            dataSource._unsupportedNodes.push(node);
             console.log('KML - Unsupported feature node: ' + node.localName);
         }
     }
@@ -2152,6 +2154,7 @@ define([
         this._pinBuilder = new PinBuilder();
         this._promises = [];
         this._networkLinks = new AssociativeArray();
+        this._unsupportedNodes = [];
 
         this._canvas = canvas;
         this._camera = camera;
@@ -2213,6 +2216,16 @@ define([
         entities : {
             get : function() {
                 return this._entityCollection;
+            }
+        },
+        /**
+         * Gets the array of KML nodes that are not yet suported by Cesium.
+         * @memberof KmlDataSource.prototype
+         * @type {Array}
+         */
+        unsupportedNodes : {
+            get : function() {
+                return this._unsupportedNodes;
             }
         },
         /**

--- a/Source/DataSources/KmlDataSource.js
+++ b/Source/DataSources/KmlDataSource.js
@@ -1954,7 +1954,7 @@ define([
         if (defined(featureProcessor)) {
             featureProcessor(dataSource, parent, node, entityCollection, styleCollection, sourceUri, uriResolver);
         } else {
-            dataSource._unsupportedNode.raiseEvent(dataSource, node);
+            dataSource._unsupportedNode.raiseEvent(dataSource, node, uriResolver);
             console.log('KML - Unsupported feature node: ' + node.localName);
         }
     }

--- a/Specs/Data/KML/unsupported.kml
+++ b/Specs/Data/KML/unsupported.kml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<kml xmlns="http://www.opengis.net/kml/2.2">
+<Document>
+	<GroundOverlay></GroundOverlay>
+	<PhotoOverlay></PhotoOverlay>
+	<ScreenOverlay></ScreenOverlay>
+	<Tour></Tour>
+</Document>
+</kml>

--- a/Specs/Data/KML/unsupported.kml
+++ b/Specs/Data/KML/unsupported.kml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <kml xmlns="http://www.opengis.net/kml/2.2">
 <Document>
-	<GroundOverlay></GroundOverlay>
 	<PhotoOverlay></PhotoOverlay>
 	<ScreenOverlay></ScreenOverlay>
 	<Tour></Tour>

--- a/Specs/DataSources/KmlDataSourceSpec.js
+++ b/Specs/DataSources/KmlDataSourceSpec.js
@@ -143,6 +143,7 @@ defineSuite([
         expect(dataSource.changedEvent).toBeInstanceOf(Event);
         expect(dataSource.errorEvent).toBeInstanceOf(Event);
         expect(dataSource.loadingEvent).toBeInstanceOf(Event);
+        expect(dataSource.unsupportedNodeEvent).toBeInstanceOf(Event);
         expect(dataSource.show).toBe(true);
     });
 
@@ -315,6 +316,21 @@ defineSuite([
         dataSource.loadingEvent.addEventListener(spy);
 
         var promise = dataSource.load('Data/KML/simple.kml');
+        expect(spy).toHaveBeenCalledWith(dataSource, true);
+        spy.calls.reset();
+
+        return promise.then(function() {
+            expect(spy).toHaveBeenCalledWith(dataSource, false);
+        });
+    });
+
+    it('raises unsupportedNodeEvent event when parsing an unsupported kml node type', function() {
+        var dataSource = new KmlDataSource(options);
+
+        var spy = jasmine.createSpy('unsupportedNodeEvent');
+        dataSource.loadingEvent.addEventListener(spy);
+
+        var promise = dataSource.load('Data/KML/unsupported.kml');
         expect(spy).toHaveBeenCalledWith(dataSource, true);
         spy.calls.reset();
 

--- a/Specs/DataSources/KmlDataSourceSpec.js
+++ b/Specs/DataSources/KmlDataSourceSpec.js
@@ -334,9 +334,10 @@ defineSuite([
             expect(spy.calls.count()).toEqual(3);
             for (var i = 0; i < nodeNames.length; i++) {
                 var args = spy.calls.argsFor(i);
-                expect(args.length).toEqual(2);
+                expect(args.length).toEqual(3);
                 expect(args[0]).toBe(dataSource);
                 expect(args[1].localName).toEqual(nodeNames[i]);
+                // args[2] could be undefined, allow for that
             }
         });
     });

--- a/Specs/DataSources/KmlDataSourceSpec.js
+++ b/Specs/DataSources/KmlDataSourceSpec.js
@@ -326,16 +326,18 @@ defineSuite([
 
     it('raises unsupportedNodeEvent event when parsing an unsupported kml node type', function() {
         var dataSource = new KmlDataSource(options);
-
         var spy = jasmine.createSpy('unsupportedNodeEvent');
         dataSource.unsupportedNodeEvent.addEventListener(spy);
 
-        var promise = dataSource.load('Data/KML/unsupported.kml');
-        expect(spy).toHaveBeenCalledWith(dataSource, true);
-        spy.calls.reset();
-
-        return promise.then(function() {
-            expect(spy).toHaveBeenCalledWith(dataSource, false);
+        return dataSource.load('Data/KML/unsupported.kml').then(function() {
+            var nodeNames = ['PhotoOverlay', 'ScreenOverlay', 'Tour'];
+            expect(spy.calls.count()).toEqual(3);
+            for (var i = 0; i < nodeNames.length; i++) {
+                var args = spy.calls.argsFor(i);
+                expect(args.length).toEqual(2);
+                expect(args[0]).toBe(dataSource);
+                expect(args[1].localName).toEqual(nodeNames[i]);
+            }
         });
     });
 

--- a/Specs/DataSources/KmlDataSourceSpec.js
+++ b/Specs/DataSources/KmlDataSourceSpec.js
@@ -328,7 +328,7 @@ defineSuite([
         var dataSource = new KmlDataSource(options);
 
         var spy = jasmine.createSpy('unsupportedNodeEvent');
-        dataSource.loadingEvent.addEventListener(spy);
+        dataSource.unsupportedNodeEvent.addEventListener(spy);
 
         var promise = dataSource.load('Data/KML/unsupported.kml');
         expect(spy).toHaveBeenCalledWith(dataSource, true);


### PR DESCRIPTION
So the individual developer has access them and decide what to do. In my case, I want to support KML ScreenOverlay(s) but there is no support for them yet in Cesium.