### PR TITLE
Revert "Update jasmine-core to version 2.5.0 🚀"

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "gulp-rename": "1.2.2",
     "gulp-replace": "0.5.4",
     "gulp-zip": "3.0.2",
-    "jasmine-core": "2.5.0",
+    "jasmine-core": "2.4.1",
     "jsdoc": "3.4.0",
     "jshint": "2.9.3",
     "jshint-stylish": "2.2.1",


### PR DESCRIPTION
Reverts AnalyticalGraphicsInc/cesium#4264

Turns out this actually broke our build because 2.5.0 appears to have a regression that breaks `jasmine.clock().tick`, causing one of the clock tests to fail.  See https://github.com/jasmine/jasmine/issues/1190 for details.