### PR TITLE
Treats null crs values as a no-op instead of failing to load

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,8 @@ Change Log
 * Fixed a bug where creating a custom geometry with attributes and indices that have values that are not a typed array would cause a crash. [#4419](https://github.com/AnalyticalGraphicsInc/cesium/pull/4419)
 * Fixed a bug with rotated, textured rectangles. [#4430](https://github.com/AnalyticalGraphicsInc/cesium/pull/4430)
 * Fixed a bug when morphing from 2D to 3D. [#4388](https://github.com/AnalyticalGraphicsInc/cesium/pull/4388)
+* `GeoJsonDataSource` now treats null crs values as a no-op instead of failing to load.
+* `GeoJsonDataSource` now gracefully handles missing style icons instead of failing to load.
 * Added `Rectangle.simpleIntersection`.
 * Added the ability to specify retina options, such as `@2x.png`, via the `MapboxImageryProvider` `format` option.
 * Removed an unnecessary reprojection of Web Mercator imagery tiles to the Geographic projection on load.  This should improve both visual quality and load performance slightly.

--- a/Source/DataSources/GeoJsonDataSource.js
+++ b/Source/DataSources/GeoJsonDataSource.js
@@ -871,12 +871,8 @@ define([
         }
 
         //Check for a Coordinate Reference System.
-        var crsFunction = defaultCrsFunction;
         var crs = geoJson.crs;
-
-        if (crs === null) {
-            throw new RuntimeError('crs is null.');
-        }
+        var crsFunction = crs !== null ? defaultCrsFunction : null;
 
         if (defined(crs)) {
             if (!defined(crs.properties)) {
@@ -912,7 +908,12 @@ define([
 
         return when(crsFunction, function(crsFunction) {
             that._entityCollection.removeAll();
-            typeHandler(that, geoJson, geoJson, crsFunction, options);
+
+            // null is a valid value for the crs, but means the entire load process becomes a no-op
+            // because we can't assume anything about the coordinates.
+            if (crsFunction !== null) {
+                typeHandler(that, geoJson, geoJson, crsFunction, options);
+            }
 
             return when.all(that._promises, function() {
                 that._promises.length = 0;

--- a/Specs/DataSources/GeoJsonDataSourceSpec.js
+++ b/Specs/DataSources/GeoJsonDataSourceSpec.js
@@ -1133,11 +1133,8 @@ defineSuite([
             crs : null
         };
 
-        return GeoJsonDataSource.load(featureWithNullCrs).then(function() {
-            fail('should not be called');
-        }).otherwise(function(error) {
-            expect(error).toBeInstanceOf(RuntimeError);
-            expect(error.message).toContain('crs is null.');
+        return GeoJsonDataSource.load(featureWithNullCrs).then(function(dataSource) {
+            expect(dataSource.entities.values.length).toBe(0);
         });
     });
 


### PR DESCRIPTION
Fixes #4438

Also updated changes from #4452, since I forgot to do that originally.