### PR TITLE
Load 'Hello World' sandcastle demo when demo from URL is not found

### DIFF
--- a/Apps/Sandcastle/CesiumSandcastle.js
+++ b/Apps/Sandcastle/CesiumSandcastle.js
@@ -1,5 +1,6 @@
 /*global require,Blob,JSHINT*/
 /*global gallery_demos*/// defined by gallery/gallery-index.js, created by build
+/*global hello_world_index*/// defined in gallery/gallery-index.js, created by build
 /*global sandcastleJsHintOptions*/// defined by jsHintOptions.js, created by build
 require({
     baseUrl : '../../Source',
@@ -138,6 +139,7 @@ require({
     var subtabs = {};
     var docError = false;
     var galleryError = false;
+    var notFound = false;
     var galleryTooltipTimer;
     var activeGalleryTooltipDemo;
     var demoTileHeightRule = findCssStyle('.demoTileThumbnail');
@@ -693,6 +695,7 @@ require({
     }
 
     function loadFromGallery(demo) {
+        notFound = false;
         document.getElementById('saveAsFile').download = demo.name + '.html';
         registry.byId('description').set('value', decodeHTML(demo.description).replace(/\\n/g, '\n'));
         registry.byId('label').set('value', decodeHTML(demo.label).replace(/\\n/g, '\n'));
@@ -802,6 +805,9 @@ require({
                 }
                 if (galleryError) {
                     appendConsole('consoleError', 'Error loading gallery, please run the build script.', true);
+                }
+                if (notFound) {
+                    appendConsole('consoleLog', 'Demo at ' + queryObject.src + ' was not found\n', true);
                 }
             }
         } else if (Cesium.defined(e.data.log)) {
@@ -1054,8 +1060,15 @@ require({
             url : 'gallery/' + name + '.html',
             handleAs : 'text',
             error : function(error) {
-                appendConsole('consoleError', error, true);
-                galleryError = true;
+                if (error.status === 404) {
+                    loadFromGallery(gallery_demos[hello_world_index])
+                        .then(function() {
+                            notFound = true;
+                        });
+                } else {
+                    galleryError = true;
+                    appendConsole('consoleError', error, true);
+                }
             }
         });
     }

--- a/Apps/Sandcastle/CesiumSandcastle.js
+++ b/Apps/Sandcastle/CesiumSandcastle.js
@@ -807,7 +807,7 @@ require({
                     appendConsole('consoleError', 'Error loading gallery, please run the build script.', true);
                 }
                 if (notFound) {
-                    appendConsole('consoleLog', 'Demo at ' + queryObject.src + ' was not found\n', true);
+                    appendConsole('consoleLog', 'Unable to load demo named ' + queryObject.src.replace('.html', '') + '\n', true);
                 }
             }
         } else if (Cesium.defined(e.data.log)) {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1125,8 +1125,10 @@ function createGalleryList() {
         fileList.push('!Apps/Sandcastle/gallery/development/**/*.html');
     }
 
+    var helloWorld;
     globby.sync(fileList).forEach(function(file) {
         var demo = filePathToModuleId(path.relative('Apps/Sandcastle/gallery', file));
+
         var demoObject = {
             name : demo,
             date : fs.statSync(file).mtime.getTime()
@@ -1137,6 +1139,10 @@ function createGalleryList() {
         }
 
         demoObjects.push(demoObject);
+
+        if (demo === 'Hello World') {
+            helloWorld = demoObject;
+        }
     });
 
     demoObjects.sort(function(a, b) {
@@ -1149,6 +1155,8 @@ function createGalleryList() {
       }
     });
 
+    var helloWorldIndex = demoObjects.indexOf(helloWorld);
+
     var i;
     for (i = 0; i < demoObjects.length; ++i) {
       demoJSONs[i] = JSON.stringify(demoObjects[i], null, 2);
@@ -1156,6 +1164,7 @@ function createGalleryList() {
 
     var contents = '\
 // This file is automatically rebuilt by the Cesium build process.\n\
+var hello_world_index = ' + helloWorldIndex + ';\n\
 var gallery_demos = [' + demoJSONs.join(', ') + '];';
 
     fs.writeFileSync(output, contents);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1155,7 +1155,7 @@ function createGalleryList() {
       }
     });
 
-    var helloWorldIndex = demoObjects.indexOf(helloWorld);
+    var helloWorldIndex = Math.max(demoObjects.indexOf(helloWorld), 0);
 
     var i;
     for (i = 0; i < demoObjects.length; ++i) {


### PR DESCRIPTION
Fixes #2182

Currently, if you go to a sandcastle link where the `src` query parameter is not the same as the name of a sandcastle demo, nothing shows up on the page except for an error message.

This change makes sandcastle load the Hello World example instead, but it doesn't change the URL and it logs an message to the console saying the demo was not found.

I added `var hello_world_index` to the `gallery-index.js` file that gets generated on `npm run build` to make it easy to load the hello world example.