### PR TITLE
DeviceOrientationCamera 

### DIFF
--- a/Source/Scene/DeviceOrientationCameraController.js
+++ b/Source/Scene/DeviceOrientationCameraController.js
@@ -53,10 +53,7 @@ define([
         };
     }
 
-    var rotQuat = new Quaternion();
     var rotMatrix = new Matrix3();
-    var adjustToWorldQuat =
-       Quaternion.fromAxisAngle(Cartesian3.UNIT_X, -CesiumMath.toRadians(90));
     var direction = new Cartesian3();
 
     function rotate(camera, alpha, beta, gamma, orient) {

--- a/Specs/Scene/DeviceOrientationCameraControllerSpec.js
+++ b/Specs/Scene/DeviceOrientationCameraControllerSpec.js
@@ -62,47 +62,58 @@ defineSuite([
             return new DeviceOrientationCameraController();
         }).toThrowDeveloperError();
     });
+    it('is at rest looking down', function() {
+      var position = Cartesian3.clone(camera.position);
 
-    it('rotates for alpha', function() {
-        var position = Cartesian3.clone(camera.position);
-        var up = Cartesian3.clone(camera.up);
+      fireEvent({
+          alpha : 0,
+          gamma: 0,
+          beta: 0
+      });
 
-        fireEvent({
-            alpha : 90.0
-        });
-
-        expect(camera.position).toEqual(position);
-        expect(camera.direction).toEqualEpsilon(Cartesian3.UNIT_Y, CesiumMath.EPSILON14);
-        expect(camera.up).toEqualEpsilon(up, CesiumMath.EPSILON14);
-        expect(camera.right).toEqualEpsilon(Cartesian3.UNIT_X, CesiumMath.EPSILON14);
+      expect(camera.position).toEqual(position);
+      expect(camera.direction).toEqualEpsilon(new Cartesian3(0, 0, -1), CesiumMath.EPSILON14);
+      expect(camera.up).toEqualEpsilon(Cartesian3.UNIT_Y, CesiumMath.EPSILON14);
+      expect(camera.right).toEqualEpsilon(Cartesian3.UNIT_X, CesiumMath.EPSILON14);
     });
 
-    it('rotates for beta', function() {
-        var position = Cartesian3.clone(camera.position);
-        var direction = Cartesian3.clone(camera.direction);
+    it('pitch to look north', function() {
+      var position = Cartesian3.clone(camera.position);
 
-        fireEvent({
-            beta : 90.0
-        });
+      fireEvent({
+          beta: 90
+      });
 
-        expect(camera.position).toEqual(position);
-        expect(camera.direction).toEqualEpsilon(direction, CesiumMath.EPSILON14);
-        expect(camera.up).toEqualEpsilon(Cartesian3.UNIT_Y, CesiumMath.EPSILON14);
-        expect(camera.right).toEqualEpsilon(Cartesian3.UNIT_Z, CesiumMath.EPSILON14);
+      expect(camera.position).toEqual(position);
+      expect(camera.direction).toEqualEpsilon(Cartesian3.UNIT_Y, CesiumMath.EPSILON14);
+      expect(camera.up).toEqualEpsilon(Cartesian3.UNIT_Z, CesiumMath.EPSILON14);
+      expect(camera.right).toEqualEpsilon(Cartesian3.UNIT_X, CesiumMath.EPSILON14);
     });
 
-    it('rotates for gamma', function() {
-        var position = Cartesian3.clone(camera.position);
-        var right = Cartesian3.clone(camera.right);
+    it('yaw to look east', function() {
+      var position = Cartesian3.clone(camera.position);
 
-        fireEvent({
-            gamma : 90.0
-        });
+      fireEvent({
+          gamma: -90
+      });
 
-        expect(camera.position).toEqual(position);
-        expect(camera.direction).toEqualEpsilon(Cartesian3.negate(Cartesian3.UNIT_Z, new Cartesian3()), CesiumMath.EPSILON14);
-        expect(camera.up).toEqualEpsilon(Cartesian3.UNIT_X, CesiumMath.EPSILON14);
-        expect(camera.right).toEqualEpsilon(right, CesiumMath.EPSILON14);
+      expect(camera.position).toEqual(position);
+      expect(camera.direction).toEqualEpsilon(Cartesian3.UNIT_X, CesiumMath.EPSILON14);
+      expect(camera.up).toEqualEpsilon(Cartesian3.UNIT_Y, CesiumMath.EPSILON14);
+      expect(camera.right).toEqualEpsilon(Cartesian3.UNIT_Z, CesiumMath.EPSILON14);
+    });
+
+    it('roll to point east', function() {
+      var position = Cartesian3.clone(camera.position);
+
+      fireEvent({
+          alpha: -90
+      });
+
+      expect(camera.position).toEqual(position);
+      expect(camera.direction).toEqualEpsilon(new Cartesian3(0, 0, -1), CesiumMath.EPSILON14);
+      expect(camera.up).toEqualEpsilon(Cartesian3.UNIT_X, CesiumMath.EPSILON14);
+      expect(camera.right).toEqualEpsilon(new Cartesian3(0, -1, 0), CesiumMath.EPSILON14);
     });
 
     it('is destroyed', function() {


### PR DESCRIPTION
WIP

An attempt to address the device orientation issues laid out in #4135

Instead of repeatedly applying deltas of the device orientation to current camera orientation this approach maps it directly to the scene (taking into account device orientation).

The overall behavior is improved as far as responding to orientation changes. Now need to look into better orientation on intializing -- shouldn't have to know where true north is to find the globe :)

Other potential issues:
- iOS does not support screen orientation API. We could probably safely default to primary-landscape (90deg) as was done before.
