### PR TITLE
Use depth-stencil for FXAA

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,7 +9,7 @@ Change Log
 * Fixed tooltips for gallery thumbnails in Sandcastle [#4702](https://github.com/AnalyticalGraphicsInc/cesium/pull/4702)
 * Fixed `Rectangle.union` to correctly account for rectangles that cross the IDL [#4732](https://github.com/AnalyticalGraphicsInc/cesium/pull/4732).
 * Fixed texture rotation for `RectangleGeometry` [#2737](https://github.com/AnalyticalGraphicsInc/cesium/issues/2737)
-* Fixed an bug that caused `GroundPrimitive` to render incorrectly. [#4747](https://github.com/AnalyticalGraphicsInc/cesium/pull/4747)
+* Fixed an bug that caused `GroundPrimitive` to render incorrectly on systems without the `WEBGL_depth_texture` extension. [#4747](https://github.com/AnalyticalGraphicsInc/cesium/pull/4747)
 
 ### 1.28 - 2016-12-01
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@ Change Log
 * Fixed tooltips for gallery thumbnails in Sandcastle [#4702](https://github.com/AnalyticalGraphicsInc/cesium/pull/4702)
 * Fixed `Rectangle.union` to correctly account for rectangles that cross the IDL [#4732](https://github.com/AnalyticalGraphicsInc/cesium/pull/4732).
 * Fixed texture rotation for `RectangleGeometry` [#2737](https://github.com/AnalyticalGraphicsInc/cesium/issues/2737)
+* Fixed an bug that caused `GroundPrimitive` to render incorrectly. [#4747](https://github.com/AnalyticalGraphicsInc/cesium/pull/4747)
 
 ### 1.28 - 2016-12-01
 

--- a/Source/Renderer/Context.js
+++ b/Source/Renderer/Context.js
@@ -193,6 +193,7 @@ define([
 
         // Override select WebGL defaults
         webglOptions.alpha = defaultValue(webglOptions.alpha, false); // WebGL default is true
+        webglOptions.stencil = defaultValue(webglOptions.stencil, true); // WebGL default is false
 
         var defaultToWebgl2 = false;
         var webgl2Supported = (typeof WebGL2RenderingContext !== 'undefined');

--- a/Source/Scene/FXAA.js
+++ b/Source/Scene/FXAA.js
@@ -36,8 +36,8 @@ define([
      */
     function FXAA(context) {
         this._texture = undefined;
-        this._depthTexture = undefined;
-        this._depthRenderbuffer = undefined;
+        this._depthStencilTexture = undefined;
+        this._depthStencilRenderbuffer = undefined;
         this._fbo = undefined;
         this._command = undefined;
 
@@ -55,13 +55,13 @@ define([
     function destroyResources(fxaa) {
         fxaa._fbo = fxaa._fbo && fxaa._fbo.destroy();
         fxaa._texture = fxaa._texture && fxaa._texture.destroy();
-        fxaa._depthTexture = fxaa._depthTexture && fxaa._depthTexture.destroy();
-        fxaa._depthRenderbuffer = fxaa._depthRenderbuffer && fxaa._depthRenderbuffer.destroy();
+        fxaa._depthStencilTexture = fxaa._depthStencilTexture && fxaa._depthStencilTexture.destroy();
+        fxaa._depthStencilRenderbuffer = fxaa._depthStencilRenderbuffer && fxaa._depthStencilRenderbuffer.destroy();
 
         fxaa._fbo = undefined;
         fxaa._texture = undefined;
-        fxaa._depthTexture = undefined;
-        fxaa._depthRenderbuffer = undefined;
+        fxaa._depthStencilTexture = undefined;
+        fxaa._depthStencilRenderbuffer = undefined;
 
         if (defined(fxaa._command)) {
             fxaa._command.shaderProgram = fxaa._command.shaderProgram && fxaa._command.shaderProgram.destroy();
@@ -77,8 +77,8 @@ define([
         var textureChanged = !defined(fxaaTexture) || fxaaTexture.width !== width || fxaaTexture.height !== height;
         if (textureChanged) {
             this._texture = this._texture && this._texture.destroy();
-            this._depthTexture = this._depthTexture && this._depthTexture.destroy();
-            this._depthRenderbuffer = this._depthRenderbuffer && this._depthRenderbuffer.destroy();
+            this._depthStencilTexture = this._depthStencilTexture && this._depthStencilTexture.destroy();
+            this._depthStencilRenderbuffer = this._depthStencilRenderbuffer && this._depthStencilRenderbuffer.destroy();
 
             this._texture = new Texture({
                 context : context,
@@ -88,20 +88,20 @@ define([
                 pixelDatatype : PixelDatatype.UNSIGNED_BYTE
             });
 
-            if (context.depthTexture) {
-                this._depthTexture = new Texture({
+            if (context.depthStencilTexture) {
+                this._depthStencilTexture = new Texture({
                     context : context,
                     width : width,
                     height : height,
-                    pixelFormat : PixelFormat.DEPTH_COMPONENT,
-                    pixelDatatype : PixelDatatype.UNSIGNED_SHORT
+                    pixelFormat : PixelFormat.DEPTH_STENCIL,
+                    pixelDatatype : PixelDatatype.UNSIGNED_INT_24_8
                 });
             } else {
-                this._depthRenderbuffer = new Renderbuffer({
+                this._depthStencilRenderbuffer = new Renderbuffer({
                     context : context,
                     width : width,
                     height : height,
-                    format : RenderbufferFormat.DEPTH_COMPONENT16
+                    format : RenderbufferFormat.DEPTH_STENCIL
                 });
             }
         }
@@ -112,8 +112,8 @@ define([
             this._fbo = new Framebuffer({
                 context : context,
                 colorTextures : [this._texture],
-                depthTexture : this._depthTexture,
-                depthRenderbuffer : this._depthRenderbuffer,
+                depthStencilTexture : this._depthStencilTexture,
+                depthStencilRenderbuffer : this._depthStencilRenderbuffer,
                 destroyAttachments : false
             });
         }


### PR DESCRIPTION
I finally discovered why stencil operations (ground primitives and silhouettes) were not working on my machine. Normally the globe depth fbo is the principal fbo for the scene, but when the depth texture extension is not supported the FXAA fbo is used. I needed to change the FXAA depth texture/renderbuffer to use depth-stencil instead.

This also explains how we got away with not passing in `stencil : true` to the WebGL context. Even if the default FBO is not initialized that way you can still create FBOs with stencil buffers. So when I turned off depth textures and fxaa, so as to use the default FBO, the ground primitives were in fact broken. I just copied some of the code from https://github.com/AnalyticalGraphicsInc/cesium/pull/4314 into here to deal with that.