### PR TITLE
Fix custom data source Sandcastle example.

### DIFF
--- a/Apps/Sandcastle/gallery/Custom DataSource.html
+++ b/Apps/Sandcastle/gallery/Custom DataSource.html
@@ -208,7 +208,7 @@ Object.defineProperties(WebGLGlobeDataSource.prototype, {
             return this._entityCluster;
         },
         set : function(value) {
-            if (!defined(value)) {
+            if (!Cesium.defined(value)) {
                 throw new Cesium.DeveloperError('value must be defined.');
             }
             this._entityCluster = value;

--- a/Apps/Sandcastle/gallery/Custom DataSource.html
+++ b/Apps/Sandcastle/gallery/Custom DataSource.html
@@ -53,6 +53,7 @@ function WebGLGlobeDataSource(name) {
     this._seriesNames = [];
     this._seriesToDisplay = undefined;
     this._heightScale = 10000000;
+    this._entityCluster = new Cesium.EntityCluster();
 }
 
 Object.defineProperties(WebGLGlobeDataSource.prototype, {
@@ -195,6 +196,22 @@ Object.defineProperties(WebGLGlobeDataSource.prototype, {
         },
         set : function(value) {
             this._entityCollection = value;
+        }
+    },
+    /**
+     * Gets or sets the clustering options for this data source. This object can be shared between multiple data sources.
+     * @memberof WebGLGlobeDataSource.prototype
+     * @type {EntityCluster}
+     */
+    clustering : {
+        get : function() {
+            return this._entityCluster;
+        },
+        set : function(value) {
+            if (!defined(value)) {
+                throw new Cesium.DeveloperError('value must be defined.');
+            }
+            this._entityCluster = value;
         }
     }
 });


### PR DESCRIPTION
The `clustering` property is now required on all `DataSource`s. Updated the Sandcastle example.