### PR TITLE
Added sqrt function to styling language

### DIFF
--- a/Apps/Sandcastle/gallery/3D Tiles Point Cloud Styling.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Point Cloud Styling.html
@@ -109,8 +109,9 @@ addStyle('Abs', {
     color : "color() * abs(${temperature} - 0.5)"
 });
 
-addStyle('Cos', {
-    color : "color() * cos(${temperature} - 0)"
+addStyle('Sqrt', {
+    color : "color() * sqrt(${temperature} - 0.5)",
+    pointSize : "10"
 });
 
 addStyle('Secondary Color', {

--- a/Apps/Sandcastle/gallery/3D Tiles Point Cloud Styling.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Point Cloud Styling.html
@@ -109,6 +109,10 @@ addStyle('Abs', {
     color : "color() * abs(${temperature} - 0.5)"
 });
 
+addStyle('Cos', {
+    color : "color() * cos(${temperature} - 0)"
+});
+
 addStyle('Sqrt', {
     color : "color() * sqrt(${temperature} - 0.5)",
     pointSize : "10"

--- a/Apps/Sandcastle/gallery/3D Tiles Point Cloud Styling.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Point Cloud Styling.html
@@ -114,7 +114,7 @@ addStyle('Cos', {
 });
 
 addStyle('Sqrt', {
-    color : "color() * sqrt(${temperature} - 0.5)",
+    color : "color() * sqrt(${temperature})",
     pointSize : "10"
 });
 

--- a/Source/Scene/Expression.js
+++ b/Source/Scene/Expression.js
@@ -928,7 +928,7 @@ define([
         return Math.abs(this._left.evaluate(feature));
     };
 
-Node.prototype._evaluateCosine = function(feature) {
+	Node.prototype._evaluateCosine = function(feature) {
         return Math.cos(this._left.evaluate(feature));
     };
 

--- a/Source/Scene/Expression.js
+++ b/Source/Scene/Expression.js
@@ -928,7 +928,7 @@ define([
         return Math.abs(this._left.evaluate(feature));
     };
 
-	Node.prototype._evaluateCosine = function(feature) {
+    Node.prototype._evaluateCosine = function(feature) {
         return Math.cos(this._left.evaluate(feature));
     };
 

--- a/Source/Scene/Expression.js
+++ b/Source/Scene/Expression.js
@@ -346,7 +346,7 @@ define([
             //>>includeEnd('debug');
             val = createRuntimeAst(expression, args[0]);
             return new Node(ExpressionNodeType.UNARY, call, val);
-        } else if (call === 'cos') {
+        } else if (call === 'sqrt') {
             //>>includeStart('debug', pragmas.debug);
             if (args.length < 1 || args.length > 1) {
                 throw new DeveloperError('Error: ' + call + ' requires exactly one argument.');
@@ -585,8 +585,8 @@ define([
                 node.evaluate = node._evaluateIsFinite;
             } else if (node._value === 'abs') {
                 node.evaluate = node._evaluateAbsoluteValue;
-            } else if (node._value === 'cos') {
-                node.evaluate = node._evaluateCosine;
+            } else if (node._value === 'sqrt') {
+                node.evaluate = node._evaluateSquareRoot;
             } else if (node._value === 'Boolean') {
                 node.evaluate = node._evaluateBooleanConversion;
             } else if (node._value === 'Number') {
@@ -918,8 +918,8 @@ define([
         return Math.abs(this._left.evaluate(feature));
     };
 
-    Node.prototype._evaluateCosine = function(feature) {
-        return Math.cos(this._left.evaluate(feature));
+    Node.prototype._evaluateSquareRoot = function(feature) {
+        return Math.sqrt(this._left.evaluate(feature));
     };
 
     Node.prototype._evaluateBooleanConversion = function(feature) {
@@ -1141,8 +1141,8 @@ define([
                     return 'float(' + left + ')';
                 } else if (value === 'abs') {
                     return 'abs(' + left + ')';
-                } else if (value === 'cos') {
-                    return 'cos(' + left + ')';
+                } else if (value === 'sqrt') {
+                    return 'sqrt(' + left + ')';
                 }
                 //>>includeStart('debug', pragmas.debug);
                 else if ((value === 'isNaN') || (value === 'isFinite') || (value === 'String')) {

--- a/Source/Scene/Expression.js
+++ b/Source/Scene/Expression.js
@@ -928,7 +928,7 @@ define([
         return Math.abs(this._left.evaluate(feature));
     };
 
-	Node.prototype._evaluateCosine = function(feature) {
+Node.prototype._evaluateCosine = function(feature) {
         return Math.cos(this._left.evaluate(feature));
     };
 

--- a/Source/Scene/Expression.js
+++ b/Source/Scene/Expression.js
@@ -346,6 +346,14 @@ define([
             //>>includeEnd('debug');
             val = createRuntimeAst(expression, args[0]);
             return new Node(ExpressionNodeType.UNARY, call, val);
+        } else if (call === 'cos') {
+            //>>includeStart('debug', pragmas.debug);
+            if (args.length < 1 || args.length > 1) {
+                throw new DeveloperError('Error: ' + call + ' requires exactly one argument.');
+            }
+            //>>includeEnd('debug');
+            val = createRuntimeAst(expression, args[0]);
+            return new Node(ExpressionNodeType.UNARY, call, val);
         } else if (call === 'sqrt') {
             //>>includeStart('debug', pragmas.debug);
             if (args.length < 1 || args.length > 1) {
@@ -585,6 +593,8 @@ define([
                 node.evaluate = node._evaluateIsFinite;
             } else if (node._value === 'abs') {
                 node.evaluate = node._evaluateAbsoluteValue;
+            } else if (node._value === 'cos') {
+                node.evaluate = node._evaluateCosine;
             } else if (node._value === 'sqrt') {
                 node.evaluate = node._evaluateSquareRoot;
             } else if (node._value === 'Boolean') {
@@ -918,6 +928,10 @@ define([
         return Math.abs(this._left.evaluate(feature));
     };
 
+	Node.prototype._evaluateCosine = function(feature) {
+        return Math.cos(this._left.evaluate(feature));
+    };
+
     Node.prototype._evaluateSquareRoot = function(feature) {
         return Math.sqrt(this._left.evaluate(feature));
     };
@@ -1141,6 +1155,8 @@ define([
                     return 'float(' + left + ')';
                 } else if (value === 'abs') {
                     return 'abs(' + left + ')';
+                } else if (value === 'cos') {
+                    return 'cos(' + left + ')';
                 } else if (value === 'sqrt') {
                     return 'sqrt(' + left + ')';
                 }

--- a/Specs/Scene/ExpressionSpec.js
+++ b/Specs/Scene/ExpressionSpec.js
@@ -833,8 +833,8 @@ defineSuite([
     });
 
     it('evaluates cos function', function() {
--        var expression = new Expression('cos(0)');
--        expect(expression.evaluate(undefined)).toEqual(1);
+        var expression = new Expression('cos(0)');
+        expect(expression.evaluate(undefined)).toEqual(1);
     });
 
     it('throws if cos function takes an invalid number of arguments', function() {

--- a/Specs/Scene/ExpressionSpec.js
+++ b/Specs/Scene/ExpressionSpec.js
@@ -832,18 +832,24 @@ defineSuite([
         }).toThrowDeveloperError();
     });
 
-    it('evaluates cos function', function() {
-        var expression = new Expression('cos(0)');
-        expect(expression.evaluate(undefined)).toEqual(1);
+        it('evaluates sqrt function', function() {
+        var expression = new Expression('sqrt(1.0)');
+        expect(expression.evaluate(undefined)).toEqual(1.0);
+
+        expression = new Expression('sqrt(4.0)');
+        expect(expression.evaluate(undefined)).toEqual(2.0);
+
+        expression = new Expression('sqrt(-1.0)');
+        expect(expression.evaluate(undefined)).toEqual(NaN);
     });
 
-    it('throws if cos function takes an invalid number of arguments', function() {
+    it('throws if sqrt function takes an invalid number of arguments', function() {
         expect(function() {
-            return new Expression('cos()');
+            return new Expression('sqrt()');
         }).toThrowDeveloperError();
 
         expect(function() {
-            return new Expression('cos(1, 2)');
+            return new Expression('sqrt(1, 2)');
         }).toThrowDeveloperError();
     });
 
@@ -1602,10 +1608,10 @@ defineSuite([
         expect(shaderExpression).toEqual(expected);
     });
 
-    it('gets shader expression for cos', function() {
-        var expression = new Expression('cos(0.0)');
+        it('gets shader expression for sqrt', function() {
+        var expression = new Expression('sqrt(1.0)');
         var shaderExpression = expression.getShaderExpression('', {});
-        var expected = 'cos(0.0)';
+        var expected = 'sqrt(1.0)';
         expect(shaderExpression).toEqual(expected);
     });
 

--- a/Specs/Scene/ExpressionSpec.js
+++ b/Specs/Scene/ExpressionSpec.js
@@ -832,6 +832,21 @@ defineSuite([
         }).toThrowDeveloperError();
     });
 
+    it('evaluates cos function', function() {
+-        var expression = new Expression('cos(0)');
+-        expect(expression.evaluate(undefined)).toEqual(1);
+    });
+
+    it('throws if cos function takes an invalid number of arguments', function() {
+        expect(function() {
+            return new Expression('cos()');
+        }).toThrowDeveloperError();
+
+        expect(function() {
+            return new Expression('cos(1, 2)');
+        }).toThrowDeveloperError();
+    });
+
         it('evaluates sqrt function', function() {
         var expression = new Expression('sqrt(1.0)');
         expect(expression.evaluate(undefined)).toEqual(1.0);
@@ -1608,7 +1623,15 @@ defineSuite([
         expect(shaderExpression).toEqual(expected);
     });
 
-        it('gets shader expression for sqrt', function() {
+    it('gets shader expression for cos', function() {
+        var expression = new Expression('cos(0.0)');
+        var shaderExpression = expression.getShaderExpression('', {});
+        var expected = 'cos(0.0)';
+        expect(shaderExpression).toEqual(expected);
+    });
+
+
+    it('gets shader expression for sqrt', function() {
         var expression = new Expression('sqrt(1.0)');
         var shaderExpression = expression.getShaderExpression('', {});
         var expected = 'sqrt(1.0)';

--- a/Specs/Scene/ExpressionSpec.js
+++ b/Specs/Scene/ExpressionSpec.js
@@ -847,7 +847,7 @@ defineSuite([
         }).toThrowDeveloperError();
     });
 
-        it('evaluates sqrt function', function() {
+    it('evaluates sqrt function', function() {
         var expression = new Expression('sqrt(1.0)');
         expect(expression.evaluate(undefined)).toEqual(1.0);
 


### PR DESCRIPTION
For #4556 

This PR supports the `sqrt` function:

- Updated `Expression.js` - Javascript and GLSL interpreters.
- Added tests to `ExpressionSpec.js`
- Added a style to `3D Tiles Point Cloud Styling.html` that uses the sqrt function to help visualize that things work.

Let me know how this looks @lilleyse 