### PR TITLE
fixed inverseTransposeModel typos

### DIFF
--- a/Documentation/Contributors/TestingGuide/README.md
+++ b/Documentation/Contributors/TestingGuide/README.md
@@ -171,9 +171,9 @@ It is also possible for Karma to run all tests against each browser installed on
 `npm run test-webgl`
 
 #### Run Only Non-WebGL Tests with Karma
- 
+
  `npm run test-non-webgl`
- 
+
 #### Run All Tests Against the Minified Release Version of Cesium
 
  `npm run test-release`
@@ -381,7 +381,7 @@ afterAll(function() {
     context.destroyForSpecs();
 });
 
-it('has czm_tranpose (2x2)', function() {
+it('has czm_transpose (2x2)', function() {
     var fs =
         'void main() { ' +
         '  mat2 m = mat2(1.0, 2.0, 3.0, 4.0); ' +

--- a/Source/Renderer/UniformState.js
+++ b/Source/Renderer/UniformState.js
@@ -261,7 +261,7 @@ define([
          * @memberof UniformState.prototype
          * @private
          */
-        inverseTranposeModel : {
+        inverseTransposeModel : {
             get : function() {
                 var m = this._inverseTransposeModel;
                 if (this._inverseTransposeModelDirty) {

--- a/Source/Scene/Model.js
+++ b/Source/Scene/Model.js
@@ -1629,7 +1629,7 @@ define([
         }
         return undefined;
     }
-    
+
     function modifyShaderForQuantizedAttributes(shader, programName, model, context) {
         var quantizedUniforms = {};
         model._quantizedUniforms[programName] = quantizedUniforms;
@@ -2386,7 +2386,7 @@ define([
         },
         MODELINVERSETRANSPOSE : function(uniformState, model) {
             return function() {
-                return uniformState.inverseTranposeModel;
+                return uniformState.inverseTransposeModel;
             };
         },
         MODELVIEWINVERSETRANSPOSE : function(uniformState, model) {

--- a/Source/Shaders/Builtin/Functions/transpose.glsl
+++ b/Source/Shaders/Builtin/Functions/transpose.glsl
@@ -1,5 +1,5 @@
 /**
- * Returns the transpose of the matrix.  The input <code>matrix</code> can be 
+ * Returns the transpose of the matrix.  The input <code>matrix</code> can be
  * a <code>mat2</code>, <code>mat3</code>, or <code>mat4</code>.
  *
  * @name czm_transpose
@@ -15,7 +15,7 @@
  * mat3 czm_transpose(mat3 matrix);
  * mat4 czm_transpose(mat4 matrix);
  *
- * // Tranpose a 3x3 rotation matrix to find its inverse.
+ * // Transpose a 3x3 rotation matrix to find its inverse.
  * mat3 eastNorthUpToEye = czm_eastNorthUpToEyeCoordinates(
  *     positionMC, normalEC);
  * mat3 eyeToEastNorthUp = czm_transpose(eastNorthUpToEye);

--- a/Source/Widgets/BaseLayerPicker/createDefaultImageryProviderViewModels.js
+++ b/Source/Widgets/BaseLayerPicker/createDefaultImageryProviderViewModels.js
@@ -181,18 +181,6 @@ area washes and organic edges over a paper texture to add warm pop to any map.\n
         }));
 
         providerViewModels.push(new ProviderViewModel({
-            name : 'MapQuest Open\u00adStreet\u00adMap',
-            iconUrl : buildModuleUrl('Widgets/Images/ImageryProviders/mapQuestOpenStreetMap.png'),
-            tooltip : 'OpenStreetMap (OSM) is a collaborative project to create a free editable \
-map of the world.\nhttp://www.openstreetmap.org',
-            creationFunction : function() {
-                return createOpenStreetMapImageryProvider({
-                    url : 'https://otile1-s.mqcdn.com/tiles/1.0.0/osm/'
-                });
-            }
-        }));
-
-        providerViewModels.push(new ProviderViewModel({
             name : 'The Black Marble',
             iconUrl : buildModuleUrl('Widgets/Images/ImageryProviders/blackMarble.png'),
             tooltip : 'The lights of cities and villages trace the outlines of civilization in this global view of the \

--- a/Specs/Renderer/BuiltinFunctionsSpec.js
+++ b/Specs/Renderer/BuiltinFunctionsSpec.js
@@ -25,7 +25,7 @@ defineSuite([
         context.destroyForSpecs();
     });
 
-    it('has czm_tranpose (2x2)', function() {
+    it('has czm_transpose (2x2)', function() {
         var fs =
             'void main() { ' +
             '  mat2 m = mat2(1.0, 2.0, 3.0, 4.0); ' +
@@ -36,7 +36,7 @@ defineSuite([
         context.verifyDrawForSpecs(fs);
     });
 
-    it('has czm_tranpose (3x3)', function() {
+    it('has czm_transpose (3x3)', function() {
         var fs =
             'void main() { ' +
             '  mat3 m = mat3(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0); ' +
@@ -47,7 +47,7 @@ defineSuite([
         context.verifyDrawForSpecs(fs);
     });
 
-    it('has czm_tranpose (4x4)', function() {
+    it('has czm_transpose (4x4)', function() {
         var fs =
             'void main() { ' +
             '  mat4 m = mat4(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0);' +


### PR DESCRIPTION
Hello, 

I corrected the typo from [Issue #3942](https://github.com/AnalyticalGraphicsInc/cesium/issues/3942). The issue only referenced the typo in [Model.js line 2132](https://github.com/AnalyticalGraphicsInc/cesium/blob/master/Source/Scene/Model.js#L2132), although there was also a typo (inverseTranposeModel) in [UniformState.js line 264](https://github.com/AnalyticalGraphicsInc/cesium/blob/bd3ddefcc1f38a8444d3bddfd0d093867a979454/Source/Renderer/UniformState.js#L264). The same typo is also in [BuiltinFunctionsSpec lines 28, 39 and 50](https://github.com/AnalyticalGraphicsInc/cesium/blob/master/Specs/Renderer/BuiltinFunctionsSpec.js), should these be corrected?

Thanks,
Andy

