### PR TITLE
Allow computing a geometry's hard normals

### DIFF
--- a/Source/Core/GeometryPipeline.js
+++ b/Source/Core/GeometryPipeline.js
@@ -1051,6 +1051,25 @@ define([
         return geometries;
     };
 
+    var scratchEdge1 = new Cartesian3();
+    var scratchEdge2 = new Cartesian3();
+
+    /**
+     * @private
+     * @param position1
+     * @param position2
+     * @param position3
+     * @returns {Cartesian3}
+     */
+    function getFaceNormal(position1, position2, position3) {
+        var result = new Cartesian3();
+        var edge1 = Cartesian3.subtract(position2, position1, scratchEdge1);
+        var edge2 = Cartesian3.subtract(position3, position1, scratchEdge2);
+        Cartesian3.cross(edge1, edge2, result);
+        Cartesian3.normalize(result, result);
+        return result;
+    }
+
     var normal = new Cartesian3();
     var v0 = new Cartesian3();
     var v1 = new Cartesian3();
@@ -1070,7 +1089,7 @@ define([
      * @example
      * Cesium.GeometryPipeline.computeNormal(geometry);
      */
-    GeometryPipeline.computeNormal = function(geometry) {
+    GeometryPipeline.computeNormal = function(geometry, isHard) {
         //>>includeStart('debug', pragmas.debug);
         if (!defined(geometry)) {
             throw new DeveloperError('geometry is required.');
@@ -1097,88 +1116,139 @@ define([
         var normalsPerVertex = new Array(numVertices);
         var normalsPerTriangle = new Array(numIndices / 3);
         var normalIndices = new Array(numIndices);
+        var normalValues;
 
-        for ( var i = 0; i < numVertices; i++) {
-            normalsPerVertex[i] = {
-                indexOffset : 0,
-                count : 0,
-                currentCount : 0
-            };
-        }
+        if (isHard) {
+            var oldPositions = [];
+            Cartesian3.unpackArray(vertices, oldPositions);
 
-        var j = 0;
-        for (i = 0; i < numIndices; i += 3) {
-            var i0 = indices[i];
-            var i1 = indices[i + 1];
-            var i2 = indices[i + 2];
-            var i03 = i0 * 3;
-            var i13 = i1 * 3;
-            var i23 = i2 * 3;
 
-            v0.x = vertices[i03];
-            v0.y = vertices[i03 + 1];
-            v0.z = vertices[i03 + 2];
-            v1.x = vertices[i13];
-            v1.y = vertices[i13 + 1];
-            v1.z = vertices[i13 + 2];
-            v2.x = vertices[i23];
-            v2.y = vertices[i23 + 1];
-            v2.z = vertices[i23 + 2];
-
-            normalsPerVertex[i0].count++;
-            normalsPerVertex[i1].count++;
-            normalsPerVertex[i2].count++;
-
-            Cartesian3.subtract(v1, v0, v1);
-            Cartesian3.subtract(v2, v0, v2);
-            normalsPerTriangle[j] = Cartesian3.cross(v1, v2, new Cartesian3());
-            j++;
-        }
-
-        var indexOffset = 0;
-        for (i = 0; i < numVertices; i++) {
-            normalsPerVertex[i].indexOffset += indexOffset;
-            indexOffset += normalsPerVertex[i].count;
-        }
-
-        j = 0;
-        var vertexNormalData;
-        for (i = 0; i < numIndices; i += 3) {
-            vertexNormalData = normalsPerVertex[indices[i]];
-            var index = vertexNormalData.indexOffset + vertexNormalData.currentCount;
-            normalIndices[index] = j;
-            vertexNormalData.currentCount++;
-
-            vertexNormalData = normalsPerVertex[indices[i + 1]];
-            index = vertexNormalData.indexOffset + vertexNormalData.currentCount;
-            normalIndices[index] = j;
-            vertexNormalData.currentCount++;
-
-            vertexNormalData = normalsPerVertex[indices[i + 2]];
-            index = vertexNormalData.indexOffset + vertexNormalData.currentCount;
-            normalIndices[index] = j;
-            vertexNormalData.currentCount++;
-
-            j++;
-        }
-
-        var normalValues = new Float32Array(numVertices * 3);
-        for (i = 0; i < numVertices; i++) {
-            var i3 = i * 3;
-            vertexNormalData = normalsPerVertex[i];
-            if (vertexNormalData.count > 0) {
-                Cartesian3.clone(Cartesian3.ZERO, normal);
-                for (j = 0; j < vertexNormalData.count; j++) {
-                    Cartesian3.add(normal, normalsPerTriangle[normalIndices[vertexNormalData.indexOffset + j]], normal);
+            var positions = new Array(numIndices);
+            var normals = new Array(numIndices);
+            var maxIndex = 0;
+            var j;
+            for (j = 0; j < numIndices; j++) {
+                index = indices[j];
+                maxIndex = Math.max(maxIndex, index);
+            }
+            // Duplicate any vertices shared by multiple indices
+            var seenIndices = {};
+            var nextIndex = maxIndex + 1;
+            for (j = 0; j < numIndices; j++) {
+                index = indices[j];
+                var position = oldPositions[index];
+                if (defined(seenIndices[index])) {
+                    positions[nextIndex] = position;
+                    indices[j] = nextIndex;
+                    nextIndex++;
+                } else {
+                    positions[index] = position;
+                    seenIndices[index] = true;
                 }
+            }
+
+            // Add face normal to each vertex normal
+            for (j = 0; j < numIndices; j += 3) {
+                var index1 = indices[j];
+                var index2 = indices[j + 1];
+                var index3 = indices[j + 2];
+                var faceNormal = getFaceNormal(positions[index1], positions[index2], positions[index3]);
+                normals[index1] = faceNormal;
+                normals[index2] = faceNormal.clone();
+                normals[index3] = faceNormal.clone();
+            }
+
+            // Normalize the normals
+            for (j = 0; j < numIndices; ++j) {
+                normal = normals[j];
                 Cartesian3.normalize(normal, normal);
-                normalValues[i3] = normal.x;
-                normalValues[i3 + 1] = normal.y;
-                normalValues[i3 + 2] = normal.z;
-            } else {
-                normalValues[i3] = 0.0;
-                normalValues[i3 + 1] = 0.0;
-                normalValues[i3 + 2] = 1.0;
+            }
+            normalValues = [];
+            Cartesian3.packArray(normals, normalValues);
+        } else {
+            // "Soft" normals
+            for (var i = 0; i < numVertices; i++) {
+                normalsPerVertex[i] = {
+                    indexOffset : 0,
+                    count : 0,
+                    currentCount : 0
+                };
+            }
+
+            var j = 0;
+            for (i = 0; i < numIndices; i += 3) {
+                var i0 = indices[i];
+                var i1 = indices[i + 1];
+                var i2 = indices[i + 2];
+                var i03 = i0 * 3;
+                var i13 = i1 * 3;
+                var i23 = i2 * 3;
+
+                v0.x = vertices[i03];
+                v0.y = vertices[i03 + 1];
+                v0.z = vertices[i03 + 2];
+                v1.x = vertices[i13];
+                v1.y = vertices[i13 + 1];
+                v1.z = vertices[i13 + 2];
+                v2.x = vertices[i23];
+                v2.y = vertices[i23 + 1];
+                v2.z = vertices[i23 + 2];
+
+                normalsPerVertex[i0].count++;
+                normalsPerVertex[i1].count++;
+                normalsPerVertex[i2].count++;
+
+                Cartesian3.subtract(v1, v0, v1);
+                Cartesian3.subtract(v2, v0, v2);
+                normalsPerTriangle[j] = Cartesian3.cross(v1, v2, new Cartesian3());
+                j++;
+            }
+
+            var indexOffset = 0;
+            for (i = 0; i < numVertices; i++) {
+                normalsPerVertex[i].indexOffset += indexOffset;
+                indexOffset += normalsPerVertex[i].count;
+            }
+
+            j = 0;
+            var vertexNormalData;
+            for (i = 0; i < numIndices; i += 3) {
+                vertexNormalData = normalsPerVertex[indices[i]];
+                var index = vertexNormalData.indexOffset + vertexNormalData.currentCount;
+                normalIndices[index] = j;
+                vertexNormalData.currentCount++;
+
+                vertexNormalData = normalsPerVertex[indices[i + 1]];
+                index = vertexNormalData.indexOffset + vertexNormalData.currentCount;
+                normalIndices[index] = j;
+                vertexNormalData.currentCount++;
+
+                vertexNormalData = normalsPerVertex[indices[i + 2]];
+                index = vertexNormalData.indexOffset + vertexNormalData.currentCount;
+                normalIndices[index] = j;
+                vertexNormalData.currentCount++;
+
+                j++;
+            }
+
+            normalValues = new Float32Array(numVertices * 3);
+            for (i = 0; i < numVertices; i++) {
+                var i3 = i * 3;
+                vertexNormalData = normalsPerVertex[i];
+                if (vertexNormalData.count > 0) {
+                    Cartesian3.clone(Cartesian3.ZERO, normal);
+                    for (j = 0; j < vertexNormalData.count; j++) {
+                        Cartesian3.add(normal, normalsPerTriangle[normalIndices[vertexNormalData.indexOffset + j]], normal);
+                    }
+                    Cartesian3.normalize(normal, normal);
+                    normalValues[i3] = normal.x;
+                    normalValues[i3 + 1] = normal.y;
+                    normalValues[i3 + 2] = normal.z;
+                } else {
+                    normalValues[i3] = 0.0;
+                    normalValues[i3 + 1] = 0.0;
+                    normalValues[i3 + 2] = 1.0;
+                }
             }
         }
 

--- a/Source/Core/GeometryPipeline.js
+++ b/Source/Core/GeometryPipeline.js
@@ -1117,29 +1117,29 @@ define([
         var normalsPerTriangle = new Array(numIndices / 3);
         var normalIndices = new Array(numIndices);
         var normalValues;
+        var index;
+        var i;
 
         if (isHard) {
             var oldPositions = [];
             Cartesian3.unpackArray(vertices, oldPositions);
 
-
             var positions = new Array(numIndices);
             var normals = new Array(numIndices);
             var maxIndex = 0;
-            var j;
-            for (j = 0; j < numIndices; j++) {
-                index = indices[j];
+            for (i = 0; i < numIndices; i++) {
+                index = indices[i];
                 maxIndex = Math.max(maxIndex, index);
             }
             // Duplicate any vertices shared by multiple indices
             var seenIndices = {};
             var nextIndex = maxIndex + 1;
-            for (j = 0; j < numIndices; j++) {
-                index = indices[j];
+            for (i = 0; i < numIndices; i++) {
+                index = indices[i];
                 var position = oldPositions[index];
                 if (defined(seenIndices[index])) {
                     positions[nextIndex] = position;
-                    indices[j] = nextIndex;
+                    indices[i] = nextIndex;
                     nextIndex++;
                 } else {
                     positions[index] = position;
@@ -1148,10 +1148,10 @@ define([
             }
 
             // Add face normal to each vertex normal
-            for (j = 0; j < numIndices; j += 3) {
-                var index1 = indices[j];
-                var index2 = indices[j + 1];
-                var index3 = indices[j + 2];
+            for (i = 0; i < numIndices; i += 3) {
+                var index1 = indices[i];
+                var index2 = indices[i + 1];
+                var index3 = indices[i + 2];
                 var faceNormal = getFaceNormal(positions[index1], positions[index2], positions[index3]);
                 normals[index1] = faceNormal;
                 normals[index2] = faceNormal.clone();
@@ -1159,15 +1159,15 @@ define([
             }
 
             // Normalize the normals
-            for (j = 0; j < numIndices; ++j) {
-                normal = normals[j];
+            for (i = 0; i < numIndices; ++i) {
+                normal = normals[i];
                 Cartesian3.normalize(normal, normal);
             }
             normalValues = [];
             Cartesian3.packArray(normals, normalValues);
         } else {
             // "Soft" normals
-            for (var i = 0; i < numVertices; i++) {
+            for (i = 0; i < numVertices; i++) {
                 normalsPerVertex[i] = {
                     indexOffset : 0,
                     count : 0,
@@ -1214,7 +1214,7 @@ define([
             var vertexNormalData;
             for (i = 0; i < numIndices; i += 3) {
                 vertexNormalData = normalsPerVertex[indices[i]];
-                var index = vertexNormalData.indexOffset + vertexNormalData.currentCount;
+                index = vertexNormalData.indexOffset + vertexNormalData.currentCount;
                 normalIndices[index] = j;
                 vertexNormalData.currentCount++;
 

--- a/Specs/Core/GeometryPipelineSpec.js
+++ b/Specs/Core/GeometryPipelineSpec.js
@@ -1345,6 +1345,25 @@ defineSuite([
         expect(geometry.attributes.normal.values).toEqual([0, 0, 1, 0, 0, 1, 0, 0, 1]);
     });
 
+    it('computeNormal computes hard normal for one triangle', function() {
+        var geometry = new Geometry({
+            attributes: {
+                position: new GeometryAttribute({
+                    values: [0, 0, 0, 1, 0, 0, 0, 1, 0],
+                    componentsPerAttribute: 3,
+                    componentDatatype : ComponentDatatype.FLOAT
+                })
+            },
+            indices : [0, 1, 2],
+            primitiveType: PrimitiveType.TRIANGLES
+        });
+
+        geometry = GeometryPipeline.computeNormal(geometry, true);
+
+        expect(geometry.attributes.normal.values.length).toEqual(3*3);
+        expect(geometry.attributes.normal.values).toEqual([0, 0, 1, 0, 0, 1, 0, 0, 1]);
+    });
+
     it('computeNormal computes normal for two triangles', function() {
         var geometry = new Geometry({
             attributes: {
@@ -1371,6 +1390,36 @@ defineSuite([
 
         a = Cartesian3.normalize(new Cartesian3(1, 0, 1), new Cartesian3());
         expect(Cartesian3.fromArray(normals, 9)).toEqualEpsilon(a, CesiumMath.EPSILON7);
+    });
+
+    it('computeNormal computes hard normal for two triangles', function() {
+        var geometry = new Geometry({
+            attributes: {
+                position: new GeometryAttribute({
+                    values: [0, 0, 0, 1, 0, 1, 1, 1, 1, 2, 0, 0],
+                    componentsPerAttribute: 3,
+                    componentDatatype : ComponentDatatype.FLOAT
+                })
+            },
+            indices : [0, 1, 2, 1, 3, 2],
+            primitiveType: PrimitiveType.TRIANGLES
+        });
+
+        geometry = GeometryPipeline.computeNormal(geometry, true);
+
+        var normals = geometry.attributes.normal.values;
+        expect(normals.length).toEqual(6*3);
+
+        var a = Cartesian3.normalize(new Cartesian3(-1, 0, 1), new Cartesian3());
+
+        expect(Cartesian3.fromArray(normals, 0)).toEqualEpsilon(a, CesiumMath.EPSILON7);
+        expect(Cartesian3.fromArray(normals, 3)).toEqualEpsilon(a, CesiumMath.EPSILON7);
+        expect(Cartesian3.fromArray(normals, 6)).toEqualEpsilon(a, CesiumMath.EPSILON7);
+
+        a = Cartesian3.normalize(new Cartesian3(1, 0, 1), new Cartesian3());
+        expect(Cartesian3.fromArray(normals, 9)).toEqualEpsilon(a, CesiumMath.EPSILON7);
+        expect(Cartesian3.fromArray(normals, 12)).toEqualEpsilon(a, CesiumMath.EPSILON7);
+        expect(Cartesian3.fromArray(normals, 15)).toEqualEpsilon(a, CesiumMath.EPSILON7);
     });
 
     it('computeNormal computes normal for six triangles', function() {
@@ -1408,6 +1457,48 @@ defineSuite([
         expect(Cartesian3.fromArray(normals, 15)).toEqualEpsilon(a, CesiumMath.EPSILON7);
 
         expect(Cartesian3.fromArray(normals, 18)).toEqualEpsilon(Cartesian3.negate(Cartesian3.UNIT_Z, new Cartesian3()), CesiumMath.EPSILON7);
+    });
+
+    it('computeNormal computes hard normal for six triangles', function() {
+        var geometry = new Geometry ({
+            attributes: {
+                position: new GeometryAttribute({
+                    values: [0, 0, 0, 1, 0, 0, 1, 0, 1, 0, 0, 1, 0, 1, 1, 0, 1, 0, 1, 1, 0],
+                    componentsPerAttribute: 3,
+                    componentDatatype : ComponentDatatype.FLOAT
+                })
+            },
+            indices : [0, 1, 2, 3, 0, 2, 4, 0, 3, 4, 5, 0, 5, 6, 0, 6, 1, 0],
+            primitiveType: PrimitiveType.TRIANGLES
+        });
+
+        geometry = GeometryPipeline.computeNormal(geometry, true);
+
+        var normals = geometry.attributes.normal.values;
+        expect(normals.length).toEqual(18*3);
+
+        var a = new Cartesian3(0, -1, 0);
+        expect(Cartesian3.fromArray(normals, 0)).toEqualEpsilon(a, CesiumMath.EPSILON7);
+        expect(Cartesian3.fromArray(normals, 3)).toEqualEpsilon(a, CesiumMath.EPSILON7);
+        expect(Cartesian3.fromArray(normals, 6)).toEqualEpsilon(a, CesiumMath.EPSILON7);
+        expect(Cartesian3.fromArray(normals, 9)).toEqualEpsilon(a, CesiumMath.EPSILON7);
+        expect(Cartesian3.fromArray(normals, 21)).toEqualEpsilon(a, CesiumMath.EPSILON7);
+        expect(Cartesian3.fromArray(normals, 24)).toEqualEpsilon(a, CesiumMath.EPSILON7);
+
+        a = new Cartesian3(-1, 0, 0);
+        expect(Cartesian3.fromArray(normals, 12)).toEqualEpsilon(a, CesiumMath.EPSILON7);
+        expect(Cartesian3.fromArray(normals, 15)).toEqualEpsilon(a, CesiumMath.EPSILON7);
+        expect(Cartesian3.fromArray(normals, 27)).toEqualEpsilon(a, CesiumMath.EPSILON7);
+        expect(Cartesian3.fromArray(normals, 30)).toEqualEpsilon(a, CesiumMath.EPSILON7);
+        expect(Cartesian3.fromArray(normals, 36)).toEqualEpsilon(a, CesiumMath.EPSILON7);
+
+        a = new Cartesian3(0, 0, -1);
+        expect(Cartesian3.fromArray(normals, 18)).toEqualEpsilon(a, CesiumMath.EPSILON7);
+        expect(Cartesian3.fromArray(normals, 39)).toEqualEpsilon(a, CesiumMath.EPSILON7);
+        expect(Cartesian3.fromArray(normals, 42)).toEqualEpsilon(a, CesiumMath.EPSILON7);
+        expect(Cartesian3.fromArray(normals, 45)).toEqualEpsilon(a, CesiumMath.EPSILON7);
+        expect(Cartesian3.fromArray(normals, 48)).toEqualEpsilon(a, CesiumMath.EPSILON7);
+        expect(Cartesian3.fromArray(normals, 51)).toEqualEpsilon(a, CesiumMath.EPSILON7);
     });
 
     it('computeBinormalAndTangent throws when geometry is undefined', function() {


### PR DESCRIPTION
In glTF-Pipeline we want to allow a command line flag for calculating 'hard' normals if normals are not already provided in the input model. Since we plan on eventually making use of `GeometryPipeline` functions in order to calculate normals, this change had to be made within Cesium.

See AnalyticalGraphicsInc/gltf-pipeline#82