### PR TITLE
Allow zero-padding components of UrlTemplateImageryProvider.

### DIFF
--- a/Source/Scene/UrlTemplateImageryProvider.js
+++ b/Source/Scene/UrlTemplateImageryProvider.js
@@ -764,8 +764,10 @@ define([
         {
             var paddingTemplate = imageryProvider.urlSchemeZeroPadding[key];
             if (typeof paddingTemplate === 'string') {
-                var templateWidth = paddingTemplate.length;
-                value = (value.length >= templateWidth) ? value : new Array(templateWidth - value.toString().length + 1).join('0') + value;
+                var paddingTemplateWidth = paddingTemplate.length;
+                if (paddingTemplateWidth > 1) {
+                    value = (value.length >= paddingTemplateWidth) ? value : new Array(paddingTemplateWidth - value.toString().length + 1).join('0') + value;
+                }
             }
         }
         return value;

--- a/Source/Scene/UrlTemplateImageryProvider.js
+++ b/Source/Scene/UrlTemplateImageryProvider.js
@@ -89,6 +89,19 @@ define([
      *     <li><code>{latitudeProjected}</code>: The latitude of the picked position in the projected coordinates of the tiling scheme.</li>
      *     <li><code>{format}</code>: The format in which to get feature information, as specified in the {@link GetFeatureInfoFormat}.</li>
      * </ul>
+     * @param {Object} [options.urlSchemeZeroPadding] Gets the URL scheme zero padding for each tile coordinate. The format is '000' where
+     * each coordinate will be padded on the left with zeros to match the width of the passed string of zeros. e.g. Setting:
+     * urlSchemeZeroPadding : { '{x}' : '0000'}
+     * will cause an 'x' value of 12 to return the string '0012' for {x} in the generated URL.
+     * It the passed object has the following keywords:
+     * <ul>
+     *  <li> <code>{z}</code>: The zero padding for the level of the tile in the tiling scheme.</li>
+     *  <li> <code>{x}</code>: The zero padding for the tile X coordinate in the tiling scheme.</li>
+     *  <li> <code>{y}</code>: The zero padding for the the tile Y coordinate in the tiling scheme.</li>
+     *  <li> <code>{reverseX}</code>: The zero padding for the tile reverseX coordinate in the tiling scheme.</li>
+     *  <li> <code>{reverseY}</code>: The zero padding for the tile reverseY coordinate in the tiling scheme.</li>
+     *  <li> <code>{reverseZ}</code>: The zero padding for the reverseZ coordinate of the tile in the tiling scheme.</li>
+     * </ul>
      * @param {String|String[]} [options.subdomains='abc'] The subdomains to use for the <code>{s}</code> placeholder in the URL template.
      *                          If this parameter is a single string, each character in the string is a subdomain.  If it is
      *                          an array, each element in the array is a subdomain.
@@ -170,6 +183,7 @@ define([
         this._errorEvent = new Event();
 
         this._url = undefined;
+        this._urlSchemeZeroPadding = undefined;
         this._pickFeaturesUrl = undefined;
         this._proxy = undefined;
         this._tileWidth = undefined;
@@ -228,6 +242,31 @@ define([
                 return this._url;
             }
         },
+
+        /**
+         * Gets the URL scheme zero padding for each tile coordinate. The format is '000' where each coordinate will be padded on
+         * the left with zeros to match the width of the passed string of zeros. e.g. Setting:
+         * urlSchemeZeroPadding : { '{x}' : '0000'}
+         * will cause an 'x' value of 12 to return the string '0012' for {x} in the generated URL.
+         * It has the following keywords:
+         * <ul>
+         *  <li> <code>{z}</code>: The zero padding for the level of the tile in the tiling scheme.</li>
+         *  <li> <code>{x}</code>: The zero padding for the tile X coordinate in the tiling scheme.</li>
+         *  <li> <code>{y}</code>: The zero padding for the the tile Y coordinate in the tiling scheme.</li>
+         *  <li> <code>{reverseX}</code>: The zero padding for the tile reverseX coordinate in the tiling scheme.</li>
+         *  <li> <code>{reverseY}</code>: The zero padding for the tile reverseY coordinate in the tiling scheme.</li>
+         *  <li> <code>{reverseZ}</code>: The zero padding for the reverseZ coordinate of the tile in the tiling scheme.</li>
+         * </ul>
+         * @memberof UrlTemplateImageryProvider.prototype
+         * @type {Object}
+         * @readonly
+         */
+        urlSchemeZeroPadding : {
+            get : function() {
+                return this._urlSchemeZeroPadding;
+            }
+        },
+
 
         /**
          * Gets the URL template to use to use to pick features.  If this property is not specified,
@@ -502,6 +541,7 @@ define([
             //>>includeEnd('debug');
             that.enablePickFeatures = defaultValue(properties.enablePickFeatures, that.enablePickFeatures);
             that._url = properties.url;
+            that._urlSchemeZeroPadding = defaultValue(properties.urlSchemeZeroPadding, that.urlSchemeZeroPadding);
             that._pickFeaturesUrl = properties.pickFeaturesUrl;
             that._proxy = properties.proxy;
             that._tileDiscardPolicy = properties.tileDiscardPolicy;
@@ -717,29 +757,46 @@ define([
         return parts;
     }
 
+    function padWithZerosIfNecessary(imageryProvider, key, value) {
+        if (imageryProvider &&
+            imageryProvider.urlSchemeZeroPadding &&
+            imageryProvider.urlSchemeZeroPadding.hasOwnProperty(key) )
+        {
+            var paddingTemplate = imageryProvider.urlSchemeZeroPadding[key];
+            if (typeof paddingTemplate === 'string') {
+                var templateWidth = paddingTemplate.length;
+                value = (value.length >= templateWidth) ? value : new Array(templateWidth - value.toString().length + 1).join('0') + value;
+            }
+        }
+        return value;
+    }
+
     function xTag(imageryProvider, x, y, level) {
-        return x;
+        return padWithZerosIfNecessary(imageryProvider, '{x}', x);
     }
 
     function reverseXTag(imageryProvider, x, y, level) {
-        return imageryProvider.tilingScheme.getNumberOfXTilesAtLevel(level) - x - 1;
+        var reverseX = imageryProvider.tilingScheme.getNumberOfXTilesAtLevel(level) - x - 1;
+        return padWithZerosIfNecessary(imageryProvider, '{reverseX}', reverseX);
     }
 
     function yTag(imageryProvider, x, y, level) {
-        return y;
+        return padWithZerosIfNecessary(imageryProvider, '{y}', y);
     }
 
     function reverseYTag(imageryProvider, x, y, level) {
-        return imageryProvider.tilingScheme.getNumberOfYTilesAtLevel(level) - y - 1;
+        var reverseY = imageryProvider.tilingScheme.getNumberOfYTilesAtLevel(level) - y - 1;
+        return padWithZerosIfNecessary(imageryProvider, '{reverseY}', reverseY);
     }
 
     function reverseZTag(imageryProvider, x, y, level) {
         var maximumLevel = imageryProvider.maximumLevel;
-        return defined(maximumLevel) && level < maximumLevel ? maximumLevel - level - 1 : level;
+        var reverseZ = defined(maximumLevel) && level < maximumLevel ? maximumLevel - level - 1 : level;
+        return padWithZerosIfNecessary(imageryProvider, '{reverseZ}', reverseZ);
     }
 
     function zTag(imageryProvider, x, y, level) {
-        return level;
+        return padWithZerosIfNecessary(imageryProvider, '{z}', level);
     }
 
     function sTag(imageryProvider, x, y, level) {

--- a/Specs/Scene/UrlTemplateImageryProviderSpec.js
+++ b/Specs/Scene/UrlTemplateImageryProviderSpec.js
@@ -259,6 +259,93 @@ defineSuite([
         });
     });
 
+    it('evaluation of schema zero padding for X Y Z as 0000', function() {
+        var provider = new UrlTemplateImageryProvider({
+            url: 'made/up/tms/server/{z}/{reverseZ}/{reverseY}/{y}/{reverseX}/{x}.PNG',
+            urlSchemeZeroPadding: {
+                '{x}'        : '0000',
+                '{y}'        : '0000',
+                '{z}'        : '0000'
+            },
+            tilingScheme: new GeographicTilingScheme(),
+            maximumLevel: 6
+        });
+
+        return pollToPromise(function() {
+            return provider.ready;
+        }).then(function() {
+            spyOn(loadImage, 'createImage').and.callFake(function(url, crossOrigin, deferred) {
+                expect(url).toEqual('made/up/tms/server/0002/3/2/0001/4/0003.PNG');
+
+                // Just return any old image.
+                loadImage.defaultCreateImage('Data/Images/Red16x16.png', crossOrigin, deferred);
+            });
+
+            return provider.requestImage(3, 1, 2).then(function(image) {
+                expect(loadImage.createImage).toHaveBeenCalled();
+                expect(image).toBeInstanceOf(Image);
+            });
+        });
+    });
+
+    it('evaluation of schema zero padding for reverseX reverseY reverseZ as 0000', function() {
+        var provider = new UrlTemplateImageryProvider({
+            url: 'made/up/tms/server/{z}/{reverseZ}/{reverseY}/{y}/{reverseX}/{x}.PNG',
+            urlSchemeZeroPadding: {
+                '{reverseX}' : '0000',
+                '{reverseY}' : '0000',
+                '{reverseZ}' : '0000'
+            },
+            tilingScheme: new GeographicTilingScheme(),
+            maximumLevel: 6
+        });
+
+        return pollToPromise(function() {
+            return provider.ready;
+        }).then(function() {
+            spyOn(loadImage, 'createImage').and.callFake(function(url, crossOrigin, deferred) {
+                expect(url).toEqual('made/up/tms/server/2/0003/0002/1/0004/3.PNG');
+
+                // Just return any old image.
+                loadImage.defaultCreateImage('Data/Images/Red16x16.png', crossOrigin, deferred);
+            });
+
+            return provider.requestImage(3, 1, 2).then(function(image) {
+                expect(loadImage.createImage).toHaveBeenCalled();
+                expect(image).toBeInstanceOf(Image);
+            });
+        });
+    });
+
+    it('evaluation of schema zero padding for x y z as 0000 and large x and y', function() {
+        var provider = new UrlTemplateImageryProvider({
+            url: 'made/up/tms/server/{z}/{reverseZ}/{reverseY}/{y}/{reverseX}/{x}.PNG',
+            urlSchemeZeroPadding: {
+                '{x}' : '0000',
+                '{y}' : '0000',
+                '{z}' : '0000'
+            },
+            tilingScheme: new GeographicTilingScheme(),
+            maximumLevel: 6
+        });
+
+        return pollToPromise(function() {
+            return provider.ready;
+        }).then(function() {
+            spyOn(loadImage, 'createImage').and.callFake(function(url, crossOrigin, deferred) {
+                expect(url).toEqual('made/up/tms/server/0005/0/21/0010/51/0012.PNG');
+
+                // Just return any old image.
+                loadImage.defaultCreateImage('Data/Images/Red16x16.png', crossOrigin, deferred);
+            });
+
+            return provider.requestImage(12, 10, 5).then(function(image) {
+                expect(loadImage.createImage).toHaveBeenCalled();
+                expect(image).toBeInstanceOf(Image);
+            });
+        });
+    });
+
     it('evaluates pattern northDegrees', function() {
         var provider = new UrlTemplateImageryProvider({
             url: '{northDegrees}',


### PR DESCRIPTION
Some Image services provide imagery with components that require padding x,y,z values with zeros. For example:

/my/example/server/{z}/{y}/{y}_{x}.PNG

with values of x y and z of 1, 2, 3 comes out as:

/my/example/server/3/2/2_1.PNG

But the images are actually at the path:

/my/example/server/3/0002/0002_0001.PNG

This addition allow a user to optionally supply the padding for each component.
