### PR TITLE
electron-prebuilt --> electron

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "bluebird": "3.4.6",
     "compressible": "2.0.8",
     "compression": "1.6.2",
-    "electron-prebuilt": "1.4.3",
+    "electron": "1.4.3",
     "event-stream": "3.3.4",
     "express": "4.14.0",
     "globby": "6.0.0",


### PR DESCRIPTION
From the [electron-prebuilt repo installation instructions](https://github.com/electron-userland/electron-prebuilt#installation):
> ...use either name, but electron is recommended, as the electron-prebuilt name is deprecated, and will only be published until the end of 2016.

`electron-prebuilt` is not deprecated *yet*, but better to be ahead of the curve, right?