### PR TITLE
Fix where refine is placed in test tilesets

### DIFF
--- a/Specs/Data/Cesium3DTiles/Batched/BatchedNoBuildings/tileset.json
+++ b/Specs/Data/Cesium3DTiles/Batched/BatchedNoBuildings/tileset.json
@@ -21,8 +21,8 @@
     }
   },
   "geometricError": 70,
-  "refine": "add",
   "root": {
+    "refine": "add",
     "boundingVolume": {
       "region": [
         -1.3197004795898053,

--- a/Specs/Data/Cesium3DTiles/Batched/BatchedTranslucent/tileset.json
+++ b/Specs/Data/Cesium3DTiles/Batched/BatchedTranslucent/tileset.json
@@ -21,8 +21,8 @@
     }
   },
   "geometricError": 70,
-  "refine": "add",
   "root": {
+    "refine": "add",
     "boundingVolume": {
       "region": [
         -1.3197004795898053,

--- a/Specs/Data/Cesium3DTiles/Batched/BatchedTranslucentOpaqueMix/tileset.json
+++ b/Specs/Data/Cesium3DTiles/Batched/BatchedTranslucentOpaqueMix/tileset.json
@@ -21,8 +21,8 @@
     }
   },
   "geometricError": 70,
-  "refine": "add",
   "root": {
+    "refine": "add",
     "boundingVolume": {
       "region": [
         -1.3197004795898053,

--- a/Specs/Data/Cesium3DTiles/Batched/BatchedWithBatchTable/tileset.json
+++ b/Specs/Data/Cesium3DTiles/Batched/BatchedWithBatchTable/tileset.json
@@ -29,8 +29,8 @@
     }
   },
   "geometricError": 70,
-  "refine": "add",
   "root": {
+    "refine": "add",
     "boundingVolume": {
       "region": [
         -1.3197004795898053,

--- a/Specs/Data/Cesium3DTiles/Batched/BatchedWithoutBatchTable/tileset.json
+++ b/Specs/Data/Cesium3DTiles/Batched/BatchedWithoutBatchTable/tileset.json
@@ -21,8 +21,8 @@
     }
   },
   "geometricError": 70,
-  "refine": "add",
   "root": {
+    "refine": "add",
     "boundingVolume": {
       "region": [
         -1.3197004795898053,

--- a/Specs/Data/Cesium3DTiles/Composite/Composite/tileset.json
+++ b/Specs/Data/Cesium3DTiles/Composite/Composite/tileset.json
@@ -21,8 +21,8 @@
     }
   },
   "geometricError": 40,
-  "refine": "add",
   "root": {
+    "refine": "add",
     "boundingVolume": {
       "region": [
         -1.3197004795898053,

--- a/Specs/Data/Cesium3DTiles/Composite/CompositeOfComposite/tileset.json
+++ b/Specs/Data/Cesium3DTiles/Composite/CompositeOfComposite/tileset.json
@@ -21,8 +21,8 @@
     }
   },
   "geometricError": 40,
-  "refine": "add",
   "root": {
+    "refine": "add",
     "boundingVolume": {
       "region": [
         -1.3197004795898053,

--- a/Specs/Data/Cesium3DTiles/Instanced/InstancedGltfEmbedded/tileset.json
+++ b/Specs/Data/Cesium3DTiles/Instanced/InstancedGltfEmbedded/tileset.json
@@ -21,8 +21,8 @@
     }
   },
   "geometricError": 40,
-  "refine": "add",
   "root": {
+    "refine": "add",
     "boundingVolume": {
       "region": [
         -1.3197004795898053,

--- a/Specs/Data/Cesium3DTiles/Instanced/InstancedGltfExternal/tileset.json
+++ b/Specs/Data/Cesium3DTiles/Instanced/InstancedGltfExternal/tileset.json
@@ -21,8 +21,8 @@
     }
   },
   "geometricError": 40,
-  "refine": "add",
   "root": {
+    "refine": "add",
     "boundingVolume": {
       "region": [
         -1.3197004795898053,

--- a/Specs/Data/Cesium3DTiles/Instanced/InstancedWithBatchTable/tileset.json
+++ b/Specs/Data/Cesium3DTiles/Instanced/InstancedWithBatchTable/tileset.json
@@ -21,8 +21,8 @@
     }
   },
   "geometricError": 40,
-  "refine": "add",
   "root": {
+    "refine": "add",
     "boundingVolume": {
       "region": [
         -1.3197004795898053,

--- a/Specs/Data/Cesium3DTiles/Instanced/InstancedWithoutBatchTable/tileset.json
+++ b/Specs/Data/Cesium3DTiles/Instanced/InstancedWithoutBatchTable/tileset.json
@@ -21,8 +21,8 @@
     }
   },
   "geometricError": 40,
-  "refine": "add",
   "root": {
+    "refine": "add",
     "boundingVolume": {
       "region": [
         -1.3197004795898053,

--- a/Specs/Data/Cesium3DTiles/Points/PointsConstantColor/tileset.json
+++ b/Specs/Data/Cesium3DTiles/Points/PointsConstantColor/tileset.json
@@ -3,8 +3,8 @@
     "version": "0.0"
   },
   "geometricError": 346.4,
-  "refine": "add",
   "root": {
+    "refine": "add",
     "boundingVolume": {
       "sphere": [
         1215011.9317263428,

--- a/Specs/Data/Cesium3DTiles/Points/PointsNoColor/tileset.json
+++ b/Specs/Data/Cesium3DTiles/Points/PointsNoColor/tileset.json
@@ -3,8 +3,8 @@
     "version": "0.0"
   },
   "geometricError": 346.4,
-  "refine": "add",
   "root": {
+    "refine": "add",
     "boundingVolume": {
       "sphere": [
         1215011.9317263428,

--- a/Specs/Data/Cesium3DTiles/Points/PointsRGB/tileset.json
+++ b/Specs/Data/Cesium3DTiles/Points/PointsRGB/tileset.json
@@ -3,8 +3,8 @@
     "version": "0.0"
   },
   "geometricError": 346.4,
-  "refine": "add",
   "root": {
+    "refine": "add",
     "boundingVolume": {
       "sphere": [
         1215011.9317263428,

--- a/Specs/Data/Cesium3DTiles/Points/PointsRGBA/tileset.json
+++ b/Specs/Data/Cesium3DTiles/Points/PointsRGBA/tileset.json
@@ -3,8 +3,8 @@
     "version": "0.0"
   },
   "geometricError": 346.4,
-  "refine": "add",
   "root": {
+    "refine": "add",
     "boundingVolume": {
       "sphere": [
         1215011.9317263428,


### PR DESCRIPTION
This problem was in the Batched, Composite, Instanced, and Points folders. At least not in the Tilesets folder.