### PR TITLE
CzmlDataSource updates

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,7 +9,7 @@ Change Log
 * Added `packArray` and `unpackArray` functions to `Cartesian2`, `Cartesian3`, and `Cartesian4`.
 * Fix some large polygon triangulations. [#2788](https://github.com/AnalyticalGraphicsInc/cesium/issues/2788)
 * Improved performance and accuracy of polygon triangulation by using the [earcut](https://github.com/mapbox/earcut) library. Loading a GeoJSON with polygons for each country was 2x faster.
-* Added CZML support for Box, Corridor and Cylinder.
+* Added CZML support for Box, Corridor and Cylinder, and added Ellipsoid subdivisions, stackPartitions, and slicePartitions.
 * `Clock` now keeps its configuration settings self-consistent. Previously, this was done by `AnimationViewModel` and could become inconsistent in certain cases. [#4007](https://github.com/AnalyticalGraphicsInc/cesium/pull/4007)
 * Updated Cardboard Sandcastle example.
 * Added the hot air balloon sample model.

--- a/Source/Core/EllipsoidOutlineGeometry.js
+++ b/Source/Core/EllipsoidOutlineGeometry.js
@@ -43,7 +43,7 @@ define([
      * @param {Cartesian3} [options.radii=Cartesian3(1.0, 1.0, 1.0)] The radii of the ellipsoid in the x, y, and z directions.
      * @param {Number} [options.stackPartitions=10] The count of stacks for the ellipsoid (1 greater than the number of parallel lines).
      * @param {Number} [options.slicePartitions=8] The count of slices for the ellipsoid (Equal to the number of radial lines).
-     * @param {Number} [options.subdivisions=128] The number of points per line, determining the granularity of the curvature .
+     * @param {Number} [options.subdivisions=128] The number of points per line, determining the granularity of the curvature.
      *
      * @exception {DeveloperError} options.stackPartitions must be greater than or equal to one.
      * @exception {DeveloperError} options.slicePartitions must be greater than or equal to zero.

--- a/Source/DataSources/CzmlDataSource.js
+++ b/Source/DataSources/CzmlDataSource.js
@@ -1190,6 +1190,9 @@ define([
         processPacketData(Boolean, ellipsoid, 'show', ellipsoidData.show, interval, sourceUri, entityCollection);
         processPacketData(Cartesian3, ellipsoid, 'radii', ellipsoidData.radii, interval, sourceUri, entityCollection);
         processMaterialPacketData(ellipsoid, 'material', ellipsoidData.material, interval, sourceUri, entityCollection);
+        processPacketData(Number, ellipsoid, 'stackPartitions', ellipsoidData.stackPartitions, interval, sourceUri, entityCollection);
+        processPacketData(Number, ellipsoid, 'slicePartitions', ellipsoidData.slicePartitions, interval, sourceUri, entityCollection);
+        processPacketData(Number, ellipsoid, 'subdivisions', ellipsoidData.subdivisions, interval, sourceUri, entityCollection);
         processPacketData(Boolean, ellipsoid, 'fill', ellipsoidData.fill, interval, sourceUri, entityCollection);
         processPacketData(Boolean, ellipsoid, 'outline', ellipsoidData.outline, interval, sourceUri, entityCollection);
         processPacketData(Color, ellipsoid, 'outlineColor', ellipsoidData.outlineColor, interval, sourceUri, entityCollection);

--- a/Source/DataSources/CzmlDataSource.js
+++ b/Source/DataSources/CzmlDataSource.js
@@ -803,9 +803,9 @@ define([
             materialData = packetData.grid;
             processPacketData(Color, existingMaterial, 'color', materialData.color, undefined, sourceUri, entityCollection);
             processPacketData(Number, existingMaterial, 'cellAlpha', materialData.cellAlpha, undefined, sourceUri, entityCollection);
+            processPacketData(Cartesian2, existingMaterial, 'lineCount', materialData.lineCount, undefined, sourceUri, entityCollection);
             processPacketData(Cartesian2, existingMaterial, 'lineThickness', materialData.lineThickness, undefined, sourceUri, entityCollection);
             processPacketData(Cartesian2, existingMaterial, 'lineOffset', materialData.lineOffset, undefined, sourceUri, entityCollection);
-            processPacketData(Cartesian2, existingMaterial, 'lineCount', materialData.lineCount, undefined, sourceUri, entityCollection);
         } else if (defined(packetData.image)) {
             if (!(existingMaterial instanceof ImageMaterialProperty)) {
                 existingMaterial = new ImageMaterialProperty();
@@ -1021,16 +1021,16 @@ define([
             entity.billboard = billboard = new BillboardGraphics();
         }
 
-        processPacketData(Color, billboard, 'color', billboardData.color, interval, sourceUri, entityCollection);
+        processPacketData(Boolean, billboard, 'show', billboardData.show, interval, sourceUri, entityCollection);
+        processPacketData(Image, billboard, 'image', billboardData.image, interval, sourceUri, entityCollection);
+        processPacketData(Number, billboard, 'scale', billboardData.scale, interval, sourceUri, entityCollection);
+        processPacketData(Cartesian2, billboard, 'pixelOffset', billboardData.pixelOffset, interval, sourceUri, entityCollection);
         processPacketData(Cartesian3, billboard, 'eyeOffset', billboardData.eyeOffset, interval, sourceUri, entityCollection);
         processPacketData(HorizontalOrigin, billboard, 'horizontalOrigin', billboardData.horizontalOrigin, interval, sourceUri, entityCollection);
-        processPacketData(Image, billboard, 'image', billboardData.image, interval, sourceUri, entityCollection);
-        processPacketData(Cartesian2, billboard, 'pixelOffset', billboardData.pixelOffset, interval, sourceUri, entityCollection);
-        processPacketData(Number, billboard, 'scale', billboardData.scale, interval, sourceUri, entityCollection);
+        processPacketData(VerticalOrigin, billboard, 'verticalOrigin', billboardData.verticalOrigin, interval, sourceUri, entityCollection);
+        processPacketData(Color, billboard, 'color', billboardData.color, interval, sourceUri, entityCollection);
         processPacketData(Rotation, billboard, 'rotation', billboardData.rotation, interval, sourceUri, entityCollection);
         processPacketData(Cartesian3, billboard, 'alignedAxis', billboardData.alignedAxis, interval, sourceUri, entityCollection);
-        processPacketData(Boolean, billboard, 'show', billboardData.show, interval, sourceUri, entityCollection);
-        processPacketData(VerticalOrigin, billboard, 'verticalOrigin', billboardData.verticalOrigin, interval, sourceUri, entityCollection);
         processPacketData(Boolean, billboard, 'sizeInMeters', billboardData.sizeInMeters, interval, sourceUri, entityCollection);
     }
 
@@ -1052,13 +1052,45 @@ define([
             entity.box = box = new BoxGraphics();
         }
 
-        processPacketData(Cartesian3, box, 'dimensions', boxData.dimensions, interval, sourceUri, entityCollection);
         processPacketData(Boolean, box, 'show', boxData.show, interval, sourceUri, entityCollection);
-        processMaterialPacketData(box, 'material', boxData.material, interval, sourceUri, entityCollection);
+        processPacketData(Cartesian3, box, 'dimensions', boxData.dimensions, interval, sourceUri, entityCollection);
         processPacketData(Boolean, box, 'fill', boxData.fill, interval, sourceUri, entityCollection);
+        processMaterialPacketData(box, 'material', boxData.material, interval, sourceUri, entityCollection);
         processPacketData(Boolean, box, 'outline', boxData.outline, interval, sourceUri, entityCollection);
         processPacketData(Color, box, 'outlineColor', boxData.outlineColor, interval, sourceUri, entityCollection);
         processPacketData(Number, box, 'outlineWidth', boxData.outlineWidth, interval, sourceUri, entityCollection);
+    }
+
+    function processCorridor(entity, packet, entityCollection, sourceUri) {
+        var corridorData = packet.corridor;
+        if (!defined(corridorData)) {
+            return;
+        }
+
+        var interval;
+        var intervalString = corridorData.interval;
+        if (defined(intervalString)) {
+            iso8601Scratch.iso8601 = intervalString;
+            interval = TimeInterval.fromIso8601(iso8601Scratch);
+        }
+
+        var corridor = entity.corridor;
+        if (!defined(corridor)) {
+            entity.corridor = corridor = new CorridorGraphics();
+        }
+
+        processPacketData(Boolean, corridor, 'show', corridorData.show, interval, sourceUri, entityCollection);
+        processPositions(corridor, 'positions', corridorData.positions, entityCollection);
+        processPacketData(Number, corridor, 'width', corridorData.width, interval, sourceUri, entityCollection);
+        processPacketData(Number, corridor, 'height', corridorData.height, interval, sourceUri, entityCollection);
+        processPacketData(Number, corridor, 'extrudedHeight', corridorData.extrudedHeight, interval, sourceUri, entityCollection);
+        processPacketData(CornerType, corridor, 'cornerType', corridorData.cornerType, interval, sourceUri, entityCollection);
+        processPacketData(Number, corridor, 'granularity', corridorData.granularity, interval, sourceUri, entityCollection);
+        processPacketData(Boolean, corridor, 'fill', corridorData.fill, interval, sourceUri, entityCollection);
+        processMaterialPacketData(corridor, 'material', corridorData.material, interval, sourceUri, entityCollection);
+        processPacketData(Boolean, corridor, 'outline', corridorData.outline, interval, sourceUri, entityCollection);
+        processPacketData(Color, corridor, 'outlineColor', corridorData.outlineColor, interval, sourceUri, entityCollection);
+        processPacketData(Number, corridor, 'outlineWidth', corridorData.outlineWidth, interval, sourceUri, entityCollection);
     }
 
     function processCylinder(entity, packet, entityCollection, sourceUri) {
@@ -1079,12 +1111,12 @@ define([
             entity.cylinder = cylinder = new CylinderGraphics();
         }
 
+        processPacketData(Boolean, cylinder, 'show', cylinderData.show, interval, sourceUri, entityCollection);
         processPacketData(Number, cylinder, 'length', cylinderData.length, interval, sourceUri, entityCollection);
         processPacketData(Number, cylinder, 'topRadius', cylinderData.topRadius, interval, sourceUri, entityCollection);
         processPacketData(Number, cylinder, 'bottomRadius', cylinderData.bottomRadius, interval, sourceUri, entityCollection);
-        processPacketData(Boolean, cylinder, 'show', cylinderData.show, interval, sourceUri, entityCollection);
-        processMaterialPacketData(cylinder, 'material', cylinderData.material, interval, sourceUri, entityCollection);
         processPacketData(Boolean, cylinder, 'fill', cylinderData.fill, interval, sourceUri, entityCollection);
+        processMaterialPacketData(cylinder, 'material', cylinderData.material, interval, sourceUri, entityCollection);
         processPacketData(Boolean, cylinder, 'outline', cylinderData.outline, interval, sourceUri, entityCollection);
         processPacketData(Color, cylinder, 'outlineColor', cylinderData.outlineColor, interval, sourceUri, entityCollection);
         processPacketData(Number, cylinder, 'outlineWidth', cylinderData.outlineWidth, interval, sourceUri, entityCollection);
@@ -1154,15 +1186,15 @@ define([
         }
 
         processPacketData(Boolean, ellipse, 'show', ellipseData.show, interval, sourceUri, entityCollection);
-        processPacketData(Rotation, ellipse, 'rotation', ellipseData.rotation, interval, sourceUri, entityCollection);
         processPacketData(Number, ellipse, 'semiMajorAxis', ellipseData.semiMajorAxis, interval, sourceUri, entityCollection);
         processPacketData(Number, ellipse, 'semiMinorAxis', ellipseData.semiMinorAxis, interval, sourceUri, entityCollection);
         processPacketData(Number, ellipse, 'height', ellipseData.height, interval, sourceUri, entityCollection);
         processPacketData(Number, ellipse, 'extrudedHeight', ellipseData.extrudedHeight, interval, sourceUri, entityCollection);
-        processPacketData(Number, ellipse, 'granularity', ellipseData.granularity, interval, sourceUri, entityCollection);
+        processPacketData(Rotation, ellipse, 'rotation', ellipseData.rotation, interval, sourceUri, entityCollection);
         processPacketData(Rotation, ellipse, 'stRotation', ellipseData.stRotation, interval, sourceUri, entityCollection);
-        processMaterialPacketData(ellipse, 'material', ellipseData.material, interval, sourceUri, entityCollection);
+        processPacketData(Number, ellipse, 'granularity', ellipseData.granularity, interval, sourceUri, entityCollection);
         processPacketData(Boolean, ellipse, 'fill', ellipseData.fill, interval, sourceUri, entityCollection);
+        processMaterialPacketData(ellipse, 'material', ellipseData.material, interval, sourceUri, entityCollection);
         processPacketData(Boolean, ellipse, 'outline', ellipseData.outline, interval, sourceUri, entityCollection);
         processPacketData(Color, ellipse, 'outlineColor', ellipseData.outlineColor, interval, sourceUri, entityCollection);
         processPacketData(Number, ellipse, 'outlineWidth', ellipseData.outlineWidth, interval, sourceUri, entityCollection);
@@ -1189,11 +1221,11 @@ define([
 
         processPacketData(Boolean, ellipsoid, 'show', ellipsoidData.show, interval, sourceUri, entityCollection);
         processPacketData(Cartesian3, ellipsoid, 'radii', ellipsoidData.radii, interval, sourceUri, entityCollection);
-        processMaterialPacketData(ellipsoid, 'material', ellipsoidData.material, interval, sourceUri, entityCollection);
         processPacketData(Number, ellipsoid, 'stackPartitions', ellipsoidData.stackPartitions, interval, sourceUri, entityCollection);
         processPacketData(Number, ellipsoid, 'slicePartitions', ellipsoidData.slicePartitions, interval, sourceUri, entityCollection);
         processPacketData(Number, ellipsoid, 'subdivisions', ellipsoidData.subdivisions, interval, sourceUri, entityCollection);
         processPacketData(Boolean, ellipsoid, 'fill', ellipsoidData.fill, interval, sourceUri, entityCollection);
+        processMaterialPacketData(ellipsoid, 'material', ellipsoidData.material, interval, sourceUri, entityCollection);
         processPacketData(Boolean, ellipsoid, 'outline', ellipsoidData.outline, interval, sourceUri, entityCollection);
         processPacketData(Color, ellipsoid, 'outlineColor', ellipsoidData.outlineColor, interval, sourceUri, entityCollection);
         processPacketData(Number, ellipsoid, 'outlineWidth', ellipsoidData.outlineWidth, interval, sourceUri, entityCollection);
@@ -1217,18 +1249,18 @@ define([
             entity.label = label = new LabelGraphics();
         }
 
+        processPacketData(Boolean, label, 'show', labelData.show, interval, sourceUri, entityCollection);
+        processPacketData(String, label, 'text', labelData.text, interval, sourceUri, entityCollection);
+        processPacketData(String, label, 'font', labelData.font, interval, sourceUri, entityCollection);
+        processPacketData(LabelStyle, label, 'style', labelData.style, interval, sourceUri, entityCollection);
+        processPacketData(Number, label, 'scale', labelData.scale, interval, sourceUri, entityCollection);
+        processPacketData(Cartesian2, label, 'pixelOffset', labelData.pixelOffset, interval, sourceUri, entityCollection);
+        processPacketData(Cartesian3, label, 'eyeOffset', labelData.eyeOffset, interval, sourceUri, entityCollection);
+        processPacketData(HorizontalOrigin, label, 'horizontalOrigin', labelData.horizontalOrigin, interval, sourceUri, entityCollection);
+        processPacketData(VerticalOrigin, label, 'verticalOrigin', labelData.verticalOrigin, interval, sourceUri, entityCollection);
         processPacketData(Color, label, 'fillColor', labelData.fillColor, interval, sourceUri, entityCollection);
         processPacketData(Color, label, 'outlineColor', labelData.outlineColor, interval, sourceUri, entityCollection);
         processPacketData(Number, label, 'outlineWidth', labelData.outlineWidth, interval, sourceUri, entityCollection);
-        processPacketData(Cartesian3, label, 'eyeOffset', labelData.eyeOffset, interval, sourceUri, entityCollection);
-        processPacketData(HorizontalOrigin, label, 'horizontalOrigin', labelData.horizontalOrigin, interval, sourceUri, entityCollection);
-        processPacketData(String, label, 'text', labelData.text, interval, sourceUri, entityCollection);
-        processPacketData(Cartesian2, label, 'pixelOffset', labelData.pixelOffset, interval, sourceUri, entityCollection);
-        processPacketData(Number, label, 'scale', labelData.scale, interval, sourceUri, entityCollection);
-        processPacketData(Boolean, label, 'show', labelData.show, interval, sourceUri, entityCollection);
-        processPacketData(VerticalOrigin, label, 'verticalOrigin', labelData.verticalOrigin, interval, sourceUri, entityCollection);
-        processPacketData(String, label, 'font', labelData.font, interval, sourceUri, entityCollection);
-        processPacketData(LabelStyle, label, 'style', labelData.style, interval, sourceUri, entityCollection);
     }
 
     function processModel(entity, packet, entityCollection, sourceUri) {
@@ -1250,12 +1282,12 @@ define([
         }
 
         processPacketData(Boolean, model, 'show', modelData.show, interval, sourceUri, entityCollection);
+        processPacketData(Uri, model, 'uri', modelData.gltf, interval, sourceUri, entityCollection);
         processPacketData(Number, model, 'scale', modelData.scale, interval, sourceUri, entityCollection);
         processPacketData(Number, model, 'minimumPixelSize', modelData.minimumPixelSize, interval, sourceUri, entityCollection);
         processPacketData(Boolean, model, 'incrementallyLoadTextures', modelData.incrementallyLoadTextures, interval, sourceUri, entityCollection);
         processPacketData(Boolean, model, 'castShadows', modelData.castShadows, interval, sourceUri, entityCollection);
         processPacketData(Boolean, model, 'receiveShadows', modelData.receiveShadows, interval, sourceUri, entityCollection);
-        processPacketData(Uri, model, 'uri', modelData.gltf, interval, sourceUri, entityCollection);
         processPacketData(Boolean, model, 'runAnimations', modelData.runAnimations, interval, sourceUri, entityCollection);
 
         var nodeTransformationsData = modelData.nodeTransformations;
@@ -1361,11 +1393,11 @@ define([
             entity.point = point = new PointGraphics();
         }
 
-        processPacketData(Color, point, 'color', pointData.color, interval, sourceUri, entityCollection);
+        processPacketData(Boolean, point, 'show', pointData.show, interval, sourceUri, entityCollection);
         processPacketData(Number, point, 'pixelSize', pointData.pixelSize, interval, sourceUri, entityCollection);
+        processPacketData(Color, point, 'color', pointData.color, interval, sourceUri, entityCollection);
         processPacketData(Color, point, 'outlineColor', pointData.outlineColor, interval, sourceUri, entityCollection);
         processPacketData(Number, point, 'outlineWidth', pointData.outlineWidth, interval, sourceUri, entityCollection);
-        processPacketData(Boolean, point, 'show', pointData.show, interval, sourceUri, entityCollection);
     }
 
     function processPolygon(entity, packet, entityCollection, sourceUri) {
@@ -1387,19 +1419,45 @@ define([
         }
 
         processPacketData(Boolean, polygon, 'show', polygonData.show, interval, sourceUri, entityCollection);
-        processMaterialPacketData(polygon, 'material', polygonData.material, interval, sourceUri, entityCollection);
+        processPositions(polygon, 'hierarchy', polygonData.positions, entityCollection);
         processPacketData(Number, polygon, 'height', polygonData.height, interval, sourceUri, entityCollection);
         processPacketData(Number, polygon, 'extrudedHeight', polygonData.extrudedHeight, interval, sourceUri, entityCollection);
-        processPacketData(Number, polygon, 'granularity', polygonData.granularity, interval, sourceUri, entityCollection);
         processPacketData(Rotation, polygon, 'stRotation', polygonData.stRotation, interval, sourceUri, entityCollection);
+        processPacketData(Number, polygon, 'granularity', polygonData.granularity, interval, sourceUri, entityCollection);
         processPacketData(Boolean, polygon, 'fill', polygonData.fill, interval, sourceUri, entityCollection);
+        processMaterialPacketData(polygon, 'material', polygonData.material, interval, sourceUri, entityCollection);
         processPacketData(Boolean, polygon, 'outline', polygonData.outline, interval, sourceUri, entityCollection);
         processPacketData(Color, polygon, 'outlineColor', polygonData.outlineColor, interval, sourceUri, entityCollection);
         processPacketData(Number, polygon, 'outlineWidth', polygonData.outlineWidth, interval, sourceUri, entityCollection);
         processPacketData(Boolean, polygon, 'perPositionHeight', polygonData.perPositionHeight, interval, sourceUri, entityCollection);
         processPacketData(Boolean, polygon, 'closeTop', polygonData.closeTop, interval, sourceUri, entityCollection);
         processPacketData(Boolean, polygon, 'closeBottom', polygonData.closeBottom, interval, sourceUri, entityCollection);
-        processPositions(polygon, 'hierarchy', polygonData.positions, entityCollection);
+    }
+
+    function processPolyline(entity, packet, entityCollection, sourceUri) {
+        var polylineData = packet.polyline;
+        if (!defined(polylineData)) {
+            return;
+        }
+
+        var interval;
+        var intervalString = polylineData.interval;
+        if (defined(intervalString)) {
+            iso8601Scratch.iso8601 = intervalString;
+            interval = TimeInterval.fromIso8601(iso8601Scratch);
+        }
+
+        var polyline = entity.polyline;
+        if (!defined(polyline)) {
+            entity.polyline = polyline = new PolylineGraphics();
+        }
+
+        processPacketData(Boolean, polyline, 'show', polylineData.show, interval, sourceUri, entityCollection);
+        processPositions(polyline, 'positions', polylineData.positions, entityCollection);
+        processPacketData(Number, polyline, 'width', polylineData.width, interval, sourceUri, entityCollection);
+        processPacketData(Number, polyline, 'granularity', polylineData.granularity, interval, sourceUri, entityCollection);
+        processMaterialPacketData(polyline, 'material', polylineData.material, interval, sourceUri, entityCollection);
+        processPacketData(Boolean, polyline, 'followSurface', polylineData.followSurface, interval, sourceUri, entityCollection);
     }
 
     function processRectangle(entity, packet, entityCollection, sourceUri) {
@@ -1422,50 +1480,18 @@ define([
 
         processPacketData(Boolean, rectangle, 'show', rectangleData.show, interval, sourceUri, entityCollection);
         processPacketData(Rectangle, rectangle, 'coordinates', rectangleData.coordinates, interval, sourceUri, entityCollection);
-        processMaterialPacketData(rectangle, 'material', rectangleData.material, interval, sourceUri, entityCollection);
         processPacketData(Number, rectangle, 'height', rectangleData.height, interval, sourceUri, entityCollection);
         processPacketData(Number, rectangle, 'extrudedHeight', rectangleData.extrudedHeight, interval, sourceUri, entityCollection);
-        processPacketData(Number, rectangle, 'granularity', rectangleData.granularity, interval, sourceUri, entityCollection);
         processPacketData(Rotation, rectangle, 'rotation', rectangleData.rotation, interval, sourceUri, entityCollection);
         processPacketData(Rotation, rectangle, 'stRotation', rectangleData.stRotation, interval, sourceUri, entityCollection);
+        processPacketData(Number, rectangle, 'granularity', rectangleData.granularity, interval, sourceUri, entityCollection);
         processPacketData(Boolean, rectangle, 'fill', rectangleData.fill, interval, sourceUri, entityCollection);
+        processMaterialPacketData(rectangle, 'material', rectangleData.material, interval, sourceUri, entityCollection);
         processPacketData(Boolean, rectangle, 'outline', rectangleData.outline, interval, sourceUri, entityCollection);
         processPacketData(Color, rectangle, 'outlineColor', rectangleData.outlineColor, interval, sourceUri, entityCollection);
         processPacketData(Number, rectangle, 'outlineWidth', rectangleData.outlineWidth, interval, sourceUri, entityCollection);
-        processPacketData(Boolean, rectangle, 'closeBottom', rectangleData.closeBottom, interval, sourceUri, entityCollection);
         processPacketData(Boolean, rectangle, 'closeTop', rectangleData.closeTop, interval, sourceUri, entityCollection);
-    }
-
-    function processCorridor(entity, packet, entityCollection, sourceUri) {
-        var corridorData = packet.corridor;
-        if (!defined(corridorData)) {
-            return;
-        }
-
-        var interval;
-        var intervalString = corridorData.interval;
-        if (defined(intervalString)) {
-            iso8601Scratch.iso8601 = intervalString;
-            interval = TimeInterval.fromIso8601(iso8601Scratch);
-        }
-
-        var corridor = entity.corridor;
-        if (!defined(corridor)) {
-            entity.corridor = corridor = new CorridorGraphics();
-        }
-
-        processPositions(corridor, 'positions', corridorData.positions, entityCollection);
-        processPacketData(Number, corridor, 'width', corridorData.width, interval, sourceUri, entityCollection);
-        processPacketData(CornerType, corridor, 'cornerType', corridorData.cornerType, interval, sourceUri, entityCollection);
-        processPacketData(Number, corridor, 'height', corridorData.height, interval, sourceUri, entityCollection);
-        processPacketData(Number, corridor, 'extrudedHeight', corridorData.extrudedHeight, interval, sourceUri, entityCollection);
-        processPacketData(Boolean, corridor, 'show', corridorData.show, interval, sourceUri, entityCollection);
-        processMaterialPacketData(corridor, 'material', corridorData.material, interval, sourceUri, entityCollection);
-        processPacketData(Number, corridor, 'granularity', corridorData.granularity, interval, sourceUri, entityCollection);
-        processPacketData(Boolean, corridor, 'fill', corridorData.fill, interval, sourceUri, entityCollection);
-        processPacketData(Boolean, corridor, 'outline', corridorData.outline, interval, sourceUri, entityCollection);
-        processPacketData(Color, corridor, 'outlineColor', corridorData.outlineColor, interval, sourceUri, entityCollection);
-        processPacketData(Number, corridor, 'outlineWidth', corridorData.outlineWidth, interval, sourceUri, entityCollection);
+        processPacketData(Boolean, rectangle, 'closeBottom', rectangleData.closeBottom, interval, sourceUri, entityCollection);
     }
 
     function processWall(entity, packet, entityCollection, sourceUri) {
@@ -1487,41 +1513,15 @@ define([
         }
 
         processPacketData(Boolean, wall, 'show', wallData.show, interval, sourceUri, entityCollection);
-        processMaterialPacketData(wall, 'material', wallData.material, interval, sourceUri, entityCollection);
+        processPositions(wall, 'positions', wallData.positions, entityCollection);
         processPacketData(Array, wall, 'minimumHeights', wallData.minimumHeights, interval, sourceUri, entityCollection);
         processPacketData(Array, wall, 'maximumHeights', wallData.maximumHeights, interval, sourceUri, entityCollection);
         processPacketData(Number, wall, 'granularity', wallData.granularity, interval, sourceUri, entityCollection);
         processPacketData(Boolean, wall, 'fill', wallData.fill, interval, sourceUri, entityCollection);
+        processMaterialPacketData(wall, 'material', wallData.material, interval, sourceUri, entityCollection);
         processPacketData(Boolean, wall, 'outline', wallData.outline, interval, sourceUri, entityCollection);
         processPacketData(Color, wall, 'outlineColor', wallData.outlineColor, interval, sourceUri, entityCollection);
         processPacketData(Number, wall, 'outlineWidth', wallData.outlineWidth, interval, sourceUri, entityCollection);
-        processPositions(wall, 'positions', wallData.positions, entityCollection);
-    }
-
-    function processPolyline(entity, packet, entityCollection, sourceUri) {
-        var polylineData = packet.polyline;
-        if (!defined(polylineData)) {
-            return;
-        }
-
-        var interval;
-        var intervalString = polylineData.interval;
-        if (defined(intervalString)) {
-            iso8601Scratch.iso8601 = intervalString;
-            interval = TimeInterval.fromIso8601(iso8601Scratch);
-        }
-
-        var polyline = entity.polyline;
-        if (!defined(polyline)) {
-            entity.polyline = polyline = new PolylineGraphics();
-        }
-
-        processPacketData(Boolean, polyline, 'show', polylineData.show, interval, sourceUri, entityCollection);
-        processPacketData(Number, polyline, 'width', polylineData.width, interval, sourceUri, entityCollection);
-        processMaterialPacketData(polyline, 'material', polylineData.material, interval, sourceUri, entityCollection);
-        processPacketData(Boolean, polyline, 'followSurface', polylineData.followSurface, interval, sourceUri, entityCollection);
-        processPacketData(Number, polyline, 'granularity', polylineData.granularity, interval, sourceUri, entityCollection);
-        processPositions(polyline, 'positions', polylineData.positions, entityCollection);
     }
 
     function processCzmlPacket(packet, entityCollection, updaterFunctions, sourceUri, dataSource) {

--- a/Source/DataSources/LabelVisualizer.js
+++ b/Source/DataSources/LabelVisualizer.js
@@ -36,7 +36,7 @@ define([
     var defaultStyle = LabelStyle.FILL;
     var defaultFillColor = Color.WHITE;
     var defaultOutlineColor = Color.BLACK;
-    var defaultOutlineWidth = 1;
+    var defaultOutlineWidth = 1.0;
     var defaultPixelOffset = Cartesian2.ZERO;
     var defaultEyeOffset = Cartesian3.ZERO;
     var defaultHorizontalOrigin = HorizontalOrigin.CENTER;

--- a/Specs/DataSources/CzmlDataSourceSpec.js
+++ b/Specs/DataSources/CzmlDataSourceSpec.js
@@ -838,7 +838,10 @@ defineSuite([
                 outlineColor : {
                     rgbaf : [0.2, 0.2, 0.2, 0.2]
                 },
-                outlineWidth : 6
+                outlineWidth : 6,
+                stackPartitions : 25,
+                slicePartitions : 26,
+                subdivisions : 27
             }
         };
 
@@ -853,6 +856,9 @@ defineSuite([
         expect(entity.ellipsoid.outline.getValue(Iso8601.MINIMUM_VALUE)).toEqual(true);
         expect(entity.ellipsoid.outlineColor.getValue(Iso8601.MINIMUM_VALUE)).toEqual(new Color(0.2, 0.2, 0.2, 0.2));
         expect(entity.ellipsoid.outlineWidth.getValue(Iso8601.MINIMUM_VALUE)).toEqual(6);
+        expect(entity.ellipsoid.stackPartitions.getValue(Iso8601.MINIMUM_VALUE)).toEqual(25);
+        expect(entity.ellipsoid.slicePartitions.getValue(Iso8601.MINIMUM_VALUE)).toEqual(26);
+        expect(entity.ellipsoid.subdivisions.getValue(Iso8601.MINIMUM_VALUE)).toEqual(27);
     });
 
     it('CZML adds data for constrained ellipsoid.', function() {


### PR DESCRIPTION
* I added some missing Ellipsoid properties which were left out of #1444
* I reordered the lines that process each CZML property to be relatively consistent, and to match the order of properties in the CZML schema.  Loosely, I put them in the order: 
 * show
 * fundamental/required properties (e.g. "image" or "text")
 * other definitional-type properties
 * fill & fill material
 * outline, outline material, outline width
 * other esoteric features

More changes to come in future PRs.