### PR TITLE
Added tweak to getSpecular shader to prevent undefined behavior

### DIFF
--- a/Source/Shaders/Builtin/Functions/getSpecular.glsl
+++ b/Source/Shaders/Builtin/Functions/getSpecular.glsl
@@ -22,5 +22,8 @@ float czm_getSpecular(vec3 lightDirectionEC, vec3 toEyeEC, vec3 normalEC, float 
 {
     vec3 toReflectedLight = reflect(-lightDirectionEC, normalEC);
     float specular = max(dot(toReflectedLight, toEyeEC), 0.0);
-    return pow(specular, max(shininess, 0.01));
+
+    // pow has undefined behavior if both parameters <= 0.
+    // Prevent this by making sure shininess is at least czm_epsilon2.
+    return pow(specular, max(shininess, czm_epsilon2));
 }

--- a/Source/Shaders/Builtin/Functions/getSpecular.glsl
+++ b/Source/Shaders/Builtin/Functions/getSpecular.glsl
@@ -22,5 +22,5 @@ float czm_getSpecular(vec3 lightDirectionEC, vec3 toEyeEC, vec3 normalEC, float 
 {
     vec3 toReflectedLight = reflect(-lightDirectionEC, normalEC);
     float specular = max(dot(toReflectedLight, toEyeEC), 0.0);
-    return pow(specular, shininess);
+    return pow(specular, max(shininess, 0.01));
 }


### PR DESCRIPTION
The result of pow is undefined if specular and shininess are both 0. We were encountering models with a shininess of 0 which would cause the models to turn black depending on the angle.

See https://www.opengl.org/sdk/docs/man/html/pow.xhtml

Still need to figure out if there is a way to test this reliably.