### PR TITLE
Fix handling of oblique fonts

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,7 @@ Change Log
 * Added support for Int32 and Uint32 in ComponentDatatypeSpec.
 * Added `GeocoderViewModel.keepExpanded` which when set to true will always keep the GeoCoder in its expanded state.
 * Added `ComponentDatatype.fromName` for getting a `ComponentDatatype` from its name.
+* Improve label quality for oblique and italic fonts. [#3782](https://github.com/AnalyticalGraphicsInc/cesium/issues/3782)
 
 ### 1.24 - 2016-08-01
 

--- a/Source/ThirdParty/measureText.js
+++ b/Source/ThirdParty/measureText.js
@@ -95,6 +95,8 @@ define(function() {
     var metrics = context2D.measureText(textstring),
         fontFamily = getCSSValue(context2D.canvas,"font-family"),
         fontSize = getCSSValue(context2D.canvas,"font-size").replace("px",""),
+        fontStyle = getCSSValue(context2D.canvas,"font-style"),
+        fontWeight = getCSSValue(context2D.canvas,"font-weight"),
         isSpace = !(/\S/.test(textstring));
         metrics.fontsize = fontSize;
 
@@ -102,7 +104,7 @@ define(function() {
     var leadDiv = document.createElement("div");
     leadDiv.style.position = "absolute";
     leadDiv.style.opacity = 0;
-    leadDiv.style.font = fontSize + "px " + fontFamily;
+    leadDiv.style.font = fontStyle + " " + fontWeight + " " + fontSize + "px " + fontFamily;
     leadDiv.innerHTML = textstring + "<br/>" + textstring;
     document.body.appendChild(leadDiv);
 
@@ -125,8 +127,10 @@ define(function() {
         canvas.style.opacity = 1;
         canvas.style.fontFamily = fontFamily;
         canvas.style.fontSize = fontSize;
+        canvas.style.fontStyle = fontStyle;
+        canvas.style.fontWeight = fontWeight;
         var ctx = canvas.getContext("2d");
-        ctx.font = fontSize + "px " + fontFamily;
+        ctx.font = fontStyle + " " + fontWeight + " " + fontSize + "px " + fontFamily;
 
         var w = canvas.width,
             h = canvas.height,


### PR DESCRIPTION
Take font weight into account when measuring text width.

Note that there will still be some issues with certain fonts due to overlapping transparent billboards. That will be fixed with #2130.

Fixes #3782

This is based on some code from @GatorScott.  Thanks Scott!