### PR TITLE
Change to a modern method of constructing synthetic pointer events.

### DIFF
--- a/Specs/DomEventSimulator.js
+++ b/Specs/DomEventSimulator.js
@@ -137,35 +137,35 @@ define([
 
     function createPointerEvent(type, options) {
         options = defaultValue(options, defaultValue.EMPTY_OBJECT);
-        var canBubble = defaultValue(options.canBubble, true);
-        var cancelable = defaultValue(options.cancelable, true);
-        var view = defaultValue(options.view, window);
-        var detail = defaultValue(options.detail, 0);
-        var screenX = defaultValue(options.screenX, 0);
-        var screenY = defaultValue(options.screenY, 0);
-        var clientX = defaultValue(options.clientX, 0);
-        var clientY = defaultValue(options.clientY, 0);
-        var ctrlKey = defaultValue(options.ctrlKey, false);
-        var altKey = defaultValue(options.altKey, false);
-        var shiftKey = defaultValue(options.shiftKey, false);
-        var metaKey = defaultValue(options.metaKey, false);
-        var button = defaultValue(options.button, 0);
-        var relatedTarget = defaultValue(options.relatedTarget, null);
-        var offsetX = defaultValue(options.offsetX, 0);
-        var offsetY = defaultValue(options.offsetY, 0);
-        var width = defaultValue(options.width, 0);
-        var height = defaultValue(options.height, 0);
-        var pressure = defaultValue(options.pressure, 0);
-        var rotation = defaultValue(options.rotation, 0);
-        var tiltX = defaultValue(options.tiltX, 0);
-        var tiltY = defaultValue(options.tiltY, 0);
-        var pointerId = defaultValue(options.pointerId, 1);
-        var pointerType = defaultValue(options.pointerType, 0);
-        var hwTimestamp = defaultValue(options.hwTimestamp, 0);
-        var isPrimary = defaultValue(options.isPrimary, 0);
 
-        var event = document.createEvent('PointerEvent');
-        event.initPointerEvent(type, canBubble, cancelable, view, detail, screenX, screenY, clientX, clientY, ctrlKey, altKey, shiftKey, metaKey, button, relatedTarget, offsetX, offsetY, width, height, pressure, rotation, tiltX, tiltY, pointerId, pointerType, hwTimestamp, isPrimary);
+        var event = new window.PointerEvent(type, {
+            canBubble : defaultValue(options.canBubble, true),
+            cancelable : defaultValue(options.cancelable, true),
+            view : defaultValue(options.view, window),
+            detail : defaultValue(options.detail, 0),
+            screenX : defaultValue(options.screenX, 0),
+            screenY : defaultValue(options.screenY, 0),
+            clientX : defaultValue(options.clientX, 0),
+            clientY : defaultValue(options.clientY, 0),
+            ctrlKey : defaultValue(options.ctrlKey, false),
+            altKey : defaultValue(options.altKey, false),
+            shiftKey : defaultValue(options.shiftKey, false),
+            metaKey : defaultValue(options.metaKey, false),
+            button : defaultValue(options.button, 0),
+            relatedTarget : defaultValue(options.relatedTarget, null),
+            offsetX : defaultValue(options.offsetX, 0),
+            offsetY : defaultValue(options.offsetY, 0),
+            width : defaultValue(options.width, 0),
+            height : defaultValue(options.height, 0),
+            pressure : defaultValue(options.pressure, 0),
+            rotation : defaultValue(options.rotation, 0),
+            tiltX : defaultValue(options.tiltX, 0),
+            tiltY : defaultValue(options.tiltY, 0),
+            pointerId : defaultValue(options.pointerId, 1),
+            pointerType : defaultValue(options.pointerType, 0),
+            hwTimestamp : defaultValue(options.hwTimestamp, 0),
+            isPrimary : defaultValue(options.isPrimary, 0)
+        });
         return event;
     }
 

--- a/Specs/DomEventSimulator.js
+++ b/Specs/DomEventSimulator.js
@@ -1,8 +1,10 @@
 /*global define*/
 define([
-        'Core/defaultValue'
+        'Core/defaultValue',
+        'Core/FeatureDetection'
     ], function(
-        defaultValue) {
+        defaultValue,
+        FeatureDetection) {
     'use strict';
 
     function createMouseEvent(type, options) {
@@ -137,35 +139,70 @@ define([
 
     function createPointerEvent(type, options) {
         options = defaultValue(options, defaultValue.EMPTY_OBJECT);
+        var event;
 
-        var event = new window.PointerEvent(type, {
-            canBubble : defaultValue(options.canBubble, true),
-            cancelable : defaultValue(options.cancelable, true),
-            view : defaultValue(options.view, window),
-            detail : defaultValue(options.detail, 0),
-            screenX : defaultValue(options.screenX, 0),
-            screenY : defaultValue(options.screenY, 0),
-            clientX : defaultValue(options.clientX, 0),
-            clientY : defaultValue(options.clientY, 0),
-            ctrlKey : defaultValue(options.ctrlKey, false),
-            altKey : defaultValue(options.altKey, false),
-            shiftKey : defaultValue(options.shiftKey, false),
-            metaKey : defaultValue(options.metaKey, false),
-            button : defaultValue(options.button, 0),
-            relatedTarget : defaultValue(options.relatedTarget, null),
-            offsetX : defaultValue(options.offsetX, 0),
-            offsetY : defaultValue(options.offsetY, 0),
-            width : defaultValue(options.width, 0),
-            height : defaultValue(options.height, 0),
-            pressure : defaultValue(options.pressure, 0),
-            rotation : defaultValue(options.rotation, 0),
-            tiltX : defaultValue(options.tiltX, 0),
-            tiltY : defaultValue(options.tiltY, 0),
-            pointerId : defaultValue(options.pointerId, 1),
-            pointerType : defaultValue(options.pointerType, 0),
-            hwTimestamp : defaultValue(options.hwTimestamp, 0),
-            isPrimary : defaultValue(options.isPrimary, 0)
-        });
+        if (FeatureDetection.isInternetExplorer()) {
+            var canBubble = defaultValue(options.canBubble, true);
+            var cancelable = defaultValue(options.cancelable, true);
+            var view = defaultValue(options.view, window);
+            var detail = defaultValue(options.detail, 0);
+            var screenX = defaultValue(options.screenX, 0);
+            var screenY = defaultValue(options.screenY, 0);
+            var clientX = defaultValue(options.clientX, 0);
+            var clientY = defaultValue(options.clientY, 0);
+            var ctrlKey = defaultValue(options.ctrlKey, false);
+            var altKey = defaultValue(options.altKey, false);
+            var shiftKey = defaultValue(options.shiftKey, false);
+            var metaKey = defaultValue(options.metaKey, false);
+            var button = defaultValue(options.button, 0);
+            var relatedTarget = defaultValue(options.relatedTarget, null);
+            var offsetX = defaultValue(options.offsetX, 0);
+            var offsetY = defaultValue(options.offsetY, 0);
+            var width = defaultValue(options.width, 0);
+            var height = defaultValue(options.height, 0);
+            var pressure = defaultValue(options.pressure, 0);
+            var rotation = defaultValue(options.rotation, 0);
+            var tiltX = defaultValue(options.tiltX, 0);
+            var tiltY = defaultValue(options.tiltY, 0);
+            var pointerId = defaultValue(options.pointerId, 1);
+            var pointerType = defaultValue(options.pointerType, 0);
+            var hwTimestamp = defaultValue(options.hwTimestamp, 0);
+            var isPrimary = defaultValue(options.isPrimary, 0);
+
+            event = document.createEvent('PointerEvent');
+            event.initPointerEvent(type, canBubble, cancelable, view, detail, screenX, screenY, clientX, clientY,
+                    ctrlKey, altKey, shiftKey, metaKey, button, relatedTarget, offsetX, offsetY, width, height,
+                    pressure, rotation, tiltX, tiltY, pointerId, pointerType, hwTimestamp, isPrimary);
+        } else {
+            event = new window.PointerEvent(type, {
+                canBubble : defaultValue(options.canBubble, true),
+                cancelable : defaultValue(options.cancelable, true),
+                view : defaultValue(options.view, window),
+                detail : defaultValue(options.detail, 0),
+                screenX : defaultValue(options.screenX, 0),
+                screenY : defaultValue(options.screenY, 0),
+                clientX : defaultValue(options.clientX, 0),
+                clientY : defaultValue(options.clientY, 0),
+                ctrlKey : defaultValue(options.ctrlKey, false),
+                altKey : defaultValue(options.altKey, false),
+                shiftKey : defaultValue(options.shiftKey, false),
+                metaKey : defaultValue(options.metaKey, false),
+                button : defaultValue(options.button, 0),
+                relatedTarget : defaultValue(options.relatedTarget, null),
+                offsetX : defaultValue(options.offsetX, 0),
+                offsetY : defaultValue(options.offsetY, 0),
+                width : defaultValue(options.width, 0),
+                height : defaultValue(options.height, 0),
+                pressure : defaultValue(options.pressure, 0),
+                rotation : defaultValue(options.rotation, 0),
+                tiltX : defaultValue(options.tiltX, 0),
+                tiltY : defaultValue(options.tiltY, 0),
+                pointerId : defaultValue(options.pointerId, 1),
+                pointerType : defaultValue(options.pointerType, 0),
+                hwTimestamp : defaultValue(options.hwTimestamp, 0),
+                isPrimary : defaultValue(options.isPrimary, 0)
+            });
+        }
         return event;
     }
 


### PR DESCRIPTION
This should fix #4740.

This fixes the problem for Chrome, and seems to work in Firefox.  I believe this works in Edge but I haven't had a chance yet to copy the fix to a Win 10 box.

Note that this PR will break the tests in IE 11, which were previously working.  The breakage looks the same as what Chrome 55 does in master now.  I don't think IE is going to be upgraded to the new way of constructing pointer events.