### PR TITLE
Safely ignore Blender's two glTF extensions

### DIFF
--- a/Source/Scene/Model.js
+++ b/Source/Scene/Model.js
@@ -2959,7 +2959,7 @@ define([
 
                 var castShadows = ShadowMode.castShadows(model._shadows);
                 var receiveShadows = ShadowMode.receiveShadows(model._shadows);
-                
+
                 var command = new DrawCommand({
                     boundingVolume : new BoundingSphere(), // updated in update()
                     cull : model.cull,
@@ -3479,6 +3479,7 @@ define([
                 var extension = extensionsUsed[index];
 
                 if (extension !== 'CESIUM_RTC' && extension !== 'KHR_binary_glTF' &&
+                    extension !== 'BLENDER_actions' && extension !== 'BLENDER_physics' &&
                     extension !== 'KHR_materials_common' && extension !== 'WEB3D_quantized_attributes') {
                     throw new RuntimeError('Unsupported glTF Extension: ' + extension);
                 }


### PR DESCRIPTION
The Blender folks are working on a [gltf exporter](https://github.com/Kupoman/blendergltf) that currently injects a pair of extensions that don't have any relevance to Cesium.  This PR simply ignores the two extensions, so the model can load without throwing.

Ideally there should be a more formal way to handle optional extensions, but that discussion is still [ongoing](https://github.com/KhronosGroup/glTF/issues/695).  In the meantime it's important for Cesium to attempt to load these models, so the exporter can be tested with an official Cesium release.