### PR TITLE
Tidy up HeadingPitchRoll API

### DIFF
--- a/Apps/Sandcastle/gallery/3D Models.html
+++ b/Apps/Sandcastle/gallery/3D Models.html
@@ -40,7 +40,8 @@ function createModel(url, height) {
     var heading = Cesium.Math.toRadians(135);
     var pitch = 0;
     var roll = 0;
-    var orientation = Cesium.Transforms.headingPitchRollQuaternion(position, heading, pitch, roll);
+    var hpr = new Cesium.HeadingPitchRoll(heading, pitch, roll);
+    var orientation = Cesium.Transforms.headingPitchRollQuaternion(position, hpr);
 
     var entity = viewer.entities.add({
         name : url,

--- a/Apps/Sandcastle/gallery/Distance Display Conditions.html
+++ b/Apps/Sandcastle/gallery/Distance Display Conditions.html
@@ -54,7 +54,8 @@ function addPointAndModel() {
 
     var position = Cesium.Cartesian3.fromDegrees(-75.59777, 40.03883, 0.0);
     var heading = Cesium.Math.toRadians(135);
-    var orientation = Cesium.Transforms.headingPitchRollQuaternion(position, heading, 0.0, 0.0);
+    var hpr = new Cesium.HeadingPitchRoll(heading, 0.0, 0.0);
+    var orientation = Cesium.Transforms.headingPitchRollQuaternion(position, hpr);
 
     viewer.entities.add({
         position : position,

--- a/Apps/Sandcastle/gallery/development/3D Models Node Explorer.html
+++ b/Apps/Sandcastle/gallery/development/3D Models Node Explorer.html
@@ -181,11 +181,9 @@ var viewer = new Cesium.Viewer('cesiumContainer');
 var scene = viewer.scene;
 
 var height = 250000.0;
-var heading = 0.0;
-var pitch = 0.0;
-var roll = 0.0;
+var hpr = new HeadingPitchRoll(0.0, 0.0, 0.0);
 var origin = Cesium.Cartesian3.fromDegrees(-123.0744619, 44.0503706, height);
-var modelMatrix = Cesium.Transforms.headingPitchRollToFixedFrame(origin, heading, pitch, roll);
+var modelMatrix = Cesium.Transforms.headingPitchRollToFixedFrame(origin, hpr);
 
 var model = scene.primitives.add(Cesium.Model.fromGltf({
     url : modelUrl,

--- a/Apps/Sandcastle/gallery/development/3D Models Node Explorer.html
+++ b/Apps/Sandcastle/gallery/development/3D Models Node Explorer.html
@@ -182,7 +182,7 @@ var scene = viewer.scene;
 
 var height = 250000.0;
 var origin = Cesium.Cartesian3.fromDegrees(-123.0744619, 44.0503706, height);
-var modelMatrix = Cesium.Transforms.headingPitchRollToFixedFrame(origin, new HeadingPitchRoll());
+var modelMatrix = Cesium.Transforms.headingPitchRollToFixedFrame(origin, new Cesium.HeadingPitchRoll());
 
 var model = scene.primitives.add(Cesium.Model.fromGltf({
     url : modelUrl,

--- a/Apps/Sandcastle/gallery/development/3D Models Node Explorer.html
+++ b/Apps/Sandcastle/gallery/development/3D Models Node Explorer.html
@@ -181,9 +181,8 @@ var viewer = new Cesium.Viewer('cesiumContainer');
 var scene = viewer.scene;
 
 var height = 250000.0;
-var hpr = new HeadingPitchRoll(0.0, 0.0, 0.0);
 var origin = Cesium.Cartesian3.fromDegrees(-123.0744619, 44.0503706, height);
-var modelMatrix = Cesium.Transforms.headingPitchRollToFixedFrame(origin, hpr);
+var modelMatrix = Cesium.Transforms.headingPitchRollToFixedFrame(origin, new HeadingPitchRoll());
 
 var model = scene.primitives.add(Cesium.Model.fromGltf({
     url : modelUrl,

--- a/Apps/Sandcastle/gallery/development/3D Models.html
+++ b/Apps/Sandcastle/gallery/development/3D Models.html
@@ -35,9 +35,10 @@ function createModel(url, height, heading, pitch, roll) {
     heading = Cesium.defaultValue(heading, 0.0);
     pitch = Cesium.defaultValue(pitch, 0.0);
     roll = Cesium.defaultValue(roll, 0.0);
+    var hpr = new HeadingPitchRoll(heading, pitch, roll);
 
     var origin = Cesium.Cartesian3.fromDegrees(-123.0744619, 44.0503706, height);
-    var modelMatrix = Cesium.Transforms.headingPitchRollToFixedFrame(origin, heading, pitch, roll);
+    var modelMatrix = Cesium.Transforms.headingPitchRollToFixedFrame(origin, hpr);
 
     scene.primitives.removeAll(); // Remove previous model
     var model = scene.primitives.add(Cesium.Model.fromGltf({

--- a/Apps/Sandcastle/gallery/development/3D Models.html
+++ b/Apps/Sandcastle/gallery/development/3D Models.html
@@ -35,7 +35,7 @@ function createModel(url, height, heading, pitch, roll) {
     heading = Cesium.defaultValue(heading, 0.0);
     pitch = Cesium.defaultValue(pitch, 0.0);
     roll = Cesium.defaultValue(roll, 0.0);
-    var hpr = new HeadingPitchRoll(heading, pitch, roll);
+    var hpr = new Cesium.HeadingPitchRoll(heading, pitch, roll);
 
     var origin = Cesium.Cartesian3.fromDegrees(-123.0744619, 44.0503706, height);
     var modelMatrix = Cesium.Transforms.headingPitchRollToFixedFrame(origin, hpr);

--- a/Apps/Sandcastle/gallery/development/HeadingPitchRoll.html
+++ b/Apps/Sandcastle/gallery/development/HeadingPitchRoll.html
@@ -107,7 +107,7 @@ var speedVector = new Cesium.Cartesian3();
 
 var planePrimitive = scene.primitives.add(Cesium.Model.fromGltf({
     url : '../../SampleData/models/CesiumAir/Cesium_Air.glb',
-    modelMatrix : Cesium.Transforms.aircraftHeadingPitchRollToFixedFrame(position, hpRoll),
+    modelMatrix : Cesium.Transforms.headingPitchRollToFixedFrame(position, hpRoll),
     minimumPixelSize : 128
 }));
 
@@ -208,7 +208,7 @@ viewer.scene.preRender.addEventListener(function(scene, time) {
     speedVector = Cesium.Cartesian3.multiplyByScalar(Cesium.Cartesian3.UNIT_X, speed / 10, speedVector);
     position = Cesium.Matrix4.multiplyByPoint(planePrimitive.modelMatrix, speedVector, position);
     pathPosition.addSample(Cesium.JulianDate.now(), position);
-    Cesium.Transforms.aircraftHeadingPitchRollToFixedFrame(position, hpRoll, undefined, planePrimitive.modelMatrix);
+    Cesium.Transforms.headingPitchRollToFixedFrame(position, hpRoll, undefined, planePrimitive.modelMatrix);
 
     if (fromBehind.checked) {
         // Zoom to model

--- a/Apps/Sandcastle/gallery/development/Multiple Shadows.html
+++ b/Apps/Sandcastle/gallery/development/Multiple Shadows.html
@@ -74,7 +74,7 @@
 
             var model = scene.primitives.add(Cesium.Model.fromGltf({
                 url : '../../SampleData/models/ShadowTester/Shadow_Tester_Point.gltf',
-                modelMatrix : Cesium.Transforms.headingPitchRollToFixedFrame(center, new HeadingPitchRoll(heading, 0.0, 0.0))
+                modelMatrix : Cesium.Transforms.headingPitchRollToFixedFrame(center, new Cesium.HeadingPitchRoll(heading, 0.0, 0.0))
             }));
 
             model.readyPromise.then(function(model) {

--- a/Apps/Sandcastle/gallery/development/Multiple Shadows.html
+++ b/Apps/Sandcastle/gallery/development/Multiple Shadows.html
@@ -74,7 +74,7 @@
 
             var model = scene.primitives.add(Cesium.Model.fromGltf({
                 url : '../../SampleData/models/ShadowTester/Shadow_Tester_Point.gltf',
-                modelMatrix : Cesium.Transforms.headingPitchRollToFixedFrame(center, heading, 0.0, 0.0)
+                modelMatrix : Cesium.Transforms.headingPitchRollToFixedFrame(center, new HeadingPitchRoll(heading, 0.0, 0.0))
             }));
 
             model.readyPromise.then(function(model) {

--- a/Apps/Sandcastle/gallery/development/Shadows.html
+++ b/Apps/Sandcastle/gallery/development/Shadows.html
@@ -585,7 +585,7 @@ function updateModels() {
 }
 
 function createModel(url, origin) {
-    var modelMatrix = Cesium.Transforms.headingPitchRollToFixedFrame(origin, new HeadingPitchRoll());
+    var modelMatrix = Cesium.Transforms.headingPitchRollToFixedFrame(origin, new Cesium.HeadingPitchRoll());
 
     var model = scene.primitives.add(Cesium.Model.fromGltf({
         url : url,
@@ -606,7 +606,7 @@ function createModel(url, origin) {
 }
 
 function createBoxRTC(origin) {
-    var modelMatrix = Cesium.Transforms.headingPitchRollToFixedFrame(origin, new HeadingPitchRoll());
+    var modelMatrix = Cesium.Transforms.headingPitchRollToFixedFrame(origin, new Cesium.HeadingPitchRoll());
 
     var boxGeometry = Cesium.BoxGeometry.createGeometry(Cesium.BoxGeometry.fromDimensions({
         vertexFormat : Cesium.PerInstanceColorAppearance.VERTEX_FORMAT,
@@ -645,7 +645,7 @@ function createBoxRTC(origin) {
 }
 
 function createBox(origin) {
-    var modelMatrix = Cesium.Transforms.headingPitchRollToFixedFrame(origin, new HeadingPitchRoll());
+    var modelMatrix = Cesium.Transforms.headingPitchRollToFixedFrame(origin, new Cesium.HeadingPitchRoll());
 
     var box = new Cesium.Primitive({
         geometryInstances : new Cesium.GeometryInstance({
@@ -670,7 +670,7 @@ function createBox(origin) {
 }
 
 function createSphere(origin) {
-    var modelMatrix = Cesium.Transforms.headingPitchRollToFixedFrame(origin, new HeadingPitchRoll());
+    var modelMatrix = Cesium.Transforms.headingPitchRollToFixedFrame(origin, new Cesium.HeadingPitchRoll());
 
     var sphere = new Cesium.Primitive({
         geometryInstances : new Cesium.GeometryInstance({

--- a/Apps/Sandcastle/gallery/development/Shadows.html
+++ b/Apps/Sandcastle/gallery/development/Shadows.html
@@ -585,8 +585,7 @@ function updateModels() {
 }
 
 function createModel(url, origin) {
-    var hpr = new HeadingPitchRoll(0.0, 0.0, 0.0);
-    var modelMatrix = Cesium.Transforms.headingPitchRollToFixedFrame(origin, hpr);
+    var modelMatrix = Cesium.Transforms.headingPitchRollToFixedFrame(origin, new HeadingPitchRoll());
 
     var model = scene.primitives.add(Cesium.Model.fromGltf({
         url : url,
@@ -607,8 +606,7 @@ function createModel(url, origin) {
 }
 
 function createBoxRTC(origin) {
-    var hpr = new HeadingPitchRoll(0.0, 0.0, 0.0);
-    var modelMatrix = Cesium.Transforms.headingPitchRollToFixedFrame(origin, hpr);
+    var modelMatrix = Cesium.Transforms.headingPitchRollToFixedFrame(origin, new HeadingPitchRoll());
 
     var boxGeometry = Cesium.BoxGeometry.createGeometry(Cesium.BoxGeometry.fromDimensions({
         vertexFormat : Cesium.PerInstanceColorAppearance.VERTEX_FORMAT,
@@ -647,8 +645,7 @@ function createBoxRTC(origin) {
 }
 
 function createBox(origin) {
-    var hpr = new HeadingPitchRoll(0.0, 0.0, 0.0);
-    var modelMatrix = Cesium.Transforms.headingPitchRollToFixedFrame(origin, hpr);
+    var modelMatrix = Cesium.Transforms.headingPitchRollToFixedFrame(origin, new HeadingPitchRoll());
 
     var box = new Cesium.Primitive({
         geometryInstances : new Cesium.GeometryInstance({
@@ -673,8 +670,7 @@ function createBox(origin) {
 }
 
 function createSphere(origin) {
-    var hpr = new HeadingPitchRoll(0.0, 0.0, 0.0);
-    var modelMatrix = Cesium.Transforms.headingPitchRollToFixedFrame(origin, hpr);
+    var modelMatrix = Cesium.Transforms.headingPitchRollToFixedFrame(origin, new HeadingPitchRoll());
 
     var sphere = new Cesium.Primitive({
         geometryInstances : new Cesium.GeometryInstance({

--- a/Apps/Sandcastle/gallery/development/Shadows.html
+++ b/Apps/Sandcastle/gallery/development/Shadows.html
@@ -585,7 +585,8 @@ function updateModels() {
 }
 
 function createModel(url, origin) {
-    var modelMatrix = Cesium.Transforms.headingPitchRollToFixedFrame(origin, 0.0, 0.0, 0.0);
+    var hpr = new HeadingPitchRoll(0.0, 0.0, 0.0);
+    var modelMatrix = Cesium.Transforms.headingPitchRollToFixedFrame(origin, hpr);
 
     var model = scene.primitives.add(Cesium.Model.fromGltf({
         url : url,
@@ -606,7 +607,8 @@ function createModel(url, origin) {
 }
 
 function createBoxRTC(origin) {
-    var modelMatrix = Cesium.Transforms.headingPitchRollToFixedFrame(origin, 0.0, 0.0, 0.0);
+    var hpr = new HeadingPitchRoll(0.0, 0.0, 0.0);
+    var modelMatrix = Cesium.Transforms.headingPitchRollToFixedFrame(origin, hpr);
 
     var boxGeometry = Cesium.BoxGeometry.createGeometry(Cesium.BoxGeometry.fromDimensions({
         vertexFormat : Cesium.PerInstanceColorAppearance.VERTEX_FORMAT,
@@ -645,7 +647,8 @@ function createBoxRTC(origin) {
 }
 
 function createBox(origin) {
-    var modelMatrix = Cesium.Transforms.headingPitchRollToFixedFrame(origin, 0.0, 0.0, 0.0);
+    var hpr = new HeadingPitchRoll(0.0, 0.0, 0.0);
+    var modelMatrix = Cesium.Transforms.headingPitchRollToFixedFrame(origin, hpr);
 
     var box = new Cesium.Primitive({
         geometryInstances : new Cesium.GeometryInstance({
@@ -670,7 +673,8 @@ function createBox(origin) {
 }
 
 function createSphere(origin) {
-    var modelMatrix = Cesium.Transforms.headingPitchRollToFixedFrame(origin, 0.0, 0.0, 0.0);
+    var hpr = new HeadingPitchRoll(0.0, 0.0, 0.0);
+    var modelMatrix = Cesium.Transforms.headingPitchRollToFixedFrame(origin, hpr);
 
     var sphere = new Cesium.Primitive({
         geometryInstances : new Cesium.GeometryInstance({

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -30,6 +30,7 @@ Change Log
     * `HeadingPitchRoll.clone` function to duplicate HeadingPitchRoll instance.
     * `HeadingPitchRoll.equals` and `HeadingPitchRoll.equalsEpsilon` functions for comparing two instances.
 * Added `Matrix3.fromHeadingPitchRoll` Computes a 3x3 rotation matrix from the provided headingPitchRoll.
+* `Transforms.headingPitchRollToFixedFrame` and `Transforms.headingPitchRollQuaternion` now take a `HeadingPitchRoll` object in addition to separate heading, pitch, and roll values.  Separate values will be deprecated in 1.30.
 
 ### 1.26 - 2016-10-03
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,7 +24,6 @@ Change Log
 * Removed an unnecessary reprojection of Web Mercator imagery tiles to the Geographic projection on load.  This should improve both visual quality and load performance slightly.
 * Fix a issue where a billboard entity would not render after toggling the show propery. [#4408](https://github.com/AnalyticalGraphicsInc/cesium/issues/4408)
 * Added `Transforms.northUpEastToFixedFrame` to compute a 4x4 local transformation matrix from a reference frame with an north-west-up axes.
-* Added `Transforms.aircraftHeadingPitchRollToFixedFrame` to create a local frame from a position and heading/pitch/roll angles. The local frame is north-west-up axed.
 * Added `Transforms.aircraftHeadingPitchRollQuaternion` which is the quaternion rotation from `Transforms.aircraftHeadingPitchRollToFixedFrame`.
 * Added `HeadingPitchRoll` :
     * `HeadingPitchRoll.fromQuaternion` function for retrieving heading-pitch-roll angles from a quaternion.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,7 +24,6 @@ Change Log
 * Removed an unnecessary reprojection of Web Mercator imagery tiles to the Geographic projection on load.  This should improve both visual quality and load performance slightly.
 * Fix a issue where a billboard entity would not render after toggling the show propery. [#4408](https://github.com/AnalyticalGraphicsInc/cesium/issues/4408)
 * Added `Transforms.northUpEastToFixedFrame` to compute a 4x4 local transformation matrix from a reference frame with an north-west-up axes.
-* Added `Transforms.aircraftHeadingPitchRollQuaternion` which is the quaternion rotation from `Transforms.aircraftHeadingPitchRollToFixedFrame`.
 * Added `HeadingPitchRoll` :
     * `HeadingPitchRoll.fromQuaternion` function for retrieving heading-pitch-roll angles from a quaternion.
     * `HeadingPitchRoll.fromDegrees` function that returns a new HeadingPitchRoll instance from angles given in degrees.

--- a/Source/Core/Transforms.js
+++ b/Source/Core/Transforms.js
@@ -496,43 +496,6 @@ define([
         return Matrix4.multiply(result, hprMatrix, result);
     };
 
-    /**
-     * Computes a 4x4 transformation matrix from a reference frame with axes computed from the heading-pitch-roll angles
-     * centered at the provided origin to the provided ellipsoid's fixed reference frame. Heading is the rotation from the local north
-     * direction where a positive angle is increasing eastward. Pitch is the rotation from the local east-north plane. Positive pitch angles
-     * are above the plane. Negative pitch angles are below the plane. Roll is the first rotation applied about the local east axis.
-     *
-     * @param {Cartesian3} origin The center point of the local reference frame.
-     * @param {HeadingPitchRoll} headingPitchRoll The heading, pitch, roll angles to apply.
-     * @param {Ellipsoid} [ellipsoid=Ellipsoid.WGS84] The ellipsoid whose fixed frame is used in the transformation.
-     * @param {Matrix4} [result] The object onto which to store the result.
-     * @returns {Matrix4} The modified result parameter or a new Matrix4 instance if none was provided.
-     *
-     * @example
-     * // Get the transform from local heading-pitch-roll at cartographic (0.0, 0.0) to Earth's fixed frame.
-     * var center = Cesium.Cartesian3.fromDegrees(0.0, 0.0);
-     * var hpr = new HeadingPitchRoll(0.0, 0.0, 0.0);
-     * var hpr.heading = -Cesium.Math.PI_OVER_TWO;
-     * var hpr.pitch = Cesium.Math.PI_OVER_FOUR;
-     * var hpr.roll = 0.0;
-     * var transform = Cesium.Transforms.aircraftHeadingPitchRollToFixedFrame(center, hpr);
-     */
-    Transforms.aircraftHeadingPitchRollToFixedFrame = function(origin, headingPitchRoll, ellipsoid, result) {
-        // checks for required parameters happen in the called functions
-        //>>includeStart('debug', pragmas.debug);
-        if (!defined(origin)) {
-            throw new DeveloperError('origin is required.');
-        }
-        if (!defined(headingPitchRoll)) {
-            throw new DeveloperError('headingPitchRoll is required.');
-        }
-        //>>includeEnd('debug');
-        var hprQuaternion = Quaternion.fromHeadingPitchRoll(headingPitchRoll.heading, headingPitchRoll.pitch, headingPitchRoll.roll, scratchHPRQuaternion);
-        var hprMatrix = Matrix4.fromTranslationQuaternionRotationScale(Cartesian3.ZERO, hprQuaternion, scratchScale, scratchHPRMatrix4);
-        result = Transforms.eastNorthUpToFixedFrame(origin, ellipsoid, result);
-        return Matrix4.multiply(result, hprMatrix, result);
-    };
-
     var scratchENUMatrix4 = new Matrix4();
     var scratchHPRMatrix3 = new Matrix3();
 
@@ -1077,6 +1040,8 @@ define([
 
         return result;
     };
+
+    Transforms.aircraftHeadingPitchRollToFixedFrame = Transforms.headingPitchRollToFixedFrame;
 
     return Transforms;
 });

--- a/Source/Core/Transforms.js
+++ b/Source/Core/Transforms.js
@@ -537,36 +537,6 @@ define([
         return Quaternion.fromRotationMatrix(rotation, result);
     };
 
-    /**
-     * Computes a quaternion from a reference frame with axes computed from the heading-pitch-roll angles
-     * centered at the provided origin. Heading is the rotation from the local north
-     * direction where a positive angle is increasing eastward. Pitch is the rotation from the local east-north plane. Positive pitch angles
-     * are above the plane. Negative pitch angles are below the plane. Roll is the first rotation applied about the local east axis.
-     *
-     * @param {Cartesian3} origin The center point of the local reference frame.
-     * @param {HeadingPitchRoll} headingPitchRoll The heading, pitch, roll angles to apply.
-     * @param {Ellipsoid} [ellipsoid=Ellipsoid.WGS84] The ellipsoid whose fixed frame is used in the transformation.
-     * @param {Quaternion} [result] The object onto which to store the result.
-     * @returns {Quaternion} The modified result parameter or a new Quaternion instance if none was provided.
-     *
-     * @example
-     * // Get the quaternion from local heading-pitch-roll at cartographic (0.0, 0.0) to Earth's fixed frame.
-     * var center = Cesium.Cartesian3.fromDegrees(0.0, 0.0);
-     * var hpr = new HeadingPitchRoll(0.0, 0.0, 0.0);
-     * var hpr.heading = -Cesium.Math.PI_OVER_TWO;
-     * var hpr.pitch = Cesium.Math.PI_OVER_FOUR;
-     * var hpr.roll = 0.0;
-     * var quaternion = Cesium.Transforms.aircraftHeadingPitchRollQuaternion(center, hpr);
-     *
-     *
-     */
-    Transforms.aircraftHeadingPitchRollQuaternion = function(origin, headingPitchRoll, ellipsoid, result) {
-        // checks for required parameters happen in the called functions
-        var transform = Transforms.headingPitchRollToFixedFrame(origin, headingPitchRoll, ellipsoid, scratchENUMatrix4);
-        var rotation = Matrix4.getRotation(transform, scratchHPRMatrix3);
-        return Quaternion.fromRotationMatrix(rotation, result);
-    };
-
     var gmstConstant0 = 6 * 3600 + 41 * 60 + 50.54841;
     var gmstConstant1 = 8640184.812866;
     var gmstConstant2 = 0.093104;
@@ -1049,6 +1019,8 @@ define([
 
         return result;
     };
+
+    Transforms.aircraftHeadingPitchRollQuaternion = Transforms.headingPitchRollQuaternion;
 
     return Transforms;
 });

--- a/Source/Core/Transforms.js
+++ b/Source/Core/Transforms.js
@@ -459,7 +459,7 @@ define([
      * are above the plane. Negative pitch angles are below the plane. Roll is the first rotation applied about the local east axis.
      *
      * @param {Cartesian3} origin The center point of the local reference frame.
-     * @param {HeadingPitchRoll} hprOrHeading A HeadingPitchRoll or the heading angle in radians.
+     * @param {HeadingPitchRoll} headingPitchRoll A HeadingPitchRoll or the heading angle in radians.
      * @param {Number?} pitch The pitch angle in radians if a HeadingPitchRoll object was not passed.
      * @param {Number?} roll The roll angle in radians if a HeadingPitchRoll object was not passed.
      * @param {Ellipsoid} [ellipsoid=Ellipsoid.WGS84] The ellipsoid whose fixed frame is used in the transformation.
@@ -474,18 +474,18 @@ define([
      * var roll = 0.0;
      * var transform = Cesium.Transforms.headingPitchRollToFixedFrame(center, heading, pitch, roll);
      */
-    Transforms.headingPitchRollToFixedFrame = function(origin, hprOrHeading, pitch, roll, ellipsoid, result) {
+    Transforms.headingPitchRollToFixedFrame = function(origin, headingPitchRoll, pitch, roll, ellipsoid, result) {
         var heading;
-        if (typeof hprOrHeading === 'object') {
+        if (typeof headingPitchRoll === 'object') {
             // Shift arguments using assignments to encourage JIT optimization.
             ellipsoid = pitch;
             result = roll;
-            heading = hprOrHeading.heading;
-            pitch = hprOrHeading.pitch;
-            roll = hprOrHeading.roll;
+            heading = headingPitchRoll.heading;
+            pitch = headingPitchRoll.pitch;
+            roll = headingPitchRoll.roll;
         } else {
             deprecationWarning('headingPitchRollToFixedFrame', 'headingPitchRollToFixedFrame with separate heading, pitch, and roll arguments was deprecated in 1.27.  It will be removed in 1.30.  Use a HeadingPitchRoll object.');
-            heading = hprOrHeading;
+            heading = headingPitchRoll;
         }
         // checks for required parameters happen in the called functions
         var hprQuaternion = Quaternion.fromHeadingPitchRoll(heading, pitch, roll, scratchHPRQuaternion);

--- a/Source/Core/Transforms.js
+++ b/Source/Core/Transforms.js
@@ -459,9 +459,7 @@ define([
      * are above the plane. Negative pitch angles are below the plane. Roll is the first rotation applied about the local east axis.
      *
      * @param {Cartesian3} origin The center point of the local reference frame.
-     * @param {HeadingPitchRoll} headingPitchRoll A HeadingPitchRoll or the heading angle in radians.
-     * @param {Number?} pitch The pitch angle in radians if a HeadingPitchRoll object was not passed.
-     * @param {Number?} roll The roll angle in radians if a HeadingPitchRoll object was not passed.
+     * @param {HeadingPitchRoll} headingPitchRoll The heading, pitch, and roll.
      * @param {Ellipsoid} [ellipsoid=Ellipsoid.WGS84] The ellipsoid whose fixed frame is used in the transformation.
      * @param {Matrix4} [result] The object onto which to store the result.
      * @returns {Matrix4} The modified result parameter or a new Matrix4 instance if none was provided.

--- a/Source/Core/Transforms.js
+++ b/Source/Core/Transforms.js
@@ -1020,7 +1020,5 @@ define([
         return result;
     };
 
-    Transforms.aircraftHeadingPitchRollQuaternion = Transforms.headingPitchRollQuaternion;
-
     return Transforms;
 });

--- a/Source/Core/Transforms.js
+++ b/Source/Core/Transforms.js
@@ -458,10 +458,8 @@ define([
      * direction where a positive angle is increasing eastward. Pitch is the rotation from the local east-north plane. Positive pitch angles
      * are above the plane. Negative pitch angles are below the plane. Roll is the first rotation applied about the local east axis.
      *
-     * You should pass a HeadingPitchRoll object.  Passing separate heading, pitch, and roll values is deprecated.
-     *
      * @param {Cartesian3} origin The center point of the local reference frame.
-     * @param {HeadingPitchRoll|Number} hprOrHeading A HeadingPitchRoll or the heading angle in radians.
+     * @param {HeadingPitchRoll} hprOrHeading A HeadingPitchRoll or the heading angle in radians.
      * @param {Number?} pitch The pitch angle in radians if a HeadingPitchRoll object was not passed.
      * @param {Number?} roll The roll angle in radians if a HeadingPitchRoll object was not passed.
      * @param {Ellipsoid} [ellipsoid=Ellipsoid.WGS84] The ellipsoid whose fixed frame is used in the transformation.

--- a/Source/Core/Transforms.js
+++ b/Source/Core/Transforms.js
@@ -553,7 +553,7 @@ define([
      */
     Transforms.aircraftHeadingPitchRollQuaternion = function(origin, headingPitchRoll, ellipsoid, result) {
         // checks for required parameters happen in the called functions
-        var transform = Transforms.aircraftHeadingPitchRollToFixedFrame(origin, headingPitchRoll, ellipsoid, scratchENUMatrix4);
+        var transform = Transforms.headingPitchRollToFixedFrame(origin, headingPitchRoll, ellipsoid, scratchENUMatrix4);
         var rotation = Matrix4.getRotation(transform, scratchHPRMatrix3);
         return Quaternion.fromRotationMatrix(rotation, result);
     };
@@ -1040,8 +1040,6 @@ define([
 
         return result;
     };
-
-    Transforms.aircraftHeadingPitchRollToFixedFrame = Transforms.headingPitchRollToFixedFrame;
 
     return Transforms;
 });

--- a/Source/Core/Transforms.js
+++ b/Source/Core/Transforms.js
@@ -529,7 +529,7 @@ define([
         //>>includeEnd('debug');
         var hprQuaternion = Quaternion.fromHeadingPitchRoll(headingPitchRoll.heading, headingPitchRoll.pitch, headingPitchRoll.roll, scratchHPRQuaternion);
         var hprMatrix = Matrix4.fromTranslationQuaternionRotationScale(Cartesian3.ZERO, hprQuaternion, scratchScale, scratchHPRMatrix4);
-        result = Transforms.northWestUpToFixedFrame(origin, ellipsoid, result);
+        result = Transforms.eastNorthUpToFixedFrame(origin, ellipsoid, result);
         return Matrix4.multiply(result, hprMatrix, result);
     };
 

--- a/Specs/Core/TransformsSpec.js
+++ b/Specs/Core/TransformsSpec.js
@@ -354,70 +354,6 @@ defineSuite([
         expect(actualTranslation).toEqual(origin);
     });
 
-    it('aircraftHeadingPitchRollToFixedFrame works without a result parameter', function() {
-        var origin = new Cartesian3(1.0, 0.0, 0.0);
-        var heading = CesiumMath.toRadians(20.0);
-        var pitch = CesiumMath.toRadians(30.0);
-        var roll = CesiumMath.toRadians(40.0);
-
-        var expectedRotation = Matrix3.fromQuaternion(Quaternion.fromHeadingPitchRoll(heading, pitch, roll));
-        var expectedX = Matrix3.getColumn(expectedRotation, 0, new Cartesian3());
-        var expectedY = Matrix3.getColumn(expectedRotation, 1, new Cartesian3());
-        var expectedZ = Matrix3.getColumn(expectedRotation, 2, new Cartesian3());
-
-        Cartesian3.fromElements(expectedX.z, expectedX.x, expectedX.y, expectedX);
-        Cartesian3.fromElements(expectedY.z, expectedY.x, expectedY.y, expectedY);
-        Cartesian3.fromElements(expectedZ.z, expectedZ.x, expectedZ.y, expectedZ);
-
-        scratchHeadingPitchRoll.heading = heading;
-        scratchHeadingPitchRoll.pitch = pitch;
-        scratchHeadingPitchRoll.roll = roll;
-
-        var returnedResult = Transforms.aircraftHeadingPitchRollToFixedFrame(origin, scratchHeadingPitchRoll, Ellipsoid.UNIT_SPHERE);
-        var actualX = Cartesian3.fromCartesian4(Matrix4.getColumn(returnedResult, 0, new Cartesian4()));
-        var actualY = Cartesian3.fromCartesian4(Matrix4.getColumn(returnedResult, 1, new Cartesian4()));
-        var actualZ = Cartesian3.fromCartesian4(Matrix4.getColumn(returnedResult, 2, new Cartesian4()));
-        var actualTranslation = Cartesian3.fromCartesian4(Matrix4.getColumn(returnedResult, 3, new Cartesian4()));
-
-        expect(actualX).toEqual(expectedX);
-        expect(actualY).toEqual(expectedY);
-        expect(actualZ).toEqual(expectedZ);
-        expect(actualTranslation).toEqual(origin);
-    });
-
-    it('aircraftHeadingPitchRollToFixedFrame works with a result parameter', function() {
-        var origin = new Cartesian3(1.0, 0.0, 0.0);
-        var heading = CesiumMath.toRadians(20.0);
-        var pitch = CesiumMath.toRadians(30.0);
-        var roll = CesiumMath.toRadians(40.0);
-
-        var expectedRotation = Matrix3.fromQuaternion(Quaternion.fromHeadingPitchRoll(heading, pitch, roll));
-        var expectedX = Matrix3.getColumn(expectedRotation, 0, new Cartesian3());
-        var expectedY = Matrix3.getColumn(expectedRotation, 1, new Cartesian3());
-        var expectedZ = Matrix3.getColumn(expectedRotation, 2, new Cartesian3());
-
-        Cartesian3.fromElements(expectedX.z, expectedX.x, expectedX.y, expectedX);
-        Cartesian3.fromElements(expectedY.z, expectedY.x, expectedY.y, expectedY);
-        Cartesian3.fromElements(expectedZ.z, expectedZ.x, expectedZ.y, expectedZ);
-
-        scratchHeadingPitchRoll.heading = heading;
-        scratchHeadingPitchRoll.pitch = pitch;
-        scratchHeadingPitchRoll.roll = roll;
-
-        var result = new Matrix4();
-        var returnedResult = Transforms.aircraftHeadingPitchRollToFixedFrame(origin, scratchHeadingPitchRoll, Ellipsoid.UNIT_SPHERE, result);
-        var actualX = Cartesian3.fromCartesian4(Matrix4.getColumn(returnedResult, 0, new Cartesian4()));
-        var actualY = Cartesian3.fromCartesian4(Matrix4.getColumn(returnedResult, 1, new Cartesian4()));
-        var actualZ = Cartesian3.fromCartesian4(Matrix4.getColumn(returnedResult, 2, new Cartesian4()));
-        var actualTranslation = Cartesian3.fromCartesian4(Matrix4.getColumn(returnedResult, 3, new Cartesian4()));
-
-        expect(returnedResult).toBe(result);
-        expect(actualX).toEqual(expectedX);
-        expect(actualY).toEqual(expectedY);
-        expect(actualZ).toEqual(expectedZ);
-        expect(actualTranslation).toEqual(origin);
-    });
-
     it('headingPitchRollQuaternion works without a result parameter', function() {
         var origin = new Cartesian3(1.0, 0.0, 0.0);
         var heading = CesiumMath.toRadians(20.0);
@@ -454,7 +390,7 @@ defineSuite([
         scratchHeadingPitchRoll.pitch = CesiumMath.toRadians(30.0);
         scratchHeadingPitchRoll.roll = CesiumMath.toRadians(40.0);
 
-        var transform = Transforms.aircraftHeadingPitchRollToFixedFrame(origin, scratchHeadingPitchRoll, Ellipsoid.UNIT_SPHERE);
+        var transform = Transforms.headingPitchRollToFixedFrame(origin, scratchHeadingPitchRoll, Ellipsoid.UNIT_SPHERE);
         var expected = Matrix4.getRotation(transform, new Matrix3());
 
         var quaternion = Transforms.aircraftHeadingPitchRollQuaternion(origin, scratchHeadingPitchRoll, Ellipsoid.UNIT_SPHERE);
@@ -468,7 +404,7 @@ defineSuite([
         scratchHeadingPitchRoll.pitch = CesiumMath.toRadians(30.0);
         scratchHeadingPitchRoll.roll = CesiumMath.toRadians(40.0);
 
-        var transform = Transforms.aircraftHeadingPitchRollToFixedFrame(origin, scratchHeadingPitchRoll, Ellipsoid.UNIT_SPHERE);
+        var transform = Transforms.headingPitchRollToFixedFrame(origin, scratchHeadingPitchRoll, Ellipsoid.UNIT_SPHERE);
         var expected = Matrix4.getRotation(transform, new Matrix3());
 
         var result = new Quaternion();
@@ -1003,18 +939,6 @@ defineSuite([
     it('headingPitchRollToFixedFrame throws without an roll', function() {
         expect(function() {
             Transforms.headingPitchRollToFixedFrame(Cartesian3.ZERO, 0.0, 0.0, undefined);
-        }).toThrowDeveloperError();
-    });
-
-    it('aircraftHeadingPitchRollToFixedFrame throws without an origin', function() {
-        expect(function() {
-            Transforms.aircraftHeadingPitchRollToFixedFrame(undefined, scratchHeadingPitchRoll);
-        }).toThrowDeveloperError();
-    });
-
-    it('aircraftHeadingPitchRollToFixedFrame throws without an headingPitchRoll', function() {
-        expect(function() {
-            Transforms.aircraftHeadingPitchRollToFixedFrame(Cartesian3.ZERO, undefined);
         }).toThrowDeveloperError();
     });
 

--- a/Specs/Core/TransformsSpec.js
+++ b/Specs/Core/TransformsSpec.js
@@ -420,36 +420,6 @@ defineSuite([
         expect(actual).toEqualEpsilon(expected, CesiumMath.EPSILON11);
     });
 
-    it('aircraftHeadingPitchRollQuaternion works without a result parameter', function() {
-        var origin = new Cartesian3(1.0, 0.0, 0.0);
-        scratchHeadingPitchRoll.heading = CesiumMath.toRadians(20.0);
-        scratchHeadingPitchRoll.pitch = CesiumMath.toRadians(30.0);
-        scratchHeadingPitchRoll.roll = CesiumMath.toRadians(40.0);
-
-        var transform = Transforms.headingPitchRollToFixedFrame(origin, scratchHeadingPitchRoll, Ellipsoid.UNIT_SPHERE);
-        var expected = Matrix4.getRotation(transform, new Matrix3());
-
-        var quaternion = Transforms.aircraftHeadingPitchRollQuaternion(origin, scratchHeadingPitchRoll, Ellipsoid.UNIT_SPHERE);
-        var actual = Matrix3.fromQuaternion(quaternion);
-        expect(actual).toEqualEpsilon(expected, CesiumMath.EPSILON11);
-    });
-
-    it('aircraftHeadingPitchRollQuaternion works with a result parameter', function() {
-        var origin = new Cartesian3(1.0, 0.0, 0.0);
-        scratchHeadingPitchRoll.heading = CesiumMath.toRadians(20.0);
-        scratchHeadingPitchRoll.pitch = CesiumMath.toRadians(30.0);
-        scratchHeadingPitchRoll.roll = CesiumMath.toRadians(40.0);
-
-        var transform = Transforms.headingPitchRollToFixedFrame(origin, scratchHeadingPitchRoll, Ellipsoid.UNIT_SPHERE);
-        var expected = Matrix4.getRotation(transform, new Matrix3());
-
-        var result = new Quaternion();
-        var quaternion = Transforms.aircraftHeadingPitchRollQuaternion(origin, scratchHeadingPitchRoll, Ellipsoid.UNIT_SPHERE, result);
-        var actual = Matrix3.fromQuaternion(quaternion);
-        expect(quaternion).toBe(result);
-        expect(actual).toEqualEpsilon(expected, CesiumMath.EPSILON11);
-    });
-
     it('computeTemeToPseudoFixedMatrix works before noon', function() {
         var time = JulianDate.fromDate(new Date('June 29, 2015 12:00:00 UTC'));
         var t = Transforms.computeTemeToPseudoFixedMatrix(time);
@@ -977,18 +947,6 @@ defineSuite([
     it('headingPitchRollToFixedFrame throws without an roll', function() {
         expect(function() {
             Transforms.headingPitchRollToFixedFrame(Cartesian3.ZERO, 0.0, 0.0, undefined);
-        }).toThrowDeveloperError();
-    });
-
-    it('aircraftHeadingPitchRollQuaternion throws without an origin', function() {
-        expect(function() {
-            Transforms.aircraftHeadingPitchRollQuaternion(undefined, scratchHeadingPitchRoll);
-        }).toThrowDeveloperError();
-    });
-
-    it('aircraftHeadingPitchRollQuaternion throws without an headingPitchRoll', function() {
-        expect(function() {
-            Transforms.aircraftHeadingPitchRollQuaternion(Cartesian3.ZERO, undefined);
         }).toThrowDeveloperError();
     });
 

--- a/Specs/Core/TransformsSpec.js
+++ b/Specs/Core/TransformsSpec.js
@@ -46,7 +46,6 @@ defineSuite([
     var negativeX = new Cartesian4(-1, 0, 0, 0);
     var negativeY = new Cartesian4(0, -1, 0, 0);
     var negativeZ = new Cartesian4(0, 0, -1, 0);
-    var scratchHeadingPitchRoll = new Quaternion();
 
     it('eastNorthUpToFixedFrame works without a result parameter', function() {
         var origin = new Cartesian3(1.0, 0.0, 0.0);

--- a/Specs/Core/TransformsSpec.js
+++ b/Specs/Core/TransformsSpec.js
@@ -245,6 +245,7 @@ defineSuite([
         var heading = CesiumMath.toRadians(20.0);
         var pitch = CesiumMath.toRadians(30.0);
         var roll = CesiumMath.toRadians(40.0);
+        var hpr = new HeadingPitchRoll(heading, pitch, roll);
 
         var expectedRotation = Matrix3.fromQuaternion(Quaternion.fromHeadingPitchRoll(heading, pitch, roll));
         var expectedX = Matrix3.getColumn(expectedRotation, 0, new Cartesian3());
@@ -255,7 +256,7 @@ defineSuite([
         Cartesian3.fromElements(expectedY.z, expectedY.x, expectedY.y, expectedY);
         Cartesian3.fromElements(expectedZ.z, expectedZ.x, expectedZ.y, expectedZ);
 
-        var returnedResult = Transforms.headingPitchRollToFixedFrame(origin, heading, pitch, roll, Ellipsoid.UNIT_SPHERE);
+        var returnedResult = Transforms.headingPitchRollToFixedFrame(origin, hpr, Ellipsoid.UNIT_SPHERE);
         var actualX = Cartesian3.fromCartesian4(Matrix4.getColumn(returnedResult, 0, new Cartesian4()));
         var actualY = Cartesian3.fromCartesian4(Matrix4.getColumn(returnedResult, 1, new Cartesian4()));
         var actualZ = Cartesian3.fromCartesian4(Matrix4.getColumn(returnedResult, 2, new Cartesian4()));
@@ -300,6 +301,7 @@ defineSuite([
         var heading = CesiumMath.toRadians(20.0);
         var pitch = CesiumMath.toRadians(30.0);
         var roll = CesiumMath.toRadians(40.0);
+        var hpr = new HeadingPitchRoll(heading, pitch, roll);
 
         var expectedRotation = Matrix3.fromQuaternion(Quaternion.fromHeadingPitchRoll(heading, pitch, roll));
         var expectedX = Matrix3.getColumn(expectedRotation, 0, new Cartesian3());
@@ -311,7 +313,7 @@ defineSuite([
         Cartesian3.fromElements(expectedZ.z, expectedZ.x, expectedZ.y, expectedZ);
 
         var result = new Matrix4();
-        var returnedResult = Transforms.headingPitchRollToFixedFrame(origin, heading, pitch, roll, Ellipsoid.UNIT_SPHERE, result);
+        var returnedResult = Transforms.headingPitchRollToFixedFrame(origin, hpr, Ellipsoid.UNIT_SPHERE, result);
         var actualX = Cartesian3.fromCartesian4(Matrix4.getColumn(returnedResult, 0, new Cartesian4()));
         var actualY = Cartesian3.fromCartesian4(Matrix4.getColumn(returnedResult, 1, new Cartesian4()));
         var actualZ = Cartesian3.fromCartesian4(Matrix4.getColumn(returnedResult, 2, new Cartesian4()));
@@ -359,8 +361,9 @@ defineSuite([
         var heading = CesiumMath.toRadians(20.0);
         var pitch = CesiumMath.toRadians(30.0);
         var roll = CesiumMath.toRadians(40.0);
+        var hpr = new HeadingPitchRoll(heading, pitch, roll);
 
-        var transform = Transforms.headingPitchRollToFixedFrame(origin, heading, pitch, roll, Ellipsoid.UNIT_SPHERE);
+        var transform = Transforms.headingPitchRollToFixedFrame(origin, hpr, Ellipsoid.UNIT_SPHERE);
         var expected = Matrix4.getRotation(transform, new Matrix3());
 
         var quaternion = Transforms.headingPitchRollQuaternion(origin, heading, pitch, roll, Ellipsoid.UNIT_SPHERE);
@@ -373,8 +376,9 @@ defineSuite([
         var heading = CesiumMath.toRadians(20.0);
         var pitch = CesiumMath.toRadians(30.0);
         var roll = CesiumMath.toRadians(40.0);
+        var hpr = new HeadingPitchRoll(heading, pitch, roll);
 
-        var transform = Transforms.headingPitchRollToFixedFrame(origin, heading, pitch, roll, Ellipsoid.UNIT_SPHERE);
+        var transform = Transforms.headingPitchRollToFixedFrame(origin, hpr, Ellipsoid.UNIT_SPHERE);
         var expected = Matrix4.getRotation(transform, new Matrix3());
 
         var result = new Quaternion();
@@ -856,8 +860,9 @@ defineSuite([
         var heading = CesiumMath.toRadians(90.0);
         var pitch = CesiumMath.toRadians(45.0);
         var roll = 0.0;
+        var hpr = new HeadingPitchRoll(heading, pitch, roll);
 
-        var modelMatrix = Transforms.headingPitchRollToFixedFrame(origin, heading, pitch, roll, ellipsoid);
+        var modelMatrix = Transforms.headingPitchRollToFixedFrame(origin, hpr, ellipsoid);
         var modelMatrix2D = Transforms.basisTo2D(projection, modelMatrix, new Matrix4());
 
         var translation2D = Cartesian3.fromCartesian4(Matrix4.getColumn(modelMatrix2D, 3, new Cartesian4()));
@@ -876,8 +881,9 @@ defineSuite([
         var heading = CesiumMath.toRadians(90.0);
         var pitch = CesiumMath.toRadians(45.0);
         var roll = 0.0;
+        var hpr = new HeadingPitchRoll(heading, pitch, roll);
 
-        var modelMatrix = Transforms.headingPitchRollToFixedFrame(origin, heading, pitch, roll, ellipsoid);
+        var modelMatrix = Transforms.headingPitchRollToFixedFrame(origin, hpr, ellipsoid);
         var modelMatrix2D = Transforms.basisTo2D(projection, modelMatrix, new Matrix4());
 
         var rotation2D = Matrix4.getRotation(modelMatrix2D, new Matrix3());
@@ -886,11 +892,11 @@ defineSuite([
         var enuInverse = Matrix4.inverseTransformation(enu, enu);
 
         var hprPlusTranslate = Matrix4.multiply(enuInverse, modelMatrix, new Matrix4());
-        var hpr = Matrix4.getRotation(hprPlusTranslate, new Matrix3());
+        var hpr2 = Matrix4.getRotation(hprPlusTranslate, new Matrix3());
 
-        var row0 = Matrix3.getRow(hpr, 0, new Cartesian3());
-        var row1 = Matrix3.getRow(hpr, 1, new Cartesian3());
-        var row2 = Matrix3.getRow(hpr, 2, new Cartesian3());
+        var row0 = Matrix3.getRow(hpr2, 0, new Cartesian3());
+        var row1 = Matrix3.getRow(hpr2, 1, new Cartesian3());
+        var row2 = Matrix3.getRow(hpr2, 2, new Cartesian3());
 
         var expected = new Matrix3();
         Matrix3.setRow(expected, 0, row2, expected);

--- a/Specs/Core/TransformsSpec.js
+++ b/Specs/Core/TransformsSpec.js
@@ -365,9 +365,9 @@ defineSuite([
         var expectedY = Matrix3.getColumn(expectedRotation, 1, new Cartesian3());
         var expectedZ = Matrix3.getColumn(expectedRotation, 2, new Cartesian3());
 
-        Cartesian3.fromElements(expectedX.z, -expectedX.y, expectedX.x, expectedX);
-        Cartesian3.fromElements(expectedY.z, -expectedY.y, expectedY.x, expectedY);
-        Cartesian3.fromElements(expectedZ.z, -expectedZ.y, expectedZ.x, expectedZ);
+        Cartesian3.fromElements(expectedX.z, expectedX.x, expectedX.y, expectedX);
+        Cartesian3.fromElements(expectedY.z, expectedY.x, expectedY.y, expectedY);
+        Cartesian3.fromElements(expectedZ.z, expectedZ.x, expectedZ.y, expectedZ);
 
         scratchHeadingPitchRoll.heading = heading;
         scratchHeadingPitchRoll.pitch = pitch;
@@ -396,9 +396,9 @@ defineSuite([
         var expectedY = Matrix3.getColumn(expectedRotation, 1, new Cartesian3());
         var expectedZ = Matrix3.getColumn(expectedRotation, 2, new Cartesian3());
 
-        Cartesian3.fromElements(expectedX.z, -expectedX.y, expectedX.x, expectedX);
-        Cartesian3.fromElements(expectedY.z, -expectedY.y, expectedY.x, expectedY);
-        Cartesian3.fromElements(expectedZ.z, -expectedZ.y, expectedZ.x, expectedZ);
+        Cartesian3.fromElements(expectedX.z, expectedX.x, expectedX.y, expectedX);
+        Cartesian3.fromElements(expectedY.z, expectedY.x, expectedY.y, expectedY);
+        Cartesian3.fromElements(expectedZ.z, expectedZ.x, expectedZ.y, expectedZ);
 
         scratchHeadingPitchRoll.heading = heading;
         scratchHeadingPitchRoll.pitch = pitch;

--- a/Specs/Core/TransformsSpec.js
+++ b/Specs/Core/TransformsSpec.js
@@ -371,6 +371,21 @@ defineSuite([
         expect(actual).toEqualEpsilon(expected, CesiumMath.EPSILON11);
     });
 
+    it('headingPitchRollQuaternion works with a HeadingPitchRoll object and without a result parameter', function() {
+        var origin = new Cartesian3(1.0, 0.0, 0.0);
+        var heading = CesiumMath.toRadians(20.0);
+        var pitch = CesiumMath.toRadians(30.0);
+        var roll = CesiumMath.toRadians(40.0);
+        var hpr = new HeadingPitchRoll(heading, pitch, roll);
+
+        var transform = Transforms.headingPitchRollToFixedFrame(origin, hpr, Ellipsoid.UNIT_SPHERE);
+        var expected = Matrix4.getRotation(transform, new Matrix3());
+
+        var quaternion = Transforms.headingPitchRollQuaternion(origin, hpr, Ellipsoid.UNIT_SPHERE);
+        var actual = Matrix3.fromQuaternion(quaternion);
+        expect(actual).toEqualEpsilon(expected, CesiumMath.EPSILON11);
+    });
+
     it('headingPitchRollQuaternion works with a result parameter', function() {
         var origin = new Cartesian3(1.0, 0.0, 0.0);
         var heading = CesiumMath.toRadians(20.0);
@@ -383,6 +398,23 @@ defineSuite([
 
         var result = new Quaternion();
         var quaternion = Transforms.headingPitchRollQuaternion(origin, heading, pitch, roll, Ellipsoid.UNIT_SPHERE, result);
+        var actual = Matrix3.fromQuaternion(quaternion);
+        expect(quaternion).toBe(result);
+        expect(actual).toEqualEpsilon(expected, CesiumMath.EPSILON11);
+    });
+
+    it('headingPitchRollQuaternion works with a HeadingPitchRoll object and a result parameter', function() {
+        var origin = new Cartesian3(1.0, 0.0, 0.0);
+        var heading = CesiumMath.toRadians(20.0);
+        var pitch = CesiumMath.toRadians(30.0);
+        var roll = CesiumMath.toRadians(40.0);
+        var hpr = new HeadingPitchRoll(heading, pitch, roll);
+
+        var transform = Transforms.headingPitchRollToFixedFrame(origin, hpr, Ellipsoid.UNIT_SPHERE);
+        var expected = Matrix4.getRotation(transform, new Matrix3());
+
+        var result = new Quaternion();
+        var quaternion = Transforms.headingPitchRollQuaternion(origin, hpr, Ellipsoid.UNIT_SPHERE, result);
         var actual = Matrix3.fromQuaternion(quaternion);
         expect(quaternion).toBe(result);
         expect(actual).toEqualEpsilon(expected, CesiumMath.EPSILON11);

--- a/Specs/Core/TransformsSpec.js
+++ b/Specs/Core/TransformsSpec.js
@@ -267,6 +267,34 @@ defineSuite([
         expect(actualTranslation).toEqual(origin);
     });
 
+    it('headingPitchRollToFixedFrame works with a HeadingPitchRoll object and without a result parameter', function() {
+        var origin = new Cartesian3(1.0, 0.0, 0.0);
+        var heading = CesiumMath.toRadians(20.0);
+        var pitch = CesiumMath.toRadians(30.0);
+        var roll = CesiumMath.toRadians(40.0);
+        var hpr = new HeadingPitchRoll(heading, pitch, roll);
+
+        var expectedRotation = Matrix3.fromQuaternion(Quaternion.fromHeadingPitchRoll(heading, pitch, roll));
+        var expectedX = Matrix3.getColumn(expectedRotation, 0, new Cartesian3());
+        var expectedY = Matrix3.getColumn(expectedRotation, 1, new Cartesian3());
+        var expectedZ = Matrix3.getColumn(expectedRotation, 2, new Cartesian3());
+
+        Cartesian3.fromElements(expectedX.z, expectedX.x, expectedX.y, expectedX);
+        Cartesian3.fromElements(expectedY.z, expectedY.x, expectedY.y, expectedY);
+        Cartesian3.fromElements(expectedZ.z, expectedZ.x, expectedZ.y, expectedZ);
+
+        var returnedResult = Transforms.headingPitchRollToFixedFrame(origin, hpr, Ellipsoid.UNIT_SPHERE);
+        var actualX = Cartesian3.fromCartesian4(Matrix4.getColumn(returnedResult, 0, new Cartesian4()));
+        var actualY = Cartesian3.fromCartesian4(Matrix4.getColumn(returnedResult, 1, new Cartesian4()));
+        var actualZ = Cartesian3.fromCartesian4(Matrix4.getColumn(returnedResult, 2, new Cartesian4()));
+        var actualTranslation = Cartesian3.fromCartesian4(Matrix4.getColumn(returnedResult, 3, new Cartesian4()));
+
+        expect(actualX).toEqual(expectedX);
+        expect(actualY).toEqual(expectedY);
+        expect(actualZ).toEqual(expectedZ);
+        expect(actualTranslation).toEqual(origin);
+    });
+
     it('headingPitchRollToFixedFrame works with a result parameter', function() {
         var origin = new Cartesian3(1.0, 0.0, 0.0);
         var heading = CesiumMath.toRadians(20.0);
@@ -284,6 +312,36 @@ defineSuite([
 
         var result = new Matrix4();
         var returnedResult = Transforms.headingPitchRollToFixedFrame(origin, heading, pitch, roll, Ellipsoid.UNIT_SPHERE, result);
+        var actualX = Cartesian3.fromCartesian4(Matrix4.getColumn(returnedResult, 0, new Cartesian4()));
+        var actualY = Cartesian3.fromCartesian4(Matrix4.getColumn(returnedResult, 1, new Cartesian4()));
+        var actualZ = Cartesian3.fromCartesian4(Matrix4.getColumn(returnedResult, 2, new Cartesian4()));
+        var actualTranslation = Cartesian3.fromCartesian4(Matrix4.getColumn(returnedResult, 3, new Cartesian4()));
+
+        expect(returnedResult).toBe(result);
+        expect(actualX).toEqual(expectedX);
+        expect(actualY).toEqual(expectedY);
+        expect(actualZ).toEqual(expectedZ);
+        expect(actualTranslation).toEqual(origin);
+    });
+
+    it('headingPitchRollToFixedFrame works with a HeadingPitchRoll object and a result parameter', function() {
+        var origin = new Cartesian3(1.0, 0.0, 0.0);
+        var heading = CesiumMath.toRadians(20.0);
+        var pitch = CesiumMath.toRadians(30.0);
+        var roll = CesiumMath.toRadians(40.0);
+        var hpr = new HeadingPitchRoll(heading, pitch, roll);
+
+        var expectedRotation = Matrix3.fromQuaternion(Quaternion.fromHeadingPitchRoll(heading, pitch, roll));
+        var expectedX = Matrix3.getColumn(expectedRotation, 0, new Cartesian3());
+        var expectedY = Matrix3.getColumn(expectedRotation, 1, new Cartesian3());
+        var expectedZ = Matrix3.getColumn(expectedRotation, 2, new Cartesian3());
+
+        Cartesian3.fromElements(expectedX.z, expectedX.x, expectedX.y, expectedX);
+        Cartesian3.fromElements(expectedY.z, expectedY.x, expectedY.y, expectedY);
+        Cartesian3.fromElements(expectedZ.z, expectedZ.x, expectedZ.y, expectedZ);
+
+        var result = new Matrix4();
+        var returnedResult = Transforms.headingPitchRollToFixedFrame(origin, hpr, Ellipsoid.UNIT_SPHERE, result);
         var actualX = Cartesian3.fromCartesian4(Matrix4.getColumn(returnedResult, 0, new Cartesian4()));
         var actualY = Cartesian3.fromCartesian4(Matrix4.getColumn(returnedResult, 1, new Cartesian4()));
         var actualZ = Cartesian3.fromCartesian4(Matrix4.getColumn(returnedResult, 2, new Cartesian4()));

--- a/Specs/Scene/ShadowMapSpec.js
+++ b/Specs/Scene/ShadowMapSpec.js
@@ -101,16 +101,15 @@ defineSuite([
         Color.unpack(backgroundColor, 0, scene.backgroundColor);
 
         sunShadowMap = scene.shadowMap;
-        var hpr = new HeadingPitchRoll(0.0, 0.0, 0.0);
 
         var boxOrigin = new Cartesian3.fromRadians(longitude, latitude, boxHeight);
-        var boxTransform = Transforms.headingPitchRollToFixedFrame(boxOrigin, hpr);
+        var boxTransform = Transforms.headingPitchRollToFixedFrame(boxOrigin, new HeadingPitchRoll());
 
         var floorOrigin = new Cartesian3.fromRadians(longitude, latitude, floorHeight);
-        var floorTransform = Transforms.headingPitchRollToFixedFrame(floorOrigin, hpr);
+        var floorTransform = Transforms.headingPitchRollToFixedFrame(floorOrigin, new HeadingPitchRoll());
 
         var roomOrigin = new Cartesian3.fromRadians(longitude, latitude, height);
-        var roomTransform = Transforms.headingPitchRollToFixedFrame(roomOrigin, hpr);
+        var roomTransform = Transforms.headingPitchRollToFixedFrame(roomOrigin, new HeadingPitchRoll());
 
         var modelPromises = [];
         modelPromises.push(loadModel({
@@ -661,11 +660,10 @@ defineSuite([
             new HeadingPitchRange(0, CesiumMath.PI_OVER_TWO, 0.1)
         ];
 
-        var hpr = new HeadingPitchRoll(0.0, 0.0, 0.0);
         for (var i = 0; i < 6; ++i) {
             var box = scene.primitives.add(Model.fromGltf({
                 url : boxUrl,
-                modelMatrix : Transforms.headingPitchRollToFixedFrame(origins[i], hpr),
+                modelMatrix : Transforms.headingPitchRollToFixedFrame(origins[i], new HeadingPitchRoll()),
                 scale : 0.2
             }));
             scene.render(); // Model is pre-loaded, render one frame to make it ready

--- a/Specs/Scene/ShadowMapSpec.js
+++ b/Specs/Scene/ShadowMapSpec.js
@@ -11,6 +11,7 @@ defineSuite([
         'Core/EllipsoidTerrainProvider',
         'Core/GeometryInstance',
         'Core/HeadingPitchRange',
+        'Core/HeadingPitchRoll',
         'Core/HeightmapTerrainData',
         'Core/JulianDate',
         'Core/Math',
@@ -43,6 +44,7 @@ defineSuite([
         EllipsoidTerrainProvider,
         GeometryInstance,
         HeadingPitchRange,
+        HeadingPitchRoll,
         HeightmapTerrainData,
         JulianDate,
         CesiumMath,
@@ -99,15 +101,16 @@ defineSuite([
         Color.unpack(backgroundColor, 0, scene.backgroundColor);
 
         sunShadowMap = scene.shadowMap;
+        var hpr = new HeadingPitchRoll(0.0, 0.0, 0.0);
 
         var boxOrigin = new Cartesian3.fromRadians(longitude, latitude, boxHeight);
-        var boxTransform = Transforms.headingPitchRollToFixedFrame(boxOrigin, 0.0, 0.0, 0.0);
+        var boxTransform = Transforms.headingPitchRollToFixedFrame(boxOrigin, hpr);
 
         var floorOrigin = new Cartesian3.fromRadians(longitude, latitude, floorHeight);
-        var floorTransform = Transforms.headingPitchRollToFixedFrame(floorOrigin, 0.0, 0.0, 0.0);
+        var floorTransform = Transforms.headingPitchRollToFixedFrame(floorOrigin, hpr);
 
         var roomOrigin = new Cartesian3.fromRadians(longitude, latitude, height);
-        var roomTransform = Transforms.headingPitchRollToFixedFrame(roomOrigin, 0.0, 0.0, 0.0);
+        var roomTransform = Transforms.headingPitchRollToFixedFrame(roomOrigin, hpr);
 
         var modelPromises = [];
         modelPromises.push(loadModel({
@@ -658,10 +661,11 @@ defineSuite([
             new HeadingPitchRange(0, CesiumMath.PI_OVER_TWO, 0.1)
         ];
 
+        var hpr = new HeadingPitchRoll(0.0, 0.0, 0.0);
         for (var i = 0; i < 6; ++i) {
             var box = scene.primitives.add(Model.fromGltf({
                 url : boxUrl,
-                modelMatrix : Transforms.headingPitchRollToFixedFrame(origins[i], 0.0, 0.0, 0.0),
+                modelMatrix : Transforms.headingPitchRollToFixedFrame(origins[i], hpr),
                 scale : 0.2
             }));
             scene.render(); // Model is pre-loaded, render one frame to make it ready


### PR DESCRIPTION
This PR uses the new `HeadingPitchRoll` objects introduced in #4047 more widely in the API. It also removes the `aircraftHeadingPitchRoll*` functions introduced in the same PR.

@pjcozzi, could you take a quick look at this to check that it's on the right track? If so, similar work needs to be done for `headingPitchRollToQuaternion` and `aircraftHeadingPitchRollQuaternion`.