### PR TITLE
Re-enable mouse after touch events

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -38,6 +38,7 @@ Change Log
 * Exposed a parametric ray-triangle intersection test to the API as `IntersectionTests.rayTriangleParametric`.
 * Added `unsupportedNodeEvent` to `KmlDataSource` that is fired whenever an unsupported node is encountered.
 * Zooming in toward some target point now keeps the target point at the same screen position. [#4016](https://github.com/AnalyticalGraphicsInc/cesium/pull/4016)
+* Re-enabled mouse inputs after a specified number of milliseconds past the most recent touch event.
 
 ### 1.22.2 - 2016-06-14
 * This is an npm only release to fix the improperly published 1.22.1. There were no code changes.

--- a/Source/Core/ScreenSpaceEventHandler.js
+++ b/Source/Core/ScreenSpaceEventHandler.js
@@ -122,8 +122,16 @@ define([
         position : new Cartesian2()
     };
 
+    function gotTouchEvent(screenSpaceEventHandler) {
+        screenSpaceEventHandler._lastSeenTouchEvent = Date.now();
+    }
+
+    function canProcessMouseEvent(screenSpaceEventHandler) {
+        return (Date.now() - screenSpaceEventHandler._lastSeenTouchEvent) > ScreenSpaceEventHandler.MouseEmulationIgnoreMilliseconds;
+    }
+
     function handleMouseDown(screenSpaceEventHandler, event) {
-        if (screenSpaceEventHandler._seenAnyTouchEvents) {
+        if (!canProcessMouseEvent(screenSpaceEventHandler)) {
             return;
         }
 
@@ -166,7 +174,7 @@ define([
     };
 
     function handleMouseUp(screenSpaceEventHandler, event) {
-        if (screenSpaceEventHandler._seenAnyTouchEvents) {
+        if (!canProcessMouseEvent(screenSpaceEventHandler)) {
             return;
         }
 
@@ -223,7 +231,7 @@ define([
     };
 
     function handleMouseMove(screenSpaceEventHandler, event) {
-        if (screenSpaceEventHandler._seenAnyTouchEvents) {
+        if (!canProcessMouseEvent(screenSpaceEventHandler)) {
             return;
         }
 
@@ -318,7 +326,7 @@ define([
     }
 
     function handleTouchStart(screenSpaceEventHandler, event) {
-        screenSpaceEventHandler._seenAnyTouchEvents = true;
+        gotTouchEvent(screenSpaceEventHandler);
 
         var changedTouches = event.changedTouches;
 
@@ -346,7 +354,7 @@ define([
     }
 
     function handleTouchEnd(screenSpaceEventHandler, event) {
-        screenSpaceEventHandler._seenAnyTouchEvents = true;
+        gotTouchEvent(screenSpaceEventHandler);
 
         var changedTouches = event.changedTouches;
 
@@ -475,7 +483,7 @@ define([
     }
 
     function handleTouchMove(screenSpaceEventHandler, event) {
-        screenSpaceEventHandler._seenAnyTouchEvents = true;
+        gotTouchEvent(screenSpaceEventHandler);
 
         var changedTouches = event.changedTouches;
 
@@ -644,7 +652,7 @@ define([
         this._inputEvents = {};
         this._buttonDown = undefined;
         this._isPinching = false;
-        this._seenAnyTouchEvents = false;
+        this._lastSeenTouchEvent = 0;
 
         this._primaryStartPosition = new Cartesian2();
         this._primaryPosition = new Cartesian2();
@@ -759,7 +767,7 @@ define([
      *
      * @example
      * handler = handler && handler.destroy();
-     * 
+     *
      * @see ScreenSpaceEventHandler#isDestroyed
      */
     ScreenSpaceEventHandler.prototype.destroy = function() {
@@ -767,6 +775,13 @@ define([
 
         return destroyObject(this);
     };
+
+    /**
+     * The amount of time, in milliseconds, that mouse events will be disabled after
+     * receiving any touch events, such that any emulated mouse events will be ignored.
+     * @default 800
+     */
+    ScreenSpaceEventHandler.MouseEmulationIgnoreMilliseconds = 800;
 
     return ScreenSpaceEventHandler;
 });

--- a/Source/Core/ScreenSpaceEventHandler.js
+++ b/Source/Core/ScreenSpaceEventHandler.js
@@ -129,7 +129,7 @@ define([
     }
 
     function canProcessMouseEvent(screenSpaceEventHandler) {
-        return (getTimestamp() - screenSpaceEventHandler._lastSeenTouchEvent) > ScreenSpaceEventHandler.MouseEmulationIgnoreMilliseconds;
+        return (getTimestamp() - screenSpaceEventHandler._lastSeenTouchEvent) > ScreenSpaceEventHandler.mouseEmulationIgnoreMilliseconds;
     }
 
     function handleMouseDown(screenSpaceEventHandler, event) {
@@ -654,7 +654,7 @@ define([
         this._inputEvents = {};
         this._buttonDown = undefined;
         this._isPinching = false;
-        this._lastSeenTouchEvent = -ScreenSpaceEventHandler.MouseEmulationIgnoreMilliseconds;
+        this._lastSeenTouchEvent = -ScreenSpaceEventHandler.mouseEmulationIgnoreMilliseconds;
 
         this._primaryStartPosition = new Cartesian2();
         this._primaryPosition = new Cartesian2();
@@ -783,7 +783,7 @@ define([
      * receiving any touch events, such that any emulated mouse events will be ignored.
      * @default 800
      */
-    ScreenSpaceEventHandler.MouseEmulationIgnoreMilliseconds = 800;
+    ScreenSpaceEventHandler.mouseEmulationIgnoreMilliseconds = 800;
 
     return ScreenSpaceEventHandler;
 });

--- a/Source/Core/ScreenSpaceEventHandler.js
+++ b/Source/Core/ScreenSpaceEventHandler.js
@@ -7,6 +7,7 @@ define([
         './destroyObject',
         './DeveloperError',
         './FeatureDetection',
+        './getTimestamp',
         './KeyboardEventModifier',
         './ScreenSpaceEventType'
     ], function(
@@ -17,6 +18,7 @@ define([
         destroyObject,
         DeveloperError,
         FeatureDetection,
+        getTimestamp,
         KeyboardEventModifier,
         ScreenSpaceEventType) {
     'use strict';
@@ -123,11 +125,11 @@ define([
     };
 
     function gotTouchEvent(screenSpaceEventHandler) {
-        screenSpaceEventHandler._lastSeenTouchEvent = Date.now();
+        screenSpaceEventHandler._lastSeenTouchEvent = getTimestamp();
     }
 
     function canProcessMouseEvent(screenSpaceEventHandler) {
-        return (Date.now() - screenSpaceEventHandler._lastSeenTouchEvent) > ScreenSpaceEventHandler.MouseEmulationIgnoreMilliseconds;
+        return (getTimestamp() - screenSpaceEventHandler._lastSeenTouchEvent) > ScreenSpaceEventHandler.MouseEmulationIgnoreMilliseconds;
     }
 
     function handleMouseDown(screenSpaceEventHandler, event) {
@@ -652,7 +654,7 @@ define([
         this._inputEvents = {};
         this._buttonDown = undefined;
         this._isPinching = false;
-        this._lastSeenTouchEvent = 0;
+        this._lastSeenTouchEvent = -ScreenSpaceEventHandler.MouseEmulationIgnoreMilliseconds;
 
         this._primaryStartPosition = new Cartesian2();
         this._primaryPosition = new Cartesian2();


### PR DESCRIPTION
Cesium's event handling has historically disabled mouse inputs once any touch input is received.  This feature was designed to protect Cesium from "emulated" mouse events that can follow touch events.  But now there are plenty of screens that offer both touch and mouse events (not at exactly the same time, but alternating during the same session).

This change modifies Cesium's anti-mouse-emulation code by making it time out after a specified number of milliseconds.  This allows the mouse inputs to re-enable after a short delay beyond the most recent touch event.  I tested this on a Surface Pro 3 in Chrome and Edge.