### PR TITLE
Fix entity zooming during startup.

### DIFF
--- a/Source/DataSources/DataSourceDisplay.js
+++ b/Source/DataSources/DataSourceDisplay.js
@@ -236,6 +236,7 @@ define([
         //>>includeEnd('debug');
 
         if (!GroundPrimitive._initialized) {
+            this._ready = false;
             return false;
         }
         
@@ -299,6 +300,10 @@ define([
             throw new DeveloperError('result is required.');
         }
         //>>includeEnd('debug');
+
+        if (!this._ready) {
+            return BoundingSphereState.PENDING;
+        }
 
         var i;
         var length;

--- a/Specs/DataSources/DataSourceDisplaySpec.js
+++ b/Specs/DataSources/DataSourceDisplaySpec.js
@@ -118,6 +118,8 @@ defineSuite([
         dataSource.entities.add(entity);
         display.dataSources.add(dataSource);
 
+        display.update(Iso8601.MINIMUM_VALUE);
+
         var result = new BoundingSphere();
         var state = display.getBoundingSphere(entity, true, result);
 
@@ -148,6 +150,8 @@ defineSuite([
         var dataSource = new MockDataSource();
         dataSource.entities.add(entity);
         display.dataSources.add(dataSource);
+
+        display.update(Iso8601.MINIMUM_VALUE);
 
         var result = new BoundingSphere();
         var state = display.getBoundingSphere(entity, true, result);
@@ -191,6 +195,8 @@ defineSuite([
         var dataSource = new MockDataSource();
         dataSource.entities.add(entity);
         display.dataSources.add(dataSource);
+        display.update(Iso8601.MINIMUM_VALUE);
+
         var result = new BoundingSphere();
         var state = display.getBoundingSphere(entity, false, result);
         expect(state).toBe(BoundingSphereState.FAILED);
@@ -202,6 +208,8 @@ defineSuite([
             dataSourceCollection : dataSourceCollection,
             scene : scene
         });
+        display.update(Iso8601.MINIMUM_VALUE);
+
         var entity = new Entity();
         var result = new BoundingSphere();
         var state = display.getBoundingSphere(entity, false, result);


### PR DESCRIPTION
If an entity zoom/track took place before `GroundPrimitive._initialized` became true, the view would be incorrect.  `DataSourceDisplay` was not properly setting it's `ready` value for this case and wasn't waiting for it in `getBoundingSphere` either.

Fixes #4172