### PR TITLE
Removed deprecated castShadows and receiveShadows

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,8 @@ Change Log
 
 * Breaking changes
     * Vertex texture fetch is now required to be supported to render polylines. Maximum vertex texture image units must be greater than zero.
+    * Removed `castShadows` and `receiveShadows` properties from `Model`, `Primitive`, and `Globe`. Use `shadows` instead with the `ShadowMode` enum, e.g. `model.shadows = ShadowMode.ENABLED`.
+    * `Viewer.terrainShadows` now uses the `ShadowMode` enum instead of a Boolean, e.g. `viewer.terrainShadows = ShadowMode.RECEIVE_ONLY`.
 * Fixed billboard rotation when sized in meters. [#3979](https://github.com/AnalyticalGraphicsInc/cesium/issues/3979)
 * Added `DebugCameraPrimitive` to visualize the view frustum of a camera.
 * Fixed touch events for the timeline [#4305](https://github.com/AnalyticalGraphicsInc/cesium/pull/4305)

--- a/Source/DataSources/CzmlDataSource.js
+++ b/Source/DataSources/CzmlDataSource.js
@@ -1409,8 +1409,6 @@ define([
         processPacketData(Number, model, 'maximumScale', modelData.maximumScale, interval, sourceUri, entityCollection);
         processPacketData(Boolean, model, 'incrementallyLoadTextures', modelData.incrementallyLoadTextures, interval, sourceUri, entityCollection);
         processPacketData(Boolean, model, 'runAnimations', modelData.runAnimations, interval, sourceUri, entityCollection);
-        processPacketData(Boolean, model, 'castShadows', modelData.castShadows, interval, sourceUri, entityCollection);
-        processPacketData(Boolean, model, 'receiveShadows', modelData.receiveShadows, interval, sourceUri, entityCollection);
         processPacketData(ShadowMode, model, 'shadows', modelData.shadows, interval, sourceUri, entityCollection);
         processPacketData(HeightReference, model, 'heightReference', modelData.heightReference, interval, sourceUri, entityCollection);
 

--- a/Source/DataSources/ModelGraphics.js
+++ b/Source/DataSources/ModelGraphics.js
@@ -47,8 +47,6 @@ define([
      * @param {Property} [options.incrementallyLoadTextures=true] Determine if textures may continue to stream in after the model is loaded.
      * @param {Property} [options.runAnimations=true] A boolean Property specifying if glTF animations specified in the model should be started.
      * @param {Property} [options.nodeTransformations] An object, where keys are names of nodes, and values are {@link TranslationRotationScale} Properties describing the transformation to apply to that node.
-     * @param {Property} [options.castShadows=true] Deprecated, use options.shadows instead. A boolean Property specifying whether the model casts shadows from each light source.
-     * @param {Property} [options.receiveShadows=true] Deprecated, use options.shadows instead. A boolean Property specifying whether the model receives shadows from shadow casters in the scene.
      * @param {Property} [options.shadows=ShadowMode.ENABLED] An enum Property specifying whether the model casts or receives shadows from each light source.
      * @param {Property} [options.heightReference=HeightReference.NONE] A Property specifying what the height is relative to.
      *
@@ -66,10 +64,6 @@ define([
         this._maximumScaleSubscription = undefined;
         this._incrementallyLoadTextures = undefined;
         this._incrementallyLoadTexturesSubscription = undefined;
-        this._castShadows = undefined;
-        this._castShadowsSubscription = undefined;
-        this._receiveShadows = undefined;
-        this._receiveShadowsSubscription = undefined;
         this._shadows = undefined;
         this._shadowsSubscription = undefined;
         this._uri = undefined;
@@ -145,24 +139,6 @@ define([
         incrementallyLoadTextures : createPropertyDescriptor('incrementallyLoadTextures'),
 
         /**
-         * Get or sets the boolean Property specifying whether the model
-         * casts shadows from each light source.
-         * @memberof ModelGraphics.prototype
-         * @type {Property}
-         * @deprecated
-         */
-        castShadows : createPropertyDescriptor('castShadows'),
-
-        /**
-         * Get or sets the boolean Property specifying whether the model
-         * receives shadows from shadow casters in the scene.
-         * @memberof ModelGraphics.prototype
-         * @type {Property}
-         * @deprecated
-         */
-        receiveShadows : createPropertyDescriptor('receiveShadows'),
-
-        /**
          * Get or sets the enum Property specifying whether the model
          * casts or receives shadows from each light source.
          * @memberof ModelGraphics.prototype
@@ -218,8 +194,6 @@ define([
         result.minimumPixelSize = this.minimumPixelSize;
         result.maximumScale = this.maximumScale;
         result.incrementallyLoadTextures = this.incrementallyLoadTextures;
-        result.castShadows = this.castShadows;
-        result.receiveShadows = this.receiveShadows;
         result.shadows = this.shadows;
         result.uri = this.uri;
         result.runAnimations = this.runAnimations;
@@ -247,8 +221,6 @@ define([
         this.minimumPixelSize = defaultValue(this.minimumPixelSize, source.minimumPixelSize);
         this.maximumScale = defaultValue(this.maximumScale, source.maximumScale);
         this.incrementallyLoadTextures = defaultValue(this.incrementallyLoadTextures, source.incrementallyLoadTextures);
-        this.castShadows = defaultValue(this.castShadows, source.castShadows);
-        this.receiveShadows = defaultValue(this.receiveShadows, source.receiveShadows);
         this.shadows = defaultValue(this.shadows, source.shadows);
         this.uri = defaultValue(this.uri, source.uri);
         this.runAnimations = defaultValue(this.runAnimations, source.runAnimations);

--- a/Source/DataSources/ModelVisualizer.js
+++ b/Source/DataSources/ModelVisualizer.js
@@ -131,21 +131,12 @@ define([
                 modelHash[entity.id] = modelData;
             }
 
-            var shadows = defaultShadows;
-            if (defined(modelGraphics._shadows)) {
-                shadows = Property.getValueOrDefault(modelGraphics._shadows, time, defaultShadows);
-            } else if (defined(modelGraphics._castShadows) || defined(modelGraphics._receiveShadows)) {
-                var castShadows = Property.getValueOrDefault(modelGraphics._castShadows, time, true);
-                var receiveShadows = Property.getValueOrDefault(modelGraphics.receiveShadows, time, true);
-                shadows = ShadowMode.fromCastReceive(castShadows, receiveShadows);
-            }
-
             model.show = true;
             model.scale = Property.getValueOrDefault(modelGraphics._scale, time, defaultScale);
             model.minimumPixelSize = Property.getValueOrDefault(modelGraphics._minimumPixelSize, time, defaultMinimumPixelSize);
             model.maximumScale = Property.getValueOrUndefined(modelGraphics._maximumScale, time);
             model.modelMatrix = Matrix4.clone(modelMatrix, model.modelMatrix);
-            model.shadows = shadows;
+            model.shadows = Property.getValueOrDefault(modelGraphics._shadows, time, defaultShadows);
             model.heightReference = Property.getValueOrDefault(modelGraphics._heightReference, time, defaultHeightReference);
 
             if (model.ready) {

--- a/Source/Scene/Globe.js
+++ b/Source/Scene/Globe.js
@@ -7,7 +7,6 @@ define([
         '../Core/defaultValue',
         '../Core/defined',
         '../Core/defineProperties',
-        '../Core/deprecationWarning',
         '../Core/destroyObject',
         '../Core/DeveloperError',
         '../Core/Ellipsoid',
@@ -38,7 +37,6 @@ define([
         defaultValue,
         defined,
         defineProperties,
-        deprecationWarning,
         destroyObject,
         DeveloperError,
         Ellipsoid,
@@ -280,46 +278,6 @@ define([
         tileLoadProgressEvent : {
             get: function() {
                 return this._surface.tileLoadProgressEvent;
-            }
-        },
-
-        /**
-         * Determines whether the globe casts shadows from each light source.
-         *
-         * @memberof Globe.prototype
-         * @type {Boolean}
-         * @deprecated
-         */
-        castShadows : {
-            get : function() {
-                deprecationWarning('Globe.castShadows', 'Globe.castShadows was deprecated in Cesium 1.25. It will be removed in 1.26. Use Globe.shadows instead.');
-                return ShadowMode.castShadows(this.shadows);
-            },
-            set : function(value) {
-                deprecationWarning('Globe.castShadows', 'Globe.castShadows was deprecated in Cesium 1.25. It will be removed in 1.26. Use Globe.shadows instead.');
-                var castShadows = value;
-                var receiveShadows = ShadowMode.receiveShadows(this.shadows);
-                this.shadows = ShadowMode.fromCastReceive(castShadows, receiveShadows);
-            }
-        },
-
-        /**
-         * Determines whether the globe receives shadows from shadow casters in the scene.
-         *
-         * @memberof Globe.prototype
-         * @type {Boolean}
-         * @deprecated
-         */
-        receiveShadows : {
-            get : function() {
-                deprecationWarning('Globe.receiveShadows', 'Globe.receiveShadows was deprecated in Cesium 1.25. It will be removed in 1.26. Use Globe.shadows instead.');
-                return ShadowMode.receiveShadows(this.shadows);
-            },
-            set : function(value) {
-                deprecationWarning('Globe.receiveShadows', 'Globe.receiveShadows was deprecated in Cesium 1.25. It will be removed in 1.26. Use Globe.shadows instead.');
-                var castShadows = ShadowMode.castShadows(this.shadows);
-                var receiveShadows = value;
-                this.shadows = ShadowMode.fromCastReceive(castShadows, receiveShadows);
             }
         }
     });

--- a/Source/Scene/Model.js
+++ b/Source/Scene/Model.js
@@ -11,7 +11,6 @@ define([
         '../Core/defaultValue',
         '../Core/defined',
         '../Core/defineProperties',
-        '../Core/deprecationWarning',
         '../Core/destroyObject',
         '../Core/DeveloperError',
         '../Core/FeatureDetection',
@@ -71,7 +70,6 @@ define([
         defaultValue,
         defined,
         defineProperties,
-        deprecationWarning,
         destroyObject,
         DeveloperError,
         FeatureDetection,
@@ -315,8 +313,6 @@ define([
      * @param {Boolean} [options.allowPicking=true] When <code>true</code>, each glTF mesh and primitive is pickable with {@link Scene#pick}.
      * @param {Boolean} [options.incrementallyLoadTextures=true] Determine if textures may continue to stream in after the model is loaded.
      * @param {Boolean} [options.asynchronous=true] Determines if model WebGL resource creation will be spread out over several frames or block until completion once all glTF files are loaded.
-     * @param {Boolean} [options.castShadows=true] Deprecated, use options.shadows instead. Determines whether the model casts shadows from each light source.
-     * @param {Boolean} [options.receiveShadows=true] Deprecated, use options.shadows instead. Determines whether the model receives shadows from shadow casters in the scene.
      * @param {ShadowMode} [options.shadows=ShadowMode.ENABLED] Determines whether the model casts or receives shadows from each light source.
      * @param {Boolean} [options.debugShowBoundingVolume=false] For debugging only. Draws the bounding sphere for each draw command in the model.
      * @param {Boolean} [options.debugWireframe=false] For debugging only. Draws the model in wireframe.
@@ -507,10 +503,6 @@ define([
         this._incrementallyLoadTextures = defaultValue(options.incrementallyLoadTextures, true);
         this._asynchronous = defaultValue(options.asynchronous, true);
 
-        // Deprecated options
-        var castShadows = defaultValue(options.castShadows, true);
-        var receiveShadows = defaultValue(options.receiveShadows, true);
-
         /**
          * Determines whether the model casts or receives shadows from each light source.
          *
@@ -518,7 +510,7 @@ define([
          *
          * @default ShadowMode.ENABLED
          */
-        this.shadows = defaultValue(options.shadows, ShadowMode.fromCastReceive(castShadows, receiveShadows));
+        this.shadows = defaultValue(options.shadows, ShadowMode.ENABLED);
         this._shadows = this.shadows;
 
         /**
@@ -866,50 +858,6 @@ define([
         dirty : {
             get : function() {
                 return this._dirty;
-            }
-        },
-
-        /**
-         * Determines whether the model casts shadows from each light source.
-         *
-         * @memberof Model.prototype
-         *
-         * @type {Boolean}
-         *
-         * @deprecated
-         */
-        castShadows : {
-            get : function() {
-                deprecationWarning('Model.castShadows', 'Model.castShadows was deprecated in Cesium 1.25. It will be removed in 1.26. Use Model.shadows instead.');
-                return ShadowMode.castShadows(this.shadows);
-            },
-            set : function(value) {
-                deprecationWarning('Model.castShadows', 'Model.castShadows was deprecated in Cesium 1.25. It will be removed in 1.26. Use Model.shadows instead.');
-                var castShadows = value;
-                var receiveShadows = ShadowMode.receiveShadows(this.shadows);
-                this.shadows = ShadowMode.fromCastReceive(castShadows, receiveShadows);
-            }
-        },
-
-        /**
-         * Determines whether the model receives shadows from shadow casters in the scene.
-         *
-         * @memberof Model.prototype
-         *
-         * @type {Boolean}
-         *
-         * @deprecated
-         */
-        receiveShadows : {
-            get : function() {
-                deprecationWarning('Model.receiveShadows', 'Model.receiveShadows was deprecated in Cesium 1.25. It will be removed in 1.26. Use Model.shadows instead.');
-                return ShadowMode.receiveShadows(this.shadows);
-            },
-            set : function(value) {
-                deprecationWarning('Model.receiveShadows', 'Model.receiveShadows was deprecated in Cesium 1.25. It will be removed in 1.26. Use Model.shadows instead.');
-                var castShadows = ShadowMode.castShadows(this.shadows);
-                var receiveShadows = value;
-                this.shadows = ShadowMode.fromCastReceive(castShadows, receiveShadows);
             }
         }
     });

--- a/Source/Scene/Primitive.js
+++ b/Source/Scene/Primitive.js
@@ -9,7 +9,6 @@ define([
         '../Core/defaultValue',
         '../Core/defined',
         '../Core/defineProperties',
-        '../Core/deprecationWarning',
         '../Core/destroyObject',
         '../Core/DeveloperError',
         '../Core/FeatureDetection',
@@ -46,7 +45,6 @@ define([
         defaultValue,
         defined,
         defineProperties,
-        deprecationWarning,
         destroyObject,
         DeveloperError,
         FeatureDetection,
@@ -112,8 +110,6 @@ define([
      * @param {Boolean} [options.cull=true] When <code>true</code>, the renderer frustum culls and horizon culls the primitive's commands based on their bounding volume.  Set this to <code>false</code> for a small performance gain if you are manually culling the primitive.
      * @param {Boolean} [options.asynchronous=true] Determines if the primitive will be created asynchronously or block until ready.
      * @param {Boolean} [options.debugShowBoundingVolume=false] For debugging only. Determines if this primitive's commands' bounding spheres are shown.
-     * @param {Boolean} [options.castShadows=true] Deprecated, use options.shadows instead. Determines whether the primitive casts shadows from each light source.
-     * @param {Boolean} [options.receiveShadows=true] Deprecated, use options.shadows instead. Determines whether the primitive receives shadows from shadow casters in the scene.
      * @param {ShadowMode} [options.shadows=ShadowMode.DISABLED] Determines whether this primitive casts or receives shadows from each light source.
      *
      * @example
@@ -288,10 +284,6 @@ define([
         }
         //>>includeEnd('debug');
 
-        // Deprecated options
-        var castShadows = defaultValue(options.castShadows, false);
-        var receiveShadows = defaultValue(options.receiveShadows, false);
-
         /**
          * Determines whether this primitive casts or receives shadows from each light source.
          *
@@ -299,7 +291,7 @@ define([
          *
          * @default ShadowMode.DISABLED
          */
-        this.shadows = defaultValue(options.shadows, ShadowMode.fromCastReceive(castShadows, receiveShadows));
+        this.shadows = defaultValue(options.shadows, ShadowMode.DISABLED);
 
         this._translucent = undefined;
 
@@ -474,46 +466,6 @@ define([
         readyPromise : {
             get : function() {
                 return this._readyPromise.promise;
-            }
-        },
-
-        /**
-         * Determines whether the primitive casts shadows from each light source.
-         *
-         * @memberof Primitive.prototype
-         * @type {Boolean}
-         * @deprecated
-         */
-        castShadows : {
-            get : function() {
-                deprecationWarning('Primitive.castShadows', 'Primitive.castShadows was deprecated in Cesium 1.25. It will be removed in 1.26. Use Primitive.shadows instead.');
-                return ShadowMode.castShadows(this.shadows);
-            },
-            set : function(value) {
-                deprecationWarning('Primitive.castShadows', 'Primitive.castShadows was deprecated in Cesium 1.25. It will be removed in 1.26. Use Primitive.shadows instead.');
-                var castShadows = value;
-                var receiveShadows = ShadowMode.receiveShadows(this.shadows);
-                this.shadows = ShadowMode.fromCastReceive(castShadows, receiveShadows);
-            }
-        },
-
-        /**
-         * Determines whether the primitive receives shadows from shadow casters in the scene.
-         *
-         * @memberof Primitive.prototype
-         * @type {Boolean}
-         * @deprecated
-         */
-        receiveShadows : {
-            get : function() {
-                deprecationWarning('Primitive.receiveShadows', 'Primitive.receiveShadows was deprecated in Cesium 1.25. It will be removed in 1.26. Use Primitive.shadows instead.');
-                return ShadowMode.receiveShadows(this.shadows);
-            },
-            set : function(value) {
-                deprecationWarning('Primitive.receiveShadows', 'Primitive.receiveShadows was deprecated in Cesium 1.25. It will be removed in 1.26. Use Primitive.shadows instead.');
-                var castShadows = ShadowMode.castShadows(this.shadows);
-                var receiveShadows = value;
-                this.shadows = ShadowMode.fromCastReceive(castShadows, receiveShadows);
             }
         }
     });

--- a/Source/Widgets/CesiumWidget/CesiumWidget.js
+++ b/Source/Widgets/CesiumWidget/CesiumWidget.js
@@ -282,15 +282,7 @@ define([
             }
             if (globe !== false) {
                 scene.globe = globe;
-                // If the passed in value is a boolean, convert to the ShadowMode enum.
-                var terrainShadows = options.terrainShadows;
-                if (terrainShadows === true) {
-                    scene.globe.shadows = ShadowMode.ENABLED;
-                } else if (terrainShadows === false) {
-                    scene.globe.shadows = ShadowMode.RECEIVE_ONLY;
-                } else {
-                    scene.globe.shadows = defaultValue(terrainShadows, ShadowMode.RECEIVE_ONLY);
-                }
+                scene.globe.shadows = defaultValue(options.terrainShadows, ShadowMode.RECEIVE_ONLY);
             }
 
             var skyBox = options.skyBox;

--- a/Source/Widgets/Viewer/Viewer.js
+++ b/Source/Widgets/Viewer/Viewer.js
@@ -974,14 +974,7 @@ Either specify options.terrainProvider instead or set options.baseLayerPicker to
                 return this.scene.globe.shadows;
             },
             set : function(value) {
-                // If the passed in value is a boolean, convert to the ShadowMode enum.
-                if (value === true) {
-                    this.scene.globe.shadows = ShadowMode.ENABLED;
-                } else if (value === false) {
-                    this.scene.globe.shadows = ShadowMode.RECEIVE_ONLY;
-                } else {
-                    this.scene.globe.shadows = value;
-                }
+                this.scene.globe.shadows = value;
             }
         },
 


### PR DESCRIPTION
Fixes #4242

`castShadows` and `receiveShadows` are now removed in favor of `ShadowMode`.
Basically just reverted most of https://github.com/AnalyticalGraphicsInc/cesium/pull/4005/commits/e862db599c56e582c9bab424a0bedd0b1637bfb0