### PR TITLE
3D Tiles - Add time to styling language

### DIFF
--- a/Apps/Sandcastle/gallery/3D Tiles Point Cloud Styling.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Point Cloud Styling.html
@@ -110,7 +110,7 @@ addStyle('Abs', {
 });
 
 addStyle('Cos', {
-    color : "color() * abs(cos(${temperature} + TILES3D_TIME / 50))"
+    color : "color() * abs(cos(${temperature} + TILES3D_TILESET_TIME))"
 });
 
 addStyle('Sqrt', {

--- a/Apps/Sandcastle/gallery/3D Tiles Point Cloud Styling.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Point Cloud Styling.html
@@ -110,7 +110,7 @@ addStyle('Abs', {
 });
 
 addStyle('Cos', {
-    color : "color() * cos(${temperature} - 0)"
+    color : "color() * abs(cos(${temperature} + TILES3D_TIME / 50))"
 });
 
 addStyle('Sqrt', {

--- a/Apps/Sandcastle/gallery/3D Tiles.html
+++ b/Apps/Sandcastle/gallery/3D Tiles.html
@@ -238,7 +238,7 @@ handler.setInputAction(function(movement) {
 
             // evaluate feature description
             if (Cesium.defined(tileset.style.meta.description)) {
-                console.log("Description : " + tileset.style.meta.description.evaluate(feature));
+                console.log("Description : " + tileset.style.meta.description.evaluate(scene.frameState, feature));
             }
 
             feature.setProperty('clicked', true);
@@ -483,13 +483,13 @@ function addStyleUI() {
     button = Sandcastle.addToolbarButton('Custom style', function() {
         var style = new Cesium.Cesium3DTileStyle();
         style.show = {
-            evaluate : function(feature) {
+            evaluate : function(frameState, feature) {
                 tileset.makeStyleDirty(); // Force the style to be constantly evaluated
                 return Cesium.Math.nextRandomNumber() > 0.5;
             }
         };
         style.color = {
-            evaluateColor : function(feature, result) {
+            evaluateColor : function(frameState, feature, result) {
                 tileset.makeStyleDirty(); // Force the style to be constantly evaluated
                 return Cesium.Color.fromRandom(undefined, result);
             }

--- a/Source/Scene/Cesium3DTileStyle.js
+++ b/Source/Scene/Cesium3DTileStyle.js
@@ -227,13 +227,13 @@ define([
          * var style = new Cesium3DTileStyle({
          *     show : '(regExp("^Chest").test(${County})) && (${YearBuilt} >= 1970)'
          * });
-         * style.show.evaluate(feature); // returns true or false depending on the feature's properties
+         * style.show.evaluate(frameState, feature); // returns true or false depending on the feature's properties
          *
          * @example
          * var style = new Cesium.Cesium3DTileStyle();
          * // Override show expression with a custom function
          * style.show = {
-         *     evaluate : function(feature) {
+         *     evaluate : function(frameState, feature) {
          *         return true;
          *     }
          * };
@@ -271,13 +271,13 @@ define([
          * var style = new Cesium3DTileStyle({
          *     color : '(${Temperature} > 90) ? color("red") : color("white")'
          * });
-         * style.color.evaluateColor(feature, result); // returns a Cesium.Color object
+         * style.color.evaluateColor(frameState, feature, result); // returns a Cesium.Color object
          *
          * @example
          * var style = new Cesium.Cesium3DTileStyle();
          * // Override color expression with a custom function
          * style.color = {
-         *     evaluateColor : function(feature, result) {
+         *     evaluateColor : function(frameState, feature, result) {
          *         return Cesium.Color.clone(Cesium.Color.WHITE, result);
          *     }
          * };
@@ -315,13 +315,13 @@ define([
          * var style = new Cesium3DTileStyle({
          *     pointSize : '(${Temperature} > 90) ? 2.0 : 1.0'
          * });
-         * style.pointSize.evaluate(feature); // returns a Number
+         * style.pointSize.evaluate(frameState, feature); // returns a Number
          *
          * @example
          * var style = new Cesium.Cesium3DTileStyle();
          * // Override pointSize expression with a custom function
          * style.pointSize = {
-         *     evaluate : function(feature) {
+         *     evaluate : function(frameState, feature) {
          *         return 1.0;
          *     }
          * };
@@ -359,7 +359,7 @@ define([
          *         description : '"Building id ${id} has height ${Height}."'
          *     }
          * });
-         * style.meta.description.evaluate(feature); // returns a String with the substituted variables
+         * style.meta.description.evaluate(frameState, feature); // returns a String with the substituted variables
          *
          * @see {@link https://github.com/AnalyticalGraphicsInc/3d-tiles/tree/master/Styling|3D Tiles Styling language}
          */

--- a/Source/Scene/Cesium3DTileStyleEngine.js
+++ b/Source/Scene/Cesium3DTileStyleEngine.js
@@ -101,12 +101,12 @@ define([
         var style = styleEngine._style;
 
         if (!content.applyStyleWithShader(frameState, style)) {
-            applyStyleWithBatchTable(content, stats, style);
+            applyStyleWithBatchTable(frameState, content, stats, style);
         }
 
     }
 
-    function applyStyleWithBatchTable(content, stats, style) {
+    function applyStyleWithBatchTable(frameState, content, stats, style) {
         var length = content.featuresLength;
         stats.numberOfFeaturesStyled += length;
 
@@ -120,8 +120,8 @@ define([
         // by using reusing a batchValues array across tiles.
         for (var i = 0; i < length; ++i) {
             var feature = content.getFeature(i);
-            feature.color = style.color.evaluateColor(feature, scratchColor);
-            feature.show = style.show.evaluate(feature);
+            feature.color = style.color.evaluateColor(frameState, feature, scratchColor);
+            feature.show = style.show.evaluate(frameState, feature);
         }
     }
 

--- a/Source/Scene/Cesium3DTileset.js
+++ b/Source/Scene/Cesium3DTileset.js
@@ -15,6 +15,7 @@ define([
         '../Core/Intersect',
         '../Core/isDataUri',
         '../Core/joinUrls',
+        '../Core/JulianDate',
         '../Core/loadJson',
         '../Core/Math',
         '../Core/Matrix4',
@@ -50,6 +51,7 @@ define([
         Intersect,
         isDataUri,
         joinUrls,
+        JulianDate,
         loadJson,
         CesiumMath,
         Matrix4,
@@ -139,6 +141,8 @@ define([
         this._processingQueue = [];
         this._selectedTiles = [];
         this._selectedTilesToStyle = [];
+        this._loadTimestamp = undefined;
+        this._timeSinceLoad = 0.0;
 
         var replacementList = new DoublyLinkedList();
 
@@ -763,6 +767,17 @@ define([
                     // Useful, for example, when setting the modelMatrix and then having the camera view the tileset.
                     this._root.updateTransform(this._modelMatrix);
                 }
+            }
+        },
+
+        /**
+         * Returns the time, in seconds, since the tileset was loaded.
+         *
+         * @type {Number}
+         */
+        timeSinceLoad : {
+            get : function() {
+                return this._timeSinceLoad;
             }
         },
 
@@ -1655,6 +1670,12 @@ define([
         if (!this.show || !defined(this._root) || (frameState.mode !== SceneMode.SCENE3D)) {
             return;
         }
+
+        if (!defined(this._loadTimestamp)) {
+            this._loadTimestamp = JulianDate.clone(frameState.time);
+        }
+
+        this._timeSinceLoad = Math.max(JulianDate.secondsDifference(frameState.time, this._loadTimestamp), 0.0);
 
         // Do not do out-of-core operations (new content requests, cache removal,
         // process new tiles) during the pick pass.

--- a/Source/Scene/ConditionsExpression.js
+++ b/Source/Scene/ConditionsExpression.js
@@ -38,7 +38,7 @@ define([
      *         ['true', 'color("#FFFFFF")']
      *     ]
      * });
-     * expression.evaluateColor(feature, result); // returns a Cesium.Color object
+     * expression.evaluateColor(frameState, feature, result); // returns a Cesium.Color object
      *
      * @see {@link https://github.com/AnalyticalGraphicsInc/3d-tiles/tree/master/Styling|3D Tiles Styling language}
      */
@@ -110,17 +110,18 @@ define([
      * primitive type will be returned. If the result is a <code>RegExp</code>, a Javascript <code>RegExp</code>
      * object will be returned. If the result is a <code>Color</code>, a {@link Color} object will be returned.
      *
+     * @param {FrameState} frameState The frame state.
      * @param {Cesium3DTileFeature} feature The feature who's properties may be used as variables in the expression.
      * @returns {Boolean|Number|String|Color|RegExp} The result of evaluating the expression.
      */
-    ConditionsExpression.prototype.evaluate = function(feature) {
+    ConditionsExpression.prototype.evaluate = function(frameState, feature) {
         var conditions = this._runtimeConditions;
         if (defined(conditions)) {
             var length = conditions.length;
             for (var i = 0; i < length; ++i) {
                 var statement = conditions[i];
-                if (statement.condition.evaluate(feature)) {
-                    return statement.expression.evaluate(feature);
+                if (statement.condition.evaluate(frameState, feature)) {
+                    return statement.expression.evaluate(frameState, feature);
                 }
             }
         }
@@ -129,18 +130,19 @@ define([
     /**
      * Evaluates the result of a Color expression, using the values defined by a feature.
      *
+     * @param {FrameState} frameState The frame state.
      * @param {Cesium3DTileFeature} feature The feature who's properties may be used as variables in the expression.
      * @param {Color} [result] The object in which to store the result
      * @returns {Color} The modified result parameter or a new Color instance if one was not provided.
      */
-    ConditionsExpression.prototype.evaluateColor = function(feature, result) {
+    ConditionsExpression.prototype.evaluateColor = function(frameState, feature, result) {
         var conditions = this._runtimeConditions;
         if (defined(conditions)) {
             var length = conditions.length;
             for (var i = 0; i < length; ++i) {
                 var statement = conditions[i];
-                if (statement.condition.evaluate(feature)) {
-                    return statement.expression.evaluateColor(feature, result);
+                if (statement.condition.evaluate(frameState, feature)) {
+                    return statement.expression.evaluateColor(frameState, feature, result);
                 }
             }
         }

--- a/Source/Scene/ConditionsExpression.js
+++ b/Source/Scene/ConditionsExpression.js
@@ -27,7 +27,7 @@ define([
      * @alias ConditionsExpression
      * @constructor
      *
-     * @param {Object} [expression] The conditions expression defined using the 3D Tiles Styling language.
+     * @param {Object} [conditionsExpression] The conditions expression defined using the 3D Tiles Styling language.
      *
      * @example
      * var expression = new Cesium.Expression({

--- a/Source/Scene/Expression.js
+++ b/Source/Scene/Expression.js
@@ -57,11 +57,11 @@ define([
      *
      * @example
      * var expression = new Cesium.Expression('(regExp("^Chest").test(${County})) && (${YearBuilt} >= 1970)');
-     * expression.evaluate(feature); // returns true or false depending on the feature's properties
+     * expression.evaluate(frameState, feature); // returns true or false depending on the feature's properties
      *
      * @example
      * var expression = new Cesium.Expression('(${Temperature} > 90) ? color("red") : color("white")');
-     * expression.evaluateColor(feature, result); // returns a Cesium.Color object
+     * expression.evaluateColor(frameState, feature, result); // returns a Cesium.Color object
      *
      * @see {@link https://github.com/AnalyticalGraphicsInc/3d-tiles/tree/master/Styling|3D Tiles Styling language}
      */
@@ -117,12 +117,13 @@ define([
      * primitive type will be returned. If the result is a <code>RegExp</code>, a Javascript <code>RegExp</code>
      * object will be returned. If the result is a <code>Color</code>, a {@link Color} object will be returned.
      *
+     * @param {FrameState} frameState The frame state.
      * @param {Cesium3DTileFeature} feature The feature who's properties may be used as variables in the expression.
      * @returns {Boolean|Number|String|Color|RegExp} The result of evaluating the expression.
      */
-    Expression.prototype.evaluate = function(feature) {
+    Expression.prototype.evaluate = function(frameState, feature) {
         ScratchStorage.reset();
-        var result = this._runtimeAst.evaluate(feature);
+        var result = this._runtimeAst.evaluate(frameState, feature);
         if (result instanceof Color) {
             return Color.clone(result);
         }
@@ -132,13 +133,14 @@ define([
     /**
      * Evaluates the result of a Color expression, using the values defined by a feature.
      *
+     * @param {FrameState} frameState The frame state.
      * @param {Cesium3DTileFeature} feature The feature who's properties may be used as variables in the expression.
      * @param {Color} [result] The object in which to store the result
      * @returns {Color} The modified result parameter or a new Color instance if one was not provided.
      */
-    Expression.prototype.evaluateColor = function(feature, result) {
+    Expression.prototype.evaluateColor = function(frameState, feature, result) {
         ScratchStorage.reset();
-        var color = this._runtimeAst.evaluate(feature);
+        var color = this._runtimeAst.evaluate(frameState, feature);
         return Color.clone(color, result);
     };
 
@@ -438,6 +440,8 @@ define([
             return new Node(ExpressionNodeType.LITERAL_NUMBER, Infinity);
         } else if (ast.name === 'undefined') {
             return new Node(ExpressionNodeType.LITERAL_UNDEFINED, undefined);
+        } else if (ast.name === 'TILES3D_TIME') {
+            return new Node(ExpressionNodeType.LITERAL_GLOBAL, ast.name);
         }
 
         //>>includeStart('debug', pragmas.debug);
@@ -622,63 +626,71 @@ define([
             node.evaluate = node._evaluateLiteralString;
         } else if (node._type === ExpressionNodeType.REGEX) {
             node.evaluate = node._evaluateRegExp;
+        } else if (node._type === ExpressionNodeType.LITERAL_GLOBAL) {
+            if (node._value === 'TILES3D_TIME') {
+                node.evaluate = evaluateTime;
+            }
         } else {
             node.evaluate = node._evaluateLiteral;
         }
     }
 
-    Node.prototype._evaluateLiteral = function(feature) {
+    function evaluateTime(frameState, feature) {
+        return frameState.frameNumber;
+    }
+
+    Node.prototype._evaluateLiteral = function(frameState, feature) {
         return this._value;
     };
 
-    Node.prototype._evaluateLiteralColor = function(feature) {
+    Node.prototype._evaluateLiteralColor = function(frameState, feature) {
         var result = ScratchStorage.getColor();
         var args = this._left;
         if (this._value === 'color') {
             if (!defined(args)) {
                 return Color.fromBytes(255, 255, 255, 255, result);
             } else if (args.length > 1) {
-                Color.fromCssColorString(args[0].evaluate(feature, result), result);
-                result.alpha = args[1].evaluate(feature, result);
+                Color.fromCssColorString(args[0].evaluate(frameState, feature, result), result);
+                result.alpha = args[1].evaluate(frameState, feature, result);
             } else {
-                Color.fromCssColorString(args[0].evaluate(feature, result), result);
+                Color.fromCssColorString(args[0].evaluate(frameState, feature, result), result);
             }
         } else if (this._value === 'rgb') {
             Color.fromBytes(
-                args[0].evaluate(feature, result),
-                args[1].evaluate(feature, result),
-                args[2].evaluate(feature, result),
+                args[0].evaluate(frameState, feature, result),
+                args[1].evaluate(frameState, feature, result),
+                args[2].evaluate(frameState, feature, result),
                 255, result);
         } else if (this._value === 'rgba') {
             // convert between css alpha (0 to 1) and cesium alpha (0 to 255)
-            var a = args[3].evaluate(feature, result) * 255;
+            var a = args[3].evaluate(frameState, feature, result) * 255;
             Color.fromBytes(
-                args[0].evaluate(feature, result),
-                args[1].evaluate(feature, result),
-                args[2].evaluate(feature, result),
+                args[0].evaluate(frameState, feature, result),
+                args[1].evaluate(frameState, feature, result),
+                args[2].evaluate(frameState, feature, result),
                 a, result);
         } else if (this._value === 'hsl') {
             Color.fromHsl(
-                args[0].evaluate(feature, result),
-                args[1].evaluate(feature, result),
-                args[2].evaluate(feature, result),
+                args[0].evaluate(frameState, feature, result),
+                args[1].evaluate(frameState, feature, result),
+                args[2].evaluate(frameState, feature, result),
                 1.0, result);
         } else if (this._value === 'hsla') {
             Color.fromHsl(
-                args[0].evaluate(feature, result),
-                args[1].evaluate(feature, result),
-                args[2].evaluate(feature, result),
-                args[3].evaluate(feature, result),
+                args[0].evaluate(frameState, feature, result),
+                args[1].evaluate(frameState, feature, result),
+                args[2].evaluate(frameState, feature, result),
+                args[3].evaluate(frameState, feature, result),
                 result);
         }
         return result;
     };
 
-    Node.prototype._evaluateLiteralString = function(feature) {
+    Node.prototype._evaluateLiteralString = function(frameState, feature) {
         return this._value;
     };
 
-    Node.prototype._evaluateVariableString = function(feature) {
+    Node.prototype._evaluateVariableString = function(frameState, feature) {
         var result = this._value;
         var match = variableRegex.exec(result);
         while (match !== null) {
@@ -694,7 +706,7 @@ define([
         return result;
     };
 
-    Node.prototype._evaluateVariable = function(feature) {
+    Node.prototype._evaluateVariable = function(frameState, feature) {
         // evaluates to undefined if the property name is not defined for that feature
         return feature.getProperty(this._value);
     };
@@ -704,32 +716,32 @@ define([
     }
 
     // PERFORMANCE_IDEA: Determine if parent property needs to be computed before runtime
-    Node.prototype._evaluateMemberDot = function(feature) {
+    Node.prototype._evaluateMemberDot = function(frameState, feature) {
         if(checkFeature(this._left)) {
             return feature.getProperty(this._right);
         }
-        var property = this._left.evaluate(feature);
+        var property = this._left.evaluate(frameState, feature);
         if (!defined(property)) {
             return undefined;
         }
         return property[this._right];
     };
 
-    Node.prototype._evaluateMemberBrackets = function(feature) {
+    Node.prototype._evaluateMemberBrackets = function(frameState, feature) {
         if(checkFeature(this._left)) {
-            return feature.getProperty(this._right.evaluate(feature));
+            return feature.getProperty(this._right.evaluate(frameState, feature));
         }
-        var property = this._left.evaluate(feature);
+        var property = this._left.evaluate(frameState, feature);
         if (!defined(property)) {
             return undefined;
         }
-        return property[this._right.evaluate(feature)];
+        return property[this._right.evaluate(frameState, feature)];
     };
 
-    Node.prototype._evaluateArray = function(feature) {
+    Node.prototype._evaluateArray = function(frameState, feature) {
         var array = [];
         for (var i = 0; i < this._value.length; i++) {
-            array[i] = this._value[i].evaluate(feature);
+            array[i] = this._value[i].evaluate(frameState, feature);
         }
         return array;
     };
@@ -737,44 +749,44 @@ define([
     // PERFORMANCE_IDEA: Have "fast path" functions that deal only with specific types
     // that we can assign if we know the types before runtime
 
-    Node.prototype._evaluateNot = function(feature) {
-        return !(this._left.evaluate(feature));
+    Node.prototype._evaluateNot = function(frameState, feature) {
+        return !(this._left.evaluate(frameState, feature));
     };
 
-    Node.prototype._evaluateNegative = function(feature) {
-        return -(this._left.evaluate(feature));
+    Node.prototype._evaluateNegative = function(frameState, feature) {
+        return -(this._left.evaluate(frameState, feature));
     };
 
-    Node.prototype._evaluatePositive = function(feature) {
-        return +(this._left.evaluate(feature));
+    Node.prototype._evaluatePositive = function(frameState, feature) {
+        return +(this._left.evaluate(frameState, feature));
     };
 
-    Node.prototype._evaluateLessThan = function(feature) {
-        var left = this._left.evaluate(feature);
-        var right = this._right.evaluate(feature);
+    Node.prototype._evaluateLessThan = function(frameState, feature) {
+        var left = this._left.evaluate(frameState, feature);
+        var right = this._right.evaluate(frameState, feature);
         return left < right;
     };
 
-    Node.prototype._evaluateLessThanOrEquals = function(feature) {
-        var left = this._left.evaluate(feature);
-        var right = this._right.evaluate(feature);
+    Node.prototype._evaluateLessThanOrEquals = function(frameState, feature) {
+        var left = this._left.evaluate(frameState, feature);
+        var right = this._right.evaluate(frameState, feature);
         return left <= right;
     };
 
-    Node.prototype._evaluateGreaterThan = function(feature) {
-        var left = this._left.evaluate(feature);
-        var right = this._right.evaluate(feature);
+    Node.prototype._evaluateGreaterThan = function(frameState, feature) {
+        var left = this._left.evaluate(frameState, feature);
+        var right = this._right.evaluate(frameState, feature);
         return left > right;
     };
 
-    Node.prototype._evaluateGreaterThanOrEquals = function(feature) {
-        var left = this._left.evaluate(feature);
-        var right = this._right.evaluate(feature);
+    Node.prototype._evaluateGreaterThanOrEquals = function(frameState, feature) {
+        var left = this._left.evaluate(frameState, feature);
+        var right = this._right.evaluate(frameState, feature);
         return left >= right;
     };
 
-    Node.prototype._evaluateOr = function(feature) {
-        var left = this._left.evaluate(feature);
+    Node.prototype._evaluateOr = function(frameState, feature) {
+        var left = this._left.evaluate(frameState, feature);
         //>>includeStart('debug', pragmas.debug);
         if (typeof(left) !== 'boolean') {
             throw new DeveloperError('Error: Operation is undefined.');
@@ -786,7 +798,7 @@ define([
             return true;
         }
 
-        var right = this._right.evaluate(feature);
+        var right = this._right.evaluate(frameState, feature);
         //>>includeStart('debug', pragmas.debug);
         if (typeof(right) !== 'boolean') {
             throw new DeveloperError('Error: Operation is undefined.');
@@ -795,8 +807,8 @@ define([
         return left || right;
     };
 
-    Node.prototype._evaluateAnd = function(feature) {
-        var left = this._left.evaluate(feature);
+    Node.prototype._evaluateAnd = function(frameState, feature) {
+        var left = this._left.evaluate(frameState, feature);
         //>>includeStart('debug', pragmas.debug);
         if (typeof(left) !== 'boolean') {
             throw new DeveloperError('Error: Operation is undefined.');
@@ -808,7 +820,7 @@ define([
             return false;
         }
 
-        var right = this._right.evaluate(feature);
+        var right = this._right.evaluate(frameState, feature);
         //>>includeStart('debug', pragmas.debug);
         if (typeof(right) !== 'boolean') {
             throw new DeveloperError('Error: Operation is undefined.');
@@ -817,27 +829,27 @@ define([
         return left && right;
     };
 
-    Node.prototype._evaluatePlus = function(feature) {
-        var left = this._left.evaluate(feature);
-        var right = this._right.evaluate(feature);
+    Node.prototype._evaluatePlus = function(frameState, feature) {
+        var left = this._left.evaluate(frameState, feature);
+        var right = this._right.evaluate(frameState, feature);
         if ((right instanceof Color) && (left instanceof Color)) {
             return Color.add(left, right, ScratchStorage.getColor());
         }
         return left + right;
     };
 
-    Node.prototype._evaluateMinus = function(feature) {
-        var left = this._left.evaluate(feature);
-        var right = this._right.evaluate(feature);
+    Node.prototype._evaluateMinus = function(frameState, feature) {
+        var left = this._left.evaluate(frameState, feature);
+        var right = this._right.evaluate(frameState, feature);
         if ((right instanceof Color) && (left instanceof Color)) {
             return Color.subtract(left, right, ScratchStorage.getColor());
         }
         return left - right;
     };
 
-    Node.prototype._evaluateTimes = function(feature) {
-        var left = this._left.evaluate(feature);
-        var right = this._right.evaluate(feature);
+    Node.prototype._evaluateTimes = function(frameState, feature) {
+        var left = this._left.evaluate(frameState, feature);
+        var right = this._right.evaluate(frameState, feature);
         if ((right instanceof Color) && (left instanceof Color)) {
             return Color.multiply(left, right, ScratchStorage.getColor());
         } else if ((right instanceof Color) && (typeof(left) === 'number')) {
@@ -848,9 +860,9 @@ define([
         return left * right;
     };
 
-    Node.prototype._evaluateDivide = function(feature) {
-        var left = this._left.evaluate(feature);
-        var right = this._right.evaluate(feature);
+    Node.prototype._evaluateDivide = function(frameState, feature) {
+        var left = this._left.evaluate(frameState, feature);
+        var right = this._right.evaluate(frameState, feature);
         if ((right instanceof Color) && (left instanceof Color)) {
             return Color.divide(left, right, ScratchStorage.getColor());
         } else if ((left instanceof Color) && (typeof(right) === 'number')) {
@@ -859,27 +871,27 @@ define([
         return left / right;
     };
 
-    Node.prototype._evaluateMod = function(feature) {
-        var left = this._left.evaluate(feature);
-        var right = this._right.evaluate(feature);
+    Node.prototype._evaluateMod = function(frameState, feature) {
+        var left = this._left.evaluate(frameState, feature);
+        var right = this._right.evaluate(frameState, feature);
         if ((right instanceof Color) && (left instanceof Color)) {
             return Color.mod(left, right, ScratchStorage.getColor());
         }
         return left % right;
     };
 
-    Node.prototype._evaluateEqualsStrict = function(feature) {
-        var left = this._left.evaluate(feature);
-        var right = this._right.evaluate(feature);
+    Node.prototype._evaluateEqualsStrict = function(frameState, feature) {
+        var left = this._left.evaluate(frameState, feature);
+        var right = this._right.evaluate(frameState, feature);
         if ((right instanceof Color) && (left instanceof Color)) {
             return Color.equals(left, right);
         }
         return left === right;
     };
 
-    Node.prototype._evaluateEquals = function(feature) {
-        var left = this._left.evaluate(feature);
-        var right = this._right.evaluate(feature);
+    Node.prototype._evaluateEquals = function(frameState, feature) {
+        var left = this._left.evaluate(frameState, feature);
+        var right = this._right.evaluate(frameState, feature);
         if ((right instanceof Color) && (left instanceof Color)) {
             return Color.equals(left, right);
         }
@@ -889,18 +901,18 @@ define([
         return left == right; // jshint ignore:line
     };
 
-    Node.prototype._evaluateNotEqualsStrict = function(feature) {
-        var left = this._left.evaluate(feature);
-        var right = this._right.evaluate(feature);
+    Node.prototype._evaluateNotEqualsStrict = function(frameState, feature) {
+        var left = this._left.evaluate(frameState, feature);
+        var right = this._right.evaluate(frameState, feature);
         if ((right instanceof Color) && (left instanceof Color)) {
             return !Color.equals(left, right);
         }
         return left !== right;
     };
 
-    Node.prototype._evaluateNotEquals = function(feature) {
-        var left = this._left.evaluate(feature);
-        var right = this._right.evaluate(feature);
+    Node.prototype._evaluateNotEquals = function(frameState, feature) {
+        var left = this._left.evaluate(frameState, feature);
+        var right = this._right.evaluate(frameState, feature);
         if ((right instanceof Color) && (left instanceof Color)) {
             return !Color.equals(left, right);
         }
@@ -909,51 +921,51 @@ define([
         return left != right; // jshint ignore:line
     };
 
-    Node.prototype._evaluateConditional = function(feature) {
-        if (this._test.evaluate(feature)) {
-            return this._left.evaluate(feature);
+    Node.prototype._evaluateConditional = function(frameState, feature) {
+        if (this._test.evaluate(frameState, feature)) {
+            return this._left.evaluate(frameState, feature);
         }
-        return this._right.evaluate(feature);
+        return this._right.evaluate(frameState, feature);
     };
 
-    Node.prototype._evaluateNaN = function(feature) {
-        return isNaN(this._left.evaluate(feature));
+    Node.prototype._evaluateNaN = function(frameState, feature) {
+        return isNaN(this._left.evaluate(frameState, feature));
     };
 
-    Node.prototype._evaluateIsFinite = function(feature) {
-        return isFinite(this._left.evaluate(feature));
+    Node.prototype._evaluateIsFinite = function(frameState, feature) {
+        return isFinite(this._left.evaluate(frameState, feature));
     };
 
-    Node.prototype._evaluateAbsoluteValue = function(feature) {
-        return Math.abs(this._left.evaluate(feature));
+    Node.prototype._evaluateAbsoluteValue = function(frameState, feature) {
+        return Math.abs(this._left.evaluate(frameState, feature));
     };
 
-    Node.prototype._evaluateCosine = function(feature) {
-        return Math.cos(this._left.evaluate(feature));
+    Node.prototype._evaluateCosine = function(frameState, feature) {
+        return Math.cos(this._left.evaluate(frameState, feature));
     };
 
-    Node.prototype._evaluateSquareRoot = function(feature) {
-        return Math.sqrt(this._left.evaluate(feature));
+    Node.prototype._evaluateSquareRoot = function(frameState, feature) {
+        return Math.sqrt(this._left.evaluate(frameState, feature));
     };
 
-    Node.prototype._evaluateBooleanConversion = function(feature) {
-        return Boolean(this._left.evaluate(feature));
+    Node.prototype._evaluateBooleanConversion = function(frameState, feature) {
+        return Boolean(this._left.evaluate(frameState, feature));
     };
 
-    Node.prototype._evaluateNumberConversion = function(feature) {
-        return Number(this._left.evaluate(feature));
+    Node.prototype._evaluateNumberConversion = function(frameState, feature) {
+        return Number(this._left.evaluate(frameState, feature));
     };
 
-    Node.prototype._evaluateStringConversion = function(feature) {
-        return String(this._left.evaluate(feature));
+    Node.prototype._evaluateStringConversion = function(frameState, feature) {
+        return String(this._left.evaluate(frameState, feature));
     };
 
-    Node.prototype._evaluateRegExp = function(feature) {
-        var pattern = this._value.evaluate(feature);
+    Node.prototype._evaluateRegExp = function(frameState, feature) {
+        var pattern = this._value.evaluate(frameState, feature);
         var flags = '';
 
         if (defined(this._left)) {
-            flags = this._left.evaluate(feature);
+            flags = this._left.evaluate(frameState, feature);
         }
 
         var exp;
@@ -967,13 +979,13 @@ define([
         return exp;
     };
 
-    Node.prototype._evaluateRegExpTest = function(feature) {
-        return this._left.evaluate(feature).test(this._right.evaluate(feature));
+    Node.prototype._evaluateRegExpTest = function(frameState, feature) {
+        return this._left.evaluate(frameState, feature).test(this._right.evaluate(frameState, feature));
     };
 
-    Node.prototype._evaluateRegExpMatch = function(feature) {
-        var left = this._left.evaluate(feature);
-        var right = this._right.evaluate(feature);
+    Node.prototype._evaluateRegExpMatch = function(frameState, feature) {
+        var left = this._left.evaluate(frameState, feature);
+        var right = this._right.evaluate(frameState, feature);
         if (left instanceof RegExp) {
             return left.test(right);
         } else if (right instanceof RegExp) {
@@ -983,9 +995,9 @@ define([
         }
     };
 
-    Node.prototype._evaluateRegExpNotMatch = function(feature) {
-        var left = this._left.evaluate(feature);
-        var right = this._right.evaluate(feature);
+    Node.prototype._evaluateRegExpNotMatch = function(frameState, feature) {
+        var left = this._left.evaluate(frameState, feature);
+        var right = this._right.evaluate(frameState, feature);
         if (left instanceof RegExp) {
             return !(left.test(right));
         } else if (right instanceof RegExp) {
@@ -995,16 +1007,16 @@ define([
         }
     };
 
-    Node.prototype._evaluateRegExpExec = function(feature) {
-        var exec = this._left.evaluate(feature).exec(this._right.evaluate(feature));
+    Node.prototype._evaluateRegExpExec = function(frameState, feature) {
+        var exec = this._left.evaluate(frameState, feature).exec(this._right.evaluate(frameState, feature));
         if (!defined(exec)) {
             return null;
         }
         return exec[1];
     };
 
-    Node.prototype._evaluateToString = function(feature) {
-        var left = this._left.evaluate(feature);
+    Node.prototype._evaluateToString = function(frameState, feature) {
+        var left = this._left.evaluate(frameState, feature);
         if ((left instanceof RegExp) || (left instanceof Color)) {
             return String(left);
         }
@@ -1286,6 +1298,10 @@ define([
                 //>>includeStart('debug', pragmas.debug);
                 throw new DeveloperError('Error generating style shader: undefined is not supported.');
                 //>>includeEnd('debug');
+            case ExpressionNodeType.LITERAL_GLOBAL:
+                if (value === 'TILES3D_TIME') {
+                    return 'czm_frameNumber';
+                }
         }
     };
 

--- a/Source/Scene/Expression.js
+++ b/Source/Scene/Expression.js
@@ -440,7 +440,7 @@ define([
             return new Node(ExpressionNodeType.LITERAL_NUMBER, Infinity);
         } else if (ast.name === 'undefined') {
             return new Node(ExpressionNodeType.LITERAL_UNDEFINED, undefined);
-        } else if (ast.name === 'TILES3D_TIME') {
+        } else if (ast.name === 'TILES3D_TILESET_TIME') {
             return new Node(ExpressionNodeType.LITERAL_GLOBAL, ast.name);
         }
 
@@ -627,7 +627,7 @@ define([
         } else if (node._type === ExpressionNodeType.REGEX) {
             node.evaluate = node._evaluateRegExp;
         } else if (node._type === ExpressionNodeType.LITERAL_GLOBAL) {
-            if (node._value === 'TILES3D_TIME') {
+            if (node._value === 'TILES3D_TILESET_TIME') {
                 node.evaluate = evaluateTime;
             }
         } else {
@@ -636,7 +636,7 @@ define([
     }
 
     function evaluateTime(frameState, feature) {
-        return frameState.frameNumber;
+        return feature._content._tileset.timeSinceLoad;
     }
 
     Node.prototype._evaluateLiteral = function(frameState, feature) {
@@ -1299,8 +1299,8 @@ define([
                 throw new DeveloperError('Error generating style shader: undefined is not supported.');
                 //>>includeEnd('debug');
             case ExpressionNodeType.LITERAL_GLOBAL:
-                if (value === 'TILES3D_TIME') {
-                    return 'czm_frameNumber';
+                if (value === 'TILES3D_TILESET_TIME') {
+                    return 'u_tilesetTime';
                 }
         }
     };

--- a/Source/Scene/ExpressionNodeType.js
+++ b/Source/Scene/ExpressionNodeType.js
@@ -21,10 +21,11 @@ define([
         LITERAL_NULL : 9,
         LITERAL_BOOLEAN : 10,
         LITERAL_NUMBER : 11,
-        LITERAL_STRING: 12,
-        LITERAL_COLOR: 13,
-        LITERAL_REGEX: 14,
-        LITERAL_UNDEFINED: 15
+        LITERAL_STRING : 12,
+        LITERAL_COLOR : 13,
+        LITERAL_REGEX : 14,
+        LITERAL_UNDEFINED : 15,
+        LITERAL_GLOBAL : 16
     };
 
     return freezeObject(ExpressionNodeType);

--- a/Source/Scene/PointCloud3DTileContent.js
+++ b/Source/Scene/PointCloud3DTileContent.js
@@ -547,6 +547,9 @@ define([
             },
             u_constantColor : function() {
                 return content._constantColor;
+            },
+            u_tilesetTime : function() {
+                return content._tileset.timeSinceLoad;
             }
         };
 
@@ -909,7 +912,8 @@ define([
                  'varying vec4 v_color; \n' +
                  'uniform float u_pointSize; \n' +
                  'uniform vec4 u_constantColor; \n' +
-                 'uniform vec4 u_highlightColor; \n';
+                 'uniform vec4 u_highlightColor; \n' +
+                 'uniform float u_tilesetTime; \n';
 
         var length = styleableProperties.length;
         for (i = 0; i < length; ++i) {

--- a/Source/Scene/StyleExpression.js
+++ b/Source/Scene/StyleExpression.js
@@ -32,21 +32,23 @@ define([
      * primitive type will be returned. If the result is a <code>RegExp</code>, a Javascript <code>RegExp</code>
      * object will be returned. If the result is a <code>Color</code>, a {@link Color} object will be returned.
      *
+     * @param {FrameState} frameState The frame state.
      * @param {Cesium3DTileFeature} feature The feature who's properties may be used as variables in the expression.
      * @returns {Boolean|Number|String|Color|RegExp} The result of evaluating the expression.
      */
-    StyleExpression.prototype.evaluate = function(feature) {
+    StyleExpression.prototype.evaluate = function(frameState, feature) {
         DeveloperError.throwInstantiationError();
     };
 
     /**
      * Evaluates the result of a Color expression, using the values defined by a feature.
      *
+     * @param {FrameState} frameState The frame state.
      * @param {Cesium3DTileFeature} feature The feature who's properties may be used as variables in the expression.
      * @param {Color} [result] The object in which to store the result
      * @returns {Color} The modified result parameter or a new Color instance if one was not provided.
      */
-    StyleExpression.prototype.evaluateColor = function(feature, result) {
+    StyleExpression.prototype.evaluateColor = function(frameState, feature, result) {
         DeveloperError.throwInstantiationError();
     };
 

--- a/Specs/Scene/Cesium3DTileStyleSpec.js
+++ b/Specs/Scene/Cesium3DTileStyleSpec.js
@@ -11,9 +11,7 @@ defineSuite([
         Expression) {
     'use strict';
 
-    var frameState = {
-        frameNumber : 0
-    };
+    var frameState = {};
 
     function MockFeature() {
         this._properties = {};

--- a/Specs/Scene/Cesium3DTileStyleSpec.js
+++ b/Specs/Scene/Cesium3DTileStyleSpec.js
@@ -11,6 +11,10 @@ defineSuite([
         Expression) {
     'use strict';
 
+    var frameState = {
+        frameNumber : 0
+    };
+
     function MockFeature() {
         this._properties = {};
     }
@@ -52,7 +56,7 @@ defineSuite([
 
     var styleUrl = './Data/Cesium3DTiles/Style/style.json';
 
-    it ('rejects readyPromise with undefined url', function() {
+    it('rejects readyPromise with undefined url', function() {
         var tileStyle = new Cesium3DTileStyle('invalid.json');
 
         return tileStyle.readyPromise.then(function(style) {
@@ -63,7 +67,7 @@ defineSuite([
         });
     });
 
-    it ('loads style from uri', function() {
+    it('loads style from uri', function() {
         var tileStyle = new Cesium3DTileStyle(styleUrl);
 
         return tileStyle.readyPromise.then(function(style) {
@@ -81,7 +85,7 @@ defineSuite([
         });
     });
 
-    it ('sets show value to default expression', function() {
+    it('sets show value to default expression', function() {
         var style = new Cesium3DTileStyle({});
         expect(style.show).toEqual(new Expression('true'));
 
@@ -89,7 +93,7 @@ defineSuite([
         expect(style.show).toEqual(new Expression('true'));
     });
 
-    it ('sets color value to default expression', function() {
+    it('sets color value to default expression', function() {
         var style = new Cesium3DTileStyle({});
         expect(style.color).toEqual(new Expression('color("#ffffff")'));
 
@@ -97,7 +101,7 @@ defineSuite([
         expect(style.color).toEqual(new Expression('color("#ffffff")'));
     });
 
-    it ('sets pointSize value to default expression', function() {
+    it('sets pointSize value to default expression', function() {
         var style = new Cesium3DTileStyle({});
         expect(style.pointSize).toEqual(new Expression('1'));
 
@@ -105,7 +109,7 @@ defineSuite([
         expect(style.pointSize).toEqual(new Expression('1'));
     });
 
-    it ('sets show value to expression', function() {
+    it('sets show value to expression', function() {
         var style = new Cesium3DTileStyle({
             show : 'true'
         });
@@ -132,7 +136,7 @@ defineSuite([
         expect(style.show).toEqual(new Expression('false'));
     });
 
-    it ('sets show value to conditional', function() {
+    it('sets show value to conditional', function() {
         var jsonExp = {
             conditions : [
                 ['${height} > 2', 'false'],
@@ -146,14 +150,14 @@ defineSuite([
         expect(style.show).toEqual(new ConditionsExpression(jsonExp));
     });
 
-    it ('sets show to undefined if not a string, boolean, or conditional', function() {
+    it('sets show to undefined if not a string, boolean, or conditional', function() {
         var style = new Cesium3DTileStyle({
             show : 1
         });
         expect(style.show).toEqual(undefined);
     });
 
-    it ('sets color value to expression', function() {
+    it('sets color value to expression', function() {
         var style = new Cesium3DTileStyle({
             color : 'color("red")'
         });
@@ -170,7 +174,7 @@ defineSuite([
         expect(style.color).toEqual(new Expression('(${height} * 10 >= 1000) ? rgba(0.0, 0.0, 1.0, 0.5) : color("blue")'));
     });
 
-    it ('sets color value to conditional', function() {
+    it('sets color value to conditional', function() {
         var jsonExp = {
             conditions : [
                 ['${height} > 2', 'color("cyan")'],
@@ -184,14 +188,14 @@ defineSuite([
         expect(style.color).toEqual(new ConditionsExpression(jsonExp));
     });
 
-    it ('sets color to undefined if not a string or conditional', function() {
+    it('sets color to undefined if not a string or conditional', function() {
         var style = new Cesium3DTileStyle({
             color : 1
         });
         expect(style.color).toEqual(undefined);
     });
 
-    it ('sets pointSize value to expression', function() {
+    it('sets pointSize value to expression', function() {
         var style = new Cesium3DTileStyle({
             pointSize : '2'
         });
@@ -208,7 +212,7 @@ defineSuite([
         expect(style.pointSize).toEqual(new Expression('2'));
     });
 
-    it ('sets pointSize value to conditional', function() {
+    it('sets pointSize value to conditional', function() {
         var jsonExp = {
             conditions : [
                 ['${height} > 2', '1.0'],
@@ -222,14 +226,14 @@ defineSuite([
         expect(style.pointSize).toEqual(new ConditionsExpression(jsonExp));
     });
 
-    it ('sets pointSize to undefined if not a number, string, or conditional', function() {
+    it('sets pointSize to undefined if not a number, string, or conditional', function() {
         var style = new Cesium3DTileStyle({
             pointSize : true
         });
         expect(style.pointSize).toEqual(undefined);
     });
 
-    it ('throws on accessing style if not ready', function() {
+    it('throws on accessing style if not ready', function() {
         var style = new Cesium3DTileStyle({});
         style._ready = false;
 
@@ -238,7 +242,7 @@ defineSuite([
         }).toThrowDeveloperError();
     });
 
-    it ('throws on accessing color if not ready', function() {
+    it('throws on accessing color if not ready', function() {
         var style = new Cesium3DTileStyle({});
         style._ready = false;
 
@@ -247,7 +251,7 @@ defineSuite([
         }).toThrowDeveloperError();
     });
 
-    it ('throws on accessing show if not ready', function() {
+    it('throws on accessing show if not ready', function() {
         var style = new Cesium3DTileStyle({});
         style._ready = false;
 
@@ -256,7 +260,7 @@ defineSuite([
         }).toThrowDeveloperError();
     });
 
-    it ('throws on accessing pointSize if not ready', function() {
+    it('throws on accessing pointSize if not ready', function() {
         var style = new Cesium3DTileStyle({});
         style._ready = false;
 
@@ -265,13 +269,13 @@ defineSuite([
         }).toThrowDeveloperError();
     });
 
-    it ('sets meta properties', function() {
+    it('sets meta properties', function() {
         var style = new Cesium3DTileStyle({
             meta : {
                 description : '"Hello, ${name}"'
             }
         });
-        expect(style.meta.description.evaluate(feature1)).toEqual("Hello, Hello");
+        expect(style.meta.description.evaluate(frameState, feature1)).toEqual("Hello, Hello");
 
         style = new Cesium3DTileStyle({
             meta : {
@@ -279,11 +283,11 @@ defineSuite([
                 volume : '${Height} * ${Width} * ${Depth}'
             }
         });
-        expect(style.meta.featureColor.evaluate(feature1)).toEqual(Color.fromBytes(38, 255, 82));
-        expect(style.meta.volume.evaluate(feature1)).toEqual(20 * 20 * 100);
+        expect(style.meta.featureColor.evaluate(frameState, feature1)).toEqual(Color.fromBytes(38, 255, 82));
+        expect(style.meta.volume.evaluate(frameState, feature1)).toEqual(20 * 20 * 100);
     });
 
-    it ('default meta has no properties', function() {
+    it('default meta has no properties', function() {
         var style = new Cesium3DTileStyle({});
         expect(style.meta).toEqual({});
 
@@ -293,7 +297,7 @@ defineSuite([
         expect(style.meta).toEqual({});
     });
 
-    it ('default meta has no properties', function() {
+    it('default meta has no properties', function() {
         var style = new Cesium3DTileStyle({});
         expect(style.meta).toEqual({});
 
@@ -303,7 +307,7 @@ defineSuite([
         expect(style.meta).toEqual({});
     });
 
-    it ('throws on accessing meta if not ready', function() {
+    it('throws on accessing meta if not ready', function() {
         var style = new Cesium3DTileStyle({});
         style._ready = false;
 
@@ -314,39 +318,39 @@ defineSuite([
 
     // Tests for examples from the style spec
 
-    it ('applies default style', function() {
+    it('applies default style', function() {
         var style = new Cesium3DTileStyle({
             "show" : "true",
             "color" : "color('#ffffff')",
             "pointSize" : "1.0"
         });
 
-        expect(style.show.evaluate(undefined)).toEqual(true);
-        expect(style.color.evaluate(undefined)).toEqual(Color.WHITE);
-        expect(style.pointSize.evaluate(undefined)).toEqual(1.0);
+        expect(style.show.evaluate(frameState, undefined)).toEqual(true);
+        expect(style.color.evaluate(frameState, undefined)).toEqual(Color.WHITE);
+        expect(style.pointSize.evaluate(frameState, undefined)).toEqual(1.0);
     });
 
-    it ('applies show style with variable', function() {
+    it('applies show style with variable', function() {
         var style = new Cesium3DTileStyle({
             "show" : "${ZipCode} == '19341'"
         });
 
-        expect(style.show.evaluate(feature1)).toEqual(true);
-        expect(style.show.evaluate(feature2)).toEqual(false);
-        expect(style.color.evaluate(undefined)).toEqual(Color.WHITE);
+        expect(style.show.evaluate(frameState, feature1)).toEqual(true);
+        expect(style.show.evaluate(frameState, feature2)).toEqual(false);
+        expect(style.color.evaluate(frameState, undefined)).toEqual(Color.WHITE);
     });
 
-    it ('applies show style with regexp and variables', function() {
+    it('applies show style with regexp and variables', function() {
         var style = new Cesium3DTileStyle({
             "show" : "(regExp('^Chest').test(${County})) && (${YearBuilt} >= 1970)"
         });
 
-        expect(style.show.evaluate(feature1)).toEqual(true);
-        expect(style.show.evaluate(feature2)).toEqual(false);
-        expect(style.color.evaluate(undefined)).toEqual(Color.WHITE);
+        expect(style.show.evaluate(frameState, feature1)).toEqual(true);
+        expect(style.show.evaluate(frameState, feature2)).toEqual(false);
+        expect(style.color.evaluate(frameState, undefined)).toEqual(Color.WHITE);
     });
 
-    it ('applies show style with complex conditional', function() {
+    it('applies show style with complex conditional', function() {
         var style = new Cesium3DTileStyle({
             "show" : {
                 "expression" : "${Height}",
@@ -360,11 +364,11 @@ defineSuite([
                 ]
             }
         });
-        expect(style.show.evaluate(feature1)).toEqual(false);
-        expect(style.show.evaluate(feature2)).toEqual(true);
+        expect(style.show.evaluate(frameState, feature1)).toEqual(false);
+        expect(style.show.evaluate(frameState, feature2)).toEqual(true);
     });
 
-    it ('applies show style with conditional', function() {
+    it('applies show style with conditional', function() {
         var style = new Cesium3DTileStyle({
             "show" : {
                 "conditions" : [
@@ -377,29 +381,29 @@ defineSuite([
                 ]
             }
         });
-        expect(style.show.evaluate(feature1)).toEqual(false);
-        expect(style.show.evaluate(feature2)).toEqual(true);
+        expect(style.show.evaluate(frameState, feature1)).toEqual(false);
+        expect(style.show.evaluate(frameState, feature2)).toEqual(true);
     });
 
-    it ('applies color style variables', function() {
+    it('applies color style variables', function() {
         var style = new Cesium3DTileStyle({
             "color" : "(${Temperature} > 90) ? color('red') : color('white')"
         });
-        expect(style.show.evaluate(feature1)).toEqual(true);
-        expect(style.color.evaluate(feature1)).toEqual(Color.WHITE);
-        expect(style.color.evaluate(feature2)).toEqual(Color.RED);
+        expect(style.show.evaluate(frameState, feature1)).toEqual(true);
+        expect(style.color.evaluate(frameState, feature1)).toEqual(Color.WHITE);
+        expect(style.color.evaluate(frameState, feature2)).toEqual(Color.RED);
     });
 
-    it ('applies color style with new color', function() {
+    it('applies color style with new color', function() {
         var style = new Cesium3DTileStyle({
             "color" : "rgba(${red}, ${green}, ${blue}, (${volume} > 100 ? 0.5 : 1.0))"
         });
-        expect(style.show.evaluate(feature1)).toEqual(true);
-        expect(style.color.evaluate(feature1)).toEqual(new Color(38/255, 255/255, 82/255, 0.5));
-        expect(style.color.evaluate(feature2)).toEqual(new Color(255/255, 30/255, 30/255, 1.0));
+        expect(style.show.evaluate(frameState, feature1)).toEqual(true);
+        expect(style.color.evaluate(frameState, feature1)).toEqual(new Color(38/255, 255/255, 82/255, 0.5));
+        expect(style.color.evaluate(frameState, feature2)).toEqual(new Color(255/255, 30/255, 30/255, 1.0));
     });
 
-    it ('applies color style that maps id to color', function() {
+    it('applies color style that maps id to color', function() {
         var style = new Cesium3DTileStyle({
             "color" : {
                 "expression" : "regExp('^1(\\d)').exec(${id})",
@@ -410,12 +414,12 @@ defineSuite([
                 ]
             }
         });
-        expect(style.show.evaluate(feature1)).toEqual(true);
-        expect(style.color.evaluate(feature1)).toEqual(Color.RED);
-        expect(style.color.evaluate(feature2)).toEqual(Color.LIME);
+        expect(style.show.evaluate(frameState, feature1)).toEqual(true);
+        expect(style.color.evaluate(frameState, feature1)).toEqual(Color.RED);
+        expect(style.color.evaluate(frameState, feature2)).toEqual(Color.LIME);
     });
 
-    it ('applies color style with complex conditional', function() {
+    it('applies color style with complex conditional', function() {
         var style = new Cesium3DTileStyle({
             "color" : {
                 "expression" : "${Height}",
@@ -429,12 +433,12 @@ defineSuite([
                 ]
             }
         });
-        expect(style.show.evaluate(feature1)).toEqual(true);
-        expect(style.color.evaluate(feature1)).toEqual(Color.BLUE);
-        expect(style.color.evaluate(feature2)).toEqual(Color.YELLOW);
+        expect(style.show.evaluate(frameState, feature1)).toEqual(true);
+        expect(style.color.evaluate(frameState, feature1)).toEqual(Color.BLUE);
+        expect(style.color.evaluate(frameState, feature2)).toEqual(Color.YELLOW);
     });
 
-    it ('applies color style with conditional', function() {
+    it('applies color style with conditional', function() {
         var style = new Cesium3DTileStyle({
             "color" : {
                 "conditions" : [
@@ -447,30 +451,30 @@ defineSuite([
                 ]
             }
         });
-        expect(style.show.evaluate(feature1)).toEqual(true);
-        expect(style.color.evaluate(feature1)).toEqual(Color.BLUE);
-        expect(style.color.evaluate(feature2)).toEqual(Color.YELLOW);
+        expect(style.show.evaluate(frameState, feature1)).toEqual(true);
+        expect(style.color.evaluate(frameState, feature1)).toEqual(Color.BLUE);
+        expect(style.color.evaluate(frameState, feature2)).toEqual(Color.YELLOW);
     });
 
-    it ('applies pointSize style with variable', function() {
+    it('applies pointSize style with variable', function() {
         var style = new Cesium3DTileStyle({
             "pointSize" : "${Temperature} / 10.0"
         });
 
-        expect(style.pointSize.evaluate(feature1)).toEqual(7.8);
-        expect(style.pointSize.evaluate(feature2)).toEqual(9.2);
+        expect(style.pointSize.evaluate(frameState, feature1)).toEqual(7.8);
+        expect(style.pointSize.evaluate(frameState, feature2)).toEqual(9.2);
     });
 
-    it ('applies pointSize style with regexp and variables', function() {
+    it('applies pointSize style with regexp and variables', function() {
         var style = new Cesium3DTileStyle({
             "pointSize" : "(regExp('^Chest').test(${County})) ? 2.0 : 1.0"
         });
 
-        expect(style.pointSize.evaluate(feature1)).toEqual(2.0);
-        expect(style.pointSize.evaluate(feature2)).toEqual(1.0);
+        expect(style.pointSize.evaluate(frameState, feature1)).toEqual(2.0);
+        expect(style.pointSize.evaluate(frameState, feature2)).toEqual(1.0);
     });
 
-    it ('applies pointSize style with complex conditional', function() {
+    it('applies pointSize style with complex conditional', function() {
         var style = new Cesium3DTileStyle({
             "pointSize" : {
                 "expression" : "${Height}",
@@ -484,11 +488,11 @@ defineSuite([
                 ]
             }
         });
-        expect(style.pointSize.evaluate(feature1)).toEqual(6);
-        expect(style.pointSize.evaluate(feature2)).toEqual(3);
+        expect(style.pointSize.evaluate(frameState, feature1)).toEqual(6);
+        expect(style.pointSize.evaluate(frameState, feature2)).toEqual(3);
     });
 
-    it ('applies pointSize style with conditional', function() {
+    it('applies pointSize style with conditional', function() {
         var style = new Cesium3DTileStyle({
             "pointSize" : {
                 "conditions" : [
@@ -501,8 +505,8 @@ defineSuite([
                 ]
             }
         });
-        expect(style.pointSize.evaluate(feature1)).toEqual(6);
-        expect(style.pointSize.evaluate(feature2)).toEqual(3);
+        expect(style.pointSize.evaluate(frameState, feature1)).toEqual(6);
+        expect(style.pointSize.evaluate(frameState, feature2)).toEqual(3);
     });
 
     it('return undefined shader functions when the style is empty', function() {

--- a/Specs/Scene/Cesium3DTilesetSpec.js
+++ b/Specs/Scene/Cesium3DTilesetSpec.js
@@ -1353,13 +1353,13 @@ defineSuite([
     it('applies custom style to a tileset', function() {
         var style = new Cesium3DTileStyle();
         style.show = {
-            evaluate : function(feature) {
+            evaluate : function(frameState, feature) {
                 return this._value;
             },
             _value : false
         };
         style.color = {
-            evaluateColor : function(feature, result) {
+            evaluateColor : function(frameState, feature, result) {
                 return Color.clone(Color.WHITE, result);
             }
         };

--- a/Specs/Scene/ConditionsExpressionSpec.js
+++ b/Specs/Scene/ConditionsExpressionSpec.js
@@ -9,6 +9,10 @@ defineSuite([
         Color) {
     'use strict';
 
+    var frameState = {
+        frameNumber : 0
+    };
+
     function MockFeature(value) {
         this._value = value;
     }
@@ -79,16 +83,16 @@ defineSuite([
 
     it('evaluates conditional', function() {
         var expression = new ConditionsExpression(jsonExp);
-        expect(expression.evaluate(new MockFeature(101))).toEqual(Color.BLUE);
-        expect(expression.evaluate(new MockFeature(52))).toEqual(Color.RED);
-        expect(expression.evaluate(new MockFeature(3))).toEqual(Color.LIME);
+        expect(expression.evaluate(frameState, new MockFeature(101))).toEqual(Color.BLUE);
+        expect(expression.evaluate(frameState, new MockFeature(52))).toEqual(Color.RED);
+        expect(expression.evaluate(frameState, new MockFeature(3))).toEqual(Color.LIME);
     });
 
     it('evaluates conditional with multiple expressions', function() {
         var expression = new ConditionsExpression(jsonExpWithMultipleExpression);
-        expect(expression.evaluate(new MockFeature(101))).toEqual(Color.BLUE);
-        expect(expression.evaluate(new MockFeature(52))).toEqual(Color.LIME);
-        expect(expression.evaluate(new MockFeature(3))).toEqual(Color.LIME);
+        expect(expression.evaluate(frameState, new MockFeature(101))).toEqual(Color.BLUE);
+        expect(expression.evaluate(frameState, new MockFeature(52))).toEqual(Color.LIME);
+        expect(expression.evaluate(frameState, new MockFeature(3))).toEqual(Color.LIME);
     });
 
     it('constructs and evaluates empty conditional', function() {
@@ -96,30 +100,30 @@ defineSuite([
             "conditions" : []
         });
         expect(expression._conditions).toEqual([]);
-        expect(expression.evaluate(new MockFeature(101))).toEqual(undefined);
-        expect(expression.evaluate(new MockFeature(52))).toEqual(undefined);
-        expect(expression.evaluate(new MockFeature(3))).toEqual(undefined);
+        expect(expression.evaluate(frameState, new MockFeature(101))).toEqual(undefined);
+        expect(expression.evaluate(frameState, new MockFeature(52))).toEqual(undefined);
+        expect(expression.evaluate(frameState, new MockFeature(3))).toEqual(undefined);
     });
 
     it('constructs and evaluates empty', function() {
         var expression = new ConditionsExpression([]);
         expect(expression._conditions).toEqual(undefined);
-        expect(expression.evaluate(new MockFeature(101))).toEqual(undefined);
-        expect(expression.evaluate(new MockFeature(52))).toEqual(undefined);
-        expect(expression.evaluate(new MockFeature(3))).toEqual(undefined);
+        expect(expression.evaluate(frameState, new MockFeature(101))).toEqual(undefined);
+        expect(expression.evaluate(frameState, new MockFeature(52))).toEqual(undefined);
+        expect(expression.evaluate(frameState, new MockFeature(3))).toEqual(undefined);
     });
 
     it('evaluates conditional with expression', function() {
         var expression = new ConditionsExpression(jsonExpWithExpression);
-        expect(expression.evaluate(new MockFeature(101))).toEqual(Color.BLUE);
-        expect(expression.evaluate(new MockFeature(52))).toEqual(Color.RED);
-        expect(expression.evaluate(new MockFeature(3))).toEqual(Color.LIME);
+        expect(expression.evaluate(frameState, new MockFeature(101))).toEqual(Color.BLUE);
+        expect(expression.evaluate(frameState, new MockFeature(52))).toEqual(Color.RED);
+        expect(expression.evaluate(frameState, new MockFeature(3))).toEqual(Color.LIME);
     });
 
     it('evaluates undefined conditional expression', function() {
         var expression = new ConditionsExpression(jsonExpWithUndefinedExpression);
         expect(expression._expression).toEqual(undefined);
-        expect(expression.evaluate(undefined)).toEqual(Color.BLUE);
+        expect(expression.evaluate(frameState, undefined)).toEqual(Color.BLUE);
     });
 
     it('gets shader function', function() {

--- a/Specs/Scene/ConditionsExpressionSpec.js
+++ b/Specs/Scene/ConditionsExpressionSpec.js
@@ -9,9 +9,7 @@ defineSuite([
         Color) {
     'use strict';
 
-    var frameState = {
-        frameNumber : 0
-    };
+    var frameState = {};
 
     function MockFeature(value) {
         this._value = value;

--- a/Specs/Scene/ExpressionSpec.js
+++ b/Specs/Scene/ExpressionSpec.js
@@ -9,12 +9,15 @@ defineSuite([
         Color) {
     'use strict';
 
-    var frameState = {
-        frameNumber : 0
-    };
+    var frameState = {};
 
     function MockFeature() {
         this._properties = {};
+        this._content = {
+            _tileset : {
+                timeSinceLoad : 0.0
+            }
+        };
     }
 
     MockFeature.prototype.addProperty = function(name, value) {
@@ -1289,12 +1292,12 @@ defineSuite([
         expect(expression.evaluate(frameState, feature)).toEqual(70);
     });
 
-    it('evaluates TILES3D_TIME expression', function() {
-        var expression = new Expression('TILES3D_TIME');
-        expect(expression.evaluate(frameState, undefined)).toEqual(0);
-        frameState.frameNumber = 1;
-        expect(expression.evaluate(frameState, undefined)).toEqual(1);
-        frameState.frameNumber = 0;
+    it('evaluates TILES3D_TILESET_TIME expression', function() {
+        var feature = new MockFeature();
+        var expression = new Expression('TILES3D_TILESET_TIME');
+        expect(expression.evaluate(frameState, feature)).toEqual(0.0);
+        feature._content._tileset.timeSinceLoad = 1.0;
+        expect(expression.evaluate(frameState, feature)).toEqual(1.0);
     });
 
     it('gets shader function', function() {
@@ -1628,10 +1631,10 @@ defineSuite([
         expect(shaderState.translucent).toBe(true);
     });
 
-    it('gets shader expression for TILES3D_TIME', function() {
-        var expression = new Expression('TILES3D_TIME');
+    it('gets shader expression for TILES3D_TILESET_TIME', function() {
+        var expression = new Expression('TILES3D_TILESET_TIME');
         var shaderExpression = expression.getShaderExpression('', {});
-        var expected = 'czm_frameNumber';
+        var expected = 'u_tilesetTime';
         expect(shaderExpression).toEqual(expected);
     });
 

--- a/Specs/Scene/ExpressionSpec.js
+++ b/Specs/Scene/ExpressionSpec.js
@@ -9,6 +9,10 @@ defineSuite([
         Color) {
     'use strict';
 
+    var frameState = {
+        frameNumber : 0
+    };
+
     function MockFeature() {
         this._properties = {};
     }
@@ -21,9 +25,9 @@ defineSuite([
         return this._properties[name];
     };
 
-    it ('parses backslashes', function() {
+    it('parses backslashes', function() {
         var expression = new Expression('"\\he\\\\\\ll\\\\o"');
-        expect(expression.evaluate(undefined)).toEqual('\\he\\\\\\ll\\\\o');
+        expect(expression.evaluate(frameState, undefined)).toEqual('\\he\\\\\\ll\\\\o');
     });
 
     it('evaluates variable', function() {
@@ -37,52 +41,52 @@ defineSuite([
         feature.addProperty('undefined', undefined);
 
         var expression = new Expression('${height}');
-        expect(expression.evaluate(feature)).toEqual(10);
+        expect(expression.evaluate(frameState, feature)).toEqual(10);
 
         expression = new Expression('\'${height}\'');
-        expect(expression.evaluate(feature)).toEqual('10');
+        expect(expression.evaluate(frameState, feature)).toEqual('10');
 
         expression = new Expression('${height}/${width}');
-        expect(expression.evaluate(feature)).toEqual(2);
+        expect(expression.evaluate(frameState, feature)).toEqual(2);
 
         expression = new Expression('${string}');
-        expect(expression.evaluate(feature)).toEqual('hello');
+        expect(expression.evaluate(frameState, feature)).toEqual('hello');
 
         expression = new Expression('\'replace ${string}\'');
-        expect(expression.evaluate(feature)).toEqual('replace hello');
+        expect(expression.evaluate(frameState, feature)).toEqual('replace hello');
 
         expression = new Expression('\'replace ${string} multiple ${height}\'');
-        expect(expression.evaluate(feature)).toEqual('replace hello multiple 10');
+        expect(expression.evaluate(frameState, feature)).toEqual('replace hello multiple 10');
 
         expression = new Expression('"replace ${string}"');
-        expect(expression.evaluate(feature)).toEqual('replace hello');
+        expect(expression.evaluate(frameState, feature)).toEqual('replace hello');
 
         expression = new Expression('\'replace ${string\'');
-        expect(expression.evaluate(feature)).toEqual('replace ${string');
+        expect(expression.evaluate(frameState, feature)).toEqual('replace ${string');
 
         expression = new Expression('${boolean}');
-        expect(expression.evaluate(feature)).toEqual(true);
+        expect(expression.evaluate(frameState, feature)).toEqual(true);
 
         expression = new Expression('\'${boolean}\'');
-        expect(expression.evaluate(feature)).toEqual('true');
+        expect(expression.evaluate(frameState, feature)).toEqual('true');
 
         expression = new Expression('${color}');
-        expect(expression.evaluate(feature)).toEqual(Color.RED);
+        expect(expression.evaluate(frameState, feature)).toEqual(Color.RED);
 
         expression = new Expression('\'${color}\'');
-        expect(expression.evaluate(feature)).toEqual(Color.RED.toString());
+        expect(expression.evaluate(frameState, feature)).toEqual(Color.RED.toString());
 
         expression = new Expression('${null}');
-        expect(expression.evaluate(feature)).toEqual(null);
+        expect(expression.evaluate(frameState, feature)).toEqual(null);
 
         expression = new Expression('\'${null}\'');
-        expect(expression.evaluate(feature)).toEqual('');
+        expect(expression.evaluate(frameState, feature)).toEqual('');
 
         expression = new Expression('${undefined}');
-        expect(expression.evaluate(feature)).toEqual(undefined);
+        expect(expression.evaluate(frameState, feature)).toEqual(undefined);
 
         expression = new Expression('\'${undefined}\'');
-        expect(expression.evaluate(feature)).toEqual('');
+        expect(expression.evaluate(frameState, feature)).toEqual('');
 
         expect(function() {
             return new Expression('${height');
@@ -175,167 +179,167 @@ defineSuite([
 
     it('evaluates literal null', function() {
         var expression = new Expression('null');
-        expect(expression.evaluate(undefined)).toEqual(null);
+        expect(expression.evaluate(frameState, undefined)).toEqual(null);
     });
 
     it('evaluates literal undefined', function() {
         var expression = new Expression('undefined');
-        expect(expression.evaluate(undefined)).toEqual(undefined);
+        expect(expression.evaluate(frameState, undefined)).toEqual(undefined);
     });
 
     it('evaluates literal boolean', function() {
         var expression = new Expression('true');
-        expect(expression.evaluate(undefined)).toEqual(true);
+        expect(expression.evaluate(frameState, undefined)).toEqual(true);
 
         expression = new Expression('false');
-        expect(expression.evaluate(undefined)).toEqual(false);
+        expect(expression.evaluate(frameState, undefined)).toEqual(false);
     });
 
     it('converts to literal boolean', function() {
         var expression = new Expression('Boolean()');
-        expect(expression.evaluate(undefined)).toEqual(false);
+        expect(expression.evaluate(frameState, undefined)).toEqual(false);
 
         expression = new Expression('Boolean(1)');
-        expect(expression.evaluate(undefined)).toEqual(true);
+        expect(expression.evaluate(frameState, undefined)).toEqual(true);
 
         expression = new Expression('Boolean("true")');
-        expect(expression.evaluate(undefined)).toEqual(true);
+        expect(expression.evaluate(frameState, undefined)).toEqual(true);
     });
 
     it('evaluates literal number', function() {
         var expression = new Expression('1');
-        expect(expression.evaluate(undefined)).toEqual(1);
+        expect(expression.evaluate(frameState, undefined)).toEqual(1);
 
         expression = new Expression('0');
-        expect(expression.evaluate(undefined)).toEqual(0);
+        expect(expression.evaluate(frameState, undefined)).toEqual(0);
 
         expression = new Expression('NaN');
-        expect(expression.evaluate(undefined)).toEqual(NaN);
+        expect(expression.evaluate(frameState, undefined)).toEqual(NaN);
 
         expression = new Expression('Infinity');
-        expect(expression.evaluate(undefined)).toEqual(Infinity);
+        expect(expression.evaluate(frameState, undefined)).toEqual(Infinity);
     });
 
     it('converts to literal number', function() {
         var expression = new Expression('Number()');
-        expect(expression.evaluate(undefined)).toEqual(0);
+        expect(expression.evaluate(frameState, undefined)).toEqual(0);
 
         expression = new Expression('Number("1")');
-        expect(expression.evaluate(undefined)).toEqual(1);
+        expect(expression.evaluate(frameState, undefined)).toEqual(1);
 
         expression = new Expression('Number(true)');
-        expect(expression.evaluate(undefined)).toEqual(1);
+        expect(expression.evaluate(frameState, undefined)).toEqual(1);
     });
 
     it('evaluates literal string', function() {
         var expression = new Expression('\'hello\'');
-        expect(expression.evaluate(undefined)).toEqual('hello');
+        expect(expression.evaluate(frameState, undefined)).toEqual('hello');
 
         expression = new Expression('\'Cesium\'');
-        expect(expression.evaluate(undefined)).toEqual('Cesium');
+        expect(expression.evaluate(frameState, undefined)).toEqual('Cesium');
 
         expression = new Expression('"Cesium"');
-        expect(expression.evaluate(undefined)).toEqual('Cesium');
+        expect(expression.evaluate(frameState, undefined)).toEqual('Cesium');
     });
 
     it('converts to literal string', function() {
         var expression = new Expression('String()');
-        expect(expression.evaluate(undefined)).toEqual('');
+        expect(expression.evaluate(frameState, undefined)).toEqual('');
 
         expression = new Expression('String(1)');
-        expect(expression.evaluate(undefined)).toEqual('1');
+        expect(expression.evaluate(frameState, undefined)).toEqual('1');
 
         expression = new Expression('String(true)');
-        expect(expression.evaluate(undefined)).toEqual('true');
+        expect(expression.evaluate(frameState, undefined)).toEqual('true');
     });
 
     it('evaluates literal color', function() {
         var expression = new Expression('color(\'#ffffff\')');
-        expect(expression.evaluate(undefined)).toEqual(Color.WHITE);
+        expect(expression.evaluate(frameState, undefined)).toEqual(Color.WHITE);
 
         expression = new Expression('color(\'#00FFFF\')');
-        expect(expression.evaluate(undefined)).toEqual(Color.CYAN);
+        expect(expression.evaluate(frameState, undefined)).toEqual(Color.CYAN);
 
         expression = new Expression('color(\'#fff\')');
-        expect(expression.evaluate(undefined)).toEqual(Color.WHITE);
+        expect(expression.evaluate(frameState, undefined)).toEqual(Color.WHITE);
 
         expression = new Expression('color(\'#0FF\')');
-        expect(expression.evaluate(undefined)).toEqual(Color.CYAN);
+        expect(expression.evaluate(frameState, undefined)).toEqual(Color.CYAN);
 
         expression = new Expression('color(\'white\')');
-        expect(expression.evaluate(undefined)).toEqual(Color.WHITE);
+        expect(expression.evaluate(frameState, undefined)).toEqual(Color.WHITE);
 
         expression = new Expression('color(\'cyan\')');
-        expect(expression.evaluate(undefined)).toEqual(Color.CYAN);
+        expect(expression.evaluate(frameState, undefined)).toEqual(Color.CYAN);
 
         expression = new Expression('color(\'white\', 0.5)');
-        expect(expression.evaluate(undefined)).toEqual(new Color(1.0, 1.0, 1.0, 0.5));
+        expect(expression.evaluate(frameState, undefined)).toEqual(new Color(1.0, 1.0, 1.0, 0.5));
 
         expression = new Expression('rgb(255, 255, 255)');
-        expect(expression.evaluate(undefined)).toEqual(Color.WHITE);
+        expect(expression.evaluate(frameState, undefined)).toEqual(Color.WHITE);
 
         expression = new Expression('rgb(100, 255, 190)');
-        expect(expression.evaluate(undefined)).toEqual(Color.fromBytes(100, 255, 190));
+        expect(expression.evaluate(frameState, undefined)).toEqual(Color.fromBytes(100, 255, 190));
 
         expression = new Expression('hsl(0, 0, 1)');
-        expect(expression.evaluate(undefined)).toEqual(Color.WHITE);
+        expect(expression.evaluate(frameState, undefined)).toEqual(Color.WHITE);
 
         expression = new Expression('hsl(1.0, 0.6, 0.7)');
-        expect(expression.evaluate(undefined)).toEqual(Color.fromHsl(1.0, 0.6, 0.7));
+        expect(expression.evaluate(frameState, undefined)).toEqual(Color.fromHsl(1.0, 0.6, 0.7));
 
         expression = new Expression('rgba(255, 255, 255, 0.5)');
-        expect(expression.evaluate(undefined)).toEqual(new Color(1.0, 1.0, 1.0, 0.5));
+        expect(expression.evaluate(frameState, undefined)).toEqual(new Color(1.0, 1.0, 1.0, 0.5));
 
         expression = new Expression('rgba(100, 255, 190, 0.25)');
-        expect(expression.evaluate(undefined)).toEqual(Color.fromBytes(100, 255, 190, 0.25 * 255));
+        expect(expression.evaluate(frameState, undefined)).toEqual(Color.fromBytes(100, 255, 190, 0.25 * 255));
 
         expression = new Expression('hsla(0, 0, 1, 0.5)');
-        expect(expression.evaluate(undefined)).toEqual(new Color(1.0, 1.0, 1.0, 0.5));
+        expect(expression.evaluate(frameState, undefined)).toEqual(new Color(1.0, 1.0, 1.0, 0.5));
 
         expression = new Expression('hsla(1.0, 0.6, 0.7, 0.75)');
-        expect(expression.evaluate(undefined)).toEqual(Color.fromHsl(1.0, 0.6, 0.7, 0.75));
+        expect(expression.evaluate(frameState, undefined)).toEqual(Color.fromHsl(1.0, 0.6, 0.7, 0.75));
 
         expression = new Expression('color()');
-        expect(expression.evaluate(undefined)).toEqual(Color.WHITE);
+        expect(expression.evaluate(frameState, undefined)).toEqual(Color.WHITE);
     });
 
     it('evaluates literal color with result parameter', function() {
         var color = new Color();
 
         var expression = new Expression('color(\'#0000ff\')');
-        expect(expression.evaluateColor(undefined, color)).toEqual(Color.BLUE);
+        expect(expression.evaluateColor(frameState, undefined, color)).toEqual(Color.BLUE);
         expect(color).toEqual(Color.BLUE);
 
         expression = new Expression('color(\'#f00\')');
-        expect(expression.evaluateColor(undefined, color)).toEqual(Color.RED);
+        expect(expression.evaluateColor(frameState, undefined, color)).toEqual(Color.RED);
         expect(color).toEqual(Color.RED);
 
         expression = new Expression('color(\'cyan\')');
-        expect(expression.evaluateColor(undefined, color)).toEqual(Color.CYAN);
+        expect(expression.evaluateColor(frameState, undefined, color)).toEqual(Color.CYAN);
         expect(color).toEqual(Color.CYAN);
 
         expression = new Expression('color(\'white\', 0.5)');
-        expect(expression.evaluateColor(undefined, color)).toEqual(new Color(1.0, 1.0, 1.0, 0.5));
+        expect(expression.evaluateColor(frameState, undefined, color)).toEqual(new Color(1.0, 1.0, 1.0, 0.5));
         expect(color).toEqual(new Color(1.0, 1.0, 1.0, 0.5));
 
         expression = new Expression('rgb(0, 0, 0)');
-        expect(expression.evaluateColor(undefined, color)).toEqual(Color.BLACK);
+        expect(expression.evaluateColor(frameState, undefined, color)).toEqual(Color.BLACK);
         expect(color).toEqual(Color.BLACK);
 
         expression = new Expression('hsl(0, 0, 1)');
-        expect(expression.evaluateColor(undefined, color)).toEqual(Color.WHITE);
+        expect(expression.evaluateColor(frameState, undefined, color)).toEqual(Color.WHITE);
         expect(color).toEqual(Color.WHITE);
 
         expression = new Expression('rgba(255, 0, 255, 0.5)');
-        expect(expression.evaluateColor(undefined, color)).toEqual(new Color(1.0, 0, 1.0, 0.5));
+        expect(expression.evaluateColor(frameState, undefined, color)).toEqual(new Color(1.0, 0, 1.0, 0.5));
         expect(color).toEqual(new Color(1.0, 0, 1.0, 0.5));
 
         expression = new Expression('hsla(0, 0, 1, 0.5)');
-        expect(expression.evaluateColor(undefined, color)).toEqual(new Color(1.0, 1.0, 1.0, 0.5));
+        expect(expression.evaluateColor(frameState, undefined, color)).toEqual(new Color(1.0, 1.0, 1.0, 0.5));
         expect(color).toEqual(new Color(1.0, 1.0, 1.0, 0.5));
 
         expression = new Expression('color()');
-        expect(expression.evaluateColor(undefined, color)).toEqual(Color.WHITE);
+        expect(expression.evaluateColor(frameState, undefined, color)).toEqual(Color.WHITE);
         expect(color).toEqual(Color.WHITE);
     });
 
@@ -347,19 +351,19 @@ defineSuite([
         feature.addProperty('alpha', 0.2);
 
         var expression = new Expression('color(${hex6})');
-        expect(expression.evaluate(feature)).toEqual(Color.WHITE);
+        expect(expression.evaluate(frameState, feature)).toEqual(Color.WHITE);
 
         expression = new Expression('color(${hex3})');
-        expect(expression.evaluate(feature)).toEqual(Color.WHITE);
+        expect(expression.evaluate(frameState, feature)).toEqual(Color.WHITE);
 
         expression = new Expression('color(${keyword})');
-        expect(expression.evaluate(feature)).toEqual(Color.WHITE);
+        expect(expression.evaluate(frameState, feature)).toEqual(Color.WHITE);
 
         expression = new Expression('color(${keyword}, ${alpha} + 0.6)');
-        expect(expression.evaluate(feature).red).toEqual(1.0);
-        expect(expression.evaluate(feature).green).toEqual(1.0);
-        expect(expression.evaluate(feature).blue).toEqual(1.0);
-        expect(expression.evaluate(feature).alpha).toEqual(0.8);
+        expect(expression.evaluate(frameState, feature).red).toEqual(1.0);
+        expect(expression.evaluate(frameState, feature).green).toEqual(1.0);
+        expect(expression.evaluate(frameState, feature).blue).toEqual(1.0);
+        expect(expression.evaluate(frameState, feature).alpha).toEqual(0.8);
     });
 
     it('evaluates rgb with expressions as arguments', function() {
@@ -369,10 +373,10 @@ defineSuite([
         feature.addProperty('blue', 255);
 
         var expression = new Expression('rgb(${red}, ${green}, ${blue})');
-        expect(expression.evaluate(feature)).toEqual(Color.fromBytes(100, 200, 255));
+        expect(expression.evaluate(frameState, feature)).toEqual(Color.fromBytes(100, 200, 255));
 
         expression = new Expression('rgb(${red}/2, ${green}/2, ${blue})');
-        expect(expression.evaluate(feature)).toEqual(Color.fromBytes(50, 100, 255));
+        expect(expression.evaluate(frameState, feature)).toEqual(Color.fromBytes(50, 100, 255));
     });
 
     it('evaluates hsl with expressions as arguments', function() {
@@ -382,10 +386,10 @@ defineSuite([
         feature.addProperty('l', 1.0);
 
         var expression = new Expression('hsl(${h}, ${s}, ${l})');
-        expect(expression.evaluate(feature)).toEqual(Color.WHITE);
+        expect(expression.evaluate(frameState, feature)).toEqual(Color.WHITE);
 
         expression = new Expression('hsl(${h} + 0.2, ${s} + 1.0, ${l} - 0.5)');
-        expect(expression.evaluate(feature)).toEqual(Color.fromHsl(0.2, 1.0, 0.5));
+        expect(expression.evaluate(frameState, feature)).toEqual(Color.fromHsl(0.2, 1.0, 0.5));
     });
 
     it('evaluates rgba with expressions as arguments', function() {
@@ -396,10 +400,10 @@ defineSuite([
         feature.addProperty('a', 0.3);
 
         var expression = new Expression('rgba(${red}, ${green}, ${blue}, ${a})');
-        expect(expression.evaluate(feature)).toEqual(Color.fromBytes(100, 200, 255, 0.3*255));
+        expect(expression.evaluate(frameState, feature)).toEqual(Color.fromBytes(100, 200, 255, 0.3*255));
 
         expression = new Expression('rgba(${red}/2, ${green}/2, ${blue}, ${a} * 2)');
-        expect(expression.evaluate(feature)).toEqual(Color.fromBytes(50, 100, 255, 0.6*255));
+        expect(expression.evaluate(frameState, feature)).toEqual(Color.fromBytes(50, 100, 255, 0.6*255));
     });
 
     it('evaluates hsla with expressions as arguments', function() {
@@ -410,10 +414,10 @@ defineSuite([
         feature.addProperty('a', 1.0);
 
         var expression = new Expression('hsla(${h}, ${s}, ${l}, ${a})');
-        expect(expression.evaluate(feature)).toEqual(Color.WHITE);
+        expect(expression.evaluate(frameState, feature)).toEqual(Color.WHITE);
 
         expression = new Expression('hsla(${h} + 0.2, ${s} + 1.0, ${l} - 0.5, ${a} / 4)');
-        expect(expression.evaluate(feature)).toEqual(Color.fromHsl(0.2, 1.0, 0.5, 0.25));
+        expect(expression.evaluate(frameState, feature)).toEqual(Color.fromHsl(0.2, 1.0, 0.5, 0.25));
     });
 
     it('evaluates rgba with expressions as arguments', function() {
@@ -424,10 +428,10 @@ defineSuite([
         feature.addProperty('alpha', 0.5);
 
         var expression = new Expression('rgba(${red}, ${green}, ${blue}, ${alpha})');
-        expect(expression.evaluate(feature)).toEqual(Color.fromBytes(100, 200, 255, 0.5 * 255));
+        expect(expression.evaluate(frameState, feature)).toEqual(Color.fromBytes(100, 200, 255, 0.5 * 255));
 
         expression = new Expression('rgba(${red}/2, ${green}/2, ${blue}, ${alpha} + 0.1)');
-        expect(expression.evaluate(feature)).toEqual(Color.fromBytes(50, 100, 255, 0.6 * 255));
+        expect(expression.evaluate(frameState, feature)).toEqual(Color.fromBytes(50, 100, 255, 0.6 * 255));
     });
 
     it('color constructors throw with wrong number of arguments', function() {
@@ -450,302 +454,302 @@ defineSuite([
 
     it('evaluates color properties', function() {
         var expression = new Expression('color(\'#ffffff\').red');
-        expect(expression.evaluate(undefined)).toEqual(1);
+        expect(expression.evaluate(frameState, undefined)).toEqual(1);
 
         expression = new Expression('rgb(255, 255, 0).green');
-        expect(expression.evaluate(undefined)).toEqual(1);
+        expect(expression.evaluate(frameState, undefined)).toEqual(1);
 
         expression = new Expression('color("cyan").blue');
-        expect(expression.evaluate(undefined)).toEqual(1);
+        expect(expression.evaluate(frameState, undefined)).toEqual(1);
 
         expression = new Expression('rgba(255, 255, 0, 0.5).alpha');
-        expect(expression.evaluate(undefined)).toEqual(0.5);
+        expect(expression.evaluate(frameState, undefined)).toEqual(0.5);
     });
 
     it('evaluates unary not', function() {
         var expression = new Expression('!true');
-        expect(expression.evaluate(undefined)).toEqual(false);
+        expect(expression.evaluate(frameState, undefined)).toEqual(false);
 
         expression = new Expression('!!true');
-        expect(expression.evaluate(undefined)).toEqual(true);
+        expect(expression.evaluate(frameState, undefined)).toEqual(true);
     });
 
     it('evaluates unary negative', function() {
         var expression = new Expression('-5');
-        expect(expression.evaluate(undefined)).toEqual(-5);
+        expect(expression.evaluate(frameState, undefined)).toEqual(-5);
 
         expression = new Expression('-(-5)');
-        expect(expression.evaluate(undefined)).toEqual(5);
+        expect(expression.evaluate(frameState, undefined)).toEqual(5);
     });
 
     it('evaluates unary positive', function() {
         var expression = new Expression('+5');
-        expect(expression.evaluate(undefined)).toEqual(5);
+        expect(expression.evaluate(frameState, undefined)).toEqual(5);
 
         expression = new Expression('+"5"');
-        expect(expression.evaluate(undefined)).toEqual(5);
+        expect(expression.evaluate(frameState, undefined)).toEqual(5);
 
         expression = new Expression('+true');
-        expect(expression.evaluate(undefined)).toEqual(1);
+        expect(expression.evaluate(frameState, undefined)).toEqual(1);
 
         expression = new Expression('+null');
-        expect(expression.evaluate(undefined)).toEqual(0);
+        expect(expression.evaluate(frameState, undefined)).toEqual(0);
     });
 
     it('evaluates binary addition', function() {
         var expression = new Expression('1 + 2');
-        expect(expression.evaluate(undefined)).toEqual(3);
+        expect(expression.evaluate(frameState, undefined)).toEqual(3);
 
         expression = new Expression('1 + 2 + 3 + 4');
-        expect(expression.evaluate(undefined)).toEqual(10);
+        expect(expression.evaluate(frameState, undefined)).toEqual(10);
     });
 
     it('evaluates binary subtraction', function() {
         var expression = new Expression('2 - 1');
-        expect(expression.evaluate(undefined)).toEqual(1);
+        expect(expression.evaluate(frameState, undefined)).toEqual(1);
 
         expression = new Expression('4 - 3 - 2 - 1');
-        expect(expression.evaluate(undefined)).toEqual(-2);
+        expect(expression.evaluate(frameState, undefined)).toEqual(-2);
     });
 
     it('evaluates binary multiplication', function() {
         var expression = new Expression('1 * 2');
-        expect(expression.evaluate(undefined)).toEqual(2);
+        expect(expression.evaluate(frameState, undefined)).toEqual(2);
 
         expression = new Expression('1 * 2 * 3 * 4');
-        expect(expression.evaluate(undefined)).toEqual(24);
+        expect(expression.evaluate(frameState, undefined)).toEqual(24);
     });
 
     it('evaluates binary division', function() {
         var expression = new Expression('2 / 1');
-        expect(expression.evaluate(undefined)).toEqual(2);
+        expect(expression.evaluate(frameState, undefined)).toEqual(2);
 
         expression = new Expression('1/2');
-        expect(expression.evaluate(undefined)).toEqual(0.5);
+        expect(expression.evaluate(frameState, undefined)).toEqual(0.5);
 
         expression = new Expression('24 / -4 / 2');
-        expect(expression.evaluate(undefined)).toEqual(-3);
+        expect(expression.evaluate(frameState, undefined)).toEqual(-3);
     });
 
     it('evaluates binary modulus', function() {
         var expression = new Expression('2 % 1');
-        expect(expression.evaluate(undefined)).toEqual(0);
+        expect(expression.evaluate(frameState, undefined)).toEqual(0);
 
         expression = new Expression('6 % 4 % 3');
-        expect(expression.evaluate(undefined)).toEqual(2);
+        expect(expression.evaluate(frameState, undefined)).toEqual(2);
     });
 
     it('evaluates binary equals strict', function() {
         var expression = new Expression('\'hello\' === \'hello\'');
-        expect(expression.evaluate(undefined)).toEqual(true);
+        expect(expression.evaluate(frameState, undefined)).toEqual(true);
 
         expression = new Expression('1 === 2');
-        expect(expression.evaluate(undefined)).toEqual(false);
+        expect(expression.evaluate(frameState, undefined)).toEqual(false);
 
         expression = new Expression('false === true === false');
-        expect(expression.evaluate(undefined)).toEqual(true);
+        expect(expression.evaluate(frameState, undefined)).toEqual(true);
 
         expression = new Expression('1 === "1"');
-        expect(expression.evaluate(undefined)).toEqual(false);
+        expect(expression.evaluate(frameState, undefined)).toEqual(false);
     });
 
     it('evaluates binary equals', function() {
         var expression = new Expression('\'hello\' == \'hello\'');
-        expect(expression.evaluate(undefined)).toEqual(true);
+        expect(expression.evaluate(frameState, undefined)).toEqual(true);
 
         expression = new Expression('1 == 2');
-        expect(expression.evaluate(undefined)).toEqual(false);
+        expect(expression.evaluate(frameState, undefined)).toEqual(false);
 
         expression = new Expression('false == true == false');
-        expect(expression.evaluate(undefined)).toEqual(true);
+        expect(expression.evaluate(frameState, undefined)).toEqual(true);
 
         expression = new Expression('1 == "1"');
-        expect(expression.evaluate(undefined)).toEqual(true);
+        expect(expression.evaluate(frameState, undefined)).toEqual(true);
     });
 
     it('evaluates binary not equals strict', function() {
         var expression = new Expression('\'hello\' !== \'hello\'');
-        expect(expression.evaluate(undefined)).toEqual(false);
+        expect(expression.evaluate(frameState, undefined)).toEqual(false);
 
         expression = new Expression('1 !== 2');
-        expect(expression.evaluate(undefined)).toEqual(true);
+        expect(expression.evaluate(frameState, undefined)).toEqual(true);
 
         expression = new Expression('false !== true !== false');
-        expect(expression.evaluate(undefined)).toEqual(true);
+        expect(expression.evaluate(frameState, undefined)).toEqual(true);
 
         expression = new Expression('1 !== "1"');
-        expect(expression.evaluate(undefined)).toEqual(true);
+        expect(expression.evaluate(frameState, undefined)).toEqual(true);
     });
 
     it('evaluates binary not equals', function() {
         var expression = new Expression('\'hello\' != \'hello\'');
-        expect(expression.evaluate(undefined)).toEqual(false);
+        expect(expression.evaluate(frameState, undefined)).toEqual(false);
 
         expression = new Expression('1 != 2');
-        expect(expression.evaluate(undefined)).toEqual(true);
+        expect(expression.evaluate(frameState, undefined)).toEqual(true);
 
         expression = new Expression('false != true != false');
-        expect(expression.evaluate(undefined)).toEqual(true);
+        expect(expression.evaluate(frameState, undefined)).toEqual(true);
 
         expression = new Expression('1 != "1"');
-        expect(expression.evaluate(undefined)).toEqual(false);
+        expect(expression.evaluate(frameState, undefined)).toEqual(false);
     });
 
     it('evaluates binary less than', function() {
         var expression = new Expression('2 < 3');
-        expect(expression.evaluate(undefined)).toEqual(true);
+        expect(expression.evaluate(frameState, undefined)).toEqual(true);
 
         expression = new Expression('2 < 2');
-        expect(expression.evaluate(undefined)).toEqual(false);
+        expect(expression.evaluate(frameState, undefined)).toEqual(false);
 
         expression = new Expression('3 < 2');
-        expect(expression.evaluate(undefined)).toEqual(false);
+        expect(expression.evaluate(frameState, undefined)).toEqual(false);
 
         expression = new Expression('true < false');
-        expect(expression.evaluate(undefined)).toEqual(false);
+        expect(expression.evaluate(frameState, undefined)).toEqual(false);
 
         expression = new Expression('color(\'blue\') < 10');
-        expect(expression.evaluate(undefined)).toEqual(false);
+        expect(expression.evaluate(frameState, undefined)).toEqual(false);
     });
 
     it('evaluates binary less than or equals', function() {
         var expression = new Expression('2 <= 3');
-        expect(expression.evaluate(undefined)).toEqual(true);
+        expect(expression.evaluate(frameState, undefined)).toEqual(true);
 
         expression = new Expression('2 <= 2');
-        expect(expression.evaluate(undefined)).toEqual(true);
+        expect(expression.evaluate(frameState, undefined)).toEqual(true);
 
         expression = new Expression('3 <= 2');
-        expect(expression.evaluate(undefined)).toEqual(false);
+        expect(expression.evaluate(frameState, undefined)).toEqual(false);
 
         expression = new Expression('true <= false');
-        expect(expression.evaluate(undefined)).toEqual(false);
+        expect(expression.evaluate(frameState, undefined)).toEqual(false);
 
         expression = new Expression('color(\'blue\') <= 10');
-        expect(expression.evaluate(undefined)).toEqual(false);
+        expect(expression.evaluate(frameState, undefined)).toEqual(false);
     });
 
     it('evaluates binary greater than', function() {
         var expression = new Expression('2 > 3');
-        expect(expression.evaluate(undefined)).toEqual(false);
+        expect(expression.evaluate(frameState, undefined)).toEqual(false);
 
         expression = new Expression('2 > 2');
-        expect(expression.evaluate(undefined)).toEqual(false);
+        expect(expression.evaluate(frameState, undefined)).toEqual(false);
 
         expression = new Expression('3 > 2');
-        expect(expression.evaluate(undefined)).toEqual(true);
+        expect(expression.evaluate(frameState, undefined)).toEqual(true);
 
         expression = new Expression('true > false');
-        expect(expression.evaluate(undefined)).toEqual(true);
+        expect(expression.evaluate(frameState, undefined)).toEqual(true);
 
         expression = new Expression('color(\'blue\') > 10');
-        expect(expression.evaluate(undefined)).toEqual(false);
+        expect(expression.evaluate(frameState, undefined)).toEqual(false);
     });
 
     it('evaluates binary greater than or equals', function() {
         var expression = new Expression('2 >= 3');
-        expect(expression.evaluate(undefined)).toEqual(false);
+        expect(expression.evaluate(frameState, undefined)).toEqual(false);
 
         expression = new Expression('2 >= 2');
-        expect(expression.evaluate(undefined)).toEqual(true);
+        expect(expression.evaluate(frameState, undefined)).toEqual(true);
 
         expression = new Expression('3 >= 2');
-        expect(expression.evaluate(undefined)).toEqual(true);
+        expect(expression.evaluate(frameState, undefined)).toEqual(true);
 
         expression = new Expression('true >= false');
-        expect(expression.evaluate(undefined)).toEqual(true);
+        expect(expression.evaluate(frameState, undefined)).toEqual(true);
 
         expression = new Expression('color(\'blue\') >= 10');
-        expect(expression.evaluate(undefined)).toEqual(false);
+        expect(expression.evaluate(frameState, undefined)).toEqual(false);
     });
 
     it('evaluates logical and', function() {
         var expression = new Expression('false && false');
-        expect(expression.evaluate(undefined)).toEqual(false);
+        expect(expression.evaluate(frameState, undefined)).toEqual(false);
 
         expression = new Expression('false && true');
-        expect(expression.evaluate(undefined)).toEqual(false);
+        expect(expression.evaluate(frameState, undefined)).toEqual(false);
 
         expression = new Expression('true && true');
-        expect(expression.evaluate(undefined)).toEqual(true);
+        expect(expression.evaluate(frameState, undefined)).toEqual(true);
 
         expression = new Expression('2 && color(\'red\')');
         expect(function() {
-            expression.evaluate(undefined);
+            expression.evaluate(frameState, undefined);
         }).toThrowDeveloperError();
     });
 
     it('throws with invalid and operands', function() {
         var expression = new Expression('2 && true');
         expect(function() {
-            expression.evaluate(undefined);
+            expression.evaluate(frameState, undefined);
         }).toThrowDeveloperError();
 
         expression = new Expression('true && color(\'red\')');
         expect(function() {
-            expression.evaluate(undefined);
+            expression.evaluate(frameState, undefined);
         }).toThrowDeveloperError();
     });
 
     it('evaluates logical or', function() {
         var expression = new Expression('false || false');
-        expect(expression.evaluate(undefined)).toEqual(false);
+        expect(expression.evaluate(frameState, undefined)).toEqual(false);
 
         expression = new Expression('false || true');
-        expect(expression.evaluate(undefined)).toEqual(true);
+        expect(expression.evaluate(frameState, undefined)).toEqual(true);
 
         expression = new Expression('true || true');
-        expect(expression.evaluate(undefined)).toEqual(true);
+        expect(expression.evaluate(frameState, undefined)).toEqual(true);
     });
 
     it('throws with invalid or operands', function() {
         var expression = new Expression('2 || false');
         expect(function() {
-            expression.evaluate(undefined);
+            expression.evaluate(frameState, undefined);
         }).toThrowDeveloperError();
 
         expression = new Expression('false || color(\'red\')');
         expect(function() {
-            expression.evaluate(undefined);
+            expression.evaluate(frameState, undefined);
         }).toThrowDeveloperError();
     });
 
     it('evaluates color operations', function() {
         var expression = new Expression('rgba(255, 0, 0, 0.5) + rgba(0, 0, 255, 0.5)');
-        expect(expression.evaluate(undefined)).toEqual(Color.MAGENTA);
+        expect(expression.evaluate(frameState, undefined)).toEqual(Color.MAGENTA);
 
         expression = new Expression('rgba(0, 255, 255, 1.0) - rgba(0, 255, 0, 0)');
-        expect(expression.evaluate(undefined)).toEqual(Color.BLUE);
+        expect(expression.evaluate(frameState, undefined)).toEqual(Color.BLUE);
 
         expression = new Expression('rgba(255, 255, 255, 1.0) * rgba(255, 0, 0, 1.0)');
-        expect(expression.evaluate(undefined)).toEqual(Color.RED);
+        expect(expression.evaluate(frameState, undefined)).toEqual(Color.RED);
 
         expression = new Expression('rgba(255, 255, 0, 1.0) * 1.0');
-        expect(expression.evaluate(undefined)).toEqual(Color.YELLOW);
+        expect(expression.evaluate(frameState, undefined)).toEqual(Color.YELLOW);
 
         expression = new Expression('1 * rgba(255, 255, 0, 1.0)');
-        expect(expression.evaluate(undefined)).toEqual(Color.YELLOW);
+        expect(expression.evaluate(frameState, undefined)).toEqual(Color.YELLOW);
 
         expression = new Expression('rgba(255, 255, 255, 1.0) / rgba(255, 255, 255, 1.0)');
-        expect(expression.evaluate(undefined)).toEqual(Color.WHITE);
+        expect(expression.evaluate(frameState, undefined)).toEqual(Color.WHITE);
 
         expression = new Expression('rgba(255, 255, 255, 1.0) / 2');
-        expect(expression.evaluate(undefined)).toEqual(new Color(0.5, 0.5, 0.5, 0.5));
+        expect(expression.evaluate(frameState, undefined)).toEqual(new Color(0.5, 0.5, 0.5, 0.5));
 
         expression = new Expression('rgba(255, 255, 255, 1.0) % rgba(255, 255, 255, 1.0)');
-        expect(expression.evaluate(undefined)).toEqual(new Color(0, 0, 0, 0));
+        expect(expression.evaluate(frameState, undefined)).toEqual(new Color(0, 0, 0, 0));
 
         expression = new Expression('color(\'green\') == color(\'green\')');
-        expect(expression.evaluate(undefined)).toEqual(true);
+        expect(expression.evaluate(frameState, undefined)).toEqual(true);
 
         expression = new Expression('color() == color()');
-        expect(expression.evaluate(undefined)).toEqual(true);
+        expect(expression.evaluate(frameState, undefined)).toEqual(true);
 
         expression = new Expression('!!color() == true');
-        expect(expression.evaluate(undefined)).toEqual(true);
+        expect(expression.evaluate(frameState, undefined)).toEqual(true);
 
         expression = new Expression('color(\'green\') != color(\'green\')');
-        expect(expression.evaluate(undefined)).toEqual(false);
+        expect(expression.evaluate(frameState, undefined)).toEqual(false);
     });
 
     it('evaluates color toString function', function() {
@@ -753,73 +757,73 @@ defineSuite([
         feature.addProperty('property', Color.BLUE);
 
         var expression = new Expression('color("red").toString()');
-        expect(expression.evaluate(undefined)).toEqual('(1, 0, 0, 1)');
+        expect(expression.evaluate(frameState, undefined)).toEqual('(1, 0, 0, 1)');
 
         expression = new Expression('rgba(0, 0, 255, 0.5).toString()');
-        expect(expression.evaluate(undefined)).toEqual('(0, 0, 1, 0.5)');
+        expect(expression.evaluate(frameState, undefined)).toEqual('(0, 0, 1, 0.5)');
 
         expression = new Expression('${property}.toString()');
-        expect(expression.evaluate(feature)).toEqual('(0, 0, 1, 1)');
+        expect(expression.evaluate(frameState, feature)).toEqual('(0, 0, 1, 1)');
     });
 
     it('evaluates isNaN function', function() {
         var expression = new Expression('isNaN()');
-        expect(expression.evaluate(undefined)).toEqual(true);
+        expect(expression.evaluate(frameState, undefined)).toEqual(true);
 
         expression = new Expression('isNaN(NaN)');
-        expect(expression.evaluate(undefined)).toEqual(true);
+        expect(expression.evaluate(frameState, undefined)).toEqual(true);
 
         expression = new Expression('isNaN(1)');
-        expect(expression.evaluate(undefined)).toEqual(false);
+        expect(expression.evaluate(frameState, undefined)).toEqual(false);
 
         expression = new Expression('isNaN(Infinity)');
-        expect(expression.evaluate(undefined)).toEqual(false);
+        expect(expression.evaluate(frameState, undefined)).toEqual(false);
 
         expression = new Expression('isNaN(null)');
-        expect(expression.evaluate(undefined)).toEqual(false);
+        expect(expression.evaluate(frameState, undefined)).toEqual(false);
 
         expression = new Expression('isNaN(true)');
-        expect(expression.evaluate(undefined)).toEqual(false);
+        expect(expression.evaluate(frameState, undefined)).toEqual(false);
 
         expression = new Expression('isNaN("hello")');
-        expect(expression.evaluate(undefined)).toEqual(true);
+        expect(expression.evaluate(frameState, undefined)).toEqual(true);
 
         expression = new Expression('isNaN(color("white"))');
-        expect(expression.evaluate(undefined)).toEqual(true);
+        expect(expression.evaluate(frameState, undefined)).toEqual(true);
     });
 
     it('evaluates isFinite function', function() {
         var expression = new Expression('isFinite()');
-        expect(expression.evaluate(undefined)).toEqual(false);
+        expect(expression.evaluate(frameState, undefined)).toEqual(false);
 
         expression = new Expression('isFinite(NaN)');
-        expect(expression.evaluate(undefined)).toEqual(false);
+        expect(expression.evaluate(frameState, undefined)).toEqual(false);
 
         expression = new Expression('isFinite(1)');
-        expect(expression.evaluate(undefined)).toEqual(true);
+        expect(expression.evaluate(frameState, undefined)).toEqual(true);
 
         expression = new Expression('isFinite(Infinity)');
-        expect(expression.evaluate(undefined)).toEqual(false);
+        expect(expression.evaluate(frameState, undefined)).toEqual(false);
 
         expression = new Expression('isFinite(null)');
-        expect(expression.evaluate(undefined)).toEqual(true);
+        expect(expression.evaluate(frameState, undefined)).toEqual(true);
 
         expression = new Expression('isFinite(true)');
-        expect(expression.evaluate(undefined)).toEqual(true);
+        expect(expression.evaluate(frameState, undefined)).toEqual(true);
 
         expression = new Expression('isFinite("hello")');
-        expect(expression.evaluate(undefined)).toEqual(false);
+        expect(expression.evaluate(frameState, undefined)).toEqual(false);
 
         expression = new Expression('isFinite(color("white"))');
-        expect(expression.evaluate(undefined)).toEqual(false);
+        expect(expression.evaluate(frameState, undefined)).toEqual(false);
     });
 
     it('evaluates abs function', function() {
         var expression = new Expression('abs(-1)');
-        expect(expression.evaluate(undefined)).toEqual(1);
+        expect(expression.evaluate(frameState, undefined)).toEqual(1);
 
         expression = new Expression('abs(1)');
-        expect(expression.evaluate(undefined)).toEqual(1);
+        expect(expression.evaluate(frameState, undefined)).toEqual(1);
     });
 
     it('throws if abs function takes an invalid number of arguments', function() {
@@ -834,7 +838,7 @@ defineSuite([
 
     it('evaluates cos function', function() {
         var expression = new Expression('cos(0)');
-        expect(expression.evaluate(undefined)).toEqual(1);
+        expect(expression.evaluate(frameState, undefined)).toEqual(1);
     });
 
     it('throws if cos function takes an invalid number of arguments', function() {
@@ -849,13 +853,13 @@ defineSuite([
 
     it('evaluates sqrt function', function() {
         var expression = new Expression('sqrt(1.0)');
-        expect(expression.evaluate(undefined)).toEqual(1.0);
+        expect(expression.evaluate(frameState, undefined)).toEqual(1.0);
 
         expression = new Expression('sqrt(4.0)');
-        expect(expression.evaluate(undefined)).toEqual(2.0);
+        expect(expression.evaluate(frameState, undefined)).toEqual(2.0);
 
         expression = new Expression('sqrt(-1.0)');
-        expect(expression.evaluate(undefined)).toEqual(NaN);
+        expect(expression.evaluate(frameState, undefined)).toEqual(NaN);
     });
 
     it('throws if sqrt function takes an invalid number of arguments', function() {
@@ -870,13 +874,13 @@ defineSuite([
 
     it('evaluates ternary conditional', function() {
         var expression = new Expression('true ? "first" : "second"');
-        expect(expression.evaluate(undefined)).toEqual('first');
+        expect(expression.evaluate(frameState, undefined)).toEqual('first');
 
         expression = new Expression('false ? "first" : "second"');
-        expect(expression.evaluate(undefined)).toEqual('second');
+        expect(expression.evaluate(frameState, undefined)).toEqual('second');
 
         expression = new Expression('(!(1 + 2 > 3)) ? (2 > 1 ? 1 + 1 : 0) : (2 > 1 ? -1 + -1 : 0)');
-        expect(expression.evaluate(undefined)).toEqual(2);
+        expect(expression.evaluate(frameState, undefined)).toEqual(2);
     });
 
     it('evaluates member expression with dot', function() {
@@ -899,36 +903,36 @@ defineSuite([
         });
 
         var expression = new Expression('${color.red}');
-        expect(expression.evaluate(feature)).toEqual(1.0);
+        expect(expression.evaluate(frameState, feature)).toEqual(1.0);
 
         expression = new Expression('${color.blue}');
-        expect(expression.evaluate(feature)).toEqual(0.0);
+        expect(expression.evaluate(frameState, feature)).toEqual(0.0);
 
         expression = new Expression('${height.blue}');
-        expect(expression.evaluate(feature)).toEqual(undefined);
+        expect(expression.evaluate(frameState, feature)).toEqual(undefined);
 
         expression = new Expression('${undefined.blue}');
-        expect(expression.evaluate(feature)).toEqual(undefined);
+        expect(expression.evaluate(frameState, feature)).toEqual(undefined);
 
         expression = new Expression('${feature}');
-        expect(expression.evaluate(feature)).toEqual({
+        expect(expression.evaluate(frameState, feature)).toEqual({
             color : Color.BLUE
         });
 
         expression = new Expression('${feature.color}');
-        expect(expression.evaluate(feature)).toEqual(Color.RED);
+        expect(expression.evaluate(frameState, feature)).toEqual(Color.RED);
 
         expression = new Expression('${feature.feature.color}');
-        expect(expression.evaluate(feature)).toEqual(Color.BLUE);
+        expect(expression.evaluate(frameState, feature)).toEqual(Color.BLUE);
 
         expression = new Expression('${feature.color.red}');
-        expect(expression.evaluate(feature)).toEqual(1.0);
+        expect(expression.evaluate(frameState, feature)).toEqual(1.0);
 
         expression = new Expression('${address.street}');
-        expect(expression.evaluate(feature)).toEqual("Example Street");
+        expect(expression.evaluate(frameState, feature)).toEqual("Example Street");
 
         expression = new Expression('${address.city}');
-        expect(expression.evaluate(feature)).toEqual("Example City");
+        expect(expression.evaluate(frameState, feature)).toEqual("Example City");
     });
 
     it('evaluates member expression with brackets', function() {
@@ -952,52 +956,52 @@ defineSuite([
         });
 
         var expression = new Expression('${color["red"]}');
-        expect(expression.evaluate(feature)).toEqual(1.0);
+        expect(expression.evaluate(frameState, feature)).toEqual(1.0);
 
         expression = new Expression('${color["blue"]}');
-        expect(expression.evaluate(feature)).toEqual(0.0);
+        expect(expression.evaluate(frameState, feature)).toEqual(0.0);
 
         expression = new Expression('${height["blue"]}');
-        expect(expression.evaluate(feature)).toEqual(undefined);
+        expect(expression.evaluate(frameState, feature)).toEqual(undefined);
 
         expression = new Expression('${undefined["blue"]}');
-        expect(expression.evaluate(feature)).toEqual(undefined);
+        expect(expression.evaluate(frameState, feature)).toEqual(undefined);
 
         expression = new Expression('${feature["color"]}');
-        expect(expression.evaluate(feature)).toEqual(Color.RED);
+        expect(expression.evaluate(frameState, feature)).toEqual(Color.RED);
 
         expression = new Expression('${feature.color["red"]}');
-        expect(expression.evaluate(feature)).toEqual(1.0);
+        expect(expression.evaluate(frameState, feature)).toEqual(1.0);
 
         expression = new Expression('${feature["color"].red}');
-        expect(expression.evaluate(feature)).toEqual(1.0);
+        expect(expression.evaluate(frameState, feature)).toEqual(1.0);
 
         expression = new Expression('${feature["color.red"]}');
-        expect(expression.evaluate(feature)).toEqual('something else');
+        expect(expression.evaluate(frameState, feature)).toEqual('something else');
 
         expression = new Expression('${feature.feature["color"]}');
-        expect(expression.evaluate(feature)).toEqual(Color.BLUE);
+        expect(expression.evaluate(frameState, feature)).toEqual(Color.BLUE);
 
         expression = new Expression('${feature["feature.color"]}');
-        expect(expression.evaluate(feature)).toEqual(Color.GREEN);
+        expect(expression.evaluate(frameState, feature)).toEqual(Color.GREEN);
 
         expression = new Expression('${address.street}');
-        expect(expression.evaluate(feature)).toEqual("Example Street");
+        expect(expression.evaluate(frameState, feature)).toEqual("Example Street");
 
         expression = new Expression('${feature.address.street}');
-        expect(expression.evaluate(feature)).toEqual("Example Street");
+        expect(expression.evaluate(frameState, feature)).toEqual("Example Street");
 
         expression = new Expression('${feature["address"].street}');
-        expect(expression.evaluate(feature)).toEqual("Example Street");
+        expect(expression.evaluate(frameState, feature)).toEqual("Example Street");
 
         expression = new Expression('${feature["address.street"]}');
-        expect(expression.evaluate(feature)).toEqual("Other Street");
+        expect(expression.evaluate(frameState, feature)).toEqual("Other Street");
 
         expression = new Expression('${address["street"]}');
-        expect(expression.evaluate(feature)).toEqual("Example Street");
+        expect(expression.evaluate(frameState, feature)).toEqual("Example Street");
 
         expression = new Expression('${address["city"]}');
-        expect(expression.evaluate(feature)).toEqual("Example City");
+        expect(expression.evaluate(frameState, feature)).toEqual("Example City");
     });
 
     it('member expressions throw without variable notation', function() {
@@ -1027,12 +1031,12 @@ defineSuite([
         });
 
         var expression = new Expression('${feature}');
-        expect(expression.evaluate(feature)).toEqual({
+        expect(expression.evaluate(frameState, feature)).toEqual({
             color : Color.BLUE
         });
 
         expression = new Expression('${feature} == ${feature.feature}');
-        expect(expression.evaluate(feature)).toEqual(true);
+        expect(expression.evaluate(frameState, feature)).toEqual(true);
     });
 
     it('constructs regex', function() {
@@ -1040,44 +1044,44 @@ defineSuite([
         feature.addProperty('pattern', "[abc]");
 
         var expression = new Expression('regExp("a")');
-        expect(expression.evaluate(undefined)).toEqual(/a/);
+        expect(expression.evaluate(frameState, undefined)).toEqual(/a/);
         expect(expression._runtimeAst._type).toEqual(ExpressionNodeType.LITERAL_REGEX);
 
         expression = new Expression('regExp("\\w")');
-        expect(expression.evaluate(undefined)).toEqual(/\w/);
+        expect(expression.evaluate(frameState, undefined)).toEqual(/\w/);
         expect(expression._runtimeAst._type).toEqual(ExpressionNodeType.LITERAL_REGEX);
 
         expression = new Expression('regExp(1 + 1)');
-        expect(expression.evaluate(undefined)).toEqual(/2/);
+        expect(expression.evaluate(frameState, undefined)).toEqual(/2/);
         expect(expression._runtimeAst._type).toEqual(ExpressionNodeType.REGEX);
 
         expression = new Expression('regExp(true)');
-        expect(expression.evaluate(undefined)).toEqual(/true/);
+        expect(expression.evaluate(frameState, undefined)).toEqual(/true/);
         expect(expression._runtimeAst._type).toEqual(ExpressionNodeType.LITERAL_REGEX);
 
         expression = new Expression('regExp()');
-        expect(expression.evaluate(undefined)).toEqual(/(?:)/);
+        expect(expression.evaluate(frameState, undefined)).toEqual(/(?:)/);
         expect(expression._runtimeAst._type).toEqual(ExpressionNodeType.LITERAL_REGEX);
 
         expression = new Expression('regExp(${pattern})');
-        expect(expression.evaluate(feature)).toEqual(/[abc]/);
+        expect(expression.evaluate(frameState, feature)).toEqual(/[abc]/);
         expect(expression._runtimeAst._type).toEqual(ExpressionNodeType.REGEX);
     });
 
     it ('constructs regex with flags', function() {
         var expression = new Expression('regExp("a", "i")');
-        expect(expression.evaluate(undefined)).toEqual(/a/i);
+        expect(expression.evaluate(frameState, undefined)).toEqual(/a/i);
         expect(expression._runtimeAst._type).toEqual(ExpressionNodeType.LITERAL_REGEX);
 
         expression = new Expression('regExp("a", "m" + "g")');
-        expect(expression.evaluate(undefined)).toEqual(/a/mg);
+        expect(expression.evaluate(frameState, undefined)).toEqual(/a/mg);
         expect(expression._runtimeAst._type).toEqual(ExpressionNodeType.REGEX);
     });
 
     it('throws if regex constructor has invalid pattern', function() {
         var expression = new Expression('regExp("(?<=\\s)" + ".")');
         expect(function() {
-            expression.evaluate(undefined);
+            expression.evaluate(frameState, undefined);
         }).toThrowDeveloperError();
 
         expect(function() {
@@ -1088,7 +1092,7 @@ defineSuite([
     it('throws if regex constructor has invalid flags', function() {
         var expression = new Expression('regExp("a" + "b", "q")');
         expect(function() {
-            expression.evaluate(undefined);
+            expression.evaluate(frameState, undefined);
         }).toThrowDeveloperError();
 
         expect(function() {
@@ -1101,19 +1105,19 @@ defineSuite([
         feature.addProperty('property', 'abc');
 
         var expression = new Expression('regExp("a").test("abc")');
-        expect(expression.evaluate(undefined)).toEqual(true);
+        expect(expression.evaluate(frameState, undefined)).toEqual(true);
 
         expression = new Expression('regExp("a").test("bcd")');
-        expect(expression.evaluate(undefined)).toEqual(false);
+        expect(expression.evaluate(frameState, undefined)).toEqual(false);
 
         expression = new Expression('regExp("quick\\s(brown).+?(jumps)", "ig").test("The Quick Brown Fox Jumps Over The Lazy Dog")');
-        expect(expression.evaluate(undefined)).toEqual(true);
+        expect(expression.evaluate(frameState, undefined)).toEqual(true);
 
         expression = new Expression('regExp("a").test()');
-        expect(expression.evaluate(undefined)).toEqual(false);
+        expect(expression.evaluate(frameState, undefined)).toEqual(false);
 
         expression = new Expression('regExp(${property}).test(${property})');
-        expect(expression.evaluate(feature)).toEqual(true);
+        expect(expression.evaluate(frameState, feature)).toEqual(true);
     });
 
     it('evaluates regex exec function', function() {
@@ -1122,22 +1126,22 @@ defineSuite([
         feature.addProperty('Name', 'Building 1');
 
         var expression = new Expression('regExp("a(.)", "i").exec("Abc")');
-        expect(expression.evaluate(undefined)).toEqual('b');
+        expect(expression.evaluate(frameState, undefined)).toEqual('b');
 
         expression = new Expression('regExp("a(.)").exec("qbc")');
-        expect(expression.evaluate(undefined)).toEqual(null);
+        expect(expression.evaluate(frameState, undefined)).toEqual(null);
 
         expression = new Expression('regExp("a(.)").exec()');
-        expect(expression.evaluate(undefined)).toEqual(null);
+        expect(expression.evaluate(frameState, undefined)).toEqual(null);
 
         expression = new Expression('regExp("quick\\s(b.*n).+?(jumps)", "ig").exec("The Quick Brown Fox Jumps Over The Lazy Dog")');
-        expect(expression.evaluate(undefined)).toEqual('Brown');
+        expect(expression.evaluate(frameState, undefined)).toEqual('Brown');
 
         expression = new Expression('regExp("(" + ${property} + ")").exec(${property})');
-        expect(expression.evaluate(feature)).toEqual('abc');
+        expect(expression.evaluate(frameState, feature)).toEqual('abc');
 
         expression = new Expression('regExp("Building\\s(\\d)").exec(${Name})');
-        expect(expression.evaluate(feature)).toEqual('1');
+        expect(expression.evaluate(frameState, feature)).toEqual('1');
     });
 
     it('evaluates regex match operator', function() {
@@ -1145,31 +1149,31 @@ defineSuite([
         feature.addProperty('property', 'abc');
 
         var expression = new Expression('regExp("a") =~ "abc"');
-        expect(expression.evaluate(undefined)).toEqual(true);
+        expect(expression.evaluate(frameState, undefined)).toEqual(true);
 
         expression = new Expression('"abc" =~ regExp("a")');
-        expect(expression.evaluate(undefined)).toEqual(true);
+        expect(expression.evaluate(frameState, undefined)).toEqual(true);
 
         expression = new Expression('regExp("a") =~ "bcd"');
-        expect(expression.evaluate(undefined)).toEqual(false);
+        expect(expression.evaluate(frameState, undefined)).toEqual(false);
 
         expression = new Expression('"bcd" =~ regExp("a")');
-        expect(expression.evaluate(undefined)).toEqual(false);
+        expect(expression.evaluate(frameState, undefined)).toEqual(false);
 
         expression = new Expression('regExp("quick\\s(brown).+?(jumps)", "ig") =~ "The Quick Brown Fox Jumps Over The Lazy Dog"');
-        expect(expression.evaluate(undefined)).toEqual(true);
+        expect(expression.evaluate(frameState, undefined)).toEqual(true);
 
         expression = new Expression('regExp("a") =~ 1');
-        expect(expression.evaluate(undefined)).toEqual(false);
+        expect(expression.evaluate(frameState, undefined)).toEqual(false);
 
         expression = new Expression('1 =~ regExp("a")');
-        expect(expression.evaluate(undefined)).toEqual(false);
+        expect(expression.evaluate(frameState, undefined)).toEqual(false);
 
         expression = new Expression('1 =~ 1');
-        expect(expression.evaluate(undefined)).toEqual(false);
+        expect(expression.evaluate(frameState, undefined)).toEqual(false);
 
         expression = new Expression('regExp(${property}) =~ ${property}');
-        expect(expression.evaluate(feature)).toEqual(true);
+        expect(expression.evaluate(frameState, feature)).toEqual(true);
     });
 
     it('evaluates regex not match operator', function() {
@@ -1177,31 +1181,31 @@ defineSuite([
         feature.addProperty('property', 'abc');
 
         var expression = new Expression('regExp("a") !~ "abc"');
-        expect(expression.evaluate(undefined)).toEqual(false);
+        expect(expression.evaluate(frameState, undefined)).toEqual(false);
 
         expression = new Expression('"abc" !~ regExp("a")');
-        expect(expression.evaluate(undefined)).toEqual(false);
+        expect(expression.evaluate(frameState, undefined)).toEqual(false);
 
         expression = new Expression('regExp("a") !~ "bcd"');
-        expect(expression.evaluate(undefined)).toEqual(true);
+        expect(expression.evaluate(frameState, undefined)).toEqual(true);
 
         expression = new Expression('"bcd" !~ regExp("a")');
-        expect(expression.evaluate(undefined)).toEqual(true);
+        expect(expression.evaluate(frameState, undefined)).toEqual(true);
 
         expression = new Expression('regExp("quick\\s(brown).+?(jumps)", "ig") !~ "The Quick Brown Fox Jumps Over The Lazy Dog"');
-        expect(expression.evaluate(undefined)).toEqual(false);
+        expect(expression.evaluate(frameState, undefined)).toEqual(false);
 
         expression = new Expression('regExp("a") !~ 1');
-        expect(expression.evaluate(undefined)).toEqual(true);
+        expect(expression.evaluate(frameState, undefined)).toEqual(true);
 
         expression = new Expression('1 !~ regExp("a")');
-        expect(expression.evaluate(undefined)).toEqual(true);
+        expect(expression.evaluate(frameState, undefined)).toEqual(true);
 
         expression = new Expression('1 !~ 1');
-        expect(expression.evaluate(undefined)).toEqual(false);
+        expect(expression.evaluate(frameState, undefined)).toEqual(false);
 
         expression = new Expression('regExp(${property}) !~ ${property}');
-        expect(expression.evaluate(feature)).toEqual(false);
+        expect(expression.evaluate(frameState, feature)).toEqual(false);
     });
 
     it('throws if test is not call with a RegExp', function() {
@@ -1219,13 +1223,13 @@ defineSuite([
         feature.addProperty('property', 'abc');
 
         var expression = new Expression('regExp().toString()');
-        expect(expression.evaluate(undefined)).toEqual('/(?:)/');
+        expect(expression.evaluate(frameState, undefined)).toEqual('/(?:)/');
 
         expression = new Expression('regExp("\\d\\s\\d", "ig").toString()');
-        expect(expression.evaluate(undefined)).toEqual('/\\d\\s\\d/gi');
+        expect(expression.evaluate(frameState, undefined)).toEqual('/\\d\\s\\d/gi');
 
         expression = new Expression('regExp(${property}).toString()');
-        expect(expression.evaluate(feature)).toEqual('/abc/');
+        expect(expression.evaluate(frameState, feature)).toEqual('/abc/');
     });
 
     it('throws when using toString on other type', function() {
@@ -1234,7 +1238,7 @@ defineSuite([
 
         var expression = new Expression('${property}.toString()');
         expect(function() {
-            return expression.evaluate(feature);
+            return expression.evaluate(frameState, feature);
         }).toThrowDeveloperError();
     });
 
@@ -1243,11 +1247,11 @@ defineSuite([
         feature.addProperty('property', 'value');
         feature.addProperty('array', [Color.GREEN, Color.PURPLE, Color.YELLOW]);
         feature.addProperty('complicatedArray', [{
-                'subproperty' : Color.ORANGE,
-                'anotherproperty' : Color.RED
-             }, {
-                'subproperty' : Color.BLUE,
-                'anotherproperty' : Color.WHITE
+            'subproperty' : Color.ORANGE,
+            'anotherproperty' : Color.RED
+         }, {
+            'subproperty' : Color.BLUE,
+            'anotherproperty' : Color.WHITE
         }]);
         feature.addProperty('temperatures', {
             "scale" : "fahrenheit",
@@ -1255,34 +1259,42 @@ defineSuite([
         });
 
         var expression = new Expression('[1, 2, 3]');
-        expect(expression.evaluate(undefined)).toEqual([1, 2, 3]);
+        expect(expression.evaluate(frameState, undefined)).toEqual([1, 2, 3]);
 
         expression = new Expression('[1+2, "hello", 2 < 3, color("blue"), ${property}]');
-        expect(expression.evaluate(feature)).toEqual([3, 'hello', true, Color.BLUE, 'value']);
+        expect(expression.evaluate(frameState, feature)).toEqual([3, 'hello', true, Color.BLUE, 'value']);
 
         expression = new Expression('[1, 2, 3] * 4');
-        expect(expression.evaluate(undefined)).toEqual(NaN);
+        expect(expression.evaluate(frameState, undefined)).toEqual(NaN);
 
         expression = new Expression('-[1, 2, 3]');
-        expect(expression.evaluate(undefined)).toEqual(NaN);
+        expect(expression.evaluate(frameState, undefined)).toEqual(NaN);
 
         expression = new Expression('${array[1]}');
-        expect(expression.evaluate(feature)).toEqual(Color.PURPLE);
+        expect(expression.evaluate(frameState, feature)).toEqual(Color.PURPLE);
 
         expression = new Expression('${complicatedArray[1].subproperty}');
-        expect(expression.evaluate(feature)).toEqual(Color.BLUE);
+        expect(expression.evaluate(frameState, feature)).toEqual(Color.BLUE);
 
         expression = new Expression('${complicatedArray[0]["anotherproperty"]}');
-        expect(expression.evaluate(feature)).toEqual(Color.RED);
+        expect(expression.evaluate(frameState, feature)).toEqual(Color.RED);
 
         expression = new Expression('${temperatures["scale"]}');
-        expect(expression.evaluate(feature)).toEqual('fahrenheit');
+        expect(expression.evaluate(frameState, feature)).toEqual('fahrenheit');
 
         expression = new Expression('${temperatures.values[0]}');
-        expect(expression.evaluate(feature)).toEqual(70);
+        expect(expression.evaluate(frameState, feature)).toEqual(70);
 
         expression = new Expression('${temperatures["values"][0]}');
-        expect(expression.evaluate(feature)).toEqual(70);
+        expect(expression.evaluate(frameState, feature)).toEqual(70);
+    });
+
+    it('evaluates TILES3D_TIME expression', function() {
+        var expression = new Expression('TILES3D_TIME');
+        expect(expression.evaluate(frameState, undefined)).toEqual(0);
+        frameState.frameNumber = 1;
+        expect(expression.evaluate(frameState, undefined)).toEqual(1);
+        frameState.frameNumber = 0;
     });
 
     it('gets shader function', function() {
@@ -1616,6 +1628,13 @@ defineSuite([
         expect(shaderState.translucent).toBe(true);
     });
 
+    it('gets shader expression for TILES3D_TIME', function() {
+        var expression = new Expression('TILES3D_TIME');
+        var shaderExpression = expression.getShaderExpression('', {});
+        var expected = 'czm_frameNumber';
+        expect(shaderExpression).toEqual(expected);
+    });
+
     it('gets shader expression for abs', function() {
         var expression = new Expression('abs(-1.0)');
         var shaderExpression = expression.getShaderExpression('', {});
@@ -1629,7 +1648,6 @@ defineSuite([
         var expected = 'cos(0.0)';
         expect(shaderExpression).toEqual(expected);
     });
-
 
     it('gets shader expression for sqrt', function() {
         var expression = new Expression('sqrt(1.0)');

--- a/Specs/Scene/StyleExpressionSpec.js
+++ b/Specs/Scene/StyleExpressionSpec.js
@@ -5,9 +5,7 @@ defineSuite([
         StyleExpression) {
     'use strict';
 
-    var frameState = {
-        frameNumber : 0
-    };
+    var frameState = {};
 
     function MockFeature() {
     }

--- a/Specs/Scene/StyleExpressionSpec.js
+++ b/Specs/Scene/StyleExpressionSpec.js
@@ -5,6 +5,10 @@ defineSuite([
         StyleExpression) {
     'use strict';
 
+    var frameState = {
+        frameNumber : 0
+    };
+
     function MockFeature() {
     }
 
@@ -17,11 +21,11 @@ defineSuite([
         var feature = new MockFeature();
 
         expect(function() {
-            return expression.evaluate(feature);
+            return expression.evaluate(frameState, feature);
         }).toThrowDeveloperError();
 
         expect(function() {
-            return expression.evaluateColor(feature);
+            return expression.evaluateColor(frameState, feature);
         }).toThrowDeveloperError();
     });
 });


### PR DESCRIPTION
For #3241 
Spec https://github.com/AnalyticalGraphicsInc/3d-tiles/issues/2

Adds support for styling based on time, which in this case is the frame count.
![cos](https://cloud.githubusercontent.com/assets/915398/20117997/e1c13ff0-a5d0-11e6-8371-bda4e06a0de6.gif)

Spec PR to follow.