### PR TITLE
loadWithXhr response handling

### DIFF
--- a/Source/Core/loadWithXhr.js
+++ b/Source/Core/loadWithXhr.js
@@ -153,12 +153,20 @@ define([
         xhr.onload = function() {
             if (xhr.status >= 200 && xhr.status < 300) {
                 if (defined(xhr.response)) {
-                    deferred.resolve(xhr.response);
+                    if (responseType === 'json' && typeof xhr.response === 'string') { //IE doesn't support responseType = 'json'
+                        try{
+                            deferred.resolve(JSON.parse(xhr.response));
+                        } catch (e) {
+                            deferred.reject(new RuntimeError('unknown XMLHttpRequest response type.'));
+                        }
+                    } else {
+                        deferred.resolve(xhr.response);
+                    }
                 } else {
                     // busted old browsers.
-                    if (defined(xhr.responseXML) && xhr.responseXML.hasChildNodes()) {
+                    if ((xhr.responseType === '' || xhr.responseType === 'document') && defined(xhr.responseXML) && xhr.responseXML.hasChildNodes()) {
                         deferred.resolve(xhr.responseXML);
-                    } else if (defined(xhr.responseText)) {
+                    } else if ((xhr.responseType === '' || xhr.responseType === 'text') && defined(xhr.responseText)) {
                         deferred.resolve(xhr.responseText);
                     } else {
                         deferred.reject(new RuntimeError('unknown XMLHttpRequest response type.'));

--- a/Source/Core/loadWithXhr.js
+++ b/Source/Core/loadWithXhr.js
@@ -1,18 +1,18 @@
 /*global define*/
 define([
-        '../ThirdParty/when',
-        './defaultValue',
-        './defined',
-        './DeveloperError',
-        './RequestErrorEvent',
-        './RuntimeError'
-    ], function(
-        when,
-        defaultValue,
-        defined,
-        DeveloperError,
-        RequestErrorEvent,
-        RuntimeError) {
+    '../ThirdParty/when',
+    './defaultValue',
+    './defined',
+    './DeveloperError',
+    './RequestErrorEvent',
+    './RuntimeError'
+], function(
+    when,
+    defaultValue,
+    defined,
+    DeveloperError,
+    RequestErrorEvent,
+    RuntimeError) {
     'use strict';
 
     /**
@@ -43,7 +43,7 @@ define([
      * }).otherwise(function(error) {
      *     // an error occurred
      * });
-     * 
+     *
      * @see loadArrayBuffer
      * @see loadBlob
      * @see loadJson
@@ -102,23 +102,23 @@ define([
         var data = dataUriRegexResult[3];
 
         switch (responseType) {
-        case '':
-        case 'text':
-            return decodeDataUriText(isBase64, data);
-        case 'arraybuffer':
-            return decodeDataUriArrayBuffer(isBase64, data);
-        case 'blob':
-            var buffer = decodeDataUriArrayBuffer(isBase64, data);
-            return new Blob([buffer], {
-                type : mimeType
-            });
-        case 'document':
-            var parser = new DOMParser();
-            return parser.parseFromString(decodeDataUriText(isBase64, data), mimeType);
-        case 'json':
-            return JSON.parse(decodeDataUriText(isBase64, data));
-        default:
-            throw new DeveloperError('Unhandled responseType: ' + responseType);
+            case '':
+            case 'text':
+                return decodeDataUriText(isBase64, data);
+            case 'arraybuffer':
+                return decodeDataUriArrayBuffer(isBase64, data);
+            case 'blob':
+                var buffer = decodeDataUriArrayBuffer(isBase64, data);
+                return new Blob([buffer], {
+                    type : mimeType
+                });
+            case 'document':
+                var parser = new DOMParser();
+                return parser.parseFromString(decodeDataUriText(isBase64, data), mimeType);
+            case 'json':
+                return JSON.parse(decodeDataUriText(isBase64, data));
+            default:
+                throw new DeveloperError('Unhandled responseType: ' + responseType);
         }
     }
 
@@ -139,7 +139,7 @@ define([
         xhr.open(method, url, true);
 
         if (defined(headers)) {
-            for ( var key in headers) {
+            for (var key in headers) {
                 if (headers.hasOwnProperty(key)) {
                     xhr.setRequestHeader(key, headers[key]);
                 }
@@ -154,10 +154,10 @@ define([
             if (xhr.status >= 200 && xhr.status < 300) {
                 if (defined(xhr.response)) {
                     if (responseType === 'json' && typeof xhr.response === 'string') { //IE doesn't support responseType = 'json'
-                        try{
+                        try {
                             deferred.resolve(JSON.parse(xhr.response));
                         } catch (e) {
-                            deferred.reject(new RuntimeError('unknown XMLHttpRequest response type.'));
+                            deferred.reject(e);
                         }
                     } else {
                         deferred.resolve(xhr.response);

--- a/Specs/Core/loadWithXhrSpec.js
+++ b/Specs/Core/loadWithXhrSpec.js
@@ -158,7 +158,66 @@ defineSuite([
         });
     });
 
-    describe('URL loading', function() {
+    describe('URL loading using XHR', function() {
+        describe('returns a promise that rejects when the request', function() {
+            it('results in an HTTP status code greater than or equal to 300', function() {
+                return loadWithXhr({
+                    url : 'http://example.invalid'
+                }).then(function(resolvedValue) {
+                    expect(resolvedValue).toBeUndefined();
+                }, function(rejectedError) {
+                    expect(rejectedError instanceof RequestErrorEvent).toBe(true);
+                });
+            });
+
+            it('loads an invalid JSON string response as JSON with a json responseType', function() {
+                return loadWithXhr({
+                    url : 'Data/htmlString.txt',
+                    responseType : 'json'
+                }).then(function(resolvedValue) {
+                    expect(resolvedValue).toBeUndefined();
+                }, function(rejectedError) {
+                    expect(rejectedError instanceof RuntimeError).toBe(true);
+                });
+            });
+        });
+
+        describe('returns a promise that resolves when the request loads', function() {
+            it('a non-null response with default responseType', function() {
+                return loadWithXhr({
+                    url : 'Data/Models/Box/ReadMe.txt'
+                }).then(function(resolvedValue) {
+                    expect(resolvedValue).toBe('CesiumBoxTest-NoTechnique.gltf is a modified glTF that has techniques, shaders & programs removed.');
+                }, function(rejectedError) {
+                    expect(rejectedError).toBeUndefined();
+                });
+            });
+
+            it('a non-null response with a browser-supported responseType', function() {
+                return loadWithXhr({
+                    url : 'Data/Models/Box/ReadMe.txt',
+                    responseType : 'text'
+                }).then(function(resolvedValue) {
+                    expect(resolvedValue).toBe('CesiumBoxTest-NoTechnique.gltf is a modified glTF that has techniques, shaders & programs removed.');
+                }, function(rejectedError) {
+                    expect(rejectedError).toBeUndefined();
+                });
+            });
+
+            it('a valid JSON string response as JSON with a json responseType', function() {
+                return loadWithXhr({
+                    url : 'Data/jsonString.txt',
+                    responseType : 'json'
+                }).then(function(resolvedValue) {
+                    expect(resolvedValue).toEqual(jasmine.objectContaining({hello : 'world'}));
+                }, function(rejectedError) {
+                    expect(rejectedError).toBeUndefined();
+                });
+            });
+        });
+    });
+
+    describe('URL loading using mocked XHR', function() {
         var fakeXHR;
 
         beforeEach(function() {
@@ -247,157 +306,9 @@ defineSuite([
                 expect(resolvedValue).toBeUndefined();
                 expect(rejectedError instanceof RequestErrorEvent).toBe(true);
             });
-
-            it('results in an HTTP status code greater than or equal to 300', function() {
-                var promise = loadWithXhr({
-                    url : 'http://example.invalid'
-                });
-
-                expect(promise).toBeDefined();
-
-                var resolvedValue;
-                var rejectedError;
-                promise.then(function(value) {
-                    resolvedValue = value;
-                }, function(error) {
-                    rejectedError = error;
-                });
-
-                expect(resolvedValue).toBeUndefined();
-                expect(rejectedError).toBeUndefined();
-
-                fakeXHR.simulateHttpError(300);
-                expect(resolvedValue).toBeUndefined();
-                expect(rejectedError instanceof RequestErrorEvent).toBe(true);
-            });
-
-            it('loads an invalid JSON string response with a json responseType', function() {
-                var promise = loadWithXhr({
-                    url : 'http://example.invalid',
-                    responseType : 'json'
-                });
-
-                expect(promise).toBeDefined();
-
-                var resolvedValue;
-                var rejectedError;
-                promise.then(function(value) {
-                    resolvedValue = value;
-                }, function(error) {
-                    rejectedError = error;
-                });
-
-                expect(resolvedValue).toBeUndefined();
-                expect(rejectedError).toBeUndefined();
-
-                var response = '<h1>Hello, World!</h1>';
-                fakeXHR.simulateLoad(response);
-                expect(resolvedValue).toBeUndefined();
-                expect(rejectedError instanceof SyntaxError).toBe(true);
-            });
-
-            it('loads a null response with an unknown XMLHttpRequest response type', function() {
-                var promise = loadWithXhr({
-                    url : 'http://example.invalid',
-                    responseType : 'json'
-                });
-
-                expect(promise).toBeDefined();
-
-                var resolvedValue;
-                var rejectedError;
-                promise.then(function(value) {
-                    resolvedValue = value;
-                }, function(error) {
-                    rejectedError = error;
-                });
-
-                expect(resolvedValue).toBeUndefined();
-                expect(rejectedError).toBeUndefined();
-
-                fakeXHR.simulateLoad();
-                expect(resolvedValue).toBeUndefined();
-                expect(rejectedError instanceof RuntimeError).toBe(true);
-                expect(rejectedError.message).toBe('unknown XMLHttpRequest response type.');
-            });
         });
 
         describe('returns a promise that resolves when the request loads', function() {
-            it('a non-null response', function() {
-                var promise = loadWithXhr({
-                    url : 'http://example.invalid'
-                });
-
-                expect(promise).toBeDefined();
-
-                var resolvedValue;
-                var rejectedError;
-                promise.then(function(value) {
-                    resolvedValue = value;
-                }, function(error) {
-                    rejectedError = error;
-                });
-
-                expect(resolvedValue).toBeUndefined();
-                expect(rejectedError).toBeUndefined();
-
-                var response = 'hello world';
-                fakeXHR.simulateLoad(response);
-                expect(resolvedValue).toEqual(response);
-                expect(rejectedError).toBeUndefined();
-            });
-
-            it('a valid JSON string response as JSON with a json responseType', function() {
-                var promise = loadWithXhr({
-                    url : 'http://example.invalid',
-                    responseType : 'json'
-                });
-
-                expect(promise).toBeDefined();
-
-                var resolvedValue;
-                var rejectedError;
-                promise.then(function(value) {
-                    resolvedValue = value;
-                }, function(error) {
-                    rejectedError = error;
-                });
-
-                expect(resolvedValue).toBeUndefined();
-                expect(rejectedError).toBeUndefined();
-
-                var jsonResponse = {"hello" : "world"};
-                var stringResponse = JSON.stringify(jsonResponse);
-                fakeXHR.simulateLoad(stringResponse);
-                expect(resolvedValue).toEqual(jsonResponse);
-                expect(rejectedError).toBeUndefined();
-            });
-
-            it('a valid JSON response as JSON with a json responseType', function() {
-                var promise = loadWithXhr({
-                    url : 'http://example.invalid',
-                    responseType : 'json'
-                });
-
-                expect(promise).toBeDefined();
-
-                var resolvedValue;
-                var rejectedError;
-                promise.then(function(value) {
-                    resolvedValue = value;
-                }, function(error) {
-                    rejectedError = error;
-                });
-
-                expect(resolvedValue).toBeUndefined();
-                expect(rejectedError).toBeUndefined();
-
-                var response = {"hello" : "world"};
-                fakeXHR.simulateLoad(response);
-                expect(resolvedValue).toEqual(response);
-                expect(rejectedError).toBeUndefined();
-            });
-
             it('a null response with a \'\' responseType and non-null responseXML with child nodes', function() {
                 var promise = loadWithXhr({
                     url : 'http://example.invalid',

--- a/Specs/Core/loadWithXhrSpec.js
+++ b/Specs/Core/loadWithXhrSpec.js
@@ -223,13 +223,6 @@ defineSuite([
 
         beforeEach(function() {
             fakeXHR = jasmine.createSpyObj('XMLHttpRequest', ['send', 'open', 'setRequestHeader', 'abort', 'getAllResponseHeaders']);
-            fakeXHR.simulateLoad = function(response) {
-                fakeXHR.status = 200;
-                fakeXHR.response = response;
-                if (typeof fakeXHR.onload === 'function') {
-                    fakeXHR.onload();
-                }
-            };
             fakeXHR.simulateError = function() {
                 fakeXHR.response = '';
                 if (typeof fakeXHR.onerror === 'function') {

--- a/Specs/Core/loadWithXhrSpec.js
+++ b/Specs/Core/loadWithXhrSpec.js
@@ -1,11 +1,21 @@
 /*global defineSuite*/
 defineSuite([
-        'Core/loadWithXhr',
-        'Core/loadImage'
-    ], function(
-        loadWithXhr,
-        loadImage) {
+    'Core/loadWithXhr',
+    'Core/loadImage',
+    'Core/RequestErrorEvent',
+    'Core/RuntimeError'
+], function(
+    loadWithXhr,
+    loadImage,
+    RequestErrorEvent,
+    RuntimeError) {
     'use strict';
+
+    it('throws with no url', function() {
+        expect(function() {
+            loadWithXhr();
+        }).toThrowDeveloperError();
+    });
 
     describe('data URI loading', function() {
         it('can load URI escaped text with default response type', function() {
@@ -33,7 +43,7 @@ defineSuite([
             });
         });
 
-        it ('can load Base64 encoded text with responseType=text', function() {
+        it('can load Base64 encoded text with responseType=text', function() {
             return loadWithXhr({
                 url : 'data:text/plain;base64,SGVsbG8sIFdvcmxkIQ==',
                 responseType : 'text'
@@ -133,17 +143,363 @@ defineSuite([
             });
         });
 
-        xit('can support 2xx HTTP status (other than 200)', function(){
+        xit('can support 2xx HTTP status (other than 200)', function() {
             return loadWithXhr({
-                method: 'POST',
-                url: 'http://jsonplaceholder.typicode.com/posts',
-                data: {
-                    title: 'foo',
-                    body: 'bar',
-                    userId: 1
+                method : 'POST',
+                url : 'http://jsonplaceholder.typicode.com/posts',
+                data : {
+                    title : 'foo',
+                    body : 'bar',
+                    userId : 1
                 }
-            }).then(function(result){
+            }).then(function(result) {
                 expect(JSON.parse(result).id).toEqual(101);
+            });
+        });
+    });
+
+    describe('URL loading', function() {
+        var fakeXHR;
+
+        beforeEach(function() {
+            fakeXHR = jasmine.createSpyObj('XMLHttpRequest', ['send', 'open', 'setRequestHeader', 'abort', 'getAllResponseHeaders']);
+            fakeXHR.simulateLoad = function(response) {
+                fakeXHR.status = 200;
+                fakeXHR.response = response;
+                if (typeof fakeXHR.onload === 'function') {
+                    fakeXHR.onload();
+                }
+            };
+            fakeXHR.simulateError = function() {
+                fakeXHR.response = '';
+                if (typeof fakeXHR.onerror === 'function') {
+                    fakeXHR.onerror();
+                }
+            };
+            fakeXHR.simulateHttpError = function(statusCode, response) {
+                fakeXHR.status = statusCode;
+                fakeXHR.response = response;
+                if (typeof fakeXHR.onload === 'function') {
+                    fakeXHR.onload();
+                }
+            };
+            fakeXHR.simulateResponseXMLLoad = function(responseXML) {
+                fakeXHR.status = 200;
+                fakeXHR.responseXML = responseXML;
+                if (typeof fakeXHR.onload === 'function') {
+                    fakeXHR.onload();
+                }
+            };
+            fakeXHR.simulateResponseTextLoad = function(responseText) {
+                fakeXHR.status = 200;
+                fakeXHR.responseText = responseText;
+                if (typeof fakeXHR.onload === 'function') {
+                    fakeXHR.onload();
+                }
+            };
+
+            spyOn(window, 'XMLHttpRequest').and.returnValue(fakeXHR);
+        });
+
+        describe('returns a promise that rejects when the request', function() {
+            it('errors', function() {
+                var promise = loadWithXhr({
+                    url : 'http://example.invalid'
+                });
+
+                expect(promise).toBeDefined();
+
+                var resolvedValue;
+                var rejectedError;
+                promise.then(function(value) {
+                    resolvedValue = value;
+                }, function(error) {
+                    rejectedError = error;
+                });
+
+                expect(resolvedValue).toBeUndefined();
+                expect(rejectedError).toBeUndefined();
+
+                fakeXHR.simulateError();
+                expect(resolvedValue).toBeUndefined();
+                expect(rejectedError instanceof RequestErrorEvent).toBe(true);
+            });
+
+            it('results in an HTTP status code less than 200', function() {
+                var promise = loadWithXhr({
+                    url : 'http://example.invalid'
+                });
+
+                expect(promise).toBeDefined();
+
+                var resolvedValue;
+                var rejectedError;
+                promise.then(function(value) {
+                    resolvedValue = value;
+                }, function(error) {
+                    rejectedError = error;
+                });
+
+                expect(resolvedValue).toBeUndefined();
+                expect(rejectedError).toBeUndefined();
+
+                fakeXHR.simulateHttpError(199);
+                expect(resolvedValue).toBeUndefined();
+                expect(rejectedError instanceof RequestErrorEvent).toBe(true);
+            });
+
+            it('results in an HTTP status code greater than or equal to 300', function() {
+                var promise = loadWithXhr({
+                    url : 'http://example.invalid'
+                });
+
+                expect(promise).toBeDefined();
+
+                var resolvedValue;
+                var rejectedError;
+                promise.then(function(value) {
+                    resolvedValue = value;
+                }, function(error) {
+                    rejectedError = error;
+                });
+
+                expect(resolvedValue).toBeUndefined();
+                expect(rejectedError).toBeUndefined();
+
+                fakeXHR.simulateHttpError(300);
+                expect(resolvedValue).toBeUndefined();
+                expect(rejectedError instanceof RequestErrorEvent).toBe(true);
+            });
+
+            it('loads an invalid JSON string response with a json responseType', function() {
+                var promise = loadWithXhr({
+                    url : 'http://example.invalid',
+                    responseType : 'json'
+                });
+
+                expect(promise).toBeDefined();
+
+                var resolvedValue;
+                var rejectedError;
+                promise.then(function(value) {
+                    resolvedValue = value;
+                }, function(error) {
+                    rejectedError = error;
+                });
+
+                expect(resolvedValue).toBeUndefined();
+                expect(rejectedError).toBeUndefined();
+
+                var response = '<h1>Hello, World!</h1>';
+                fakeXHR.simulateLoad(response);
+                expect(resolvedValue).toBeUndefined();
+                expect(rejectedError instanceof SyntaxError).toBe(true);
+            });
+
+            it('loads a null response with an unknown XMLHttpRequest response type', function() {
+                var promise = loadWithXhr({
+                    url : 'http://example.invalid',
+                    responseType : 'json'
+                });
+
+                expect(promise).toBeDefined();
+
+                var resolvedValue;
+                var rejectedError;
+                promise.then(function(value) {
+                    resolvedValue = value;
+                }, function(error) {
+                    rejectedError = error;
+                });
+
+                expect(resolvedValue).toBeUndefined();
+                expect(rejectedError).toBeUndefined();
+
+                fakeXHR.simulateLoad();
+                expect(resolvedValue).toBeUndefined();
+                expect(rejectedError instanceof RuntimeError).toBe(true);
+                expect(rejectedError.message).toBe('unknown XMLHttpRequest response type.');
+            });
+        });
+
+        describe('returns a promise that resolves when the request loads', function() {
+            it('a non-null response', function() {
+                var promise = loadWithXhr({
+                    url : 'http://example.invalid'
+                });
+
+                expect(promise).toBeDefined();
+
+                var resolvedValue;
+                var rejectedError;
+                promise.then(function(value) {
+                    resolvedValue = value;
+                }, function(error) {
+                    rejectedError = error;
+                });
+
+                expect(resolvedValue).toBeUndefined();
+                expect(rejectedError).toBeUndefined();
+
+                var response = 'hello world';
+                fakeXHR.simulateLoad(response);
+                expect(resolvedValue).toEqual(response);
+                expect(rejectedError).toBeUndefined();
+            });
+
+            it('a valid JSON string response as JSON with a json responseType', function() {
+                var promise = loadWithXhr({
+                    url : 'http://example.invalid',
+                    responseType : 'json'
+                });
+
+                expect(promise).toBeDefined();
+
+                var resolvedValue;
+                var rejectedError;
+                promise.then(function(value) {
+                    resolvedValue = value;
+                }, function(error) {
+                    rejectedError = error;
+                });
+
+                expect(resolvedValue).toBeUndefined();
+                expect(rejectedError).toBeUndefined();
+
+                var jsonResponse = {"hello" : "world"};
+                var stringResponse = JSON.stringify(jsonResponse);
+                fakeXHR.simulateLoad(stringResponse);
+                expect(resolvedValue).toEqual(jsonResponse);
+                expect(rejectedError).toBeUndefined();
+            });
+
+            it('a valid JSON response as JSON with a json responseType', function() {
+                var promise = loadWithXhr({
+                    url : 'http://example.invalid',
+                    responseType : 'json'
+                });
+
+                expect(promise).toBeDefined();
+
+                var resolvedValue;
+                var rejectedError;
+                promise.then(function(value) {
+                    resolvedValue = value;
+                }, function(error) {
+                    rejectedError = error;
+                });
+
+                expect(resolvedValue).toBeUndefined();
+                expect(rejectedError).toBeUndefined();
+
+                var response = {"hello" : "world"};
+                fakeXHR.simulateLoad(response);
+                expect(resolvedValue).toEqual(response);
+                expect(rejectedError).toBeUndefined();
+            });
+
+            it('a null response with a \'\' responseType and non-null responseXML with child nodes', function() {
+                var promise = loadWithXhr({
+                    url : 'http://example.invalid',
+                    responseType : ''
+                });
+
+                expect(promise).toBeDefined();
+
+                var resolvedValue;
+                var rejectedError;
+                promise.then(function(value) {
+                    resolvedValue = value;
+                }, function(error) {
+                    rejectedError = error;
+                });
+
+                expect(resolvedValue).toBeUndefined();
+                expect(rejectedError).toBeUndefined();
+
+                var responseXML = {
+                    hasChildNodes : jasmine.createSpy('hasChildNodes').and.returnValue(true)
+                };
+                fakeXHR.simulateResponseXMLLoad(responseXML);
+                expect(resolvedValue).toEqual(responseXML);
+                expect(rejectedError).toBeUndefined();
+            });
+
+            it('a null response with a document responseType and non-null responseXML with child nodes', function() {
+                var promise = loadWithXhr({
+                    url : 'http://example.invalid',
+                    responseType : 'document'
+                });
+
+                expect(promise).toBeDefined();
+
+                var resolvedValue;
+                var rejectedError;
+                promise.then(function(value) {
+                    resolvedValue = value;
+                }, function(error) {
+                    rejectedError = error;
+                });
+
+                expect(resolvedValue).toBeUndefined();
+                expect(rejectedError).toBeUndefined();
+
+                var responseXML = {
+                    hasChildNodes : jasmine.createSpy('hasChildNodes').and.returnValue(true)
+                };
+                fakeXHR.simulateResponseXMLLoad(responseXML);
+                expect(resolvedValue).toEqual(responseXML);
+                expect(rejectedError).toBeUndefined();
+            });
+
+            it('a null response with a \'\' responseType and non-null responseText', function() {
+                var promise = loadWithXhr({
+                    url : 'http://example.invalid',
+                    responseType : ''
+                });
+
+                expect(promise).toBeDefined();
+
+                var resolvedValue;
+                var rejectedError;
+                promise.then(function(value) {
+                    resolvedValue = value;
+                }, function(error) {
+                    rejectedError = error;
+                });
+
+                expect(resolvedValue).toBeUndefined();
+                expect(rejectedError).toBeUndefined();
+
+                var responseText = 'hello world';
+                fakeXHR.simulateResponseTextLoad(responseText);
+                expect(resolvedValue).toEqual(responseText);
+                expect(rejectedError).toBeUndefined();
+            });
+
+            it('a null response with a text responseType and non-null responseText', function() {
+                var promise = loadWithXhr({
+                    url : 'http://example.invalid',
+                    responseType : 'text'
+                });
+
+                expect(promise).toBeDefined();
+
+                var resolvedValue;
+                var rejectedError;
+                promise.then(function(value) {
+                    resolvedValue = value;
+                }, function(error) {
+                    rejectedError = error;
+                });
+
+                expect(resolvedValue).toBeUndefined();
+                expect(rejectedError).toBeUndefined();
+
+                var responseText = 'hello world';
+                fakeXHR.simulateResponseTextLoad(responseText);
+                expect(resolvedValue).toEqual(responseText);
+                expect(rejectedError).toBeUndefined();
             });
         });
     });

--- a/Specs/Core/loadWithXhrSpec.js
+++ b/Specs/Core/loadWithXhrSpec.js
@@ -163,10 +163,10 @@ defineSuite([
             it('results in an HTTP status code greater than or equal to 300', function() {
                 return loadWithXhr({
                     url : 'http://example.invalid'
-                }).then(function(resolvedValue) {
-                    expect(resolvedValue).toBeUndefined();
-                }, function(rejectedError) {
-                    expect(rejectedError instanceof RequestErrorEvent).toBe(true);
+                }).then(function() {
+                    fail('expected promise to reject');
+                }).otherwise(function(err) {
+                    expect(err instanceof RequestErrorEvent).toBe(true);
                 });
             });
 
@@ -174,11 +174,11 @@ defineSuite([
                 return loadWithXhr({
                     url : 'Data/htmlString.txt',
                     responseType : 'json'
-                }).then(function(resolvedValue) {
-                    expect(resolvedValue).toBeUndefined();
-                }, function(rejectedError) {
-                    expect(rejectedError).toBeDefined();
-                    expect(rejectedError instanceof Error).toBe(true);
+                }).then(function() {
+                    fail('expected promise to reject');
+                }).otherwise(function(err) {
+                    expect(err).toBeDefined();
+                    expect(err instanceof Error).toBe(true);
                 });
             });
         });
@@ -187,10 +187,8 @@ defineSuite([
             it('a non-null response with default responseType', function() {
                 return loadWithXhr({
                     url : 'Data/Models/Box/ReadMe.txt'
-                }).then(function(resolvedValue) {
-                    expect(resolvedValue).toBe('CesiumBoxTest-NoTechnique.gltf is a modified glTF that has techniques, shaders & programs removed.');
-                }, function(rejectedError) {
-                    expect(rejectedError).toBeUndefined();
+                }).then(function(result) {
+                    expect(result).toBe('CesiumBoxTest-NoTechnique.gltf is a modified glTF that has techniques, shaders & programs removed.');
                 });
             });
 
@@ -198,10 +196,8 @@ defineSuite([
                 return loadWithXhr({
                     url : 'Data/Models/Box/ReadMe.txt',
                     responseType : 'text'
-                }).then(function(resolvedValue) {
-                    expect(resolvedValue).toBe('CesiumBoxTest-NoTechnique.gltf is a modified glTF that has techniques, shaders & programs removed.');
-                }, function(rejectedError) {
-                    expect(rejectedError).toBeUndefined();
+                }).then(function(result) {
+                    expect(result).toBe('CesiumBoxTest-NoTechnique.gltf is a modified glTF that has techniques, shaders & programs removed.');
                 });
             });
 
@@ -209,10 +205,8 @@ defineSuite([
                 return loadWithXhr({
                     url : 'Data/jsonString.txt',
                     responseType : 'json'
-                }).then(function(resolvedValue) {
-                    expect(resolvedValue).toEqual(jasmine.objectContaining({hello : 'world'}));
-                }, function(rejectedError) {
-                    expect(rejectedError).toBeUndefined();
+                }).then(function(result) {
+                    expect(result).toEqual(jasmine.objectContaining({hello : 'world'}));
                 });
             });
         });
@@ -266,7 +260,7 @@ defineSuite([
                 var rejectedError;
                 promise.then(function(value) {
                     resolvedValue = value;
-                }, function(error) {
+                }).otherwise(function (error) {
                     rejectedError = error;
                 });
 
@@ -289,7 +283,7 @@ defineSuite([
                 var rejectedError;
                 promise.then(function(value) {
                     resolvedValue = value;
-                }, function(error) {
+                }).otherwise(function (error) {
                     rejectedError = error;
                 });
 
@@ -315,7 +309,7 @@ defineSuite([
                 var rejectedError;
                 promise.then(function(value) {
                     resolvedValue = value;
-                }, function(error) {
+                }).otherwise(function (error) {
                     rejectedError = error;
                 });
 
@@ -342,7 +336,7 @@ defineSuite([
                 var rejectedError;
                 promise.then(function(value) {
                     resolvedValue = value;
-                }, function(error) {
+                }).otherwise(function (error) {
                     rejectedError = error;
                 });
 
@@ -369,7 +363,7 @@ defineSuite([
                 var rejectedError;
                 promise.then(function(value) {
                     resolvedValue = value;
-                }, function(error) {
+                }).otherwise(function (error) {
                     rejectedError = error;
                 });
 
@@ -394,7 +388,7 @@ defineSuite([
                 var rejectedError;
                 promise.then(function(value) {
                     resolvedValue = value;
-                }, function(error) {
+                }).otherwise(function (error) {
                     rejectedError = error;
                 });
 

--- a/Specs/Core/loadWithXhrSpec.js
+++ b/Specs/Core/loadWithXhrSpec.js
@@ -170,14 +170,15 @@ defineSuite([
                 });
             });
 
-            it('loads an invalid JSON string response as JSON with a json responseType', function() {
+            it('loads an invalid JSON string response with a json responseType', function() {
                 return loadWithXhr({
                     url : 'Data/htmlString.txt',
                     responseType : 'json'
                 }).then(function(resolvedValue) {
                     expect(resolvedValue).toBeUndefined();
                 }, function(rejectedError) {
-                    expect(rejectedError instanceof RuntimeError).toBe(true);
+                    expect(rejectedError).toBeDefined();
+                    expect(rejectedError instanceof Error).toBe(true);
                 });
             });
         });

--- a/Specs/Data/htmlString.txt
+++ b/Specs/Data/htmlString.txt
@@ -1,0 +1,1 @@
+<html>Hello, world!</html>

--- a/Specs/Data/jsonString.txt
+++ b/Specs/Data/jsonString.txt
@@ -1,0 +1,1 @@
+{"hello": "world"}


### PR DESCRIPTION
Add a workaround for `xhr.responseType = 'json'` for IE, which doesn't support that type. Additionally, add checks before attempting to access `xhr.responseXML` or `xhr.responseText`, which throws if `responseType` isn't an appropriate type.

`loadWithXhrSpec` currently only has tests for data URI loading. Is there a good way to test sending/loading of data without passing an actual URL? Mocking/spying doesn't seem possible as is since the request isn't publicly accessible.