### PR TITLE
Rename all instances of binormal as bitangent

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,7 @@ Change Log
 * Fixed a bug that caused all models to use the same highlight color. [#4798] (https://github.com/AnalyticalGraphicsInc/cesium/pull/4798)
 * Fixed KML for when color is an empty string [#4826](https://github.com/AnalyticalGraphicsInc/cesium/pull/4826)
 * Added support for WMS version 1.3 by using CRS vice SRS query string parameter to request projection. SRS is still used for older versions.
+* The attribute `perInstanceAttribute` of `DebugAppearance` has been made optional and defaults to `false`.
 
 ### 1.29 - 2017-01-02
 * Improved 3D Models

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,8 +4,10 @@ Change Log
 ### 1.30 - 2017-02-01
 * Deprecated
     * The properties `url` and `key` will be removed from `GeocoderViewModel` in 1.31. These properties will be available on geocoder services that support them, like `BingMapsGeocoderService`.
+    * The function `createBinormalAndBitangent` of `GeometryPipeline` will be removed in 1.31. Use the function `createTangentAndBitangent` instead. [#4856](https://github.com/AnalyticalGraphicsInc/cesium/pull/4856)
 * Breaking changes
     * Removed separate `heading`, `pitch`, `roll` parameters from `Transform.headingPitchRollToFixedFrame` and `Transform.headingPitchRollQuaternion`. Pass a `headingPitchRoll` object instead. [#4843](https://github.com/AnalyticalGraphicsInc/cesium/pull/4843)
+    * The property `binornmal` has been renamed to `bitangent` for `Geometry` and `VertexFormat`. [#4856](https://github.com/AnalyticalGraphicsInc/cesium/pull/4856)
 * Added support for custom geocoder services and autocomplete [#4723](https://github.com/AnalyticalGraphicsInc/cesium/pull/4723).
     * Added [Custom Geocoder Sandcastle example](http://localhost:8080/Apps/Sandcastle/index.html?src=Custom%20Geocoder.html)
 * Added `GeocoderService`, an interface for geocoders.

--- a/Source/Core/BoxGeometry.js
+++ b/Source/Core/BoxGeometry.js
@@ -245,7 +245,7 @@ define([
         var positions;
 
         if (vertexFormat.position &&
-                (vertexFormat.st || vertexFormat.normal || vertexFormat.binormal || vertexFormat.tangent)) {
+                (vertexFormat.st || vertexFormat.normal || vertexFormat.tangent || vertexFormat.bitangent)) {
             if (vertexFormat.position) {
                 // 8 corner points.  Duplicated 3 times each for each incident edge/face.
                 positions = new Float64Array(6 * 4 * 3);
@@ -599,97 +599,97 @@ define([
                 });
             }
 
-            if (vertexFormat.binormal) {
-                var binormals = new Float32Array(6 * 4 * 3);
+            if (vertexFormat.bitangent) {
+                var bitangents = new Float32Array(6 * 4 * 3);
 
                 // +z face
-                binormals[0] = 0.0;
-                binormals[1] = 1.0;
-                binormals[2] = 0.0;
-                binormals[3] = 0.0;
-                binormals[4] = 1.0;
-                binormals[5] = 0.0;
-                binormals[6] = 0.0;
-                binormals[7] = 1.0;
-                binormals[8] = 0.0;
-                binormals[9] = 0.0;
-                binormals[10] = 1.0;
-                binormals[11] = 0.0;
+                bitangents[0] = 0.0;
+                bitangents[1] = 1.0;
+                bitangents[2] = 0.0;
+                bitangents[3] = 0.0;
+                bitangents[4] = 1.0;
+                bitangents[5] = 0.0;
+                bitangents[6] = 0.0;
+                bitangents[7] = 1.0;
+                bitangents[8] = 0.0;
+                bitangents[9] = 0.0;
+                bitangents[10] = 1.0;
+                bitangents[11] = 0.0;
 
                 // -z face
-                binormals[12] = 0.0;
-                binormals[13] = 1.0;
-                binormals[14] = 0.0;
-                binormals[15] = 0.0;
-                binormals[16] = 1.0;
-                binormals[17] = 0.0;
-                binormals[18] = 0.0;
-                binormals[19] = 1.0;
-                binormals[20] = 0.0;
-                binormals[21] = 0.0;
-                binormals[22] = 1.0;
-                binormals[23] = 0.0;
+                bitangents[12] = 0.0;
+                bitangents[13] = 1.0;
+                bitangents[14] = 0.0;
+                bitangents[15] = 0.0;
+                bitangents[16] = 1.0;
+                bitangents[17] = 0.0;
+                bitangents[18] = 0.0;
+                bitangents[19] = 1.0;
+                bitangents[20] = 0.0;
+                bitangents[21] = 0.0;
+                bitangents[22] = 1.0;
+                bitangents[23] = 0.0;
 
                 // +x face
-                binormals[24] = 0.0;
-                binormals[25] = 0.0;
-                binormals[26] = 1.0;
-                binormals[27] = 0.0;
-                binormals[28] = 0.0;
-                binormals[29] = 1.0;
-                binormals[30] = 0.0;
-                binormals[31] = 0.0;
-                binormals[32] = 1.0;
-                binormals[33] = 0.0;
-                binormals[34] = 0.0;
-                binormals[35] = 1.0;
+                bitangents[24] = 0.0;
+                bitangents[25] = 0.0;
+                bitangents[26] = 1.0;
+                bitangents[27] = 0.0;
+                bitangents[28] = 0.0;
+                bitangents[29] = 1.0;
+                bitangents[30] = 0.0;
+                bitangents[31] = 0.0;
+                bitangents[32] = 1.0;
+                bitangents[33] = 0.0;
+                bitangents[34] = 0.0;
+                bitangents[35] = 1.0;
 
                 // -x face
-                binormals[36] = 0.0;
-                binormals[37] = 0.0;
-                binormals[38] = 1.0;
-                binormals[39] = 0.0;
-                binormals[40] = 0.0;
-                binormals[41] = 1.0;
-                binormals[42] = 0.0;
-                binormals[43] = 0.0;
-                binormals[44] = 1.0;
-                binormals[45] = 0.0;
-                binormals[46] = 0.0;
-                binormals[47] = 1.0;
+                bitangents[36] = 0.0;
+                bitangents[37] = 0.0;
+                bitangents[38] = 1.0;
+                bitangents[39] = 0.0;
+                bitangents[40] = 0.0;
+                bitangents[41] = 1.0;
+                bitangents[42] = 0.0;
+                bitangents[43] = 0.0;
+                bitangents[44] = 1.0;
+                bitangents[45] = 0.0;
+                bitangents[46] = 0.0;
+                bitangents[47] = 1.0;
 
                 // +y face
-                binormals[48] = 0.0;
-                binormals[49] = 0.0;
-                binormals[50] = 1.0;
-                binormals[51] = 0.0;
-                binormals[52] = 0.0;
-                binormals[53] = 1.0;
-                binormals[54] = 0.0;
-                binormals[55] = 0.0;
-                binormals[56] = 1.0;
-                binormals[57] = 0.0;
-                binormals[58] = 0.0;
-                binormals[59] = 1.0;
+                bitangents[48] = 0.0;
+                bitangents[49] = 0.0;
+                bitangents[50] = 1.0;
+                bitangents[51] = 0.0;
+                bitangents[52] = 0.0;
+                bitangents[53] = 1.0;
+                bitangents[54] = 0.0;
+                bitangents[55] = 0.0;
+                bitangents[56] = 1.0;
+                bitangents[57] = 0.0;
+                bitangents[58] = 0.0;
+                bitangents[59] = 1.0;
 
                 // -y face
-                binormals[60] = 0.0;
-                binormals[61] = 0.0;
-                binormals[62] = 1.0;
-                binormals[63] = 0.0;
-                binormals[64] = 0.0;
-                binormals[65] = 1.0;
-                binormals[66] = 0.0;
-                binormals[67] = 0.0;
-                binormals[68] = 1.0;
-                binormals[69] = 0.0;
-                binormals[70] = 0.0;
-                binormals[71] = 1.0;
+                bitangents[60] = 0.0;
+                bitangents[61] = 0.0;
+                bitangents[62] = 1.0;
+                bitangents[63] = 0.0;
+                bitangents[64] = 0.0;
+                bitangents[65] = 1.0;
+                bitangents[66] = 0.0;
+                bitangents[67] = 0.0;
+                bitangents[68] = 1.0;
+                bitangents[69] = 0.0;
+                bitangents[70] = 0.0;
+                bitangents[71] = 1.0;
 
-                attributes.binormal = new GeometryAttribute({
+                attributes.bitangent = new GeometryAttribute({
                     componentDatatype : ComponentDatatype.FLOAT,
                     componentsPerAttribute : 3,
-                    values : binormals
+                    values : bitangents
                 });
             }
 

--- a/Source/Core/CorridorGeometry.js
+++ b/Source/Core/CorridorGeometry.js
@@ -58,16 +58,16 @@ define([
     function addNormals(attr, normal, left, front, back, vertexFormat) {
         var normals = attr.normals;
         var tangents = attr.tangents;
-        var binormals = attr.binormals;
+        var bitangents = attr.bitangents;
         var forward = Cartesian3.normalize(Cartesian3.cross(left, normal, scratch1), scratch1);
         if (vertexFormat.normal) {
             CorridorGeometryLibrary.addAttribute(normals, normal, front, back);
         }
-        if (vertexFormat.binormal) {
-            CorridorGeometryLibrary.addAttribute(binormals, left, front, back);
-        }
         if (vertexFormat.tangent) {
             CorridorGeometryLibrary.addAttribute(tangents, forward, front, back);
+        }
+        if (vertexFormat.bitangent) {
+            CorridorGeometryLibrary.addAttribute(bitangents, left, front, back);
         }
     }
 
@@ -119,11 +119,11 @@ define([
         var finalPositions = new Float64Array(size);
         var normals = (vertexFormat.normal) ? new Float32Array(size) : undefined;
         var tangents = (vertexFormat.tangent) ? new Float32Array(size) : undefined;
-        var binormals = (vertexFormat.binormal) ? new Float32Array(size) : undefined;
+        var bitangents = (vertexFormat.bitangent) ? new Float32Array(size) : undefined;
         var attr = {
             normals : normals,
             tangents : tangents,
-            binormals : binormals
+            bitangents : bitangents
         };
         var front = 0;
         var back = size - 1;
@@ -408,11 +408,11 @@ define([
             });
         }
 
-        if (vertexFormat.binormal) {
-            attributes.binormal = new GeometryAttribute({
+        if (vertexFormat.bitangent) {
+            attributes.bitangent = new GeometryAttribute({
                 componentDatatype : ComponentDatatype.FLOAT,
                 componentsPerAttribute : 3,
-                values : attr.binormals
+                values : attr.bitangents
             });
         }
 
@@ -423,31 +423,31 @@ define([
     }
 
     function extrudedAttributes(attributes, vertexFormat) {
-        if (!vertexFormat.normal && !vertexFormat.binormal && !vertexFormat.tangent && !vertexFormat.st) {
+        if (!vertexFormat.normal && !vertexFormat.tangent && !vertexFormat.bitangent && !vertexFormat.st) {
             return attributes;
         }
         var positions = attributes.position.values;
         var topNormals;
-        var topBinormals;
-        if (vertexFormat.normal || vertexFormat.binormal) {
+        var topBitangents;
+        if (vertexFormat.normal || vertexFormat.bitangent) {
             topNormals = attributes.normal.values;
-            topBinormals = attributes.binormal.values;
+            topBitangents = attributes.bitangent.values;
         }
         var size = attributes.position.values.length / 18;
         var threeSize = size * 3;
         var twoSize = size * 2;
         var sixSize = threeSize * 2;
         var i;
-        if (vertexFormat.normal || vertexFormat.binormal || vertexFormat.tangent) {
+        if (vertexFormat.normal || vertexFormat.bitangent || vertexFormat.tangent) {
             var normals = (vertexFormat.normal) ? new Float32Array(threeSize * 6) : undefined;
-            var binormals = (vertexFormat.binormal) ? new Float32Array(threeSize * 6) : undefined;
             var tangents = (vertexFormat.tangent) ? new Float32Array(threeSize * 6) : undefined;
+            var bitangents = (vertexFormat.bitangent) ? new Float32Array(threeSize * 6) : undefined;
             var topPosition = cartesian1;
             var bottomPosition = cartesian2;
             var previousPosition = cartesian3;
             var normal = cartesian4;
             var tangent = cartesian5;
-            var binormal = cartesian6;
+            var bitangent = cartesian6;
             var attrIndex = sixSize;
             for (i = 0; i < threeSize; i += 3) {
                 var attrIndexOffset = attrIndex + sixSize;
@@ -463,17 +463,17 @@ define([
                     CorridorGeometryLibrary.addAttribute(normals, normal, attrIndex);
                     CorridorGeometryLibrary.addAttribute(normals, normal, attrIndex + 3);
                 }
-                if (vertexFormat.tangent || vertexFormat.binormal) {
-                    binormal = Cartesian3.fromArray(topNormals, i, binormal);
-                    if (vertexFormat.binormal) {
-                        CorridorGeometryLibrary.addAttribute(binormals, binormal, attrIndexOffset);
-                        CorridorGeometryLibrary.addAttribute(binormals, binormal, attrIndexOffset + 3);
-                        CorridorGeometryLibrary.addAttribute(binormals, binormal, attrIndex);
-                        CorridorGeometryLibrary.addAttribute(binormals, binormal, attrIndex + 3);
+                if (vertexFormat.tangent || vertexFormat.bitangent) {
+                    bitangent = Cartesian3.fromArray(topNormals, i, bitangent);
+                    if (vertexFormat.bitangent) {
+                        CorridorGeometryLibrary.addAttribute(bitangents, bitangent, attrIndexOffset);
+                        CorridorGeometryLibrary.addAttribute(bitangents, bitangent, attrIndexOffset + 3);
+                        CorridorGeometryLibrary.addAttribute(bitangents, bitangent, attrIndex);
+                        CorridorGeometryLibrary.addAttribute(bitangents, bitangent, attrIndex + 3);
                     }
 
                     if (vertexFormat.tangent) {
-                        tangent = Cartesian3.normalize(Cartesian3.cross(binormal, normal, tangent), tangent);
+                        tangent = Cartesian3.normalize(Cartesian3.cross(bitangent, normal, tangent), tangent);
                         CorridorGeometryLibrary.addAttribute(tangents, tangent, attrIndexOffset);
                         CorridorGeometryLibrary.addAttribute(tangents, tangent, attrIndexOffset + 3);
                         CorridorGeometryLibrary.addAttribute(tangents, tangent, attrIndex);
@@ -495,12 +495,12 @@ define([
                 attributes.normal = undefined;
             }
 
-            if (vertexFormat.binormal) {
-                binormals.set(topBinormals); //top
-                binormals.set(topBinormals, threeSize); //bottom
-                attributes.binormal.values = binormals;
+            if (vertexFormat.bitangent) {
+                bitangents.set(topBitangents); //top
+                bitangents.set(topBitangents, threeSize); //bottom
+                attributes.bitangent.values = bitangents;
             } else {
-                attributes.binormal = undefined;
+                attributes.bitangent = undefined;
             }
 
             if (vertexFormat.tangent) {
@@ -562,9 +562,9 @@ define([
     function computePositionsExtruded(params, vertexFormat) {
         var topVertexFormat = new VertexFormat({
             position : vertexFormat.position,
-            normal : (vertexFormat.normal || vertexFormat.binormal || params.shadowVolume),
+            normal : (vertexFormat.normal || vertexFormat.bitangent || params.shadowVolume),
             tangent : vertexFormat.tangent,
-            binormal : (vertexFormat.normal || vertexFormat.binormal),
+            bitangent : (vertexFormat.normal || vertexFormat.bitangent),
             st : vertexFormat.st
         });
         var ellipsoid = params.ellipsoid;

--- a/Source/Core/CylinderGeometry.js
+++ b/Source/Core/CylinderGeometry.js
@@ -35,7 +35,7 @@ define([
 
     var radiusScratch = new Cartesian2();
     var normalScratch = new Cartesian3();
-    var binormalScratch = new Cartesian3();
+    var bitangentScratch = new Cartesian3();
     var tangentScratch = new Cartesian3();
     var positionScratch = new Cartesian3();
 
@@ -217,22 +217,22 @@ define([
         var st = (vertexFormat.st) ? new Float32Array(numVertices * 2) : undefined;
         var normals = (vertexFormat.normal) ? new Float32Array(numVertices * 3) : undefined;
         var tangents = (vertexFormat.tangent) ? new Float32Array(numVertices * 3) : undefined;
-        var binormals = (vertexFormat.binormal) ? new Float32Array(numVertices * 3) : undefined;
+        var bitangents = (vertexFormat.bitangent) ? new Float32Array(numVertices * 3) : undefined;
 
         var i;
-        var computeNormal = (vertexFormat.normal || vertexFormat.tangent || vertexFormat.binormal);
+        var computeNormal = (vertexFormat.normal || vertexFormat.tangent || vertexFormat.bitangent);
 
         if (computeNormal) {
-            var computeTangent = (vertexFormat.tangent || vertexFormat.binormal);
+            var computeTangent = (vertexFormat.tangent || vertexFormat.bitangent);
 
             var normalIndex = 0;
             var tangentIndex = 0;
-            var binormalIndex = 0;
+            var bitangentIndex = 0;
 
             var normal = normalScratch;
             normal.z = 0;
             var tangent = tangentScratch;
-            var binormal = binormalScratch;
+            var bitangent = bitangentScratch;
 
             for (i = 0; i < slices; i++) {
                 var angle = i / slices * CesiumMath.TWO_PI;
@@ -264,14 +264,14 @@ define([
                         tangents[tangentIndex++] = tangent.z;
                     }
 
-                    if (vertexFormat.binormal) {
-                        binormal = Cartesian3.normalize(Cartesian3.cross(normal, tangent, binormal), binormal);
-                        binormals[binormalIndex++] = binormal.x;
-                        binormals[binormalIndex++] = binormal.y;
-                        binormals[binormalIndex++] = binormal.z;
-                        binormals[binormalIndex++] = binormal.x;
-                        binormals[binormalIndex++] = binormal.y;
-                        binormals[binormalIndex++] = binormal.z;
+                    if (vertexFormat.bitangent) {
+                        bitangent = Cartesian3.normalize(Cartesian3.cross(normal, tangent, bitangent), bitangent);
+                        bitangents[bitangentIndex++] = bitangent.x;
+                        bitangents[bitangentIndex++] = bitangent.y;
+                        bitangents[bitangentIndex++] = bitangent.z;
+                        bitangents[bitangentIndex++] = bitangent.x;
+                        bitangents[bitangentIndex++] = bitangent.y;
+                        bitangents[bitangentIndex++] = bitangent.z;
                     }
                 }
             }
@@ -287,10 +287,10 @@ define([
                     tangents[tangentIndex++] = 0;
                     tangents[tangentIndex++] = 0;
                 }
-                if (vertexFormat.binormal) {
-                    binormals[binormalIndex++] = 0;
-                    binormals[binormalIndex++] = -1;
-                    binormals[binormalIndex++] = 0;
+                if (vertexFormat.bitangent) {
+                    bitangents[bitangentIndex++] = 0;
+                    bitangents[bitangentIndex++] = -1;
+                    bitangents[bitangentIndex++] = 0;
                 }
             }
 
@@ -305,10 +305,10 @@ define([
                     tangents[tangentIndex++] = 0;
                     tangents[tangentIndex++] = 0;
                 }
-                if (vertexFormat.binormal) {
-                    binormals[binormalIndex++] = 0;
-                    binormals[binormalIndex++] = 1;
-                    binormals[binormalIndex++] = 0;
+                if (vertexFormat.bitangent) {
+                    bitangents[bitangentIndex++] = 0;
+                    bitangents[bitangentIndex++] = 1;
+                    bitangents[bitangentIndex++] = 0;
                 }
             }
         }
@@ -383,11 +383,11 @@ define([
             });
         }
 
-        if (vertexFormat.binormal) {
-            attributes.binormal = new GeometryAttribute({
+        if (vertexFormat.bitangent) {
+            attributes.bitangent = new GeometryAttribute({
                 componentDatatype : ComponentDatatype.FLOAT,
                 componentsPerAttribute : 3,
-                values : binormals
+                values : bitangents
             });
         }
 

--- a/Source/Core/EllipseGeometry.js
+++ b/Source/Core/EllipseGeometry.js
@@ -65,7 +65,7 @@ define([
 
     var scratchNormal = new Cartesian3();
     var scratchTangent = new Cartesian3();
-    var scratchBinormal = new Cartesian3();
+    var scratchBitangent = new Cartesian3();
 
     var scratchCartographic = new Cartographic();
     var projectedCenterScratch = new Cartesian3();
@@ -86,17 +86,17 @@ define([
         var textureCoordinates = (vertexFormat.st) ? new Float32Array(size * 2) : undefined;
         var normals = (vertexFormat.normal) ? new Float32Array(size * 3) : undefined;
         var tangents = (vertexFormat.tangent) ? new Float32Array(size * 3) : undefined;
-        var binormals = (vertexFormat.binormal) ? new Float32Array(size * 3) : undefined;
+        var bitangents = (vertexFormat.bitangent) ? new Float32Array(size * 3) : undefined;
 
         var extrudeNormals = (shadowVolume) ? new Float32Array(size * 3) : undefined;
 
         var textureCoordIndex = 0;
 
         // Raise positions to a height above the ellipsoid and compute the
-        // texture coordinates, normals, tangents, and binormals.
+        // texture coordinates, normals, tangents, and bitangents.
         var normal = scratchNormal;
         var tangent = scratchTangent;
-        var binormal = scratchBinormal;
+        var bitangent = scratchBitangent;
 
         var projection = new GeographicProjection(ellipsoid);
         var projectedCenter = projection.project(ellipsoid.cartesianToCartographic(center, scratchCartographic), projectedCenterScratch);
@@ -139,7 +139,7 @@ define([
                 textureCoordinates[textureCoordIndex++] = texCoordScratch.y;
             }
 
-            if (vertexFormat.normal || vertexFormat.tangent || vertexFormat.binormal || shadowVolume) {
+            if (vertexFormat.normal || vertexFormat.tangent || vertexFormat.bitangent || shadowVolume) {
                 normal = ellipsoid.geodeticSurfaceNormal(position, normal);
 
                 if (shadowVolume) {
@@ -148,8 +148,8 @@ define([
                     extrudeNormals[i2 + bottomOffset] = -normal.z;
                 }
 
-                if (vertexFormat.normal || vertexFormat.tangent || vertexFormat.binormal) {
-                    if (vertexFormat.tangent || vertexFormat.binormal) {
+                if (vertexFormat.normal || vertexFormat.tangent || vertexFormat.bitangent) {
+                    if (vertexFormat.tangent || vertexFormat.bitangent) {
                         tangent = Cartesian3.normalize(Cartesian3.cross(Cartesian3.UNIT_Z, normal, tangent), tangent);
                         Matrix3.multiplyByVector(textureMatrix, tangent, tangent);
                     }
@@ -175,15 +175,15 @@ define([
                         }
                     }
 
-                    if (vertexFormat.binormal) {
-                        binormal = Cartesian3.normalize(Cartesian3.cross(normal, tangent, binormal), binormal);
-                        binormals[i] = binormal.x;
-                        binormals[i1] = binormal.y;
-                        binormals[i2] = binormal.z;
+                    if (vertexFormat.bitangent) {
+                        bitangent = Cartesian3.normalize(Cartesian3.cross(normal, tangent, bitangent), bitangent);
+                        bitangents[i ] = bitangent.x;
+                        bitangents[i1] = bitangent.y;
+                        bitangents[i2] = bitangent.z;
                         if (extrude) {
-                            binormals[i + bottomOffset] = binormal.x;
-                            binormals[i1 + bottomOffset] = binormal.y;
-                            binormals[i2 + bottomOffset] = binormal.z;
+                            bitangents[i  + bottomOffset] = bitangent.x;
+                            bitangents[i1 + bottomOffset] = bitangent.y;
+                            bitangents[i2 + bottomOffset] = bitangent.z;
                         }
                     }
                 }
@@ -233,11 +233,11 @@ define([
             });
         }
 
-        if (vertexFormat.binormal) {
-            attributes.binormal = new GeometryAttribute({
+        if (vertexFormat.bitangent) {
+            attributes.bitangent = new GeometryAttribute({
                 componentDatatype : ComponentDatatype.FLOAT,
                 componentsPerAttribute : 3,
-                values : binormals
+                values : bitangents
             });
         }
 
@@ -389,7 +389,7 @@ define([
         var textureCoordinates = (vertexFormat.st) ? new Float32Array(size * 2) : undefined;
         var normals = (vertexFormat.normal) ? new Float32Array(size * 3) : undefined;
         var tangents = (vertexFormat.tangent) ? new Float32Array(size * 3) : undefined;
-        var binormals = (vertexFormat.binormal) ? new Float32Array(size * 3) : undefined;
+        var bitangents = (vertexFormat.bitangent) ? new Float32Array(size * 3) : undefined;
 
         var shadowVolume = options.shadowVolume;
         var extrudeNormals = (shadowVolume) ? new Float32Array(size * 3) : undefined;
@@ -397,10 +397,10 @@ define([
         var textureCoordIndex = 0;
 
         // Raise positions to a height above the ellipsoid and compute the
-        // texture coordinates, normals, tangents, and binormals.
+        // texture coordinates, normals, tangents, and bitangents.
         var normal = scratchNormal;
         var tangent = scratchTangent;
-        var binormal = scratchBinormal;
+        var bitangent = scratchBitangent;
 
         var projection = new GeographicProjection(ellipsoid);
         var projectedCenter = projection.project(ellipsoid.cartesianToCartographic(center, scratchCartographic), projectedCenterScratch);
@@ -466,9 +466,9 @@ define([
                 finalPositions[i2] = position.z;
             }
 
-            if (vertexFormat.normal || vertexFormat.tangent || vertexFormat.binormal) {
+            if (vertexFormat.normal || vertexFormat.tangent || vertexFormat.bitangent) {
 
-                binormal = Cartesian3.clone(normal, binormal);
+                bitangent = Cartesian3.clone(normal, bitangent);
                 var next = Cartesian3.fromArray(positions, (i + 3) % length, scratchCartesian4);
                 Cartesian3.subtract(next, position, next);
                 var bottom = Cartesian3.subtract(extrudedPosition, position, scratchCartesian3);
@@ -486,7 +486,7 @@ define([
                 }
 
                 if (vertexFormat.tangent) {
-                    tangent = Cartesian3.normalize(Cartesian3.cross(binormal, normal, tangent), tangent);
+                    tangent = Cartesian3.normalize(Cartesian3.cross(bitangent, normal, tangent), tangent);
                     tangents[i] = tangent.x;
                     tangents[i1] = tangent.y;
                     tangents[i2] = tangent.z;
@@ -496,14 +496,14 @@ define([
                     tangents[i + 2 + length] = tangent.z;
                 }
 
-                if (vertexFormat.binormal) {
-                    binormals[i] = binormal.x;
-                    binormals[i1] = binormal.y;
-                    binormals[i2] = binormal.z;
+                if (vertexFormat.bitangent) {
+                    bitangents[i ] = bitangent.x;
+                    bitangents[i1] = bitangent.y;
+                    bitangents[i2] = bitangent.z;
 
-                    binormals[i + length] = binormal.x;
-                    binormals[i1 + length] = binormal.y;
-                    binormals[i2 + length] = binormal.z;
+                    bitangents[i  + length] = bitangent.x;
+                    bitangents[i1 + length] = bitangent.y;
+                    bitangents[i2 + length] = bitangent.z;
                 }
             }
         }
@@ -550,11 +550,11 @@ define([
             });
         }
 
-        if (vertexFormat.binormal) {
-            attributes.binormal = new GeometryAttribute({
+        if (vertexFormat.bitangent) {
+            attributes.bitangent = new GeometryAttribute({
                 componentDatatype : ComponentDatatype.FLOAT,
                 componentsPerAttribute : 3,
-                values : binormals
+                values : bitangents
             });
         }
 

--- a/Source/Core/EllipseGeometry.js
+++ b/Source/Core/EllipseGeometry.js
@@ -181,7 +181,7 @@ define([
                         bitangents[i1] = bitangent.y;
                         bitangents[i2] = bitangent.z;
                         if (extrude) {
-                            bitangents[i  + bottomOffset] = bitangent.x;
+                            bitangents[i + bottomOffset] = bitangent.x;
                             bitangents[i1 + bottomOffset] = bitangent.y;
                             bitangents[i2 + bottomOffset] = bitangent.z;
                         }
@@ -501,7 +501,7 @@ define([
                     bitangents[i1] = bitangent.y;
                     bitangents[i2] = bitangent.z;
 
-                    bitangents[i  + length] = bitangent.x;
+                    bitangents[i + length] = bitangent.x;
                     bitangents[i1 + length] = bitangent.y;
                     bitangents[i2 + length] = bitangent.z;
                 }

--- a/Source/Core/EllipsoidGeometry.js
+++ b/Source/Core/EllipsoidGeometry.js
@@ -36,7 +36,7 @@ define([
     var scratchPosition = new Cartesian3();
     var scratchNormal = new Cartesian3();
     var scratchTangent = new Cartesian3();
-    var scratchBinormal = new Cartesian3();
+    var scratchBitangent = new Cartesian3();
     var scratchNormalST = new Cartesian3();
     var defaultRadii = new Cartesian3(1.0, 1.0, 1.0);
 
@@ -209,7 +209,7 @@ define([
 
         var normals = (vertexFormat.normal) ? new Float32Array(vertexCount * 3) : undefined;
         var tangents = (vertexFormat.tangent) ? new Float32Array(vertexCount * 3) : undefined;
-        var binormals = (vertexFormat.binormal) ? new Float32Array(vertexCount * 3) : undefined;
+        var bitangents = (vertexFormat.bitangent) ? new Float32Array(vertexCount * 3) : undefined;
         var st = (vertexFormat.st) ? new Float32Array(vertexCount * 2) : undefined;
 
         var cosTheta = new Array(slicePartitions);
@@ -267,9 +267,9 @@ define([
         var stIndex = 0;
         var normalIndex = 0;
         var tangentIndex = 0;
-        var binormalIndex = 0;
+        var bitangentIndex = 0;
 
-        if (vertexFormat.st || vertexFormat.normal || vertexFormat.tangent || vertexFormat.binormal) {
+        if (vertexFormat.st || vertexFormat.normal || vertexFormat.tangent || vertexFormat.bitangent) {
             for( i = 0; i < vertexCount; i++) {
                 var position = Cartesian3.fromArray(positions, i * 3, scratchPosition);
                 var normal = ellipsoid.geodeticSurfaceNormal(position, scratchNormal);
@@ -299,7 +299,7 @@ define([
                     normals[normalIndex++] = normal.z;
                 }
 
-                if (vertexFormat.tangent || vertexFormat.binormal) {
+                if (vertexFormat.tangent || vertexFormat.bitangent) {
                     var tangent = scratchTangent;
                     if (i < slicePartitions || i > vertexCount - slicePartitions - 1) {
                         Cartesian3.cross(Cartesian3.UNIT_X, normal, tangent);
@@ -315,13 +315,13 @@ define([
                         tangents[tangentIndex++] = tangent.z;
                     }
 
-                    if (vertexFormat.binormal) {
-                        var binormal = Cartesian3.cross(normal, tangent, scratchBinormal);
-                        Cartesian3.normalize(binormal, binormal);
+                    if (vertexFormat.bitangent) {
+                        var bitangent = Cartesian3.cross(normal, tangent, scratchBitangent);
+                        Cartesian3.normalize(bitangent, bitangent);
 
-                        binormals[binormalIndex++] = binormal.x;
-                        binormals[binormalIndex++] = binormal.y;
-                        binormals[binormalIndex++] = binormal.z;
+                        bitangents[bitangentIndex++] = bitangent.x;
+                        bitangents[bitangentIndex++] = bitangent.y;
+                        bitangents[bitangentIndex++] = bitangent.z;
                     }
                 }
             }
@@ -350,11 +350,11 @@ define([
                 });
             }
 
-            if (vertexFormat.binormal) {
-                attributes.binormal = new GeometryAttribute({
+            if (vertexFormat.bitangent) {
+                attributes.bitangent = new GeometryAttribute({
                     componentDatatype : ComponentDatatype.FLOAT,
                     componentsPerAttribute : 3,
-                    values : binormals
+                    values : bitangents
                 });
             }
         }

--- a/Source/Core/Geometry.js
+++ b/Source/Core/Geometry.js
@@ -85,7 +85,7 @@ define([
          *    <li><code>position</code> - 3D vertex position.  64-bit floating-point (for precision).  3 components per attribute.  See {@link VertexFormat#position}.</li>
          *    <li><code>normal</code> - Normal (normalized), commonly used for lighting.  32-bit floating-point.  3 components per attribute.  See {@link VertexFormat#normal}.</li>
          *    <li><code>st</code> - 2D texture coordinate.  32-bit floating-point.  2 components per attribute.  See {@link VertexFormat#st}.</li>
-         *    <li><code>binormal</code> - Binormal (normalized), used for tangent-space effects like bump mapping.  32-bit floating-point.  3 components per attribute.  See {@link VertexFormat#binormal}.</li>
+         *    <li><code>bitangent</code> - Bitangent (normalized), used for tangent-space effects like bump mapping.  32-bit floating-point.  3 components per attribute.  See {@link VertexFormat#bitangent}.</li>
          *    <li><code>tangent</code> - Tangent (normalized), used for tangent-space effects like bump mapping.  32-bit floating-point.  3 components per attribute.  See {@link VertexFormat#tangent}.</li>
          * </ul>
          * </p>
@@ -114,7 +114,7 @@ define([
          *   componentsPerAttribute : 3,
          *   values : new Float32Array(0)
          * });
-         * 
+         *
          * @see GeometryAttribute
          * @see VertexFormat
          */

--- a/Source/Core/GeometryAttributes.js
+++ b/Source/Core/GeometryAttributes.js
@@ -55,7 +55,7 @@ define([
         this.st = options.st;
 
         /**
-         * The binormal attribute (normalized), which is used for tangent-space effects like bump mapping.
+         * The bitangent attribute (normalized), which is used for tangent-space effects like bump mapping.
          * <p>
          * 32-bit floating-point.  3 components per attribute.
          * </p>
@@ -64,7 +64,7 @@ define([
          *
          * @default undefined
          */
-        this.binormal = options.binormal;
+        this.bitangent = options.bitangent;
 
         /**
          * The tangent attribute (normalized), which is used for tangent-space effects like bump mapping.

--- a/Source/Core/PolygonGeometry.js
+++ b/Source/Core/PolygonGeometry.js
@@ -107,12 +107,12 @@ define([
     var scratchPosition = new Cartesian3();
     var scratchNormal = new Cartesian3();
     var scratchTangent = new Cartesian3();
-    var scratchBinormal = new Cartesian3();
+    var scratchBitangent = new Cartesian3();
     var p1Scratch = new Cartesian3();
     var p2Scratch = new Cartesian3();
     var scratchPerPosNormal = new Cartesian3();
     var scratchPerPosTangent = new Cartesian3();
-    var scratchPerPosBinormal = new Cartesian3();
+    var scratchPerPosBitangent = new Cartesian3();
 
     var appendTextureCoordinatesOrigin = new Cartesian2();
     var appendTextureCoordinatesCartesian2 = new Cartesian2();
@@ -124,7 +124,7 @@ define([
         var vertexFormat = options.vertexFormat;
         var geometry = options.geometry;
         var shadowVolume = options.shadowVolume;
-        if (vertexFormat.st || vertexFormat.normal || vertexFormat.tangent || vertexFormat.binormal || shadowVolume) {
+        if (vertexFormat.st || vertexFormat.normal || vertexFormat.tangent || vertexFormat.bitangent || shadowVolume) {
             // PERFORMANCE_IDEA: Compute before subdivision, then just interpolate during subdivision.
             // PERFORMANCE_IDEA: Compute with createGeometryFromPositions() for fast path when there's no holes.
             var boundingRectangle = options.boundingRectangle;
@@ -153,7 +153,7 @@ define([
                 }
             }
             var tangents = vertexFormat.tangent ? new Float32Array(length) : undefined;
-            var binormals = vertexFormat.binormal ? new Float32Array(length) : undefined;
+            var bitangents = vertexFormat.bitangent ? new Float32Array(length) : undefined;
             var extrudeNormals = shadowVolume ? new Float32Array(length) : undefined;
 
             var textureCoordIndex = 0;
@@ -161,7 +161,7 @@ define([
 
             var normal = scratchNormal;
             var tangent = scratchTangent;
-            var binormal = scratchBinormal;
+            var bitangent = scratchBitangent;
             var recomputeNormal = true;
 
             var rotation = Quaternion.fromAxisAngle(tangentPlane._plane.normal, stRotation, appendTextureCoordinatesQuaternion);
@@ -200,7 +200,7 @@ define([
                     textureCoordIndex += 2;
                 }
 
-                if (vertexFormat.normal || vertexFormat.tangent || vertexFormat.binormal || shadowVolume) {
+                if (vertexFormat.normal || vertexFormat.tangent || vertexFormat.bitangent || shadowVolume) {
                     var attrIndex1 = attrIndex + 1;
                     var attrIndex2 = attrIndex + 2;
 
@@ -224,28 +224,28 @@ define([
                             }
                         }
 
-                        if (vertexFormat.tangent || vertexFormat.binormal) {
-                            binormal = ellipsoid.geodeticSurfaceNormal(position, binormal);
+                        if (vertexFormat.tangent || vertexFormat.bitangent) {
+                            bitangent = ellipsoid.geodeticSurfaceNormal(position, bitangent);
                             if (vertexFormat.tangent) {
-                                tangent = Cartesian3.normalize(Cartesian3.cross(binormal, normal, tangent), tangent);
+                                tangent = Cartesian3.normalize(Cartesian3.cross(bitangent, normal, tangent), tangent);
                             }
                         }
                     } else {
                         normal = ellipsoid.geodeticSurfaceNormal(position, normal);
-                        if (vertexFormat.tangent || vertexFormat.binormal) {
+                        if (vertexFormat.tangent || vertexFormat.bitangent) {
                             if (perPositionHeight) {
                                 scratchPerPosNormal = Cartesian3.fromArray(normals, attrIndex, scratchPerPosNormal);
                                 scratchPerPosTangent = Cartesian3.cross(Cartesian3.UNIT_Z, scratchPerPosNormal, scratchPerPosTangent);
                                 scratchPerPosTangent = Cartesian3.normalize(Matrix3.multiplyByVector(textureMatrix, scratchPerPosTangent, scratchPerPosTangent), scratchPerPosTangent);
-                                if (vertexFormat.binormal) {
-                                    scratchPerPosBinormal = Cartesian3.normalize(Cartesian3.cross(scratchPerPosNormal, scratchPerPosTangent, scratchPerPosBinormal), scratchPerPosBinormal);
+                                if (vertexFormat.bitangent) {
+                                    scratchPerPosBitangent = Cartesian3.normalize(Cartesian3.cross(scratchPerPosNormal, scratchPerPosTangent, scratchPerPosBitangent), scratchPerPosBitangent);
                                 }
                             }
 
                             tangent = Cartesian3.cross(Cartesian3.UNIT_Z, normal, tangent);
                             tangent = Cartesian3.normalize(Matrix3.multiplyByVector(textureMatrix, tangent, tangent), tangent);
-                            if (vertexFormat.binormal) {
-                                binormal = Cartesian3.normalize(Cartesian3.cross(normal, tangent, binormal), binormal);
+                            if (vertexFormat.bitangent) {
+                                bitangent = Cartesian3.normalize(Cartesian3.cross(normal, tangent, bitangent), bitangent);
                             }
                         }
                     }
@@ -301,21 +301,21 @@ define([
                         }
                     }
 
-                    if (vertexFormat.binormal) {
+                    if (vertexFormat.bitangent) {
                         if (bottom) {
-                            binormals[attrIndex + bottomOffset] = binormal.x;
-                            binormals[attrIndex1 + bottomOffset] = binormal.y;
-                            binormals[attrIndex2 + bottomOffset] = binormal.z;
+                            bitangents[attrIndex  + bottomOffset] = bitangent.x;
+                            bitangents[attrIndex1 + bottomOffset] = bitangent.y;
+                            bitangents[attrIndex2 + bottomOffset] = bitangent.z;
                         }
                         if (top) {
                             if (perPositionHeight) {
-                                binormals[attrIndex] = scratchPerPosBinormal.x;
-                                binormals[attrIndex1] = scratchPerPosBinormal.y;
-                                binormals[attrIndex2] = scratchPerPosBinormal.z;
+                                bitangents[attrIndex ] = scratchPerPosBitangent.x;
+                                bitangents[attrIndex1] = scratchPerPosBitangent.y;
+                                bitangents[attrIndex2] = scratchPerPosBitangent.z;
                             } else {
-                                binormals[attrIndex] = binormal.x;
-                                binormals[attrIndex1] = binormal.y;
-                                binormals[attrIndex2] = binormal.z;
+                                bitangents[attrIndex ] = bitangent.x;
+                                bitangents[attrIndex1] = bitangent.y;
+                                bitangents[attrIndex2] = bitangent.z;
                             }
                         }
                     }
@@ -347,11 +347,11 @@ define([
                 });
             }
 
-            if (vertexFormat.binormal) {
-                geometry.attributes.binormal = new GeometryAttribute({
+            if (vertexFormat.bitangent) {
+                geometry.attributes.bitangent = new GeometryAttribute({
                     componentDatatype : ComponentDatatype.FLOAT,
                     componentsPerAttribute : 3,
-                    values : binormals
+                    values : bitangents
                 });
             }
 

--- a/Source/Core/PolygonGeometry.js
+++ b/Source/Core/PolygonGeometry.js
@@ -303,17 +303,17 @@ define([
 
                     if (vertexFormat.bitangent) {
                         if (bottom) {
-                            bitangents[attrIndex  + bottomOffset] = bitangent.x;
+                            bitangents[attrIndex + bottomOffset] = bitangent.x;
                             bitangents[attrIndex1 + bottomOffset] = bitangent.y;
                             bitangents[attrIndex2 + bottomOffset] = bitangent.z;
                         }
                         if (top) {
                             if (perPositionHeight) {
-                                bitangents[attrIndex ] = scratchPerPosBitangent.x;
+                                bitangents[attrIndex] = scratchPerPosBitangent.x;
                                 bitangents[attrIndex1] = scratchPerPosBitangent.y;
                                 bitangents[attrIndex2] = scratchPerPosBitangent.z;
                             } else {
-                                bitangents[attrIndex ] = bitangent.x;
+                                bitangents[attrIndex] = bitangent.x;
                                 bitangents[attrIndex1] = bitangent.y;
                                 bitangents[attrIndex2] = bitangent.z;
                             }

--- a/Source/Core/PolylineVolumeGeometry.js
+++ b/Source/Core/PolylineVolumeGeometry.js
@@ -96,7 +96,7 @@ define([
             indices[index++] = lr;
         }
 
-        if (vertexFormat.st || vertexFormat.tangent || vertexFormat.binormal) { // st required for tangent/binormal calculation
+        if (vertexFormat.st || vertexFormat.tangent || vertexFormat.bitangent) { // st required for tangent/bitangent calculation
             var st = new Float32Array(vertexCount * 2);
             var lengthSt = 1 / (length - 1);
             var heightSt = 1 / (boundingRectangle.height);
@@ -164,19 +164,19 @@ define([
             geometry = GeometryPipeline.computeNormal(geometry);
         }
 
-        if (vertexFormat.tangent || vertexFormat.binormal) {
+        if (vertexFormat.tangent || vertexFormat.bitangent) {
             try {
-                geometry = GeometryPipeline.computeBinormalAndTangent(geometry);
+                geometry = GeometryPipeline.computeTangentAndBitangent(geometry);
             } catch (e) {
-                oneTimeWarning('polyline-volume-tangent-binormal', 'Unable to compute tangents and binormals for polyline volume geometry');
+                oneTimeWarning('polyline-volume-tangent-bitangent', 'Unable to compute tangents and bitangents for polyline volume geometry');
                 //TODO https://github.com/AnalyticalGraphicsInc/cesium/issues/3609
             }
 
             if (!vertexFormat.tangent) {
                 geometry.attributes.tangent = undefined;
             }
-            if (!vertexFormat.binormal) {
-                geometry.attributes.binormal = undefined;
+            if (!vertexFormat.bitangent) {
+                geometry.attributes.bitangent = undefined;
             }
             if (!vertexFormat.st) {
                 geometry.attributes.st = undefined;

--- a/Source/Core/RectangleGeometry.js
+++ b/Source/Core/RectangleGeometry.js
@@ -56,7 +56,7 @@ define([
     var positionScratch = new Cartesian3();
     var normalScratch = new Cartesian3();
     var tangentScratch = new Cartesian3();
-    var binormalScratch = new Cartesian3();
+    var bitangentScratch = new Cartesian3();
     var rectangleScratch = new Rectangle();
     var stScratch = new Cartesian2();
     var bottomBoundingSphere = new BoundingSphere();
@@ -87,11 +87,11 @@ define([
                 values : attributes.tangents
             });
         }
-        if (vertexFormat.binormal) {
-            geo.attributes.binormal = new GeometryAttribute({
+        if (vertexFormat.bitangent) {
+            geo.attributes.bitangent = new GeometryAttribute({
                 componentDatatype : ComponentDatatype.FLOAT,
                 componentsPerAttribute : 3,
-                values : attributes.binormals
+                values : attributes.bitangents
             });
         }
         return geo;
@@ -102,10 +102,10 @@ define([
 
         var normals = (vertexFormat.normal) ? new Float32Array(length) : undefined;
         var tangents = (vertexFormat.tangent) ? new Float32Array(length) : undefined;
-        var binormals = (vertexFormat.binormal) ? new Float32Array(length) : undefined;
+        var bitangents = (vertexFormat.bitangent) ? new Float32Array(length) : undefined;
 
         var attrIndex = 0;
-        var binormal = binormalScratch;
+        var bitangent = bitangentScratch;
         var tangent = tangentScratch;
         var normal = normalScratch;
         for (var i = 0; i < length; i += 3) {
@@ -113,32 +113,32 @@ define([
             var attrIndex1 = attrIndex + 1;
             var attrIndex2 = attrIndex + 2;
 
-            if (vertexFormat.normal || vertexFormat.tangent || vertexFormat.binormal) {
+            if (vertexFormat.normal || vertexFormat.tangent || vertexFormat.bitangent) {
                 normal = ellipsoid.geodeticSurfaceNormal(p, normal);
-                if (vertexFormat.tangent || vertexFormat.binormal) {
+                if (vertexFormat.tangent || vertexFormat.bitangent) {
                     Cartesian3.cross(Cartesian3.UNIT_Z, normal, tangent);
                     Matrix3.multiplyByVector(tangentRotationMatrix, tangent, tangent);
                     Cartesian3.normalize(tangent, tangent);
 
-                    if (vertexFormat.binormal) {
-                        Cartesian3.normalize(Cartesian3.cross(normal, tangent, binormal), binormal);
+                    if (vertexFormat.bitangent) {
+                        Cartesian3.normalize(Cartesian3.cross(normal, tangent, bitangent), bitangent);
                     }
                 }
 
                 if (vertexFormat.normal) {
-                    normals[attrIndex] = normal.x;
+                    normals[attrIndex ] = normal.x;
                     normals[attrIndex1] = normal.y;
                     normals[attrIndex2] = normal.z;
                 }
                 if (vertexFormat.tangent) {
-                    tangents[attrIndex] = tangent.x;
+                    tangents[attrIndex ] = tangent.x;
                     tangents[attrIndex1] = tangent.y;
                     tangents[attrIndex2] = tangent.z;
                 }
-                if (vertexFormat.binormal) {
-                    binormals[attrIndex] = binormal.x;
-                    binormals[attrIndex1] = binormal.y;
-                    binormals[attrIndex2] = binormal.z;
+                if (vertexFormat.bitangent) {
+                    bitangents[attrIndex ] = bitangent.x;
+                    bitangents[attrIndex1] = bitangent.y;
+                    bitangents[attrIndex2] = bitangent.z;
                 }
             }
             attrIndex += 3;
@@ -147,7 +147,7 @@ define([
             positions : positions,
             normals : normals,
             tangents : tangents,
-            binormals : binormals
+            bitangents : bitangents
         });
     }
 
@@ -158,20 +158,20 @@ define([
 
         var normals = (vertexFormat.normal) ? new Float32Array(length) : undefined;
         var tangents = (vertexFormat.tangent) ? new Float32Array(length) : undefined;
-        var binormals = (vertexFormat.binormal) ? new Float32Array(length) : undefined;
+        var bitangents = (vertexFormat.bitangent) ? new Float32Array(length) : undefined;
 
         var normalIndex = 0;
         var tangentIndex = 0;
-        var binormalIndex = 0;
+        var bitangentIndex = 0;
         var recomputeNormal = true;
 
-        var binormal = binormalScratch;
+        var bitangent = bitangentScratch;
         var tangent = tangentScratch;
         var normal = normalScratch;
         for (var i = 0; i < length; i += 6) {
             var p = Cartesian3.fromArray(positions, i, positionScratch);
 
-            if (vertexFormat.normal || vertexFormat.tangent || vertexFormat.binormal) {
+            if (vertexFormat.normal || vertexFormat.tangent || vertexFormat.bitangent) {
                 var p1 = Cartesian3.fromArray(positions, (i + 6) % length, v1Scratch);
                 if (recomputeNormal) {
                     var p2 = Cartesian3.fromArray(positions, (i + 3) % length, v2Scratch);
@@ -185,10 +185,10 @@ define([
                     recomputeNormal = true;
                 }
 
-                if (vertexFormat.tangent || vertexFormat.binormal) {
-                    binormal = ellipsoid.geodeticSurfaceNormal(p, binormal);
+                if (vertexFormat.tangent || vertexFormat.bitangent) {
+                    bitangent = ellipsoid.geodeticSurfaceNormal(p, bitangent);
                     if (vertexFormat.tangent) {
-                        tangent = Cartesian3.normalize(Cartesian3.cross(binormal, normal, tangent), tangent);
+                        tangent = Cartesian3.normalize(Cartesian3.cross(bitangent, normal, tangent), tangent);
                     }
                 }
 
@@ -210,13 +210,13 @@ define([
                     tangents[tangentIndex++] = tangent.z;
                 }
 
-                if (vertexFormat.binormal) {
-                    binormals[binormalIndex++] = binormal.x;
-                    binormals[binormalIndex++] = binormal.y;
-                    binormals[binormalIndex++] = binormal.z;
-                    binormals[binormalIndex++] = binormal.x;
-                    binormals[binormalIndex++] = binormal.y;
-                    binormals[binormalIndex++] = binormal.z;
+                if (vertexFormat.bitangent) {
+                    bitangents[bitangentIndex++] = bitangent.x;
+                    bitangents[bitangentIndex++] = bitangent.y;
+                    bitangents[bitangentIndex++] = bitangent.z;
+                    bitangents[bitangentIndex++] = bitangent.x;
+                    bitangents[bitangentIndex++] = bitangent.y;
+                    bitangents[bitangentIndex++] = bitangent.z;
                 }
             }
         }
@@ -225,7 +225,7 @@ define([
             positions : positions,
             normals : normals,
             tangents : tangents,
-            binormals : binormals
+            bitangents : bitangents
         });
     }
 
@@ -365,7 +365,7 @@ define([
 
         var normals = (vertexFormat.normal) ? new Float32Array(newLength) : undefined;
         var tangents = (vertexFormat.tangent) ? new Float32Array(newLength) : undefined;
-        var binormals = (vertexFormat.binormal) ? new Float32Array(newLength) : undefined;
+        var bitangents = (vertexFormat.bitangent) ? new Float32Array(newLength) : undefined;
         var textures = (vertexFormat.st) ? new Float32Array(newLength/3*2) : undefined;
         var topSt;
         var topNormals;
@@ -404,11 +404,11 @@ define([
             tangents.set(topTangents, length);
             topBottomGeo.attributes.tangent.values = tangents;
         }
-        if (vertexFormat.binormal) {
-            var topBinormals = topBottomGeo.attributes.binormal.values;
-            binormals.set(topBinormals);
-            binormals.set(topBinormals, length);
-            topBottomGeo.attributes.binormal.values = binormals;
+        if (vertexFormat.bitangent) {
+            var topBitangents = topBottomGeo.attributes.bitangent.values;
+            bitangents.set(topBitangents);
+            bitangents.set(topBitangents, length);
+            topBottomGeo.attributes.bitangent.values = bitangents;
         }
         if (vertexFormat.st) {
             topSt = topBottomGeo.attributes.st.values;

--- a/Source/Core/RectangleGeometry.js
+++ b/Source/Core/RectangleGeometry.js
@@ -126,17 +126,17 @@ define([
                 }
 
                 if (vertexFormat.normal) {
-                    normals[attrIndex ] = normal.x;
+                    normals[attrIndex] = normal.x;
                     normals[attrIndex1] = normal.y;
                     normals[attrIndex2] = normal.z;
                 }
                 if (vertexFormat.tangent) {
-                    tangents[attrIndex ] = tangent.x;
+                    tangents[attrIndex] = tangent.x;
                     tangents[attrIndex1] = tangent.y;
                     tangents[attrIndex2] = tangent.z;
                 }
                 if (vertexFormat.bitangent) {
-                    bitangents[attrIndex ] = bitangent.x;
+                    bitangents[attrIndex] = bitangent.x;
                     bitangents[attrIndex1] = bitangent.y;
                     bitangents[attrIndex2] = bitangent.z;
                 }

--- a/Source/Core/VertexFormat.js
+++ b/Source/Core/VertexFormat.js
@@ -71,7 +71,7 @@ define([
         this.st = defaultValue(options.st, false);
 
         /**
-         * When <code>true</code>, the vertex has a binormal attribute (normalized), which is used for tangent-space effects like bump mapping.
+         * When <code>true</code>, the vertex has a bitangent attribute (normalized), which is used for tangent-space effects like bump mapping.
          * <p>
          * 32-bit floating-point.  3 components per attribute.
          * </p>
@@ -80,7 +80,7 @@ define([
          *
          * @default false
          */
-        this.binormal = defaultValue(options.binormal, false);
+        this.bitangent = defaultValue(options.bitangent, false);
 
         /**
          * When <code>true</code>, the vertex has a tangent attribute (normalized), which is used for tangent-space effects like bump mapping.
@@ -182,7 +182,7 @@ define([
     }));
 
     /**
-     * An immutable vertex format with well-known attributes: position, normal, st, binormal, and tangent.
+     * An immutable vertex format with well-known attributes: position, normal, st, tangent, and bitangent.
      *
      * @type {VertexFormat}
      * @constant
@@ -190,15 +190,15 @@ define([
      * @see VertexFormat#position
      * @see VertexFormat#normal
      * @see VertexFormat#st
-     * @see VertexFormat#binormal
      * @see VertexFormat#tangent
+     * @see VertexFormat#bitangent
      */
     VertexFormat.ALL = freezeObject(new VertexFormat({
         position : true,
         normal : true,
         st : true,
-        binormal : true,
-        tangent  : true
+        tangent  : true,
+        bitangent : true
     }));
 
     /**
@@ -245,8 +245,8 @@ define([
         array[startingIndex++] = value.position ? 1.0 : 0.0;
         array[startingIndex++] = value.normal ? 1.0 : 0.0;
         array[startingIndex++] = value.st ? 1.0 : 0.0;
-        array[startingIndex++] = value.binormal ? 1.0 : 0.0;
         array[startingIndex++] = value.tangent ? 1.0 : 0.0;
+        array[startingIndex++] = value.bitangent ? 1.0 : 0.0;
         array[startingIndex++] = value.color ? 1.0 : 0.0;
 
         return array;
@@ -273,12 +273,12 @@ define([
             result = new VertexFormat();
         }
 
-        result.position = array[startingIndex++] === 1.0;
-        result.normal   = array[startingIndex++] === 1.0;
-        result.st       = array[startingIndex++] === 1.0;
-        result.binormal = array[startingIndex++] === 1.0;
-        result.tangent  = array[startingIndex++] === 1.0;
-        result.color    = array[startingIndex++] === 1.0;
+        result.position  = array[startingIndex++] === 1.0;
+        result.normal    = array[startingIndex++] === 1.0;
+        result.st        = array[startingIndex++] === 1.0;
+        result.tangent   = array[startingIndex++] === 1.0;
+        result.bitangent = array[startingIndex++] === 1.0;
+        result.color     = array[startingIndex++] === 1.0;
         return result;
     };
 
@@ -300,8 +300,8 @@ define([
         result.position = vertexFormat.position;
         result.normal = vertexFormat.normal;
         result.st = vertexFormat.st;
-        result.binormal = vertexFormat.binormal;
         result.tangent = vertexFormat.tangent;
+        result.bitangent = vertexFormat.bitangent;
         result.color = vertexFormat.color;
         return result;
     };

--- a/Source/Core/WallGeometry.js
+++ b/Source/Core/WallGeometry.js
@@ -38,7 +38,7 @@ define([
     var scratchCartesian3Position3 = new Cartesian3();
     var scratchCartesian3Position4 = new Cartesian3();
     var scratchCartesian3Position5 = new Cartesian3();
-    var scratchBinormal = new Cartesian3();
+    var scratchBitangent = new Cartesian3();
     var scratchTangent = new Cartesian3();
     var scratchNormal = new Cartesian3();
 
@@ -377,12 +377,12 @@ define([
         var positions = vertexFormat.position ? new Float64Array(size) : undefined;
         var normals = vertexFormat.normal ? new Float32Array(size) : undefined;
         var tangents = vertexFormat.tangent ? new Float32Array(size) : undefined;
-        var binormals = vertexFormat.binormal ? new Float32Array(size) : undefined;
+        var bitangents = vertexFormat.bitangent ? new Float32Array(size) : undefined;
         var textureCoordinates = vertexFormat.st ? new Float32Array(size / 3 * 2) : undefined;
 
         var positionIndex = 0;
         var normalIndex = 0;
-        var binormalIndex = 0;
+        var bitangentIndex = 0;
         var tangentIndex = 0;
         var stIndex = 0;
 
@@ -390,7 +390,7 @@ define([
         // points being even and upper points being odd
         var normal = scratchNormal;
         var tangent = scratchTangent;
-        var binormal = scratchBinormal;
+        var bitangent = scratchBitangent;
         var recomputeNormal = true;
         length /= 3;
         var i;
@@ -420,7 +420,7 @@ define([
                 textureCoordinates[stIndex++] = 1.0;
             }
 
-            if (vertexFormat.normal || vertexFormat.tangent || vertexFormat.binormal) {
+            if (vertexFormat.normal || vertexFormat.tangent || vertexFormat.bitangent) {
                 var nextPosition;
                 var nextTop = Cartesian3.clone(Cartesian3.ZERO, scratchCartesian3Position5);
                 var groundPosition = ellipsoid.scaleToGeodeticSurface(Cartesian3.fromArray(topPositions, i3, scratchCartesian3Position2), scratchCartesian3Position2);
@@ -443,8 +443,8 @@ define([
                     if (vertexFormat.tangent) {
                         tangent = Cartesian3.normalize(Cartesian3.subtract(nextPosition, groundPosition, tangent), tangent);
                     }
-                    if (vertexFormat.binormal) {
-                        binormal = Cartesian3.normalize(Cartesian3.cross(normal, tangent, binormal), binormal);
+                    if (vertexFormat.bitangent) {
+                        bitangent = Cartesian3.normalize(Cartesian3.cross(normal, tangent, bitangent), bitangent);
                     }
                 }
 
@@ -468,14 +468,14 @@ define([
                     tangents[tangentIndex++] = tangent.z;
                 }
 
-                if (vertexFormat.binormal) {
-                    binormals[binormalIndex++] = binormal.x;
-                    binormals[binormalIndex++] = binormal.y;
-                    binormals[binormalIndex++] = binormal.z;
+                if (vertexFormat.bitangent) {
+                    bitangents[bitangentIndex++] = bitangent.x;
+                    bitangents[bitangentIndex++] = bitangent.y;
+                    bitangents[bitangentIndex++] = bitangent.z;
 
-                    binormals[binormalIndex++] = binormal.x;
-                    binormals[binormalIndex++] = binormal.y;
-                    binormals[binormalIndex++] = binormal.z;
+                    bitangents[bitangentIndex++] = bitangent.x;
+                    bitangents[bitangentIndex++] = bitangent.y;
+                    bitangents[bitangentIndex++] = bitangent.z;
                 }
             }
         }
@@ -506,11 +506,11 @@ define([
             });
         }
 
-        if (vertexFormat.binormal) {
-            attributes.binormal = new GeometryAttribute({
+        if (vertexFormat.bitangent) {
+            attributes.bitangent = new GeometryAttribute({
                 componentDatatype : ComponentDatatype.FLOAT,
                 componentsPerAttribute : 3,
-                values : binormals
+                values : bitangents
             });
         }
 

--- a/Source/Scene/DebugAppearance.js
+++ b/Source/Scene/DebugAppearance.js
@@ -26,7 +26,7 @@ define([
      *
      * @param {Object} options Object with the following properties:
      * @param {String} options.attributeName The name of the attribute to visualize.
-     * @param {Boolean} options.perInstanceAttribute Boolean that determines whether this attribute is a per-instance geometry attribute.
+     * @param {Boolean} [options.perInstanceAttribute=false] Boolean that determines whether this attribute is a per-instance geometry attribute.
      * @param {String} [options.glslDatatype='vec3'] The GLSL datatype of the attribute.  Supported datatypes are <code>float</code>, <code>vec2</code>, <code>vec3</code>, and <code>vec4</code>.
      * @param {String} [options.vertexShaderSource] Optional GLSL vertex shader source to override the default vertex shader.
      * @param {String} [options.fragmentShaderSource] Optional GLSL fragment shader source to override the default fragment shader.
@@ -51,10 +51,11 @@ define([
         if (!defined(attributeName)) {
             throw new DeveloperError('options.attributeName is required.');
         }
-        if (!defined(perInstanceAttribute)) {
-            throw new DeveloperError('options.perInstanceAttribute is required.');
-        }
         //>>includeEnd('debug');
+
+        if (!defined(perInstanceAttribute)) {
+            perInstanceAttribute = false;
+        }
 
         var glslDatatype = defaultValue(options.glslDatatype, 'vec3');
         var varyingName = 'v_' + attributeName;

--- a/Source/Scene/DebugAppearance.js
+++ b/Source/Scene/DebugAppearance.js
@@ -17,7 +17,7 @@ define([
      * Visualizes a vertex attribute by displaying it as a color for debugging.
      * <p>
      * Components for well-known unit-length vectors, i.e., <code>normal</code>,
-     * <code>binormal</code>, and <code>tangent</code>, are scaled and biased
+     * <code>tangent</code>, and <code>bitangent</code>, are scaled and biased
      * from [-1.0, 1.0] to (-1.0, 1.0).
      * </p>
      *
@@ -61,7 +61,7 @@ define([
         var getColor;
 
         // Well-known normalized vector attributes in VertexFormat
-        if ((attributeName === 'normal') || (attributeName === 'binormal') || (attributeName === 'tangent')) {
+        if ((attributeName === 'normal') || (attributeName === 'tangent') || (attributeName === 'bitangent')) {
             getColor = 'vec4 getColor() { return vec4((' + varyingName + ' + vec3(1.0)) * 0.5, 1.0); }\n';
         } else {
             // All other attributes, both well-known and custom

--- a/Source/Scene/EllipsoidSurfaceAppearance.js
+++ b/Source/Scene/EllipsoidSurfaceAppearance.js
@@ -24,7 +24,7 @@ define([
      * and {@link RectangleGeometry}, which supports all materials like {@link MaterialAppearance}
      * with {@link MaterialAppearance.MaterialSupport.ALL}.  However, this appearance requires
      * fewer vertex attributes since the fragment shader can procedurally compute <code>normal</code>,
-     * <code>binormal</code>, and <code>tangent</code>.
+     * <code>tangent</code>, and <code>bitangent</code>.
      *
      * @alias EllipsoidSurfaceAppearance
      * @constructor

--- a/Source/Scene/MaterialAppearance.js
+++ b/Source/Scene/MaterialAppearance.js
@@ -311,7 +311,7 @@ define([
         /**
          * All materials, including those that work in tangent space, are supported.
          * This requires <code>position</code>, <code>normal</code>, <code>st</code>,
-         * <code>binormal</code>, and <code>tangent</code> vertex attributes.
+         * <code>tangent</code>, and <code>bitangent</code> vertex attributes.
          *
          * @constant
          */

--- a/Source/Scene/Primitive.js
+++ b/Source/Scene/Primitive.js
@@ -889,10 +889,10 @@ define([
         }
 
         var containsTangent = vertexShaderSource.search(/attribute\s+vec3\s+tangent;/g) !== -1;
-        var containsBinormal = vertexShaderSource.search(/attribute\s+vec3\s+binormal;/g) !== -1;
+        var containsBitangent = vertexShaderSource.search(/attribute\s+vec3\s+bitangent;/g) !== -1;
 
         var numComponents = containsSt && containsNormal ? 2.0 : 1.0;
-        numComponents += containsTangent || containsBinormal ? 1 : 0;
+        numComponents += containsTangent || containsBitangent ? 1 : 0;
 
         var type = (numComponents > 1) ? 'vec' + numComponents : 'float';
 
@@ -908,12 +908,12 @@ define([
             decode += '    st = czm_decompressTextureCoordinates(' + stComponent + ');\n';
         }
 
-        if (containsNormal && containsTangent && containsBinormal) {
+        if (containsNormal && containsTangent && containsBitangent) {
             globalDecl +=
                 'vec3 normal;\n' +
                 'vec3 tangent;\n' +
-                'vec3 binormal;\n';
-            decode += '    czm_octDecode(' + attributeName + '.' + (containsSt ? 'yz' : 'xy') + ', normal, tangent, binormal);\n';
+                'vec3 bitangent;\n';
+            decode += '    czm_octDecode(' + attributeName + '.' + (containsSt ? 'yz' : 'xy') + ', normal, tangent, bitangent);\n';
         } else {
             if (containsNormal) {
                 globalDecl += 'vec3 normal;\n';
@@ -925,9 +925,9 @@ define([
                 decode += '    tangent = czm_octDecode(' + attributeName + '.' + (containsSt && containsNormal ? 'z' : 'y') + ');\n';
             }
 
-            if (containsBinormal) {
-                globalDecl += 'vec3 binormal;\n';
-                decode += '    binormal = czm_octDecode(' + attributeName + '.' + (containsSt && containsNormal ? 'z' : 'y') + ');\n';
+            if (containsBitangent) {
+                globalDecl += 'vec3 bitangent;\n';
+                decode += '    bitangent = czm_octDecode(' + attributeName + '.' + (containsSt && containsNormal ? 'z' : 'y') + ');\n';
             }
         }
 
@@ -935,7 +935,7 @@ define([
         modifiedVS = modifiedVS.replace(/attribute\s+vec3\s+normal;/g, '');
         modifiedVS = modifiedVS.replace(/attribute\s+vec2\s+st;/g, '');
         modifiedVS = modifiedVS.replace(/attribute\s+vec3\s+tangent;/g, '');
-        modifiedVS = modifiedVS.replace(/attribute\s+vec3\s+binormal;/g, '');
+        modifiedVS = modifiedVS.replace(/attribute\s+vec3\s+bitangent;/g, '');
         modifiedVS = ShaderSource.replaceMain(modifiedVS, 'czm_non_compressed_main');
         var compressedMain =
             'void main() \n' +

--- a/Source/Scene/createTangentSpaceDebugPrimitive.js
+++ b/Source/Scene/createTangentSpaceDebugPrimitive.js
@@ -23,8 +23,8 @@ define([
 
     /**
      * Creates a {@link Primitive} to visualize well-known vector vertex attributes:
-     * <code>normal</code>, <code>binormal</code>, and <code>tangent</code>.  Normal
-     * is red; binormal is green; and tangent is blue.  If an attribute is not
+     * <code>normal</code>, <code>tangent</code>, and <code>bitangent</code>.  Normal
+     * is red; tangent is green; and bitangent is blue.  If an attribute is not
      * present, it is not drawn.
      *
      * @exports createTangentSpaceDebugPrimitive
@@ -73,9 +73,9 @@ define([
             }));
         }
 
-        if (defined(attributes.binormal)) {
+        if (defined(attributes.tangent)) {
             instances.push(new GeometryInstance({
-              geometry : GeometryPipeline.createLineSegmentsForVectors(geometry, 'binormal', length),
+              geometry : GeometryPipeline.createLineSegmentsForVectors(geometry, 'tangent', length),
               attributes : {
                   color : new ColorGeometryInstanceAttribute(0.0, 1.0, 0.0, 1.0)
               },
@@ -83,9 +83,9 @@ define([
             }));
         }
 
-        if (defined(attributes.tangent)) {
+        if (defined(attributes.bitangent)) {
             instances.push(new GeometryInstance({
-              geometry : GeometryPipeline.createLineSegmentsForVectors(geometry, 'tangent', length),
+              geometry : GeometryPipeline.createLineSegmentsForVectors(geometry, 'bitangent', length),
               attributes : {
                   color : new ColorGeometryInstanceAttribute(0.0, 0.0, 1.0, 1.0)
               },

--- a/Source/Shaders/Appearances/AllMaterialAppearanceFS.glsl
+++ b/Source/Shaders/Appearances/AllMaterialAppearanceFS.glsl
@@ -1,13 +1,13 @@
 varying vec3 v_positionEC;
 varying vec3 v_normalEC;
 varying vec3 v_tangentEC;
-varying vec3 v_binormalEC;
+varying vec3 v_bitangentEC;
 varying vec2 v_st;
 
 void main()
 {
-    vec3 positionToEyeEC = -v_positionEC; 
-    mat3 tangentToEyeMatrix = czm_tangentToEyeSpaceMatrix(v_normalEC, v_tangentEC, v_binormalEC);
+    vec3 positionToEyeEC = -v_positionEC;
+    mat3 tangentToEyeMatrix = czm_tangentToEyeSpaceMatrix(v_normalEC, v_tangentEC, v_bitangentEC);
 
     vec3 normalEC = normalize(v_normalEC);
 #ifdef FACE_FORWARD
@@ -20,8 +20,8 @@ void main()
     materialInput.positionToEyeEC = positionToEyeEC;
     materialInput.st = v_st;
     czm_material material = czm_getMaterial(materialInput);
-    
-#ifdef FLAT    
+
+#ifdef FLAT
     gl_FragColor = vec4(material.diffuse + material.emission, material.alpha);
 #else
     gl_FragColor = czm_phong(normalize(positionToEyeEC), material);

--- a/Source/Shaders/Appearances/AllMaterialAppearanceVS.glsl
+++ b/Source/Shaders/Appearances/AllMaterialAppearanceVS.glsl
@@ -2,25 +2,25 @@ attribute vec3 position3DHigh;
 attribute vec3 position3DLow;
 attribute vec3 normal;
 attribute vec3 tangent;
-attribute vec3 binormal;
+attribute vec3 bitangent;
 attribute vec2 st;
 attribute float batchId;
 
 varying vec3 v_positionEC;
 varying vec3 v_normalEC;
 varying vec3 v_tangentEC;
-varying vec3 v_binormalEC;
+varying vec3 v_bitangentEC;
 varying vec2 v_st;
 
-void main() 
+void main()
 {
     vec4 p = czm_computePosition();
 
     v_positionEC = (czm_modelViewRelativeToEye * p).xyz;      // position in eye coordinates
     v_normalEC = czm_normal * normal;                         // normal in eye coordinates
     v_tangentEC = czm_normal * tangent;                       // tangent in eye coordinates
-    v_binormalEC = czm_normal * binormal;                     // binormal in eye coordinates
+    v_bitangentEC = czm_normal * bitangent;                   // bitangent in eye coordinates
     v_st = st;
-    
+
     gl_Position = czm_modelViewProjectionRelativeToEye * p;
 }

--- a/Source/Shaders/Builtin/Functions/tangentToEyeSpaceMatrix.glsl
+++ b/Source/Shaders/Builtin/Functions/tangentToEyeSpaceMatrix.glsl
@@ -3,23 +3,23 @@
  *
  * @name czm_tangentToEyeSpaceMatrix
  * @glslFunction
- * 
+ *
  * @param {vec3} normalEC The normal vector in eye coordinates.
  * @param {vec3} tangentEC The tangent vector in eye coordinates.
- * @param {vec3} binormalEC The binormal vector in eye coordinates.
+ * @param {vec3} bitangentEC The bitangent vector in eye coordinates.
  *
  * @returns {mat3} The matrix that transforms from tangent space to eye space.
  *
  * @example
- * mat3 tangentToEye = czm_tangentToEyeSpaceMatrix(normalEC, tangentEC, binormalEC);
+ * mat3 tangentToEye = czm_tangentToEyeSpaceMatrix(normalEC, tangentEC, bitangentEC);
  * vec3 normal = tangentToEye * texture2D(normalMap, st).xyz;
  */
-mat3 czm_tangentToEyeSpaceMatrix(vec3 normalEC, vec3 tangentEC, vec3 binormalEC)
+mat3 czm_tangentToEyeSpaceMatrix(vec3 normalEC, vec3 tangentEC, vec3 bitangentEC)
 {
     vec3 normal = normalize(normalEC);
     vec3 tangent = normalize(tangentEC);
-    vec3 binormal = normalize(binormalEC);
-    return mat3(tangent.x,  tangent.y,  tangent.z,
-                binormal.x, binormal.y, binormal.z,
-                normal.x,   normal.y,   normal.z);
+    vec3 bitangent = normalize(bitangentEC);
+    return mat3(tangent.x  , tangent.y  , tangent.z,
+                bitangent.x, bitangent.y, bitangent.z,
+                normal.x   , normal.y   , normal.z);
 }

--- a/Specs/Core/BoxGeometrySpec.js
+++ b/Specs/Core/BoxGeometrySpec.js
@@ -54,7 +54,7 @@ defineSuite([
         expect(m.attributes.position.values.length).toEqual(numVertices * 3);
         expect(m.attributes.normal.values.length).toEqual(numVertices * 3);
         expect(m.attributes.tangent.values.length).toEqual(numVertices * 3);
-        expect(m.attributes.binormal.values.length).toEqual(numVertices * 3);
+        expect(m.attributes.bitangent.values.length).toEqual(numVertices * 3);
         expect(m.attributes.st.values.length).toEqual(numVertices * 2);
 
         expect(m.indices.length).toEqual(numTriangles * 3);

--- a/Specs/Core/CircleGeometrySpec.js
+++ b/Specs/Core/CircleGeometrySpec.js
@@ -74,7 +74,7 @@ defineSuite([
         expect(m.attributes.st.values.length).toEqual(numVertices * 2);
         expect(m.attributes.normal.values.length).toEqual(numVertices * 3);
         expect(m.attributes.tangent.values.length).toEqual(numVertices * 3);
-        expect(m.attributes.binormal.values.length).toEqual(numVertices * 3);
+        expect(m.attributes.bitangent.values.length).toEqual(numVertices * 3);
         expect(m.indices.length).toEqual(numTriangles * 3);
     });
 
@@ -110,7 +110,7 @@ defineSuite([
         expect(m.attributes.st.values.length).toEqual(numVertices * 2);
         expect(m.attributes.normal.values.length).toEqual(numVertices * 3);
         expect(m.attributes.tangent.values.length).toEqual(numVertices * 3);
-        expect(m.attributes.binormal.values.length).toEqual(numVertices * 3);
+        expect(m.attributes.bitangent.values.length).toEqual(numVertices * 3);
         expect(m.indices.length).toEqual(numTriangles * 3);
     });
 

--- a/Specs/Core/CorridorGeometrySpec.js
+++ b/Specs/Core/CorridorGeometrySpec.js
@@ -78,7 +78,7 @@ defineSuite([
         expect(m.attributes.st.values.length).toEqual(numVertices * 2);
         expect(m.attributes.normal.values.length).toEqual(numVertices * 3);
         expect(m.attributes.tangent.values.length).toEqual(numVertices * 3);
-        expect(m.attributes.binormal.values.length).toEqual(numVertices * 3);
+        expect(m.attributes.bitangent.values.length).toEqual(numVertices * 3);
         expect(m.indices.length).toEqual(numTriangles * 3);
     });
 
@@ -118,7 +118,7 @@ defineSuite([
         expect(m.attributes.st.values.length).toEqual(numVertices * 2);
         expect(m.attributes.normal.values.length).toEqual(numVertices * 3);
         expect(m.attributes.tangent.values.length).toEqual(numVertices * 3);
-        expect(m.attributes.binormal.values.length).toEqual(numVertices * 3);
+        expect(m.attributes.bitangent.values.length).toEqual(numVertices * 3);
         expect(m.indices.length).toEqual(numTriangles * 3);
     });
 

--- a/Specs/Core/CylinderGeometrySpec.js
+++ b/Specs/Core/CylinderGeometrySpec.js
@@ -73,7 +73,7 @@ defineSuite([
         expect(m.attributes.st.values.length).toEqual(numVertices * 2);
         expect(m.attributes.normal.values.length).toEqual(numVertices * 3);
         expect(m.attributes.tangent.values.length).toEqual(numVertices * 3);
-        expect(m.attributes.binormal.values.length).toEqual(numVertices * 3);
+        expect(m.attributes.bitangent.values.length).toEqual(numVertices * 3);
         expect(m.indices.length).toEqual(numTriangles * 3);
     });
 

--- a/Specs/Core/EllipseGeometrySpec.js
+++ b/Specs/Core/EllipseGeometrySpec.js
@@ -96,7 +96,7 @@ defineSuite([
         expect(m.attributes.st.values.length).toEqual(numVertices * 2);
         expect(m.attributes.normal.values.length).toEqual(numVertices * 3);
         expect(m.attributes.tangent.values.length).toEqual(numVertices * 3);
-        expect(m.attributes.binormal.values.length).toEqual(numVertices * 3);
+        expect(m.attributes.bitangent.values.length).toEqual(numVertices * 3);
         expect(m.indices.length).toEqual(numTriangles * 3);
     });
 
@@ -159,7 +159,7 @@ defineSuite([
         expect(m.attributes.st.values.length).toEqual(numVertices * 2);
         expect(m.attributes.normal.values.length).toEqual(numVertices * 3);
         expect(m.attributes.tangent.values.length).toEqual(numVertices * 3);
-        expect(m.attributes.binormal.values.length).toEqual(numVertices * 3);
+        expect(m.attributes.bitangent.values.length).toEqual(numVertices * 3);
         expect(m.indices.length).toEqual(numTriangles * 3);
     });
 
@@ -230,7 +230,7 @@ defineSuite([
         expect(sv._extrudedHeight).toBe(minHeightFunc());
         expect(sv._height).toBe(maxHeightFunc());
 
-        expect(sv._vertexFormat.binormal).toBe(VertexFormat.POSITION_ONLY.binormal);
+        expect(sv._vertexFormat.bitangent).toBe(VertexFormat.POSITION_ONLY.bitangent);
         expect(sv._vertexFormat.color).toBe(VertexFormat.POSITION_ONLY.color);
         expect(sv._vertexFormat.normal).toBe(VertexFormat.POSITION_ONLY.normal);
         expect(sv._vertexFormat.position).toBe(VertexFormat.POSITION_ONLY.position);

--- a/Specs/Core/EllipsoidGeometrySpec.js
+++ b/Specs/Core/EllipsoidGeometrySpec.js
@@ -56,7 +56,7 @@ defineSuite([
         expect(m.attributes.st.values.length).toEqual(numVertices * 2);
         expect(m.attributes.normal.values.length).toEqual(numVertices * 3);
         expect(m.attributes.tangent.values.length).toEqual(numVertices * 3);
-        expect(m.attributes.binormal.values.length).toEqual(numVertices * 3);
+        expect(m.attributes.bitangent.values.length).toEqual(numVertices * 3);
         expect(m.indices.length).toEqual(numTriangles * 3);
     });
 
@@ -70,18 +70,18 @@ defineSuite([
         var positions = m.attributes.position.values;
         var normals = m.attributes.normal.values;
         var tangents = m.attributes.tangent.values;
-        var binormals = m.attributes.binormal.values;
+        var bitangents = m.attributes.bitangent.values;
 
         for ( var i = 0; i < positions.length; i += 3) {
             var position = Cartesian3.fromArray(positions, i);
             var normal = Cartesian3.fromArray(normals, i);
             var tangent = Cartesian3.fromArray(tangents, i);
-            var binormal = Cartesian3.fromArray(binormals, i);
+            var bitangent = Cartesian3.fromArray(bitangents, i);
 
             expect(Cartesian3.magnitude(position)).toEqualEpsilon(1.0, CesiumMath.EPSILON10);
             expect(normal).toEqualEpsilon(Cartesian3.normalize(position, new Cartesian3()), CesiumMath.EPSILON7);
             expect(Cartesian3.dot(Cartesian3.UNIT_Z, tangent)).not.toBeLessThan(0.0);
-            expect(binormal).toEqualEpsilon(Cartesian3.cross(normal, tangent, new Cartesian3()), CesiumMath.EPSILON7);
+            expect(bitangent).toEqualEpsilon(Cartesian3.cross(normal, tangent, new Cartesian3()), CesiumMath.EPSILON7);
         }
     });
 

--- a/Specs/Core/GeometryPipelineSpec.js
+++ b/Specs/Core/GeometryPipelineSpec.js
@@ -1632,7 +1632,7 @@ defineSuite([
                                                         -0.4082482904638631, -0.8164965809277261, 0.4082482904638631], CesiumMath.EPSILON7);
     });
 
-    it ('computeTangentAndBitangent computes tangent and bitangent for an BoxGeometry', function() {
+    it ('computeTangentAndBitangent computes tangent and bitangent for BoxGeometry', function() {
         var geometry = BoxGeometry.createGeometry(new BoxGeometry({
             vertexFormat : new VertexFormat({
                 position : true,
@@ -1668,7 +1668,7 @@ defineSuite([
         }
     });
 
-    it ('computeBinormalAndTangent computes tangent and binormal for an BoxGeometry', function() {
+    it ('computeBinormalAndTangent computes tangent and binormal for BoxGeometry', function() {
         // This test is for the deprecated computeBinormalAndTangent API
         // It tests to assert that the binormal attribute is set correctly and
         // is a copy of the bitangent attribute

--- a/Specs/Core/GeometryPipelineSpec.js
+++ b/Specs/Core/GeometryPipelineSpec.js
@@ -195,7 +195,7 @@ defineSuite([
         });
 
         expect(function() {
-            GeometryPipeline.createLineSegmentsForVectors(geometry, 'binormal');
+            GeometryPipeline.createLineSegmentsForVectors(geometry, 'bitangent');
         }).toThrowDeveloperError();
     });
 
@@ -1410,13 +1410,13 @@ defineSuite([
         expect(Cartesian3.fromArray(normals, 18)).toEqualEpsilon(Cartesian3.negate(Cartesian3.UNIT_Z, new Cartesian3()), CesiumMath.EPSILON7);
     });
 
-    it('computeBinormalAndTangent throws when geometry is undefined', function() {
+    it('computeTangentAndBitangent throws when geometry is undefined', function() {
         expect(function() {
-            GeometryPipeline.computeBinormalAndTangent();
+            GeometryPipeline.computeTangentAndBitangent();
         }).toThrowDeveloperError();
     });
 
-    it('computeBinormalAndTangent throws when position is undefined', function() {
+    it('computeTangentAndBitangent throws when position is undefined', function() {
         var geometry = new Geometry({
             attributes: {
                 normal: new GeometryAttribute({
@@ -1436,11 +1436,11 @@ defineSuite([
         });
 
         expect(function() {
-            GeometryPipeline.computeBinormalAndTangent(geometry);
+            GeometryPipeline.computeTangentAndBitangent(geometry);
        }).toThrowDeveloperError();
     });
 
-    it('computeBinormalAndTangent throws when normal is undefined', function() {
+    it('computeTangentAndBitangent throws when normal is undefined', function() {
         var geometry = new Geometry({
             attributes: {
                 position: new GeometryAttribute({
@@ -1460,11 +1460,11 @@ defineSuite([
         });
 
         expect(function() {
-            GeometryPipeline.computeBinormalAndTangent(geometry);
+            GeometryPipeline.computeTangentAndBitangent(geometry);
        }).toThrowDeveloperError();
     });
 
-    it('computeBinormalAndTangent throws when st is undefined', function() {
+    it('computeTangentAndBitangent throws when st is undefined', function() {
         var geometry = new Geometry({
             attributes: {
                 position: new GeometryAttribute({
@@ -1485,11 +1485,11 @@ defineSuite([
         });
 
         expect(function() {
-            GeometryPipeline.computeBinormalAndTangent(geometry);
+            GeometryPipeline.computeTangentAndBitangent(geometry);
        }).toThrowDeveloperError();
     });
 
-    it('computeBinormalAndTangent throws when geometry.indices is undefined', function() {
+    it('computeTangentAndBitangent throws when geometry.indices is undefined', function() {
         var geometry = new Geometry({
             attributes: {
                 position: new GeometryAttribute({
@@ -1513,11 +1513,11 @@ defineSuite([
         });
 
         expect(function() {
-             GeometryPipeline.computeBinormalAndTangent(geometry);
+             GeometryPipeline.computeTangentAndBitangent(geometry);
         }).toThrowDeveloperError();
     });
 
-    it('computeBinormalAndTangent throws when indices is not a multiple of 3', function() {
+    it('computeTangentAndBitangent throws when indices is not a multiple of 3', function() {
         var geometry = new Geometry({
             attributes: {
                 position: new GeometryAttribute({
@@ -1543,11 +1543,11 @@ defineSuite([
         });
 
         expect(function() {
-            GeometryPipeline.computeBinormalAndTangent(geometry);
+            GeometryPipeline.computeTangentAndBitangent(geometry);
        }).toThrowDeveloperError();
     });
 
-    it('computeBinormalAndTangent throws when primitive type is not triangle', function() {
+    it('computeTangentAndBitangent throws when primitive type is not triangle', function() {
         var geometry = new Geometry({
             attributes: {
                 position: new GeometryAttribute({
@@ -1573,11 +1573,11 @@ defineSuite([
         });
 
         expect(function() {
-            GeometryPipeline.computeBinormalAndTangent(geometry);
+            GeometryPipeline.computeTangentAndBitangent(geometry);
        }).toThrowDeveloperError();
     });
 
-    it('computeBinormalAndTangent computes tangent and binormal for one triangle', function() {
+    it('computeTangentAndBitangent computes tangent and bitangent for one triangle', function() {
         var geometry = new Geometry({
             attributes: {
                 position: new GeometryAttribute({
@@ -1596,13 +1596,13 @@ defineSuite([
         });
 
         geometry = GeometryPipeline.computeNormal(geometry);
-        geometry = GeometryPipeline.computeBinormalAndTangent(geometry);
+        geometry = GeometryPipeline.computeTangentAndBitangent(geometry);
 
         expect(geometry.attributes.tangent.values).toEqual([1, 0, 0, 1, 0, 0, 1, 0, 0]);
-        expect(geometry.attributes.binormal.values).toEqual([0, 1, 0, 0, 1, 0, 0, 1, 0]);
+        expect(geometry.attributes.bitangent.values).toEqual([0, 1, 0, 0, 1, 0, 0, 1, 0]);
     });
 
-    it('computeBinormalAndTangent computes tangent and binormal for two triangles', function() {
+    it('computeTangentAndBitangent computes tangent and bitangent for two triangles', function() {
         var geometry = new Geometry({
             attributes: {
                 position: new GeometryAttribute({
@@ -1621,18 +1621,57 @@ defineSuite([
         });
 
         geometry = GeometryPipeline.computeNormal(geometry);
-        geometry = GeometryPipeline.computeBinormalAndTangent(geometry);
+        geometry = GeometryPipeline.computeTangentAndBitangent(geometry);
         expect(geometry.attributes.tangent.values).toEqualEpsilon([0.7071067811865475, 0, 0.7071067811865475,
                                                         0, 1, 0,
                                                         0, 1, 0,
                                                         -0.5773502691896258, 0.5773502691896258, 0.5773502691896258], CesiumMath.EPSILON7);
-        expect(geometry.attributes.binormal.values).toEqualEpsilon([0, 1, 0,
+        expect(geometry.attributes.bitangent.values).toEqualEpsilon([0, 1, 0,
                                                         -1, 0, 0,
                                                         -1, 0, 0,
                                                         -0.4082482904638631, -0.8164965809277261, 0.4082482904638631], CesiumMath.EPSILON7);
     });
 
+    it ('computeTangentAndBitangent computes tangent and bitangent for an BoxGeometry', function() {
+        var geometry = BoxGeometry.createGeometry(new BoxGeometry({
+            vertexFormat : new VertexFormat({
+                position : true,
+                normal : true,
+                st : true
+            }),
+            maximum : new Cartesian3(250000.0, 250000.0, 250000.0),
+            minimum : new Cartesian3(-250000.0, -250000.0, -250000.0)
+        }));
+        geometry = GeometryPipeline.computeTangentAndBitangent(geometry);
+        var actualTangents = geometry.attributes.tangent.values;
+        var actualBitangents = geometry.attributes.bitangent.values;
+
+        var expectedGeometry = BoxGeometry.createGeometry(new BoxGeometry({
+            vertexFormat: VertexFormat.ALL,
+            maximum : new Cartesian3(250000.0, 250000.0, 250000.0),
+            minimum : new Cartesian3(-250000.0, -250000.0, -250000.0)
+        }));
+        var expectedTangents = expectedGeometry.attributes.tangent.values;
+        var expectedBitangents = expectedGeometry.attributes.bitangent.values;
+
+        expect(actualTangents.length).toEqual(expectedTangents.length);
+        expect(actualBitangents.length).toEqual(expectedBitangents.length);
+
+        for (var i = 0; i < actualTangents.length; i += 3) {
+            var actual = Cartesian3.fromArray(actualTangents, i);
+            var expected = Cartesian3.fromArray(expectedTangents, i);
+            expect(actual).toEqualEpsilon(expected, CesiumMath.EPSILON1);
+
+            actual = Cartesian3.fromArray(actualBitangents, i);
+            expected = Cartesian3.fromArray(expectedBitangents, i);
+            expect(actual).toEqualEpsilon(expected, CesiumMath.EPSILON1);
+        }
+    });
+
     it ('computeBinormalAndTangent computes tangent and binormal for an BoxGeometry', function() {
+        // This test is for the deprecated computeBinormalAndTangent API
+        // It tests to assert that the binormal attribute is set correctly and
+        // is a copy of the bitangent attribute
         var geometry = BoxGeometry.createGeometry(new BoxGeometry({
             vertexFormat : new VertexFormat({
                 position : true,
@@ -1652,10 +1691,10 @@ defineSuite([
             minimum : new Cartesian3(-250000.0, -250000.0, -250000.0)
         }));
         var expectedTangents = expectedGeometry.attributes.tangent.values;
-        var expectedBinormals = expectedGeometry.attributes.binormal.values;
+        var expectedBitangents = expectedGeometry.attributes.bitangent.values;
 
         expect(actualTangents.length).toEqual(expectedTangents.length);
-        expect(actualBinormals.length).toEqual(expectedBinormals.length);
+        expect(actualBinormals.length).toEqual(expectedBitangents.length);
 
         for (var i = 0; i < actualTangents.length; i += 3) {
             var actual = Cartesian3.fromArray(actualTangents, i);
@@ -1663,7 +1702,7 @@ defineSuite([
             expect(actual).toEqualEpsilon(expected, CesiumMath.EPSILON1);
 
             actual = Cartesian3.fromArray(actualBinormals, i);
-            expected = Cartesian3.fromArray(expectedBinormals, i);
+            expected = Cartesian3.fromArray(expectedBitangents, i);
             expect(actual).toEqualEpsilon(expected, CesiumMath.EPSILON1);
         }
     });
@@ -1770,28 +1809,28 @@ defineSuite([
         }
     });
 
-    it('compressVertices packs compressed tangents and binormals', function() {
+    it('compressVertices packs compressed tangents and bitangents', function() {
         var geometry = BoxGeometry.createGeometry(new BoxGeometry({
             vertexFormat : new VertexFormat({
                 position : true,
                 normal : true,
                 tangent : true,
-                binormal : true
+                bitangent : true
             }),
             maximum : new Cartesian3(250000.0, 250000.0, 250000.0),
             minimum : new Cartesian3(-250000.0, -250000.0, -250000.0)
         }));
         expect(geometry.attributes.normal).toBeDefined();
         expect(geometry.attributes.tangent).toBeDefined();
-        expect(geometry.attributes.binormal).toBeDefined();
+        expect(geometry.attributes.bitangent).toBeDefined();
         var originalNormals = Array.prototype.slice.call(geometry.attributes.normal.values);
         var originalTangents = Array.prototype.slice.call(geometry.attributes.tangent.values);
-        var originalBinormals = Array.prototype.slice.call(geometry.attributes.binormal.values);
+        var originalBitangents = Array.prototype.slice.call(geometry.attributes.bitangent.values);
 
         geometry = GeometryPipeline.compressVertices(geometry);
 
         expect(geometry.attributes.tangent).not.toBeDefined();
-        expect(geometry.attributes.binormal).not.toBeDefined();
+        expect(geometry.attributes.bitangent).not.toBeDefined();
         expect(geometry.attributes.compressedAttributes).toBeDefined();
 
         var compressedNormals = geometry.attributes.compressedAttributes.values;
@@ -1799,15 +1838,15 @@ defineSuite([
 
         var normal = new Cartesian3();
         var tangent = new Cartesian3();
-        var binormal = new Cartesian3();
+        var bitangent = new Cartesian3();
 
         for (var i = 0; i < compressedNormals.length; i += 2) {
             var compressed = Cartesian2.fromArray(compressedNormals, i, new Cartesian2());
-            AttributeCompression.octUnpack(compressed, normal, tangent, binormal);
+            AttributeCompression.octUnpack(compressed, normal, tangent, bitangent);
 
             expect(normal).toEqualEpsilon(Cartesian3.fromArray(originalNormals, i / 2 * 3), CesiumMath.EPSILON2);
             expect(tangent).toEqualEpsilon(Cartesian3.fromArray(originalTangents, i / 2 * 3), CesiumMath.EPSILON2);
-            expect(binormal).toEqualEpsilon(Cartesian3.fromArray(originalBinormals, i / 2 * 3), CesiumMath.EPSILON2);
+            expect(bitangent).toEqualEpsilon(Cartesian3.fromArray(originalBitangents, i / 2 * 3), CesiumMath.EPSILON2);
         }
     });
 
@@ -2433,7 +2472,7 @@ defineSuite([
                         componentsPerAttribute : 3,
                         values : new Float32Array([-1.0, 0.0, 0.0, -1.0, 0.0, 0.0, -1.0, 0.0, 0.0])
                     }),
-                    binormal : new GeometryAttribute({
+                    bitangent : new GeometryAttribute({
                         componentDatatype : ComponentDatatype.FLOAT,
                         componentsPerAttribute : 3,
                         values : new Float32Array([0.0, -1.0, 0.0, 0.0, -1.0, 0.0, 0.0, -1.0, 0.0])
@@ -2458,8 +2497,8 @@ defineSuite([
         expect(instance.westHemisphereGeometry.attributes.position.values.length).toEqual(3 * 3);
         expect(instance.westHemisphereGeometry.attributes.normal).toBeDefined();
         expect(instance.westHemisphereGeometry.attributes.normal.values.length).toEqual(3 * 3);
-        expect(instance.westHemisphereGeometry.attributes.binormal).toBeDefined();
-        expect(instance.westHemisphereGeometry.attributes.binormal.values.length).toEqual(3 * 3);
+        expect(instance.westHemisphereGeometry.attributes.bitangent).toBeDefined();
+        expect(instance.westHemisphereGeometry.attributes.bitangent.values.length).toEqual(3 * 3);
         expect(instance.westHemisphereGeometry.attributes.tangent).toBeDefined();
         expect(instance.westHemisphereGeometry.attributes.tangent.values.length).toEqual(3 * 3);
         expect(instance.westHemisphereGeometry.attributes.st).toBeDefined();
@@ -2472,8 +2511,8 @@ defineSuite([
         expect(instance.eastHemisphereGeometry.attributes.position.values.length).toEqual(5 * 3);
         expect(instance.eastHemisphereGeometry.attributes.normal).toBeDefined();
         expect(instance.eastHemisphereGeometry.attributes.normal.values.length).toEqual(5 * 3);
-        expect(instance.eastHemisphereGeometry.attributes.binormal).toBeDefined();
-        expect(instance.eastHemisphereGeometry.attributes.binormal.values.length).toEqual(5 * 3);
+        expect(instance.eastHemisphereGeometry.attributes.bitangent).toBeDefined();
+        expect(instance.eastHemisphereGeometry.attributes.bitangent.values.length).toEqual(5 * 3);
         expect(instance.eastHemisphereGeometry.attributes.tangent).toBeDefined();
         expect(instance.eastHemisphereGeometry.attributes.tangent.values.length).toEqual(5 * 3);
         expect(instance.eastHemisphereGeometry.attributes.st).toBeDefined();

--- a/Specs/Core/PolygonGeometrySpec.js
+++ b/Specs/Core/PolygonGeometrySpec.js
@@ -150,7 +150,7 @@ defineSuite([
         expect(p.attributes.st.values.length).toEqual(numVertices * 2);
         expect(p.attributes.normal.values.length).toEqual(numVertices * 3);
         expect(p.attributes.tangent.values.length).toEqual(numVertices * 3);
-        expect(p.attributes.binormal.values.length).toEqual(numVertices * 3);
+        expect(p.attributes.bitangent.values.length).toEqual(numVertices * 3);
         expect(p.indices.length).toEqual(numTriangles * 3);
     });
 
@@ -502,7 +502,7 @@ defineSuite([
         expect(p.attributes.st.values.length).toEqual(numVertices * 2);
         expect(p.attributes.normal.values.length).toEqual(numVertices * 3);
         expect(p.attributes.tangent.values.length).toEqual(numVertices * 3);
-        expect(p.attributes.binormal.values.length).toEqual(numVertices * 3);
+        expect(p.attributes.bitangent.values.length).toEqual(numVertices * 3);
         expect(p.indices.length).toEqual(numTriangles * 3);
     });
 

--- a/Specs/Core/PolylineVolumeGeometrySpec.js
+++ b/Specs/Core/PolylineVolumeGeometrySpec.js
@@ -121,7 +121,7 @@ defineSuite([
         expect(m.attributes.st.values.length).toEqual(numVertices * 2);
         expect(m.attributes.normal.values.length).toEqual(numVertices * 3);
         expect(m.attributes.tangent.values.length).toEqual(numVertices * 3);
-        expect(m.attributes.binormal.values.length).toEqual(numVertices * 3);
+        expect(m.attributes.bitangent.values.length).toEqual(numVertices * 3);
         expect(m.indices.length).toEqual(numTriangles * 3);
     });
 

--- a/Specs/Core/RectangleGeometrySpec.js
+++ b/Specs/Core/RectangleGeometrySpec.js
@@ -72,7 +72,7 @@ defineSuite([
         expect(m.attributes.st.values.length).toEqual(numVertices * 2);
         expect(m.attributes.normal.values.length).toEqual(numVertices * 3);
         expect(m.attributes.tangent.values.length).toEqual(numVertices * 3);
-        expect(m.attributes.binormal.values.length).toEqual(numVertices * 3);
+        expect(m.attributes.bitangent.values.length).toEqual(numVertices * 3);
         expect(m.indices.length).toEqual(numTriangles * 3);
     });
 
@@ -217,7 +217,7 @@ defineSuite([
         expect(m.attributes.st.values.length).toEqual(numVertices * 2);
         expect(m.attributes.normal.values.length).toEqual(numVertices * 3);
         expect(m.attributes.tangent.values.length).toEqual(numVertices * 3);
-        expect(m.attributes.binormal.values.length).toEqual(numVertices * 3);
+        expect(m.attributes.bitangent.values.length).toEqual(numVertices * 3);
         expect(m.indices.length).toEqual(numTriangles * 3);
     });
 

--- a/Specs/Core/SphereGeometrySpec.js
+++ b/Specs/Core/SphereGeometrySpec.js
@@ -56,7 +56,7 @@ defineSuite([
         expect(m.attributes.st.values.length).toEqual(numVertices * 2);
         expect(m.attributes.normal.values.length).toEqual(numVertices * 3);
         expect(m.attributes.tangent.values.length).toEqual(numVertices * 3);
-        expect(m.attributes.binormal.values.length).toEqual(numVertices * 3);
+        expect(m.attributes.bitangent.values.length).toEqual(numVertices * 3);
         expect(m.indices.length).toEqual(numTriangles * 3);
     });
 
@@ -71,18 +71,18 @@ defineSuite([
         var positions = m.attributes.position.values;
         var normals = m.attributes.normal.values;
         var tangents = m.attributes.tangent.values;
-        var binormals = m.attributes.binormal.values;
+        var bitangents = m.attributes.bitangent.values;
 
         for ( var i = 0; i < positions.length; i += 3) {
             var position = Cartesian3.fromArray(positions, i);
             var normal = Cartesian3.fromArray(normals, i);
             var tangent = Cartesian3.fromArray(tangents, i);
-            var binormal = Cartesian3.fromArray(binormals, i);
+            var bitangent = Cartesian3.fromArray(bitangents, i);
 
             expect(Cartesian3.magnitude(position)).toEqualEpsilon(1.0, CesiumMath.EPSILON10);
             expect(normal).toEqualEpsilon(Cartesian3.normalize(position, position), CesiumMath.EPSILON7);
             expect(Cartesian3.dot(Cartesian3.UNIT_Z, tangent)).not.toBeLessThan(0.0);
-            expect(binormal).toEqualEpsilon(Cartesian3.cross(normal, tangent, normal), CesiumMath.EPSILON7);
+            expect(bitangent).toEqualEpsilon(Cartesian3.cross(normal, tangent, normal), CesiumMath.EPSILON7);
         }
     });
 

--- a/Specs/Core/WallGeometrySpec.js
+++ b/Specs/Core/WallGeometrySpec.js
@@ -228,7 +228,7 @@ defineSuite([
         expect(w.attributes.position.values.length).toEqual(numPositions * 3);
         expect(w.attributes.normal.values.length).toEqual(numPositions * 3);
         expect(w.attributes.tangent.values.length).toEqual(numPositions * 3);
-        expect(w.attributes.binormal.values.length).toEqual(numPositions * 3);
+        expect(w.attributes.bitangent.values.length).toEqual(numPositions * 3);
         expect(w.attributes.st.values.length).toEqual(numPositions * 2);
         expect(w.indices.length).toEqual(numTriangles * 3);
     });

--- a/Specs/Renderer/BuiltinFunctionsSpec.js
+++ b/Specs/Renderer/BuiltinFunctionsSpec.js
@@ -114,10 +114,10 @@ defineSuite([
         var fs =
             'void main() { ' +
             '  vec3 tangent = vec3(1.0, 0.0, 0.0); ' +
-            '  vec3 binormal = vec3(0.0, 1.0, 0.0); ' +
+            '  vec3 bitangent = vec3(0.0, 1.0, 0.0); ' +
             '  vec3 normal = vec3(0.0, 0.0, 1.0); ' +
             '  mat3 expected = mat3(1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0); ' +
-            '  mat3 actual = czm_tangentToEyeSpaceMatrix(normal, tangent, binormal); ' +
+            '  mat3 actual = czm_tangentToEyeSpaceMatrix(normal, tangent, bitangent); ' +
             '  gl_FragColor = vec4(actual == expected); ' +
             '}';
         context.verifyDrawForSpecs(fs);

--- a/Specs/Scene/DebugAppearanceSpec.js
+++ b/Specs/Scene/DebugAppearanceSpec.js
@@ -63,7 +63,7 @@ defineSuite([
         }).toThrowDeveloperError();
     });
 
-    it('default construct with normal, binormal, or tangent attribute name', function() {
+    it('default construct with normal, bitangent, or tangent attribute name', function() {
         var a = new DebugAppearance({
             attributeName : 'normal',
             perInstanceAttribute : false
@@ -202,16 +202,16 @@ defineSuite([
         expect(scene.renderForSpecs()).not.toEqual([0, 0, 0, 255]);
     });
 
-    it('renders binormal', function() {
+    it('renders bitangent', function() {
         var vertexFormat = new VertexFormat({
             position : true,
             normal : true,
-            binormal : true
+            bitangent : true
         });
         primitive = new Primitive({
             geometryInstances : createInstance(vertexFormat),
             appearance : new DebugAppearance({
-                attributeName : 'binormal',
+                attributeName : 'bitangent',
                 perInstanceAttribute : false
             }),
             asynchronous : false,


### PR DESCRIPTION
Fixes #4822 

The PR deprecates `GeometryPipeline.createBinormalAndTangent` and recommends using the new `GeometryPipeline.createTangentAndBitangent` function.

The attributes have also been renamed to bitangent. This could cause some breakage.

This PR also makes the default value for `DebugAppearance.perInstanceAttribute` to `false` (was previously a required attribute).

Note: This PR fixes trailing whitespace in the files modified.