### PR TITLE
Fixes to JSDoc

### DIFF
--- a/Source/Core/Math.js
+++ b/Source/Core/Math.js
@@ -486,7 +486,7 @@ define([
             throw new DeveloperError('angle is required.');
         }
         //>>includeEnd('debug');
-        
+
         return CesiumMath.clamp(angle, -1*CesiumMath.PI_OVER_TWO, CesiumMath.PI_OVER_TWO);
     };
 
@@ -496,13 +496,13 @@ define([
      * @param {Number} angle in radians
      * @returns {Number} The angle in the range [<code>-CesiumMath.PI</code>, <code>CesiumMath.PI</code>].
      */
-    CesiumMath.negativePiToPi = function(x) {
+    CesiumMath.negativePiToPi = function(angle) {
         //>>includeStart('debug', pragmas.debug);
-        if (!defined(x)) {
-            throw new DeveloperError('x is required.');
+        if (!defined(angle)) {
+            throw new DeveloperError('angle is required.');
         }
         //>>includeEnd('debug');
-        return CesiumMath.zeroToTwoPi(x + CesiumMath.PI) - CesiumMath.PI;
+        return CesiumMath.zeroToTwoPi(angle + CesiumMath.PI) - CesiumMath.PI;
     };
 
     /**
@@ -511,14 +511,14 @@ define([
      * @param {Number} angle in radians
      * @returns {Number} The angle in the range [0, <code>CesiumMath.TWO_PI</code>].
      */
-    CesiumMath.zeroToTwoPi = function(x) {
+    CesiumMath.zeroToTwoPi = function(angle) {
         //>>includeStart('debug', pragmas.debug);
-        if (!defined(x)) {
-            throw new DeveloperError('x is required.');
+        if (!defined(angle)) {
+            throw new DeveloperError('angle is required.');
         }
         //>>includeEnd('debug');
-        var mod = CesiumMath.mod(x, CesiumMath.TWO_PI);
-        if (Math.abs(mod) < CesiumMath.EPSILON14 && Math.abs(x) > CesiumMath.EPSILON14) {
+        var mod = CesiumMath.mod(angle, CesiumMath.TWO_PI);
+        if (Math.abs(mod) < CesiumMath.EPSILON14 && Math.abs(angle) > CesiumMath.EPSILON14) {
             return CesiumMath.TWO_PI;
         }
         return mod;
@@ -592,7 +592,7 @@ define([
      * @example
      * //Compute 7!, which is equal to 5040
      * var computedFactorial = Cesium.Math.factorial(7);
-     * 
+     *
      * @see {@link http://en.wikipedia.org/wiki/Factorial|Factorial on Wikipedia}
      */
     CesiumMath.factorial = function(n) {

--- a/Source/Core/Matrix2.js
+++ b/Source/Core/Matrix2.js
@@ -106,18 +106,18 @@ define([
      * @param {Matrix2} [result] The object onto which to store the result.
      * @returns {Matrix2} The modified result parameter or a new Matrix2 instance if one was not provided. (Returns undefined if matrix is undefined)
      */
-    Matrix2.clone = function(values, result) {
-        if (!defined(values)) {
+    Matrix2.clone = function(matrix, result) {
+        if (!defined(matrix)) {
             return undefined;
         }
         if (!defined(result)) {
-            return new Matrix2(values[0], values[2],
-                               values[1], values[3]);
+            return new Matrix2(matrix[0], matrix[2],
+                               matrix[1], matrix[3]);
         }
-        result[0] = values[0];
-        result[1] = values[1];
-        result[2] = values[2];
-        result[3] = values[3];
+        result[0] = matrix[0];
+        result[1] = matrix[1];
+        result[2] = matrix[2];
+        result[3] = matrix[3];
         return result;
     };
 

--- a/Source/Core/Matrix3.js
+++ b/Source/Core/Matrix3.js
@@ -131,24 +131,24 @@ define([
      * @param {Matrix3} [result] The object onto which to store the result.
      * @returns {Matrix3} The modified result parameter or a new Matrix3 instance if one was not provided. (Returns undefined if matrix is undefined)
      */
-    Matrix3.clone = function(values, result) {
-        if (!defined(values)) {
+    Matrix3.clone = function(matrix, result) {
+        if (!defined(matrix)) {
             return undefined;
         }
         if (!defined(result)) {
-            return new Matrix3(values[0], values[3], values[6],
-                               values[1], values[4], values[7],
-                               values[2], values[5], values[8]);
+            return new Matrix3(matrix[0], matrix[3], matrix[6],
+                               matrix[1], matrix[4], matrix[7],
+                               matrix[2], matrix[5], matrix[8]);
         }
-        result[0] = values[0];
-        result[1] = values[1];
-        result[2] = values[2];
-        result[3] = values[3];
-        result[4] = values[4];
-        result[5] = values[5];
-        result[6] = values[6];
-        result[7] = values[7];
-        result[8] = values[8];
+        result[0] = matrix[0];
+        result[1] = matrix[1];
+        result[2] = matrix[2];
+        result[3] = matrix[3];
+        result[4] = matrix[4];
+        result[5] = matrix[5];
+        result[6] = matrix[6];
+        result[7] = matrix[7];
+        result[8] = matrix[8];
         return result;
     };
 
@@ -420,7 +420,7 @@ define([
     /**
      * Computes a Matrix3 instance representing the cross product equivalent matrix of a Cartesian3 vector.
      *
-     * @param {Cartesian3} the vector on the left hand side of the cross product operation.
+     * @param {Cartesian3} vector the vector on the left hand side of the cross product operation.
      * @param {Matrix3} [result] The object in which the result will be stored, if undefined a new instance will be created.
      * @returns {Matrix3} The modified result parameter, or a new Matrix3 instance if one was not provided.
      *


### PR DESCRIPTION
This is a part of #4530.

This is just the start of this correction with more fixes to come. The 3 commits push fix 10 out of 168 warnings, so a long way to go.

Note: The changes may include some `block tab` -> `space` conversions, or removes trailing whitespaces.

**Question: There are some warning in `Source/ThirdParty`, should we fix this too?**

Once I get feedback on how to take this forward, I'll just keep going onto more files.