### PR TITLE
Rename check function ('boolean' -> 'bool')

### DIFF
--- a/Source/Core/Check.js
+++ b/Source/Core/Check.js
@@ -1,14 +1,10 @@
 /*global define*/
 define([
-    './defaultValue',
     './defined',
-    './DeveloperError',
-    './isArray'
+    './DeveloperError'
     ], function(
-        defaultValue,
         defined,
-        DeveloperError,
-        isArray) {
+        DeveloperError) {
     'use strict';
 
     /**

--- a/Source/Core/Check.js
+++ b/Source/Core/Check.js
@@ -136,7 +136,7 @@ define([
      * @param {String} name The name of the variable being tested
      * @exception {DeveloperError} test must be typeof 'boolean'
      */
-    Check.typeOf.boolean = function (test, name) {
+    Check.typeOf.bool = function (test, name) {
         if (typeof test !== 'boolean') {
             throw new DeveloperError(getFailedTypeErrorMessage(typeof test, 'boolean', name));
         }

--- a/Specs/Core/CheckSpec.js
+++ b/Specs/Core/CheckSpec.js
@@ -6,27 +6,27 @@ defineSuite([
     'use strict';
 
     describe('type checks', function () {
-        it('Check.typeOf.boolean does not throw when passed a boolean', function () {
+        it('Check.typeOf.bool does not throw when passed a boolean', function () {
             expect(function () {
-                Check.typeOf.boolean(true);
+                Check.typeOf.bool(true);
             }).not.toThrowDeveloperError();
         });
 
         it('Check.typeOf.boolean throws when passed a non-boolean', function () {
             expect(function () {
-                Check.typeOf.boolean({}, 'mockName');
+                Check.typeOf.bool({}, 'mockName');
             }).toThrowDeveloperError();
             expect(function () {
-                Check.typeOf.boolean([], 'mockName');
+                Check.typeOf.bool([], 'mockName');
             }).toThrowDeveloperError();
             expect(function () {
-                Check.typeOf.boolean(1, 'mockName');
+                Check.typeOf.bool(1, 'mockName');
             }).toThrowDeveloperError();
             expect(function () {
-                Check.typeOf.boolean('snth', 'mockName');
+                Check.typeOf.bool('snth', 'mockName');
             }).toThrowDeveloperError();
             expect(function () {
-                Check.typeOf.boolean(function () {return true;}, 'mockName');
+                Check.typeOf.bool(function () {return true;}, 'mockName');
             }).toThrowDeveloperError();
         });
 


### PR DESCRIPTION
Fixes an issue with older build tools that fail when keywords reserved in earlier ES specs are used.

Issue described in #4726.