### PR TITLE
3D Tiles - refine to visible children in replacement refinement

### DIFF
--- a/Apps/Sandcastle/gallery/3D Tiles.html
+++ b/Apps/Sandcastle/gallery/3D Tiles.html
@@ -69,8 +69,9 @@ function loadTileset(url) {
 
     tileset = scene.primitives.add(new Cesium.Cesium3DTileset({
         url : url,
-        debugShowStatistics : true,
-        maximumNumberOfLoadedTiles : 3
+        debugShowStatistics : true
+//        , maximumNumberOfLoadedTiles : 3
+//       , refineToVisible : true
     }));
 
     return tileset.readyPromise.then(function(tileset) {

--- a/Source/Core/DoublyLinkedList.js
+++ b/Source/Core/DoublyLinkedList.js
@@ -82,9 +82,11 @@ define([
     };
 
     DoublyLinkedList.prototype.splice = function(node, nextNode) {
+        //>>includeStart('debug', pragmas.debug);
         if (!defined(node) || !defined(nextNode)) {
             throw new DeveloperError('node and nextNode are required.');
         }
+        //>>includeEnd('debug');
 
         if (node === nextNode) {
             return;

--- a/Source/Scene/Cesium3DTile.js
+++ b/Source/Scene/Cesium3DTile.js
@@ -520,9 +520,13 @@ define([
      * @private
      */
     Cesium3DTile.prototype.contentsVisibility = function(cullingVolume) {
+        var boundingVolume = this._contentBoundingVolume;
+        if (!defined(boundingVolume)) {
+            return Intersect.INSIDE;
+        }
         // PERFORMANCE_IDEA: is it possible to burn less CPU on this test since we know the
         // tile's (not the content's) bounding volume intersects the culling volume?
-        return cullingVolume.computeVisibility(this.contentBoundingVolume);
+        return cullingVolume.computeVisibility(boundingVolume);
     };
 
     /**

--- a/Source/Scene/Cesium3DTile.js
+++ b/Source/Scene/Cesium3DTile.js
@@ -293,7 +293,7 @@ define([
          *
          * @private
          */
-        this.planeMask = true;
+        this.visibilityPlaneMask = true;
 
         /**
          * The last frame number the tile was selected in.
@@ -484,7 +484,7 @@ define([
 
         // Restore properties set per frame to their defaults
         this.distanceToCamera = 0;
-        this.planeMask = 0;
+        this.visibilityPlaneMask = 0;
         this.selected = false;
         this.lastSelectedFrameNumber = 0;
         this.lastStyleTime = 0;
@@ -497,13 +497,13 @@ define([
      * Determines whether the tile's bounding volume intersects the culling volume.
      *
      * @param {CullingVolume} cullingVolume The culling volume whose intersection with the tile is to be tested.
-     * @param {Number} parentPlaneMask The parent's plane mask to speed up the visibility check.
+     * @param {Number} parentVisibilityPlaneMask The parent's plane mask to speed up the visibility check.
      * @returns {Number} A plane mask as described above in {@link CullingVolume#computeVisibilityWithPlaneMask}.
      *
      * @private
      */
-    Cesium3DTile.prototype.visibility = function(cullingVolume, parentPlaneMask) {
-        return cullingVolume.computeVisibilityWithPlaneMask(this._boundingVolume, parentPlaneMask);
+    Cesium3DTile.prototype.visibility = function(cullingVolume, parentVisibilityPlaneMask) {
+        return cullingVolume.computeVisibilityWithPlaneMask(this._boundingVolume, parentVisibilityPlaneMask);
     };
 
     /**

--- a/Source/Scene/Cesium3DTile.js
+++ b/Source/Scene/Cesium3DTile.js
@@ -294,6 +294,13 @@ define([
         this.replaced = false;
 
         /**
+         * The stored plane mask from the visibility check during tree traversal.
+         *
+         * @type {Boolean}
+         */
+        this.planeMask = true;
+
+        /**
          * The last frame number the tile was selected in.
          *
          * @type {Number}

--- a/Source/Scene/Cesium3DTile.js
+++ b/Source/Scene/Cesium3DTile.js
@@ -269,15 +269,6 @@ define([
         this.distanceToCamera = 0;
 
         /**
-         * The plane mask of the parent for use with {@link CullingVolume#computeVisibilityWithPlaneMask}).
-         *
-         * @type {Number}
-         *
-         * @private
-         */
-        this.parentPlaneMask = 0;
-
-        /**
          * Marks if the tile is selected this frame.
          *
          * @type {Boolean}
@@ -290,13 +281,17 @@ define([
          * Marks if the tile is replaced this frame.
          *
          * @type {Boolean}
+         *
+         * @private
          */
         this.replaced = false;
 
         /**
          * The stored plane mask from the visibility check during tree traversal.
          *
-         * @type {Boolean}
+         * @type {Number}
+         *
+         * @private
          */
         this.planeMask = true;
 
@@ -489,7 +484,7 @@ define([
 
         // Restore properties set per frame to their defaults
         this.distanceToCamera = 0;
-        this.parentPlaneMask = 0;
+        this.planeMask = 0;
         this.selected = false;
         this.lastSelectedFrameNumber = 0;
         this.lastStyleTime = 0;
@@ -502,17 +497,18 @@ define([
      * Determines whether the tile's bounding volume intersects the culling volume.
      *
      * @param {CullingVolume} cullingVolume The culling volume whose intersection with the tile is to be tested.
+     * @param {Number} parentPlaneMask The parent's plane mask to speed up the visibility check.
      * @returns {Number} A plane mask as described above in {@link CullingVolume#computeVisibilityWithPlaneMask}.
      *
      * @private
      */
-    Cesium3DTile.prototype.visibility = function(cullingVolume) {
-        return cullingVolume.computeVisibilityWithPlaneMask(this._boundingVolume, this.parentPlaneMask);
+    Cesium3DTile.prototype.visibility = function(cullingVolume, parentPlaneMask) {
+        return cullingVolume.computeVisibilityWithPlaneMask(this._boundingVolume, parentPlaneMask);
     };
 
     /**
-     * Determines whether the tile's content's bounding volume intersects the culling volume. If the tile doesn't
-     * have content it checks the tile's bounding volume instead.
+     * Assuming the tile's bounding volume intersects the culling volume, determines
+     * whether the tile's content's bounding volume intersects the culling volume.
      *
      * @param {CullingVolume} cullingVolume The culling volume whose intersection with the tile's content is to be tested.
      * @returns {Intersect} The result of the intersection: the tile's content is completely outside, completely inside, or intersecting the culling volume.
@@ -520,6 +516,8 @@ define([
      * @private
      */
     Cesium3DTile.prototype.contentsVisibility = function(cullingVolume) {
+        // Assumes the tile's bounding volume intersects the culling volume already, so
+        // just return Intersect.INSIDE if there is no content bounding volume.
         var boundingVolume = this._contentBoundingVolume;
         if (!defined(boundingVolume)) {
             return Intersect.INSIDE;

--- a/Source/Scene/Cesium3DTileset.js
+++ b/Source/Scene/Cesium3DTileset.js
@@ -962,7 +962,6 @@ define([
                             // Use parent's geometric error with child's box to see if we already meet the SSE
                             if (getScreenSpaceError(t.geometricError, child, frameState) > maximumScreenSpaceError) {
                                 child.visibilityPlaneMask = child.visibility(cullingVolume, visibilityPlaneMask);
-                                // If the child is visible...
                                 if (isVisible(child.visibilityPlaneMask)) {
                                     if (child.contentUnloaded) {
                                         requestContent(tileset, child, outOfCore);

--- a/Source/Scene/Cesium3DTileset.js
+++ b/Source/Scene/Cesium3DTileset.js
@@ -797,8 +797,8 @@ define([
 
     ///////////////////////////////////////////////////////////////////////////
 
-    function isVisible(planeMask) {
-        return planeMask !== CullingVolume.MASK_OUTSIDE;
+    function isVisible(visibilityPlaneMask) {
+        return visibilityPlaneMask !== CullingVolume.MASK_OUTSIDE;
     }
 
     function requestContent(tileset, tile, outOfCore) {
@@ -882,8 +882,8 @@ define([
             return;
         }
 
-        root.planeMask = root.visibility(cullingVolume, CullingVolume.MASK_INDETERMINATE);
-        if (root.planeMask === CullingVolume.MASK_OUTSIDE) {
+        root.visibilityPlaneMask = root.visibility(cullingVolume, CullingVolume.MASK_INDETERMINATE);
+        if (root.visibilityPlaneMask === CullingVolume.MASK_OUTSIDE) {
             return;
         }
 
@@ -906,8 +906,8 @@ define([
             var parentTransform = defined(t.parent) ? t.parent.computedTransform : tileset.modelMatrix;
             t.computedTransform = Matrix4.multiply(parentTransform, t.transform, t.computedTransform);
 
-            var planeMask = t.planeMask;
-            var fullyVisible = (planeMask === CullingVolume.MASK_INSIDE);
+            var visibilityPlaneMask = t.visibilityPlaneMask;
+            var fullyVisible = (visibilityPlaneMask === CullingVolume.MASK_INSIDE);
 
             touch(tileset, t, outOfCore);
 
@@ -927,7 +927,7 @@ define([
                 // and geometric error are equal to its parent.
                 if (t.contentReady) {
                     child = t.children[0];
-                    child.planeMask = t.planeMask;
+                    child.visibilityPlaneMask = t.visibilityPlaneMask;
                     child.distanceToCamera = t.distanceToCamera;
                     if (child.contentUnloaded) {
                         requestContent(tileset, child, outOfCore);
@@ -961,9 +961,9 @@ define([
                             child = children[k];
                             // Use parent's geometric error with child's box to see if we already meet the SSE
                             if (getScreenSpaceError(t.geometricError, child, frameState) > maximumScreenSpaceError) {
-                                child.planeMask = child.visibility(cullingVolume, planeMask);
+                                child.visibilityPlaneMask = child.visibility(cullingVolume, visibilityPlaneMask);
                                 // If the child is visible...
-                                if (isVisible(child.planeMask)) {
+                                if (isVisible(child.visibilityPlaneMask)) {
                                     if (child.contentUnloaded) {
                                         requestContent(tileset, child, outOfCore);
                                     } else {
@@ -994,8 +994,8 @@ define([
                     var someVisibleChildrenLoaded = false;
                     for (k = 0; k < childrenLength; ++k) {
                         child = children[k];
-                        child.planeMask = child.visibility(frameState.cullingVolume, planeMask);
-                        if (isVisible(child.planeMask)) {
+                        child.visibilityPlaneMask = child.visibility(frameState.cullingVolume, visibilityPlaneMask);
+                        if (isVisible(child.visibilityPlaneMask)) {
                             if (child.contentReady) {
                                 someVisibleChildrenLoaded = true;
                             } else {
@@ -1029,7 +1029,7 @@ define([
 
                         for (k = 0; k < childrenLength; ++k) {
                             child = children[k];
-                            if (isVisible(child.planeMask)) {
+                            if (isVisible(child.visibilityPlaneMask)) {
                                 if (child.contentUnloaded) {
                                     requestContent(tileset, child, outOfCore);
                                 } else {
@@ -1041,7 +1041,7 @@ define([
                         // Tile does not meet SSE and its visible children are loaded. Refine to them in front-to-back order.
                         for (k = 0; k < childrenLength; ++k) {
                             child = children[k];
-                            if (isVisible(child.planeMask)) {
+                            if (isVisible(child.visibilityPlaneMask)) {
                                 stack.push(child);
                             }
                         }

--- a/Source/Scene/Cesium3DTileset.js
+++ b/Source/Scene/Cesium3DTileset.js
@@ -865,7 +865,7 @@ define([
         // may be potentially replaced.  Tiles are moved to the right of the sentinel
         // when they are selected so they will not be replaced.
         var replacementList = tileset._replacementList;
-        tileset._replacementList.splice(replacementList.tail, tileset._replacementSentinel);
+        replacementList.splice(replacementList.tail, tileset._replacementSentinel);
 
         var root = tileset._root;
         root.distanceToCamera = root.distanceToTile(frameState);

--- a/Source/Scene/Cesium3DTileset.js
+++ b/Source/Scene/Cesium3DTileset.js
@@ -1076,7 +1076,8 @@ define([
                     }
 
                     if (!allVisibleChildrenLoaded) {
-                        // TODO : render parent against a plane mask of its visible children so there is no overlap
+                        // TODO : render parent against a plane mask of its visible children so there is no overlap,
+                        //        then the refineToVisible flags can be removed.
 
                         // Tile does not meet SSE.  Add its commands and push its visible children to the stack.
                         // The parent tile and child tiles will render simultaneously until all visible children

--- a/Source/Scene/Cesium3DTileset.js
+++ b/Source/Scene/Cesium3DTileset.js
@@ -838,7 +838,10 @@ define([
         }
     }
 
-    function touch(tileset, tile) {
+    function touch(tileset, tile, outOfCore) {
+        if (!outOfCore) {
+            return;
+        }
         var node = tile.replacementNode;
         if (defined(node)) {
             tileset._replacementList.splice(tileset._replacementSentinel, node);
@@ -903,7 +906,7 @@ define([
             }
             var fullyVisible = (planeMask === CullingVolume.MASK_INSIDE);
 
-            touch(tileset, t);
+            touch(tileset, t, outOfCore);
 
             // Tile is inside/intersects the view frustum.  How many pixels is its geometric error?
             var sse = getScreenSpaceError(t.geometricError, t, frameState);
@@ -1013,7 +1016,7 @@ define([
                                     // Touch loaded child even though it is not selected this frame since
                                     // we want to keep it in the cache for when all children are loaded
                                     // and this tile can refine to them.
-                                    touch(tileset, child);
+                                    touch(tileset, child, outOfCore);
                                 }
                             }
                         }
@@ -1028,7 +1031,7 @@ define([
                             // Touch the child tile now even if it turns out not to be visible when
                             // it comes off the stack.  Since replacement refinement requires all child
                             // tiles to be loaded to refine to them, we want to keep it in the cache.
-                            touch(tileset, child);
+                            touch(tileset, child, outOfCore);
                         }
 
                         t.replaced = true;

--- a/Source/Scene/Cesium3DTileset.js
+++ b/Source/Scene/Cesium3DTileset.js
@@ -1072,7 +1072,7 @@ define([
             for (j = 0; j < descendantsLength; ++j) {
                 descendant = refiningTile.descendantsWithContent[j];
                 if (!descendant.selected && !descendant.replaced &&
-                    (descendant.contentsVisibility(frameState.cullingVolume) !== Intersect.OUTSIDE)) {
+                    (frameState.cullingVolume.computeVisibility(descendant.contentBoundingVolume) !== Intersect.OUTSIDE)) {
                         refinable = false;
                         break;
                 }

--- a/Specs/Scene/Cesium3DTilesetSpec.js
+++ b/Specs/Scene/Cesium3DTilesetSpec.js
@@ -514,7 +514,6 @@ defineSuite([
         });
     });
 
-
     it('replacement refinement - refines to visible ready children', function() {
         viewRootOnly();
         return Cesium3DTilesTester.loadTileset(scene, tilesetUrl).then(function(tileset) {

--- a/Specs/Scene/Cesium3DTilesetSpec.js
+++ b/Specs/Scene/Cesium3DTilesetSpec.js
@@ -547,7 +547,6 @@ defineSuite([
                 expect(stats.visited).toEqual(5); // All tiles are visited
                 expect(stats.numberContentReady).toEqual(5); // All tiles are loaded
                 expect(stats.numberOfCommands).toEqual(4); // Root is replaced by its 4 children
-
             });
         });
     });

--- a/Specs/Scene/Cesium3DTilesetSpec.js
+++ b/Specs/Scene/Cesium3DTilesetSpec.js
@@ -5,7 +5,6 @@ defineSuite([
         'Core/Color',
         'Core/defined',
         'Core/HeadingPitchRange',
-        'Core/Intersect',
         'Core/loadWithXhr',
         'Core/Matrix4',
         'Core/RequestScheduler',
@@ -24,7 +23,6 @@ defineSuite([
         Color,
         defined,
         HeadingPitchRange,
-        Intersect,
         loadWithXhr,
         Matrix4,
         RequestScheduler,
@@ -364,26 +362,6 @@ defineSuite([
             expect(stats.visited).toEqual(1); // Visits the root, but stops early
             expect(stats.numberOfCommands).toEqual(0);
             expect(tileset._root.visibility(scene.frameState.cullingVolume)).toEqual(CullingVolume.MASK_OUTSIDE);
-            expect(tileset._root.contentsVisibility(scene.frameState.cullingVolume)).toEqual(Intersect.OUTSIDE);
-        });
-    });
-
-    it('does not select empty tiles when outside of view frustum', function() {
-        return Cesium3DTilesTester.loadTileset(scene, tilesetEmptyRootUrl).then(function(tileset) {
-            scene.renderForSpecs();
-            var stats = tileset._statistics;
-            expect(stats.visited).toEqual(5);
-            expect(stats.numberOfCommands).toEqual(4);
-
-            // Orient camera to face the sky
-            var center = Cartesian3.fromRadians(centerLongitude, centerLatitude, 100);
-            scene.camera.lookAt(center, new HeadingPitchRange(0.0, 1.57, 10.0));
-
-            scene.renderForSpecs();
-            expect(stats.visited).toEqual(1); // Visits the root, but stops early
-            expect(stats.numberOfCommands).toEqual(0);
-            expect(tileset._root.visibility(scene.frameState.cullingVolume)).toEqual(CullingVolume.MASK_OUTSIDE);
-            expect(tileset._root.contentsVisibility(scene.frameState.cullingVolume)).toEqual(Intersect.OUTSIDE);
         });
     });
 


### PR DESCRIPTION
For #3241 

>Performance: optimize replacement refinement - instead of requesting all children when a tile needs to refine, request only the visible ones, and then allow refining a tile if all the required visible tiles are loaded (instead of all - including invisible - tiles). When the camera moves, and children that are not yet loaded are needed, either render the parent or render the available children and the parent with clipping.

When not all visible children are loaded, I go with a third approach - render the parent and available children together, which is slightly noticeable in some cases but doesn't hurt visual quality since the other visible children usually load in soon after.

Since the visibility check must now happen in the replacement refinement path, I save the result and don't recheck the visibility once the tile is popped from the stack. I modified the additive refinement path to do the same, store the `planeMask` now and use later.

I also ended up reverting https://github.com/AnalyticalGraphicsInc/cesium/pull/4280 because otherwise the bounding volume check will happen twice, first in the `selectTiles` loop, and again in `selectTile`. This only applies to tiles without content bounding volumes, which is many replacement tilesets. As long as `contentsVisibility` is called after `visibility` is already checked, this should be ok.

Some numbers:

Now that we don't need to request all children, and instead just the visible ones, there are some memory improvements. In real world tilesets I've noticed between 14% to 50% savings in the number of loaded tiles. These numbers below are for a generic replacement refinement tileset:

**Before**

|View|Loaded|Rendered|Total tiles in tileset|
|-----|--------|-----------|-----|
|**Horizon**|233|152|341|
|**Straight Down**|135|53|341|

**After**

|View|Loaded|Rendered|Total tiles in tileset|
|-----|----|-----------|--------|
|**Horizon**|210|152|341|
|**Straight Down**|86|53|341|

