### PR TITLE
Return packed array

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@ Change Log
 * Fixed an exception that would occur when switching to 2D view when shadows are enabled. [#4051](https://github.com/AnalyticalGraphicsInc/cesium/issues/4051)
 * Fixed an issue causing entities to disappear when updating multiple entities simultaneously. [#4096](https://github.com/AnalyticalGraphicsInc/cesium/issues/4096)
 * Normalizing the velocity vector produced by `VelocityVectorProperty` is now optional.
+* Pack funcions now return the result array  [#4156](https://github.com/AnalyticalGraphicsInc/cesium/pull/4156)
 * Added optional `rangeMax` parameter to `Math.toSNorm` and `Math.fromSNorm`. [#4121](https://github.com/AnalyticalGraphicsInc/cesium/pull/4121)
 
 ### 1.23 - 2016-07-01

--- a/Source/Core/BoundingRectangle.js
+++ b/Source/Core/BoundingRectangle.js
@@ -74,6 +74,8 @@ define([
      * @param {BoundingRectangle} value The value to pack.
      * @param {Number[]} array The array to pack into.
      * @param {Number} [startingIndex=0] The index into the array at which to start packing the elements.
+     *
+     * @returns {Number[]} The array that was packed into
      */
     BoundingRectangle.pack = function(value, array, startingIndex) {
         //>>includeStart('debug', pragmas.debug);

--- a/Source/Core/BoundingRectangle.js
+++ b/Source/Core/BoundingRectangle.js
@@ -91,6 +91,8 @@ define([
         array[startingIndex++] = value.y;
         array[startingIndex++] = value.width;
         array[startingIndex] = value.height;
+
+        return array;
     };
 
     /**

--- a/Source/Core/BoundingSphere.js
+++ b/Source/Core/BoundingSphere.js
@@ -811,6 +811,8 @@ define([
      * @param {BoundingSphere} value The value to pack.
      * @param {Number[]} array The array to pack into.
      * @param {Number} [startingIndex=0] The index into the array at which to start packing the elements.
+     *
+     * @returns {Number[]} The array that was packed into
      */
     BoundingSphere.pack = function(value, array, startingIndex) {
         //>>includeStart('debug', pragmas.debug);

--- a/Source/Core/BoundingSphere.js
+++ b/Source/Core/BoundingSphere.js
@@ -830,6 +830,8 @@ define([
         array[startingIndex++] = center.y;
         array[startingIndex++] = center.z;
         array[startingIndex] = value.radius;
+
+        return array;
     };
 
     /**

--- a/Source/Core/BoxGeometry.js
+++ b/Source/Core/BoxGeometry.js
@@ -85,14 +85,14 @@ define([
      *
      * @exception {DeveloperError} All dimensions components must be greater than or equal to zero.
      *
-     * 
+     *
      * @example
      * var box = Cesium.BoxGeometry.fromDimensions({
      *   vertexFormat : Cesium.VertexFormat.POSITION_ONLY,
      *   dimensions : new Cesium.Cartesian3(500000.0, 500000.0, 500000.0)
      * });
      * var geometry = Cesium.BoxGeometry.createGeometry(box);
-     * 
+     *
      * @see BoxGeometry.createGeometry
      */
     BoxGeometry.fromDimensions = function(options) {
@@ -124,7 +124,7 @@ define([
      * @returns {BoxGeometry}
      *
      *
-     * 
+     *
      * @example
      * var aabb = Cesium.AxisAlignedBoundingBox.fromPoints(Cesium.Cartesian3.fromDegreesArray([
      *      -72.0, 40.0,
@@ -134,7 +134,7 @@ define([
      *      -68.0, 40.0
      * ]));
      * var box = Cesium.BoxGeometry.fromAxisAlignedBoundingBox(aabb);
-     * 
+     *
      * @see BoxGeometry.createGeometry
      */
     BoxGeometry.fromAxisAlignedBoundingBox = function (boundingBox) {
@@ -176,6 +176,8 @@ define([
         Cartesian3.pack(value._minimum, array, startingIndex);
         Cartesian3.pack(value._maximum, array, startingIndex + Cartesian3.packedLength);
         VertexFormat.pack(value._vertexFormat, array, startingIndex + 2 * Cartesian3.packedLength);
+
+        return array;
     };
 
     var scratchMin = new Cartesian3();

--- a/Source/Core/BoxGeometry.js
+++ b/Source/Core/BoxGeometry.js
@@ -160,6 +160,8 @@ define([
      * @param {BoxGeometry} value The value to pack.
      * @param {Number[]} array The array to pack into.
      * @param {Number} [startingIndex=0] The index into the array at which to start packing the elements.
+     *
+     * @returns {Number[]} The array that was packed into
      */
     BoxGeometry.pack = function(value, array, startingIndex) {
         //>>includeStart('debug', pragmas.debug);

--- a/Source/Core/BoxOutlineGeometry.js
+++ b/Source/Core/BoxOutlineGeometry.js
@@ -75,13 +75,13 @@ define([
      *
      * @exception {DeveloperError} All dimensions components must be greater than or equal to zero.
      *
-     * 
+     *
      * @example
      * var box = Cesium.BoxOutlineGeometry.fromDimensions({
      *   dimensions : new Cesium.Cartesian3(500000.0, 500000.0, 500000.0)
      * });
      * var geometry = Cesium.BoxOutlineGeometry.createGeometry(box);
-     * 
+     *
      * @see BoxOutlineGeometry.createGeometry
      */
     BoxOutlineGeometry.fromDimensions = function(options) {
@@ -122,7 +122,7 @@ define([
      *      -68.0, 40.0
      * ]));
      * var box = Cesium.BoxOutlineGeometry.fromAxisAlignedBoundingBox(aabb);
-     * 
+     *
      *  @see BoxOutlineGeometry.createGeometry
      */
     BoxOutlineGeometry.fromAxisAlignedBoundingBox = function(boundingBox) {
@@ -163,6 +163,7 @@ define([
 
         Cartesian3.pack(value._min, array, startingIndex);
         Cartesian3.pack(value._max, array, startingIndex + Cartesian3.packedLength);
+        return array;
     };
 
     var scratchMin = new Cartesian3();

--- a/Source/Core/BoxOutlineGeometry.js
+++ b/Source/Core/BoxOutlineGeometry.js
@@ -148,6 +148,8 @@ define([
      * @param {BoxOutlineGeometry} value The value to pack.
      * @param {Number[]} array The array to pack into.
      * @param {Number} [startingIndex=0] The index into the array at which to start packing the elements.
+     *
+     * @returns {Number[]} The array that was packed into
      */
     BoxOutlineGeometry.pack = function(value, array, startingIndex) {
         //>>includeStart('debug', pragmas.debug);

--- a/Source/Core/Cartesian2.js
+++ b/Source/Core/Cartesian2.js
@@ -128,6 +128,8 @@ define([
 
         array[startingIndex++] = value.x;
         array[startingIndex] = value.y;
+
+        return array;
     };
 
     /**

--- a/Source/Core/Cartesian2.js
+++ b/Source/Core/Cartesian2.js
@@ -113,6 +113,8 @@ define([
      * @param {Cartesian2} value The value to pack.
      * @param {Number[]} array The array to pack into.
      * @param {Number} [startingIndex=0] The index into the array at which to start packing the elements.
+     *
+     * @returns {Number[]} The array that was packed into
      */
     Cartesian2.pack = function(value, array, startingIndex) {
         //>>includeStart('debug', pragmas.debug);

--- a/Source/Core/Cartesian3.js
+++ b/Source/Core/Cartesian3.js
@@ -158,6 +158,8 @@ define([
         array[startingIndex++] = value.x;
         array[startingIndex++] = value.y;
         array[startingIndex] = value.z;
+
+        return array;
     };
 
     /**

--- a/Source/Core/Cartesian3.js
+++ b/Source/Core/Cartesian3.js
@@ -141,6 +141,8 @@ define([
      * @param {Cartesian3} value The value to pack.
      * @param {Number[]} array The array to pack into.
      * @param {Number} [startingIndex=0] The index into the array at which to start packing the elements.
+     *
+     * @returns {Number[]} The array that was packed into
      */
     Cartesian3.pack = function(value, array, startingIndex) {
         //>>includeStart('debug', pragmas.debug);

--- a/Source/Core/Cartesian4.js
+++ b/Source/Core/Cartesian4.js
@@ -140,6 +140,8 @@ define([
      * @param {Cartesian4} value The value to pack.
      * @param {Number[]} array The array to pack into.
      * @param {Number} [startingIndex=0] The index into the array at which to start packing the elements.
+     *
+     * @returns {Number[]} The array that was packed into
      */
     Cartesian4.pack = function(value, array, startingIndex) {
         //>>includeStart('debug', pragmas.debug);

--- a/Source/Core/Cartesian4.js
+++ b/Source/Core/Cartesian4.js
@@ -157,6 +157,8 @@ define([
         array[startingIndex++] = value.y;
         array[startingIndex++] = value.z;
         array[startingIndex] = value.w;
+
+        return array;
     };
 
     /**

--- a/Source/Core/CircleGeometry.js
+++ b/Source/Core/CircleGeometry.js
@@ -88,6 +88,8 @@ define([
      * @param {CircleGeometry} value The value to pack.
      * @param {Number[]} array The array to pack into.
      * @param {Number} [startingIndex=0] The index into the array at which to start packing the elements.
+     *
+     * @returns {Number[]} The array that was packed into
      */
     CircleGeometry.pack = function(value, array, startingIndex) {
         //>>includeStart('debug', pragmas.debug);

--- a/Source/Core/CircleGeometry.js
+++ b/Source/Core/CircleGeometry.js
@@ -95,7 +95,7 @@ define([
             throw new DeveloperError('value is required');
         }
         //>>includeEnd('debug');
-        EllipseGeometry.pack(value._ellipseGeometry, array, startingIndex);
+        return EllipseGeometry.pack(value._ellipseGeometry, array, startingIndex);
     };
 
     var scratchEllipseGeometry = new EllipseGeometry({
@@ -176,7 +176,7 @@ define([
             vertexFormat : VertexFormat.POSITION_ONLY
         });
     };
-    
+
     defineProperties(CircleGeometry.prototype, {
         /**
          * @private

--- a/Source/Core/CircleOutlineGeometry.js
+++ b/Source/Core/CircleOutlineGeometry.js
@@ -80,6 +80,8 @@ define([
      * @param {CircleOutlineGeometry} value The value to pack.
      * @param {Number[]} array The array to pack into.
      * @param {Number} [startingIndex=0] The index into the array at which to start packing the elements.
+     *
+     * @returns {Number[]} The array that was packed into
      */
     CircleOutlineGeometry.pack = function(value, array, startingIndex) {
         //>>includeStart('debug', pragmas.debug);

--- a/Source/Core/CircleOutlineGeometry.js
+++ b/Source/Core/CircleOutlineGeometry.js
@@ -87,7 +87,7 @@ define([
             throw new DeveloperError('value is required');
         }
         //>>includeEnd('debug');
-        EllipseOutlineGeometry.pack(value._ellipseGeometry, array, startingIndex);
+        return EllipseOutlineGeometry.pack(value._ellipseGeometry, array, startingIndex);
     };
 
     var scratchEllipseGeometry = new EllipseOutlineGeometry({

--- a/Source/Core/Color.js
+++ b/Source/Core/Color.js
@@ -369,7 +369,7 @@ define([
      * @example
      * var cesiumBlue = Cesium.Color.fromCssColorString('#67ADDF');
      * var green = Cesium.Color.fromCssColorString('green');
-     * 
+     *
      * @see {@link http://www.w3.org/TR/css3-color|CSS color values}
      */
     Color.fromCssColorString = function(color, result) {
@@ -456,6 +456,8 @@ define([
         array[startingIndex++] = value.green;
         array[startingIndex++] = value.blue;
         array[startingIndex] = value.alpha;
+
+        return array;
     };
 
     /**
@@ -648,7 +650,7 @@ define([
      *
      * @example
      * var rgba = Cesium.Color.BLUE.toRgba();
-     * 
+     *
      * @see Color.fromRgba
      */
     Color.prototype.toRgba = function() {

--- a/Source/Core/Color.js
+++ b/Source/Core/Color.js
@@ -440,6 +440,8 @@ define([
      * @param {Color} value The value to pack.
      * @param {Number[]} array The array to pack into.
      * @param {Number} [startingIndex=0] The index into the array at which to start packing the elements.
+     *
+     * @returns {Number[]} The array that was packed into
      */
     Color.pack = function(value, array, startingIndex) {
         //>>includeStart('debug', pragmas.debug);

--- a/Source/Core/CorridorGeometry.js
+++ b/Source/Core/CorridorGeometry.js
@@ -808,6 +808,8 @@ define([
      * @param {CorridorGeometry} value The value to pack.
      * @param {Number[]} array The array to pack into.
      * @param {Number} [startingIndex=0] The index into the array at which to start packing the elements.
+     *
+     * @returns {Number[]} The array that was packed into
      */
     CorridorGeometry.pack = function(value, array, startingIndex) {
         //>>includeStart('debug', pragmas.debug);

--- a/Source/Core/CorridorGeometry.js
+++ b/Source/Core/CorridorGeometry.js
@@ -843,6 +843,8 @@ define([
         array[startingIndex++] = value._extrudedHeight;
         array[startingIndex++] = value._cornerType;
         array[startingIndex]   = value._granularity;
+
+        return array;
     };
 
     var scratchEllipsoid = Ellipsoid.clone(Ellipsoid.UNIT_SPHERE);

--- a/Source/Core/CorridorOutlineGeometry.js
+++ b/Source/Core/CorridorOutlineGeometry.js
@@ -361,6 +361,8 @@ define([
      * @param {CorridorOutlineGeometry} value The value to pack.
      * @param {Number[]} array The array to pack into.
      * @param {Number} [startingIndex=0] The index into the array at which to start packing the elements.
+     *
+     * @returns {Number[]} The array that was packed into
      */
     CorridorOutlineGeometry.pack = function(value, array, startingIndex) {
         //>>includeStart('debug', pragmas.debug);

--- a/Source/Core/CorridorOutlineGeometry.js
+++ b/Source/Core/CorridorOutlineGeometry.js
@@ -390,6 +390,8 @@ define([
         array[startingIndex++] = value._extrudedHeight;
         array[startingIndex++] = value._cornerType;
         array[startingIndex]   = value._granularity;
+
+        return array;
     };
 
     var scratchEllipsoid = Ellipsoid.clone(Ellipsoid.UNIT_SPHERE);

--- a/Source/Core/CylinderGeometry.js
+++ b/Source/Core/CylinderGeometry.js
@@ -114,6 +114,8 @@ define([
      * @param {CylinderGeometry} value The value to pack.
      * @param {Number[]} array The array to pack into.
      * @param {Number} [startingIndex=0] The index into the array at which to start packing the elements.
+     *
+     * @returns {Number[]} The array that was packed into
      */
     CylinderGeometry.pack = function(value, array, startingIndex) {
         //>>includeStart('debug', pragmas.debug);

--- a/Source/Core/CylinderGeometry.js
+++ b/Source/Core/CylinderGeometry.js
@@ -134,6 +134,8 @@ define([
         array[startingIndex++] = value._topRadius;
         array[startingIndex++] = value._bottomRadius;
         array[startingIndex]   = value._slices;
+
+        return array;
     };
 
     var scratchVertexFormat = new VertexFormat();

--- a/Source/Core/CylinderOutlineGeometry.js
+++ b/Source/Core/CylinderOutlineGeometry.js
@@ -123,6 +123,8 @@ define([
         array[startingIndex++] = value._bottomRadius;
         array[startingIndex++] = value._slices;
         array[startingIndex]   = value._numberOfVerticalLines;
+
+        return array;
     };
 
     var scratchOptions = {

--- a/Source/Core/CylinderOutlineGeometry.js
+++ b/Source/Core/CylinderOutlineGeometry.js
@@ -1,3 +1,4 @@
+
 /*global define*/
 define([
         './BoundingSphere',
@@ -105,6 +106,8 @@ define([
      * @param {CylinderOutlineGeometry} value The value to pack.
      * @param {Number[]} array The array to pack into.
      * @param {Number} [startingIndex=0] The index into the array at which to start packing the elements.
+     *
+     * @returns {Number[]} The array that was packed into
      */
     CylinderOutlineGeometry.pack = function(value, array, startingIndex) {
         //>>includeStart('debug', pragmas.debug);

--- a/Source/Core/EllipseGeometry.js
+++ b/Source/Core/EllipseGeometry.js
@@ -741,6 +741,8 @@ define([
      * @param {EllipseGeometry} value The value to pack.
      * @param {Number[]} array The array to pack into.
      * @param {Number} [startingIndex=0] The index into the array at which to start packing the elements.
+     *
+     * @returns {Number[]} The array that was packed into
      */
     EllipseGeometry.pack = function(value, array, startingIndex) {
         //>>includeStart('debug', pragmas.debug);

--- a/Source/Core/EllipseGeometry.js
+++ b/Source/Core/EllipseGeometry.js
@@ -774,6 +774,8 @@ define([
         array[startingIndex++] = value._granularity;
         array[startingIndex++] = value._extrudedHeight;
         array[startingIndex] = value._extrude ? 1.0 : 0.0;
+
+        return array;
     };
 
     var scratchCenter = new Cartesian3();

--- a/Source/Core/EllipseOutlineGeometry.js
+++ b/Source/Core/EllipseOutlineGeometry.js
@@ -211,6 +211,8 @@ define([
      * @param {EllipseOutlineGeometry} value The value to pack.
      * @param {Number[]} array The array to pack into.
      * @param {Number} [startingIndex=0] The index into the array at which to start packing the elements.
+     *
+     * @returns {Number[]} The array that was packed into
      */
     EllipseOutlineGeometry.pack = function(value, array, startingIndex) {
         //>>includeStart('debug', pragmas.debug);

--- a/Source/Core/EllipseOutlineGeometry.js
+++ b/Source/Core/EllipseOutlineGeometry.js
@@ -239,6 +239,8 @@ define([
         array[startingIndex++] = defaultValue(value._extrudedHeight, 0.0);
         array[startingIndex++] = value._extrude ? 1.0 : 0.0;
         array[startingIndex]   = value._numberOfVerticalLines;
+
+        return array;
     };
 
     var scratchCenter = new Cartesian3();

--- a/Source/Core/Ellipsoid.js
+++ b/Source/Core/Ellipsoid.js
@@ -285,6 +285,8 @@ define([
         startingIndex = defaultValue(startingIndex, 0);
 
         Cartesian3.pack(value._radii, array, startingIndex);
+
+        return array;
     };
 
     /**

--- a/Source/Core/Ellipsoid.js
+++ b/Source/Core/Ellipsoid.js
@@ -271,6 +271,8 @@ define([
      * @param {Ellipsoid} value The value to pack.
      * @param {Number[]} array The array to pack into.
      * @param {Number} [startingIndex=0] The index into the array at which to start packing the elements.
+     *
+     * @returns {Number[]} The array that was packed into
      */
     Ellipsoid.pack = function(value, array, startingIndex) {
         //>>includeStart('debug', pragmas.debug);

--- a/Source/Core/EllipsoidGeometry.js
+++ b/Source/Core/EllipsoidGeometry.js
@@ -103,6 +103,8 @@ define([
      * @param {EllipsoidGeometry} value The value to pack.
      * @param {Number[]} array The array to pack into.
      * @param {Number} [startingIndex=0] The index into the array at which to start packing the elements.
+     *
+     * @returns {Number[]} The array that was packed into
      */
     EllipsoidGeometry.pack = function(value, array, startingIndex) {
         //>>includeStart('debug', pragmas.debug);

--- a/Source/Core/EllipsoidGeometry.js
+++ b/Source/Core/EllipsoidGeometry.js
@@ -124,6 +124,8 @@ define([
 
         array[startingIndex++] = value._stackPartitions;
         array[startingIndex]   = value._slicePartitions;
+
+        return array;
     };
 
     var scratchRadii = new Cartesian3();

--- a/Source/Core/EllipsoidOutlineGeometry.js
+++ b/Source/Core/EllipsoidOutlineGeometry.js
@@ -96,6 +96,8 @@ define([
      * @param {EllipsoidOutlineGeometry} value The value to pack.
      * @param {Number[]} array The array to pack into.
      * @param {Number} [startingIndex=0] The index into the array at which to start packing the elements.
+     *
+     * @returns {Number[]} The array that was packed into
      */
     EllipsoidOutlineGeometry.pack = function(value, array, startingIndex) {
         //>>includeStart('debug', pragmas.debug);

--- a/Source/Core/EllipsoidOutlineGeometry.js
+++ b/Source/Core/EllipsoidOutlineGeometry.js
@@ -115,6 +115,8 @@ define([
         array[startingIndex++] = value._stackPartitions;
         array[startingIndex++] = value._slicePartitions;
         array[startingIndex]   = value._subdivisions;
+
+        return array;
     };
 
     var scratchRadii = new Cartesian3();

--- a/Source/Core/Matrix2.js
+++ b/Source/Core/Matrix2.js
@@ -52,6 +52,8 @@ define([
      * @param {Matrix2} value The value to pack.
      * @param {Number[]} array The array to pack into.
      * @param {Number} [startingIndex=0] The index into the array at which to start packing the elements.
+     *
+     * @returns {Number[]} The array that was packed into
      */
     Matrix2.pack = function(value, array, startingIndex) {
         //>>includeStart('debug', pragmas.debug);

--- a/Source/Core/Matrix2.js
+++ b/Source/Core/Matrix2.js
@@ -70,6 +70,8 @@ define([
         array[startingIndex++] = value[1];
         array[startingIndex++] = value[2];
         array[startingIndex++] = value[3];
+
+        return array;
     };
 
     /**
@@ -686,7 +688,7 @@ define([
      * @example
      * // Instead of Cesium.Matrix2.multiply(m, Cesium.Matrix2.fromScale(scale), m);
      * Cesium.Matrix2.multiplyByScale(m, scale, m);
-     * 
+     *
      * @see Matrix2.fromScale
      * @see Matrix2.multiplyByUniformScale
      */

--- a/Source/Core/Matrix3.js
+++ b/Source/Core/Matrix3.js
@@ -90,6 +90,8 @@ define([
         array[startingIndex++] = value[6];
         array[startingIndex++] = value[7];
         array[startingIndex++] = value[8];
+
+        return array;
     };
 
     /**
@@ -977,7 +979,7 @@ define([
      * @example
      * // Instead of Cesium.Matrix3.multiply(m, Cesium.Matrix3.fromScale(scale), m);
      * Cesium.Matrix3.multiplyByScale(m, scale, m);
-     * 
+     *
      * @see Matrix3.fromScale
      * @see Matrix3.multiplyByUniformScale
      */

--- a/Source/Core/Matrix3.js
+++ b/Source/Core/Matrix3.js
@@ -67,6 +67,8 @@ define([
      * @param {Matrix3} value The value to pack.
      * @param {Number[]} array The array to pack into.
      * @param {Number} [startingIndex=0] The index into the array at which to start packing the elements.
+     *
+     * @returns {Number[]} The array that was packed into
      */
     Matrix3.pack = function(value, array, startingIndex) {
         //>>includeStart('debug', pragmas.debug);

--- a/Source/Core/Matrix4.js
+++ b/Source/Core/Matrix4.js
@@ -99,6 +99,8 @@ define([
      * @param {Matrix4} value The value to pack.
      * @param {Number[]} array The array to pack into.
      * @param {Number} [startingIndex=0] The index into the array at which to start packing the elements.
+     *
+     * @returns {Number[]} The array that was packed into
      */
     Matrix4.pack = function(value, array, startingIndex) {
         //>>includeStart('debug', pragmas.debug);

--- a/Source/Core/Matrix4.js
+++ b/Source/Core/Matrix4.js
@@ -129,6 +129,8 @@ define([
         array[startingIndex++] = value[13];
         array[startingIndex++] = value[14];
         array[startingIndex] = value[15];
+
+        return array;
     };
 
     /**
@@ -1795,7 +1797,7 @@ define([
      * @example
      * // Instead of Cesium.Matrix4.multiply(m, Cesium.Matrix4.fromUniformScale(scale), m);
      * Cesium.Matrix4.multiplyByUniformScale(m, scale, m);
-     * 
+     *
      * @see Matrix4.fromUniformScale
      * @see Matrix4.multiplyByScale
      */
@@ -1834,7 +1836,7 @@ define([
      * @example
      * // Instead of Cesium.Matrix4.multiply(m, Cesium.Matrix4.fromScale(scale), m);
      * Cesium.Matrix4.multiplyByScale(m, scale, m);
-     * 
+     *
      * @see Matrix4.fromScale
      * @see Matrix4.multiplyByUniformScale
      */

--- a/Source/Core/NearFarScalar.js
+++ b/Source/Core/NearFarScalar.js
@@ -84,6 +84,8 @@ define([
      * @param {NearFarScalar} value The value to pack.
      * @param {Number[]} array The array to pack into.
      * @param {Number} [startingIndex=0] The index into the array at which to start packing the elements.
+     *
+     * @returns {Number[]} The array that was packed into
      */
     NearFarScalar.pack = function(value, array, startingIndex) {
         //>>includeStart('debug', pragmas.debug);

--- a/Source/Core/NearFarScalar.js
+++ b/Source/Core/NearFarScalar.js
@@ -101,6 +101,8 @@ define([
         array[startingIndex++] = value.nearValue;
         array[startingIndex++] = value.far;
         array[startingIndex] = value.farValue;
+
+        return array;
     };
 
     /**

--- a/Source/Core/PolygonGeometry.js
+++ b/Source/Core/PolygonGeometry.js
@@ -661,6 +661,8 @@ define([
      * @param {PolygonGeometry} value The value to pack.
      * @param {Number[]} array The array to pack into.
      * @param {Number} [startingIndex=0] The index into the array at which to start packing the elements.
+     *
+     * @returns {Number[]} The array that was packed into
      */
     PolygonGeometry.pack = function(value, array, startingIndex) {
         //>>includeStart('debug', pragmas.debug);

--- a/Source/Core/PolygonGeometry.js
+++ b/Source/Core/PolygonGeometry.js
@@ -694,6 +694,8 @@ define([
         array[startingIndex++] = value._closeTop ? 1.0 : 0.0;
         array[startingIndex++] = value._closeBottom ? 1.0 : 0.0;
         array[startingIndex] = value.packedLength;
+
+        return array;
     };
 
     var scratchEllipsoid = Ellipsoid.clone(Ellipsoid.UNIT_SPHERE);

--- a/Source/Core/PolygonOutlineGeometry.js
+++ b/Source/Core/PolygonOutlineGeometry.js
@@ -354,6 +354,8 @@ define([
         array[startingIndex++] = value._extrude ? 1.0 : 0.0;
         array[startingIndex++] = value._perPositionHeight ? 1.0 : 0.0;
         array[startingIndex++] = value.packedLength;
+
+        return array;
     };
 
     var scratchEllipsoid = Ellipsoid.clone(Ellipsoid.UNIT_SPHERE);

--- a/Source/Core/PolygonOutlineGeometry.js
+++ b/Source/Core/PolygonOutlineGeometry.js
@@ -330,6 +330,8 @@ define([
      * @param {PolygonOutlineGeometry} value The value to pack.
      * @param {Number[]} array The array to pack into.
      * @param {Number} [startingIndex=0] The index into the array at which to start packing the elements.
+     *
+     * @returns {Number[]} The array that was packed into
      */
     PolygonOutlineGeometry.pack = function(value, array, startingIndex) {
         //>>includeStart('debug', pragmas.debug);

--- a/Source/Core/PolylineGeometry.js
+++ b/Source/Core/PolylineGeometry.js
@@ -158,6 +158,8 @@ define([
      * @param {PolylineGeometry} value The value to pack.
      * @param {Number[]} array The array to pack into.
      * @param {Number} [startingIndex=0] The index into the array at which to start packing the elements.
+     *
+     * @returns {Number[]} The array that was packed into
      */
     PolylineGeometry.pack = function(value, array, startingIndex) {
         //>>includeStart('debug', pragmas.debug);

--- a/Source/Core/PolylineGeometry.js
+++ b/Source/Core/PolylineGeometry.js
@@ -199,6 +199,8 @@ define([
         array[startingIndex++] = value._colorsPerVertex ? 1.0 : 0.0;
         array[startingIndex++] = value._followSurface ? 1.0 : 0.0;
         array[startingIndex]   = value._granularity;
+
+        return array;
     };
 
     var scratchEllipsoid = Ellipsoid.clone(Ellipsoid.UNIT_SPHERE);

--- a/Source/Core/PolylineVolumeGeometry.js
+++ b/Source/Core/PolylineVolumeGeometry.js
@@ -253,6 +253,8 @@ define([
      * @param {PolylineVolumeGeometry} value The value to pack.
      * @param {Number[]} array The array to pack into.
      * @param {Number} [startingIndex=0] The index into the array at which to start packing the elements.
+     *
+     * @returns {Number[]} The array that was packed into
      */
     PolylineVolumeGeometry.pack = function(value, array, startingIndex) {
         //>>includeStart('debug', pragmas.debug);

--- a/Source/Core/PolylineVolumeGeometry.js
+++ b/Source/Core/PolylineVolumeGeometry.js
@@ -292,6 +292,8 @@ define([
 
         array[startingIndex++] = value._cornerType;
         array[startingIndex]   = value._granularity;
+
+        return array;
     };
 
     var scratchEllipsoid = Ellipsoid.clone(Ellipsoid.UNIT_SPHERE);

--- a/Source/Core/PolylineVolumeOutlineGeometry.js
+++ b/Source/Core/PolylineVolumeOutlineGeometry.js
@@ -165,6 +165,8 @@ define([
      * @param {PolylineVolumeOutlineGeometry} value The value to pack.
      * @param {Number[]} array The array to pack into.
      * @param {Number} [startingIndex=0] The index into the array at which to start packing the elements.
+     *
+     * @returns {Number[]} The array that was packed into
      */
     PolylineVolumeOutlineGeometry.pack = function(value, array, startingIndex) {
         //>>includeStart('debug', pragmas.debug);

--- a/Source/Core/PolylineVolumeOutlineGeometry.js
+++ b/Source/Core/PolylineVolumeOutlineGeometry.js
@@ -201,6 +201,8 @@ define([
 
         array[startingIndex++] = value._cornerType;
         array[startingIndex]   = value._granularity;
+
+        return array;
     };
 
     var scratchEllipsoid = Ellipsoid.clone(Ellipsoid.UNIT_SPHERE);

--- a/Source/Core/Quaternion.js
+++ b/Source/Core/Quaternion.js
@@ -226,6 +226,8 @@ define([
      * @param {Quaternion} value The value to pack.
      * @param {Number[]} array The array to pack into.
      * @param {Number} [startingIndex=0] The index into the array at which to start packing the elements.
+     *
+     * @returns {Number[]} The array that was packed into
      */
     Quaternion.pack = function(value, array, startingIndex) {
         //>>includeStart('debug', pragmas.debug);

--- a/Source/Core/Quaternion.js
+++ b/Source/Core/Quaternion.js
@@ -244,6 +244,8 @@ define([
         array[startingIndex++] = value.y;
         array[startingIndex++] = value.z;
         array[startingIndex] = value.w;
+
+        return array;
     };
 
     /**
@@ -911,7 +913,7 @@ define([
      * // 2. compute the squad interpolation as above but where the first quaternion is a end point.
      * var s1 = Cesium.Quaternion.computeInnerQuadrangle(quaternions[0], quaternions[1], quaternions[2], new Cesium.Quaternion());
      * var q = Cesium.Quaternion.squad(quaternions[0], quaternions[1], quaternions[0], s1, t, new Cesium.Quaternion());
-     * 
+     *
      * @see Quaternion#computeInnerQuadrangle
      */
     Quaternion.squad = function(q0, q1, s0, s1, t, result) {

--- a/Source/Core/Rectangle.js
+++ b/Source/Core/Rectangle.js
@@ -120,6 +120,8 @@ define([
         array[startingIndex++] = value.south;
         array[startingIndex++] = value.east;
         array[startingIndex] = value.north;
+
+        return array;
     };
 
     /**

--- a/Source/Core/Rectangle.js
+++ b/Source/Core/Rectangle.js
@@ -102,6 +102,8 @@ define([
      * @param {Rectangle} value The value to pack.
      * @param {Number[]} array The array to pack into.
      * @param {Number} [startingIndex=0] The index into the array at which to start packing the elements.
+     *
+     * @returns {Number[]} The array that was packed into
      */
     Rectangle.pack = function(value, array, startingIndex) {
         //>>includeStart('debug', pragmas.debug);

--- a/Source/Core/RectangleGeometry.js
+++ b/Source/Core/RectangleGeometry.js
@@ -630,6 +630,8 @@ define([
      * @param {RectangleGeometry} value The value to pack.
      * @param {Number[]} array The array to pack into.
      * @param {Number} [startingIndex=0] The index into the array at which to start packing the elements.
+     *
+     * @returns {Number[]} The array that was packed into
      */
     RectangleGeometry.pack = function(value, array, startingIndex) {
         //>>includeStart('debug', pragmas.debug);

--- a/Source/Core/RectangleGeometry.js
+++ b/Source/Core/RectangleGeometry.js
@@ -664,6 +664,8 @@ define([
         array[startingIndex++] = value._extrude ? 1.0 : 0.0;
         array[startingIndex++] = value._closeTop ? 1.0 : 0.0;
         array[startingIndex]   = value._closeBottom ? 1.0 : 0.0;
+
+        return array;
     };
 
     var scratchRectangle = new Rectangle();

--- a/Source/Core/RectangleOutlineGeometry.js
+++ b/Source/Core/RectangleOutlineGeometry.js
@@ -230,6 +230,8 @@ define([
      * @param {RectangleOutlineGeometry} value The value to pack.
      * @param {Number[]} array The array to pack into.
      * @param {Number} [startingIndex=0] The index into the array at which to start packing the elements.
+     *
+     * @returns {Number[]} The array that was packed into
      */
     RectangleOutlineGeometry.pack = function(value, array, startingIndex) {
         //>>includeStart('debug', pragmas.debug);

--- a/Source/Core/RectangleOutlineGeometry.js
+++ b/Source/Core/RectangleOutlineGeometry.js
@@ -255,6 +255,8 @@ define([
         array[startingIndex++] = value._rotation;
         array[startingIndex++] = defined(value._extrudedHeight) ? 1.0 : 0.0;
         array[startingIndex] = defaultValue(value._extrudedHeight, 0.0);
+
+        return array;
     };
 
     var scratchRectangle = new Rectangle();

--- a/Source/Core/SimplePolylineGeometry.js
+++ b/Source/Core/SimplePolylineGeometry.js
@@ -180,6 +180,8 @@ define([
         array[startingIndex++] = value._colorsPerVertex ? 1.0 : 0.0;
         array[startingIndex++] = value._followSurface ? 1.0 : 0.0;
         array[startingIndex]   = value._granularity;
+
+        return array;
     };
 
     /**

--- a/Source/Core/SimplePolylineGeometry.js
+++ b/Source/Core/SimplePolylineGeometry.js
@@ -143,6 +143,8 @@ define([
      * @param {SimplePolylineGeometry} value The value to pack.
      * @param {Number[]} array The array to pack into.
      * @param {Number} [startingIndex=0] The index into the array at which to start packing the elements.
+     *
+     * @returns {Number[]} The array that was packed into
      */
     SimplePolylineGeometry.pack = function(value, array, startingIndex) {
         //>>includeStart('debug', pragmas.debug);

--- a/Source/Core/SphereGeometry.js
+++ b/Source/Core/SphereGeometry.js
@@ -73,7 +73,7 @@ define([
         }
         //>>includeEnd('debug');
 
-        EllipsoidGeometry.pack(value._ellipsoidGeometry, array, startingIndex);
+        return EllipsoidGeometry.pack(value._ellipsoidGeometry, array, startingIndex);
     };
 
     var scratchEllipsoidGeometry = new EllipsoidGeometry();

--- a/Source/Core/SphereGeometry.js
+++ b/Source/Core/SphereGeometry.js
@@ -65,6 +65,8 @@ define([
      * @param {SphereGeometry} value The value to pack.
      * @param {Number[]} array The array to pack into.
      * @param {Number} [startingIndex=0] The index into the array at which to start packing the elements.
+     *
+     * @returns {Number[]} The array that was packed into
      */
     SphereGeometry.pack = function(value, array, startingIndex) {
         //>>includeStart('debug', pragmas.debug);

--- a/Source/Core/SphereOutlineGeometry.js
+++ b/Source/Core/SphereOutlineGeometry.js
@@ -71,7 +71,7 @@ define([
         }
         //>>includeEnd('debug');
 
-        EllipsoidOutlineGeometry.pack(value._ellipsoidGeometry, array, startingIndex);
+        return EllipsoidOutlineGeometry.pack(value._ellipsoidGeometry, array, startingIndex);
     };
 
     var scratchEllipsoidGeometry = new EllipsoidOutlineGeometry();

--- a/Source/Core/SphereOutlineGeometry.js
+++ b/Source/Core/SphereOutlineGeometry.js
@@ -63,6 +63,8 @@ define([
      * @param {SphereOutlineGeometry} value The value to pack.
      * @param {Number[]} array The array to pack into.
      * @param {Number} [startingIndex=0] The index into the array at which to start packing the elements.
+     *
+     * @returns {Number[]} The array that was packed into
      */
     SphereOutlineGeometry.pack = function(value, array, startingIndex) {
         //>>includeStart('debug', pragmas.debug);

--- a/Source/Core/VertexFormat.js
+++ b/Source/Core/VertexFormat.js
@@ -227,6 +227,8 @@ define([
      * @param {VertexFormat} value The value to pack.
      * @param {Number[]} array The array to pack into.
      * @param {Number} [startingIndex=0] The index into the array at which to start packing the elements.
+     *
+     * @returns {Number[]} The array that was packed into
      */
     VertexFormat.pack = function(value, array, startingIndex) {
         //>>includeStart('debug', pragmas.debug);

--- a/Source/Core/VertexFormat.js
+++ b/Source/Core/VertexFormat.js
@@ -246,6 +246,8 @@ define([
         array[startingIndex++] = value.binormal ? 1.0 : 0.0;
         array[startingIndex++] = value.tangent ? 1.0 : 0.0;
         array[startingIndex++] = value.color ? 1.0 : 0.0;
+
+        return array;
     };
 
     /**

--- a/Source/Core/WallGeometry.js
+++ b/Source/Core/WallGeometry.js
@@ -183,6 +183,8 @@ define([
         startingIndex += VertexFormat.packedLength;
 
         array[startingIndex] = value._granularity;
+
+        return array;
     };
 
     var scratchEllipsoid = Ellipsoid.clone(Ellipsoid.UNIT_SPHERE);

--- a/Source/Core/WallGeometry.js
+++ b/Source/Core/WallGeometry.js
@@ -133,6 +133,8 @@ define([
      * @param {WallGeometry} value The value to pack.
      * @param {Number[]} array The array to pack into.
      * @param {Number} [startingIndex=0] The index into the array at which to start packing the elements.
+     *
+     * @returns {Number[]} The array that was packed into
      */
     WallGeometry.pack = function(value, array, startingIndex) {
         //>>includeStart('debug', pragmas.debug);

--- a/Source/Core/WallOutlineGeometry.js
+++ b/Source/Core/WallOutlineGeometry.js
@@ -167,6 +167,8 @@ define([
         startingIndex += Ellipsoid.packedLength;
 
         array[startingIndex]   = value._granularity;
+
+        return array;
     };
 
     var scratchEllipsoid = Ellipsoid.clone(Ellipsoid.UNIT_SPHERE);

--- a/Source/Core/WallOutlineGeometry.js
+++ b/Source/Core/WallOutlineGeometry.js
@@ -120,6 +120,8 @@ define([
      * @param {WallOutlineGeometry} value The value to pack.
      * @param {Number[]} array The array to pack into.
      * @param {Number} [startingIndex=0] The index into the array at which to start packing the elements.
+     *
+     * @returns {Number[]} The array that was packed into
      */
     WallOutlineGeometry.pack = function(value, array, startingIndex) {
         //>>includeStart('debug', pragmas.debug);

--- a/Source/DataSources/Rotation.js
+++ b/Source/DataSources/Rotation.js
@@ -34,7 +34,7 @@ define([
      * //a SampledProperty(Number) instead.  Note, the actual
      * //return value is in radians, not degrees.
      * property.getValue(time2);
-     * 
+     *
      * @see PackableForInterpolation
      */
     var Rotation = {
@@ -64,6 +64,8 @@ define([
 
             startingIndex = defaultValue(startingIndex, 0);
             array[startingIndex] = value;
+
+            return array;
         },
 
         /**

--- a/Source/DataSources/Rotation.js
+++ b/Source/DataSources/Rotation.js
@@ -50,6 +50,8 @@ define([
          * @param {Rotation} value The value to pack.
          * @param {Number[]} array The array to pack into.
          * @param {Number} [startingIndex=0] The index into the array at which to start packing the elements.
+         *
+         * @returns {Number[]} The array that was packed into
          */
         pack : function(value, array, startingIndex) {
             //>>includeStart('debug', pragmas.debug);

--- a/Specs/createPackableSpecs.js
+++ b/Specs/createPackableSpecs.js
@@ -14,8 +14,8 @@ define([
 
         it(namePrefix + ' can pack', function() {
             var packedArray = [];
-            packedArray = packable.pack(instance, packedArray);
-            expect(packedArray).toBeDefined();
+            var returnArray = packable.pack(instance, packedArray);
+            expect(returnArray).toBe(packedArray);
             var packedLength = defined(packable.packedLength) ? packable.packedLength : instance.packedLength;
             expect(packedArray.length).toEqual(packedLength);
             expect(packedArray).toEqualEpsilon(packedInstance, CesiumMath.EPSILON15);

--- a/Specs/createPackableSpecs.js
+++ b/Specs/createPackableSpecs.js
@@ -14,7 +14,8 @@ define([
 
         it(namePrefix + ' can pack', function() {
             var packedArray = [];
-            packable.pack(instance, packedArray);
+            packedArray = packable.pack(instance, packedArray);
+            expect(packedArray).toBeDefined();
             var packedLength = defined(packable.packedLength) ? packable.packedLength : instance.packedLength;
             expect(packedArray.length).toEqual(packedLength);
             expect(packedArray).toEqualEpsilon(packedInstance, CesiumMath.EPSILON15);


### PR DESCRIPTION
This make all `pack` functions return the packed array.  This helpful if I want to do something like 

``` javascript
var myObject = {
   position: Cartesian3.pack(position, new Array(3));
} 
```

I also think it's all around more intuitive.  I know we do this a lot, but to me this syntax is weird
``` javascript
Cartesian3.pack(position, array);
```

And this makes much more sense 
``` javascript
array = Cartesian3.pack(position, array);
```