### PR TITLE
Fix material batch entities from disappearing

### DIFF
--- a/Source/DataSources/StaticGeometryPerMaterialBatch.js
+++ b/Source/DataSources/StaticGeometryPerMaterialBatch.js
@@ -68,10 +68,8 @@ define([
 
     Batch.prototype.remove = function(updater) {
         var id = updater.entity.id;
-        var createPrimitive = this.updaters.remove(id);
-
-        if (createPrimitive) {
-            this.geometry.remove(id);
+        this.createPrimitive = this.geometry.remove(id) || this.createPrimitive;
+        if (this.updaters.remove(id)) {
             this.updatersWithAttributes.remove(id);
             var unsubscribe = this.subscriptions.get(id);
             if (defined(unsubscribe)) {
@@ -79,8 +77,7 @@ define([
                 this.subscriptions.remove(id);
             }
         }
-        this.createPrimitive = createPrimitive;
-        return createPrimitive;
+        return this.createPrimitive;
     };
 
     Batch.prototype.update = function(time) {


### PR DESCRIPTION
Fixes #4096 

`createPrimitive` was always being incorrectly set to false whenever an entity not in the batch tried to be removed from the batch, causing the entity actually in the batch to never be created. The code in `StaticGeometryColorBatch` was correct, so I just copied it from there to `StaticGeometryPerMaterialBatch`.
