### PR TITLE
When the texture is not rotated, the rendering fails

### DIFF
--- a/Source/Core/RectangleGeometry.js
+++ b/Source/Core/RectangleGeometry.js
@@ -802,6 +802,7 @@ define([
         options.textureMatrix = textureMatrix;
         options.tangentRotationMatrix = tangentRotationMatrix;
         options.size = options.width * options.height;
+        options.stRotation = stRotation;
 
         var geometry;
         var boundingSphere;

--- a/Source/Core/RectangleGeometryLibrary.js
+++ b/Source/Core/RectangleGeometryLibrary.js
@@ -55,8 +55,13 @@ define([
         position.z = kZ / gamma;
 
         if (defined(options.vertexFormat) && options.vertexFormat.st) {
-            st.x = (stLongitude - rectangle.west) * options.lonScalar;
-            st.y = (stLatitude - rectangle.south) * options.latScalar;
+            st.x = (stLongitude - rectangle.west);
+            st.y = (stLatitude - rectangle.south);
+
+            if (!options.stRotation) {
+                st.x = st.x * options.lonScalar;
+                st.y = st.y * options.latScalar;
+            }
 
             Matrix2.multiplyByVector(options.textureMatrix, st, st);
         }


### PR DESCRIPTION
Combine the patch that @dwhipps suggested to fix the bug #2737 and #4515
