### PR TITLE
Correctly reset billboard position after height reference changed to none

### DIFF
--- a/Source/Scene/Label.js
+++ b/Source/Scene/Label.js
@@ -736,9 +736,12 @@ define([
                     if (defined(glyph.billboard)) {
                         // Set all the private values here, because we already clamped to ground
                         //  so we don't want to do it again for every glyph
-                        glyph.billboard._position = value;
-                        glyph.billboard._actualPosition = value;
+
                         glyph.billboard._clampedPosition = value;
+
+                        value = defaultValue(value, this._position);
+                        Cartesian3.clone(value, glyph.billboard._position);
+                        Cartesian3.clone(value, glyph.billboard._actualPosition);
                     }
                 }
             }

--- a/Specs/Scene/LabelCollectionSpec.js
+++ b/Specs/Scene/LabelCollectionSpec.js
@@ -1463,6 +1463,25 @@ defineSuite([
             expect(label.pixelOffset.y).toEqual(yOffset);
         });
 
+
+        it('Correctly updates billboard position when height reference changes', function() {
+            var position1 = new Cartesian3(1.0, 2.0, 3.0);
+            var label = labels.add({
+                position : position1,
+                text : 'abc'
+            });
+
+            scene.renderForSpecs();
+            var glyph = label._glyphs[0];
+            var billboard = glyph.billboard;
+            expect(billboard.position).toEqual(label.position);
+
+            label._clampedPosition = undefined;
+
+            expect(billboard.position).toEqual(label.position);
+        });
+
+
         it('should set vertexTranslate of billboards correctly when font size changes', function() {
             var label = labels.add({
                 text : 'apl',

--- a/Specs/Scene/LabelCollectionSpec.js
+++ b/Specs/Scene/LabelCollectionSpec.js
@@ -15,6 +15,7 @@ defineSuite([
         'Renderer/ContextLimits',
         'Scene/HeightReference',
         'Scene/HorizontalOrigin',
+        'Scene/Globe',
         'Scene/Label',
         'Scene/LabelStyle',
         'Scene/OrthographicFrustum',
@@ -37,6 +38,7 @@ defineSuite([
         ContextLimits,
         HeightReference,
         HorizontalOrigin,
+        Globe,
         Label,
         LabelStyle,
         OrthographicFrustum,
@@ -1463,12 +1465,16 @@ defineSuite([
             expect(label.pixelOffset.y).toEqual(yOffset);
         });
 
-
         it('Correctly updates billboard position when height reference changes', function() {
+            scene.globe = new Globe();
+            var labelsWithScene = new LabelCollection({scene : scene});
+            scene.primitives.add(labelsWithScene);
+
             var position1 = new Cartesian3(1.0, 2.0, 3.0);
-            var label = labels.add({
+            var label = labelsWithScene.add({
                 position : position1,
-                text : 'abc'
+                text : 'abc',
+                heightReference : HeightReference.CLAMP_TO_GROUND
             });
 
             scene.renderForSpecs();
@@ -1476,11 +1482,12 @@ defineSuite([
             var billboard = glyph.billboard;
             expect(billboard.position).toEqual(label.position);
 
-            label._clampedPosition = undefined;
+            label.heightReference = HeightReference.NONE;
+            scene.renderForSpecs();
 
             expect(billboard.position).toEqual(label.position);
+            scene.primitives.remove(labelsWithScene);
         });
-
 
         it('should set vertexTranslate of billboards correctly when font size changes', function() {
             var label = labels.add({


### PR DESCRIPTION
Fixes #4300

`Billboard` sets `label. _clampedPosition = undefined` when the height reference is changed to none.  This was then setting the label glyph billboard positions to undefined as well.  This change properly resets them to `label.position` after height reference is changed no none.

Test example:

``` javascript
var viewer = new Cesium.Viewer('cesiumContainer');

var labelCollection = viewer.scene.primitives.add(new Cesium.LabelCollection({
    scene : viewer.scene
}));

var pos = Cesium.Cartesian3.fromDegrees(-110, 50, 1000);
var label = labelCollection.add({
    position : pos,
    text: 'text',
    heightReference: Cesium.HeightReference.CLAMP_TO_GROUND
});

var clamp = true;
Sandcastle.addToolbarButton('Toggle Height Reference', function() {
    clamp = !clamp;
    var heightReference = clamp ? Cesium.HeightReference.CLAMP_TO_GROUND : Cesium.HeightReference.NONE;
    label.heightReference = heightReference;
});

viewer.scene.camera.flyTo({
    destination: pos
});
```