### PR TITLE
Fixed typo when creating GroundPrimitives.

### DIFF
--- a/Apps/Sandcastle/gallery/CZML Polygon - Intervals, Availability.html
+++ b/Apps/Sandcastle/gallery/CZML Polygon - Intervals, Availability.html
@@ -138,10 +138,8 @@ var czml = [{
     }
 }];
 
-Cesium.GroundPrimitive.initializeTerrainHeights().then(function() {
-    var viewer = new Cesium.Viewer('cesiumContainer');
-    viewer.dataSources.add(Cesium.CzmlDataSource.load(czml));
-});
+var viewer = new Cesium.Viewer('cesiumContainer');
+viewer.dataSources.add(Cesium.CzmlDataSource.load(czml));
 
   //Sandcastle_End
     Sandcastle.finishedLoading();

--- a/Apps/Sandcastle/gallery/CZML Polygon - Intervals, Availability.html
+++ b/Apps/Sandcastle/gallery/CZML Polygon - Intervals, Availability.html
@@ -138,8 +138,10 @@ var czml = [{
     }
 }];
 
-var viewer = new Cesium.Viewer('cesiumContainer');
-viewer.dataSources.add(Cesium.CzmlDataSource.load(czml));
+Cesium.GroundPrimitive.initializeTerrainHeights().then(function() {
+    var viewer = new Cesium.Viewer('cesiumContainer');
+    viewer.dataSources.add(Cesium.CzmlDataSource.load(czml));
+});
 
   //Sandcastle_End
     Sandcastle.finishedLoading();

--- a/Source/DataSources/CorridorGeometryUpdater.js
+++ b/Source/DataSources/CorridorGeometryUpdater.js
@@ -592,7 +592,7 @@ define([
                 }
 
                 this._primitive = groundPrimitives.add(new GroundPrimitive({
-                    geometryInstance : new GeometryInstance({
+                    geometryInstances : new GeometryInstance({
                         id : entity,
                         geometry : new CorridorGeometry(options),
                         attributes: {

--- a/Source/DataSources/DataSourceDisplay.js
+++ b/Source/DataSources/DataSourceDisplay.js
@@ -7,6 +7,7 @@ define([
         '../Core/destroyObject',
         '../Core/DeveloperError',
         '../Core/EventHelper',
+        '../Scene/GroundPrimitive',
         './BillboardVisualizer',
         './BoundingSphereState',
         './BoxGeometryUpdater',
@@ -33,6 +34,7 @@ define([
         destroyObject,
         DeveloperError,
         EventHelper,
+        GroundPrimitive,
         BillboardVisualizer,
         BoundingSphereState,
         BoxGeometryUpdater,
@@ -77,6 +79,8 @@ define([
             throw new DeveloperError('dataSourceCollection is required.');
         }
         //>>includeEnd('debug');
+        
+        GroundPrimitive.initializeTerrainHeights();
 
         var scene = options.scene;
         var dataSourceCollection = options.dataSourceCollection;
@@ -231,6 +235,10 @@ define([
         }
         //>>includeEnd('debug');
 
+        if (!GroundPrimitive._initialized) {
+            return false;
+        }
+        
         var result = true;
 
         var i;

--- a/Source/DataSources/EllipseGeometryUpdater.js
+++ b/Source/DataSources/EllipseGeometryUpdater.js
@@ -609,7 +609,7 @@ define([
                 }
 
                 this._primitive = groundPrimitives.add(new GroundPrimitive({
-                    geometryInstance : new GeometryInstance({
+                    geometryInstances : new GeometryInstance({
                         id : entity,
                         geometry : new EllipseGeometry(options),
                         attributes: {

--- a/Source/DataSources/PolygonGeometryUpdater.js
+++ b/Source/DataSources/PolygonGeometryUpdater.js
@@ -630,7 +630,7 @@ define([
                 }
 
                 this._primitive = groundPrimitives.add(new GroundPrimitive({
-                    geometryInstance : new GeometryInstance({
+                    geometryInstances : new GeometryInstance({
                         id : entity,
                         geometry : new PolygonGeometry(options),
                         attributes: {

--- a/Source/DataSources/RectangleGeometryUpdater.js
+++ b/Source/DataSources/RectangleGeometryUpdater.js
@@ -602,7 +602,7 @@ define([
                 }
 
                 this._primitive = groundPrimitives.add(new GroundPrimitive({
-                    geometryInstance : new GeometryInstance({
+                    geometryInstances : new GeometryInstance({
                         id : entity,
                         geometry : new RectangleGeometry(options),
                         attributes: {

--- a/Specs/DataSources/DataSourceDisplaySpec.js
+++ b/Specs/DataSources/DataSourceDisplaySpec.js
@@ -35,6 +35,11 @@ defineSuite([
 
     afterAll(function() {
         scene.destroyForSpecs();
+
+        // Leave ground primitive uninitialized
+        GroundPrimitive._initialized = false;
+        GroundPrimitive._initPromise = undefined;
+        GroundPrimitive._terrainHeights = undefined;
     });
 
     afterEach(function() {
@@ -347,6 +352,7 @@ defineSuite([
     it('verify update returns false till terrain heights are initialized', function() {
         GroundPrimitive._initialized = false;
         GroundPrimitive._initPromise = undefined;
+        GroundPrimitive._terrainHeights = undefined;
 
         var source1 = new MockDataSource();
         var source2 = new MockDataSource();

--- a/Specs/DataSources/DataSourceDisplaySpec.js
+++ b/Specs/DataSources/DataSourceDisplaySpec.js
@@ -7,6 +7,7 @@ defineSuite([
         'DataSources/BoundingSphereState',
         'DataSources/DataSourceCollection',
         'DataSources/Entity',
+        'Scene/GroundPrimitive',
         'Specs/createScene',
         'Specs/MockDataSource'
     ], function(
@@ -17,6 +18,7 @@ defineSuite([
         BoundingSphereState,
         DataSourceCollection,
         Entity,
+        GroundPrimitive,
         createScene,
         MockDataSource) {
     'use strict';
@@ -27,6 +29,8 @@ defineSuite([
     beforeAll(function() {
         scene = createScene();
         dataSourceCollection = new DataSourceCollection();
+
+        return GroundPrimitive.initializeTerrainHeights();
     });
 
     afterAll(function() {
@@ -338,5 +342,28 @@ defineSuite([
         expect(function(){
             return display.update();
         }).toThrowDeveloperError();
+    });
+
+    it('verify update returns false till terrain heights are initialized', function() {
+        GroundPrimitive._initialized = false;
+        GroundPrimitive._initPromise = undefined;
+
+        var source1 = new MockDataSource();
+        var source2 = new MockDataSource();
+
+        display = new DataSourceDisplay({
+            scene : scene,
+            dataSourceCollection : dataSourceCollection,
+            visualizersCallback : visualizersCallback
+        });
+        dataSourceCollection.add(source1);
+        dataSourceCollection.add(source2);
+        display.update(Iso8601.MINIMUM_VALUE);
+        expect(display.ready).toBe(false);
+
+        return GroundPrimitive.initializeTerrainHeights().then(function() {
+            display.update(Iso8601.MINIMUM_VALUE);
+            expect(display.ready).toBe(true);
+        });
     });
 }, 'WebGL');

--- a/Specs/DataSources/GeometryVisualizerSpec.js
+++ b/Specs/DataSources/GeometryVisualizerSpec.js
@@ -22,6 +22,7 @@ defineSuite([
         'DataSources/StaticGeometryPerMaterialBatch',
         'DataSources/StaticGroundGeometryColorBatch',
         'DataSources/StaticOutlineGeometryBatch',
+        'Scene/GroundPrimitive',
         'Specs/createDynamicProperty',
         'Specs/createScene',
         'Specs/pollToPromise'
@@ -48,6 +49,7 @@ defineSuite([
         StaticGeometryPerMaterialBatch,
         StaticGroundGeometryColorBatch,
         StaticOutlineGeometryBatch,
+        GroundPrimitive,
         createDynamicProperty,
         createScene,
         pollToPromise) {
@@ -58,10 +60,17 @@ defineSuite([
     var scene;
     beforeAll(function() {
         scene = createScene();
+
+        return GroundPrimitive.initializeTerrainHeights();
     });
 
     afterAll(function() {
         scene.destroyForSpecs();
+
+        // Leave ground primitive uninitialized
+        GroundPrimitive._initialized = false;
+        GroundPrimitive._initPromise = undefined;
+        GroundPrimitive._terrainHeights = undefined;
     });
 
     it('Can create and destroy', function() {

--- a/Specs/Scene/GroundPrimitiveSpec.js
+++ b/Specs/Scene/GroundPrimitiveSpec.js
@@ -70,20 +70,23 @@ defineSuite([
     var primitive;
     var depthPrimitive;
 
-    beforeAll(function(done) {
+    beforeAll(function() {
         scene = createScene();
         scene.fxaa = false;
 
         context = scene.context;
 
         ellipsoid = Ellipsoid.WGS84;
-        GroundPrimitive.initializeTerrainHeights().then(function() {
-           done();
-        });
+        return GroundPrimitive.initializeTerrainHeights();
     });
 
     afterAll(function() {
         scene.destroyForSpecs();
+
+        // Leave ground primitive uninitialized
+        GroundPrimitive._initialized = false;
+        GroundPrimitive._initPromise = undefined;
+        GroundPrimitive._terrainHeights = undefined;
     });
 
     function MockGlobePrimitive(primitive) {


### PR DESCRIPTION
`GroundPrimitives` changed its interface to accept more than one `GeometryInstance` at some point and the dynamic geometries that used them weren't updated.

Not exactly sure how to test this, as I can't verify a primitive has any `GeometryInstance`s once its created by the dynamic geometry updater.

CC #4160 @hpinkos 