### PR TITLE
Fixing a bug with the textures when the rectangle is rotated

### DIFF
--- a/Source/Core/RectangleGeometryLibrary.js
+++ b/Source/Core/RectangleGeometryLibrary.js
@@ -55,13 +55,10 @@ define([
         position.z = kZ / gamma;
 
         if (defined(options.vertexFormat) && options.vertexFormat.st) {
-            st.x = (stLongitude - rectangle.west) * options.lonScalar - 0.5;
-            st.y = (stLatitude - rectangle.south) * options.latScalar - 0.5;
+            st.x = (stLongitude - rectangle.west) * options.lonScalar;
+            st.y = (stLatitude - rectangle.south) * options.latScalar;
 
             Matrix2.multiplyByVector(options.textureMatrix, st, st);
-
-            st.x += 0.5;
-            st.y += 0.5;
         }
     };
 


### PR DESCRIPTION
I've detected problems with the textures of a rectangle when it is rotated (#2737). This pull request fixes (at least) all the use cases where the rotation fails