### PR TITLE
Add Judy Weng to CONTRIBUTORS.md

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -103,6 +103,7 @@
 * [Tom Novacek](https://github.com/novacto2)
 * [Olivier Guyot-Roullot](https://github.com/theOgrable)
 * [Andy Fry](https://github.com/andyfry01)
+* [Judy Weng](http://github.com/JudyWeng)
 * [Jorge Piera Llodra](https://github.com/jorpiell)
 * [Tom Payne](https://github.com/twpayne)
 * [Leesa Fini](https://github.com/leesafini)


### PR DESCRIPTION
@JudyWeng is in `CONTRIBUTORS.md` on the 3d-tiles branch, merging into master to avoid future merge conflicts.