### PR TITLE
Fixes #4444 - Rendering crashes with a 0 width LineRing clamped to ground

### DIFF
--- a/Source/Core/CorridorGeometry.js
+++ b/Source/Core/CorridorGeometry.js
@@ -679,8 +679,8 @@ define([
 
     function computeRectangle(positions, ellipsoid, width, cornerType) {
         var cleanPositions = arrayRemoveDuplicates(positions, Cartesian3.equalsEpsilon);
-        var length = cleanPositions.length - 1;
-        if (length === 0 || width === 0) {
+        var length = cleanPositions.length;
+        if (length < 2 || width <= 0) {
             return new Rectangle();
         }
         var halfWidth = width * 0.5;
@@ -709,14 +709,14 @@ define([
         }
 
         // Compute the rest
-        for (var i = 0; i < length; ++i) {
+        for (var i = 0; i < length-1; ++i) {
             computeOffsetPoints(cleanPositions[i], cleanPositions[i+1], ellipsoid, halfWidth,
                 scratchCartographicMin, scratchCartographicMax);
         }
 
         // Compute ending point
-        var last = cleanPositions[length];
-        Cartesian3.subtract(last, cleanPositions[length-1], scratchCartesianOffset);
+        var last = cleanPositions[length-1];
+        Cartesian3.subtract(last, cleanPositions[length-2], scratchCartesianOffset);
         Cartesian3.normalize(scratchCartesianOffset, scratchCartesianOffset);
         Cartesian3.multiplyByScalar(scratchCartesianOffset, halfWidth, scratchCartesianOffset);
         Cartesian3.add(last, scratchCartesianOffset, scratchCartesianEnds);

--- a/Source/Core/PolylineGeometry.js
+++ b/Source/Core/PolylineGeometry.js
@@ -311,9 +311,9 @@ define([
         var positions = arrayRemoveDuplicates(polylineGeometry._positions, Cartesian3.equalsEpsilon);
         var positionsLength = positions.length;
 
-        // A width of 0.0 or less is not a valid geometry, but in order to support external data
+        // A width of a pixel or less is not a valid geometry, but in order to support external data
         // that may have errors we treat this as an empty geometry.
-        if (positionsLength < 2 || width < 0.0) {
+        if (positionsLength < 2 || width < 1.0) {
             return undefined;
         }
 

--- a/Source/Core/PolylineGeometry.js
+++ b/Source/Core/PolylineGeometry.js
@@ -313,7 +313,7 @@ define([
 
         // A width of a pixel or less is not a valid geometry, but in order to support external data
         // that may have errors we treat this as an empty geometry.
-        if (positionsLength < 2 || width < 1.0) {
+        if (positionsLength < 2 || width <= 0.0) {
             return undefined;
         }
 

--- a/Source/Core/PolylineGeometry.js
+++ b/Source/Core/PolylineGeometry.js
@@ -124,8 +124,8 @@ define([
         if ((!defined(positions)) || (positions.length < 2)) {
             throw new DeveloperError('At least two positions are required.');
         }
-        if (width < 1.0) {
-            throw new DeveloperError('width must be greater than or equal to one.');
+        if (typeof width !== 'number') {
+            throw new DeveloperError('width must be a number');
         }
         if (defined(colors) && ((colorsPerVertex && colors.length < positions.length) || (!colorsPerVertex && colors.length < positions.length - 1))) {
             throw new DeveloperError('colors has an invalid length.');
@@ -309,9 +309,11 @@ define([
         var k;
 
         var positions = arrayRemoveDuplicates(polylineGeometry._positions, Cartesian3.equalsEpsilon);
-
         var positionsLength = positions.length;
-        if (positionsLength < 2) {
+
+        // A width of 0.0 or less is not a valid geometry, but in order to support external data
+        // that may have errors we treat this as an empty geometry.
+        if (positionsLength < 2 || width < 0.0) {
             return undefined;
         }
 

--- a/Specs/Core/PolylineGeometrySpec.js
+++ b/Specs/Core/PolylineGeometrySpec.js
@@ -31,13 +31,13 @@ defineSuite([
         }).toThrowDeveloperError();
     });
 
-    it('constructor throws with invalid width', function() {
+    it('constructor does not throw with invalid width', function() {
         expect(function() {
             return new PolylineGeometry({
                 positions : [Cartesian3.ZERO, Cartesian3.UNIT_X],
                 width : -1
             });
-        }).toThrowDeveloperError();
+        }).not.toThrowDeveloperError();
     });
 
     it('constructor throws with invalid number of colors', function() {

--- a/Specs/Core/PolylineGeometrySpec.js
+++ b/Specs/Core/PolylineGeometrySpec.js
@@ -31,15 +31,6 @@ defineSuite([
         }).toThrowDeveloperError();
     });
 
-    it('constructor does not throw with invalid width', function() {
-        expect(function() {
-            return new PolylineGeometry({
-                positions : [Cartesian3.ZERO, Cartesian3.UNIT_X],
-                width : -1
-            });
-        }).not.toThrowDeveloperError();
-    });
-
     it('constructor throws with invalid number of colors', function() {
         expect(function() {
             return new PolylineGeometry({
@@ -47,6 +38,19 @@ defineSuite([
                 colors : []
             });
         }).toThrowDeveloperError();
+    });
+
+    it('constructor returns undefined when line width is negative', function() {
+        var positions = [new Cartesian3(1.0, 0.0, 0.0), new Cartesian3(0.0, 1.0, 0.0), new Cartesian3(0.0, 0.0, 1.0)];
+        var line = PolylineGeometry.createGeometry(new PolylineGeometry({
+            positions : positions,
+            width : -1.0,
+            vertexFormat : VertexFormat.ALL,
+            granularity : Math.PI,
+            ellipsoid: Ellipsoid.UNIT_SPHERE
+        }));
+
+        expect(line).toBeUndefined();
     });
 
     it('constructor computes all vertex attributes', function() {


### PR DESCRIPTION
- [x] support empty `PolylineGeometry`
- [x] support empty `CorridorGeometry`

Support for empty geometries seem to have already been implemented (in cba80f179ef1340ca481b636951c3cccfb64f34e) for most geometry types, including `CorridorGeometry`. See discussion in #4444.