### PR TITLE
Fix shadowed models in 2D

### DIFF
--- a/Source/Scene/OIT.js
+++ b/Source/Scene/OIT.js
@@ -17,8 +17,7 @@ define([
         '../Shaders/AdjustTranslucentFS',
         '../Shaders/CompositeOITFS',
         './BlendEquation',
-        './BlendFunction',
-        './SceneMode'
+        './BlendFunction'
     ], function(
         BoundingRectangle,
         Color,
@@ -37,8 +36,7 @@ define([
         AdjustTranslucentFS,
         CompositeOITFS,
         BlendEquation,
-        BlendFunction,
-        SceneMode) {
+        BlendFunction) {
     'use strict';
 
     /**
@@ -528,7 +526,6 @@ define([
         var length = commands.length;
 
         var shadowsEnabled = scene.frameState.shadowHints.shadowsEnabled;
-        var scene2D = scene.mode === SceneMode.SCENE2D;
 
         passState.framebuffer = oit._adjustTranslucentFBO;
         oit._adjustTranslucentCommand.execute(context, passState);
@@ -540,7 +537,7 @@ define([
 
         for (j = 0; j < length; ++j) {
             command = commands[j];
-            derivedCommand = shadowsEnabled && !scene2D ? command.derivedCommands.oit.shadows.translucentCommand : command.derivedCommands.oit.translucentCommand;
+            derivedCommand = shadowsEnabled ? command.derivedCommands.oit.shadows.translucentCommand : command.derivedCommands.oit.translucentCommand;
             executeFunction(derivedCommand, scene, context, passState, debugFramebuffer);
         }
 
@@ -548,7 +545,7 @@ define([
 
         for (j = 0; j < length; ++j) {
             command = commands[j];
-            derivedCommand = shadowsEnabled && !scene2D ? command.derivedCommands.oit.shadows.alphaCommand : command.derivedCommands.oit.alphaCommand;
+            derivedCommand = shadowsEnabled ? command.derivedCommands.oit.shadows.alphaCommand : command.derivedCommands.oit.alphaCommand;
             executeFunction(derivedCommand, scene, context, passState, debugFramebuffer);
         }
 
@@ -561,7 +558,6 @@ define([
         var length = commands.length;
 
         var shadowsEnabled = scene.frameState.shadowHints.shadowsEnabled;
-        var scene2D = scene.mode === SceneMode.SCENE2D;
 
         passState.framebuffer = oit._adjustTranslucentFBO;
         oit._adjustTranslucentCommand.execute(context, passState);
@@ -571,7 +567,7 @@ define([
 
         for (var j = 0; j < length; ++j) {
             var command = commands[j];
-            var derivedCommand = shadowsEnabled && !scene2D ? command.derivedCommands.oit.shadows.translucentCommand : command.derivedCommands.oit.translucentCommand;
+            var derivedCommand = shadowsEnabled ? command.derivedCommands.oit.shadows.translucentCommand : command.derivedCommands.oit.translucentCommand;
             executeFunction(derivedCommand, scene, context, passState, debugFramebuffer);
         }
 

--- a/Source/Scene/OIT.js
+++ b/Source/Scene/OIT.js
@@ -17,7 +17,8 @@ define([
         '../Shaders/AdjustTranslucentFS',
         '../Shaders/CompositeOITFS',
         './BlendEquation',
-        './BlendFunction'
+        './BlendFunction',
+        './SceneMode'
     ], function(
         BoundingRectangle,
         Color,
@@ -36,7 +37,8 @@ define([
         AdjustTranslucentFS,
         CompositeOITFS,
         BlendEquation,
-        BlendFunction) {
+        BlendFunction,
+        SceneMode) {
     'use strict';
 
     /**
@@ -525,6 +527,9 @@ define([
         var framebuffer = passState.framebuffer;
         var length = commands.length;
 
+        var shadowsEnabled = scene.frameState.shadowHints.shadowsEnabled;
+        var scene2D = scene.mode === SceneMode.SCENE2D;
+
         passState.framebuffer = oit._adjustTranslucentFBO;
         oit._adjustTranslucentCommand.execute(context, passState);
         passState.framebuffer = oit._adjustAlphaFBO;
@@ -535,7 +540,7 @@ define([
 
         for (j = 0; j < length; ++j) {
             command = commands[j];
-            derivedCommand = command.derivedCommands.oit.translucentCommand;
+            derivedCommand = shadowsEnabled && !scene2D ? command.derivedCommands.oit.shadows.translucentCommand : command.derivedCommands.oit.translucentCommand;
             executeFunction(derivedCommand, scene, context, passState, debugFramebuffer);
         }
 
@@ -543,7 +548,7 @@ define([
 
         for (j = 0; j < length; ++j) {
             command = commands[j];
-            derivedCommand = command.derivedCommands.oit.alphaCommand;
+            derivedCommand = shadowsEnabled && !scene2D ? command.derivedCommands.oit.shadows.alphaCommand : command.derivedCommands.oit.alphaCommand;
             executeFunction(derivedCommand, scene, context, passState, debugFramebuffer);
         }
 
@@ -555,6 +560,9 @@ define([
         var framebuffer = passState.framebuffer;
         var length = commands.length;
 
+        var shadowsEnabled = scene.frameState.shadowHints.shadowsEnabled;
+        var scene2D = scene.mode === SceneMode.SCENE2D;
+
         passState.framebuffer = oit._adjustTranslucentFBO;
         oit._adjustTranslucentCommand.execute(context, passState);
 
@@ -563,7 +571,7 @@ define([
 
         for (var j = 0; j < length; ++j) {
             var command = commands[j];
-            var derivedCommand = command.derivedCommands.oit.translucentCommand;
+            var derivedCommand = shadowsEnabled && !scene2D ? command.derivedCommands.oit.shadows.translucentCommand : command.derivedCommands.oit.translucentCommand;
             executeFunction(derivedCommand, scene, context, passState, debugFramebuffer);
         }
 

--- a/Source/Scene/Scene.js
+++ b/Source/Scene/Scene.js
@@ -1128,11 +1128,11 @@ define([
 
             var oit = scene._oit;
             if (command.pass === Pass.TRANSLUCENT && defined(oit) && oit.isSupported()) {
-                if (!scene.scene3DOnly || !(lightShadowsEnabled && command.receiveShadows)) {
-                    derivedCommands.oit = oit.createDerivedCommands(command, context, derivedCommands.oit);
-                }
                 if (lightShadowsEnabled && command.receiveShadows) {
+                    derivedCommands.oit = defined(derivedCommands.oit) ? derivedCommands.oit : {};
                     derivedCommands.oit.shadows = oit.createDerivedCommands(command.derivedCommands.shadows.receiveCommand, context, derivedCommands.oit.shadows);
+                } else {
+                    derivedCommands.oit = oit.createDerivedCommands(command, context, derivedCommands.oit);
                 }
             }
         }

--- a/Source/Scene/Scene.js
+++ b/Source/Scene/Scene.js
@@ -1130,10 +1130,11 @@ define([
 
             var oit = scene._oit;
             if (command.pass === Pass.TRANSLUCENT && defined(oit) && oit.isSupported()) {
-                if (lightShadowsEnabled && command.receiveShadows) {
-                    derivedCommands.oit = oit.createDerivedCommands(command.derivedCommands.shadows.receiveCommand, context, derivedCommands.oit);
-                } else {
+                if (!scene.scene3DOnly || !(lightShadowsEnabled && command.receiveShadows)) {
                     derivedCommands.oit = oit.createDerivedCommands(command, context, derivedCommands.oit);
+                }
+                if (lightShadowsEnabled && command.receiveShadows) {
+                    derivedCommands.oit.shadows = oit.createDerivedCommands(command.derivedCommands.shadows.receiveCommand, context, derivedCommands.oit.shadows);
                 }
             }
         }

--- a/Source/Scene/Scene.js
+++ b/Source/Scene/Scene.js
@@ -1108,15 +1108,13 @@ define([
         var lightShadowMaps = frameState.shadowHints.lightShadowMaps;
         var lightShadowsEnabled = shadowsEnabled && (lightShadowMaps.length > 0);
 
+        // Update derived commands when any shadow maps become dirty
         var shadowsDirty = false;
-        if (shadowsEnabled && (command.receiveShadows || command.castShadows)) {
-            // Update derived commands when any shadow maps become dirty
-            var lastDirtyTime = frameState.shadowHints.lastDirtyTime;
-            if (command.lastDirtyTime !== lastDirtyTime) {
-                command.lastDirtyTime = lastDirtyTime;
-                command.dirty = true;
-                shadowsDirty = true;
-            }
+        var lastDirtyTime = frameState.shadowHints.lastDirtyTime;
+        if (command.lastDirtyTime !== lastDirtyTime) {
+            command.lastDirtyTime = lastDirtyTime;
+            command.dirty = true;
+            shadowsDirty = true;
         }
 
         if (command.dirty) {
@@ -2145,8 +2143,15 @@ define([
         var shadowMaps = frameState.shadowMaps;
         var length = shadowMaps.length;
 
-        frameState.shadowHints.shadowsEnabled = (length > 0) && !frameState.passes.pick && (scene.mode === SceneMode.SCENE3D);
-        if (!frameState.shadowHints.shadowsEnabled) {
+
+        var shadowsEnabled = (length > 0) && !frameState.passes.pick && (scene.mode === SceneMode.SCENE3D);
+        if (shadowsEnabled !== frameState.shadowHints.shadowsEnabled) {
+            // Update derived commands when shadowsEnabled changes
+            ++frameState.shadowHints.lastDirtyTime;
+            frameState.shadowHints.shadowsEnabled = shadowsEnabled;
+        }
+
+        if (!shadowsEnabled) {
             return;
         }
 

--- a/Source/Scene/Scene.js
+++ b/Source/Scene/Scene.js
@@ -2143,7 +2143,6 @@ define([
         var shadowMaps = frameState.shadowMaps;
         var length = shadowMaps.length;
 
-
         var shadowsEnabled = (length > 0) && !frameState.passes.pick && (scene.mode === SceneMode.SCENE3D);
         if (shadowsEnabled !== frameState.shadowHints.shadowsEnabled) {
             // Update derived commands when shadowsEnabled changes


### PR DESCRIPTION
Creates two sets of derived OIT commands when changing the scene mode is allowed. One for just OIT in 2D and one with OIT + shadows for 3D/CV.

Fixes #4378.

CC @pjcozzi @lilleyse 