### PR TITLE
Invalidate cache variable when Timeline is resized.

### DIFF
--- a/Source/Widgets/Timeline/Timeline.js
+++ b/Source/Widgets/Timeline/Timeline.js
@@ -784,6 +784,7 @@ define([
         this._trackListEle.height = trackListHeight;
         this._makeTics();
 
+        this._lastXPos = undefined;
         this._lastWidth = width;
         this._lastHeight = height;
     };


### PR DESCRIPTION
If `Timeline.updateFromClock` was triggered while timeline had a width of 0, the `_lastXPos` variable would be cached as 0 for all values. If the currentTime was set to the start time after this happened, the value would still be 0 when the timeline was resized but the caching would prevent the scrubber from properly updating the position.  The simple solution is to clear the cache on resize to force a scrubber update.

CC @emackey 