### PR TITLE
Cleanup Source directory for JSDoc warnings

### DIFF
--- a/Source/Core/BingMapsGeocoderService.js
+++ b/Source/Core/BingMapsGeocoderService.js
@@ -25,8 +25,7 @@ define([
      * @constructor
      *
      * @param {Object} options Object with the following properties:
-     * @param {String} [key] A key to use with the Bing Maps geocoding service
-     * @param {Boolean} autoComplete Indicates whether this service shall be used to fetch auto-complete suggestions
+     * @param {String} [options.key] A key to use with the Bing Maps geocoding service
      */
     function BingMapsGeocoderService(options) {
         options = defaultValue(options, defaultValue.EMPTY_OBJECT);

--- a/Source/Core/Credit.js
+++ b/Source/Core/Credit.js
@@ -147,7 +147,7 @@ define([
     /**
      * Returns true if the credits are equal
      *
-     * @param {Credit} credits The credit to compare to.
+     * @param {Credit} credit The credit to compare to.
      * @returns {Boolean} <code>true</code> if left and right are equal, <code>false</code> otherwise.
      */
     Credit.prototype.equals = function(credit) {

--- a/Source/Core/Ellipsoid.js
+++ b/Source/Core/Ellipsoid.js
@@ -208,7 +208,9 @@ define([
     /**
      * Computes an Ellipsoid from a Cartesian specifying the radii in x, y, and z directions.
      *
-     * @param {Cartesian3} [radii=Cartesian3.ZERO] The ellipsoid's radius in the x, y, and z directions.
+     * @param {Cartesian3} [cartesian=Cartesian3.ZERO] The ellipsoid's radius in the x, y, and z directions.
+     * @param {Ellipsoid} [result] The object onto which to store the result, or undefined if a new
+     *                    instance should be created.
      * @returns {Ellipsoid} A new Ellipsoid instance.
      *
      * @exception {DeveloperError} All radii components must be greater than or equal to zero.

--- a/Source/Core/EllipsoidGeodesic.js
+++ b/Source/Core/EllipsoidGeodesic.js
@@ -337,6 +337,7 @@ define([
      * Provides the location of a point at the indicated portion along the geodesic.
      *
      * @param {Number} fraction The portion of the distance between the initial and final points.
+     * @param {Cartographic} result The object in which to store the result.
      * @returns {Cartographic} The location of the point along the geodesic.
      */
     EllipsoidGeodesic.prototype.interpolateUsingFraction = function(fraction, result) {
@@ -347,6 +348,7 @@ define([
      * Provides the location of a point at the indicated distance along the geodesic.
      *
      * @param {Number} distance The distance from the inital point to the point of interest along the geodesic
+     * @param {Cartographic} result The object in which to store the result.
      * @returns {Cartographic} The location of the point along the geodesic.
      *
      * @exception {DeveloperError} start and end must be set before calling function interpolateUsingSurfaceDistance

--- a/Source/Core/OrientedBoundingBox.js
+++ b/Source/Core/OrientedBoundingBox.js
@@ -199,6 +199,7 @@ define([
     /**
      * Computes an OrientedBoundingBox given extents in the east-north-up space of the tangent plane.
      *
+     * @param {Plane} tangentPlane The tangent place corresponding to east-north-up.
      * @param {Number} minimumX Minimum X extent in tangent plane space.
      * @param {Number} maximumX Maximum X extent in tangent plane space.
      * @param {Number} minimumY Minimum Y extent in tangent plane space.

--- a/Source/Core/PolylinePipeline.js
+++ b/Source/Core/PolylinePipeline.js
@@ -202,10 +202,10 @@ define([
 
     /**
      * Subdivides polyline and raises all points to the specified height.  Returns an array of numbers to represent the positions.
-     * @param {Cartesian3[]} positions The array of type {Cartesian3} representing positions.
-     * @param {Number|Number[]} [height=0.0] A number or array of numbers representing the heights of each position.
-     * @param {Number} [granularity = CesiumMath.RADIANS_PER_DEGREE] The distance, in radians, between each latitude and longitude. Determines the number of positions in the buffer.
-     * @param {Ellipsoid} [ellipsoid=Ellipsoid.WGS84] The ellipsoid on which the positions lie.
+     * @param {Cartesian3[]} options.positions The array of type {Cartesian3} representing positions.
+     * @param {Number|Number[]} [options.height=0.0] A number or array of numbers representing the heights of each position.
+     * @param {Number} [options.granularity = CesiumMath.RADIANS_PER_DEGREE] The distance, in radians, between each latitude and longitude. Determines the number of positions in the buffer.
+     * @param {Ellipsoid} [options.ellipsoid=Ellipsoid.WGS84] The ellipsoid on which the positions lie.
      * @returns {Number[]} A new array of positions of type {Number} that have been subdivided and raised to the surface of the ellipsoid.
      *
      * @example
@@ -289,10 +289,10 @@ define([
 
     /**
      * Subdivides polyline and raises all points to the specified height. Returns an array of new {Cartesian3} positions.
-     * @param {Cartesian3[]} positions The array of type {Cartesian3} representing positions.
-     * @param {Number|Number[]} [height=0.0] A number or array of numbers representing the heights of each position.
-     * @param {Number} [granularity = CesiumMath.RADIANS_PER_DEGREE] The distance, in radians, between each latitude and longitude. Determines the number of positions in the buffer.
-     * @param {Ellipsoid} [ellipsoid=Ellipsoid.WGS84] The ellipsoid on which the positions lie.
+     * @param {Cartesian3[]} options.positions The array of type {Cartesian3} representing positions.
+     * @param {Number|Number[]} [options.height=0.0] A number or array of numbers representing the heights of each position.
+     * @param {Number} [options.granularity = CesiumMath.RADIANS_PER_DEGREE] The distance, in radians, between each latitude and longitude. Determines the number of positions in the buffer.
+     * @param {Ellipsoid} [options.ellipsoid=Ellipsoid.WGS84] The ellipsoid on which the positions lie.
      * @returns {Cartesian3[]} A new array of cartesian3 positions that have been subdivided and raised to the surface of the ellipsoid.
      *
      * @example

--- a/Source/Core/Quaternion.js
+++ b/Source/Core/Quaternion.js
@@ -301,7 +301,7 @@ define([
      *
      * @param {Number[]} array The array previously packed for interpolation.
      * @param {Number[]} sourceArray The original packed array.
-     * @param {Number} [startingIndex=0] The startingIndex used to convert the array.
+     * @param {Number} [firstIndex=0] The firstIndex used to convert the array.
      * @param {Number} [lastIndex=packedArray.length] The lastIndex used to convert the array.
      * @param {Quaternion} [result] The object into which to store the result.
      * @returns {Quaternion} The modified result parameter or a new Quaternion instance if one was not provided.

--- a/Source/Core/Simon1994PlanetaryPositions.js
+++ b/Source/Core/Simon1994PlanetaryPositions.js
@@ -509,9 +509,9 @@ define([
      * @param {Cartesian3} [result] The object onto which to store the result.
      * @returns {Cartesian3} Calculated sun position
      */
-    Simon1994PlanetaryPositions.computeSunPositionInEarthInertialFrame= function(date, result){
-        if (!defined(date)) {
-            date = JulianDate.now();
+    Simon1994PlanetaryPositions.computeSunPositionInEarthInertialFrame= function(julianDate, result){
+        if (!defined(julianDate)) {
+            julianDate = JulianDate.now();
         }
 
         if (!defined(result)) {
@@ -519,11 +519,11 @@ define([
         }
 
         //first forward transformation
-        translation = computeSimonEarthMoonBarycenter(date, translation);
+        translation = computeSimonEarthMoonBarycenter(julianDate, translation);
         result = Cartesian3.negate(translation, result);
 
         //second forward transformation
-        computeSimonEarth(date, translation);
+        computeSimonEarth(julianDate, translation);
 
         Cartesian3.subtract(result, translation, result);
         Matrix3.multiplyByVector(axesTransformation, result, result);
@@ -538,12 +538,12 @@ define([
      * @param {Cartesian3} [result] The object onto which to store the result.
      * @returns {Cartesian3} Calculated moon position
      */
-    Simon1994PlanetaryPositions.computeMoonPositionInEarthInertialFrame = function(date, result){
-        if (!defined(date)) {
-            date = JulianDate.now();
+    Simon1994PlanetaryPositions.computeMoonPositionInEarthInertialFrame = function(julianDate, result){
+        if (!defined(julianDate)) {
+            julianDate = JulianDate.now();
         }
 
-        result = computeSimonMoon(date, result);
+        result = computeSimonMoon(julianDate, result);
         Matrix3.multiplyByVector(axesTransformation, result, result);
 
         return result;

--- a/Source/Core/Spherical.js
+++ b/Source/Core/Spherical.js
@@ -31,7 +31,7 @@ define([
      * Converts the provided Cartesian3 into Spherical coordinates.
      *
      * @param {Cartesian3} cartesian3 The Cartesian3 to be converted to Spherical.
-     * @param {Spherical} [spherical] The object in which the result will be stored, if undefined a new instance will be created.
+     * @param {Spherical} [result] The object in which the result will be stored, if undefined a new instance will be created.
      * @returns {Spherical} The modified result parameter, or a new instance if one was not provided.
      */
     Spherical.fromCartesian3 = function(cartesian3, result) {

--- a/Source/Core/TerrainMesh.js
+++ b/Source/Core/TerrainMesh.js
@@ -27,6 +27,7 @@ define([
       * @param {Number} [vertexStride=6] The number of components in each vertex.
       * @param {OrientedBoundingBox} [orientedBoundingBox] A bounding box that completely contains the tile.
       * @param {TerrainEncoding} encoding Information used to decode the mesh.
+      * @param {Number} exaggeration The amount that this mesh was exaggerated.
       *
       * @private
       */

--- a/Source/Core/TimeIntervalCollection.js
+++ b/Source/Core/TimeIntervalCollection.js
@@ -217,8 +217,8 @@ define([
      * @param {JulianDate} julianDate The date to check.
      * @returns {Boolean} <code>true</code> if the collection contains the specified date, <code>false</code> otherwise.
      */
-    TimeIntervalCollection.prototype.contains = function(date) {
-        return this.indexOf(date) >= 0;
+    TimeIntervalCollection.prototype.contains = function(julianDate) {
+        return this.indexOf(julianDate) >= 0;
     };
 
     var indexOfScratch = new TimeInterval();

--- a/Source/Core/VertexFormat.js
+++ b/Source/Core/VertexFormat.js
@@ -285,7 +285,7 @@ define([
     /**
      * Duplicates a VertexFormat instance.
      *
-     * @param {VertexFormat} cartesian The vertex format to duplicate.
+     * @param {VertexFormat} vertexFormat The vertex format to duplicate.
      * @param {VertexFormat} [result] The object onto which to store the result.
      * @returns {VertexFormat} The modified result parameter or a new VertexFormat instance if one was not provided. (Returns undefined if vertexFormat is undefined)
      */

--- a/Source/Core/getImagePixels.js
+++ b/Source/Core/getImagePixels.js
@@ -14,6 +14,8 @@ define([
      * @exports getImagePixels
      *
      * @param {Image} image The image to extract pixels from.
+     * @param {Number} width The width of the image. If not defined, then image.width is assigned.
+     * @param {Number} height The height of the image. If not defined, then image.height is assigned.
      * @returns {CanvasPixelArray} The pixels of the image.
      */
     function getImagePixels(image, width, height) {

--- a/Source/DataSources/CorridorGeometryUpdater.js
+++ b/Source/DataSources/CorridorGeometryUpdater.js
@@ -243,7 +243,7 @@ define([
          * Gets the property specifying whether the geometry
          * casts or receives shadows from each light source.
          * @memberof CorridorGeometryUpdater.prototype
-         * 
+         *
          * @type {Property}
          * @readonly
          */
@@ -552,6 +552,7 @@ define([
      * Creates the dynamic updater to be used when GeometryUpdater#isDynamic is true.
      *
      * @param {PrimitiveCollection} primitives The primitive collection to use.
+     * @param {PrimitiveCollection} groundPrimitives The ground primitives collection to use.
      * @returns {DynamicGeometryUpdater} The dynamic updater used to update the geometry each frame.
      *
      * @exception {DeveloperError} This instance does not represent dynamic geometry.

--- a/Source/DataSources/CzmlDataSource.js
+++ b/Source/DataSources/CzmlDataSource.js
@@ -1852,7 +1852,7 @@ define([
     /**
      * Creates a Promise to a new instance loaded with the provided CZML data.
      *
-     * @param {String|Object} data A url or CZML object to be processed.
+     * @param {String|Object} czml A url or CZML object to be processed.
      * @param {Object} [options] An object with the following properties:
      * @param {String} [options.sourceUri] Overrides the url to use for resolving relative links.
      * @returns {Promise.<CzmlDataSource>} A promise that resolves to the new instance once the data is processed.

--- a/Source/DataSources/EllipseGeometryUpdater.js
+++ b/Source/DataSources/EllipseGeometryUpdater.js
@@ -246,7 +246,7 @@ define([
          * Gets the property specifying whether the geometry
          * casts or receives shadows from each light source.
          * @memberof EllipseGeometryUpdater.prototype
-         * 
+         *
          * @type {Property}
          * @readonly
          */
@@ -566,6 +566,7 @@ define([
      * Creates the dynamic updater to be used when GeometryUpdater#isDynamic is true.
      *
      * @param {PrimitiveCollection} primitives The primitive collection to use.
+     * @param {PrimitiveCollection} groundPrimitives The ground primitives collection to use.
      * @returns {DynamicGeometryUpdater} The dynamic updater used to update the geometry each frame.
      *
      * @exception {DeveloperError} This instance does not represent dynamic geometry.

--- a/Source/DataSources/EntityView.js
+++ b/Source/DataSources/EntityView.js
@@ -258,7 +258,7 @@ define([
     * Should be called each animation frame to update the camera
     * to the latest settings.
     * @param {JulianDate} time The current animation time.
-    * @param {BoundingSphere} current bounding sphere of the object.
+    * @param {BoundingSphere} boundingSphere bounding sphere of the object.
     *
     */
     EntityView.prototype.update = function(time, boundingSphere) {

--- a/Source/DataSources/PolygonGeometryUpdater.js
+++ b/Source/DataSources/PolygonGeometryUpdater.js
@@ -248,7 +248,7 @@ define([
          * Gets the property specifying whether the geometry
          * casts or receives shadows from each light source.
          * @memberof PolygonGeometryUpdater.prototype
-         * 
+         *
          * @type {Property}
          * @readonly
          */
@@ -582,6 +582,7 @@ define([
      * Creates the dynamic updater to be used when GeometryUpdater#isDynamic is true.
      *
      * @param {PrimitiveCollection} primitives The primitive collection to use.
+     * @param {PrimitiveCollection} groundPrimitives The ground primitive collection to use.
      * @returns {DynamicGeometryUpdater} The dynamic updater used to update the geometry each frame.
      *
      * @exception {DeveloperError} This instance does not represent dynamic geometry.
@@ -663,7 +664,7 @@ define([
         options.closeBottom = closeBottomValue;
 
         var shadows = this._geometryUpdater.shadowsProperty.getValue(time);
-        
+
         if (Property.getValueOrDefault(polygon.fill, time, true)) {
             var fillMaterialProperty = geometryUpdater.fillMaterialProperty;
             var material = MaterialProperty.getValue(time, fillMaterialProperty, this._material);

--- a/Source/DataSources/Rotation.js
+++ b/Source/DataSources/Rotation.js
@@ -124,7 +124,7 @@ define([
          *
          * @param {Number[]} array The array previously packed for interpolation.
          * @param {Number[]} sourceArray The original packed array.
-         * @param {Number} [startingIndex=0] The startingIndex used to convert the array.
+         * @param {Number} [firstIndex=0] The firstIndex used to convert the array.
          * @param {Number} [lastIndex=packedArray.length] The lastIndex used to convert the array.
          * @param {Rotation} [result] The object into which to store the result.
          * @returns {Rotation} The modified result parameter or a new Rotation instance if one was not provided.

--- a/Source/DataSources/SampledPositionProperty.js
+++ b/Source/DataSources/SampledPositionProperty.js
@@ -274,8 +274,8 @@ define([
      * @param {Number[]} packedSamples The array of packed samples.
      * @param {JulianDate} [epoch] If any of the dates in packedSamples are numbers, they are considered an offset from this epoch, in seconds.
      */
-    SampledPositionProperty.prototype.addSamplesPackedArray = function(data, epoch) {
-        this._property.addSamplesPackedArray(data, epoch);
+    SampledPositionProperty.prototype.addSamplesPackedArray = function(packedSamples, epoch) {
+        this._property.addSamplesPackedArray(packedSamples, epoch);
     };
 
     /**

--- a/Source/Renderer/Buffer.js
+++ b/Source/Renderer/Buffer.js
@@ -145,7 +145,7 @@ define([
      * @param {ArrayBufferView} [options.typedArray] A typed array containing the data to copy to the buffer.
      * @param {Number} [options.sizeInBytes] A <code>Number</code> defining the size of the buffer in bytes. Required if options.typedArray is not given.
      * @param {BufferUsage} options.usage Specifies the expected usage pattern of the buffer. On some GL implementations, this can significantly affect performance. See {@link BufferUsage}.
-     * @param {IndexDatatype} indexDatatype The datatype of indices in the buffer.
+     * @param {IndexDatatype} options.indexDatatype The datatype of indices in the buffer.
      * @returns {IndexBuffer} The index buffer, ready to be attached to a vertex array.
      *
      * @exception {DeveloperError} Must specify either <options.typedArray> or <options.sizeInBytes>, but not both.

--- a/Source/Renderer/ComputeCommand.js
+++ b/Source/Renderer/ComputeCommand.js
@@ -108,7 +108,7 @@ define([
     /**
      * Executes the compute command.
      *
-     * @param {Context} context The context that processes the compute command.
+     * @param {Context} computeEngine The context that processes the compute command.
      */
     ComputeCommand.prototype.execute = function(computeEngine) {
         computeEngine.execute(this);

--- a/Source/Scene/BingMapsImageryProvider.js
+++ b/Source/Scene/BingMapsImageryProvider.js
@@ -554,7 +554,7 @@ define([
      *                   instances.  The array may be empty if no features are found at the given location.
      *                   It may also be undefined if picking is not supported.
      */
-    BingMapsImageryProvider.prototype.pickFeatures = function() {
+    BingMapsImageryProvider.prototype.pickFeatures = function(x, y, level, longitude, latitude) {
         return undefined;
     };
 

--- a/Source/Scene/CameraEventAggregator.js
+++ b/Source/Scene/CameraEventAggregator.js
@@ -252,7 +252,7 @@ define([
      * @alias CameraEventAggregator
      * @constructor
      *
-     * @param {Canvas} [element=document] The element to handle events for.
+     * @param {Canvas} [canvas=document] The element to handle events for.
      *
      * @see ScreenSpaceEventHandler
      */

--- a/Source/Scene/CreditDisplay.js
+++ b/Source/Scene/CreditDisplay.js
@@ -270,8 +270,6 @@ define([
 
     /**
      * Resets the credit display to a beginning of frame state, clearing out current credits.
-     *
-     * @param {Credit} credit The credit to display
      */
     CreditDisplay.prototype.beginFrame = function() {
         this._currentFrameCredits.imageCredits.length = 0;
@@ -280,8 +278,6 @@ define([
 
     /**
      * Sets the credit display to the end of frame state, displaying current credits in the credit container
-     *
-     * @param {Credit} credit The credit to display
      */
     CreditDisplay.prototype.endFrame = function() {
         var textCredits = this._defaultTextCredits.concat(this._currentFrameCredits.textCredits);

--- a/Source/Scene/FrameState.js
+++ b/Source/Scene/FrameState.js
@@ -9,6 +9,7 @@ define([
      * State information about the current frame.  An instance of this class
      * is provided to update functions.
      *
+     * @param {Context} context The rendering context.
      * @param {CreditDisplay} creditDisplay Handles adding and removing credits from an HTML element
      *
      * @alias FrameState

--- a/Source/Scene/GoogleEarthImageryProvider.js
+++ b/Source/Scene/GoogleEarthImageryProvider.js
@@ -95,7 +95,7 @@ define([
      *     url : 'https://earth.localdomain',
      *     channel : 1008
      * });
-     * 
+     *
      * @see {@link http://www.w3.org/TR/cors/|Cross-Origin Resource Sharing}
      */
     function GoogleEarthImageryProvider(options) {
@@ -568,7 +568,7 @@ define([
      *                   instances.  The array may be empty if no features are found at the given location.
      *                   It may also be undefined if picking is not supported.
      */
-    GoogleEarthImageryProvider.prototype.pickFeatures = function() {
+    GoogleEarthImageryProvider.prototype.pickFeatures = function(x, y, level, longitude, latitude) {
         return undefined;
     };
 

--- a/Source/Scene/GridImageryProvider.js
+++ b/Source/Scene/GridImageryProvider.js
@@ -37,7 +37,7 @@ define([
      * @param {Color} [options.color=Color(1.0, 1.0, 1.0, 0.4)] The color to draw grid lines.
      * @param {Color} [options.glowColor=Color(0.0, 1.0, 0.0, 0.05)] The color to draw glow for grid lines.
      * @param {Number} [options.glowWidth=6] The width of lines used for rendering the line glow effect.
-     * @param {Color} [backgroundColor=Color(0.0, 0.5, 0.0, 0.2)] Background fill color.
+     * @param {Color} [options.backgroundColor=Color(0.0, 0.5, 0.0, 0.2)] Background fill color.
      * @param {Number} [options.tileWidth=256] The width of the tile for level-of-detail selection purposes.
      * @param {Number} [options.tileHeight=256] The height of the tile for level-of-detail selection purposes.
      * @param {Number} [options.canvasSize=256] The size of the canvas used for rendering.
@@ -344,7 +344,7 @@ define([
      *                   instances.  The array may be empty if no features are found at the given location.
      *                   It may also be undefined if picking is not supported.
      */
-    GridImageryProvider.prototype.pickFeatures = function() {
+    GridImageryProvider.prototype.pickFeatures = function(x, y, level, longitude, latitude) {
         return undefined;
     };
 

--- a/Source/Scene/ImageryLayer.js
+++ b/Source/Scene/ImageryLayer.js
@@ -576,7 +576,7 @@ define([
                 if (!defined(clippedImageryRectangle)) {
                     continue;
                 }
-                
+
                 minV = Math.max(0.0, (clippedImageryRectangle.south - terrainRectangle.south) / terrainRectangle.height);
 
                 // If this is the southern-most imagery tile mapped to this terrain tile,
@@ -1059,6 +1059,7 @@ define([
     /**
      * Gets the level with the specified world coordinate spacing between texels, or less.
      *
+     * @param {ImageryLayer} layer The imagery layer to use.
      * @param {Number} texelSpacing The texel spacing for which to find a corresponding level.
      * @param {Number} latitudeClosestToEquator The latitude closest to the equator that we're concerned with.
      * @returns {Number} The level with the specified texel spacing or less.

--- a/Source/Scene/ImageryProvider.js
+++ b/Source/Scene/ImageryProvider.js
@@ -299,6 +299,7 @@ define([
      * too many requests pending, this function will instead return undefined, indicating
      * that the request should be retried later.
      *
+     * @param {ImageryProvider} imageryProvider The imagery provider for the URL.
      * @param {String} url The URL of the image.
      * @returns {Promise.<Image|Canvas>|undefined} A promise for the image that will resolve when the image is available, or
      *          undefined if there are too many active requests to the server, and the request

--- a/Source/Scene/Polyline.js
+++ b/Source/Scene/Polyline.js
@@ -41,6 +41,7 @@ define([
      * @param {Cartesian3[]} [options.positions] The positions.
      * @param {Object} [options.id] The user-defined object to be returned when this polyline is picked.
      * @param {DistanceDisplayCondition} [options.distanceDisplayCondition] The condition specifying at what distance from the camera that this polyline will be displayed.
+     * @param {PolylineCollection} polylineCollection The renderable polyline collection.
      *
      * @see PolylineCollection
      *

--- a/Source/Scene/SingleTileImageryProvider.js
+++ b/Source/Scene/SingleTileImageryProvider.js
@@ -401,7 +401,7 @@ define([
      *                   instances.  The array may be empty if no features are found at the given location.
      *                   It may also be undefined if picking is not supported.
      */
-    SingleTileImageryProvider.prototype.pickFeatures = function() {
+    SingleTileImageryProvider.prototype.pickFeatures = function(x, y, level, longitude, latitude) {
         return undefined;
     };
 

--- a/Source/Scene/TileCoordinatesImageryProvider.js
+++ b/Source/Scene/TileCoordinatesImageryProvider.js
@@ -282,7 +282,7 @@ define([
      *                   instances.  The array may be empty if no features are found at the given location.
      *                   It may also be undefined if picking is not supported.
      */
-    TileCoordinatesImageryProvider.prototype.pickFeatures = function() {
+    TileCoordinatesImageryProvider.prototype.pickFeatures = function(x, y, level, longitude, latitude) {
         return undefined;
     };
 

--- a/Source/Scene/WebMapTileServiceImageryProvider.js
+++ b/Source/Scene/WebMapTileServiceImageryProvider.js
@@ -89,7 +89,7 @@ define([
      *     credit : new Cesium.Credit('U. S. Geological Survey')
      * });
      * viewer.imageryLayers.addImageryProvider(shadedRelief2);
-     * 
+     *
      * @see ArcGisMapServerImageryProvider
      * @see BingMapsImageryProvider
      * @see GoogleEarthImageryProvider
@@ -458,7 +458,7 @@ define([
      *                   instances.  The array may be empty if no features are found at the given location.
      *                   It may also be undefined if picking is not supported.
      */
-    WebMapTileServiceImageryProvider.prototype.pickFeatures = function() {
+    WebMapTileServiceImageryProvider.prototype.pickFeatures = function(x, y, level, longitude, latitude) {
         return undefined;
     };
 

--- a/Source/Widgets/CesiumInspector/CesiumInspectorViewModel.js
+++ b/Source/Widgets/CesiumInspector/CesiumInspectorViewModel.js
@@ -70,6 +70,7 @@ define([
      * @constructor
      *
      * @param {Scene} scene The scene instance to use.
+     * @param {PerformanceContainer} performanceContainer The instance to use for performance container.
      *
      * @exception {DeveloperError} scene is required.
      */

--- a/Source/Widgets/Viewer/viewerPerformanceWatchdogMixin.js
+++ b/Source/Widgets/Viewer/viewerPerformanceWatchdogMixin.js
@@ -20,6 +20,7 @@ define([
      * @exports viewerPerformanceWatchdogMixin
      *
      * @param {Viewer} viewer The viewer instance.
+     * @param {Object} [options] An object with properties.
      * @param {String} [options.lowFrameRateMessage='This application appears to be performing poorly on your system.  Please try using a different web browser or updating your video drivers.'] The
      *        message to display when a low frame rate is detected.  The message is interpeted as HTML, so make sure
      *        it comes from a trusted source so that your application is not vulnerable to cross-site scripting attacks.

--- a/Source/Workers/cesiumWorkerBootstrapper.js
+++ b/Source/Workers/cesiumWorkerBootstrapper.js
@@ -178,8 +178,9 @@ var requirejs, require, define;
     /**
      * Constructs an error with a pointer to an URL with more information.
      * @param {String} id the error ID that maps to an ID on a web page.
-     * @param {String} message human readable error.
+     * @param {String} msg human readable error.
      * @param {Error} [err] the original error, if there is one.
+     * @param {RequireModules} requireModules The modules required but not found.
      *
      * @returns {Error}
      */


### PR DESCRIPTION
This is a part of #4530.

This PR completes the entire `Source` directory.
The following functions have parameters added to them based on the documentation:
* `BingMapsImageryProvider.prototype.pickFeatures`
* `GoogleEarthImageryProvider.prototype.pickFeatures`
* `GridImageryProvider.prototype.pickFeatures`
* `SingleTileImageryProvider.prototype.pickFeatures`
* `TileCoordinatesImageryProvider.prototype.pickFeatures`
* `WebMapTileServiceImageryProvider.prototype.pickFeatures`

All of these have been changed from
```*.prototype.pickFeatures = function() {``` to
```*.prototype.pickFeatures = function(x, y, level, longitude, latitude) {```

As with #4850, this PR may include fixes to block tabs and trailing whitespaces.

Following this PR, the following warnings remain (all in ThirdParty):
* Autolinker.js - 10 warnings
* jsUnitCore.js - 50 warnings
* require.js - 1 warning
* vim.js - 2 warnings