### PR TITLE
Fixes to tests caused by breaking API change in Transform heading pitch roll

### DIFF
--- a/Specs/Scene/Batched3DModel3DTileContentSpec.js
+++ b/Specs/Scene/Batched3DModel3DTileContentSpec.js
@@ -4,6 +4,7 @@ defineSuite([
         'Core/Cartesian3',
         'Core/deprecationWarning',
         'Core/HeadingPitchRange',
+        'Core/HeadingPitchRoll',
         'Core/Transforms',
         'Specs/Cesium3DTilesTester',
         'Specs/createScene'
@@ -12,6 +13,7 @@ defineSuite([
         Cartesian3,
         deprecationWarning,
         HeadingPitchRange,
+        HeadingPitchRoll,
         Transforms,
         Cesium3DTilesTester,
         createScene) {
@@ -169,7 +171,8 @@ defineSuite([
             var newLongitude = -1.31962;
             var newLatitude = 0.698874;
             var newCenter = Cartesian3.fromRadians(newLongitude, newLatitude, 0.0);
-            var newTransform = Transforms.headingPitchRollToFixedFrame(newCenter, 0.0, 0.0, 0.0);
+            var newHPR = new HeadingPitchRoll();
+            var newTransform = Transforms.headingPitchRollToFixedFrame(newCenter, newHPR);
 
             // Update tile transform
             tileset._root.transform = newTransform;

--- a/Specs/Scene/Cesium3DTileSpec.js
+++ b/Specs/Scene/Cesium3DTileSpec.js
@@ -4,6 +4,7 @@ defineSuite([
         'Core/Cartesian3',
         'Core/clone',
         'Core/defined',
+        'Core/HeadingPitchRoll',
         'Core/Math',
         'Core/Matrix3',
         'Core/Matrix4',
@@ -18,6 +19,7 @@ defineSuite([
         Cartesian3,
         clone,
         defined,
+        HeadingPitchRoll,
         CesiumMath,
         Matrix3,
         Matrix4,
@@ -136,7 +138,8 @@ defineSuite([
 
     function getTileTransform(longitude, latitude) {
         var transformCenter = Cartesian3.fromRadians(longitude, latitude, 0.0);
-        var transformMatrix = Transforms.headingPitchRollToFixedFrame(transformCenter, 0.0, 0.0, 0.0);
+        var hpr = new HeadingPitchRoll();
+        var transformMatrix = Transforms.headingPitchRollToFixedFrame(transformCenter, hpr);
         return Matrix4.pack(transformMatrix, new Array(16));
     }
 

--- a/Specs/Scene/EllipsoidPrimitiveSpec.js
+++ b/Specs/Scene/EllipsoidPrimitiveSpec.js
@@ -55,7 +55,7 @@ defineSuite([
         var e = new EllipsoidPrimitive({
             center : new Cartesian3(1.0, 2.0, 3.0),
             radii : new Cartesian3(4.0, 5.0, 6.0),
-            modelMatrix : Matrix4.fromScale(2.0),
+            modelMatrix : Matrix4.fromUniformScale(2.0),
             show : false,
             material : material,
             id : 'id',
@@ -64,7 +64,7 @@ defineSuite([
 
         expect(e.center).toEqual(new Cartesian3(1.0, 2.0, 3.0));
         expect(e.radii).toEqual(new Cartesian3(4.0, 5.0, 6.0));
-        expect(e.modelMatrix).toEqual(Matrix4.fromScale(2.0));
+        expect(e.modelMatrix).toEqual(Matrix4.fromUniformScale(2.0));
         expect(e.show).toEqual(false);
         expect(e.material).toBe(material);
         expect(e.id).toEqual('id');

--- a/Specs/Scene/Instanced3DModel3DTileContentSpec.js
+++ b/Specs/Scene/Instanced3DModel3DTileContentSpec.js
@@ -3,6 +3,7 @@ defineSuite([
         'Scene/Instanced3DModel3DTileContent',
         'Core/Cartesian3',
         'Core/HeadingPitchRange',
+        'Core/HeadingPitchRoll',
         'Core/Transforms',
         'Scene/Cesium3DTileContentState',
         'Scene/TileBoundingSphere',
@@ -12,6 +13,7 @@ defineSuite([
         Instanced3DModel3DTileContent,
         Cartesian3,
         HeadingPitchRange,
+        HeadingPitchRoll,
         Transforms,
         Cesium3DTileContentState,
         TileBoundingSphere,
@@ -198,7 +200,8 @@ defineSuite([
             var newLongitude = -1.31962;
             var newLatitude = 0.698874;
             var newCenter = Cartesian3.fromRadians(newLongitude, newLatitude, 15.0);
-            var newTransform = Transforms.headingPitchRollToFixedFrame(newCenter, 0.0, 0.0, 0.0);
+            var newHPR = new HeadingPitchRoll();
+            var newTransform = Transforms.headingPitchRollToFixedFrame(newCenter, newHPR);
 
             // Update tile transform
             tileset._root.transform = newTransform;

--- a/Specs/Scene/ModelInstanceCollectionSpec.js
+++ b/Specs/Scene/ModelInstanceCollectionSpec.js
@@ -6,6 +6,7 @@ defineSuite([
         'Core/defaultValue',
         'Core/defined',
         'Core/HeadingPitchRange',
+        'Core/HeadingPitchRoll',
         'Core/JulianDate',
         'Core/Math',
         'Core/Matrix4',
@@ -25,6 +26,7 @@ defineSuite([
         defaultValue,
         defined,
         HeadingPitchRange,
+        HeadingPitchRoll,
         JulianDate,
         CesiumMath,
         Matrix4,
@@ -127,7 +129,8 @@ defineSuite([
             var heading = Math.PI/2.0;
             var pitch = 0.0;
             var roll = 0.0;
-            var modelMatrix = Transforms.headingPitchRollToFixedFrame(position, heading, pitch, roll);
+            var hpr = new HeadingPitchRoll(heading, pitch, roll);
+            var modelMatrix = Transforms.headingPitchRollToFixedFrame(position, hpr);
             instances.push({
                 modelMatrix : modelMatrix
             });

--- a/Specs/Scene/PointCloud3DTileContentSpec.js
+++ b/Specs/Scene/PointCloud3DTileContentSpec.js
@@ -6,6 +6,7 @@ defineSuite([
         'Core/ComponentDatatype',
         'Core/defined',
         'Core/HeadingPitchRange',
+        'Core/HeadingPitchRoll',
         'Core/Transforms',
         'Scene/Cesium3DTileStyle',
         'Scene/Expression',
@@ -18,6 +19,7 @@ defineSuite([
         ComponentDatatype,
         defined,
         HeadingPitchRange,
+        HeadingPitchRoll,
         Transforms,
         Cesium3DTileStyle,
         Expression,
@@ -233,7 +235,8 @@ defineSuite([
             var newLongitude = -1.31962;
             var newLatitude = 0.698874;
             var newCenter = Cartesian3.fromRadians(newLongitude, newLatitude, 5.0);
-            var newTransform = Transforms.headingPitchRollToFixedFrame(newCenter, 0.0, 0.0, 0.0);
+            var newHPR = new HeadingPitchRoll();
+            var newTransform = Transforms.headingPitchRollToFixedFrame(newCenter, newHPR);
 
             // Update tile transform
             tileset._root.transform = newTransform;


### PR DESCRIPTION
This is related to #4506.
Fixing that issue in master broke tests in the 3d-tiles branch. This PR fixes those tests.