### PR TITLE
Fix Terrain Shadows

### DIFF
--- a/Source/Shaders/GlobeVS.glsl
+++ b/Source/Shaders/GlobeVS.glsl
@@ -110,13 +110,13 @@ void main()
     height = height * (u_minMaxHeight.y - u_minMaxHeight.x) + u_minMaxHeight.x;
     position = (u_scaleAndBias * vec4(position, 1.0)).xyz;
 
-#if defined(ENABLE_VERTEX_LIGHTING) && defined(INCLUDE_WEB_MERCATOR_Y)
+#if (defined(ENABLE_VERTEX_LIGHTING) || defined(GENERATE_POSITION_AND_NORMAL)) && defined(INCLUDE_WEB_MERCATOR_Y)
     float webMercatorT = czm_decompressTextureCoordinates(compressed0.w).x;
     float encodedNormal = compressed1;
 #elif defined(INCLUDE_WEB_MERCATOR_Y)
     float webMercatorT = czm_decompressTextureCoordinates(compressed0.w).x;
     float encodedNormal = 0.0;
-#elif defined(ENABLE_VERTEX_LIGHTING)
+#elif defined(ENABLE_VERTEX_LIGHTING) || defined(GENERATE_POSITION_AND_NORMAL)
     float webMercatorT = textureCoordinates.y;
     float encodedNormal = compressed0.w;
 #else
@@ -130,10 +130,10 @@ void main()
     float height = position3DAndHeight.w;
     vec2 textureCoordinates = textureCoordAndEncodedNormals.xy;
 
-#if defined(ENABLE_VERTEX_LIGHTING) && defined(INCLUDE_WEB_MERCATOR_Y)
+#if (defined(ENABLE_VERTEX_LIGHTING) || defined(GENERATE_POSITION_AND_NORMAL)) && defined(INCLUDE_WEB_MERCATOR_Y)
     float webMercatorT = textureCoordAndEncodedNormals.z;
     float encodedNormal = textureCoordAndEncodedNormals.w;
-#elif defined(ENABLE_VERTEX_LIGHTING)
+#elif defined(ENABLE_VERTEX_LIGHTING) || defined(GENERATE_POSITION_AND_NORMAL)
     float webMercatorT = textureCoordinates.y;
     float encodedNormal = textureCoordAndEncodedNormals.z;
 #elif defined(INCLUDE_WEB_MERCATOR_Y)


### PR DESCRIPTION
Fixes #4479 

The shadow normals were being calculated incorrectly because some of the new ifdefs were not using `GENERATE_POSITION_AND_NORMAL` (shadows specific flag).