### PR TITLE
3D Tiles - Ternary Functions (fixed)

### DIFF
--- a/Apps/Sandcastle/gallery/3D Tiles Point Cloud Styling.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Point Cloud Styling.html
@@ -134,6 +134,11 @@ addStyle('Min and Max', {
     pointSize : "5"
 });
 
+addStyle('Clamp and Mix', {
+    color : "clamp(color(), 0.0, 100.0)",
+    pointSize : "mix(0.0, 2.0, 0.5) * 5"
+});
+
 addStyle('Secondary Color', {
     color : {
         expression : "[${secondaryColor}[0], ${secondaryColor}[1], ${secondaryColor}[2], 1.0]",

--- a/Apps/Sandcastle/gallery/3D Tiles Point Cloud Styling.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Point Cloud Styling.html
@@ -135,7 +135,7 @@ addStyle('Min and Max', {
 });
 
 addStyle('Clamp and Mix', {
-    color : "clamp(color(), 0.0, 100.0)",
+    color : "clamp(${temperature}, 0.1, 0.2)",
     pointSize : "mix(0.0, 2.0, 0.5) * 5"
 });
 

--- a/Apps/Sandcastle/gallery/3D Tiles Point Cloud Styling.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Point Cloud Styling.html
@@ -135,8 +135,8 @@ addStyle('Min and Max', {
 });
 
 addStyle('Clamp and Mix', {
-    color : "clamp(${temperature}, 0.1, 0.2)",
-    pointSize : "mix(0.0, 2.0, 0.5) * 5"
+    color : "color() * clamp(${temperature}, 0.1, 0.2)",
+    pointSize : "mix(${temperature}, 2.0, 0.5) * 0.2"
 });
 
 addStyle('Secondary Color', {

--- a/Source/Scene/Expression.js
+++ b/Source/Scene/Expression.js
@@ -384,7 +384,7 @@ define([
             return new Node(ExpressionNodeType.UNARY, call);
         } else if (defined(unaryFunctions[call])) {
             //>>includeStart('debug', pragmas.debug);
-            if (args.length < 1 || args.length > 1) {
+            if (args.length !== 1) {
                 throw new DeveloperError('Error: ' + call + ' requires exactly one argument.');
             }
             //>>includeEnd('debug');
@@ -392,7 +392,7 @@ define([
             return new Node(ExpressionNodeType.UNARY, call, val);
         } else if (defined(binaryFunctions[call])) {
             //>>includeStart('debug', pragmas.debug);
-            if (args.length < 2 || args.length > 2) {
+            if (args.length !== 2) {
                 throw new DeveloperError('Error: ' + call + ' requires exactly two arguments.');
             }
             //>>includeEnd('debug');
@@ -401,7 +401,7 @@ define([
             return new Node(ExpressionNodeType.BINARY, call, left, right);
         } else if (defined(ternaryFunctions[call])) {
             //>>includeStart('debug', pragmas.debug);
-            if (args.length < 3 || args.length > 3) {
+            if (args.length !== 3) {
                 throw new DeveloperError('Error: ' + call + ' requires exactly three arguments.');
             }
             //>>includeEnd('debug');
@@ -614,14 +614,14 @@ define([
                 node.evaluate = node._evaluateIsClass;
             } else if (node._value === 'getExactClassName') {
                 node.evaluate = node._evaluategetExactClassName;
-            } else if (defined(unaryFunctions[node._value])) {
-                node.evaluate = getEvaluateUnaryFunction(node._value);
             } else if (node._value === 'Boolean') {
                 node.evaluate = node._evaluateBooleanConversion;
             } else if (node._value === 'Number') {
                 node.evaluate = node._evaluateNumberConversion;
             } else if (node._value === 'String') {
                 node.evaluate = node._evaluateStringConversion;
+            } else if (defined(unaryFunctions[node._value])) {
+                node.evaluate = getEvaluateUnaryFunction(node._value);
             }
         } else if (node._type === ExpressionNodeType.BINARY) {
             if (node._value === '+') {
@@ -1241,14 +1241,14 @@ define([
                     return 'bool(' + left + ')';
                 } else if (value === 'Number') {
                     return 'float(' + left + ')';
-                } else if (defined(unaryFunctions[value])) {
-                    return value + '(' + left + ')';
                 } else if (value === 'abs') {
                     return 'abs(' + left + ')';
                 } else if (value === 'cos') {
                     return 'cos(' + left + ')';
                 } else if (value === 'sqrt') {
                     return 'sqrt(' + left + ')';
+                } else if (defined(unaryFunctions[value])) {
+                    return value + '(' + left + ')';
                 }
                 //>>includeStart('debug', pragmas.debug);
                 else if ((value === 'isNaN') || (value === 'isFinite') || (value === 'String') || (value === 'isExactClass') || (value === 'isClass') || (value === 'getExactClassName')) {

--- a/Source/Scene/ExpressionNodeType.js
+++ b/Source/Scene/ExpressionNodeType.js
@@ -1,8 +1,8 @@
 /*global define*/
 define([
-    '../Core/freezeObject'
+        '../Core/freezeObject'
 ], function(
-    freezeObject) {
+        freezeObject) {
     'use strict';
 
     /**

--- a/Source/Scene/ExpressionNodeType.js
+++ b/Source/Scene/ExpressionNodeType.js
@@ -1,8 +1,8 @@
 /*global define*/
 define([
-        '../Core/freezeObject'
-    ], function(
-        freezeObject) {
+    '../Core/freezeObject'
+], function(
+    freezeObject) {
     'use strict';
 
     /**
@@ -12,20 +12,21 @@ define([
         VARIABLE : 0,
         UNARY : 1,
         BINARY : 2,
-        CONDITIONAL : 3,
-        MEMBER : 4,
-        FUNCTION_CALL : 5,
-        ARRAY : 6,
-        REGEX: 7,
-        VARIABLE_IN_STRING : 8,
-        LITERAL_NULL : 9,
-        LITERAL_BOOLEAN : 10,
-        LITERAL_NUMBER : 11,
-        LITERAL_STRING : 12,
-        LITERAL_COLOR : 13,
-        LITERAL_REGEX : 14,
-        LITERAL_UNDEFINED : 15,
-        LITERAL_GLOBAL : 16
+        TERNARY : 3,
+        CONDITIONAL : 4,
+        MEMBER : 5,
+        FUNCTION_CALL : 6,
+        ARRAY : 7,
+        REGEX: 8,
+        VARIABLE_IN_STRING : 9,
+        LITERAL_NULL : 10,
+        LITERAL_BOOLEAN : 11,
+        LITERAL_NUMBER : 12,
+        LITERAL_STRING : 13,
+        LITERAL_COLOR : 14,
+        LITERAL_REGEX : 15,
+        LITERAL_UNDEFINED : 16,
+        LITERAL_GLOBAL : 17
     };
 
     return freezeObject(ExpressionNodeType);

--- a/Specs/Scene/ExpressionSpec.js
+++ b/Specs/Scene/ExpressionSpec.js
@@ -1064,6 +1064,58 @@ defineSuite([
         }).toThrowDeveloperError();
     });
 
+    it('evaluates clamp function', function() {
+        var expression = new Expression('clamp(50.0, 0.0, 100.0)');
+        expect(expression.evaluate(frameState, undefined)).toEqual(50.0);
+
+        expression = new Expression('clamp(50.0, 0.0, 25.0)');
+        expect(expression.evaluate(frameState, undefined)).toEqual(25.0);
+
+        expression = new Expression('clamp(50.0, 75.0, 100.0)');
+        expect(expression.evaluate(frameState, undefined)).toEqual(75.0);
+    });
+
+    it('throws if clamp function takes an invalid number of arguments', function() {
+        expect(function() {
+            return new Expression('clamp()');
+        }).toThrowDeveloperError();
+
+        expect(function() {
+            return new Expression('clamp(1)');
+        }).toThrowDeveloperError();
+
+        expect(function() {
+            return new Expression('clamp(1, 2)');
+        }).toThrowDeveloperError();
+
+        expect(function() {
+            return new Expression('clamp(1, 2, 3, 4)');
+        }).toThrowDeveloperError();
+    });
+
+    it('evaluates mix function', function() {
+        var expression = new Expression('mix(0.0, 2.0, 0.5)');
+        expect(expression.evaluate(frameState, undefined)).toEqual(1.0);
+    });
+
+    it('throws if mix function takes an invalid number of arguments', function() {
+        expect(function() {
+            return new Expression('mix()');
+        }).toThrowDeveloperError();
+
+        expect(function() {
+            return new Expression('mix(1)');
+        }).toThrowDeveloperError();
+
+        expect(function() {
+            return new Expression('mix(1, 2)');
+        }).toThrowDeveloperError();
+
+        expect(function() {
+            return new Expression('mix(1, 2, 3, 4)');
+        }).toThrowDeveloperError();
+    });
+
     it('evaluates atan2 function', function() {
         var expression = new Expression('atan2(0,1)');
         expect(expression.evaluate(frameState, undefined)).toEqualEpsilon(0.0, CesiumMath.EPSILON10);
@@ -1952,6 +2004,20 @@ defineSuite([
         var expression = new Expression('sqrt(1.0)');
         var shaderExpression = expression.getShaderExpression('', {});
         var expected = 'sqrt(1.0)';
+        expect(shaderExpression).toEqual(expected);
+    });
+
+    it('gets shader expression for clamp', function() {
+        var expression = new Expression('clamp(50.0, 0.0, 100.0)');
+        var shaderExpression = expression.getShaderExpression('', {});
+        var expected = 'clamp(50.0, 0.0, 100.0)';
+        expect(shaderExpression).toEqual(expected);
+    });
+
+    it('gets shader expression for mix', function() {
+        var expression = new Expression('mix(0.0, 2.0, 0.5)');
+        var shaderExpression = expression.getShaderExpression('', {});
+        var expected = 'mix(0.0, 2.0, 0.5)';
         expect(shaderExpression).toEqual(expected);
     });
 


### PR DESCRIPTION
Previously, I had incorrectly merged into my branch from master in #4709, for issue #4694. This PR is even with the 3d-tiles branch, except the changes I had made for the ternary functions, and so the files changed should reflect only the 4 I changed. Implemented in this PR are the mix and clamp functions  for the 3d-tiles styling language. @lilleyse 