### PR TITLE
Fix polygon offset check for shadows

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -41,6 +41,7 @@ Change Log
 * Fix warning when using Webpack. [#4467](https://github.com/AnalyticalGraphicsInc/cesium/pull/4467)
 * Fix primitive bounding sphere bug that would cause a crash when loading data sources. [#4431](https://github.com/AnalyticalGraphicsInc/cesium/issues/4431)
 * Fix a crash when clustering is enabled, an entity has a label graphics defined, but the label isn't visible. [#4414](https://github.com/AnalyticalGraphicsInc/cesium/issues/4414)
+* Fixed a shadow aliasing issue where polygon offset was not being applied. [#4559](https://github.com/AnalyticalGraphicsInc/cesium/pull/4559)
 
 ### 1.26 - 2016-10-03
 

--- a/Source/Scene/ShadowMap.js
+++ b/Source/Scene/ShadowMap.js
@@ -185,8 +185,9 @@ define([
         this._needsUpdate = true;
 
         // In IE11 polygon offset is not functional.
+        // TODO : Also disabled for Chrome temporarily. Re-enable once https://groups.google.com/forum/#!topic/webgl-dev-list/E1dAG65QBhg is resolved.
         var polygonOffsetSupported = true;
-        if (FeatureDetection.isInternetExplorer()) {
+        if (FeatureDetection.isInternetExplorer() || FeatureDetection.isChrome()) {
             polygonOffsetSupported = false;
         }
         this._polygonOffsetSupported = polygonOffsetSupported;

--- a/Source/Scene/ShadowMap.js
+++ b/Source/Scene/ShadowMap.js
@@ -186,7 +186,7 @@ define([
 
         // In IE11 polygon offset is not functional.
         var polygonOffsetSupported = true;
-        if (FeatureDetection.isInternetExplorer) {
+        if (FeatureDetection.isInternetExplorer()) {
             polygonOffsetSupported = false;
         }
         this._polygonOffsetSupported = polygonOffsetSupported;

--- a/Source/Scene/ShadowMap.js
+++ b/Source/Scene/ShadowMap.js
@@ -185,7 +185,7 @@ define([
         this._needsUpdate = true;
 
         // In IE11 polygon offset is not functional.
-        // TODO : Also disabled for Chrome temporarily. Re-enable once https://groups.google.com/forum/#!topic/webgl-dev-list/E1dAG65QBhg is resolved.
+        // TODO : Also disabled for Chrome temporarily. Re-enable once https://github.com/AnalyticalGraphicsInc/cesium/issues/4560 is resolved.
         var polygonOffsetSupported = true;
         if (FeatureDetection.isInternetExplorer() || FeatureDetection.isChrome()) {
             polygonOffsetSupported = false;

--- a/Source/Scene/ShadowMap.js
+++ b/Source/Scene/ShadowMap.js
@@ -185,9 +185,9 @@ define([
         this._needsUpdate = true;
 
         // In IE11 polygon offset is not functional.
-        // TODO : Also disabled for Chrome temporarily. Re-enable once https://github.com/AnalyticalGraphicsInc/cesium/issues/4560 is resolved.
+        // TODO : Also disabled for Chrome (ANGLE) temporarily. Re-enable once https://github.com/AnalyticalGraphicsInc/cesium/issues/4560 is resolved.
         var polygonOffsetSupported = true;
-        if (FeatureDetection.isInternetExplorer() || FeatureDetection.isChrome()) {
+        if (FeatureDetection.isInternetExplorer() || (FeatureDetection.isChrome() && FeatureDetection.isWindows())) {
             polygonOffsetSupported = false;
         }
         this._polygonOffsetSupported = polygonOffsetSupported;

--- a/Source/Scene/ShadowMapShader.js
+++ b/Source/Scene/ShadowMapShader.js
@@ -233,7 +233,7 @@ define([
             fsSource += '    shadowParameters.depthBias *= max(depth * 0.01, 1.0); \n';
         } else if (!polygonOffsetSupported) {
             // If polygon offset isn't supported push the depth back based on view, however this
-            // causing light leaking at further away views
+            // causes light leaking at further away views
             fsSource += '    shadowParameters.depthBias *= mix(1.0, 100.0, depth * 0.0015); \n';
         }
 

--- a/Source/Scene/ShadowMapShader.js
+++ b/Source/Scene/ShadowMapShader.js
@@ -134,6 +134,7 @@ define([
         var hasPositionVarying = defined(positionVaryingName);
 
         var usesDepthTexture = shadowMap._usesDepthTexture;
+        var polygonOffsetSupported = shadowMap._polygonOffsetSupported;
         var isPointLight = shadowMap._isPointLight;
         var isSpotLight = shadowMap._isSpotLight;
         var hasCascades = shadowMap._numberOfCascades > 1;
@@ -230,7 +231,9 @@ define([
         if (isTerrain) {
             // Scale depth bias based on view distance to reduce z-fighting in distant terrain
             fsSource += '    shadowParameters.depthBias *= max(depth * 0.01, 1.0); \n';
-        } else {
+        } else if (!polygonOffsetSupported) {
+            // If polygon offset isn't supported push the depth back based on view, however this
+            // causing light leaking at further away views
             fsSource += '    shadowParameters.depthBias *= mix(1.0, 100.0, depth * 0.0015); \n';
         }
 


### PR DESCRIPTION
Yeah...

I think the Chrome 49->50 switch happened right before I introduced this bug so I never noticed that I had accidentally turned polygon offset off.

Now shadow aliasing should be reduced in Firefox. However `glPolygonOffset` still seems to have almost no effect in Chrome which I opened an issue for here: https://groups.google.com/forum/#!topic/webgl-dev-list/E1dAG65QBhg. Shadowing in Chrome works fine now in version 49 or when ANGLE is disabled in the current version.

