### PR TITLE
Rename Check.typeOf.function -> Check.typeOf.func

### DIFF
--- a/Source/Core/Check.js
+++ b/Source/Core/Check.js
@@ -88,7 +88,7 @@ define([
      * @param {String} name The name of the variable being tested
      * @exception {DeveloperError} test must be typeof 'function'
      */
-    Check.typeOf.function = function (test, name) {
+    Check.typeOf.func = function (test, name) {
         if (typeof test !== 'function') {
             throw new DeveloperError(getFailedTypeErrorMessage(typeof test, 'function', name));
         }

--- a/Specs/Core/CheckSpec.js
+++ b/Specs/Core/CheckSpec.js
@@ -30,27 +30,27 @@ defineSuite([
             }).toThrowDeveloperError();
         });
 
-        it('Check.typeOf.function does not throw when passed a function', function () {
+        it('Check.typeOf.func does not throw when passed a function', function () {
             expect(function () {
-                Check.typeOf.function(function () {return true;}, 'mockName');
+                Check.typeOf.func(function () {return true;}, 'mockName');
             }).not.toThrowDeveloperError();
         });
 
-        it('Check.typeOf.function throws when passed a non-function', function () {
+        it('Check.typeOf.func throws when passed a non-function', function () {
             expect(function () {
-                Check.typeOf.function({}, 'mockName');
+                Check.typeOf.func({}, 'mockName');
             }).toThrowDeveloperError();
             expect(function () {
-                Check.typeOf.function([], 'mockName');
+                Check.typeOf.func([], 'mockName');
             }).toThrowDeveloperError();
             expect(function () {
-                Check.typeOf.function(1, 'mockName');
+                Check.typeOf.func(1, 'mockName');
             }).toThrowDeveloperError();
             expect(function () {
-                Check.typeOf.function('snth', 'mockName');
+                Check.typeOf.func('snth', 'mockName');
             }).toThrowDeveloperError();
             expect(function () {
-                Check.typeOf.function(true, 'mockName');
+                Check.typeOf.func(true, 'mockName');
             }).toThrowDeveloperError();
         });
 


### PR DESCRIPTION
Fixes #4796 by avoiding replacing `function` with `func`.