### PR TITLE
Snorm range max

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@ Change Log
 * Fixed an issue causing entities to disappear when updating multiple entities simultaneously. [#4096](https://github.com/AnalyticalGraphicsInc/cesium/issues/4096)
 * Added support in CZML for expressing `BillboardGraphics.alignedAxis` as the velocity vector of an entity, using `velocityReference` syntax.
 * Normalizing the velocity vector produced by `VelocityVectorProperty` is now optional.
+* Added `AttributeCompression.octEncodeInRange`, `AttributeCompression.octDecodeInRange` and an optional `rangeMax` parameter to `Math.toSNorm` and `Math.fromSNorm`, to support oct-encoding with variable precision. [#4121](https://github.com/AnalyticalGraphicsInc/cesium/pull/4121)
 
 ### 1.23 - 2016-07-01
 

--- a/Source/Core/AttributeCompression.js
+++ b/Source/Core/AttributeCompression.js
@@ -27,20 +27,20 @@ define([
     /**
      * Encodes a normalized vector into 2 SNORM values in the range of [0-rangeMax] following the 'oct' encoding.
      *
-     * Oct encoding is a compact representation of unit length vectors.  The encoding and decoding functions are low cost, and represent the normalized vector within 1 degree of error.
+     * Oct encoding is a compact representation of unit length vectors.
      * The 'oct' encoding is described in "A Survey of Efficient Representations of Independent Unit Vectors",
      * Cigolle et al 2014: {@link http://jcgt.org/published/0003/02/01/}
      *
-     * @param {Cartesian3} vector The normalized vector to be compressed into 2 byte 'oct' encoding.
-     * @param {Cartesian2} result The 2 byte oct-encoded unit length vector.
-     * @param {Number} [rangeMax=255] The maximum value of the SNORM range, 255 by default.
-     * @returns {Cartesian2} The 2 byte oct-encoded unit length vector.
+     * @param {Cartesian3} vector The normalized vector to be compressed into 2 component 'oct' encoding.
+     * @param {Cartesian2} result The 2 component oct-encoded unit length vector.
+     * @param {Number} rangeMax The maximum value of the SNORM range.
+     * @returns {Cartesian2} The 2 component oct-encoded unit length vector.
      *
      * @exception {DeveloperError} vector must be normalized.
      *
-     * @see AttributeCompression.octDecode
+     * @see AttributeCompression.octDecodeInRange
      */
-    AttributeCompression.octEncode = function(vector, result, rangeMax) {
+    AttributeCompression.octEncodeInRange = function(vector, rangeMax, result) {
         //>>includeStart('debug', pragmas.debug);
         if (!defined(vector)) {
             throw new DeveloperError('vector is required.');
@@ -71,19 +71,35 @@ define([
     };
 
     /**
+     * Encodes a normalized vector into 2 SNORM values in the range of [0-255] following the 'oct' encoding.
+     *
+     * @param {Cartesian3} vector The normalized vector to be compressed into 2 byte 'oct' encoding.
+     * @param {Cartesian2} result The 2 byte oct-encoded unit length vector.
+     * @returns {Cartesian2} The 2 byte oct-encoded unit length vector.
+     * 
+     * @exception {DeveloperError} vector must be normalized.
+     * 
+     * @see AttributeCompression.octEncodeInRange
+     * @see AttributeCompression.octDecode
+     */
+    AttributeCompression.octEncode = function(vector, result) {
+        return AttributeCompression.octEncodeInRange(vector, 255, result);
+    };
+
+    /**
      * Decodes a unit-length vector in 'oct' encoding to a normalized 3-component vector.
      *
      * @param {Number} x The x component of the oct-encoded unit length vector.
      * @param {Number} y The y component of the oct-encoded unit length vector.
+     * @param {Number} rangeMax The maximum value of the SNORM range.
      * @param {Cartesian3} result The decoded and normalized vector
-     * @param {Number} [rangeMax=255] The maximum value of the SNORM range, 255 by default.
      * @returns {Cartesian3} The decoded and normalized vector.
      *
-     * @exception {DeveloperError} x and y must be a signed normalized integer between 0 and rangeMax.
+     * @exception {DeveloperError} x and y must be an unsigned normalized integer between 0 and rangeMax.
      *
-     * @see AttributeCompression.octEncode
+     * @see AttributeCompression.octEncodeInRange
      */
-    AttributeCompression.octDecode = function(x, y, result, rangeMax) {
+    AttributeCompression.octDecodeInRange = function(x, y, rangeMax, result) {
         rangeMax = defaultValue(rangeMax, 255);
 
         //>>includeStart('debug', pragmas.debug);
@@ -107,6 +123,22 @@ define([
         }
 
         return Cartesian3.normalize(result, result);
+    };
+
+    /**
+     * Decodes a unit-length vector in 2 byte 'oct' encoding to a normalized 3-component vector.
+     * 
+     * @param {Number} x The x component of the oct-encoded unit length vector.
+     * @param {Number} y The y component of the oct-encoded unit length vector.
+     * @param {Cartesian3} result The decoded and normalized vector.
+     * @returns {Cartesian3} The decoded and normalized vector.
+     * 
+     * @exception {DeveloperError} x and y must be an unsigned normalized integer between 0 and 255.
+     * 
+     * @see AttributeCompression.octDecodeInRange
+     */
+    AttributeCompression.octDecode = function(x, y, result) {
+        return AttributeCompression.octDecodeInRange(x, y, 255, result);
     };
 
     /**

--- a/Source/Core/AttributeCompression.js
+++ b/Source/Core/AttributeCompression.js
@@ -33,7 +33,7 @@ define([
      *
      * @param {Cartesian3} vector The normalized vector to be compressed into 2 component 'oct' encoding.
      * @param {Cartesian2} result The 2 component oct-encoded unit length vector.
-     * @param {Number} rangeMax The maximum value of the SNORM range. The encoded vector is stored in log2(rangeMax) bits.
+     * @param {Number} rangeMax The maximum value of the SNORM range. The encoded vector is stored in log2(rangeMax+1) bits.
      * @returns {Cartesian2} The 2 component oct-encoded unit length vector.
      *
      * @exception {DeveloperError} vector must be normalized.
@@ -90,7 +90,7 @@ define([
      *
      * @param {Number} x The x component of the oct-encoded unit length vector.
      * @param {Number} y The y component of the oct-encoded unit length vector.
-     * @param {Number} rangeMax The maximum value of the SNORM range. The encoded vector is stored in log2(rangeMax) bits.
+     * @param {Number} rangeMax The maximum value of the SNORM range. The encoded vector is stored in log2(rangeMax+1) bits.
      * @param {Cartesian3} result The decoded and normalized vector
      * @returns {Cartesian3} The decoded and normalized vector.
      *

--- a/Source/Core/AttributeCompression.js
+++ b/Source/Core/AttributeCompression.js
@@ -53,7 +53,6 @@ define([
             throw new DeveloperError('vector must be normalized.');
         }
         //>>includeEnd('debug');
-        rangeMax = defaultValue(rangeMax, 255);
 
         result.x = vector.x / (Math.abs(vector.x) + Math.abs(vector.y) + Math.abs(vector.z));
         result.y = vector.y / (Math.abs(vector.x) + Math.abs(vector.y) + Math.abs(vector.z));
@@ -100,8 +99,6 @@ define([
      * @see AttributeCompression.octEncodeInRange
      */
     AttributeCompression.octDecodeInRange = function(x, y, rangeMax, result) {
-        rangeMax = defaultValue(rangeMax, 255);
-
         //>>includeStart('debug', pragmas.debug);
         if (!defined(result)) {
             throw new DeveloperError('result is required.');

--- a/Source/Core/AttributeCompression.js
+++ b/Source/Core/AttributeCompression.js
@@ -84,16 +84,17 @@ define([
      * @see AttributeCompression.octEncode
      */
     AttributeCompression.octDecode = function(x, y, result, rangeMax) {
+        rangeMax = defaultValue(rangeMax, 255);
+
         //>>includeStart('debug', pragmas.debug);
         if (!defined(result)) {
             throw new DeveloperError('result is required.');
         }
-        if (x < 0 || x > 255 || y < 0 || y > 255) {
-            throw new DeveloperError('x and y must be a signed normalized integer between 0 and 255');
+        if (x < 0 || x > rangeMax || y < 0 || y > rangeMax) {
+            throw new DeveloperError('x and y must be a signed normalized integer between 0 and ' + rangeMax);
         }
         //>>includeEnd('debug');
-        rangeMax = defaultValue(rangeMax, 255);
-        
+
         result.x = CesiumMath.fromSNorm(x, rangeMax);
         result.y = CesiumMath.fromSNorm(y, rangeMax);
         result.z = 1.0 - (Math.abs(result.x) + Math.abs(result.y));

--- a/Source/Core/AttributeCompression.js
+++ b/Source/Core/AttributeCompression.js
@@ -33,7 +33,7 @@ define([
      *
      * @param {Cartesian3} vector The normalized vector to be compressed into 2 component 'oct' encoding.
      * @param {Cartesian2} result The 2 component oct-encoded unit length vector.
-     * @param {Number} rangeMax The maximum value of the SNORM range.
+     * @param {Number} rangeMax The maximum value of the SNORM range. The encoded vector is stored in log2(rangeMax) bits.
      * @returns {Cartesian2} The 2 component oct-encoded unit length vector.
      *
      * @exception {DeveloperError} vector must be normalized.
@@ -90,7 +90,7 @@ define([
      *
      * @param {Number} x The x component of the oct-encoded unit length vector.
      * @param {Number} y The y component of the oct-encoded unit length vector.
-     * @param {Number} rangeMax The maximum value of the SNORM range.
+     * @param {Number} rangeMax The maximum value of the SNORM range. The encoded vector is stored in log2(rangeMax) bits.
      * @param {Cartesian3} result The decoded and normalized vector
      * @returns {Cartesian3} The decoded and normalized vector.
      *

--- a/Source/Core/Math.js
+++ b/Source/Core/Math.js
@@ -218,10 +218,10 @@ define([
     };
 
     /**
-     * Converts a scalar value in the range [-1.0, 1.0] to an SNORM in the range [0, rangeMax]
+     * Converts a scalar value in the range [-1.0, 1.0] to a SNORM in the range [0, rangeMax]
      * @param {Number} value The scalar value in the range [-1.0, 1.0]
      * @param {Number} [rangeMax=255] The maximum value in the mapped range, 255 by default.
-     * @returns {Number} An SNORM value, where 0 maps to -1.0 and rangeMax maps to 1.0.
+     * @returns {Number} A SNORM value, where 0 maps to -1.0 and rangeMax maps to 1.0.
      *
      * @see CesiumMath.fromSNorm
      */
@@ -231,7 +231,7 @@ define([
     };
 
     /**
-     * Converts an SNORM value in the range [0, rangeMax] to a scalar in the range [-1.0, 1.0].
+     * Converts a SNORM value in the range [0, rangeMax] to a scalar in the range [-1.0, 1.0].
      * @param {Number} value SNORM value in the range [0, 255]
      * @param {Number} [rangeMax=255] The maximum value in the SNORM range, 255 by default.
      * @returns {Number} Scalar in the range [-1.0, 1.0].

--- a/Source/Core/Math.js
+++ b/Source/Core/Math.js
@@ -218,25 +218,29 @@ define([
     };
 
     /**
-     * Converts a scalar value in the range [-1.0, 1.0] to a 8-bit 2's complement number.
+     * Converts a scalar value in the range [-1.0, 1.0] to an SNORM in the range [0, rangeMax]
      * @param {Number} value The scalar value in the range [-1.0, 1.0]
-     * @returns {Number} The 8-bit 2's complement number, where 0 maps to -1.0 and 255 maps to 1.0.
+     * @param {Number} [rangeMax=255] The maximum value in the mapped range, 255 by default.
+     * @returns {Number} An SNORM value, where 0 maps to -1.0 and rangeMax maps to 1.0.
      *
      * @see CesiumMath.fromSNorm
      */
-    CesiumMath.toSNorm = function(value) {
-        return Math.round((CesiumMath.clamp(value, -1.0, 1.0) * 0.5 + 0.5) * 255.0);
+    CesiumMath.toSNorm = function(value, rangeMax) {
+        rangeMax = defaultValue(rangeMax, 255);
+        return Math.round((CesiumMath.clamp(value, -1.0, 1.0) * 0.5 + 0.5) * rangeMax);
     };
 
     /**
-     * Converts a SNORM value in the range [0, 255] to a scalar in the range [-1.0, 1.0].
+     * Converts an SNORM value in the range [0, rangeMax] to a scalar in the range [-1.0, 1.0].
      * @param {Number} value SNORM value in the range [0, 255]
+     * @param {Number} [rangeMax=255] The maximum value in the SNORM range, 255 by default.
      * @returns {Number} Scalar in the range [-1.0, 1.0].
      *
      * @see CesiumMath.toSNorm
      */
-    CesiumMath.fromSNorm = function(value) {
-        return CesiumMath.clamp(value, 0.0, 255.0) / 255.0 * 2.0 - 1.0;
+    CesiumMath.fromSNorm = function(value, rangeMax) {
+        rangeMax = defaultValue(rangeMax, 255);
+        return CesiumMath.clamp(value, 0.0, rangeMax) / rangeMax * 2.0 - 1.0;
     };
 
     /**

--- a/Specs/Core/AttributeCompressionSpec.js
+++ b/Specs/Core/AttributeCompressionSpec.js
@@ -169,6 +169,77 @@ defineSuite([
         expect(AttributeCompression.octDecode(encoded.x, encoded.y, result)).toEqualEpsilon(normal, epsilon);
     });
 
+    it('oct encoding high precision', function() {
+        var rangeMax = 4294967295;
+        var epsilon = CesiumMath.EPSILON8;
+
+        var encoded = new Cartesian2();
+        var result = new Cartesian3();
+        var normal = new Cartesian3(0.0, 0.0, 1.0);
+        AttributeCompression.octEncode(normal, encoded, rangeMax);
+        expect(AttributeCompression.octDecode(encoded.x, encoded.y, result, rangeMax)).toEqualEpsilon(normal, epsilon);
+
+        normal = new Cartesian3(0.0, 0.0, -1.0);
+        AttributeCompression.octEncode(normal, encoded, rangeMax);
+        expect(AttributeCompression.octDecode(encoded.x, encoded.y, result, rangeMax)).toEqualEpsilon(normal, epsilon);
+
+        normal = new Cartesian3(0.0, 1.0, 0.0);
+        AttributeCompression.octEncode(normal, encoded, rangeMax);
+        expect(AttributeCompression.octDecode(encoded.x, encoded.y, result, rangeMax)).toEqualEpsilon(normal, epsilon);
+
+        normal = new Cartesian3(0.0, -1.0, 0.0);
+        AttributeCompression.octEncode(normal, encoded, rangeMax);
+        expect(AttributeCompression.octDecode(encoded.x, encoded.y, result, rangeMax)).toEqualEpsilon(normal, epsilon);
+
+        normal = new Cartesian3(1.0, 0.0, 0.0);
+        AttributeCompression.octEncode(normal, encoded, rangeMax);
+        expect(AttributeCompression.octDecode(encoded.x, encoded.y, result, rangeMax)).toEqualEpsilon(normal, epsilon);
+
+        normal = new Cartesian3(-1.0, 0.0, 0.0);
+        AttributeCompression.octEncode(normal, encoded, rangeMax);
+        expect(AttributeCompression.octDecode(encoded.x, encoded.y, result, rangeMax)).toEqualEpsilon(normal, epsilon);
+
+        normal = new Cartesian3(1.0, 1.0, 1.0);
+        Cartesian3.normalize(normal, normal);
+        AttributeCompression.octEncode(normal, encoded, rangeMax);
+        expect(AttributeCompression.octDecode(encoded.x, encoded.y, result, rangeMax)).toEqualEpsilon(normal, epsilon);
+
+        normal = new Cartesian3(1.0, -1.0, 1.0);
+        Cartesian3.normalize(normal, normal);
+        AttributeCompression.octEncode(normal, encoded, rangeMax);
+        expect(AttributeCompression.octDecode(encoded.x, encoded.y, result, rangeMax)).toEqualEpsilon(normal, epsilon);
+
+        normal = new Cartesian3(-1.0, -1.0, 1.0);
+        Cartesian3.normalize(normal, normal);
+        AttributeCompression.octEncode(normal, encoded, rangeMax);
+        expect(AttributeCompression.octDecode(encoded.x, encoded.y, result, rangeMax)).toEqualEpsilon(normal, epsilon);
+
+        normal = new Cartesian3(-1.0, 1.0, 1.0);
+        Cartesian3.normalize(normal, normal);
+        AttributeCompression.octEncode(normal, encoded, rangeMax);
+        expect(AttributeCompression.octDecode(encoded.x, encoded.y, result, rangeMax)).toEqualEpsilon(normal, epsilon);
+
+        normal = new Cartesian3(1.0, 1.0, -1.0);
+        Cartesian3.normalize(normal, normal);
+        AttributeCompression.octEncode(normal, encoded, rangeMax);
+        expect(AttributeCompression.octDecode(encoded.x, encoded.y, result, rangeMax)).toEqualEpsilon(normal, epsilon);
+
+        normal = new Cartesian3(1.0, -1.0, -1.0);
+        Cartesian3.normalize(normal, normal);
+        AttributeCompression.octEncode(normal, encoded, rangeMax);
+        expect(AttributeCompression.octDecode(encoded.x, encoded.y, result, rangeMax)).toEqualEpsilon(normal, epsilon);
+
+        normal = new Cartesian3(-1.0, 1.0, -1.0);
+        Cartesian3.normalize(normal, normal);
+        AttributeCompression.octEncode(normal, encoded, rangeMax);
+        expect(AttributeCompression.octDecode(encoded.x, encoded.y, result, rangeMax)).toEqualEpsilon(normal, epsilon);
+
+        normal = new Cartesian3(-1.0, -1.0, -1.0);
+        Cartesian3.normalize(normal, normal);
+        AttributeCompression.octEncode(normal, encoded, rangeMax);
+        expect(AttributeCompression.octDecode(encoded.x, encoded.y, result, rangeMax)).toEqualEpsilon(normal, epsilon);
+    });
+
     it('octFloat encoding', function() {
         var epsilon = CesiumMath.EPSILON1;
 

--- a/Specs/Core/AttributeCompressionSpec.js
+++ b/Specs/Core/AttributeCompressionSpec.js
@@ -79,23 +79,21 @@ defineSuite([
     it('throws oct decode result undefined', function() {
         var result;
         expect(function() {
-            AttributeCompression.octDecode(Cartesian2.ZERO, result);
+            AttributeCompression.octDecode(0, 0, result);
         }).toThrowDeveloperError();
     });
 
     it('throws oct decode x out of bounds', function() {
         var result = new Cartesian3();
-        var invalidSNorm = new Cartesian2(256, 0);
         expect(function() {
-            AttributeCompression.octDecode(invalidSNorm, result);
+            AttributeCompression.octDecode(256, 0, result);
         }).toThrowDeveloperError();
     });
 
     it('throws oct decode y out of bounds', function() {
         var result = new Cartesian3();
-        var invalidSNorm = new Cartesian2(0, 256);
         expect(function() {
-            AttributeCompression.octDecode(invalidSNorm, result);
+            AttributeCompression.octDecode(0, 256, result);
         }).toThrowDeveloperError();
     });
 

--- a/Specs/Core/AttributeCompressionSpec.js
+++ b/Specs/Core/AttributeCompressionSpec.js
@@ -176,68 +176,68 @@ defineSuite([
         var encoded = new Cartesian2();
         var result = new Cartesian3();
         var normal = new Cartesian3(0.0, 0.0, 1.0);
-        AttributeCompression.octEncode(normal, encoded, rangeMax);
-        expect(AttributeCompression.octDecode(encoded.x, encoded.y, result, rangeMax)).toEqualEpsilon(normal, epsilon);
+        AttributeCompression.octEncodeInRange(normal, rangeMax, encoded);
+        expect(AttributeCompression.octDecodeInRange(encoded.x, encoded.y, rangeMax, result)).toEqualEpsilon(normal, epsilon);
 
         normal = new Cartesian3(0.0, 0.0, -1.0);
-        AttributeCompression.octEncode(normal, encoded, rangeMax);
-        expect(AttributeCompression.octDecode(encoded.x, encoded.y, result, rangeMax)).toEqualEpsilon(normal, epsilon);
+        AttributeCompression.octEncodeInRange(normal, rangeMax, encoded);
+        expect(AttributeCompression.octDecodeInRange(encoded.x, encoded.y, rangeMax, result)).toEqualEpsilon(normal, epsilon);
 
         normal = new Cartesian3(0.0, 1.0, 0.0);
-        AttributeCompression.octEncode(normal, encoded, rangeMax);
-        expect(AttributeCompression.octDecode(encoded.x, encoded.y, result, rangeMax)).toEqualEpsilon(normal, epsilon);
+        AttributeCompression.octEncodeInRange(normal, rangeMax, encoded);
+        expect(AttributeCompression.octDecodeInRange(encoded.x, encoded.y, rangeMax, result)).toEqualEpsilon(normal, epsilon);
 
         normal = new Cartesian3(0.0, -1.0, 0.0);
-        AttributeCompression.octEncode(normal, encoded, rangeMax);
-        expect(AttributeCompression.octDecode(encoded.x, encoded.y, result, rangeMax)).toEqualEpsilon(normal, epsilon);
+        AttributeCompression.octEncodeInRange(normal, rangeMax, encoded);
+        expect(AttributeCompression.octDecodeInRange(encoded.x, encoded.y, rangeMax, result)).toEqualEpsilon(normal, epsilon);
 
         normal = new Cartesian3(1.0, 0.0, 0.0);
-        AttributeCompression.octEncode(normal, encoded, rangeMax);
-        expect(AttributeCompression.octDecode(encoded.x, encoded.y, result, rangeMax)).toEqualEpsilon(normal, epsilon);
+        AttributeCompression.octEncodeInRange(normal, rangeMax, encoded);
+        expect(AttributeCompression.octDecodeInRange(encoded.x, encoded.y, rangeMax, result)).toEqualEpsilon(normal, epsilon);
 
         normal = new Cartesian3(-1.0, 0.0, 0.0);
-        AttributeCompression.octEncode(normal, encoded, rangeMax);
-        expect(AttributeCompression.octDecode(encoded.x, encoded.y, result, rangeMax)).toEqualEpsilon(normal, epsilon);
+        AttributeCompression.octEncodeInRange(normal, rangeMax, encoded);
+        expect(AttributeCompression.octDecodeInRange(encoded.x, encoded.y, rangeMax, result)).toEqualEpsilon(normal, epsilon);
 
         normal = new Cartesian3(1.0, 1.0, 1.0);
         Cartesian3.normalize(normal, normal);
-        AttributeCompression.octEncode(normal, encoded, rangeMax);
-        expect(AttributeCompression.octDecode(encoded.x, encoded.y, result, rangeMax)).toEqualEpsilon(normal, epsilon);
+        AttributeCompression.octEncodeInRange(normal, rangeMax, encoded);
+        expect(AttributeCompression.octDecodeInRange(encoded.x, encoded.y, rangeMax, result)).toEqualEpsilon(normal, epsilon);
 
         normal = new Cartesian3(1.0, -1.0, 1.0);
         Cartesian3.normalize(normal, normal);
-        AttributeCompression.octEncode(normal, encoded, rangeMax);
-        expect(AttributeCompression.octDecode(encoded.x, encoded.y, result, rangeMax)).toEqualEpsilon(normal, epsilon);
+        AttributeCompression.octEncodeInRange(normal, rangeMax, encoded);
+        expect(AttributeCompression.octDecodeInRange(encoded.x, encoded.y, rangeMax, result)).toEqualEpsilon(normal, epsilon);
 
         normal = new Cartesian3(-1.0, -1.0, 1.0);
         Cartesian3.normalize(normal, normal);
-        AttributeCompression.octEncode(normal, encoded, rangeMax);
-        expect(AttributeCompression.octDecode(encoded.x, encoded.y, result, rangeMax)).toEqualEpsilon(normal, epsilon);
+        AttributeCompression.octEncodeInRange(normal, rangeMax, encoded);
+        expect(AttributeCompression.octDecodeInRange(encoded.x, encoded.y, rangeMax, result)).toEqualEpsilon(normal, epsilon);
 
         normal = new Cartesian3(-1.0, 1.0, 1.0);
         Cartesian3.normalize(normal, normal);
-        AttributeCompression.octEncode(normal, encoded, rangeMax);
-        expect(AttributeCompression.octDecode(encoded.x, encoded.y, result, rangeMax)).toEqualEpsilon(normal, epsilon);
+        AttributeCompression.octEncodeInRange(normal, rangeMax, encoded);
+        expect(AttributeCompression.octDecodeInRange(encoded.x, encoded.y, rangeMax, result)).toEqualEpsilon(normal, epsilon);
 
         normal = new Cartesian3(1.0, 1.0, -1.0);
         Cartesian3.normalize(normal, normal);
-        AttributeCompression.octEncode(normal, encoded, rangeMax);
-        expect(AttributeCompression.octDecode(encoded.x, encoded.y, result, rangeMax)).toEqualEpsilon(normal, epsilon);
+        AttributeCompression.octEncodeInRange(normal, rangeMax, encoded);
+        expect(AttributeCompression.octDecodeInRange(encoded.x, encoded.y, rangeMax, result)).toEqualEpsilon(normal, epsilon);
 
         normal = new Cartesian3(1.0, -1.0, -1.0);
         Cartesian3.normalize(normal, normal);
-        AttributeCompression.octEncode(normal, encoded, rangeMax);
-        expect(AttributeCompression.octDecode(encoded.x, encoded.y, result, rangeMax)).toEqualEpsilon(normal, epsilon);
+        AttributeCompression.octEncodeInRange(normal, rangeMax, encoded);
+        expect(AttributeCompression.octDecodeInRange(encoded.x, encoded.y, rangeMax, result)).toEqualEpsilon(normal, epsilon);
 
         normal = new Cartesian3(-1.0, 1.0, -1.0);
         Cartesian3.normalize(normal, normal);
-        AttributeCompression.octEncode(normal, encoded, rangeMax);
-        expect(AttributeCompression.octDecode(encoded.x, encoded.y, result, rangeMax)).toEqualEpsilon(normal, epsilon);
+        AttributeCompression.octEncodeInRange(normal, rangeMax, encoded);
+        expect(AttributeCompression.octDecodeInRange(encoded.x, encoded.y, rangeMax, result)).toEqualEpsilon(normal, epsilon);
 
         normal = new Cartesian3(-1.0, -1.0, -1.0);
         Cartesian3.normalize(normal, normal);
-        AttributeCompression.octEncode(normal, encoded, rangeMax);
-        expect(AttributeCompression.octDecode(encoded.x, encoded.y, result, rangeMax)).toEqualEpsilon(normal, epsilon);
+        AttributeCompression.octEncodeInRange(normal, rangeMax, encoded);
+        expect(AttributeCompression.octDecodeInRange(encoded.x, encoded.y, rangeMax, result)).toEqualEpsilon(normal, epsilon);
     });
 
     it('octFloat encoding', function() {


### PR DESCRIPTION
Adds the ability to vary the range size for SNORM and oct-encoding values for [#100](https://github.com/AnalyticalGraphicsInc/3d-tiles/pull/100#issuecomment-232740405).

@pjcozzi, can you look at this when you get a chance?

You can use this to get oct24P and oct32P.