### PR TITLE
Event class - removing multiple listeners from within a callback(s) yields some unexpected results

### DIFF
--- a/Source/Core/Event.js
+++ b/Source/Core/Event.js
@@ -153,6 +153,12 @@ define([
         if (this._recursionLevel === 0){
             //Actually remove items removed in removeEventListener.
             var toRemove = this._toRemove;
+
+            // This array is not necessarily in the correct order.
+            // For example  - if some listener callback removes **other** listener it wouldn't be in the correct order.
+            // So we have to sort it before the (reversed) loop...
+            toRemove.sort();
+
             length = toRemove.length;
             for (i = length - 1; i >= 0; i--) {
                 var index = toRemove[i];

--- a/Specs/Core/EventSpec.js
+++ b/Specs/Core/EventSpec.js
@@ -111,7 +111,7 @@ defineSuite([
                 },
                 doRecursiveCall : function(evt) {
                     if (counter < 1){
-                        counter ++;
+                        counter++;
                         event.raiseEvent();
                     }
                 },
@@ -132,7 +132,7 @@ defineSuite([
         expect(callbacks.doNothing2.calls.count()).toEqual(2);
     });
 
-    it('recursion counter is increased and decreased properly', function() {
+    it('event._recursionLevel is increased and decreased properly', function() {
 
         var counter = 0;
         var recursionLevel;
@@ -146,7 +146,7 @@ defineSuite([
                 },
                 doRecursiveCall : function(evt) {
                     if (counter < 1){
-                        counter ++;
+                        counter++;
                         event.raiseEvent();
                     } else {
                         recursionLevel = event._recursionLevel;
@@ -170,6 +170,7 @@ defineSuite([
 
 
     });
+
     it('addEventListener and removeEventListener works with same function of different scopes', function() {
         var Scope = function() {
             this.timesCalled = 0;

--- a/Specs/Core/EventSpec.js
+++ b/Specs/Core/EventSpec.js
@@ -91,8 +91,8 @@ defineSuite([
         event.addEventListener(doNothing);
         event.addEventListener(removeEventCb);
         event.addEventListener(removeEventCb2);
-        event.addEventListener(removeEventCb3);
         event.addEventListener(doNothing2);
+        event.addEventListener(removeEventCb3);
         event.raiseEvent();
         expect(event.numberOfListeners).toEqual(2);
         expect(event._listeners.indexOf(doNothing2)).toEqual(1);
@@ -132,7 +132,7 @@ defineSuite([
         expect(callbacks.doNothing2.calls.count()).toEqual(2);
     });
 
-    it('event._recursionLevel is increased and decreased properly', function() {
+    it('event._recursionLevel has the correct value', function() {
 
         var counter = 0;
         var recursionLevel;

--- a/Specs/Core/EventSpec.js
+++ b/Specs/Core/EventSpec.js
@@ -84,7 +84,6 @@ defineSuite([
             event.removeEventListener(removeEventCb3);
         };
 
-
         var doNothing2 = function(evt) {
         };
 
@@ -102,22 +101,22 @@ defineSuite([
 
         var counter = 0;
         var callbacks = {
-                doNothing: function(evt) {
-                },
-                removeEventCb : function(evt) {
-                    event.removeEventListener(callbacks.removeEventCb);
-                },
-                doNothing2 : function(evt) {
-                },
-                doRecursiveCall : function(evt) {
-                    if (counter < 1){
-                        counter++;
-                        event.raiseEvent();
-                    }
-                },
-                removeEventCb2 : function(evt) {
-                    event.removeEventListener(callbacks.removeEventCb2);
+            doNothing : function(evt) {
+            },
+            removeEventCb : function(evt) {
+                event.removeEventListener(callbacks.removeEventCb);
+            },
+            doNothing2 : function(evt) {
+            },
+            doRecursiveCall : function(evt) {
+                if (counter < 1) {
+                    counter++;
+                    event.raiseEvent();
                 }
+            },
+            removeEventCb2 : function(evt) {
+                event.removeEventListener(callbacks.removeEventCb2);
+            }
         };
 
         spyOn(callbacks, 'doNothing2').and.callThrough();
@@ -137,26 +136,25 @@ defineSuite([
         var counter = 0;
         var recursionLevel;
         var callbacks = {
-                doNothing: function(evt) {
-                },
-                removeEventCb : function(evt) {
-                    event.removeEventListener(callbacks.removeEventCb);
-                },
-                doNothing2 : function(evt) {
-                },
-                doRecursiveCall : function(evt) {
-                    if (counter < 1){
-                        counter++;
-                        event.raiseEvent();
-                    } else {
-                        recursionLevel = event._recursionLevel;
-                    }
-                },
-                removeEventCb2 : function(evt) {
-                    event.removeEventListener(callbacks.removeEventCb2);
+            doNothing : function(evt) {
+            },
+            removeEventCb : function(evt) {
+                event.removeEventListener(callbacks.removeEventCb);
+            },
+            doNothing2 : function(evt) {
+            },
+            doRecursiveCall : function(evt) {
+                if (counter < 1) {
+                    counter++;
+                    event.raiseEvent();
+                } else {
+                    recursionLevel = event._recursionLevel;
                 }
+            },
+            removeEventCb2 : function(evt) {
+                event.removeEventListener(callbacks.removeEventCb2);
+            }
         };
-
 
         event.addEventListener(callbacks.doNothing);
         event.addEventListener(callbacks.removeEventCb);
@@ -169,6 +167,46 @@ defineSuite([
         expect(event._recursionLevel).toEqual(0);
 
 
+    });
+
+    it('can remove from withing a callback in event with mutiple listeners when the deletion is not the listeners order', function() {
+
+        /**
+         *  if you comment out the toRemove.sort() (in Event class) this spec should fail
+         */
+
+        var doNothing = function(evt) {
+        };
+
+        var doNothing2 = function(evt) {
+        };
+        var removeEventCb = function(evt) {
+            event.removeEventListener(removeEventCb);
+            //remove previous callback so it would pushed to toRemove **after** this CB
+            event.removeEventListener(doNothing2);
+
+        };
+
+        var removeEventCb2 = function(evt) {
+            event.removeEventListener(removeEventCb2);
+            //remove previous callback so it would pushed to toRemove **after** two CBs
+            event.removeEventListener(doNothing);
+        };
+
+        var doNothing3 = function(evt) {
+        };
+        var doNothing4 = function(evt) {
+        };
+        event.addEventListener(doNothing);
+        event.addEventListener(doNothing2);
+        event.addEventListener(doNothing3);
+        event.addEventListener(removeEventCb);
+        event.addEventListener(removeEventCb2);
+        event.addEventListener(doNothing4);
+        event.raiseEvent();
+        expect(event.numberOfListeners).toEqual(2);
+        expect(event._listeners.indexOf(doNothing3)).toEqual(0);
+        expect(event._listeners.indexOf(doNothing4)).toEqual(1);
     });
 
     it('addEventListener and removeEventListener works with same function of different scopes', function() {


### PR DESCRIPTION
I found 3 problems with current implemetation:

1. [This code](https://github.com/AnalyticalGraphicsInc/cesium/blob/master/Source/Core/Event.js#L154) changes the `listeners` array within a loop so the next indices are pointing to the wrong position in the array, and the wrong elements are deleted.
[This spec](https://github.com/duvifn/cesium/blob/fix_Event.removeEventListener/Specs/Core/EventSpec.js#L71), running with current Event class code, would fail.

2.  When calling `raiseEvent` recursively  (listener that calls the `raiseEvent` again).
In this case the delete operation occurs despite the fact that it inside a 'raiseEvent' since `this._insideRaiseEvent` is reset by the second call.
[This spec](https://github.com/duvifn/cesium/blob/fix_Event.removeEventListener/Specs/Core/EventSpec.js#L100) running with current Event class code, would fail.

3. `toRemove` array has to be sorted before [this loop](https://github.com/AnalyticalGraphicsInc/cesium/blob/master/Source/Core/Event.js#L154).
[This spec](https://github.com/duvifn/cesium/blob/fix_Event.removeEventListener/Specs/Core/EventSpec.js#L172) running with the **fixed code**, when toRemove.sort() is commented out, would fail.


I fixed the code and added some new specs.