### PR TITLE
Make default proxy smarter

### DIFF
--- a/Source/Core/DefaultProxy.js
+++ b/Source/Core/DefaultProxy.js
@@ -22,7 +22,8 @@ define(function() {
      * @returns {String} proxied resource
      */
     DefaultProxy.prototype.getURL = function(resource) {
-        return this.proxy + '?' + encodeURIComponent(resource);
+        var prefix = this.proxy.indexOf('?') === -1 ? '?' : '';
+        return this.proxy + prefix + encodeURIComponent(resource);
     };
 
     return DefaultProxy;


### PR DESCRIPTION
With this change, the question mark is only added when it is not already present in the proxy string.