### PR TITLE
Fix sortRequires task's newlines

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -21,6 +21,7 @@ var gulpInsert = require('gulp-insert');
 var gulpZip = require('gulp-zip');
 var gulpRename = require('gulp-rename');
 var gulpReplace = require('gulp-replace');
+var os = require('os');
 var Promise = require('bluebird');
 var requirejs = require('requirejs');
 var karma = require('karma').Server;
@@ -796,15 +797,15 @@ gulp.task('sortRequires', function() {
 
             var outputNames = ']';
             if (sortedNames.length > 0) {
-                outputNames = '\r\n        ' +
-                              sortedNames.join(',\r\n        ') +
-                              '\r\n    ]';
+                outputNames = os.EOL + '        ' +
+                              sortedNames.join(',' + os.EOL + '        ') +
+                              os.EOL + '    ]';
             }
 
             var outputIdentifiers = '(';
             if (sortedIdentifiers.length > 0) {
-                outputIdentifiers = '(\r\n        ' +
-                                    sortedIdentifiers.join(',\r\n        ');
+                outputIdentifiers = '(' + os.EOL + '        ' +
+                                    sortedIdentifiers.join(',' + os.EOL + '        ');
             }
 
             contents = result[1] +


### PR DESCRIPTION
As @mramato pointed out, this gulp task is currently sets end of line characters as Windows specific newlines. This PR uses Node's OS module to ensure system dependent newlines are used.