### PR TITLE
Fixed ground clamping example to zoom to geometries

### DIFF
--- a/Apps/Sandcastle/gallery/Ground Clamping.html
+++ b/Apps/Sandcastle/gallery/Ground Clamping.html
@@ -92,7 +92,7 @@ Sandcastle.addDefaultToolbarMenu([{
             }
         });
 
-        viewer.trackedEntity = e;
+        viewer.zoomTo(e);
     }
 }, {
     text : 'Draw Polygon',
@@ -109,7 +109,7 @@ Sandcastle.addDefaultToolbarMenu([{
             }
         });
 
-        viewer.trackedEntity = e;
+        viewer.zoomTo(e);
     }
 }, {
     text : 'Draw Rectangle',
@@ -121,7 +121,7 @@ Sandcastle.addDefaultToolbarMenu([{
             }
         });
 
-        viewer.trackedEntity = e;
+        viewer.zoomTo(e);
     }
 }], 'zoomButtons');
 


### PR DESCRIPTION
Polygons, corridors and rectangles don't have an `Entity.position` so they can't be tracked. Fixed to use `zoomTo`.