### PR TITLE
Shadow map fixes

### DIFF
--- a/Source/Core/FeatureDetection.js
+++ b/Source/Core/FeatureDetection.js
@@ -29,11 +29,12 @@ define([
     function isChrome() {
         if (!defined(isChromeResult)) {
             isChromeResult = false;
-
-            var fields = (/ Chrome\/([\.0-9]+)/).exec(theNavigator.userAgent);
-            if (fields !== null) {
-                isChromeResult = true;
-                chromeVersionResult = extractVersion(fields[1]);
+            if (/Google Inc/.test(theNavigator.vendor)) {
+                var fields = (/ Chrome\/([\.0-9]+)/).exec(theNavigator.userAgent);
+                if (fields !== null) {
+                    isChromeResult = true;
+                    chromeVersionResult = extractVersion(fields[1]);
+                }
             }
         }
 
@@ -116,6 +117,24 @@ define([
         return isInternetExplorer() && internetExplorerVersionResult;
     }
 
+    var isEdgeResult;
+    var edgeVersionResult;
+    function isEdge() {
+        if (!defined(isEdgeResult)) {
+            isEdgeResult = false;
+            var fields = (/ Edge\/([\.0-9]+)/).exec(theNavigator.userAgent);
+            if (fields !== null) {
+                isEdgeResult = true;
+                edgeVersionResult = extractVersion(fields[1]);
+            }
+        }
+        return isEdgeResult;
+    }
+
+    function edgeVersion() {
+        return isEdge() && edgeVersionResult;
+    }
+
     var isFirefoxResult;
     var firefoxVersionResult;
     function isFirefox() {
@@ -193,6 +212,8 @@ define([
         webkitVersion : webkitVersion,
         isInternetExplorer : isInternetExplorer,
         internetExplorerVersion : internetExplorerVersion,
+        isEdge : isEdge,
+        edgeVersion : edgeVersion,
         isFirefox : isFirefox,
         firefoxVersion : firefoxVersion,
         isWindows : isWindows,

--- a/Source/Scene/Scene.js
+++ b/Source/Scene/Scene.js
@@ -2586,7 +2586,7 @@ define([
     };
 
     var scratchPackedDepth = new Cartesian4();
-    var packedDepthScale = new Cartesian4(1.0, 1.0 / 255.0, 1.0 / 65025.0, 1.0 / 160581375.0);
+    var packedDepthScale = new Cartesian4(1.0, 1.0 / 255.0, 1.0 / 65025.0, 1.0 / 16581375.0);
 
     /**
      * Returns the cartesian position reconstructed from the depth buffer and window position.

--- a/Source/Scene/ShadowMap.js
+++ b/Source/Scene/ShadowMap.js
@@ -184,8 +184,9 @@ define([
         this._outOfViewPrevious = false;
         this._needsUpdate = true;
 
-        // In IE11 polygon offset is not functional.
-        // TODO : Also disabled for Chrome (ANGLE) temporarily. Re-enable once https://github.com/AnalyticalGraphicsInc/cesium/issues/4560 is resolved.
+        // In IE11 and Edge polygon offset is not functional.
+        // TODO : Also disabled for instances of Firefox and Chrome running ANGLE that do not support depth textures.
+        // Re-enable once https://github.com/AnalyticalGraphicsInc/cesium/issues/4560 is resolved.
         var polygonOffsetSupported = true;
         if (FeatureDetection.isInternetExplorer() || FeatureDetection.isEdge() || ((FeatureDetection.isChrome() || FeatureDetection.isFirefox()) && FeatureDetection.isWindows() && !context.depthTexture)) {
             polygonOffsetSupported = false;

--- a/Source/Scene/ShadowMap.js
+++ b/Source/Scene/ShadowMap.js
@@ -187,7 +187,7 @@ define([
         // In IE11 polygon offset is not functional.
         // TODO : Also disabled for Chrome (ANGLE) temporarily. Re-enable once https://github.com/AnalyticalGraphicsInc/cesium/issues/4560 is resolved.
         var polygonOffsetSupported = true;
-        if (FeatureDetection.isInternetExplorer() || (FeatureDetection.isChrome() && FeatureDetection.isWindows())) {
+        if (FeatureDetection.isInternetExplorer() || FeatureDetection.isEdge() || ((FeatureDetection.isChrome() || FeatureDetection.isFirefox()) && FeatureDetection.isWindows() && !context.depthTexture)) {
             polygonOffsetSupported = false;
         }
         this._polygonOffsetSupported = polygonOffsetSupported;
@@ -1471,10 +1471,10 @@ define([
             var isTerrain = command.pass === Pass.GLOBE;
             var isOpaque = command.pass !== Pass.TRANSLUCENT;
             var isPointLight = shadowMap._isPointLight;
-            var useDepthTexture = shadowMap._usesDepthTexture;
+            var usesDepthTexture= shadowMap._usesDepthTexture;
 
             var castVS = ShadowMapShader.createShadowCastVertexShader(vertexShaderSource, isPointLight, isTerrain);
-            var castFS = ShadowMapShader.createShadowCastFragmentShader(fragmentShaderSource, isPointLight, useDepthTexture, isOpaque);
+            var castFS = ShadowMapShader.createShadowCastFragmentShader(fragmentShaderSource, isPointLight, usesDepthTexture, isOpaque);
 
             castShader = ShaderProgram.fromCache({
                 context : context,

--- a/Source/Scene/ShadowMapShader.js
+++ b/Source/Scene/ShadowMapShader.js
@@ -48,7 +48,7 @@ define([
         });
     };
 
-    ShadowMapShader.createShadowCastFragmentShader = function(fs, isPointLight, useDepthTexture, opaque) {
+    ShadowMapShader.createShadowCastFragmentShader = function(fs, isPointLight, usesDepthTexture, opaque) {
         var defines = fs.defines.slice(0);
         var sources = fs.sources.slice(0);
 
@@ -92,7 +92,7 @@ define([
                 'float distance = length(' + positionVaryingName + '); \n' +
                 'distance /= shadowMap_lightPositionEC.w; // radius \n' +
                 'gl_FragColor = czm_packDepth(distance); \n';
-        } else if (useDepthTexture) {
+        } else if (usesDepthTexture) {
             fsSource += 'gl_FragColor = vec4(1.0); \n';
         } else {
             fsSource += 'gl_FragColor = czm_packDepth(gl_FragCoord.z); \n';

--- a/Source/Shaders/Builtin/Functions/packDepth.glsl
+++ b/Source/Shaders/Builtin/Functions/packDepth.glsl
@@ -11,7 +11,7 @@ vec4 czm_packDepth(float depth)
 {
     // See Aras Pranckevičius' post Encoding Floats to RGBA
     // http://aras-p.info/blog/2009/07/30/encoding-floats-to-rgba-the-final/
-    vec4 enc = vec4(1.0, 255.0, 65025.0, 160581375.0) * depth;
+    vec4 enc = vec4(1.0, 255.0, 65025.0, 16581375.0) * depth;
     enc = fract(enc);
     enc -= enc.yzww * vec4(1.0 / 255.0, 1.0 / 255.0, 1.0 / 255.0, 0.0);
     return enc;

--- a/Source/Shaders/Builtin/Functions/unpackDepth.glsl
+++ b/Source/Shaders/Builtin/Functions/unpackDepth.glsl
@@ -12,5 +12,5 @@
  {
     // See Aras Pranckevičius' post Encoding Floats to RGBA
     // http://aras-p.info/blog/2009/07/30/encoding-floats-to-rgba-the-final/
-    return dot(packedDepth, vec4(1.0, 1.0 / 255.0, 1.0 / 65025.0, 1.0 / 160581375.0));
+    return dot(packedDepth, vec4(1.0, 1.0 / 255.0, 1.0 / 65025.0, 1.0 / 16581375.0));
  }

--- a/Specs/Core/FeatureDetectionSpec.js
+++ b/Specs/Core/FeatureDetectionSpec.js
@@ -77,6 +77,18 @@ defineSuite([
         }
     });
 
+    it('detects Edge', function() {
+        var isEdge = FeatureDetection.isEdge();
+        expect(typeof isEdge).toEqual('boolean');
+
+        if (isEdge) {
+            var edgeVersion = FeatureDetection.edgeVersion();
+            checkVersionArray(edgeVersion);
+
+            console.log('detected Edge ' + edgeVersion.join('.'));
+        }
+    });
+
     it('detects Firefox', function() {
         var isFirefox = FeatureDetection.isFirefox();
         expect(typeof isFirefox).toEqual('boolean');


### PR DESCRIPTION
Merge #4614 first

Related to https://github.com/AnalyticalGraphicsInc/cesium/issues/4560

I changed `160581375.0` to `16581375.0`. There was a typo in the original blog post: http://aras-p.info/blog/2009/07/30/encoding-floats-to-rgba-the-final/#comment-553113170. This affected a couple areas, but I didn't notice any change in behavior after.

Now `polygonOffset` is enabled unless the user is on IE, on Edge, or using ANGLE without depth texture support.