### PR TITLE
Added important documentation to PointGraphics.

### DIFF
--- a/Source/DataSources/PointGraphics.js
+++ b/Source/DataSources/PointGraphics.js
@@ -29,6 +29,7 @@ define([
      * @param {Property} [options.show=true] A boolean Property specifying the visibility of the point.
      * @param {Property} [options.scaleByDistance] A {@link NearFarScalar} Property used to scale the point based on distance.
      * @param {Property} [options.translucencyByDistance] A {@link NearFarScalar} Property used to set translucency based on distance from the camera.
+     * @param {Property} [options.heightReference=HeightReference.NONE] A Property specifying what the height is relative to.
      */
     function PointGraphics(options) {
         this._color = undefined;


### PR DESCRIPTION
The "heightReference" option parameter description was missing so it was impossible to know that one could set the height reference of PointGraphics, without digging into the source.