### PR TITLE
Timeline should not use ISO8601 as an intermediate format.

### DIFF
--- a/Source/Widgets/Timeline/Timeline.js
+++ b/Source/Widgets/Timeline/Timeline.js
@@ -378,15 +378,17 @@ define([
 
         // epochJulian: a nearby time to be considered "zero seconds", should be a round-ish number by human standards.
         var epochJulian;
+        var gregorianDate = JulianDate.toGregorianDate(startJulian);
         if (duration > 315360000) { // 3650+ days visible, epoch is start of the first visible century.
-            epochJulian = JulianDate.fromIso8601(JulianDate.toDate(startJulian).toISOString().substring(0, 2) + '00-01-01T00:00:00Z');
+            epochJulian = JulianDate.fromDate(new Date(Date.UTC(Math.floor(gregorianDate.year / 100) * 100, 0)));
         } else if (duration > 31536000) { // 365+ days visible, epoch is start of the first visible decade.
-            epochJulian = JulianDate.fromIso8601(JulianDate.toDate(startJulian).toISOString().substring(0, 3) + '0-01-01T00:00:00Z');
+            epochJulian = JulianDate.fromDate(new Date(Date.UTC(Math.floor(gregorianDate.year / 10) * 10, 0)));
         } else if (duration > 86400) { // 1+ day(s) visible, epoch is start of the year.
-            epochJulian = JulianDate.fromIso8601(JulianDate.toDate(startJulian).toISOString().substring(0, 4) + '-01-01T00:00:00Z');
+            epochJulian = JulianDate.fromDate(new Date(Date.UTC(gregorianDate.year, 0)));
         } else { // Less than a day on timeline, epoch is midnight of the visible day.
-            epochJulian = JulianDate.fromIso8601(JulianDate.toDate(startJulian).toISOString().substring(0, 10) + 'T00:00:00Z');
+            epochJulian = JulianDate.fromDate(new Date(Date.UTC(gregorianDate.year, gregorianDate.month, gregorianDate.day)));
         }
+
         // startTime: Seconds offset of the left side of the timeline from epochJulian.
         var startTime = JulianDate.secondsDifference(this._startJulian, JulianDate.addSeconds(epochJulian, epsilonTime, new JulianDate()));
         // endTime: Seconds offset of the right side of the timeline from epochJulian.


### PR DESCRIPTION
This fixes #4544 and replaces #4553.

Basically, makeTics was using ISO8601 and JavaScript dates as an intermediate format for computing it's Julian epoch.  This lead to all kinds of problems for very early or late dates.

This fixes the crash and everything works, but there are still labeling problems when you go before 4713 BCE, but I'll write up a new issue to deal with that separately since it's a mode widespread Cesium problem.

CC @erikmaarten @emackey 