### PR TITLE
Fix bounding volume for tiny ground primitives

### DIFF
--- a/Source/Scene/GroundPrimitive.js
+++ b/Source/Scene/GroundPrimitive.js
@@ -425,7 +425,7 @@ define([
 
     function getComputeMinimumHeightFunction(primitive) {
         return function(granularity, ellipsoid) {
-            return primitive._minHeight;
+            return primitive._minHeight - 15;
         };
     }
 

--- a/Specs/Scene/GroundPrimitiveSpec.js
+++ b/Specs/Scene/GroundPrimitiveSpec.js
@@ -874,6 +874,23 @@ defineSuite([
         expect(primitive.getGeometryInstanceAttributes('unknown')).not.toBeDefined();
     });
 
+    it('has a smaller minimum height to avoid z fighting', function() {
+        primitive = new GroundPrimitive({
+            geometryInstances : rectangleInstance
+        });
+
+        spyOn(RectangleGeometry, 'createShadowVolume').and.callThrough();
+
+        var frameState = scene.frameState;
+        primitive.update(frameState);
+
+        expect(RectangleGeometry.createShadowVolume).toHaveBeenCalled();
+        var args = RectangleGeometry.createShadowVolume.calls.allArgs();
+        var minFunction = args[0][1];
+        var value = minFunction(rectangle._granularity, rectangle._ellipsoid);
+        expect(value).toEqual(primitive._minHeight - 15);
+    });
+
     it('isDestroyed', function() {
         primitive = new GroundPrimitive();
         expect(primitive.isDestroyed()).toEqual(false);


### PR DESCRIPTION
Fixes #4326

The bounding box minimum wasn't quite low enough for really really tiny ground primitives which resulted in z-fighting

``` javascript
var viewer = new Cesium.Viewer('cesiumContainer');
var r1 = new Cesium.Rectangle(-0.2865044365070024, 0.49644278153576343, -0.28647774383347757, 0.496452001539263);
viewer.scene.primitives.add(new Cesium.GroundPrimitive({
    geometryInstances : [new Cesium.GeometryInstance({
        geometry : new Cesium.RectangleGeometry({
            rectangle : r1,
            vertexFormat : Cesium.PerInstanceColorAppearance.VERTEX_FORMAT
        }),
        attributes: {
            color: Cesium.ColorGeometryInstanceAttribute.fromColor(new Cesium.Color(1.0, 0.0, 0.0, 0.5))
        }
    })],
    appearance : new Cesium.PerInstanceColorAppearance({
        closed : true
    })
}));
viewer.scene.camera.setView({
    destination: r1
});
```