### PR TITLE
Only execute receiveShadows commands for shadows that original from light sources

### DIFF
--- a/Source/Scene/FrameState.js
+++ b/Source/Scene/FrameState.js
@@ -171,6 +171,23 @@ define([
 
         this.shadowHints = {
             /**
+             * Whether there are any active shadow maps this frame.
+             * @type {Boolean}
+             */
+            shadowsEnabled : true,
+
+            /**
+             * All shadow maps that are enabled this frame.
+             */
+             shadowMaps : [],
+
+            /**
+             * Shadow maps that originate from light sources. Does not include shadow maps that are used for
+             * analytical purposes. Only these shadow maps will be used to generate receive shadows shaders.
+             */
+            lightShadowMaps : [],
+
+            /**
              * The near plane of the scene's frustum commands. Used for fitting cascaded shadow maps.
              * @type {Number}
              */

--- a/Source/Scene/Scene.js
+++ b/Source/Scene/Scene.js
@@ -2149,6 +2149,15 @@ define([
             return;
         }
 
+        // Check if the shadow maps are different than the shadow maps last frame.
+        // If so, the derived commands need to be updated.
+        for (var j = 0; j < length; ++j) {
+            if (shadowMaps[j] !== frameState.shadowHints.shadowMaps[j]) {
+                ++frameState.shadowHints.lastDirtyTime;
+                break;
+            }
+        }
+
         frameState.shadowHints.shadowMaps.length = 0;
         frameState.shadowHints.lightShadowMaps.length = 0;
 

--- a/Source/Scene/Scene.js
+++ b/Source/Scene/Scene.js
@@ -1488,7 +1488,7 @@ define([
         }
 
         var shadowsEnabled = scene.frameState.shadowHints.shadowsEnabled;
-        var lightShadowsEnabled = shadowsEnabled && (scene.frameState.shadowHints.lightShadowMaps.length) > 0;
+        var lightShadowsEnabled = shadowsEnabled && (scene.frameState.shadowHints.lightShadowMaps.length > 0);
 
         if (scene.debugShowCommands || scene.debugShowFrustums) {
             executeDebugCommand(command, scene, passState);
@@ -1837,14 +1837,13 @@ define([
             var command = commandList[i];
             updateDerivedCommands(scene, command);
 
-            // Don't insert globe commands with the rest of the scene commands since they are handled separately
             if (command.castShadows && (command.pass === Pass.GLOBE || command.pass === Pass.OPAQUE || command.pass === Pass.TRANSLUCENT)) {
                 if (isVisible(command, shadowVolume)) {
                     if (isPointLight) {
                         for (var k = 0; k < numberOfPasses; ++k) {
                             passes[k].commandList.push(command);
                         }
-                    } else if (numberOfPasses <= 1) {
+                    } else if (numberOfPasses === 1) {
                         passes[0].commandList.push(command);
                     } else {
                         var wasVisible = false;


### PR DESCRIPTION
This fixes an issue where shadow maps that are used for analysis purposes cause shadows to be rendered in the actual scene when `receiveShadows` is true. This PR makes a distinction between a shadow map that originates from a light source vs. from some other source.