### PR TITLE
3D Tiles - Fix transform

### DIFF
--- a/Source/Scene/Cesium3DTile.js
+++ b/Source/Scene/Cesium3DTile.js
@@ -77,6 +77,7 @@ define([
      * @constructor
      */
     function Cesium3DTile(tileset, baseUrl, header, parent) {
+        this._tileset = tileset;
         this._header = header;
         var contentHeader = header.content;
 
@@ -605,6 +606,33 @@ define([
         }
     };
 
+    /**
+     * Update the tile's transform. The transform is applied to the tile's bounding volumes.
+     *
+     * @private
+     */
+    Cesium3DTile.prototype.updateTransform = function() {
+        var parentTransform = defined(this.parent) ? this.parent.computedTransform : this._tileset.modelMatrix;
+        this.computedTransform = Matrix4.multiply(parentTransform, this.transform, this.computedTransform);
+        var transformDirty = !Matrix4.equals(this.computedTransform, this._computedTransform);
+        if (transformDirty) {
+            this._transformDirty = true;
+            Matrix4.clone(this.computedTransform, this._computedTransform);
+
+            // Update the bounding volumes
+            var header = this._header;
+            var content = this._header.content;
+            this._boundingVolume = this.createBoundingVolume(header.boundingVolume, this.computedTransform, this._boundingVolume);
+            if (defined(this._contentBoundingVolume)) {
+                this._contentBoundingVolume = this.createBoundingVolume(content.boundingVolume, this.computedTransform, this._contentBoundingVolume);
+            }
+
+            // Destroy the debug bounding volumes. They will be generated fresh.
+            this._debugBoundingVolume = this._debugBoundingVolume && this._debugBoundingVolume.destroy();
+            this._debugContentBoundingVolume = this._debugContentBoundingVolume && this._debugContentBoundingVolume.destroy();
+        }
+    };
+
     function applyDebugSettings(tile, tileset, frameState) {
         // Tiles do not have a content.boundingVolume if it is the same as the tile's boundingVolume.
         var hasContentBoundingVolume = defined(tile._header.content) && defined(tile._header.content.boundingVolume);
@@ -637,35 +665,15 @@ define([
         }
     }
 
-    function updateTransform(tile) {
-        var transformDirty = !Matrix4.equals(tile.computedTransform, tile._computedTransform);
-        if (transformDirty) {
-            Matrix4.clone(tile.computedTransform, tile._computedTransform);
-
-            // Update the bounding volumes
-            var header = tile._header;
-            var content = tile._header.content;
-            tile._boundingVolume = tile.createBoundingVolume(header.boundingVolume, tile.computedTransform, tile._boundingVolume);
-            if (defined(tile._contentBoundingVolume)) {
-                tile._contentBoundingVolume = tile.createBoundingVolume(content.boundingVolume, tile.computedTransform, tile._contentBoundingVolume);
-            }
-
-            // Destroy the debug bounding volumes. They will be generated fresh.
-            tile._debugBoundingVolume = tile._debugBoundingVolume && tile._debugBoundingVolume.destroy();
-            tile._debugContentBoundingVolume = tile._debugContentBoundingVolume && tile._debugContentBoundingVolume.destroy();
-        }
-        tile._transformDirty = transformDirty;
-    }
-
     /**
      * Get the draw commands needed to render this tile.
      *
      * @private
      */
     Cesium3DTile.prototype.update = function(tileset, frameState) {
-        updateTransform(this);
         applyDebugSettings(this, tileset, frameState);
         this._content.update(tileset, frameState);
+        this._transformDirty = false;
     };
 
     var scratchCommandList = [];

--- a/Source/Scene/Cesium3DTile.js
+++ b/Source/Scene/Cesium3DTile.js
@@ -77,7 +77,6 @@ define([
      * @constructor
      */
     function Cesium3DTile(tileset, baseUrl, header, parent) {
-        this._tileset = tileset;
         this._header = header;
         var contentHeader = header.content;
 

--- a/Specs/Scene/Cesium3DTileSpec.js
+++ b/Specs/Scene/Cesium3DTileSpec.js
@@ -256,8 +256,8 @@ defineSuite([
             // Change the transform
             var newLongitude = -1.012;
             var newLatitude = 0.698874;
-            tile.computedTransform = getTileTransform(newLongitude, newLatitude);
-            tile.update(mockTileset);
+            tile.transform = getTileTransform(newLongitude, newLatitude);
+            tile.updateTransform();
 
             // Check the new transform
             var newCenter = Cartesian3.fromRadians(newLongitude, newLatitude);

--- a/Specs/Scene/Cesium3DTilesetSpec.js
+++ b/Specs/Scene/Cesium3DTilesetSpec.js
@@ -1516,6 +1516,7 @@ defineSuite([
     it('propagates tile transform down the tree', function() {
         return Cesium3DTilesTester.loadTileset(scene, tilesetWithTransformsUrl).then(function(tileset) {
             scene.renderForSpecs();
+            var stats = tileset._statistics;
             var root = tileset._root;
             var rootTransform = Matrix4.unpack(root._header.transform);
 
@@ -1523,7 +1524,7 @@ defineSuite([
             var childTransform = Matrix4.unpack(child._header.transform);
             var computedTransform = Matrix4.multiply(rootTransform, childTransform, new Matrix4());
 
-            expect(tileset._selectedTiles.length).toBe(2);
+            expect(stats.numberOfCommands).toBe(2);
             expect(root.computedTransform).toEqual(rootTransform);
             expect(child.computedTransform).toEqual(computedTransform);
 
@@ -1533,6 +1534,24 @@ defineSuite([
             computedTransform = Matrix4.multiply(tilesetTransform, computedTransform, computedTransform);
             scene.renderForSpecs();
             expect(child.computedTransform).toEqual(computedTransform);
+
+            // Set the modelMatrix somewhere off screen
+            tileset.modelMatrix = Matrix4.fromTranslation(new Cartesian3(0.0, 100000.0, 0.0));
+            scene.renderForSpecs();
+            expect(stats.numberOfCommands).toBe(0);
+
+            // Now bring it back
+            tileset.modelMatrix = Matrix4.IDENTITY;
+            scene.renderForSpecs();
+            expect(stats.numberOfCommands).toBe(2);
+
+            // Do the same steps for a tile transform
+            child.transform = Matrix4.fromTranslation(new Cartesian3(0.0, 100000.0, 0.0));
+            scene.renderForSpecs();
+            expect(stats.numberOfCommands).toBe(1);
+            child.transform = Matrix4.IDENTITY;
+            scene.renderForSpecs();
+            expect(stats.numberOfCommands).toBe(2);
         });
     });
 

--- a/Specs/Scene/PointCloud3DTileContentSpec.js
+++ b/Specs/Scene/PointCloud3DTileContentSpec.js
@@ -226,7 +226,6 @@ defineSuite([
 
             // Update tile transform
             tileset._root.transform = newTransform;
-            scene.renderForSpecs();
 
             // Move the camera to the new location
             setCamera(newLongitude, newLatitude);


### PR DESCRIPTION
For #3241 

This fixes an issue where the transform for a tile isn't updated unless the tile is selected. This is problematic when the tile is out of view initially and any change to its transform has no effect since the tile won't be selected.

Now the transform is updated in `selectTiles` rather than each tile's `update` so that the bounding volumes are correct before any distance/culling checks happen.
