### PR TITLE
viewerDragDropMixin uses flyToOnDrop option

### DIFF
--- a/Source/Widgets/Viewer/viewerDragDropMixin.js
+++ b/Source/Widgets/Viewer/viewerDragDropMixin.js
@@ -79,7 +79,7 @@ define([
 
         //Local variables to be closed over by defineProperties.
         var dropEnabled = true;
-        var flyToOnDrop = true;
+        var flyToOnDrop = defaultValue(options.flyToOnDrop, true);
         var dropError = new Event();
         var clearOnDrop = defaultValue(options.clearOnDrop, true);
         var dropTarget = defaultValue(options.dropTarget, viewer.container);

--- a/Specs/Widgets/Viewer/viewerDragDropMixinSpec.js
+++ b/Specs/Widgets/Viewer/viewerDragDropMixinSpec.js
@@ -58,6 +58,7 @@ defineSuite([
         expect(viewer.dropEnabled).toEqual(true);
         expect(viewer.clearOnDrop).toEqual(true);
         expect(viewer.clampToGround).toEqual(true);
+        expect(viewer.flyToOnDrop).toEqual(true);
     });
 
     it('clearOnDrop defaults to true when dataSourceBrowser is not used', function() {
@@ -73,12 +74,14 @@ defineSuite([
         viewer.extend(viewerDragDropMixin, {
             dropTarget : document.body,
             clearOnDrop : false,
-            clampToGround : false
+            clampToGround : false,
+            flyToOnDrop: false
         });
         expect(viewer.dropTarget).toBe(document.body);
         expect(viewer.dropEnabled).toEqual(true);
         expect(viewer.clearOnDrop).toEqual(false);
         expect(viewer.clampToGround).toEqual(false);
+        expect(viewer.flyToOnDrop).toEqual(false);
     });
 
     it('mixin works with dropTarget id string', function() {


### PR DESCRIPTION
The doc for `viewerDragDropMixin` advertised this nifty option to set `flyToOnDrop`, but never actually looked at the passed in value