### PR TITLE
Remove floating-point texture requirement

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@ Change Log
 * `TextureAtlas.borderWidthInPixels` has always been applied to the upper and right edges of each internal texture, but is now also applied to the bottom and left edges of the entire TextureAtlas, guaranteeing borders on all sides regardless of position within the atlas.
 * Added support for saving html and css in Github Gists. [#4125](https://github.com/AnalyticalGraphicsInc/cesium/issues/4125)
 * Fixed `Cartographic.fromCartesian` when the cartesian is not on the ellipsoid surface. [#4611](https://github.com/AnalyticalGraphicsInc/cesium/issues/4611)
+* Fall back to packing floats into an unsigned byte texture when floating point textures are unsupported. [#4563](https://github.com/AnalyticalGraphicsInc/cesium/issues/4563)
 
 ### 1.27 - 2016-11-01
 * Deprecated

--- a/Source/Scene/BatchTable.js
+++ b/Source/Scene/BatchTable.js
@@ -104,6 +104,13 @@ define([
             return;
         }
 
+        // PERFORMANCE_IDEA: We may be able to arrange the attributes so they can be packing into fewer texels.
+        // Right now, an attribute with one component uses an entire texel when 4 single component attributes can
+        // be packed into a texel.
+        //
+        // Packing floats into unsigned byte textures makes the problem worse. A single component float attribute
+        // will be packed into a single texel leaving 3 texels unused. 4 texels are reserved for each float attribute
+        // regardless of how many components it has.
         var pixelDatatype = getDatatype(attributes);
         var textureFloatSupported = context.floatingPointTexture;
         var packFloats = pixelDatatype === PixelDatatype.FLOAT && !textureFloatSupported;

--- a/Source/Scene/PolylineCollection.js
+++ b/Source/Scene/PolylineCollection.js
@@ -391,25 +391,21 @@ define([
             componentDatatype : ComponentDatatype.UNSIGNED_BYTE,
             componentsPerAttribute : 4,
             normalize : true
+        }, {
+            functionName : 'batchTable_getCenterHigh',
+            componentDatatype : ComponentDatatype.FLOAT,
+            componentsPerAttribute : 3
+        }, {
+            functionName : 'batchTable_getCenterLowAndRadius',
+            componentDatatype : ComponentDatatype.FLOAT,
+            componentsPerAttribute : 4
+        }, {
+            functionName : 'batchTable_getDistanceDisplayCondition',
+            componentDatatype : ComponentDatatype.FLOAT,
+            componentsPerAttribute : 2
         }];
 
-        if (defined(context.floatingPointTexture)) {
-            attributes.push({
-                functionName : 'batchTable_getCenterHigh',
-                componentDatatype : ComponentDatatype.FLOAT,
-                componentsPerAttribute : 3
-            }, {
-                functionName : 'batchTable_getCenterLowAndRadius',
-                componentDatatype : ComponentDatatype.FLOAT,
-                componentsPerAttribute : 4
-            }, {
-                functionName : 'batchTable_getDistanceDisplayCondition',
-                componentDatatype : ComponentDatatype.FLOAT,
-                componentsPerAttribute : 2
-            });
-        }
-
-        collection._batchTable = new BatchTable(attributes, collection._polylines.length);
+        collection._batchTable = new BatchTable(context, attributes, collection._polylines.length);
     }
 
     var scratchUpdatePolylineEncodedCartesian = new EncodedCartesian3();
@@ -1150,11 +1146,7 @@ define([
             return;
         }
 
-        var defines = [];
-        if (context.floatingPointTexture) {
-            defines.push('DISTANCE_DISPLAY_CONDITION');
-        }
-
+        var defines = ['DISTANCE_DISPLAY_CONDITION'];
         var vsSource = batchTable.getVertexShaderCallback()(PolylineVS);
         var vs = new ShaderSource({
             defines : defines,

--- a/Source/Scene/Primitive.js
+++ b/Source/Scene/Primitive.js
@@ -608,7 +608,7 @@ define([
         }
 
         var attributesLength = attributes.length;
-        var batchTable = new BatchTable(attributes, numberOfInstances);
+        var batchTable = new BatchTable(context, attributes, numberOfInstances);
 
         for (i = 0; i < numberOfInstances; ++i) {
             var instance = instances[i];

--- a/Specs/Scene/BatchTableSpec.js
+++ b/Specs/Scene/BatchTableSpec.js
@@ -3,6 +3,7 @@ defineSuite([
         'Scene/BatchTable',
         'Core/Cartesian4',
         'Core/ComponentDatatype',
+        'Core/Math',
         'Renderer/PixelDatatype',
         'Renderer/Texture',
         'Specs/createScene'
@@ -10,6 +11,7 @@ defineSuite([
         BatchTable,
         Cartesian4,
         ComponentDatatype,
+        CesiumMath,
         PixelDatatype,
         Texture,
         createScene) {
@@ -33,14 +35,16 @@ defineSuite([
     }, {
         functionName : 'batchTable_getCenter',
         componentDatatype : ComponentDatatype.FLOAT,
-        componentsPerAttribute : 3
+        componentsPerAttribute : 4
     }];
 
     var batchTable;
     var scene;
+    var context;
 
     beforeAll(function() {
         scene = createScene();
+        context = scene.context;
     });
 
     afterAll(function() {
@@ -52,25 +56,31 @@ defineSuite([
     });
 
     it('constructor', function() {
-        batchTable = new BatchTable(unsignedByteAttributes, 2);
+        batchTable = new BatchTable(context, unsignedByteAttributes, 2);
         expect(batchTable.attributes).toBe(unsignedByteAttributes);
         expect(batchTable.numberOfInstances).toEqual(2);
     });
 
+    it('constructior throws without context', function() {
+        expect(function() {
+            batchTable = new BatchTable(undefined, unsignedByteAttributes, 5);
+        }).toThrowDeveloperError();
+    });
+
     it('constructior throws without attributes', function() {
         expect(function() {
-            batchTable = new BatchTable(undefined, 5);
+            batchTable = new BatchTable(context, undefined, 5);
         }).toThrowDeveloperError();
     });
 
     it('constructor throws without number of instances', function() {
         expect(function() {
-            batchTable = new BatchTable(unsignedByteAttributes, undefined);
+            batchTable = new BatchTable(context, unsignedByteAttributes, undefined);
         }).toThrowDeveloperError();
     });
 
     it('sets and gets entries in the table', function() {
-        batchTable = new BatchTable(unsignedByteAttributes, 5);
+        batchTable = new BatchTable(context, unsignedByteAttributes, 5);
 
         var i;
         var color = new Cartesian4(0, 1, 2, 3);
@@ -92,8 +102,69 @@ defineSuite([
         expect(batchTable.getBatchedAttribute(3, 1)).toEqual(color);
     });
 
+    it('sets and gets entries in the table with float attributes', function() {
+        var context = {
+            floatingPointTexture : true
+        };
+        batchTable = new BatchTable(context, floatAttributes, 5);
+
+        var i;
+        var color = new Cartesian4(0, 1, 2, 3);
+
+        for (i = 0; i < batchTable.numberOfInstances; ++i) {
+            batchTable.setBatchedAttribute(i, 0, 1);
+            batchTable.setBatchedAttribute(i, 1, color);
+        }
+
+        for (i = 0; i < batchTable.numberOfInstances; ++i) {
+            expect(batchTable.getBatchedAttribute(3, 0)).toEqual(1);
+            expect(batchTable.getBatchedAttribute(3, 1)).toEqual(color);
+        }
+
+        color = new Cartesian4(4, 5, 6, 7);
+        batchTable.setBatchedAttribute(3, 0, 0);
+        batchTable.setBatchedAttribute(3, 1, color);
+        expect(batchTable.getBatchedAttribute(3, 0)).toEqual(0);
+        expect(batchTable.getBatchedAttribute(3, 1)).toEqual(color);
+    });
+
+    it('sets and gets entries in the table with float attributes and forced packing', function() {
+        var context = {
+            floatingPointTexture : false
+        };
+        batchTable = new BatchTable(context, floatAttributes, 5);
+
+        var i;
+        var color = new Cartesian4(1.23456e12, -2.34567e30, 3.45678e-6, -4.56789e-10);
+
+        for (i = 0; i < batchTable.numberOfInstances; ++i) {
+            batchTable.setBatchedAttribute(i, 0, 1);
+            batchTable.setBatchedAttribute(i, 1, color);
+        }
+
+        var value;
+        for (i = 0; i < batchTable.numberOfInstances; ++i) {
+            value = batchTable.getBatchedAttribute(3, 0);
+            expect(value).toEqual(1);
+            value = batchTable.getBatchedAttribute(3, 1);
+            expect(value).toEqualEpsilon(color, CesiumMath.EPSILON6);
+        }
+
+        color = new Cartesian4(0, Number.MAX_VALUE, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY);
+        batchTable.setBatchedAttribute(3, 0, 0);
+        batchTable.setBatchedAttribute(3, 1, color);
+
+        value = batchTable.getBatchedAttribute(3, 0);
+        expect(value).toEqual(0);
+        value = batchTable.getBatchedAttribute(3, 1);
+        expect(value.x).toEqual(0.0);
+        expect(value.y).toEqual(Number.POSITIVE_INFINITY);
+        expect(value.z).toEqual(Number.POSITIVE_INFINITY);
+        expect(value.w).toEqual(Number.NEGATIVE_INFINITY);
+    });
+
     it('gets with result parameter', function() {
-        batchTable = new BatchTable(unsignedByteAttributes, 5);
+        batchTable = new BatchTable(context, unsignedByteAttributes, 5);
         var color = new Cartesian4(0, 1, 2, 3);
         batchTable.setBatchedAttribute(0, 1, color);
 
@@ -104,7 +175,7 @@ defineSuite([
     });
 
     it('get entry throws when instance index is out of range', function() {
-        batchTable = new BatchTable(unsignedByteAttributes, 5);
+        batchTable = new BatchTable(context, unsignedByteAttributes, 5);
         expect(function() {
             batchTable.getBatchedAttribute(-1, 0);
         }).toThrowDeveloperError();
@@ -114,7 +185,7 @@ defineSuite([
     });
 
     it('get entry throws when attribute index is out of range', function() {
-        batchTable = new BatchTable(unsignedByteAttributes, 5);
+        batchTable = new BatchTable(context, unsignedByteAttributes, 5);
         expect(function() {
             batchTable.getBatchedAttribute(0, -1);
         }).toThrowDeveloperError();
@@ -124,7 +195,7 @@ defineSuite([
     });
 
     it('set entry throws when instance index is out of range', function() {
-        batchTable = new BatchTable(unsignedByteAttributes, 5);
+        batchTable = new BatchTable(context, unsignedByteAttributes, 5);
         expect(function() {
             batchTable.setBatchedAttribute(-1, 0, 0);
         }).toThrowDeveloperError();
@@ -134,7 +205,7 @@ defineSuite([
     });
 
     it('set entry throws when attribute index is out of range', function() {
-        batchTable = new BatchTable(unsignedByteAttributes, 5);
+        batchTable = new BatchTable(context, unsignedByteAttributes, 5);
         expect(function() {
             batchTable.setBatchedAttribute(0, -1, 1);
         }).toThrowDeveloperError();
@@ -144,14 +215,14 @@ defineSuite([
     });
 
     it('set entry throws when value is undefined', function() {
-        batchTable = new BatchTable(unsignedByteAttributes, 5);
+        batchTable = new BatchTable(context, unsignedByteAttributes, 5);
         expect(function() {
             batchTable.setBatchedAttribute(0, 0, undefined);
         }).toThrowDeveloperError();
     });
 
     it('creates a uniform callback with unsigned byte texture', function() {
-        batchTable = new BatchTable(unsignedByteAttributes, 5);
+        batchTable = new BatchTable(context, unsignedByteAttributes, 5);
         batchTable.update(scene.frameState);
 
         var uniforms = batchTable.getUniformMapCallback()({});
@@ -168,33 +239,36 @@ defineSuite([
         expect(uniforms.batchTextureStep().w).toBeGreaterThan(0);
     });
 
-    it('creates a uniform callback with unsigned byte texture', function() {
-        batchTable = new BatchTable(floatAttributes, 5);
+    it('creates a uniform callback with float texture', function() {
+        if (!context.floatingPointTexture) {
+            return;
+        }
+
+        batchTable = new BatchTable(context, floatAttributes, 5);
+        batchTable.update(scene.frameState);
+
+        var uniforms = batchTable.getUniformMapCallback()({});
+        expect(uniforms.batchTexture).toBeDefined();
+        expect(uniforms.batchTexture()).toBeInstanceOf(Texture);
+        expect(uniforms.batchTexture().pixelDatatype).toEqual(PixelDatatype.FLOAT);
+        expect(uniforms.batchTextureDimensions).toBeDefined();
+        expect(uniforms.batchTextureDimensions().x).toBeGreaterThan(0);
+        expect(uniforms.batchTextureDimensions().y).toBeGreaterThan(0);
+        expect(uniforms.batchTextureStep).toBeDefined();
+        expect(uniforms.batchTextureStep().x).toBeGreaterThan(0);
+        expect(uniforms.batchTextureStep().y).toBeGreaterThan(0);
+        expect(uniforms.batchTextureStep().z).toBeGreaterThan(0);
+        expect(uniforms.batchTextureStep().w).toBeGreaterThan(0);
 
         if (scene.context.floatingPointTexture) {
-            batchTable.update(scene.frameState);
-
-            var uniforms = batchTable.getUniformMapCallback()({});
-            expect(uniforms.batchTexture).toBeDefined();
-            expect(uniforms.batchTexture()).toBeInstanceOf(Texture);
             expect(uniforms.batchTexture().pixelDatatype).toEqual(PixelDatatype.FLOAT);
-            expect(uniforms.batchTextureDimensions).toBeDefined();
-            expect(uniforms.batchTextureDimensions().x).toBeGreaterThan(0);
-            expect(uniforms.batchTextureDimensions().y).toBeGreaterThan(0);
-            expect(uniforms.batchTextureStep).toBeDefined();
-            expect(uniforms.batchTextureStep().x).toBeGreaterThan(0);
-            expect(uniforms.batchTextureStep().y).toBeGreaterThan(0);
-            expect(uniforms.batchTextureStep().z).toBeGreaterThan(0);
-            expect(uniforms.batchTextureStep().w).toBeGreaterThan(0);
         } else {
-            expect(function() {
-                batchTable.update(scene.frameState);
-            }).toThrowRuntimeError();
+            expect(uniforms.batchTexture().pixelDatatype).toEqual(PixelDatatype.UNSIGNED_BYTE);
         }
     });
 
     it('create shader functions', function() {
-        batchTable = new BatchTable(unsignedByteAttributes, 5);
+        batchTable = new BatchTable(context, unsignedByteAttributes, 5);
 
         var shader = 'void main() { gl_Position = vec4(0.0); }';
         var modifiedShader = batchTable.getVertexShaderCallback()(shader);
@@ -203,7 +277,7 @@ defineSuite([
     });
 
     it('isDestroyed', function() {
-        batchTable = new BatchTable(unsignedByteAttributes, 5);
+        batchTable = new BatchTable(context, unsignedByteAttributes, 5);
         expect(batchTable.isDestroyed()).toEqual(false);
         batchTable.destroy();
         expect(batchTable.isDestroyed()).toEqual(true);

--- a/Specs/Scene/PolylineCollectionSpec.js
+++ b/Specs/Scene/PolylineCollectionSpec.js
@@ -1227,10 +1227,6 @@ defineSuite([
     });
 
     it('renders with a distance display condition', function() {
-        if (!scene.context.floatingPointTexture) {
-            return;
-        }
-
         var near = 100.0;
         var far = 10000.0;
 


### PR DESCRIPTION
Add falling back to packing floats into unsigned byte texture when floating point textures aren't supported.

Fixes #4563.