### PR TITLE
Add `GeocoderViewModel.keepExpanded`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@ Change Log
 * Fixed an issue causing error if KML has a clamped to ground LineString with color. [#4131](https://github.com/AnalyticalGraphicsInc/cesium/issues/4131)
 * Camera flights now disable collision with the terrain until all of the terrain in the area has finished loading. This prevents the camera from being moved to be above lower resolution terrain when flying to a position close to higher resolution terrain. [#4075](https://github.com/AnalyticalGraphicsInc/cesium/issues/4075)
 * Added support for Int32 and Uint32 in ComponentDatatypeSpec.
+* Added `GeocoderViewModel.keepExpanded` which when set to true will always keep the GeoCoder in its expanded state.
 
 ### 1.24 - 2016-08-01
 

--- a/Source/Widgets/Geocoder/Geocoder.js
+++ b/Source/Widgets/Geocoder/Geocoder.js
@@ -69,7 +69,7 @@ define([
 value: searchText,\
 valueUpdate: "afterkeydown",\
 disable: isSearchInProgress,\
-css: { "cesium-geocoder-input-wide" : searchText.length > 0 }');
+css: { "cesium-geocoder-input-wide" : keepExpanded || searchText.length > 0 }');
         form.appendChild(textBox);
 
         var searchButton = document.createElement('span');

--- a/Source/Widgets/Geocoder/GeocoderViewModel.js
+++ b/Source/Widgets/Geocoder/GeocoderViewModel.js
@@ -82,7 +82,15 @@ define([
             }
         });
 
-        knockout.track(this, ['_searchText', '_isSearchInProgress']);
+        /**
+         * Gets or sets a value indicating if this instance should always show its text input field.
+         *
+         * @type {Boolean}
+         * @default false
+         */
+        this.keepExpanded = false;
+
+        knockout.track(this, ['_searchText', '_isSearchInProgress', 'keepExpanded']);
 
         /**
          * Gets a value indicating whether a search is currently in progress.  This property is observable.

--- a/Specs/Widgets/Geocoder/GeocoderViewModelSpec.js
+++ b/Specs/Widgets/Geocoder/GeocoderViewModelSpec.js
@@ -38,6 +38,7 @@ defineSuite([
         expect(viewModel.flightDuration).toBe(flightDuration);
         expect(viewModel.url).toBe(url);
         expect(viewModel.key).toBe(key);
+        expect(viewModel.keepExpanded).toBe(false);
     });
 
     it('can get and set flight duration', function() {


### PR DESCRIPTION
Add `GeocoderViewModel.keepExpanded`, which when set to true will always keep the GeoCoder in its expanded state. This is useful in situations when the Gecoder is being used without other buttons and you want it to be more obvious.

CC @hpinkos 