### PR TITLE
Billboards from KMLs aren't shown

### DIFF
--- a/Source/DataSources/KmlDataSource.js
+++ b/Source/DataSources/KmlDataSource.js
@@ -487,7 +487,7 @@ define([
     var colorOptions = {};
 
     function parseColorString(value, isRandom) {
-        if (!defined(value)) {
+        if (!defined(value) || value === '') {
             return undefined;
         }
 


### PR DESCRIPTION
Some KMLs has empty color string for PlaceMarks style. In that case color parsed in Cesium `NaN, NaN, NaN, NaN` and Billboard wasn't visible.