### PR TITLE
Fix billboard and label clamping

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@ Change Log
 * Breaking changes
     * 
 * Fixed a crash that would occur when using dynamic `distanceDisplayCondition` properties. [#4403](https://github.com/AnalyticalGraphicsInc/cesium/pull/4403)
+* Fixed several bugs that lead to billboards and labels being improperly clamped to terrain.
 * Fixed a bug affected models with multiple meshes without indices. [#4237](https://github.com/AnalyticalGraphicsInc/cesium/issues/4237)
 * Fixed a glTF transparency bug where `blendFuncSeparate` parameters were loaded in the wrong order. [#4435](https://github.com/AnalyticalGraphicsInc/cesium/pull/4435)
 * Fixed a bug where creating a custom geometry with attributes and indices that have values that are not a typed array would cause a crash. [#4419](https://github.com/AnalyticalGraphicsInc/cesium/pull/4419)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,7 +8,7 @@ Change Log
 * Breaking changes
     * 
 * Fixed a crash that would occur when using dynamic `distanceDisplayCondition` properties. [#4403](https://github.com/AnalyticalGraphicsInc/cesium/pull/4403)
-* Fixed several bugs that lead to billboards and labels being improperly clamped to terrain.
+* Fixed several bugs that lead to billboards and labels being improperly clamped to terrain. [#4396](https://github.com/AnalyticalGraphicsInc/cesium/issues/4396), [#4062](https://github.com/AnalyticalGraphicsInc/cesium/issues/4062)
 * Fixed a bug affected models with multiple meshes without indices. [#4237](https://github.com/AnalyticalGraphicsInc/cesium/issues/4237)
 * Fixed a glTF transparency bug where `blendFuncSeparate` parameters were loaded in the wrong order. [#4435](https://github.com/AnalyticalGraphicsInc/cesium/pull/4435)
 * Fixed a bug where creating a custom geometry with attributes and indices that have values that are not a typed array would cause a crash. [#4419](https://github.com/AnalyticalGraphicsInc/cesium/pull/4419)

--- a/Source/Scene/Label.js
+++ b/Source/Scene/Label.js
@@ -166,15 +166,15 @@ define([
                 if (!Cartesian3.equals(position, value)) {
                     Cartesian3.clone(value, position);
 
-                    if (this._heightReference === HeightReference.NONE) {
-                        var glyphs = this._glyphs;
-                        for (var i = 0, len = glyphs.length; i < len; i++) {
-                            var billboard = glyphs[i].billboard;
-                            if (defined(billboard)) {
-                                billboard.position = value;
-                            }
+                    var glyphs = this._glyphs;
+                    for (var i = 0, len = glyphs.length; i < len; i++) {
+                        var billboard = glyphs[i].billboard;
+                        if (defined(billboard)) {
+                            billboard.position = value;
                         }
-                    } else {
+                    }
+
+                    if (this._heightReference !== HeightReference.NONE) {
                         this._updateClamping();
                     }
                 }

--- a/Source/Scene/QuadtreePrimitive.js
+++ b/Source/Scene/QuadtreePrimitive.js
@@ -617,11 +617,7 @@ define([
         var ellipsoid = projection.ellipsoid;
 
         while (tilesToUpdateHeights.length > 0) {
-            var tile = tilesToUpdateHeights[tilesToUpdateHeights.length - 1];
-            if (tile !== primitive._lastTileUpdated) {
-                primitive._lastTileIndex = 0;
-            }
-
+            var tile = tilesToUpdateHeights[0];
             var customData = tile.customData;
             var customDataLength = customData.length;
 
@@ -682,11 +678,11 @@ define([
             }
 
             if (timeSliceMax) {
-                primitive._lastTileUpdated = tile;
                 primitive._lastTileIndex = i;
                 break;
             } else {
-                tilesToUpdateHeights.pop();
+                primitive._lastTileIndex = 0;
+                tilesToUpdateHeights.shift();
             }
         }
     }


### PR DESCRIPTION
Turns out that billboard and label clamping were fundamentally broken because the `QuadtreePrimitive` was processing the tile queue in the wrong order.  It was always pulling new tiles from the back of the array rather than the front, which meant that data would get processed in the wrong order causing old tiles to take precedence over newer tiles.

Additionally, there was a bad if block in `Label.js` which caused the initial position of the individual label billboards to not be properly set when clamping was on, instead we should always set the positions before calling `_updateClamping` (if needed).

Fixes #4396 and #4062

I already talked to @bagnell about this and he agreed it was a straight up bug.  I would love to add unit tests for these, but I'm not sure what the best strategy would be.

There are still several other clamping related issues that I'm looking into; but I wanted to keep these PRs small for easier review.