### PR TITLE
3D Tiles - Changed numberReady to numberContentReady

### DIFF
--- a/Source/Scene/Cesium3DTileset.js
+++ b/Source/Scene/Cesium3DTileset.js
@@ -174,7 +174,7 @@ define([
             // Loading stats
             numberOfPendingRequests : 0,
             numberProcessing : 0,
-            numberContentReady : 0, // Number of tiles with content loaded
+            numberContentReady : 0, // Number of tiles with content loaded, does not include empty tiles
             numberTotal : 0, // Number of tiles in tileset.json (and other tileset.json files as they are loaded)
             // Styling stats
             numberOfTilesStyled : 0,

--- a/Source/Scene/Cesium3DTileset.js
+++ b/Source/Scene/Cesium3DTileset.js
@@ -174,7 +174,7 @@ define([
             // Loading stats
             numberOfPendingRequests : 0,
             numberProcessing : 0,
-            numberReady : 0, // Number of tiles with content loaded
+            numberContentReady : 0, // Number of tiles with content loaded
             numberTotal : 0, // Number of tiles in tileset.json (and other tileset.json files as they are loaded)
             // Styling stats
             numberOfTilesStyled : 0,
@@ -331,7 +331,7 @@ define([
         this.numberOfCommands = -1;
         this.numberOfPendingRequests = -1;
         this.numberProcessing = -1;
-        this.numberReady = -1;
+        this.numberContentReady = -1;
         this.numberTotal = -1;
         this.numberOfTilesStyled = -1;
         this.numberOfFeaturesStyled = -1;
@@ -1092,10 +1092,10 @@ define([
                 // Remove from processing queue
                 tileset._processingQueue.splice(index, 1);
                 --tileset._statistics.numberProcessing;
-                ++tileset._statistics.numberReady;
                 if (tile.hasContent) {
                     // RESEARCH_IDEA: ability to unload tiles (without content) for an
                     // external tileset when all the tiles are unloaded.
+                    ++tileset._statistics.numberContentReady;
                     tile.replacementNode = tileset._replacementList.add(tile);
                 }
             } else {
@@ -1141,7 +1141,7 @@ define([
              last.selected !== tileset._selectedTiles.length ||
              last.numberOfPendingRequests !== stats.numberOfPendingRequests ||
              last.numberProcessing !== stats.numberProcessing ||
-             last.numberReady !== stats.numberReady ||
+             last.numberContentReady !== stats.numberContentReady ||
              last.numberTotal !== stats.numberTotal ||
              last.numberOfTilesStyled !== stats.numberOfTilesStyled ||
              last.numberOfFeaturesStyled !== stats.numberOfFeaturesStyled);
@@ -1169,7 +1169,7 @@ define([
                 // --- Cache/loading stats
                 ' | Requests: ' + stats.numberOfPendingRequests +
                 ', Processing: ' + stats.numberProcessing +
-                ', Ready: ' + stats.numberReady +
+                ', Content Ready: ' + stats.numberContentReady +
                 // Total number of tiles includes tiles without content, so "Ready" may never reach
                 // "Total."  Total also will increase when a tile with a tileset.json content is loaded.
                 ', Total: ' + stats.numberTotal +
@@ -1187,7 +1187,7 @@ define([
         last.selected = tileset._selectedTiles.length;
         last.numberOfPendingRequests = stats.numberOfPendingRequests;
         last.numberProcessing = stats.numberProcessing;
-        last.numberReady = stats.numberReady;
+        last.numberContentReady = stats.numberContentReady;
         last.numberTotal = stats.numberTotal;
         last.numberOfTilesStyled = stats.numberOfTilesStyled;
         last.numberOfFeaturesStyled = stats.numberOfFeaturesStyled;
@@ -1240,7 +1240,7 @@ define([
             node = node.next;
             replacementList.remove(currentNode);
 
-            --stats.numberReady;
+            --stats.numberContentReady;
         }
     }
 


### PR DESCRIPTION
Changed `numberReady` to `numberContentReady` and now excluding tiles without content from the count. This makes the statistics more clear as to how many tiles actually have content loaded.

I decided not to change `numberProcessing` to `numberContentProcessing` because it would have no effect.