### PR TITLE
Fix ShadowMap NaNs

### DIFF
--- a/Source/Scene/ShadowMap.js
+++ b/Source/Scene/ShadowMap.js
@@ -1316,6 +1316,7 @@ define([
         var far;
         if (shadowMap._fitNearFar) {
             // shadowFar can be very large, so limit to shadowMap.maximumDistance
+            // Push the far plane slightly further than the near plane to avoid degenerate frustum
             near = Math.min(frameState.shadowHints.nearPlane, shadowMap.maximumDistance);
             far = Math.min(frameState.shadowHints.farPlane, shadowMap.maximumDistance + 1.0);
         } else {

--- a/Source/Scene/ShadowMap.js
+++ b/Source/Scene/ShadowMap.js
@@ -951,9 +951,9 @@ define([
         this.frustum = undefined;
         this.positionCartographic = new Cartographic();
         this.positionWC = new Cartesian3();
-        this.directionWC = new Cartesian3();
-        this.upWC = new Cartesian3();
-        this.rightWC = new Cartesian3();
+        this.directionWC = Cartesian3.clone(Cartesian3.UNIT_Z);
+        this.upWC = Cartesian3.clone(Cartesian3.UNIT_Y);
+        this.rightWC = Cartesian3.clone(Cartesian3.UNIT_X);
         this.viewProjectionMatrix = new Matrix4();
     }
 
@@ -1317,7 +1317,7 @@ define([
         if (shadowMap._fitNearFar) {
             // shadowFar can be very large, so limit to shadowMap.maximumDistance
             near = Math.min(frameState.shadowHints.nearPlane, shadowMap.maximumDistance);
-            far = Math.min(frameState.shadowHints.farPlane, shadowMap.maximumDistance);
+            far = Math.min(frameState.shadowHints.farPlane, shadowMap.maximumDistance + 1.0);
         } else {
             near = camera.frustum.near;
             far = shadowMap.maximumDistance;


### PR DESCRIPTION
For https://github.com/AnalyticalGraphicsInc/cesium/pull/3605

@hpinkos 

This fixes the NaNs.

Terrain shadows are still broken after https://github.com/AnalyticalGraphicsInc/cesium/pull/4339 was merged. I'm still investigating this but wanted to get the NaN fixes in the meantime.