### PR TITLE
Fix can't read x of undefined when getting window coordinates

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@ Change Log
 * `Clock` now keeps its configuration settings self-consistent. Previously, this was done by `AnimationViewModel` and could become inconsistent in certain cases. [#4007](https://github.com/AnalyticalGraphicsInc/cesium/pull/4007)
 * Updated Cardboard Sandcastle example.
 * Added the hot air balloon sample model.
+* Fix "Cannot read property 'x' of undefined" error when calling SceneTransforms.wgs84ToWindowCoordinates in certain cases. [#4022](https://github.com/AnalyticalGraphicsInc/cesium/pull/4022)
 
 ### 1.22.2 - 2016-06-14
 * This is an npm only release to fix the improperly published 1.22.1. There were no code changes.
@@ -42,7 +43,7 @@ Change Log
 * Fixed exaggerated terrain tiles disappearing. [#3676](https://github.com/AnalyticalGraphicsInc/cesium/issues/3676)
 * Fixed a bug that could cause incorrect normals to be computed for exaggerated terrain, especially for low-detail tiles. [#3904](https://github.com/AnalyticalGraphicsInc/cesium/pull/3904)
 * Fixed a bug that was causing errors to be thrown when picking and terrain was enabled. [#3779](https://github.com/AnalyticalGraphicsInc/cesium/issues/3779)
-* Fixed a bug that was causing the atmosphere to disappear when only atmosphere is visible. [#3347](https://github.com/AnalyticalGraphicsInc/cesium/issues/3347) 
+* Fixed a bug that was causing the atmosphere to disappear when only atmosphere is visible. [#3347](https://github.com/AnalyticalGraphicsInc/cesium/issues/3347)
 * Fixed infinite horizontal 2D scrolling in IE/Edge. [#3893](https://github.com/AnalyticalGraphicsInc/cesium/issues/3893)
 * Fixed a bug that would cause a crash is the camera was on the IDL in 2D. [#3951](https://github.com/AnalyticalGraphicsInc/cesium/issues/3951)
 * Fixed issue where a repeating model animation doesn't play when the clock is set to a time before the model was created. [#3932](https://github.com/AnalyticalGraphicsInc/cesium/issues/3932)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -51,6 +51,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to Cesiu
    * [Mike Macaulay](https://github.com/mmacaula)
    * [Nathan Schulte](https://github.com/nmschulte)
    * [Jed Fong](https://github.com/jedfong)
+   * [Brandon McAllister](https://github.com/bmcallis)
 * [Inovaworks](http://www.inovaworks.com/)
    * [Sergio Flores](https://github.com/relfos)
 * [CubeWerx Inc.](http://www.cubewerx.com/)

--- a/Source/Scene/SceneTransforms.js
+++ b/Source/Scene/SceneTransforms.js
@@ -174,7 +174,7 @@ define([
                 Cartesian3.clone(cameraPosition, camera.position);
                 camera.frustum = frustum.clone();
 
-                Cartesian2.clone(scratchWindowCoord0, result);
+                result = Cartesian2.clone(scratchWindowCoord0, result);
                 if (result.x < 0.0 || result.x > canvas.clientWidth) {
                     result.x = scratchWindowCoord1.x;
                 }

--- a/Specs/Scene/SceneTransformsSpec.js
+++ b/Specs/Scene/SceneTransformsSpec.js
@@ -192,4 +192,19 @@ defineSuite([
         expect(drawingBufferCoordinates.x).toBeLessThan(1.0);
         expect(drawingBufferCoordinates.y).toBeLessThan(1.0);
     });
+
+    it('should not error when zoomed out and in 2D', function(done) {
+        var scene = createScene();
+        scene.camera.setView({
+            destination : Cartesian3.fromDegrees(75, 15, 30000000.0)
+        });
+
+        // Update scene state
+        scene.morphTo2D(0);
+        scene.renderForSpecs();
+
+        var position = Cartesian3.fromDegrees(-80, 25);
+        var windowCoordinates = SceneTransforms.wgs84ToWindowCoordinates(scene, position);
+        expect(windowCoordinates).toBeDefined();
+    });
 }, 'WebGL');

--- a/Specs/Scene/SceneTransformsSpec.js
+++ b/Specs/Scene/SceneTransformsSpec.js
@@ -206,5 +206,6 @@ defineSuite([
         var position = Cartesian3.fromDegrees(-80, 25);
         var windowCoordinates = SceneTransforms.wgs84ToWindowCoordinates(scene, position);
         expect(windowCoordinates).toBeDefined();
+        scene.destroyForSpecs();
     });
 }, 'WebGL');


### PR DESCRIPTION
In certain situations, 2D mode and zoomed out far, calling
SceneTransforms.wgs84ToWindowCoordinates without passing in a result
object results in "TypeError: Cannot read property 'x' of undefined".