### PR TITLE
Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+# http://editorconfig.org
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.scss]
+indent_size = 2

--- a/.editorconfig
+++ b/.editorconfig
@@ -10,6 +10,3 @@ insert_final_newline = true
 
 [*.md]
 trim_trailing_whitespace = false
-
-[*.scss]
-indent_size = 2


### PR DESCRIPTION
[editorconfig](http://editorconfig.org/) tells supporting editors how to format files (e.g. use 4 spaces for indentation instead of tabs).  Lots of editors (including WebStorm) support it out of the box (http://editorconfig.org/#download) and others support it with a plugin.

I just copied the one we've been using for awhile in terriajs, and removed the scss rule since Cesium doesn't use scss.  It doesn't do much, but what it does do should be uncontroversial.  A lot more tweaking can be done, of course, if desired.