### PR TITLE
Switch to glsl-strip-comments

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -13,7 +13,7 @@ var request = require('request');
 var globby = require('globby');
 var jshint = require('gulp-jshint');
 var rimraf = require('rimraf');
-var stripComments = require('strip-comments');
+var glslStripComments = require('glsl-strip-comments');
 var mkdirp = require('mkdirp');
 var eventStream = require('event-stream');
 var gulp = require('gulp');
@@ -992,7 +992,7 @@ function glslToJavaScript(minify, minifyStateFilePath) {
         }
 
         if (minify) {
-            contents = stripComments(contents);
+            contents = glslStripComments(contents);
             contents = contents.replace(/\s+$/gm, '').replace(/^\s+/gm, '').replace(/\n+/gm, '\n');
             contents += '\n';
         }

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "event-stream": "^3.3.4",
     "express": "^4.14.0",
     "globby": "^6.1.0",
+    "glsl-strip-comments": "^1.0.0",
     "gulp": "^3.9.1",
     "gulp-insert": "^0.5.0",
     "gulp-jshint": "^2.0.4",
@@ -66,7 +67,6 @@
     "mkdirp": "^0.5.1",
     "request": "^2.79.0",
     "rimraf": "^2.5.4",
-    "strip-comments": "0.3.2",
     "yargs": "^6.4.0"
   },
   "scripts": {


### PR DESCRIPTION
Merge #4705 first.

We were stuck on an old version of `strip-comments` that just happened to work on glsl via regex.  This new module actually uses a tokenizer and seems to be more well maintained.