### PR TITLE
Fix handling of pointermove on touch devices

### DIFF
--- a/Source/Core/ScreenSpaceEventHandler.js
+++ b/Source/Core/ScreenSpaceEventHandler.js
@@ -619,8 +619,12 @@ define([
             var positions = screenSpaceEventHandler._positions;
 
             var identifier = event.pointerId;
-            getPosition(screenSpaceEventHandler, event, positions.get(identifier));
+            var position = positions.get(identifier);
+            if(!defined(position)){
+                return;
+            }
 
+            getPosition(screenSpaceEventHandler, event, position);
             fireTouchMoveEvents(screenSpaceEventHandler, event);
 
             var previousPositions = screenSpaceEventHandler._previousPositions;


### PR DESCRIPTION
`ScreenSpaceEventHandler` did not handle the case where a `pointerdown` happens on an element other than the canvas and then use held down and moved onto the canvas.  Essentially, it always assumed that the list of positions in the initial pointerdown were available in the pointermove, they aren't.

This problem only happens on touch devices with PointerEvent.