### PR TITLE
Changed terrain provider urls in Sandcastle demos

### DIFF
--- a/Apps/Sandcastle/gallery/Cardboard.html
+++ b/Apps/Sandcastle/gallery/Cardboard.html
@@ -35,7 +35,7 @@ var viewer = new Cesium.Viewer('cesiumContainer', {
 viewer.scene.globe.enableLighting = true;
 
 viewer.terrainProvider = new Cesium.CesiumTerrainProvider({
-    url : '//assets.agi.com/stk-terrain/world',
+    url : 'https://assets.agi.com/stk-terrain/world',
     requestVertexNormals : true
 });
 

--- a/Apps/Sandcastle/gallery/Shadows.html
+++ b/Apps/Sandcastle/gallery/Shadows.html
@@ -37,7 +37,7 @@ var viewer = new Cesium.Viewer('cesiumContainer', {
 });
 
 viewer.terrainProvider = new Cesium.CesiumTerrainProvider({
-    url : '//assets.agi.com/stk-terrain/world',
+    url : 'https://assets.agi.com/stk-terrain/world',
     requestWaterMask : true,
     requestVertexNormals : true
 });

--- a/Apps/Sandcastle/gallery/development/Multiple Shadows.html
+++ b/Apps/Sandcastle/gallery/development/Multiple Shadows.html
@@ -44,7 +44,7 @@
             timeline : false
         });
         viewer.terrainProvider = new Cesium.CesiumTerrainProvider({
-            url : '//assets.agi.com/stk-terrain/world',
+            url : 'https://assets.agi.com/stk-terrain/world',
             requestWaterMask : true,
             requestVertexNormals : true
         });

--- a/Apps/Sandcastle/gallery/development/Shadows.html
+++ b/Apps/Sandcastle/gallery/development/Shadows.html
@@ -482,7 +482,7 @@ var pointLightCamera = new Cesium.Camera(scene);
 var spotLightCamera = new Cesium.Camera(scene);
 
 var cesiumTerrainProvider = new Cesium.CesiumTerrainProvider({
-    url : '//assets.agi.com/stk-terrain/world',
+    url : 'https://assets.agi.com/stk-terrain/world',
     requestWaterMask : true,
     requestVertexNormals : true
 });


### PR DESCRIPTION
Changed `//assets.agi.com/stk-terrain/world` to `https://assets.agi.com/stk-terrain/world` in some demos to match the other demos.
