### PR TITLE
Add arrayFill for gracefully handling lack of Array.prototype.fill support in IE and Safari

### DIFF
--- a/Source/Core/arrayFill.js
+++ b/Source/Core/arrayFill.js
@@ -1,0 +1,66 @@
+/*global define*/
+define([
+        './DeveloperError',
+        './defaultValue',
+        './defined'
+    ], function(
+        DeveloperError,
+        defaultValue,
+        defined) {
+    'use strict';
+
+    /**
+     *
+     * @private
+     *
+     * @param array
+     * @param value
+     * @param start
+     * @param end
+     *
+     * @returns The resulting array.
+     */
+    function arrayFill(array, value, start, end) {
+        //>>includeStart('debug', pragmas.debug);
+        if (!defined(array) || typeof array !== 'object') {
+            throw new DeveloperError('Array is required.');
+        }
+        if (!defined(value)) {
+            throw new DeveloperError('Value is required.');
+        }
+        if (defined(start) && (typeof start !== 'number')) {
+            throw new DeveloperError('Start must be a valid index.');
+        }
+        if (defined(end) && (typeof end !== 'number')) {
+            throw new DeveloperError('End must be a valid index.');
+        }
+        //>>includeEnd('debug');
+
+        if (typeof array.fill !== 'undefined') {
+            return array.fill(value, start, end);
+        }
+
+        var length = array.length >>> 0;
+
+        // Truncate and default to 0
+        var relativeStart = start >> 0;
+
+        // If negative, find wrap around position
+        var k = (relativeStart < 0) ? Math.max(length + relativeStart, 0) : Math.min(relativeStart, length);
+
+        var relativeEnd = defaultValue(end >> 0, length);
+
+        // If negative, find wrap around position
+        var final = (relativeEnd < 0) ? Math.max(length + relativeEnd, 0) : Math.min(relativeEnd, length);
+
+        // Fill array accordingly
+        while (k < final) {
+            array[k] = value;
+            k++;
+        }
+
+        return array;
+    }
+    
+    return arrayFill;
+});

--- a/Source/Core/arrayFill.js
+++ b/Source/Core/arrayFill.js
@@ -11,32 +11,32 @@ define([
 
     /**
      * Fill an array or a portion of an array with a given value.
-     * @private
      *
      * @param {Array} array The array to fill.
-     * @param {*} value The value to fill the array with.
+     * @param {Object} value The value to fill the array with.
      * @param {Number} start The index to start filling at.
      * @param {Number} end The index to end stop at.
      *
      * @returns {Array} The resulting array.
+     * @private
      */
     function arrayFill(array, value, start, end) {
         //>>includeStart('debug', pragmas.debug);
         if (!defined(array) || typeof array !== 'object') {
-            throw new DeveloperError('Array is required.');
+            throw new DeveloperError('array is required.');
         }
         if (!defined(value)) {
-            throw new DeveloperError('Value is required.');
+            throw new DeveloperError('value is required.');
         }
-        if (defined(start) && (typeof start !== 'number')) {
-            throw new DeveloperError('Start must be a valid index.');
+        if (typeof start !== 'number') {
+            throw new DeveloperError('start must be a valid index.');
         }
-        if (defined(end) && (typeof end !== 'number')) {
-            throw new DeveloperError('End must be a valid index.');
+        if (typeof end !== 'number') {
+            throw new DeveloperError('end must be a valid index.');
         }
         //>>includeEnd('debug');
 
-        if (typeof array.fill !== 'undefined') {
+        if (typeof array.fill === 'function') {
             return array.fill(value, start, end);
         }
 

--- a/Source/Core/arrayFill.js
+++ b/Source/Core/arrayFill.js
@@ -10,15 +10,15 @@ define([
     'use strict';
 
     /**
-     *
+     * Fill an array or a portion of an array with a given value.
      * @private
      *
-     * @param array
-     * @param value
-     * @param start
-     * @param end
+     * @param {Array} array The array to fill.
+     * @param {*} value The value to fill the array with.
+     * @param {Number} start The index to start filling at.
+     * @param {Number} end The index to end stop at.
      *
-     * @returns The resulting array.
+     * @returns {Array} The resulting array.
      */
     function arrayFill(array, value, start, end) {
         //>>includeStart('debug', pragmas.debug);

--- a/Source/Core/arrayFill.js
+++ b/Source/Core/arrayFill.js
@@ -14,8 +14,8 @@ define([
      *
      * @param {Array} array The array to fill.
      * @param {Object} value The value to fill the array with.
-     * @param {Number} start The index to start filling at.
-     * @param {Number} end The index to end stop at.
+     * @param {Number} [start=0] The index to start filling at.
+     * @param {Number} [end=array.length] The index to end stop at.
      *
      * @returns {Array} The resulting array.
      * @private
@@ -28,10 +28,10 @@ define([
         if (!defined(value)) {
             throw new DeveloperError('value is required.');
         }
-        if (typeof start !== 'number') {
+        if (defined(start) && typeof start !== 'number') {
             throw new DeveloperError('start must be a valid index.');
         }
-        if (typeof end !== 'number') {
+        if (defined(end) && typeof end !== 'number') {
             throw new DeveloperError('end must be a valid index.');
         }
         //>>includeEnd('debug');
@@ -41,14 +41,10 @@ define([
         }
 
         var length = array.length >>> 0;
-
         var relativeStart = defaultValue(start, 0);
-
         // If negative, find wrap around position
         var k = (relativeStart < 0) ? Math.max(length + relativeStart, 0) : Math.min(relativeStart, length);
-        
         var relativeEnd = defaultValue(end, length);
-        
         // If negative, find wrap around position
         var final = (relativeEnd < 0) ? Math.max(length + relativeEnd, 0) : Math.min(relativeEnd, length);
 

--- a/Source/Core/arrayFill.js
+++ b/Source/Core/arrayFill.js
@@ -42,14 +42,13 @@ define([
 
         var length = array.length >>> 0;
 
-        // Truncate and default to 0
-        var relativeStart = start >> 0;
+        var relativeStart = defaultValue(start, 0);
 
         // If negative, find wrap around position
         var k = (relativeStart < 0) ? Math.max(length + relativeStart, 0) : Math.min(relativeStart, length);
-
-        var relativeEnd = defaultValue(end >> 0, length);
-
+        
+        var relativeEnd = defaultValue(end, length);
+        
         // If negative, find wrap around position
         var final = (relativeEnd < 0) ? Math.max(length + relativeEnd, 0) : Math.min(relativeEnd, length);
 
@@ -58,7 +57,6 @@ define([
             array[k] = value;
             k++;
         }
-
         return array;
     }
     

--- a/Source/Scene/Cesium3DTileBatchTableResources.js
+++ b/Source/Scene/Cesium3DTileBatchTableResources.js
@@ -1,5 +1,6 @@
 /*global define*/
 define([
+        '../Core/arrayFill',
         '../Core/Cartesian2',
         '../Core/Cartesian4',
         '../Core/clone',
@@ -23,6 +24,7 @@ define([
         './CullFace',
         './Pass'
     ], function(
+        arrayFill,
         Cartesian2,
         Cartesian4,
         clone,
@@ -111,7 +113,7 @@ define([
             // Default batch texture to RGBA = 255: white highlight (RGB) and show/alpha = true/255 (A).
             var byteLength = getByteLength(batchTableResources);
             var bytes = new Uint8Array(byteLength);
-            bytes.fill(255);
+            arrayFill(bytes, 255);
             batchTableResources._batchValues = bytes;
         }
 
@@ -123,7 +125,7 @@ define([
             var byteLength = 2 * batchTableResources.featuresLength;
             var bytes = new Uint8Array(byteLength);
             // [Show = true, Alpha = 255]
-            bytes.fill(255);
+            arrayFill(bytes, 255);
             batchTableResources._showAlphaProperties = bytes;
         }
         return batchTableResources._showAlphaProperties;

--- a/Specs/Core/arrayFillSpec.js
+++ b/Specs/Core/arrayFillSpec.js
@@ -10,27 +10,27 @@ defineSuite([
         array = [0, 0, 0, 0];
     });
     
-    it('will fill an entire array', function() {
+    fit('will fill an entire array', function() {
         arrayFill(array, 1);
         expect(array).toEqual([1, 1, 1, 1]);
     });
     
-    it('will fill a portion of an array', function() {
+    fit('will fill a portion of an array', function() {
         arrayFill(array, 1, 1, 3);
         expect(array).toEqual([0, 1, 1, 0]);
     });
     
-    it('will wrap around negative values', function() {
+    fit('will wrap around negative values', function() {
         arrayFill(array, 1, -2, -1);
         expect(array).toEqual([0, 0, 1, 0]);
     });
 
-    it('will fill until end if no end is provided', function() {
+    fit('will fill until end if no end is provided', function() {
         arrayFill(array, 1, 1);
         expect(array).toEqual([0, 1, 1, 1]);
     });
     
-    it('will throw an error if no array is provided', function() {
+    fit('will throw an error if no array is provided', function() {
         expect(function() {
             arrayFill(undefined, 1, 0, 1);
         }).toThrowDeveloperError('Array is required.');

--- a/Specs/Core/arrayFillSpec.js
+++ b/Specs/Core/arrayFillSpec.js
@@ -11,27 +11,27 @@ defineSuite([
         array = [0, 0, 0, 0];
     });
     
-    fit('will fill an entire array', function() {
+    it('will fill an entire array', function() {
         arrayFill(array, 1);
         expect(array).toEqual([1, 1, 1, 1]);
     });
     
-    fit('will fill a portion of an array', function() {
+    it('will fill a portion of an array', function() {
         arrayFill(array, 1, 1, 3);
         expect(array).toEqual([0, 1, 1, 0]);
     });
     
-    fit('will wrap around negative values', function() {
+    it('will wrap around negative values', function() {
         arrayFill(array, 1, -2, -1);
         expect(array).toEqual([0, 0, 1, 0]);
     });
 
-    fit('will fill until end if no end is provided', function() {
+    it('will fill until end if no end is provided', function() {
         arrayFill(array, 1, 1);
         expect(array).toEqual([0, 1, 1, 1]);
     });
     
-    fit('will throw an error if no array is provided', function() {
+    it('will throw an error if no array is provided', function() {
         expect(function() {
             arrayFill(undefined, 1, 0, 1);
         }).toThrowDeveloperError('array is required.');

--- a/Specs/Core/arrayFillSpec.js
+++ b/Specs/Core/arrayFillSpec.js
@@ -3,7 +3,8 @@ defineSuite([
         'Core/arrayFill'
     ], function(
         arrayFill) {
-
+    'use strict';
+    
     var array;
 
     beforeEach(function() {

--- a/Specs/Core/arrayFillSpec.js
+++ b/Specs/Core/arrayFillSpec.js
@@ -54,5 +54,4 @@ defineSuite([
             arrayFill(array, 1, 1, array);
         }).toThrowDeveloperError('End must be a valid index.');
     });
-
 });

--- a/Specs/Core/arrayFillSpec.js
+++ b/Specs/Core/arrayFillSpec.js
@@ -1,0 +1,57 @@
+/*global defineSuite*/
+defineSuite([
+        'Core/arrayFill'
+    ], function(
+        arrayFill) {
+
+    var array;
+
+    beforeEach(function() {
+        array = [0, 0, 0, 0];
+    });
+    
+    it('will fill an entire array', function() {
+        arrayFill(array, 1);
+        expect(array).toEqual([1, 1, 1, 1]);
+    });
+    
+    it('will fill a portion of an array', function() {
+        arrayFill(array, 1, 1, 3);
+        expect(array).toEqual([0, 1, 1, 0]);
+    });
+    
+    it('will wrap around negative values', function() {
+        arrayFill(array, 1, -2, -1);
+        expect(array).toEqual([0, 0, 1, 0]);
+    });
+
+    it('will fill until end if no end is provided', function() {
+        arrayFill(array, 1, 1);
+        expect(array).toEqual([0, 1, 1, 1]);
+    });
+    
+    it('will throw an error if no array is provided', function() {
+        expect(function() {
+            arrayFill(undefined, 1, 0, 1);
+        }).toThrowDeveloperError('Array is required.');
+    });
+
+    it('will throw an error if no array is provided', function() {
+        expect(function() {
+            arrayFill(array, undefined, 0, 1);
+        }).toThrowDeveloperError('Value is required.');
+    });
+
+    it('will throw an error if given an invalid start index', function() {
+        expect(function() {
+            arrayFill(array, 1, array, 1);
+        }).toThrowDeveloperError('Start must be a valid index.');
+    });
+    
+    it('will throw an error if given an invalid end index', function() {
+        expect(function() {
+            arrayFill(array, 1, 1, array);
+        }).toThrowDeveloperError('End must be a valid index.');
+    });
+
+});

--- a/Specs/Core/arrayFillSpec.js
+++ b/Specs/Core/arrayFillSpec.js
@@ -34,24 +34,24 @@ defineSuite([
     fit('will throw an error if no array is provided', function() {
         expect(function() {
             arrayFill(undefined, 1, 0, 1);
-        }).toThrowDeveloperError('Array is required.');
+        }).toThrowDeveloperError('array is required.');
     });
 
     it('will throw an error if no array is provided', function() {
         expect(function() {
             arrayFill(array, undefined, 0, 1);
-        }).toThrowDeveloperError('Value is required.');
+        }).toThrowDeveloperError('value is required.');
     });
 
     it('will throw an error if given an invalid start index', function() {
         expect(function() {
             arrayFill(array, 1, array, 1);
-        }).toThrowDeveloperError('Start must be a valid index.');
+        }).toThrowDeveloperError('start must be a valid index.');
     });
     
     it('will throw an error if given an invalid end index', function() {
         expect(function() {
             arrayFill(array, 1, 1, array);
-        }).toThrowDeveloperError('End must be a valid index.');
+        }).toThrowDeveloperError('end must be a valid index.');
     });
 });


### PR DESCRIPTION
Closes #3614 

Tested on Chrome, Safari, and Firefox. Safari relies on the alternate implementation of `arrayFill`, but this still needs to be tested in IE