### PR TITLE
Fix LabelCollection CV bounding sphere test

### DIFF
--- a/Specs/Scene/LabelCollectionSpec.js
+++ b/Specs/Scene/LabelCollectionSpec.js
@@ -1739,7 +1739,7 @@ defineSuite([
         var expected = BoundingSphere.fromPoints(projectedPositions);
         expected.center = new Cartesian3(0.0, expected.center.x, expected.center.y);
         expect(actual.center).toEqualEpsilon(expected.center, CesiumMath.EPSILON8);
-        expect(actual.radius).toBeGreaterThan(expected.radius);
+        expect(actual.radius).not.toBeLessThan(expected.radius);
     });
 
     it('computes bounding sphere in 2D', function() {


### PR DESCRIPTION
Fixes #4566.

@bagnell can you please confirm this is not masking an actual bug?

To reproduce the failure, run
```
npm run release
npm run test -- --browsers Electron --release --suppressPassed
```
in `master`, then do the same in this branch.

There are other test failures in this configuration, some or maybe all of which may be fixed in the `webgl-mock-for-tests` branch.