### PR TITLE
Fix electron tests on windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "karma": "1.3.0",
     "karma-chrome-launcher": "2.0.0",
     "karma-detect-browsers": "2.1.0",
-    "karma-electron-launcher": "0.1.0",
+    "karma-electron": "5.1.1",
     "karma-firefox-launcher": "1.0.0",
     "karma-ie-launcher": "1.0.0",
     "karma-jasmine": "1.0.2",


### PR DESCRIPTION
Running the tests via Electron on Windows was broken because `karma-electron-launcher` is unmaintained and no longer compatible with the newer `electron` package.  This uses `karma-electron` instead, which is maintained and up to date.