### PR TITLE
Prevent default 'pinch' behavior on touch devices.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -34,6 +34,7 @@ Change Log
     * `HeadingPitchRoll.equals` and `HeadingPitchRoll.equalsEpsilon` functions for comparing two instances.
 * Added `Matrix3.fromHeadingPitchRoll` Computes a 3x3 rotation matrix from the provided headingPitchRoll.
 * `Transforms.headingPitchRollToFixedFrame` and `Transforms.headingPitchRollQuaternion` now take a `HeadingPitchRoll` object in addition to separate heading, pitch, and roll values.  Separate values will be deprecated in 1.30.
+* Prevent execution of default device/browser behaviour when handling "pinch" touch event/gesture.
 
 ### 1.26 - 2016-10-03
 

--- a/Source/Core/ScreenSpaceEventHandler.js
+++ b/Source/Core/ScreenSpaceEventHandler.js
@@ -482,6 +482,10 @@ define([
                 Cartesian2.clone(positions.values[1], touch2StartEvent.position2);
 
                 action(touch2StartEvent);
+
+                // Touch-enabled devices, in particular iOS can have many default behaviours for 
+                // "pinch" events, which can still be executed unless we prevent them here.
+                event.preventDefault();
             }
         }
     }


### PR DESCRIPTION
Now prevents the default pinch behaviour when Cesium handles the event.

This fixes an annoying bug on iOS Safari which can cause the whole page to zoom in/out, as the browser is attempting to zoom the `<div>`.