### PR TITLE
Turned RequestScheduler.prioritize off for karma tests

### DIFF
--- a/Specs/Scene/Cesium3DTileSpec.js
+++ b/Specs/Scene/Cesium3DTileSpec.js
@@ -216,4 +216,4 @@ defineSuite([
             expect(tile._debugBoundingVolume).toBeDefined();
         });
     });
-});
+}, 'WebGL');

--- a/Specs/Scene/Tileset3DTileContentSpec.js
+++ b/Specs/Scene/Tileset3DTileContentSpec.js
@@ -53,4 +53,4 @@ defineSuite([
         return Cesium3DTilesTester.tileDestroysBeforeLoad(scene, tilesetOfTilesetsUrl);
     });
 
-});
+}, 'WebGL');

--- a/Specs/karma-main.js
+++ b/Specs/karma-main.js
@@ -54,6 +54,8 @@
         'Specs/customizeJasmine'
     ], function(
         customizeJasmine) {
+                    // Disable request prioritization since it interferes with tests that expect a request to go through immediately.
+                    Cesium.RequestScheduler.prioritize = false;
 
                     customizeJasmine(jasmine.getEnv(), included, excluded, webglValidation, release);
 


### PR DESCRIPTION
From here: https://github.com/AnalyticalGraphicsInc/cesium/issues/3241

> Fix test failures when running with Karma (makes Travis CI fail): npm run test -- --exclude WebGL --browsers Electron --failTaskOnError --suppressPassed

This disables request prioritization since it interferes with tests that expect a request to go through immediately. I made a similar fix before for jasmine tests: https://github.com/AnalyticalGraphicsInc/cesium/blob/3d-tiles/Specs/spec-main.js#L61-L62

@pjcozzi @mramato is there a better alternative here?
