### PR TITLE
Firefox OIT fix

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,7 @@ Change Log
 * Added `WebGLConstants` enum.  Previously, this was part of the private Renderer API. [#4731](https://github.com/AnalyticalGraphicsInc/cesium/pull/4731)
 * Fixed an bug that caused `GroundPrimitive` to render incorrectly on systems without the `WEBGL_depth_texture` extension. [#4747](https://github.com/AnalyticalGraphicsInc/cesium/pull/4747)
 * Fixed default Mapbox token and added a watermark to notify users that they need to sign up for their own token.
+* Fixed translucency in Firefox 50. https://github.com/AnalyticalGraphicsInc/cesium/pull/4762
 
 ### 1.28 - 2016-12-01
 

--- a/Source/Scene/FXAA.js
+++ b/Source/Scene/FXAA.js
@@ -88,7 +88,7 @@ define([
                 pixelDatatype : PixelDatatype.UNSIGNED_BYTE
             });
 
-            if (context.depthStencilTexture) {
+            if (context.depthTexture) {
                 this._depthStencilTexture = new Texture({
                     context : context,
                     width : width,

--- a/Source/Scene/OIT.js
+++ b/Source/Scene/OIT.js
@@ -113,19 +113,27 @@ define([
     function updateTextures(oit, context, width, height) {
         destroyTextures(oit);
 
+        var source = new Float32Array(width * height * 4);
+
         oit._accumulationTexture = new Texture({
             context : context,
-            width : width,
-            height : height,
             pixelFormat : PixelFormat.RGBA,
-            pixelDatatype : PixelDatatype.FLOAT
+            pixelDatatype : PixelDatatype.FLOAT,
+            source : {
+                arrayBufferView : source,
+                width : width,
+                height : height
+            }
         });
         oit._revealageTexture = new Texture({
             context : context,
-            width : width,
-            height : height,
             pixelFormat : PixelFormat.RGBA,
-            pixelDatatype : PixelDatatype.FLOAT
+            pixelDatatype : PixelDatatype.FLOAT,
+            source : {
+                arrayBufferView : source,
+                width : width,
+                height : height
+            }
         });
     }
 

--- a/Source/Scene/OIT.js
+++ b/Source/Scene/OIT.js
@@ -113,6 +113,8 @@ define([
     function updateTextures(oit, context, width, height) {
         destroyTextures(oit);
 
+        // Use zeroed arraybuffer instead of null to initialize texture
+        // to workaround Firefox 50. https://github.com/AnalyticalGraphicsInc/cesium/pull/4762
         var source = new Float32Array(width * height * 4);
 
         oit._accumulationTexture = new Texture({


### PR DESCRIPTION
Fixes https://github.com/AnalyticalGraphicsInc/cesium/issues/4658

There seems to be an issue where a texture that is not initialized with a source and is bound to an FBO color attachment (besides the 0th) cannot be rendered to correctly.

So instead of passing `null` to `pixels` I pass in an empty array buffer.

I consider this just a workaround until the actual bug is fixed. I have a small test case that is displaying the same issue so I'm going to file a Firefox bug.