### PR TITLE
Check for CESIUM_RTC_MODELVIEW in ModelInstanceCollection

### DIFF
--- a/Source/Scene/ModelInstanceCollection.js
+++ b/Source/Scene/ModelInstanceCollection.js
@@ -195,8 +195,9 @@ define([
         var instancedUniformsByProgram = {};
         collection._instancedUniformsByProgram = instancedUniformsByProgram;
 
-        var modelSemantics = ['MODEL', 'MODELVIEW', 'MODELVIEWPROJECTION', 'MODELINVERSE', 'MODELVIEWINVERSE', 'MODELVIEWPROJECTIONINVERSE', 'MODELINVERSETRANSPOSE', 'MODELVIEWINVERSETRANSPOSE'];
-        var supportedSemantics = ['MODELVIEW', 'MODELVIEWPROJECTION', 'MODELVIEWINVERSETRANSPOSE'];
+        //
+        var modelSemantics = ['MODEL', 'MODELVIEW', 'CESIUM_RTC_MODELVIEW', 'MODELVIEWPROJECTION', 'MODELINVERSE', 'MODELVIEWINVERSE', 'MODELVIEWPROJECTIONINVERSE', 'MODELINVERSETRANSPOSE', 'MODELVIEWINVERSETRANSPOSE'];
+        var supportedSemantics = ['MODELVIEW', 'CESIUM_RTC_MODELVIEW', 'MODELVIEWPROJECTION', 'MODELVIEWINVERSETRANSPOSE'];
 
         var gltf = collection._model.gltf;
         var techniques = gltf.techniques;
@@ -253,7 +254,7 @@ define([
                 if (instancedUniforms.hasOwnProperty(uniform)) {
                     var semantic = instancedUniforms[uniform];
                     var varName;
-                    if (semantic === 'MODELVIEW') {
+                    if (semantic === 'MODELVIEW' || semantic === 'CESIUM_RTC_MODELVIEW') {
                         varName = 'czm_instanced_modelView';
                     } else if (semantic === 'MODELVIEWPROJECTION') {
                         varName = 'czm_instanced_modelViewProjection';

--- a/Source/Scene/ModelInstanceCollection.js
+++ b/Source/Scene/ModelInstanceCollection.js
@@ -195,7 +195,7 @@ define([
         var instancedUniformsByProgram = {};
         collection._instancedUniformsByProgram = instancedUniformsByProgram;
 
-        //
+        // When using CESIUM_RTC_MODELVIEW the CESIUM_RTC center is ignored. Instances are always rendered relative-to-center.
         var modelSemantics = ['MODEL', 'MODELVIEW', 'CESIUM_RTC_MODELVIEW', 'MODELVIEWPROJECTION', 'MODELINVERSE', 'MODELVIEWINVERSE', 'MODELVIEWPROJECTIONINVERSE', 'MODELINVERSETRANSPOSE', 'MODELVIEWINVERSETRANSPOSE'];
         var supportedSemantics = ['MODELVIEW', 'CESIUM_RTC_MODELVIEW', 'MODELVIEWPROJECTION', 'MODELVIEWINVERSETRANSPOSE'];
 


### PR DESCRIPTION
For #3241 

The actual RTC_CENTER is ignored since instances are always rendered relative-to-center.