### PR TITLE
Add Edge to FeatureDetection

### DIFF
--- a/Source/Core/FeatureDetection.js
+++ b/Source/Core/FeatureDetection.js
@@ -29,7 +29,8 @@ define([
     function isChrome() {
         if (!defined(isChromeResult)) {
             isChromeResult = false;
-            if (/Google Inc/.test(theNavigator.vendor)) {
+            // Edge contains Chrome in the user agent too
+            if (!isEdge()) {
                 var fields = (/ Chrome\/([\.0-9]+)/).exec(theNavigator.userAgent);
                 if (fields !== null) {
                     isChromeResult = true;
@@ -51,8 +52,8 @@ define([
         if (!defined(isSafariResult)) {
             isSafariResult = false;
 
-            // Chrome contains Safari in the user agent too
-            if (!isChrome() && (/ Safari\/[\.0-9]+/).test(theNavigator.userAgent)) {
+            // Chrome and Edge contain Safari in the user agent too
+            if (!isChrome() && !isEdge() && (/ Safari\/[\.0-9]+/).test(theNavigator.userAgent)) {
                 var fields = (/ Version\/([\.0-9]+)/).exec(theNavigator.userAgent);
                 if (fields !== null) {
                     isSafariResult = true;

--- a/Source/Core/FeatureDetection.js
+++ b/Source/Core/FeatureDetection.js
@@ -29,11 +29,12 @@ define([
     function isChrome() {
         if (!defined(isChromeResult)) {
             isChromeResult = false;
-
-            var fields = (/ Chrome\/([\.0-9]+)/).exec(theNavigator.userAgent);
-            if (fields !== null) {
-                isChromeResult = true;
-                chromeVersionResult = extractVersion(fields[1]);
+            if (/Google Inc/.test(theNavigator.vendor)) {
+                var fields = (/ Chrome\/([\.0-9]+)/).exec(theNavigator.userAgent);
+                if (fields !== null) {
+                    isChromeResult = true;
+                    chromeVersionResult = extractVersion(fields[1]);
+                }
             }
         }
 
@@ -116,6 +117,24 @@ define([
         return isInternetExplorer() && internetExplorerVersionResult;
     }
 
+    var isEdgeResult;
+    var edgeVersionResult;
+    function isEdge() {
+        if (!defined(isEdgeResult)) {
+            isEdgeResult = false;
+            var fields = (/ Edge\/([\.0-9]+)/).exec(theNavigator.userAgent);
+            if (fields !== null) {
+                isEdgeResult = true;
+                edgeVersionResult = extractVersion(fields[1]);
+            }
+        }
+        return isEdgeResult;
+    }
+
+    function edgeVersion() {
+        return isEdge() && edgeVersionResult;
+    }
+
     var isFirefoxResult;
     var firefoxVersionResult;
     function isFirefox() {
@@ -193,6 +212,8 @@ define([
         webkitVersion : webkitVersion,
         isInternetExplorer : isInternetExplorer,
         internetExplorerVersion : internetExplorerVersion,
+        isEdge : isEdge,
+        edgeVersion : edgeVersion,
         isFirefox : isFirefox,
         firefoxVersion : firefoxVersion,
         isWindows : isWindows,

--- a/Specs/Core/FeatureDetectionSpec.js
+++ b/Specs/Core/FeatureDetectionSpec.js
@@ -77,6 +77,18 @@ defineSuite([
         }
     });
 
+    it('detects Edge', function() {
+        var isEdge = FeatureDetection.isEdge();
+        expect(typeof isEdge).toEqual('boolean');
+
+        if (isEdge) {
+            var edgeVersion = FeatureDetection.edgeVersion();
+            checkVersionArray(edgeVersion);
+
+            console.log('detected Edge ' + edgeVersion.join('.'));
+        }
+    });
+
     it('detects Firefox', function() {
         var isFirefox = FeatureDetection.isFirefox();
         expect(typeof isFirefox).toEqual('boolean');


### PR DESCRIPTION
Checks the `navigator.userAgent` to see if Edge is present. On Chrome, IE, and Firefox it is not.

I also changed the `isChrome` test because Edge contains Chrome in its `userAgent`.

I may have to fix `isSafari` as well for the same reason, but it might be ok since it also checks `/ Version\/([\.0-9]+)/` which would result in null on Edge. I'll test on Monday.