### PR TITLE
Fix s3 deploy when branches have same prefix as other branch.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -371,7 +371,8 @@ function deployCesium(bucketName, uploadDirectory, cacheControl, done) {
 
     return getCredentials()
     .then(function() {
-        return listAll(s3, bucketName, uploadDirectory, existingBlobs)
+        var prefix = uploadDirectory + '/';
+        return listAll(s3, bucketName, prefix, existingBlobs)
         .then(function() {
             return globby([
                 'Apps/**',
@@ -538,11 +539,11 @@ function getMimeType(filename) {
 }
 
 // get all files currently in bucket asynchronously
-function listAll(s3, bucketName, directory, files, marker) {
+function listAll(s3, bucketName, prefix, files, marker) {
     return s3.listObjectsAsync({
         Bucket : bucketName,
         MaxKeys : 1000,
-        Prefix: directory,
+        Prefix : prefix,
         Marker : marker
     })
     .then(function(data) {
@@ -553,7 +554,7 @@ function listAll(s3, bucketName, directory, files, marker) {
 
         if (data.IsTruncated) {
             // get next page of results
-            return listAll(s3, bucketName, directory, files, files[files.length - 1]);
+            return listAll(s3, bucketName, prefix, files, files[files.length - 1]);
         }
     });
 }


### PR DESCRIPTION
Turns out our deploy step had a nasty bug where branches would collide if they started with the name of another branch, for example `3d-tiles` would try and delete the deployment files for `3d-tiles-transform`.  This is because AWS prefixes need to end with a trailing `/` in order to list only child files.  So `3d-tiles` would return all files from all branches that start with `3d-tiles`, whereas `3d-tiles/` only gets files from
`3d-tiles` as desired.

Ones this is merged down into `3d-tiles` and related branches, all of the CI processes should finally start to pass.