### PR TITLE
Touch now works on timeline bar.

### DIFF
--- a/Source/Widgets/Timeline/Timeline.js
+++ b/Source/Widgets/Timeline/Timeline.js
@@ -702,9 +702,9 @@ define([
             var len = e.touches.length, leftX = timeline._topDiv.getBoundingClientRect().left;
             if (timeline._touchMode === timelineTouchMode.singleTap) {
                 timeline._touchMode = timelineTouchMode.scrub;
-                timeline._handleTouchMove(e);
+                timeline._onTouchMove(e);
             } else if (timeline._touchMode === timelineTouchMode.scrub) {
-                timeline._handleTouchMove(e);
+                timeline._onTouchMove(e);
             }
             timeline._mouseMode = timelineMouseMode.touchOnly;
             if (len !== 1) {


### PR DESCRIPTION
_handleTouchMove was an old function that was removed (commit 1b1dea57276f36186c455091e01ca0156346e588).

Replacing with _onTouchMove allows the touch to work on the timeline.

To experience this bug:
1. Go to http://cesiumjs.org/Cesium/Apps/Sandcastle/index.html?src=Hello%20World.html&label=Showcases
2. Using touch (or an emulation in Chrome), touch the timeline bar (make sure it's touch, not a mouse).
3. Uncaught TypeError: timeline._handleTouchMove is not a function.