### PR TITLE
When drawing primitives with no indices, no offset is necessary

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@ Change Log
 * Breaking changes
     * 
 * Fixed a crash that would occur when using dynamic `distanceDisplayCondition` properties. [#4403](https://github.com/AnalyticalGraphicsInc/cesium/pull/4403)
+* Fixed a bug affected models with multiple meshes without indices. [#4237](https://github.com/AnalyticalGraphicsInc/cesium/issues/4237)
 
 ### 1.26 - 2016-10-03
 

--- a/Source/Renderer/Context.js
+++ b/Source/Renderer/Context.js
@@ -938,7 +938,7 @@ define([
         } else {
             count = defaultValue(count, va.numberOfVertices);
             if (instanceCount === 0) {
-                context._gl.drawArrays(primitiveType, offset, count);
+                context._gl.drawArrays(primitiveType, 0, count);
             } else {
                 context.glDrawArraysInstanced(primitiveType, offset, count, instanceCount);
             }

--- a/Source/Renderer/Context.js
+++ b/Source/Renderer/Context.js
@@ -938,7 +938,7 @@ define([
         } else {
             count = defaultValue(count, va.numberOfVertices);
             if (instanceCount === 0) {
-                context._gl.drawArrays(primitiveType, 0, count);
+                context._gl.drawArrays(primitiveType, offset, count);
             } else {
                 context.glDrawArraysInstanced(primitiveType, offset, count, instanceCount);
             }

--- a/Source/Scene/Model.js
+++ b/Source/Scene/Model.js
@@ -2893,10 +2893,7 @@ define([
                     offset = (ix.byteOffset / IndexDatatype.getSizeInBytes(ix.componentType));  // glTF has offset in bytes.  Cesium has offsets in indices
                 }
                 else {
-                    var positions = accessors[primitive.attributes.POSITION];
-                    count = positions.count;
-                    var accessorInfo = getBinaryAccessor(positions);
-                    offset = (positions.byteOffset / (accessorInfo.componentsPerAttribute*ComponentDatatype.getSizeInBytes(positions.componentType)));
+                    offset = 0; // for primitives without indices, the offset is baked into the corresponding VertexArray
                 }
 
                 var um = uniformMaps[primitive.material];

--- a/Source/Scene/Model.js
+++ b/Source/Scene/Model.js
@@ -2893,7 +2893,9 @@ define([
                     offset = (ix.byteOffset / IndexDatatype.getSizeInBytes(ix.componentType));  // glTF has offset in bytes.  Cesium has offsets in indices
                 }
                 else {
-                    offset = 0; // for primitives without indices, the offset is baked into the corresponding VertexArray
+                    var positions = accessors[primitive.attributes.POSITION];
+                    count = positions.count;
+                    offset = 0;
                 }
 
                 var um = uniformMaps[primitive.material];


### PR DESCRIPTION
Fixes #4237. Our view of the buffer data already takes the offset into account, so that isn't necessary here.