### PR TITLE
Update Primitive and GroundPrimitive to use BatchTable

### DIFF
--- a/Source/Core/Geometry.js
+++ b/Source/Core/Geometry.js
@@ -158,7 +158,7 @@ define([
         /**
          * @private
          */
-        this.boundingSphereCV = undefined;
+        this.boundingSphereCV = options.boundingSphereCV;
     }
 
     /**

--- a/Source/Core/GeometryPipeline.js
+++ b/Source/Core/GeometryPipeline.js
@@ -1033,7 +1033,7 @@ define([
             var instance = instances[i];
             if (defined(instance.geometry)) {
                 instanceGeometry.push(instance);
-            } else {
+            } else if (defined(instance.westHemisphereGeometry) && defined(instance.eastHemisphereGeometry)) {
                 instanceSplitGeometry.push(instance);
             }
         }

--- a/Source/Scene/GroundPrimitive.js
+++ b/Source/Scene/GroundPrimitive.js
@@ -740,8 +740,10 @@ define([
         var context = frameState.context;
 
         var vs = ShadowVolumeVS;
+        vs = primitive._primitive._batchTable.getVertexShaderCallback()(vs);
         vs = Primitive._modifyShaderPosition(primitive, vs, frameState.scene3DOnly);
         vs = Primitive._appendShowToShader(primitive._primitive, vs);
+        vs = Primitive._updateColorAttribute(primitive._primitive, vs);
 
         var fs = ShadowVolumeFS;
         var attributeLocations = primitive._primitive._attributeLocations;
@@ -755,6 +757,9 @@ define([
         });
 
         if (primitive._primitive.allowPicking) {
+            var vsPick = ShaderSource.createPickVertexShaderSource(vs);
+            vsPick = Primitive._updatePickColorAttribute(vsPick);
+
             var pickFS = new ShaderSource({
                 sources : [fs],
                 pickColorQualifier : 'varying'
@@ -762,7 +767,7 @@ define([
             primitive._spPick = ShaderProgram.replaceCache({
                 context : context,
                 shaderProgram : primitive._spPick,
-                vertexShaderSource : ShaderSource.createPickVertexShaderSource(vs),
+                vertexShaderSource : vsPick,
                 fragmentShaderSource : pickFS,
                 attributeLocations : attributeLocations
             });
@@ -782,6 +787,7 @@ define([
         colorCommands.length = length;
 
         var vaIndex = 0;
+        var uniformMap = primitive._batchTable.getUniformMapCallback()(groundPrimitive._uniformMap);
 
         for (var i = 0; i < length; i += 3) {
             var vertexArray = primitive._va[vaIndex++];
@@ -798,7 +804,7 @@ define([
             command.vertexArray = vertexArray;
             command.renderState = groundPrimitive._rsStencilPreloadPass;
             command.shaderProgram = groundPrimitive._sp;
-            command.uniformMap = groundPrimitive._uniformMap;
+            command.uniformMap = uniformMap;
             command.pass = Pass.GROUND;
 
             // stencil depth command
@@ -813,7 +819,7 @@ define([
             command.vertexArray = vertexArray;
             command.renderState = groundPrimitive._rsStencilDepthPass;
             command.shaderProgram = groundPrimitive._sp;
-            command.uniformMap = groundPrimitive._uniformMap;
+            command.uniformMap = uniformMap;
             command.pass = Pass.GROUND;
 
             // color command
@@ -828,7 +834,7 @@ define([
             command.vertexArray = vertexArray;
             command.renderState = groundPrimitive._rsColorPass;
             command.shaderProgram = groundPrimitive._sp;
-            command.uniformMap = groundPrimitive._uniformMap;
+            command.uniformMap = uniformMap;
             command.pass = Pass.GROUND;
         }
     }
@@ -840,6 +846,7 @@ define([
         pickCommands.length = length;
 
         var pickIndex = 0;
+        var uniformMap = primitive._batchTable.getUniformMapCallback()(groundPrimitive._uniformMap);
 
         for (var j = 0; j < length; j += 3) {
             var pickOffset = pickOffsets[pickIndex++];
@@ -862,7 +869,7 @@ define([
             command.count = count;
             command.renderState = groundPrimitive._rsStencilPreloadPass;
             command.shaderProgram = groundPrimitive._sp;
-            command.uniformMap = groundPrimitive._uniformMap;
+            command.uniformMap = uniformMap;
             command.pass = Pass.GROUND;
 
             // stencil depth command
@@ -879,7 +886,7 @@ define([
             command.count = count;
             command.renderState = groundPrimitive._rsStencilDepthPass;
             command.shaderProgram = groundPrimitive._sp;
-            command.uniformMap = groundPrimitive._uniformMap;
+            command.uniformMap = uniformMap;
             command.pass = Pass.GROUND;
 
             // color command
@@ -896,7 +903,7 @@ define([
             command.count = count;
             command.renderState = groundPrimitive._rsPickPass;
             command.shaderProgram = groundPrimitive._spPick;
-            command.uniformMap = groundPrimitive._uniformMap;
+            command.uniformMap = uniformMap;
             command.pass = Pass.GROUND;
         }
     }

--- a/Source/Scene/PolylineCollection.js
+++ b/Source/Scene/PolylineCollection.js
@@ -396,7 +396,14 @@ define([
     }
 
     /**
-     * @private
+     * Called when {@link Viewer} or {@link CesiumWidget} render the scene to
+     * get the draw commands needed to render this primitive.
+     * <p>
+     * Do not call this function directly.  This is documented just to
+     * list the exceptions that may be propagated when the scene is rendered:
+     * </p>
+     *
+     * @exception {RuntimeError} Vertex texture fetch support is required to render primitives with per-instance attributes. The maximum number of vertex texture image units must be greater than zero.
      */
     PolylineCollection.prototype.update = function(frameState) {
         removePolylines(this);

--- a/Source/Scene/PolylineCollection.js
+++ b/Source/Scene/PolylineCollection.js
@@ -18,8 +18,10 @@ define([
         '../Core/Math',
         '../Core/Matrix4',
         '../Core/Plane',
+        '../Core/RuntimeError',
         '../Renderer/Buffer',
         '../Renderer/BufferUsage',
+        '../Renderer/ContextLimits',
         '../Renderer/DrawCommand',
         '../Renderer/RenderState',
         '../Renderer/ShaderProgram',
@@ -53,8 +55,10 @@ define([
         CesiumMath,
         Matrix4,
         Plane,
+        RuntimeError,
         Buffer,
         BufferUsage,
+        ContextLimits,
         DrawCommand,
         RenderState,
         ShaderProgram,
@@ -409,6 +413,9 @@ define([
         var properties = this._propertiesChanged;
 
         if (this._createBatchTable) {
+            if (ContextLimits.maximumVertexTextureImageUnits === 0) {
+                throw new RuntimeError('Vertex texture fetch support is required to render polylines. The maximum number of vertex texture image units must be greater than zero.');
+            }
             createBatchTable(this, context);
             this._createBatchTable = false;
         }

--- a/Source/Scene/Primitive.js
+++ b/Source/Scene/Primitive.js
@@ -700,12 +700,12 @@ define([
     }
 
     function cloneInstance(instance, geometry) {
-        return new GeometryInstance({
+        return {
             geometry : geometry,
             modelMatrix : Matrix4.clone(instance.modelMatrix),
             pickPrimitive : instance.pickPrimitive,
             id : instance.id
-        });
+        };
     }
 
     var positionRegex = /attribute\s+vec(?:3|4)\s+(.*)3DHigh;/g;
@@ -1034,7 +1034,7 @@ define([
                 primitive.modelMatrix = Matrix4.clone(result.modelMatrix, primitive.modelMatrix);
                 primitive._pickOffsets = result.pickOffsets;
 
-                if (defined(primitive._geometries)) {
+                if (defined(primitive._geometries) && primitive._geometries.length > 0) {
                     primitive._state = PrimitiveState.COMBINED;
                 } else {
                     setReady(primitive, frameState, PrimitiveState.FAILED, undefined);
@@ -1066,10 +1066,7 @@ define([
                 createdGeometry = geometry.constructor.createGeometry(geometry);
             }
 
-            if (defined(createdGeometry)) {
-                clonedInstances[geometryIndex++] = cloneInstance(instance, createdGeometry);
-            }
-
+            clonedInstances[geometryIndex++] = cloneInstance(instance, createdGeometry);
             instanceIds.push(instance.id);
         }
 
@@ -1095,7 +1092,7 @@ define([
         primitive.modelMatrix = Matrix4.clone(result.modelMatrix, primitive.modelMatrix);
         primitive._pickOffsets = result.pickOffsets;
 
-        if (defined(primitive._geometries)) {
+        if (defined(primitive._geometries) && primitive._geometries.length > 0) {
             primitive._state = PrimitiveState.COMBINED;
         } else {
             setReady(primitive, frameState, PrimitiveState.FAILED, undefined);

--- a/Source/Scene/Primitive.js
+++ b/Source/Scene/Primitive.js
@@ -1034,9 +1034,6 @@ define([
                 primitive.modelMatrix = Matrix4.clone(result.modelMatrix, primitive.modelMatrix);
                 primitive._pickOffsets = result.pickOffsets;
 
-                // TODO
-                //var invalidInstancesIndices = packedResult.invalidInstancesIndices;
-
                 if (defined(primitive._geometries)) {
                     primitive._state = PrimitiveState.COMBINED;
                 } else {

--- a/Source/Scene/Primitive.js
+++ b/Source/Scene/Primitive.js
@@ -823,7 +823,7 @@ define([
             'void main() \n' +
             '{ \n' +
             '    czm_non_show_main(); \n' +
-            '    gl_Position *= czm_batchTable_show; \n' +
+            '    gl_Position *= czm_batchTable_show(batchId); \n' +
             '}';
 
         return renamedVS + '\n' + showMain;

--- a/Source/Scene/Primitive.js
+++ b/Source/Scene/Primitive.js
@@ -940,27 +940,6 @@ define([
         //>>includeEnd('debug');
     }
 
-    function createPickIds(context, primitive, instances) {
-        var pickColors = [];
-        var length = instances.length;
-
-        for (var i = 0; i < length; ++i) {
-            var pickObject = {
-                primitive : defaultValue(instances[i].pickPrimitive, primitive)
-            };
-
-            if (defined(instances[i].id)) {
-                pickObject.id = instances[i].id;
-            }
-
-            var pickId = context.createPickId(pickObject);
-            primitive._pickIds.push(pickId);
-            pickColors.push(pickId.color);
-        }
-
-        return pickColors;
-    }
-
     function getUniformFunction(uniforms, name) {
         return function() {
             return uniforms[name];
@@ -1057,19 +1036,16 @@ define([
             var transferableObjects = [];
             instances = (isArray(primitive.geometryInstances)) ? primitive.geometryInstances : [primitive.geometryInstances];
 
-            var allowPicking = primitive.allowPicking;
             var scene3DOnly = frameState.scene3DOnly;
             var projection = frameState.mapProjection;
 
             var promise = combineGeometryTaskProcessor.scheduleTask(PrimitivePipeline.packCombineGeometryParameters({
                 createGeometryResults : primitive._createGeometryResults,
                 instances : instances,
-                pickIds : allowPicking ? createPickIds(frameState.context, primitive, instances) : undefined,
                 ellipsoid : projection.ellipsoid,
                 projection : projection,
                 elementIndexUintSupported : frameState.context.elementIndexUint,
                 scene3DOnly : scene3DOnly,
-                allowPicking : allowPicking,
                 vertexCacheOptimize : primitive.vertexCacheOptimize,
                 compressVertices : primitive.compressVertices,
                 modelMatrix : primitive.modelMatrix,
@@ -1154,19 +1130,16 @@ define([
         geometries.length = geometryIndex;
         clonedInstances.length = geometryIndex;
 
-        var allowPicking = primitive.allowPicking;
         var scene3DOnly = frameState.scene3DOnly;
         var projection = frameState.mapProjection;
 
         var result = PrimitivePipeline.combineGeometry({
             instances : clonedInstances,
             invalidInstances : invalidInstances,
-            pickIds : allowPicking ? createPickIds(frameState.context, primitive, clonedInstances) : undefined,
             ellipsoid : projection.ellipsoid,
             projection : projection,
             elementIndexUintSupported : frameState.context.elementIndexUint,
             scene3DOnly : scene3DOnly,
-            allowPicking : allowPicking,
             vertexCacheOptimize : primitive.vertexCacheOptimize,
             compressVertices : primitive.compressVertices,
             modelMatrix : primitive.modelMatrix,

--- a/Source/Scene/Primitive.js
+++ b/Source/Scene/Primitive.js
@@ -1401,6 +1401,7 @@ define([
      * @exception {DeveloperError} All instance geometries must have the same primitiveType.
      * @exception {DeveloperError} Appearance and material have a uniform with the same name.
      * @exception {DeveloperError} Primitive.modelMatrix is only supported in 3D mode.
+     * @exception {RuntimeError} Vertex texture fetch support is required to render primitives with per-instance attributes. The maximum number of vertex texture image units must be greater than zero.
      */
     Primitive.prototype.update = function(frameState) {
         if (((!defined(this.geometryInstances)) && (this._va.length === 0)) ||

--- a/Source/Scene/Primitive.js
+++ b/Source/Scene/Primitive.js
@@ -1422,7 +1422,9 @@ define([
         if (!defined(this._batchTable)) {
             createBatchTable(this, frameState.context);
         }
-        this._batchTable.update(frameState);
+        if (this._batchTable.attributes.length > 0) {
+            this._batchTable.update(frameState);
+        }
 
         if (this._state !== PrimitiveState.COMPLETE && this._state !== PrimitiveState.COMBINED) {
             if (this.asynchronous) {

--- a/Source/Scene/Primitive.js
+++ b/Source/Scene/Primitive.js
@@ -21,10 +21,12 @@ define([
         '../Core/GeometryInstanceAttribute',
         '../Core/isArray',
         '../Core/Matrix4',
+        '../Core/RuntimeError',
         '../Core/subdivideArray',
         '../Core/TaskProcessor',
         '../Renderer/Buffer',
         '../Renderer/BufferUsage',
+        '../Renderer/ContextLimits',
         '../Renderer/DrawCommand',
         '../Renderer/RenderState',
         '../Renderer/ShaderProgram',
@@ -60,10 +62,12 @@ define([
         GeometryInstanceAttribute,
         isArray,
         Matrix4,
+        RuntimeError,
         subdivideArray,
         TaskProcessor,
         Buffer,
         BufferUsage,
+        ContextLimits,
         DrawCommand,
         RenderState,
         ShaderProgram,
@@ -1419,10 +1423,14 @@ define([
             return;
         }
 
+        var context = frameState.context;
         if (!defined(this._batchTable)) {
-            createBatchTable(this, frameState.context);
+            createBatchTable(this, context);
         }
         if (this._batchTable.attributes.length > 0) {
+            if (ContextLimits.maximumVertexTextureImageUnits === 0) {
+                throw new RuntimeError('Vertex texture fetch support is required to render primitives with per-instance attributes. The maximum number of vertex texture image units must be greater than zero.');
+            }
             this._batchTable.update(frameState);
         }
 
@@ -1464,7 +1472,6 @@ define([
             createRS = true;
         }
 
-        var context = frameState.context;
         if (defined(this._material)) {
             this._material.update(context);
         }

--- a/Source/Scene/PrimitivePipeline.js
+++ b/Source/Scene/PrimitivePipeline.js
@@ -109,6 +109,37 @@ define([
         }
     }
 
+    function addGeometryBatchId(geometry, batchId) {
+        var attributes = geometry.attributes;
+        var positionAttr = attributes.position;
+        var numberOfComponents = positionAttr.values.length / positionAttr.componentsPerAttribute;
+
+        attributes.batchId = new GeometryAttribute({
+            componentDatatype : ComponentDatatype.FLOAT,
+            componentsPerAttribute : 1,
+            values : new Float32Array(numberOfComponents)
+        });
+
+        var values = attributes.batchId.values;
+        for (var j = 0; j < numberOfComponents; ++j) {
+            values[j] = batchId;
+        }
+    }
+
+    function addBatchIds(instances) {
+        var length = instances.length;
+
+        for (var i = 0; i < length; ++i) {
+            var instance = instances[i];
+            if (defined(instance.geometry)) {
+                addGeometryBatchId(instance.geometry, i);
+            } else {
+                addGeometryBatchId(instance.westHemisphereGeometry, i);
+                addGeometryBatchId(instance.eastHemisphereGeometry, i);
+            }
+        }
+    }
+
     function getCommonPerInstanceAttributeNames(instances) {
         var length = instances.length;
 
@@ -217,6 +248,8 @@ define([
                 GeometryPipeline.splitLongitude(instances[i]);
             }
         }
+
+        addBatchIds(instances);
 
         // Add pickColor attribute for picking individual instances
         if (allowPicking) {

--- a/Source/Scene/PrimitivePipeline.js
+++ b/Source/Scene/PrimitivePipeline.js
@@ -59,10 +59,9 @@ define([
 
         if (toWorld) {
             for (i = 0; i < length; ++i) {
-                if (!defined(instances[i].geometry)) {
-                    continue;
+                if (defined(instances[i].geometry)) {
+                    GeometryPipeline.transformToWorldCoordinates(instances[i]);
                 }
-                GeometryPipeline.transformToWorldCoordinates(instances[i]);
             }
         } else {
             // Leave geometry in local coordinate system; auto update model-matrix.
@@ -136,10 +135,9 @@ define([
         // Clip to IDL
         if (!scene3DOnly) {
             for (i = 0; i < length; ++i) {
-                if (!defined(instances[i].geometry)) {
-                    continue;
+                if (defined(instances[i].geometry)) {
+                    GeometryPipeline.splitLongitude(instances[i]);
                 }
-                GeometryPipeline.splitLongitude(instances[i]);
             }
         }
 
@@ -668,7 +666,7 @@ define([
 
         var i = 1;
         while (i < buffer.length) {
-            if(buffer[i++] === 1.0) {
+            if (buffer[i++] === 1.0) {
                 result[count++] = BoundingSphere.unpack(buffer, i);
             }
             i += BoundingSphere.packedLength;

--- a/Source/Shaders/Appearances/AllMaterialAppearanceVS.glsl
+++ b/Source/Shaders/Appearances/AllMaterialAppearanceVS.glsl
@@ -4,6 +4,7 @@ attribute vec3 normal;
 attribute vec3 tangent;
 attribute vec3 binormal;
 attribute vec2 st;
+attribute float batchId;
 
 varying vec3 v_positionEC;
 varying vec3 v_normalEC;

--- a/Source/Shaders/Appearances/BasicMaterialAppearanceVS.glsl
+++ b/Source/Shaders/Appearances/BasicMaterialAppearanceVS.glsl
@@ -1,6 +1,7 @@
 attribute vec3 position3DHigh;
 attribute vec3 position3DLow;
 attribute vec3 normal;
+attribute float batchId;
 
 varying vec3 v_positionEC;
 varying vec3 v_normalEC;

--- a/Source/Shaders/Appearances/EllipsoidSurfaceAppearanceVS.glsl
+++ b/Source/Shaders/Appearances/EllipsoidSurfaceAppearanceVS.glsl
@@ -1,6 +1,7 @@
 attribute vec3 position3DHigh;
 attribute vec3 position3DLow;
 attribute vec2 st;
+attribute float batchId;
 
 varying vec3 v_positionMC;
 varying vec3 v_positionEC;

--- a/Source/Shaders/Appearances/PerInstanceColorAppearanceVS.glsl
+++ b/Source/Shaders/Appearances/PerInstanceColorAppearanceVS.glsl
@@ -2,6 +2,7 @@ attribute vec3 position3DHigh;
 attribute vec3 position3DLow;
 attribute vec3 normal;
 attribute vec4 color;
+attribute float batchId;
 
 varying vec3 v_positionEC;
 varying vec3 v_normalEC;

--- a/Source/Shaders/Appearances/PerInstanceFlatColorAppearanceVS.glsl
+++ b/Source/Shaders/Appearances/PerInstanceFlatColorAppearanceVS.glsl
@@ -1,6 +1,7 @@
 attribute vec3 position3DHigh;
 attribute vec3 position3DLow;
 attribute vec4 color;
+attribute float batchId;
 
 varying vec4 v_color;
 

--- a/Source/Shaders/Appearances/PointAppearanceVS.glsl
+++ b/Source/Shaders/Appearances/PointAppearanceVS.glsl
@@ -1,6 +1,7 @@
 attribute vec3 position3DHigh;
 attribute vec3 position3DLow;
 attribute vec3 color;
+attribute float batchId;
 
 uniform float pointSize;
 

--- a/Source/Shaders/Appearances/PolylineColorAppearanceVS.glsl
+++ b/Source/Shaders/Appearances/PolylineColorAppearanceVS.glsl
@@ -6,6 +6,7 @@ attribute vec3 nextPosition3DHigh;
 attribute vec3 nextPosition3DLow;
 attribute vec2 expandAndWidth;
 attribute vec4 color;
+attribute float batchId;
 
 varying vec4 v_color;
 

--- a/Source/Shaders/Appearances/PolylineMaterialAppearanceVS.glsl
+++ b/Source/Shaders/Appearances/PolylineMaterialAppearanceVS.glsl
@@ -6,6 +6,7 @@ attribute vec3 nextPosition3DHigh;
 attribute vec3 nextPosition3DLow;
 attribute vec2 expandAndWidth;
 attribute vec2 st;
+attribute float batchId;
 
 varying float v_width;
 varying vec2 v_st;

--- a/Source/Shaders/Appearances/TexturedMaterialAppearanceVS.glsl
+++ b/Source/Shaders/Appearances/TexturedMaterialAppearanceVS.glsl
@@ -2,6 +2,7 @@ attribute vec3 position3DHigh;
 attribute vec3 position3DLow;
 attribute vec3 normal;
 attribute vec2 st;
+attribute float batchId;
 
 varying vec3 v_positionEC;
 varying vec3 v_normalEC;

--- a/Source/Shaders/ShadowVolumeVS.glsl
+++ b/Source/Shaders/ShadowVolumeVS.glsl
@@ -1,6 +1,7 @@
 attribute vec3 position3DHigh;
 attribute vec3 position3DLow;
 attribute vec4 color;
+attribute float batchId;
 
 // emulated noperspective
 varying float v_WindowZ;

--- a/Specs/Scene/DebugAppearanceSpec.js
+++ b/Specs/Scene/DebugAppearanceSpec.js
@@ -67,7 +67,8 @@ defineSuite([
 
     it('default construct with normal, binormal, or tangent attribute name', function() {
         var a = new DebugAppearance({
-            attributeName : 'normal'
+            attributeName : 'normal',
+            perInstanceAttribute : false
         });
 
         expect(a.vertexShaderSource).toBeDefined();
@@ -87,7 +88,8 @@ defineSuite([
 
     it('default construct with st attribute name', function() {
         var a = new DebugAppearance({
-            attributeName : 'st'
+            attributeName : 'st',
+            perInstanceAttribute : false
         });
 
         expect(a.vertexShaderSource).toBeDefined();
@@ -108,7 +110,8 @@ defineSuite([
     it('debug appearance with float attribute name', function() {
         var a = new DebugAppearance({
             attributeName : 'rotation',
-            glslDatatype : 'float'
+            glslDatatype : 'float',
+            perInstanceAttribute : true
         });
 
         expect(a.vertexShaderSource).toBeDefined();
@@ -129,7 +132,8 @@ defineSuite([
     it('debug appearance with vec3 attribute name', function() {
         var a = new DebugAppearance({
             attributeName : 'str',
-            glslDatatype : 'vec3'
+            glslDatatype : 'vec3',
+            perInstanceAttribute : false
         });
 
         expect(a.vertexShaderSource).toBeDefined();
@@ -150,7 +154,8 @@ defineSuite([
     it('debug appearance with vec4 attribute name', function() {
         var a = new DebugAppearance({
             attributeName : 'quaternion',
-            glslDatatype : 'vec4'
+            glslDatatype : 'vec4',
+            perInstanceAttribute : true
         });
 
         expect(a.vertexShaderSource).toBeDefined();
@@ -172,7 +177,8 @@ defineSuite([
         expect(function() {
             return new DebugAppearance({
                 attributeName : 'invalid_datatype',
-                glslDatatype : 'invalid'
+                glslDatatype : 'invalid',
+                perInstanceAttribute : true
             });
         }).toThrowDeveloperError();
     });
@@ -185,7 +191,8 @@ defineSuite([
         primitive = new Primitive({
             geometryInstances : createInstance(vertexFormat),
             appearance : new DebugAppearance({
-                attributeName : 'normal'
+                attributeName : 'normal',
+                perInstanceAttribute : false
             }),
             asynchronous : false,
             compressVertices : false
@@ -206,7 +213,8 @@ defineSuite([
         primitive = new Primitive({
             geometryInstances : createInstance(vertexFormat),
             appearance : new DebugAppearance({
-                attributeName : 'binormal'
+                attributeName : 'binormal',
+                perInstanceAttribute : false
             }),
             asynchronous : false,
             compressVertices : false
@@ -227,7 +235,8 @@ defineSuite([
         primitive = new Primitive({
             geometryInstances : createInstance(vertexFormat),
             appearance : new DebugAppearance({
-                attributeName : 'tangent'
+                attributeName : 'tangent',
+                perInstanceAttribute : false
             }),
             asynchronous : false,
             compressVertices : false
@@ -247,7 +256,8 @@ defineSuite([
         primitive = new Primitive({
             geometryInstances : createInstance(vertexFormat),
             appearance : new DebugAppearance({
-                attributeName : 'st'
+                attributeName : 'st',
+                perInstanceAttribute : false
             }),
             asynchronous : false,
             compressVertices : false
@@ -272,7 +282,8 @@ defineSuite([
             geometryInstances : rectangleInstance,
             appearance : new DebugAppearance({
                 attributeName : 'debug',
-                glslDatatype : 'float'
+                glslDatatype : 'float',
+                perInstanceAttribute : true
             }),
             asynchronous : false
         });
@@ -296,7 +307,8 @@ defineSuite([
             geometryInstances : rectangleInstance,
             appearance : new DebugAppearance({
                 attributeName : 'debug',
-                glslDatatype : 'vec2'
+                glslDatatype : 'vec2',
+                perInstanceAttribute : true
             }),
             asynchronous : false
         });
@@ -320,7 +332,8 @@ defineSuite([
             geometryInstances : rectangleInstance,
             appearance : new DebugAppearance({
                 attributeName : 'debug',
-                glslDatatype : 'vec3'
+                glslDatatype : 'vec3',
+                perInstanceAttribute : true
             }),
             asynchronous : false
         });
@@ -344,7 +357,8 @@ defineSuite([
             geometryInstances : rectangleInstance,
             appearance : new DebugAppearance({
                 attributeName : 'debug',
-                glslDatatype : 'vec4'
+                glslDatatype : 'vec4',
+                perInstanceAttribute : true
             }),
             asynchronous : false
         });


### PR DESCRIPTION
Updates `Primitive` and `GroundPrimitive` to use `BatchTable` instead of per-instance attributes.

This needs to be merged before #4309. It will fix the `PolylineGeometryUpdater` crashes in that branch.