### PR TITLE
Fix morphing from 2D to 3D

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,7 @@ Change Log
 * Added `DebugCameraPrimitive` to visualize the view frustum of a camera.
 * Added support for clustering `Billboard`, `Label` and `Point` entities. [#4240](https://github.com/AnalyticalGraphicsInc/cesium/pull/4240)
 * Added `DistanceDisplayCondition`s to all primitives to determine the range interval from the camera for when it will be visible.
+* Fix a bug when morphing from 2D to 3D. [#4388](https://github.com/AnalyticalGraphicsInc/cesium/pull/4388)
 
 ### 1.25 - 2016-09-01
 

--- a/Source/Scene/QuadtreePrimitive.js
+++ b/Source/Scene/QuadtreePrimitive.js
@@ -313,7 +313,9 @@ define([
      */
     QuadtreePrimitive.prototype.endFrame = function(frameState) {
         var passes = frameState.passes;
-        if (!passes.render) {
+        if (!passes.render || frameState.mode === SceneMode.MORPHING) {
+            // Only process the load queue for a single pass.
+            // Don't process the load queue or update heights during the morph flights.
             return;
         }
 

--- a/Source/Scene/SceneTransitioner.js
+++ b/Source/Scene/SceneTransitioner.js
@@ -358,9 +358,10 @@ define([
     var scratch2DTo3DFrustum = new PerspectiveFrustum();
 
     function morphFrom2DTo3D(transitioner, duration, ellipsoid) {
-        duration *= 0.5;
+        duration /= 3.0;
 
         var scene = transitioner._scene;
+        var camera = scene.camera;
         var frustum = scratch2DTo3DFrustum;
         frustum.aspectRatio = scene.drawingBufferWidth / scene.drawingBufferHeight;
         frustum.fov = CesiumMath.toRadians(60.0);
@@ -373,7 +374,6 @@ define([
             Cartesian3.normalize(camera3D.direction, camera3D.direction);
             Cartesian3.clone(Cartesian3.UNIT_Z, camera3D.up);
         } else {
-            var camera = scene.camera;
             camera.position.z = camera.frustum.right - camera.frustum.left;
 
             camera3D = getColumbusViewTo3DCamera(transitioner, ellipsoid);
@@ -384,9 +384,57 @@ define([
         var complete = complete3DCallback(camera3D);
         createMorphHandler(transitioner, complete);
 
-        morphOrthographicToPerspective(transitioner, duration, camera3D, function() {
-            morphFromColumbusViewTo3D(transitioner, duration, camera3D, complete);
-        });
+        var startPos = Cartesian3.clone(camera.position, scratch3DToCVStartPos);
+        var startDir = Cartesian3.clone(camera.direction, scratch3DToCVStartDir);
+        var startUp = Cartesian3.clone(camera.up, scratch3DToCVStartUp);
+
+        var endPos = Cartesian3.fromElements(0.0, 0.0, 5.0 * ellipsoid.maximumRadius, scratch3DToCVEndPos);
+        var endDir = Cartesian3.negate(Cartesian3.UNIT_Z, scratch3DToCVEndDir);
+        var endUp = Cartesian3.clone(Cartesian3.UNIT_Y, scratch3DToCVEndUp);
+
+        var startRight = camera.frustum.right;
+        var endRight = endPos.z * 0.5;
+
+        function update(value) {
+            columbusViewMorph(startPos, endPos, value.time, camera.position);
+            columbusViewMorph(startDir, endDir, value.time, camera.direction);
+            columbusViewMorph(startUp, endUp, value.time, camera.up);
+            Cartesian3.cross(camera.direction, camera.up, camera.right);
+            Cartesian3.normalize(camera.right, camera.right);
+
+            var frustum = camera.frustum;
+            frustum.right = CesiumMath.lerp(startRight, endRight, value.time);
+            frustum.left = -frustum.right;
+            frustum.top = frustum.right * (scene.drawingBufferHeight / scene.drawingBufferWidth);
+            frustum.bottom = -frustum.top;
+
+            camera.position.z = 2.0 * scene.mapProjection.ellipsoid.maximumRadius;
+        }
+
+        if (duration > 0.0) {
+            var tween = scene.tweens.add({
+                duration : duration,
+                easingFunction : EasingFunction.QUARTIC_OUT,
+                startObject : {
+                    time : 0.0
+                },
+                stopObject : {
+                    time : 1.0
+                },
+                update : update,
+                complete : function() {
+                    scene._mode = SceneMode.MORPHING;
+                    morphOrthographicToPerspective(transitioner, duration, camera3D, function() {
+                        morphFromColumbusViewTo3D(transitioner, duration, camera3D, complete);
+                    });
+                }
+            });
+            transitioner._currentTweens.push(tween);
+        } else {
+            morphOrthographicToPerspective(transitioner, duration, camera3D, function() {
+                morphFromColumbusViewTo3D(transitioner, duration, camera3D, complete);
+            });
+        }
     }
 
     function columbusViewMorph(startPosition, endPosition, time, result) {


### PR DESCRIPTION
Fixes #4383. 

Not just when tracking models. It also happens for any of the geometry Sandcastle examples. For example, double click one of the boxes in the box example to track it. When morphing to 3D from 2D, the camera position will remain the same when switching from an orthographic projection to a perspective projection. It was much more noticeable in the model example. This change adds back the flight to the home view.