### PR TITLE
Typo in sandcastle CZML demo

### DIFF
--- a/Apps/Sandcastle/gallery/CZML.html
+++ b/Apps/Sandcastle/gallery/CZML.html
@@ -42,8 +42,7 @@ Sandcastle.addToolbarButton('Vehicle', function() {
     viewer.scene.camera.setView({
         destination:  Cesium.Cartesian3.fromDegrees(-116.52, 35.02, 95000),
         orientation: {
-            heading: 6,
-            picth: -Cesium.Math.PI_OVER_TWO
+            heading: 6
         }
     });
 });


### PR DESCRIPTION
Got rid of `picth` because `-Cesium.Math.PI_OVER_TWO` is the default camera pitch for `setView` anyway