### PR TITLE
Geometry regression

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -39,6 +39,7 @@ Change Log
 * Prevent execution of default device/browser behaviour when handling "pinch" touch event/gesture.
 * Fixed a crash when zooming from touch input on viewer initialization. [#4177](https://github.com/AnalyticalGraphicsInc/cesium/issues/4177)
 * Fix warning when using Webpack. [#4467](https://github.com/AnalyticalGraphicsInc/cesium/pull/4467)
+* Fix primitive bounding sphere bug that would cause a crash when loading data sources. [#4431](https://github.com/AnalyticalGraphicsInc/cesium/issues/4431)
 
 ### 1.26 - 2016-10-03
 

--- a/Source/Scene/Primitive.js
+++ b/Source/Scene/Primitive.js
@@ -1194,6 +1194,10 @@ define([
 
         for (var i = 0; i < length; ++i) {
             var boundingSphere = boundingSpheres[i];
+            if (!defined(boundingSphere)) {
+                continue;
+            }
+
             var modelMatrix = primitive.modelMatrix;
             if (defined(modelMatrix)) {
                 boundingSphere = BoundingSphere.transform(boundingSphere, modelMatrix, boundingSphere);

--- a/Source/Scene/PrimitivePipeline.js
+++ b/Source/Scene/PrimitivePipeline.js
@@ -667,8 +667,9 @@ define([
         var i = 1;
         while (i < buffer.length) {
             if (buffer[i++] === 1.0) {
-                result[count++] = BoundingSphere.unpack(buffer, i);
+                result[count] = BoundingSphere.unpack(buffer, i);
             }
+            ++count;
             i += BoundingSphere.packedLength;
         }
 

--- a/Specs/Scene/PrimitiveSpec.js
+++ b/Specs/Scene/PrimitiveSpec.js
@@ -1027,6 +1027,42 @@ defineSuite([
         });
     });
 
+    it('can mix valid and invalid geometry', function() {
+        var instances = [];
+        instances.push(rectangleInstance1);
+        instances.push(new GeometryInstance({
+            geometry : PolygonGeometry.fromPositions({
+                positions : []
+            }),
+            attributes : {
+                color : new ColorGeometryInstanceAttribute(1.0, 0.0, 1.0, 1.0),
+            },
+            id : 'invalid'
+        }));
+        instances.push(rectangleInstance2);
+
+        primitive = new Primitive({
+            geometryInstances : instances,
+            appearance : new PerInstanceColorAppearance({
+                flat : true
+            })
+        });
+
+        var frameState = scene.frameState;
+
+        return pollToPromise(function() {
+            primitive.update(frameState);
+            if (frameState.afterRender.length > 0) {
+                frameState.afterRender[0]();
+            }
+            return primitive.ready;
+        }).then(function() {
+            expect(primitive.getGeometryInstanceAttributes('rectangle1').boundingSphere).toBeDefined();
+            expect(primitive.getGeometryInstanceAttributes('rectangle2').boundingSphere).toBeDefined();
+            expect(primitive.getGeometryInstanceAttributes('invalid').boundingSphere).not.toBeDefined();
+        });
+    });
+
     it('shader validation', function() {
         primitive = new Primitive({
             geometryInstances : [rectangleInstance1, rectangleInstance2],


### PR DESCRIPTION
Unpacking bounding spheres from the combine web worker was pushing all of the invalid geometry bounding spheres to the end of the array. This caused some geometry to have the wrong bounding spheres. `undefined` bounding spheres are for invalid geometry and can be safely ignored when updating the batch table.

Fixes #4431.