### PR TITLE
Added abs function to styling language

### DIFF
--- a/Apps/Sandcastle/gallery/3D Tiles Point Cloud Styling.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Point Cloud Styling.html
@@ -105,6 +105,10 @@ addStyle('Mod', {
     show : "${id} % 2 == 0"
 });
 
+addStyle('Abs', {
+    color : "color() * abs(${temperature} - 0.5)"
+});
+
 addStyle('Secondary Color', {
     color : {
         expression : "[${secondaryColor}[0], ${secondaryColor}[1], ${secondaryColor}[2], 1.0]",

--- a/Source/Scene/Expression.js
+++ b/Source/Scene/Expression.js
@@ -338,6 +338,14 @@ define([
             }
             val = createRuntimeAst(expression, args[0]);
             return new Node(ExpressionNodeType.UNARY, call, val);
+        } else if (call === 'abs') {
+            //>>includeStart('debug', pragmas.debug);
+            if (args.length < 1 || args.length > 1) {
+                throw new DeveloperError('Error: ' + call + ' requires exactly one argument.');
+            }
+            //>>includeEnd('debug');
+            val = createRuntimeAst(expression, args[0]);
+            return new Node(ExpressionNodeType.UNARY, call, val);
         } else if (call === 'Boolean') {
             if (args.length === 0) {
                 return new Node(ExpressionNodeType.LITERAL_BOOLEAN, false);
@@ -567,6 +575,8 @@ define([
                 node.evaluate = node._evaluateNaN;
             } else if (node._value === 'isFinite') {
                 node.evaluate = node._evaluateIsFinite;
+            } else if (node._value === 'abs') {
+                node.evaluate = node._evaluateAbsoluteValue;
             } else if (node._value === 'Boolean') {
                 node.evaluate = node._evaluateBooleanConversion;
             } else if (node._value === 'Number') {
@@ -894,6 +904,10 @@ define([
         return isFinite(this._left.evaluate(feature));
     };
 
+    Node.prototype._evaluateAbsoluteValue = function(feature) {
+        return Math.abs(this._left.evaluate(feature));
+    };
+
     Node.prototype._evaluateBooleanConversion = function(feature) {
         return Boolean(this._left.evaluate(feature));
     };
@@ -1111,6 +1125,8 @@ define([
                     return 'bool(' + left + ')';
                 } else if (value === 'Number') {
                     return 'float(' + left + ')';
+                } else if (value === 'abs') {
+                    return 'abs(' + left + ')';
                 }
                 //>>includeStart('debug', pragmas.debug);
                 else if ((value === 'isNaN') || (value === 'isFinite') || (value === 'String')) {

--- a/Specs/Scene/ExpressionSpec.js
+++ b/Specs/Scene/ExpressionSpec.js
@@ -1580,6 +1580,13 @@ defineSuite([
         expect(shaderState.translucent).toBe(true);
     });
 
+    it('gets shader expression for abs', function() {
+        var expression = new Expression('abs(-1.0)');
+        var shaderExpression = expression.getShaderExpression('', {});
+        var expected = 'abs(-1.0)';
+        expect(shaderExpression).toEqual(expected);
+    });
+
     it('throws when getting shader expression for regex', function() {
         var expression = new Expression('regExp("a").test("abc")');
         expect(function() {

--- a/Specs/Scene/ExpressionSpec.js
+++ b/Specs/Scene/ExpressionSpec.js
@@ -814,6 +814,24 @@ defineSuite([
         expect(expression.evaluate(undefined)).toEqual(false);
     });
 
+    it('evaluates abs function', function() {
+        var expression = new Expression('abs(-1)');
+        expect(expression.evaluate(undefined)).toEqual(1);
+
+        expression = new Expression('abs(1)');
+        expect(expression.evaluate(undefined)).toEqual(1);
+    });
+
+    it('throws if abs function takes an invalid number of arguments', function() {
+        expect(function() {
+            return new Expression('abs()');
+        }).toThrowDeveloperError();
+
+        expect(function() {
+            return new Expression('abs(1, 2)');
+        }).toThrowDeveloperError();
+    });
+
     it('evaluates ternary conditional', function() {
         var expression = new Expression('true ? "first" : "second"');
         expect(expression.evaluate(undefined)).toEqual('first');


### PR DESCRIPTION
For https://github.com/AnalyticalGraphicsInc/3d-tiles/issues/2
I added a section to the end of that issue listing the additional functions we plan to implement for the styling language. That list is not exhaustive though, so other ideas are welcome.

This PR supports just the `abs` function.
* Updated `Expression.js` - Javascript and GLSL interpreters.
* Added tests to `ExpressionSpec.js`
* Added a style to `3D Tiles Point Cloud Styling.html`

@leesafini @Dylan-Brown This will be a good PR to reference as we go through the list of styling functions. At first we'll start will other unary operations and then move to operations on vectors. Since vec3/vec4 support is needed for the vector operations, I will add that before we get to those.

@pjcozzi