### PR TITLE
KML empty string for color

### DIFF
--- a/Source/DataSources/KmlDataSource.js
+++ b/Source/DataSources/KmlDataSource.js
@@ -487,7 +487,7 @@ define([
     var colorOptions = {};
 
     function parseColorString(value, isRandom) {
-        if (!defined(value)) {
+        if (!defined(value) || /^\s*$/gm.test(value)) {
             return undefined;
         }
 

--- a/Specs/DataSources/KmlDataSourceSpec.js
+++ b/Specs/DataSources/KmlDataSourceSpec.js
@@ -1014,6 +1014,23 @@ defineSuite([
         });
     });
 
+    it('Styles: empty color', function() {
+        CesiumMath.setRandomNumberSeed(0);
+
+        var kml = '<?xml version="1.0" encoding="UTF-8"?>\
+            <Placemark>\
+              <Style>\
+                  <IconStyle>\
+                      <color></color>\
+                  </IconStyle>\
+              </Style>\
+            </Placemark>';
+
+        return KmlDataSource.load(parser.parseFromString(kml, "text/xml"), options).then(function(dataSource) {
+            expect(dataSource.entities.values[0].billboard.color).toBeUndefined();
+        });
+    });
+
     it('Styles: Applies expected styles to Point geometry', function() {
         var kml = '<?xml version="1.0" encoding="UTF-8"?>\
         <Document xmlns="http://www.opengis.net/kml/2.2"\


### PR DESCRIPTION
Replaces #4821

> Some KMLs has empty color string for PlaceMarks style. In that case color parsed in Cesium NaN, NaN, NaN, NaN and Billboard wasn't visible.