### PR TITLE
3D Tiles - Get batch id name from semantic

### DIFF
--- a/Source/Scene/Cesium3DTileBatchTable.js
+++ b/Source/Scene/Cesium3DTileBatchTable.js
@@ -476,7 +476,7 @@ define([
     /**
      * @private
      */
-    Cesium3DTileBatchTable.prototype.getVertexShaderCallback = function(handleTranslucent) {
+    Cesium3DTileBatchTable.prototype.getVertexShaderCallback = function(handleTranslucent, batchIdAttributeName) {
         if (this.featuresLength === 0) {
             return;
         }
@@ -495,7 +495,7 @@ define([
                     'void main() \n' +
                     '{ \n' +
                     '    tile_main(); \n' +
-                    '    vec2 st = computeSt(a_batchId); \n' +
+                    '    vec2 st = computeSt(' + batchIdAttributeName + '); \n' +
                     '    vec4 featureProperties = texture2D(tile_batchTexture, st); \n' +
                     '    float show = ceil(featureProperties.a); \n' +      // 0 - false, non-zeo - true
                     '    gl_Position *= show; \n';                          // Per-feature show/hide
@@ -528,7 +528,7 @@ define([
                     'void main() \n' +
                     '{ \n' +
                     '    tile_main(); \n' +
-                    '    tile_featureSt = computeSt(a_batchId); \n' +
+                    '    tile_featureSt = computeSt(' + batchIdAttributeName + '); \n' +
                     '}';
             }
 
@@ -709,7 +709,7 @@ define([
         };
     };
 
-    Cesium3DTileBatchTable.prototype.getPickVertexShaderCallback = function() {
+    Cesium3DTileBatchTable.prototype.getPickVertexShaderCallback = function(batchIdAttributeName) {
         if (this.featuresLength === 0) {
             return;
         }
@@ -727,7 +727,7 @@ define([
                     'void main() \n' +
                     '{ \n' +
                     '    tile_main(); \n' +
-                    '    vec2 st = computeSt(a_batchId); \n' +
+                    '    vec2 st = computeSt(' + batchIdAttributeName + '); \n' +
                     '    vec4 featureProperties = texture2D(tile_batchTexture, st); \n' +
                     '    float show = ceil(featureProperties.a); \n' +    // 0 - false, non-zero - true
                     '    gl_Position *= show; \n' +                       // Per-feature show/hide
@@ -739,7 +739,7 @@ define([
                     'void main() \n' +
                     '{ \n' +
                     '    tile_main(); \n' +
-                    '    tile_featureSt = computeSt(a_batchId); \n' +
+                    '    tile_featureSt = computeSt(' + batchIdAttributeName + '); \n' +
                     '}';
             }
 

--- a/Source/Scene/ModelInstanceCollection.js
+++ b/Source/Scene/ModelInstanceCollection.js
@@ -17,7 +17,7 @@ define([
         '../Renderer/DrawCommand',
         '../Renderer/ShaderSource',
         '../ThirdParty/when',
-        './getDiffuseUniformName',
+        './getAttributeOrUniformBySemantic',
         './Model',
         './SceneMode',
         './ShadowMode'
@@ -39,7 +39,7 @@ define([
         DrawCommand,
         ShaderSource,
         when,
-        getDiffuseUniformName,
+        getAttributeOrUniformBySemantic,
         Model,
         SceneMode,
         ShadowMode) {
@@ -304,7 +304,7 @@ define([
             vertexShaderCached = instancedSource;
 
             if (usesBatchTable) {
-                instancedSource = collection._batchTable.getVertexShaderCallback(true)(instancedSource);
+                instancedSource = collection._batchTable.getVertexShaderCallback(true, 'a_batchId')(instancedSource);
             }
 
             return instancedSource;
@@ -316,7 +316,7 @@ define([
             var batchTable = collection._batchTable;
             if (defined(batchTable)) {
                 var gltf = collection._model.gltf;
-                var diffuseUniformName = getDiffuseUniformName(gltf);
+                var diffuseUniformName = getAttributeOrUniformBySemantic(gltf, '_3DTILESDIFFUSE');
                 var colorBlendMode = batchTable._content._tileset.colorBlendMode;
                 fs = batchTable.getFragmentShaderCallback(true, colorBlendMode, diffuseUniformName)(fs);
             }
@@ -329,7 +329,7 @@ define([
             // Use the vertex shader that was generated earlier
             vs = vertexShaderCached;
             if (defined(collection._batchTable)) {
-                vs = collection._batchTable.getPickVertexShaderCallback()(vs);
+                vs = collection._batchTable.getPickVertexShaderCallback('a_batchId')(vs);
             }
             return vs;
         };
@@ -392,7 +392,7 @@ define([
     function getVertexShaderNonInstancedCallback(collection) {
         return function(vs) {
             if (defined(collection._batchTable)) {
-                vs = collection._batchTable.getVertexShaderCallback(true)(vs);
+                vs = collection._batchTable.getVertexShaderCallback(true, 'a_batchId')(vs);
                 // Treat a_batchId as a uniform rather than a vertex attribute
                 vs = 'uniform float a_batchId\n;' + vs;
             }
@@ -403,7 +403,7 @@ define([
     function getPickVertexShaderNonInstancedCallback(collection) {
         return function(vs) {
             if (defined(collection._batchTable)) {
-                vs = collection._batchTable.getPickVertexShaderCallback()(vs);
+                vs = collection._batchTable.getPickVertexShaderCallback('a_batchId')(vs);
                 // Treat a_batchId as a uniform rather than a vertex attribute
                 vs = 'uniform float a_batchId\n;' + vs;
             }

--- a/Source/Scene/PointCloud3DTileContent.js
+++ b/Source/Scene/PointCloud3DTileContent.js
@@ -1063,7 +1063,7 @@ define([
 
         if (hasBatchTable) {
             // Batched points always use the HIGHLIGHT color blend mode
-            drawVS = batchTable.getVertexShaderCallback(false)(drawVS);
+            drawVS = batchTable.getVertexShaderCallback(false, 'a_batchId')(drawVS);
             drawFS = batchTable.getFragmentShaderCallback(false, Cesium3DTileColorBlendMode.HIGHLIGHT)(drawFS);
         }
 
@@ -1071,7 +1071,7 @@ define([
         var pickFS = fs;
 
         if (hasBatchTable) {
-            pickVS = batchTable.getPickVertexShaderCallback()(pickVS);
+            pickVS = batchTable.getPickVertexShaderCallback('a_batchId')(pickVS);
             pickFS = batchTable.getPickFragmentShaderCallback()(pickFS);
         } else {
             pickFS = ShaderSource.createPickFragmentShaderSource(pickFS, 'uniform');

--- a/Source/Scene/getAttributeOrUniformBySemantic.js
+++ b/Source/Scene/getAttributeOrUniformBySemantic.js
@@ -1,28 +1,30 @@
 /*global define*/
-define([
-        '../Core/defined'
-], function(
-        defined) {
+define([], function() {
     'use strict';
 
     /**
-     * Get the diffuse uniform with the _3DTILESDIFFUSE semantic.
+     * Return the uniform or attribute that has the given semantic.
      *
      * @private
      */
-    function getDiffuseUniformName(gltf) {
+    function getAttributeOrUniformBySemantic(gltf, semantic) {
         var techniques = gltf.techniques;
         for (var techniqueName in techniques) {
             if (techniques.hasOwnProperty(techniqueName)) {
                 var technique = techniques[techniqueName];
                 var parameters = technique.parameters;
+                var attributes = technique.attributes;
                 var uniforms = technique.uniforms;
+                for (var attributeName in attributes) {
+                    if (attributes.hasOwnProperty(attributeName)) {
+                        if (parameters[attributes[attributeName]].semantic === semantic) {
+                            return attributeName;
+                        }
+                    }
+                }
                 for (var uniformName in uniforms) {
                     if (uniforms.hasOwnProperty(uniformName)) {
-                        var parameterName = uniforms[uniformName];
-                        var parameter = parameters[parameterName];
-                        var semantic = parameter.semantic;
-                        if (defined(semantic) && (semantic === '_3DTILESDIFFUSE')) {
+                        if (parameters[uniforms[uniformName]].semantic === semantic) {
                             return uniformName;
                         }
                     }
@@ -32,5 +34,5 @@ define([
         return undefined;
     }
 
-    return getDiffuseUniformName;
+    return getAttributeOrUniformBySemantic;
 });


### PR DESCRIPTION
Instead of hard-coding `a_batchId` when generating shaders in `Cesium3DTileBatchTable`, it gets the name of the batch id attribute based on which gltf parameter uses the `BATCHID` semantic. This gives 3D Tiles generators more flexibility in naming their batch id attribute.

If this change seems good the 3D Tiles spec will also need to be updated.

@pjcozzi @tfili