### PR TITLE
RectangleGeometry rotation bug

### DIFF
--- a/Source/Core/RectangleGeometryLibrary.js
+++ b/Source/Core/RectangleGeometryLibrary.js
@@ -112,7 +112,7 @@ define([
         var granYSin = 0.0;
         var granXSin = 0.0;
 
-        if (defined(rotation)) { // rotation doesn't work when center is on/near IDL
+        if (defined(rotation) && rotation !== 0) { // rotation doesn't work when center is on/near IDL
             var cosRotation = Math.cos(rotation);
             granYCos *= cosRotation;
             granXCos *= cosRotation;

--- a/Specs/Core/RectangleGeometrySpec.js
+++ b/Specs/Core/RectangleGeometrySpec.js
@@ -293,16 +293,14 @@ defineSuite([
     });
 
     it('computing rectangle property with zero rotation', function() {
-        var rectangle = Rectangle.MAX_VALUE;
-        var geometry = new RectangleGeometry({
-            vertexFormat : VertexFormat.POSITION_ONLY,
-            rectangle : rectangle,
-            granularity : 1.0,
-            rotation : 0
-        });
-
-        var r = geometry.rectangle;
-        expect(r).toEqual(rectangle);
+        expect(function() {
+            return RectangleGeometry.createGeometry(new RectangleGeometry({
+                vertexFormat : VertexFormat.POSITION_ONLY,
+                rectangle : Rectangle.MAX_VALUE,
+                granularity : 1.0,
+                rotation : 0
+            }));
+        }).not.toThrowDeveloperError();
     });
 
     var rectangle = new RectangleGeometry({

--- a/Specs/Core/RectangleGeometrySpec.js
+++ b/Specs/Core/RectangleGeometrySpec.js
@@ -292,6 +292,19 @@ defineSuite([
         expect(CesiumMath.toDegrees(r.west)).toEqual(-1.4094456877799821);
     });
 
+    it('computing rectangle property with zero rotation', function() {
+        var rectangle = Rectangle.MAX_VALUE;
+        var geometry = new RectangleGeometry({
+            vertexFormat : VertexFormat.POSITION_ONLY,
+            rectangle : rectangle,
+            granularity : 1.0,
+            rotation : 0
+        });
+
+        var r = geometry.rectangle;
+        expect(r).toEqual(rectangle);
+    });
+
     var rectangle = new RectangleGeometry({
         vertexFormat : VertexFormat.POSITION_ONLY,
         rectangle : new Rectangle(-2.0, -1.0, 0.0, 1.0),


### PR DESCRIPTION
Fixes #4204

There was a floating point error that happened if `rectangle === Rectangle.MAX_VALUE` and `rotation === 0` that would make the values of north and south go just barely out of bounds after entering this if block: https://github.com/AnalyticalGraphicsInc/cesium/blob/master/Source/Core/RectangleGeometryLibrary.js#L116
Changing the code to skip that block if the rotation is 0 fixed the problem.