### PR TITLE
Ensure Sandcastle gallery is sorted alphabetically

### DIFF
--- a/Apps/Sandcastle/CesiumSandcastle.js
+++ b/Apps/Sandcastle/CesiumSandcastle.js
@@ -1106,7 +1106,7 @@ require({
 
     function addFileToGallery(index) {
         var searchDemos = dom.byId('searchDemos');
-        createGalleryButton(index, searchDemos, 'searchDemo');
+        searchDemos.appendChild(createGalleryButton(index, 'searchDemo'));
         return loadDemoFromFile(index);
     }
 
@@ -1134,12 +1134,12 @@ require({
                 }
                 var tabName = label + 'Demos';
                 var tab = dom.byId(tabName);
-                createGalleryButton(index, tab, tabName);
+                tab.appendChild(createGalleryButton(index, tabName));
             }
         }
     }
 
-    function createGalleryButton(index, tab, tabName) {
+    function createGalleryButton(index, tabName) {
         var demo = gallery_demos[index];
         var imgSrc = 'templates/Gallery_tile.jpg';
         if (Cesium.defined(demo.img)) {
@@ -1150,7 +1150,6 @@ require({
         demoLink.id = demo.name + tabName;
         demoLink.className = 'linkButton';
         demoLink.href = 'gallery/' + encodeURIComponent(demo.name) + '.html';
-        tab.appendChild(demoLink);
 
         if (demo.name === "Hello World") {
             newDemo = demo;
@@ -1184,13 +1183,15 @@ require({
                       '<img src="' + imgSrc + '" class="demoTileThumbnail" alt="" onDragStart="return false;" />'
         }).placeAt(demoLink);
 
-        on(dom.byId(demoLink.id), 'mouseover', function() {
+        on(demoLink, 'mouseover', function() {
             scheduleGalleryTooltip(demo);
         });
 
-        on(dom.byId(demoLink.id), 'mouseout', function() {
+        on(demoLink, 'mouseout', function() {
             closeGalleryTooltip();
         });
+
+        return demoLink;
     }
 
     var promise;
@@ -1241,7 +1242,7 @@ require({
             var demos = dom.byId('allDemos');
             for (i = 0; i < len; ++i) {
                 if (!/Development/i.test(gallery_demos[i].label)) {
-                    createGalleryButton(i, demos, 'all');
+                    demos.appendChild(createGalleryButton(i, 'all'));
                 }
             }
 

--- a/Apps/Sandcastle/CesiumSandcastle.js
+++ b/Apps/Sandcastle/CesiumSandcastle.js
@@ -1102,9 +1102,20 @@ require({
         loading = false;
     }
 
+    function insertSortedById(parentTab, galleryButton) {
+        var child;
+        for (child = parentTab.lastChild; child !== null; child = child.previousSibling) {
+            if (galleryButton.id >= child.id) {
+                parentTab.insertBefore(galleryButton, child.nextSibling);
+                return;
+            }
+        }
+        parentTab.appendChild(galleryButton);
+    }
+
     function addFileToGallery(demo) {
         var searchDemos = dom.byId('searchDemos');
-        searchDemos.appendChild(createGalleryButton(demo, 'searchDemo'));
+        insertSortedById(searchDemos, createGalleryButton(demo, 'searchDemo'));
         return loadDemoFromFile(demo);
     }
 
@@ -1131,7 +1142,7 @@ require({
                 }
                 var tabName = label + 'Demos';
                 var tab = dom.byId(tabName);
-                tab.appendChild(createGalleryButton(demo, tabName));
+                insertSortedById(tab, createGalleryButton(demo, tabName));
             }
         }
     }
@@ -1239,7 +1250,7 @@ require({
             for (i = 0; i < len; ++i) {
                 var demo = gallery_demos[i];
                 if (!/Development/i.test(demo.label)) {
-                    demos.appendChild(createGalleryButton(demo, 'all'));
+                    insertSortedById(demos, createGalleryButton(demo, 'all'));
                 }
             }
 

--- a/Apps/Sandcastle/CesiumSandcastle.js
+++ b/Apps/Sandcastle/CesiumSandcastle.js
@@ -1044,9 +1044,7 @@ require({
         });
     }
 
-    function loadDemoFromFile(index) {
-        var demo = gallery_demos[index];
-
+    function loadDemoFromFile(demo) {
         return requestDemo(demo.name).then(function(value) {
             // Store the file contents for later searching.
             demo.code = value;
@@ -1092,7 +1090,7 @@ require({
                 content : demo.description.replace(/\\n/g, '<br/>')
             });
 
-            addFileToTab(index);
+            addFileToTab(demo);
             return demo;
         });
     }
@@ -1104,10 +1102,10 @@ require({
         loading = false;
     }
 
-    function addFileToGallery(index) {
+    function addFileToGallery(demo) {
         var searchDemos = dom.byId('searchDemos');
-        searchDemos.appendChild(createGalleryButton(index, 'searchDemo'));
-        return loadDemoFromFile(index);
+        searchDemos.appendChild(createGalleryButton(demo, 'searchDemo'));
+        return loadDemoFromFile(demo);
     }
 
     function onShowCallback() {
@@ -1116,8 +1114,7 @@ require({
         };
     }
 
-    function addFileToTab(index) {
-        var demo = gallery_demos[index];
+    function addFileToTab(demo) {
         if (demo.label !== '') {
             var labels = demo.label.split(',');
             for (var j = 0; j < labels.length; j++) {
@@ -1134,13 +1131,12 @@ require({
                 }
                 var tabName = label + 'Demos';
                 var tab = dom.byId(tabName);
-                tab.appendChild(createGalleryButton(index, tabName));
+                tab.appendChild(createGalleryButton(demo, tabName));
             }
         }
     }
 
-    function createGalleryButton(index, tabName) {
-        var demo = gallery_demos[index];
+    function createGalleryButton(demo, tabName) {
         var imgSrc = 'templates/Gallery_tile.jpg';
         if (Cesium.defined(demo.img)) {
             imgSrc = 'gallery/' + demo.img;
@@ -1217,7 +1213,7 @@ require({
         var queryName = queryObject.src.replace('.html', '');
         var promises = [];
         for (i = 0; i < len; ++i) {
-            promises.push(addFileToGallery(i));
+            promises.push(addFileToGallery(gallery_demos[i]));
         }
 
         promise = all(promises).then(function(results) {
@@ -1241,17 +1237,19 @@ require({
 
             var demos = dom.byId('allDemos');
             for (i = 0; i < len; ++i) {
-                if (!/Development/i.test(gallery_demos[i].label)) {
-                    demos.appendChild(createGalleryButton(i, 'all'));
+                var demo = gallery_demos[i];
+                if (!/Development/i.test(demo.label)) {
+                    demos.appendChild(createGalleryButton(demo, 'all'));
                 }
             }
 
             if (!queryInGalleryIndex) {
-                gallery_demos.push({
-                                       name : queryName,
-                                       description : ''
-                                   });
-                return addFileToGallery(gallery_demos.length - 1);
+                var emptyDemo = {
+                    name : queryName,
+                    description : ''
+                };
+                gallery_demos.push(emptyDemo);
+                return addFileToGallery(emptyDemo);
             }
         });
     }

--- a/Apps/Sandcastle/CesiumSandcastle.js
+++ b/Apps/Sandcastle/CesiumSandcastle.js
@@ -1212,13 +1212,6 @@ require({
         var i;
         var len = gallery_demos.length;
 
-        // Sort alphabetically.  This will eventually be a user option.
-        gallery_demos.sort(function(a, b) {
-            var aName = a.name.toUpperCase();
-            var bName = b.name.toUpperCase();
-            return bName < aName ? 1 : bName > aName ? -1 : 0;
-        });
-
         var queryInGalleryIndex = false;
         var queryName = queryObject.src.replace('.html', '');
         var promises = [];

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1109,7 +1109,8 @@ function createSpecList() {
 }
 
 function createGalleryList() {
-    var demos = [];
+    var demoObjects = [];
+    var demoJSONs = [];
     var output = path.join('Apps', 'Sandcastle', 'gallery', 'gallery-index.js');
 
     var fileList = ['Apps/Sandcastle/gallery/**/*.html'];
@@ -1128,12 +1129,27 @@ function createGalleryList() {
             demoObject.img = demo + '.jpg';
         }
 
-        demos.push(JSON.stringify(demoObject, null, 2));
+        demoObjects.push(demoObject);
     });
+
+    demoObjects.sort(function(a, b) {
+      if (a.name < b.name) {
+        return -1;
+      } else if (a.name > b.name) {
+        return 1;
+      } else {
+        return 0;
+      }
+    });
+
+    var i;
+    for (i = 0; i < demoObjects.length; ++i) {
+      demoJSONs[i] = JSON.stringify(demoObjects[i], null, 2);
+    }
 
     var contents = '\
 // This file is automatically rebuilt by the Cesium build process.\n\
-var gallery_demos = [' + demos.join(', ') + '];';
+var gallery_demos = [' + demoJSONs.join(', ') + '];';
 
     fs.writeFileSync(output, contents);
 }


### PR DESCRIPTION
This is an attempt to fix #4056.

Changes:

* Sort gallery entries when building `gallery-index.js`, so that the order is deterministic (previously the order of entries depended on the order in which they returned when reading the directory entries).
* Assume that `gallery_index` is already sorted.

With this PR, the order of `gallery_index` should never change, so entities should remain sorted.

cc @emackey 