### PR TITLE
Add ability to cancel camera flights

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,8 @@ Change Log
 * Deprecated
     * Deprecated `castShadows` and `receiveShadows` properties from `Model`, `Primitive`, and `Globe`. They will be removed in 1.26. Use `shadows` instead with the `ShadowMode` enum, e.g. `model.shadows = ShadowMode.ENABLED`.
     * `Viewer.terrainShadows` now uses the `ShadowMode` enum instead of a Boolean, e.g. `viewer.terrainShadows = ShadowMode.RECEIVE_ONLY`. Boolean support will be dropped in 1.26.
+* Added `Camera.cancelFlight` to cancel the existing camera flight if it exists.
+* Fix overlapping camera flights by always cancelling the previous flight when a new one is created.
 * Updated the online [model converter](http://cesiumjs.org/convertmodel.html) to convert OBJ models to glTF with [obj2gltf](https://github.com/AnalyticalGraphicsInc/OBJ2GLTF), as well as optimize existing glTF models with the [gltf-pipeline](https://github.com/AnalyticalGraphicsInc/gltf-pipeline).  Also added an option to compress geometry using the glTF [WEB3D_quantized_attributes](https://github.com/KhronosGroup/glTF/blob/master/extensions/Vendor/WEB3D_quantized_attributes/README.md) extension.
 * Added `shadows` property to the entity API for `Box`, `Corridor`, `Cylinder`, `Ellipse`, `Ellipsoid`, `Polygon`, `Polyline`, `PoylineVolume`, `Rectangle`, and `Wall`. [#4005](https://github.com/AnalyticalGraphicsInc/cesium/pull/4005)
 * Fixed an issue causing error if KML has a clamped to ground LineString with color. [#4131](https://github.com/AnalyticalGraphicsInc/cesium/issues/4131)

--- a/Specs/Scene/CameraSpec.js
+++ b/Specs/Scene/CameraSpec.js
@@ -2103,25 +2103,63 @@ defineSuite([
         });
 
         var options = {
+            destination : Cartesian3.fromDegrees(-117.16, 32.71, 15000.0),
+            orientation : {
+                heading : 0,
+                pitch : 1,
+                roll : 2
+            },
+            duration : 3,
+            complete : function() {
+            },
+            cancel : function() {
+            },
+            endTransform : new Matrix4(),
+            convert : true,
+            maximumHeight : 100,
+            easingFunction : function() {
+            }
+        };
+        camera.flyTo(options);
+
+        var args = CameraFlightPath.createTween.calls.argsFor(0);
+        var passedOptions = args[1];
+
+        expect(CameraFlightPath.createTween).toHaveBeenCalled();
+        expect(args[0]).toBe(scene);
+        expect(passedOptions.destination).toBe(options.destination);
+        expect(passedOptions.heading).toBe(options.orientation.heading);
+        expect(passedOptions.pitch).toBe(options.orientation.pitch);
+        expect(passedOptions.roll).toBe(options.orientation.roll);
+        expect(typeof passedOptions.complete).toBe('function'); //complete function is wrapped by camera.
+        expect(passedOptions.cancel).toBe(options.cancel);
+        expect(passedOptions.endTransform).toBe(options.endTransform);
+        expect(passedOptions.convert).toBe(options.convert);
+        expect(passedOptions.maximumHeight).toBe(options.maximumHeight);
+        expect(passedOptions.easingFunction).toBe(options.easingFunction);
+    });
+
+    it('can cancel a flight', function() {
+        spyOn(CameraFlightPath, 'createTween').and.returnValue({
+            startObject : {},
+            stopObject: {},
+            duration : 0.001,
+            cancelTween: jasmine.createSpy('cancelTween')
+        });
+
+        var options = {
             destination : Cartesian3.fromDegrees(-117.16, 32.71, 15000.0)
         };
         camera.flyTo(options);
 
-        var expectedOptions = {
-            destination : options.destination,
-            heading : undefined,
-            pitch : undefined,
-            roll : undefined,
-            duration : undefined,
-            complete : undefined,
-            cancel : undefined,
-            endTransform : undefined,
-            convert : undefined,
-            maximumHeight : undefined,
-            easingFunction : undefined
-        };
+        expect(camera._currentFlight).toBeDefined();
 
-        expect(CameraFlightPath.createTween).toHaveBeenCalledWith(scene, expectedOptions);
+        var createdTween = camera._currentFlight;
+        spyOn(createdTween, 'cancelTween');
+        camera.cancelFlight();
+
+        expect(createdTween.cancelTween).toHaveBeenCalled();
+        expect(camera._currentFlight).toBeUndefined();
     });
 
     it('flyTo with heading, pitch and roll', function() {


### PR DESCRIPTION
This was so simple that it makes me worry there was an issue I glossed over that caused us not to expose this earlier?

1. Added `Camera.cancelFlight` to cancel the existing camera flight if it exists.
2. Fix overlapping camera flights by always cancelling the previous flight when a new one is created.

Fixes #2027