### PR TITLE
3d-tiles: Allow karma release tests to run.

### DIFF
--- a/Specs/karma-main.js
+++ b/Specs/karma-main.js
@@ -51,11 +51,13 @@
         }
 
         require([
+        'Core/RequestScheduler',
         'Specs/customizeJasmine'
     ], function(
+        RequestScheduler,
         customizeJasmine) {
                     // Disable request prioritization since it interferes with tests that expect a request to go through immediately.
-                    Cesium.RequestScheduler.prioritize = false;
+                    RequestScheduler.prioritize = false;
 
                     customizeJasmine(jasmine.getEnv(), included, excluded, webglValidation, release);
 


### PR DESCRIPTION
#4175 provided an initial fix, but it doesn't work for release tests, this works in both debug and release modes.