### PR TITLE
Clear RequestScheduler before each test

### DIFF
--- a/Source/Core/RequestScheduler.js
+++ b/Source/Core/RequestScheduler.js
@@ -384,6 +384,8 @@ define([
 
     /**
      * Clears the request scheduler before each spec.
+     *
+     * @private
      */
     RequestScheduler.clearForSpecs = function() {
         activeRequestsByServer = {};

--- a/Source/Core/RequestScheduler.js
+++ b/Source/Core/RequestScheduler.js
@@ -383,6 +383,20 @@ define([
     }
 
     /**
+     * Clears the request scheduler before each spec.
+     */
+    RequestScheduler.clearForSpecs = function() {
+        activeRequestsByServer = {};
+        activeRequests = 0;
+        budgets = [];
+        leftoverRequests = [];
+        deferredRequests = new Queue();
+        stats = {
+            numberOfRequestsThisFrame : 0
+        };
+    };
+
+    /**
      * Specifies the maximum number of requests that can be simultaneously open to a single server.  If this value is higher than
      * the number of requests per server actually allowed by the web browser, Cesium's ability to prioritize requests will be adversely
      * affected.

--- a/Specs/Core/RequestSchedulerSpec.js
+++ b/Specs/Core/RequestSchedulerSpec.js
@@ -448,6 +448,7 @@ defineSuite([
         deferreds[0].resolve();
         deferreds[1].resolve();
 
+        RequestScheduler.debugShowStatistics = false;
         RequestScheduler.resetBudgets();
     });
 });

--- a/Specs/customizeJasmine.js
+++ b/Specs/customizeJasmine.js
@@ -9,7 +9,7 @@ define([
         equalsMethodEqualityTester) {
     "use strict";
 
-    return function (env, includedCategory, excludedCategory, webglValidation, release) {
+    return function (env, includedCategory, excludedCategory, webglValidation, release, RequestScheduler) {
         function defineSuite(deps, name, suite, categories, focus) {
             /*global define,describe,fdescribe*/
             if (typeof suite === 'object' || typeof suite === 'string') {
@@ -43,6 +43,9 @@ define([
             });
         }
 
+        // Disable request prioritization since it interferes with tests that expect a request to go through immediately.
+        RequestScheduler.prioritize = false;
+
         window.fdefineSuite = function(deps, name, suite, categories) {
             defineSuite(deps, name, suite, categories, true);
         };
@@ -72,6 +75,8 @@ define([
 
         window.it = function(description, f, timeout, categories) {
             originalIt(description, function(done) {
+                // Clear the RequestScheduler before for each test in case requests are still active from previous tests
+                RequestScheduler.clearForSpecs();
                 var result = f();
                 when(result, function() {
                     done();

--- a/Specs/karma-main.js
+++ b/Specs/karma-main.js
@@ -59,7 +59,7 @@
                     // Disable request prioritization since it interferes with tests that expect a request to go through immediately.
                     RequestScheduler.prioritize = false;
 
-                    customizeJasmine(jasmine.getEnv(), included, excluded, webglValidation, release);
+                    customizeJasmine(jasmine.getEnv(), included, excluded, webglValidation, release, RequestScheduler);
 
                     var specFiles = Object.keys(__karma__.files).filter(function(file) {
                         return /Spec\.js$/.test(file);

--- a/Specs/karma-main.js
+++ b/Specs/karma-main.js
@@ -56,9 +56,6 @@
     ], function(
         RequestScheduler,
         customizeJasmine) {
-                    // Disable request prioritization since it interferes with tests that expect a request to go through immediately.
-                    RequestScheduler.prioritize = false;
-
                     customizeJasmine(jasmine.getEnv(), included, excluded, webglValidation, release, RequestScheduler);
 
                     var specFiles = Object.keys(__karma__.files).filter(function(file) {

--- a/Specs/spec-main.js
+++ b/Specs/spec-main.js
@@ -139,6 +139,8 @@
 
         window.it = function(description, f, timeout, categories) {
             originalIt(description, function(done) {
+                // Clear the RequestScheduler before for each test in case requests are still active from previous tests
+                Cesium.RequestScheduler.clearForSpecs();
                 var result = f();
                 when(result, function() {
                     done();


### PR DESCRIPTION
Recently a new test was added to master whose request is not manually resolved correctly. There were a bunch of cases like this that I had fixed when I first started the `RequestScheduler`, but it's hard to keep track of all the new changes. Overall the fact that the `RequestScheduler` state persists across tests has been error-prone. So this clears the `RequestScheduler` before each test.