### PR TITLE
Cesium3DTile check for ready promise after request is made 

### DIFF
--- a/Source/Scene/Batched3DModel3DTileContent.js
+++ b/Source/Scene/Batched3DModel3DTileContent.js
@@ -165,7 +165,9 @@ define([
                 that.state = Cesium3DTileContentState.FAILED;
                 that._readyPromise.reject(error);
             });
+            return true;
         }
+        return false;
     };
 
     /**

--- a/Source/Scene/Batched3DModel3DTileContent.js
+++ b/Source/Scene/Batched3DModel3DTileContent.js
@@ -154,20 +154,22 @@ define([
             type : RequestType.TILES3D,
             distance : distance
         }));
-        if (defined(promise)) {
-            this.state = Cesium3DTileContentState.LOADING;
-            promise.then(function(arrayBuffer) {
-                if (that.isDestroyed()) {
-                    return when.reject('tileset is destroyed');
-                }
-                that.initialize(arrayBuffer);
-            }).otherwise(function(error) {
-                that.state = Cesium3DTileContentState.FAILED;
-                that._readyPromise.reject(error);
-            });
-            return true;
+
+        if (!defined(promise)) {
+            return false;
         }
-        return false;
+
+        this.state = Cesium3DTileContentState.LOADING;
+        promise.then(function(arrayBuffer) {
+            if (that.isDestroyed()) {
+                return when.reject('tileset is destroyed');
+            }
+            that.initialize(arrayBuffer);
+        }).otherwise(function(error) {
+            that.state = Cesium3DTileContentState.FAILED;
+            that._readyPromise.reject(error);
+        });
+        return true;
     };
 
     /**

--- a/Source/Scene/Cesium3DTile.js
+++ b/Source/Scene/Cesium3DTile.js
@@ -202,7 +202,9 @@ define([
 
         this._createContent = createContent;
         this._content = createContent();
-        addContentReadyPromise(this);
+        if (!hasContent && !hasTilesetContent) {
+            addContentReadyPromise(this);
+        }
 
         this._requestServer = requestServer;
 
@@ -408,7 +410,9 @@ define([
      * @private
      */
     Cesium3DTile.prototype.requestContent = function() {
-        this._content.request();
+        if (this._content.request()) {
+            addContentReadyPromise(this);
+        }
     };
 
     /**
@@ -440,7 +444,9 @@ define([
 
         this._content = this._content && this._content.destroy();
         this._content = this._createContent();
-        addContentReadyPromise(this);
+        if (!this.hasContent && !this.hasTilesetContent) {
+            addContentReadyPromise(this);
+        }
 
         this.replacementNode = undefined;
 

--- a/Source/Scene/Cesium3DTileContent.js
+++ b/Source/Scene/Cesium3DTileContent.js
@@ -159,6 +159,8 @@ define([
      * not part of the public Cesium API.
      * </p>
      *
+     * @returns {Boolean} Whether the request was initiated. May be false if the RequestScheduler is full.
+     *
      * @private
      */
     Cesium3DTileContent.prototype.request = function() {

--- a/Source/Scene/Composite3DTileContent.js
+++ b/Source/Scene/Composite3DTileContent.js
@@ -150,20 +150,22 @@ define([
             type : RequestType.TILES3D,
             distance : distance
         }));
-        if (defined(promise)) {
-            this.state = Cesium3DTileContentState.LOADING;
-            promise.then(function(arrayBuffer) {
-                if (that.isDestroyed()) {
-                    return when.reject('tileset is destroyed');
-                }
-                that.initialize(arrayBuffer);
-            }).otherwise(function(error) {
-                that.state = Cesium3DTileContentState.FAILED;
-                that._readyPromise.reject(error);
-            });
-            return true;
+
+        if (!defined(promise)) {
+            return false;
         }
-        return false;
+
+        this.state = Cesium3DTileContentState.LOADING;
+        promise.then(function(arrayBuffer) {
+            if (that.isDestroyed()) {
+                return when.reject('tileset is destroyed');
+            }
+            that.initialize(arrayBuffer);
+        }).otherwise(function(error) {
+            that.state = Cesium3DTileContentState.FAILED;
+            that._readyPromise.reject(error);
+        });
+        return true;
     };
 
     /**

--- a/Source/Scene/Composite3DTileContent.js
+++ b/Source/Scene/Composite3DTileContent.js
@@ -161,7 +161,9 @@ define([
                 that.state = Cesium3DTileContentState.FAILED;
                 that._readyPromise.reject(error);
             });
+            return true;
         }
+        return false;
     };
 
     /**

--- a/Source/Scene/Instanced3DModel3DTileContent.js
+++ b/Source/Scene/Instanced3DModel3DTileContent.js
@@ -178,7 +178,9 @@ define([
                 that.state = Cesium3DTileContentState.FAILED;
                 that._readyPromise.reject(error);
             });
+            return true;
         }
+        return false;
     };
 
     /**

--- a/Source/Scene/Instanced3DModel3DTileContent.js
+++ b/Source/Scene/Instanced3DModel3DTileContent.js
@@ -167,20 +167,22 @@ define([
             type : RequestType.TILES3D,
             distance : distance
         }));
-        if (defined(promise)) {
-            this.state = Cesium3DTileContentState.LOADING;
-            promise.then(function(arrayBuffer) {
-                if (that.isDestroyed()) {
-                    return when.reject('tileset is destroyed');
-                }
-                that.initialize(arrayBuffer);
-            }).otherwise(function(error) {
-                that.state = Cesium3DTileContentState.FAILED;
-                that._readyPromise.reject(error);
-            });
-            return true;
+
+        if (!defined(promise)) {
+            return false;
         }
-        return false;
+
+        this.state = Cesium3DTileContentState.LOADING;
+        promise.then(function(arrayBuffer) {
+            if (that.isDestroyed()) {
+                return when.reject('tileset is destroyed');
+            }
+            that.initialize(arrayBuffer);
+        }).otherwise(function(error) {
+            that.state = Cesium3DTileContentState.FAILED;
+            that._readyPromise.reject(error);
+        });
+        return true;
     };
 
     /**

--- a/Source/Scene/Points3DTileContent.js
+++ b/Source/Scene/Points3DTileContent.js
@@ -144,20 +144,22 @@ define([
             type : RequestType.TILES3D,
             distance : distance
         }));
-        if (defined(promise)) {
-            this.state = Cesium3DTileContentState.LOADING;
-            promise.then(function(arrayBuffer) {
-                if (that.isDestroyed()) {
-                    return when.reject('tileset is destroyed');
-                }
-                that.initialize(arrayBuffer);
-            }).otherwise(function(error) {
-                that.state = Cesium3DTileContentState.FAILED;
-                that._readyPromise.reject(error);
-            });
-            return true;
+
+        if (!defined(promise)) {
+            return false;
         }
-        return false;
+
+        this.state = Cesium3DTileContentState.LOADING;
+        promise.then(function(arrayBuffer) {
+            if (that.isDestroyed()) {
+                return when.reject('tileset is destroyed');
+            }
+            that.initialize(arrayBuffer);
+        }).otherwise(function(error) {
+            that.state = Cesium3DTileContentState.FAILED;
+            that._readyPromise.reject(error);
+        });
+        return true;
     };
 
     /**

--- a/Source/Scene/Points3DTileContent.js
+++ b/Source/Scene/Points3DTileContent.js
@@ -155,7 +155,9 @@ define([
                 that.state = Cesium3DTileContentState.FAILED;
                 that._readyPromise.reject(error);
             });
+            return true;
         }
+        return false;
     };
 
     /**

--- a/Source/Scene/Tileset3DTileContent.js
+++ b/Source/Scene/Tileset3DTileContent.js
@@ -109,6 +109,7 @@ define([
             that.state = Cesium3DTileContentState.FAILED;
             that._readyPromise.reject(error);
         });
+        return true;
     };
 
     /**


### PR DESCRIPTION
Fixes https://github.com/AnalyticalGraphicsInc/cesium/issues/3453

A tile now starts waiting for its readyPromise only when it is requested rather than at construction time. Empty tiles are a special case where the readyPromise is checked right away because it is resolved immediately. 