### PR TITLE
3D Tiles Styling - Check for type mismatches in JS and shader backends

### DIFF
--- a/Source/Scene/Expression.js
+++ b/Source/Scene/Expression.js
@@ -960,7 +960,13 @@ define([
     // that we can assign if we know the types before runtime
 
     Node.prototype._evaluateNot = function(frameState, feature) {
-        return !(this._left.evaluate(frameState, feature));
+        var left = this._left.evaluate(frameState, feature);
+        //>>includeStart('debug', pragmas.debug);
+        if (typeof(left) !== 'boolean') {
+            throw new DeveloperError('Error: Operation is undefined.');
+        }
+        //>>includeEnd('debug');
+        return !left;
     };
 
     Node.prototype._evaluateNegative = function(frameState, feature) {
@@ -971,39 +977,77 @@ define([
             return Cartesian3.negate(left, ScratchStorage.getCartesian3());
         } else if (left instanceof Cartesian4) {
             return Cartesian4.negate(left, ScratchStorage.getCartesian4());
+        } else if (typeof(left) === 'number') {
+            return -left;
         }
-        return -left;
+
+        //>>includeStart('debug', pragmas.debug);
+        throw new DeveloperError('Error: Operation is undefined.');
+        //>>includeEnd('debug');
+        return -left; // jshint ignore:line
     };
 
     Node.prototype._evaluatePositive = function(frameState, feature) {
         var left = this._left.evaluate(frameState, feature);
-        if ((left instanceof Cartesian2) || (left instanceof Cartesian3) || (left instanceof Cartesian4)) {
-            return left;
+
+        //>>includeStart('debug', pragmas.debug);
+        if (!((left instanceof Cartesian2) || (left instanceof Cartesian3) || (left instanceof Cartesian4) || (typeof(left) === 'number'))) {
+            throw new DeveloperError('Error: Operation is undefined.');
         }
-        return +left;
+        //>>includeEnd('debug');
+
+        return left;
     };
 
     Node.prototype._evaluateLessThan = function(frameState, feature) {
         var left = this._left.evaluate(frameState, feature);
         var right = this._right.evaluate(frameState, feature);
+
+        //>>includeStart('debug', pragmas.debug);
+        if ((typeof(left) !== 'number') || (typeof(right) !== 'number')) {
+            throw new DeveloperError('Error: Operation is undefined.');
+        }
+        //>>includeEnd('debug');
+
         return left < right;
     };
 
     Node.prototype._evaluateLessThanOrEquals = function(frameState, feature) {
         var left = this._left.evaluate(frameState, feature);
         var right = this._right.evaluate(frameState, feature);
+
+        //>>includeStart('debug', pragmas.debug);
+        if ((typeof(left) !== 'number') || (typeof(right) !== 'number')) {
+            throw new DeveloperError('Error: Operation is undefined.');
+        }
+        //>>includeEnd('debug');
+
         return left <= right;
     };
 
     Node.prototype._evaluateGreaterThan = function(frameState, feature) {
         var left = this._left.evaluate(frameState, feature);
         var right = this._right.evaluate(frameState, feature);
+
+        //>>includeStart('debug', pragmas.debug);
+        if ((typeof(left) !== 'number') || (typeof(right) !== 'number')) {
+            throw new DeveloperError('Error: Operation is undefined.');
+        }
+        //>>includeEnd('debug');
+
         return left > right;
     };
 
     Node.prototype._evaluateGreaterThanOrEquals = function(frameState, feature) {
         var left = this._left.evaluate(frameState, feature);
         var right = this._right.evaluate(frameState, feature);
+
+        //>>includeStart('debug', pragmas.debug);
+        if ((typeof(left) !== 'number') || (typeof(right) !== 'number')) {
+            throw new DeveloperError('Error: Operation is undefined.');
+        }
+        //>>includeEnd('debug');
+
         return left >= right;
     };
 
@@ -1060,8 +1104,17 @@ define([
             return Cartesian3.add(left, right, ScratchStorage.getCartesian3());
         } else if ((right instanceof Cartesian4) && (left instanceof Cartesian4)) {
             return Cartesian4.add(left, right, ScratchStorage.getCartesian4());
+        } else if ((typeof(left) === 'string') || (typeof(right) === 'string')) {
+            return left + right;
+        } else if ((typeof(left) === 'number') && (typeof(right) === 'number')) {
+            return left + right;
         }
-        return left + right;
+
+        //>>includeStart('debug', pragmas.debug);
+        throw new DeveloperError('Error: Operation is undefined.');
+        //>>includeEnd('debug');
+
+        return left + right; // jshint ignore:line
     };
 
     Node.prototype._evaluateMinus = function(frameState, feature) {
@@ -1073,8 +1126,15 @@ define([
             return Cartesian3.subtract(left, right, ScratchStorage.getCartesian3());
         } else if ((right instanceof Cartesian4) && (left instanceof Cartesian4)) {
             return Cartesian4.subtract(left, right, ScratchStorage.getCartesian4());
+        } else if ((typeof(left) === 'number') && (typeof(right) === 'number')) {
+            return left - right;
         }
-        return left - right;
+
+        //>>includeStart('debug', pragmas.debug);
+        throw new DeveloperError('Error: Operation is undefined.');
+        //>>includeEnd('debug');
+
+        return left - right; // jshint ignore:line
     };
 
     Node.prototype._evaluateTimes = function(frameState, feature) {
@@ -1098,8 +1158,15 @@ define([
             return Cartesian4.multiplyByScalar(right, left, ScratchStorage.getCartesian4());
         } else if ((left instanceof Cartesian4) && (typeof(right) === 'number')) {
             return Cartesian4.multiplyByScalar(left, right, ScratchStorage.getCartesian4());
+        } else if ((typeof(left) === 'number') && (typeof(right) === 'number')) {
+            return left * right;
         }
-        return left * right;
+
+        //>>includeStart('debug', pragmas.debug);
+        throw new DeveloperError('Error: Operation is undefined.');
+        //>>includeEnd('debug');
+
+        return left * right; // jshint ignore:line
     };
 
     Node.prototype._evaluateDivide = function(frameState, feature) {
@@ -1117,8 +1184,15 @@ define([
             return Cartesian4.divideComponents(left, right, ScratchStorage.getCartesian4());
         } else if ((left instanceof Cartesian4) && (typeof(right) === 'number')) {
             return Cartesian4.divideByScalar(left, right, ScratchStorage.getCartesian4());
+        } else if ((typeof(left) === 'number') && (typeof(right) === 'number')) {
+            return left / right;
         }
-        return left / right;
+
+        //>>includeStart('debug', pragmas.debug);
+        throw new DeveloperError('Error: Operation is undefined.');
+        //>>includeEnd('debug');
+
+        return left / right; // jshint ignore:line
     };
 
     Node.prototype._evaluateMod = function(frameState, feature) {
@@ -1130,8 +1204,15 @@ define([
             return Cartesian3.fromElements(left.x % right.x, left.y % right.y, left.z % right.z, ScratchStorage.getCartesian3());
         } else if ((right instanceof Cartesian4) && (left instanceof Cartesian4)) {
             return Cartesian4.fromElements(left.x % right.x, left.y % right.y, left.z % right.z, left.w % right.w, ScratchStorage.getCartesian4());
+        } else if ((typeof(left) === 'number') && (typeof(right) === 'number')) {
+            return left % right;
         }
-        return left % right;
+
+        //>>includeStart('debug', pragmas.debug);
+        throw new DeveloperError('Error: Operation is undefined.');
+        //>>includeEnd('debug');
+
+        return left % right; // jshint ignore:line
     };
 
     Node.prototype._evaluateEqualsStrict = function(frameState, feature) {

--- a/Source/Scene/Expression.js
+++ b/Source/Scene/Expression.js
@@ -311,7 +311,7 @@ define([
                 var j = exp.indexOf('}');
                 //>>includeStart('debug', pragmas.debug);
                 if (j < 0) {
-                    throw new DeveloperError('Error: unmatched {.');
+                    throw new DeveloperError('Unmatched {.');
                 }
                 //>>includeEnd('debug');
                 result += "czm_" + exp.substr(i + 2, j - (i + 2));
@@ -353,7 +353,7 @@ define([
                 // Make sure this is called on a valid type
                 //>>includeStart('debug', pragmas.debug);
                 if (object.callee.name !== 'regExp') {
-                    throw new DeveloperError('Error: ' + call + ' is not a function.');
+                    throw new DeveloperError(call + ' is not a function.');
                 }
                 //>>includeEnd('debug');
                 if (argsLength === 0) {
@@ -372,7 +372,7 @@ define([
             }
 
             //>>includeStart('debug', pragmas.debug);
-            throw new DeveloperError('Error: Unexpected function call "' + call + '".');
+            throw new DeveloperError('Unexpected function call "' + call + '".');
             //>>includeEnd('debug');
         }
 
@@ -391,7 +391,7 @@ define([
         } else if (call === 'rgb' || call === 'hsl') {
             //>>includeStart('debug', pragmas.debug);
             if (argsLength < 3) {
-                throw new DeveloperError('Error: ' + call + ' requires three arguments.');
+                throw new DeveloperError(call + ' requires three arguments.');
             }
             //>>includeEnd('debug');
             val = [
@@ -403,7 +403,7 @@ define([
         } else if (call === 'rgba' || call === 'hsla') {
             //>>includeStart('debug', pragmas.debug);
             if (argsLength < 4) {
-                throw new DeveloperError('Error: ' + call + ' requires four arguments.');
+                throw new DeveloperError(call + ' requires four arguments.');
             }
             //>>includeEnd('debug');
             val = [
@@ -433,7 +433,7 @@ define([
         } else if (call === 'isExactClass' || call === 'isClass') {
             //>>includeStart('debug', pragmas.debug);
             if (argsLength < 1 || argsLength > 1) {
-                throw new DeveloperError('Error: ' + call + ' requires exactly one argument.');
+                throw new DeveloperError(call + ' requires exactly one argument.');
             }
             //>>includeEnd('debug');
             val = createRuntimeAst(expression, args[0]);
@@ -441,14 +441,14 @@ define([
         } else if (call === 'getExactClassName') {
             //>>includeStart('debug', pragmas.debug);
             if (argsLength > 0) {
-                throw new DeveloperError('Error: ' + call + ' does not take any argument.');
+                throw new DeveloperError(call + ' does not take any argument.');
             }
             //>>includeEnd('debug');
             return new Node(ExpressionNodeType.UNARY, call);
         } else if (defined(unaryFunctions[call])) {
             //>>includeStart('debug', pragmas.debug);
             if (argsLength !== 1) {
-                throw new DeveloperError('Error: ' + call + ' requires exactly one argument.');
+                throw new DeveloperError(call + ' requires exactly one argument.');
             }
             //>>includeEnd('debug');
             val = createRuntimeAst(expression, args[0]);
@@ -456,7 +456,7 @@ define([
         } else if (defined(binaryFunctions[call])) {
             //>>includeStart('debug', pragmas.debug);
             if (argsLength !== 2) {
-                throw new DeveloperError('Error: ' + call + ' requires exactly two arguments.');
+                throw new DeveloperError(call + ' requires exactly two arguments.');
             }
             //>>includeEnd('debug');
             left = createRuntimeAst(expression, args[0]);
@@ -465,7 +465,7 @@ define([
         } else if (defined(ternaryFunctions[call])) {
             //>>includeStart('debug', pragmas.debug);
             if (argsLength !== 3) {
-                throw new DeveloperError('Error: ' + call + ' requires exactly three arguments.');
+                throw new DeveloperError(call + ' requires exactly three arguments.');
             }
             //>>includeEnd('debug');
             left = createRuntimeAst(expression, args[0]);
@@ -495,7 +495,7 @@ define([
         }
 
         //>>includeStart('debug', pragmas.debug);
-        throw new DeveloperError('Error: Unexpected function call "' + call + '".');
+        throw new DeveloperError('Unexpected function call "' + call + '".');
         //>>includeEnd('debug');
     }
 
@@ -557,7 +557,7 @@ define([
         }
 
         //>>includeStart('debug', pragmas.debug);
-        throw new DeveloperError('Error: ' + ast.name + ' is not defined.');
+        throw new DeveloperError(ast.name + ' is not defined.');
         //>>includeEnd('debug');
     }
 
@@ -604,7 +604,7 @@ define([
                 node = new Node(ExpressionNodeType.UNARY, op, child);
             } else {
                 //>>includeStart('debug', pragmas.debug);
-                throw new DeveloperError('Error: Unexpected operator "' + op + '".');
+                throw new DeveloperError('Unexpected operator "' + op + '".');
                 //>>includeEnd('debug');
             }
         } else if (ast.type === 'BinaryExpression') {
@@ -615,7 +615,7 @@ define([
                 node = new Node(ExpressionNodeType.BINARY, op, left, right);
             } else {
                 //>>includeStart('debug', pragmas.debug);
-                throw new DeveloperError('Error: Unexpected operator "' + op + '".');
+                throw new DeveloperError('Unexpected operator "' + op + '".');
                 //>>includeEnd('debug');
             }
         } else if (ast.type === 'LogicalExpression') {
@@ -642,9 +642,9 @@ define([
         //>>includeStart('debug', pragmas.debug);
         else if (ast.type === 'Compound') {
             // empty expression or multiple expressions
-            throw new DeveloperError('Error: Provide exactly one expression.');
+            throw new DeveloperError('Provide exactly one expression.');
         }  else {
-            throw new DeveloperError('Error: Cannot parse expression.');
+            throw new DeveloperError('Cannot parse expression.');
         }
         //>>includeEnd('debug');
 
@@ -774,6 +774,9 @@ define([
             } else if (left instanceof Cartesian4) {
                 return Cartesian4.fromElements(evaluate(left.x), evaluate(left.y), evaluate(left.z), evaluate(left.w), ScratchStorage.getCartesian4());
             }
+            //>>includeStart('debug', pragmas.debug);
+            throw new DeveloperError('Function "' + call + '" requires a vector or number argument. Argument is ' + left + '.');
+            //>>includeEnd('debug');
             return evaluate(left);
         };
     }
@@ -854,6 +857,7 @@ define([
         // vec2(vec4(1), 1)  // too many components
 
         var components = ScratchStorage.getArray();
+        var call = this._value;
         var args = this._left;
         var argsLength = args.length;
         for (var i = 0; i < argsLength; ++i) {
@@ -867,19 +871,23 @@ define([
             } else if (value instanceof Cartesian4) {
                 components.push(value.x, value.y, value.z, value.w);
             }
+            //>>includeStart('debug', pragmas.debug);
+            else {
+                throw new DeveloperError('"' + call + '" argument must be a vector or number. Argument is ' + value + '.');
+            }
+            //>>includeEnd('debug');
         }
 
         var componentsLength = components.length;
-        var call = this._value;
         var vectorLength = parseInt(call.charAt(3));
 
         //>>includeStart('debug', pragmas.debug);
         if (componentsLength === 0) {
-            throw new DeveloperError('Error: Invalid ' + call + ' constructor. No valid arguments.');
+            throw new DeveloperError('Invalid ' + call + ' constructor. No valid arguments.');
         } else if ((componentsLength < vectorLength) && (componentsLength > 1)) {
-            throw new DeveloperError('Error: Invalid ' + call + ' constructor. Not enough arguments.');
+            throw new DeveloperError('Invalid ' + call + ' constructor. Not enough arguments.');
         } else if ((componentsLength > vectorLength) && (argsLength > 1)) {
-            throw new DeveloperError('Error: Invalid ' + call + ' constructor. Too many arguments.');
+            throw new DeveloperError('Invalid ' + call + ' constructor. Too many arguments.');
         }
         //>>includeEnd('debug');
 
@@ -994,7 +1002,7 @@ define([
         var left = this._left.evaluate(frameState, feature);
         //>>includeStart('debug', pragmas.debug);
         if (typeof(left) !== 'boolean') {
-            throw new DeveloperError('Error: Operation is undefined.');
+            throw new DeveloperError('Operator "!" requires a Boolean argument. Argument is type "' + typeof(left) + '".');
         }
         //>>includeEnd('debug');
         return !left;
@@ -1013,7 +1021,7 @@ define([
         }
 
         //>>includeStart('debug', pragmas.debug);
-        throw new DeveloperError('Error: Operation is undefined.');
+        throw new DeveloperError('Operator "-" requires a vector or number argument. Argument is ' + left + '.');
         //>>includeEnd('debug');
         return -left; // jshint ignore:line
     };
@@ -1023,7 +1031,7 @@ define([
 
         //>>includeStart('debug', pragmas.debug);
         if (!((left instanceof Cartesian2) || (left instanceof Cartesian3) || (left instanceof Cartesian4) || (typeof(left) === 'number'))) {
-            throw new DeveloperError('Error: Operation is undefined.');
+            throw new DeveloperError('Operator "+" requires a vector or number argument. Argument is ' + left + '.');
         }
         //>>includeEnd('debug');
 
@@ -1036,7 +1044,7 @@ define([
 
         //>>includeStart('debug', pragmas.debug);
         if ((typeof(left) !== 'number') || (typeof(right) !== 'number')) {
-            throw new DeveloperError('Error: Operation is undefined.');
+            throw new DeveloperError('Operator "<" requires number arguments. Arguments are ' + left + ' and ' + right + '.');
         }
         //>>includeEnd('debug');
 
@@ -1049,7 +1057,7 @@ define([
 
         //>>includeStart('debug', pragmas.debug);
         if ((typeof(left) !== 'number') || (typeof(right) !== 'number')) {
-            throw new DeveloperError('Error: Operation is undefined.');
+            throw new DeveloperError('Operator "<=" requires number arguments. Arguments are ' + left + ' and ' + right + '.');
         }
         //>>includeEnd('debug');
 
@@ -1062,7 +1070,7 @@ define([
 
         //>>includeStart('debug', pragmas.debug);
         if ((typeof(left) !== 'number') || (typeof(right) !== 'number')) {
-            throw new DeveloperError('Error: Operation is undefined.');
+            throw new DeveloperError('Operator ">" requires number arguments. Arguments are ' + left + ' and ' + right + '.');
         }
         //>>includeEnd('debug');
 
@@ -1075,7 +1083,7 @@ define([
 
         //>>includeStart('debug', pragmas.debug);
         if ((typeof(left) !== 'number') || (typeof(right) !== 'number')) {
-            throw new DeveloperError('Error: Operation is undefined.');
+            throw new DeveloperError('Operator ">=" requires number arguments. Arguments are ' + left + ' and ' + right + '.');
         }
         //>>includeEnd('debug');
 
@@ -1086,7 +1094,7 @@ define([
         var left = this._left.evaluate(frameState, feature);
         //>>includeStart('debug', pragmas.debug);
         if (typeof(left) !== 'boolean') {
-            throw new DeveloperError('Error: Operation is undefined.');
+            throw new DeveloperError('Operator "||" requires boolean arguments. First argument is ' + left + '.');
         }
         //>>includeEnd('debug');
 
@@ -1098,7 +1106,7 @@ define([
         var right = this._right.evaluate(frameState, feature);
         //>>includeStart('debug', pragmas.debug);
         if (typeof(right) !== 'boolean') {
-            throw new DeveloperError('Error: Operation is undefined.');
+            throw new DeveloperError('Operator "||" requires boolean arguments. Second argument is ' + right + '.');
         }
         //>>includeEnd('debug');
         return left || right;
@@ -1108,7 +1116,7 @@ define([
         var left = this._left.evaluate(frameState, feature);
         //>>includeStart('debug', pragmas.debug);
         if (typeof(left) !== 'boolean') {
-            throw new DeveloperError('Error: Operation is undefined.');
+            throw new DeveloperError('Operator "&&" requires boolean arguments. First argument is ' + left + '.');
         }
         //>>includeEnd('debug');
 
@@ -1120,7 +1128,7 @@ define([
         var right = this._right.evaluate(frameState, feature);
         //>>includeStart('debug', pragmas.debug);
         if (typeof(right) !== 'boolean') {
-            throw new DeveloperError('Error: Operation is undefined.');
+            throw new DeveloperError('Operator "&&" requires boolean arguments. Second argument is ' + right + '.');
         }
         //>>includeEnd('debug');
         return left && right;
@@ -1136,13 +1144,14 @@ define([
         } else if ((right instanceof Cartesian4) && (left instanceof Cartesian4)) {
             return Cartesian4.add(left, right, ScratchStorage.getCartesian4());
         } else if ((typeof(left) === 'string') || (typeof(right) === 'string')) {
+            // If only one argument is a string, the other argument calls its toString function.
             return left + right;
         } else if ((typeof(left) === 'number') && (typeof(right) === 'number')) {
             return left + right;
         }
 
         //>>includeStart('debug', pragmas.debug);
-        throw new DeveloperError('Error: Operation is undefined.');
+        throw new DeveloperError('Operator "+" requires vector or number arguments of matching types, or at least one string argument. Arguments are ' + left + ' and ' + right + '.');
         //>>includeEnd('debug');
 
         return left + right; // jshint ignore:line
@@ -1162,7 +1171,7 @@ define([
         }
 
         //>>includeStart('debug', pragmas.debug);
-        throw new DeveloperError('Error: Operation is undefined.');
+        throw new DeveloperError('Operator "-" requires vector or number arguments of matching types. Arguments are ' + left + ' and ' + right + '.');
         //>>includeEnd('debug');
 
         return left - right; // jshint ignore:line
@@ -1194,7 +1203,7 @@ define([
         }
 
         //>>includeStart('debug', pragmas.debug);
-        throw new DeveloperError('Error: Operation is undefined.');
+        throw new DeveloperError('Operator "*" requires vector or number arguments. If both arguments are vectors they must be matching types. Arguments are ' + left + ' and ' + right + '.');
         //>>includeEnd('debug');
 
         return left * right; // jshint ignore:line
@@ -1220,7 +1229,7 @@ define([
         }
 
         //>>includeStart('debug', pragmas.debug);
-        throw new DeveloperError('Error: Operation is undefined.');
+        throw new DeveloperError('Operator "/" requires vector or number arguments of matching types, or a number as the second argument. Arguments are ' + left + ' and ' + right + '.');
         //>>includeEnd('debug');
 
         return left / right; // jshint ignore:line
@@ -1240,7 +1249,7 @@ define([
         }
 
         //>>includeStart('debug', pragmas.debug);
-        throw new DeveloperError('Error: Operation is undefined.');
+        throw new DeveloperError('Operator "%" requires vector or number arguments of matching types. Arguments are ' + left + ' and ' + right + '.');
         //>>includeEnd('debug');
 
         return left % right; // jshint ignore:line
@@ -1396,7 +1405,7 @@ define([
         }
         //>>includeStart('debug', pragmas.debug);
         else {
-            throw new DeveloperError('Error: Unexpected function call "' + this._value + '".');
+            throw new DeveloperError('Unexpected function call "' + this._value + '".');
         }
         //>>includeEnd('debug');
     };

--- a/Source/Scene/Expression.js
+++ b/Source/Scene/Expression.js
@@ -777,7 +777,7 @@ define([
             //>>includeStart('debug', pragmas.debug);
             throw new DeveloperError('Function "' + call + '" requires a vector or number argument. Argument is ' + left + '.');
             //>>includeEnd('debug');
-            return evaluate(left);
+            return evaluate(left); // jshint ignore:line
         };
     }
 
@@ -873,7 +873,7 @@ define([
             }
             //>>includeStart('debug', pragmas.debug);
             else {
-                throw new DeveloperError('"' + call + '" argument must be a vector or number. Argument is ' + value + '.');
+                throw new DeveloperError(call + ' argument must be a vector or number. Argument is ' + value + '.');
             }
             //>>includeEnd('debug');
         }
@@ -1002,7 +1002,7 @@ define([
         var left = this._left.evaluate(frameState, feature);
         //>>includeStart('debug', pragmas.debug);
         if (typeof(left) !== 'boolean') {
-            throw new DeveloperError('Operator "!" requires a Boolean argument. Argument is type "' + typeof(left) + '".');
+            throw new DeveloperError('Operator "!" requires a boolean argument. Argument is ' + left + '.');
         }
         //>>includeEnd('debug');
         return !left;
@@ -1144,7 +1144,7 @@ define([
         } else if ((right instanceof Cartesian4) && (left instanceof Cartesian4)) {
             return Cartesian4.add(left, right, ScratchStorage.getCartesian4());
         } else if ((typeof(left) === 'string') || (typeof(right) === 'string')) {
-            // If only one argument is a string, the other argument calls its toString function.
+            // If only one argument is a string the other argument calls its toString function.
             return left + right;
         } else if ((typeof(left) === 'number') && (typeof(right) === 'number')) {
             return left + right;

--- a/Source/Scene/PointCloud3DTileContent.js
+++ b/Source/Scene/PointCloud3DTileContent.js
@@ -1108,6 +1108,19 @@ define([
             fragmentShaderSource : pickFS,
             attributeLocations : attributeLocations
         });
+
+        try {
+            // Check if the shader compiles correctly. If not there is likely a syntax error with the style.
+            drawCommand.shaderProgram._bind();
+        } catch (error) {
+            //>>includeStart('debug', pragmas.debug);
+            // Turn the RuntimeError into a DeveloperError and rephrase it.
+            throw new DeveloperError('Error generating style shader: this may be caused by a type mismatch, index out-of-bounds, or other syntax error.');
+            //>>includeEnd('debug');
+
+            // In release silently ignore and recreate the shader without a style. Tell jsHint to ignore this line.
+            createShaders(content, frameState, undefined);  // jshint ignore:line
+        }
     }
 
     /**

--- a/Specs/Scene/ExpressionSpec.js
+++ b/Specs/Scene/ExpressionSpec.js
@@ -595,6 +595,13 @@ defineSuite([
         }).toThrowDeveloperError();
     });
 
+    it('throws if vec2 has invalid argument', function() {
+        var expression = new Expression('vec2("1")');
+        expect(function() {
+            expression.evaluate(frameState, undefined);
+        }).toThrowDeveloperError();
+    });
+
     it('evaluates vec3', function() {
         var expression = new Expression('vec3(2.0)');
         expect(expression.evaluate(frameState, undefined)).toEqual(new Cartesian3(2.0, 2.0, 2.0));
@@ -637,6 +644,13 @@ defineSuite([
         }).toThrowDeveloperError();
 
         expression = new Expression('vec3(vec4(3.0, 4.0, 5.0, 6.0), 1.0)');
+        expect(function() {
+            expression.evaluate(frameState, undefined);
+        }).toThrowDeveloperError();
+    });
+
+    it('throws if vec3 has invalid argument', function() {
+        var expression = new Expression('vec3(1.0, "1.0", 2.0)');
         expect(function() {
             expression.evaluate(frameState, undefined);
         }).toThrowDeveloperError();
@@ -695,6 +709,13 @@ defineSuite([
         }).toThrowDeveloperError();
     });
 
+    it('throws if vec4 has invalid argument', function() {
+        var expression = new Expression('vec4(1.0, "2.0", 3.0, 4.0)');
+        expect(function() {
+            expression.evaluate(frameState, undefined);
+        }).toThrowDeveloperError();
+    });
+
     it('evaluates vector with expressions as arguments', function() {
         var feature = new MockFeature();
         feature.addProperty('height', 2);
@@ -722,6 +743,20 @@ defineSuite([
         expect(expression.evaluate(frameState, undefined)).toEqual(3.0);
 
         expression = new Expression('vec4(1.0, 2.0, 3.0, 4.0).w');
+        expect(expression.evaluate(frameState, undefined)).toEqual(4.0);
+    });
+
+    it('evaluates vector properties (r, g, b, a)', function() {
+        var expression = new Expression('vec4(1.0, 2.0, 3.0, 4.0).r');
+        expect(expression.evaluate(frameState, undefined)).toEqual(1.0);
+
+        expression = new Expression('vec4(1.0, 2.0, 3.0, 4.0).g');
+        expect(expression.evaluate(frameState, undefined)).toEqual(2.0);
+
+        expression = new Expression('vec4(1.0, 2.0, 3.0, 4.0).b');
+        expect(expression.evaluate(frameState, undefined)).toEqual(3.0);
+
+        expression = new Expression('vec4(1.0, 2.0, 3.0, 4.0).a');
         expect(expression.evaluate(frameState, undefined)).toEqual(4.0);
     });
 
@@ -753,12 +788,33 @@ defineSuite([
         expect(expression.evaluate(frameState, undefined)).toEqual(4.0);
     });
 
+    it('evaluates vector properties (["r"], ["g"], ["b"]. ["a"])', function() {
+        var expression = new Expression('vec4(1.0, 2.0, 3.0, 4.0)["r"]');
+        expect(expression.evaluate(frameState, undefined)).toEqual(1.0);
+
+        expression = new Expression('vec4(1.0, 2.0, 3.0, 4.0)["g"]');
+        expect(expression.evaluate(frameState, undefined)).toEqual(2.0);
+
+        expression = new Expression('vec4(1.0, 2.0, 3.0, 4.0)["b"]');
+        expect(expression.evaluate(frameState, undefined)).toEqual(3.0);
+
+        expression = new Expression('vec4(1.0, 2.0, 3.0, 4.0)["a"]');
+        expect(expression.evaluate(frameState, undefined)).toEqual(4.0);
+    });
+
     it('evaluates unary not', function() {
         var expression = new Expression('!true');
         expect(expression.evaluate(frameState, undefined)).toEqual(false);
 
         expression = new Expression('!!true');
         expect(expression.evaluate(frameState, undefined)).toEqual(true);
+    });
+
+    it('throws if unary not takes invalid argument', function() {
+        var expression = new Expression('!"true"');
+        expect(function() {
+            expression.evaluate(frameState, undefined);
+        }).toThrowDeveloperError();
     });
 
     it('evaluates unary negative', function() {
@@ -769,18 +825,23 @@ defineSuite([
         expect(expression.evaluate(frameState, undefined)).toEqual(5);
     });
 
+    it('throws if unary negative takes invalid argument', function() {
+        var expression = new Expression('-"56"');
+        expect(function() {
+            expression.evaluate(frameState, undefined);
+        }).toThrowDeveloperError();
+    });
+
     it('evaluates unary positive', function() {
         var expression = new Expression('+5');
         expect(expression.evaluate(frameState, undefined)).toEqual(5);
+    });
 
-        expression = new Expression('+"5"');
-        expect(expression.evaluate(frameState, undefined)).toEqual(5);
-
-        expression = new Expression('+true');
-        expect(expression.evaluate(frameState, undefined)).toEqual(1);
-
-        expression = new Expression('+null');
-        expect(expression.evaluate(frameState, undefined)).toEqual(0);
+    it('throws if unary positive takes invalid argument', function() {
+        var expression = new Expression('+"56"');
+        expect(function() {
+            expression.evaluate(frameState, undefined);
+        }).toThrowDeveloperError();
     });
 
     it('evaluates binary addition', function() {
@@ -791,6 +852,50 @@ defineSuite([
         expect(expression.evaluate(frameState, undefined)).toEqual(10);
     });
 
+    it('evaluates binary addition with strings', function() {
+        var expression = new Expression('1 + "10"');
+        expect(expression.evaluate(frameState, undefined)).toEqual('110');
+
+        expression = new Expression('"10" + 1');
+        expect(expression.evaluate(frameState, undefined)).toEqual('101');
+
+        expression = new Expression('"name_" + "building"');
+        expect(expression.evaluate(frameState, undefined)).toEqual('name_building');
+
+        expression = new Expression('"name_" + true');
+        expect(expression.evaluate(frameState, undefined)).toEqual('name_true');
+
+        expression = new Expression('"name_" + null');
+        expect(expression.evaluate(frameState, undefined)).toEqual('name_null');
+
+        expression = new Expression('"name_" + undefined');
+        expect(expression.evaluate(frameState, undefined)).toEqual('name_undefined');
+
+        expression = new Expression('"name_" + vec2(1.1)');
+        expect(expression.evaluate(frameState, undefined)).toEqual('name_(1.1, 1.1)');
+
+        expression = new Expression('"name_" + vec3(1.1)');
+        expect(expression.evaluate(frameState, undefined)).toEqual('name_(1.1, 1.1, 1.1)');
+
+        expression = new Expression('"name_" + vec4(1.1)');
+        expect(expression.evaluate(frameState, undefined)).toEqual('name_(1.1, 1.1, 1.1, 1.1)');
+
+        expression = new Expression('"name_" + regExp("a")');
+        expect(expression.evaluate(frameState, undefined)).toEqual('name_/a/');
+    });
+
+    it('throws if binary addition takes invalid arguments', function() {
+        var expression = new Expression('vec2(1.0) + vec3(1.0)');
+        expect(function() {
+            expression.evaluate(frameState, undefined);
+        }).toThrowDeveloperError();
+
+        expression = new Expression('1.0 + vec3(1.0)');
+        expect(function() {
+            expression.evaluate(frameState, undefined);
+        }).toThrowDeveloperError();
+    });
+
     it('evaluates binary subtraction', function() {
         var expression = new Expression('2 - 1');
         expect(expression.evaluate(frameState, undefined)).toEqual(1);
@@ -799,12 +904,41 @@ defineSuite([
         expect(expression.evaluate(frameState, undefined)).toEqual(-2);
     });
 
+    it('throws if binary subtraction takes invalid arguments', function() {
+        var expression = new Expression('vec2(1.0) - vec3(1.0)');
+        expect(function() {
+            expression.evaluate(frameState, undefined);
+        }).toThrowDeveloperError();
+
+        expression = new Expression('1.0 - vec3(1.0)');
+        expect(function() {
+            expression.evaluate(frameState, undefined);
+        }).toThrowDeveloperError();
+
+        expression = new Expression('"name1" - "name2"');
+        expect(function() {
+            expression.evaluate(frameState, undefined);
+        }).toThrowDeveloperError();
+    });
+
     it('evaluates binary multiplication', function() {
         var expression = new Expression('1 * 2');
         expect(expression.evaluate(frameState, undefined)).toEqual(2);
 
         expression = new Expression('1 * 2 * 3 * 4');
         expect(expression.evaluate(frameState, undefined)).toEqual(24);
+    });
+
+    it('throws if binary multiplication takes invalid arguments', function() {
+        var expression = new Expression('vec2(1.0) * vec3(1.0)');
+        expect(function() {
+            expression.evaluate(frameState, undefined);
+        }).toThrowDeveloperError();
+
+        expression = new Expression('vec2(1.0) * "name"');
+        expect(function() {
+            expression.evaluate(frameState, undefined);
+        }).toThrowDeveloperError();
     });
 
     it('evaluates binary division', function() {
@@ -818,12 +952,46 @@ defineSuite([
         expect(expression.evaluate(frameState, undefined)).toEqual(-3);
     });
 
+    it('throws if binary division takes invalid arguments', function() {
+        var expression = new Expression('vec2(1.0) / vec3(1.0)');
+        expect(function() {
+            expression.evaluate(frameState, undefined);
+        }).toThrowDeveloperError();
+
+        expression = new Expression('vec2(1.0) / "2.0"');
+        expect(function() {
+            expression.evaluate(frameState, undefined);
+        }).toThrowDeveloperError();
+
+        expression = new Expression('1.0 / vec4(1.0)');
+        expect(function() {
+            expression.evaluate(frameState, undefined);
+        }).toThrowDeveloperError();
+    });
+
     it('evaluates binary modulus', function() {
         var expression = new Expression('2 % 1');
         expect(expression.evaluate(frameState, undefined)).toEqual(0);
 
         expression = new Expression('6 % 4 % 3');
         expect(expression.evaluate(frameState, undefined)).toEqual(2);
+    });
+
+    it('throws if binary modulus takes invalid arguments', function() {
+        var expression = new Expression('vec2(1.0) % vec3(1.0)');
+        expect(function() {
+            expression.evaluate(frameState, undefined);
+        }).toThrowDeveloperError();
+
+        expression = new Expression('vec2(1.0) % "2.0"');
+        expect(function() {
+            expression.evaluate(frameState, undefined);
+        }).toThrowDeveloperError();
+
+        expression = new Expression('1.0 % vec4(1.0)');
+        expect(function() {
+            expression.evaluate(frameState, undefined);
+        }).toThrowDeveloperError();
     });
 
     it('evaluates binary equals strict', function() {
@@ -891,12 +1059,28 @@ defineSuite([
 
         expression = new Expression('3 < 2');
         expect(expression.evaluate(frameState, undefined)).toEqual(false);
+    });
+
+    it('throws if binary less than takes invalid arguments', function() {
+        var expression = new Expression('vec2(1.0) < vec2(2.0)');
+        expect(function() {
+            expression.evaluate(frameState, undefined);
+        }).toThrowDeveloperError();
+
+        expression = new Expression('1 < vec3(1.0)');
+        expect(function() {
+            expression.evaluate(frameState, undefined);
+        }).toThrowDeveloperError();
 
         expression = new Expression('true < false');
-        expect(expression.evaluate(frameState, undefined)).toEqual(false);
+        expect(function() {
+            expression.evaluate(frameState, undefined);
+        }).toThrowDeveloperError();
 
         expression = new Expression('color(\'blue\') < 10');
-        expect(expression.evaluate(frameState, undefined)).toEqual(false);
+        expect(function() {
+            expression.evaluate(frameState, undefined);
+        }).toThrowDeveloperError();
     });
 
     it('evaluates binary less than or equals', function() {
@@ -908,12 +1092,33 @@ defineSuite([
 
         expression = new Expression('3 <= 2');
         expect(expression.evaluate(frameState, undefined)).toEqual(false);
+    });
+
+    it('throws if binary less than or equals takes invalid arguments', function() {
+        var expression = new Expression('vec2(1.0) <= vec2(2.0)');
+        expect(function() {
+            expression.evaluate(frameState, undefined);
+        }).toThrowDeveloperError();
+
+        expression = new Expression('1 <= vec3(1.0)');
+        expect(function() {
+            expression.evaluate(frameState, undefined);
+        }).toThrowDeveloperError();
+
+        expression = new Expression('1.0 <= "5"');
+        expect(function() {
+            expression.evaluate(frameState, undefined);
+        }).toThrowDeveloperError();
 
         expression = new Expression('true <= false');
-        expect(expression.evaluate(frameState, undefined)).toEqual(false);
+        expect(function() {
+            expression.evaluate(frameState, undefined);
+        }).toThrowDeveloperError();
 
         expression = new Expression('color(\'blue\') <= 10');
-        expect(expression.evaluate(frameState, undefined)).toEqual(false);
+        expect(function() {
+            expression.evaluate(frameState, undefined);
+        }).toThrowDeveloperError();
     });
 
     it('evaluates binary greater than', function() {
@@ -925,12 +1130,33 @@ defineSuite([
 
         expression = new Expression('3 > 2');
         expect(expression.evaluate(frameState, undefined)).toEqual(true);
+    });
+
+    it('throws if binary greater than takes invalid arguments', function() {
+        var expression = new Expression('vec2(1.0) > vec2(2.0)');
+        expect(function() {
+            expression.evaluate(frameState, undefined);
+        }).toThrowDeveloperError();
+
+        expression = new Expression('1 > vec3(1.0)');
+        expect(function() {
+            expression.evaluate(frameState, undefined);
+        }).toThrowDeveloperError();
+
+        expression = new Expression('1.0 > "5"');
+        expect(function() {
+            expression.evaluate(frameState, undefined);
+        }).toThrowDeveloperError();
 
         expression = new Expression('true > false');
-        expect(expression.evaluate(frameState, undefined)).toEqual(true);
+        expect(function() {
+            expression.evaluate(frameState, undefined);
+        }).toThrowDeveloperError();
 
         expression = new Expression('color(\'blue\') > 10');
-        expect(expression.evaluate(frameState, undefined)).toEqual(false);
+        expect(function() {
+            expression.evaluate(frameState, undefined);
+        }).toThrowDeveloperError();
     });
 
     it('evaluates binary greater than or equals', function() {
@@ -942,12 +1168,33 @@ defineSuite([
 
         expression = new Expression('3 >= 2');
         expect(expression.evaluate(frameState, undefined)).toEqual(true);
+    });
+
+    it('throws if binary greater than or equals takes invalid arguments', function() {
+        var expression = new Expression('vec2(1.0) >= vec2(2.0)');
+        expect(function() {
+            expression.evaluate(frameState, undefined);
+        }).toThrowDeveloperError();
+
+        expression = new Expression('1 >= vec3(1.0)');
+        expect(function() {
+            expression.evaluate(frameState, undefined);
+        }).toThrowDeveloperError();
+
+        expression = new Expression('1.0 >= "5"');
+        expect(function() {
+            expression.evaluate(frameState, undefined);
+        }).toThrowDeveloperError();
 
         expression = new Expression('true >= false');
-        expect(expression.evaluate(frameState, undefined)).toEqual(true);
+        expect(function() {
+            expression.evaluate(frameState, undefined);
+        }).toThrowDeveloperError();
 
         expression = new Expression('color(\'blue\') >= 10');
-        expect(expression.evaluate(frameState, undefined)).toEqual(false);
+        expect(function() {
+            expression.evaluate(frameState, undefined);
+        }).toThrowDeveloperError();
     });
 
     it('evaluates logical and', function() {
@@ -1033,9 +1280,6 @@ defineSuite([
         expect(expression.evaluate(frameState, undefined)).toEqual(true);
 
         expression = new Expression('color() == color()');
-        expect(expression.evaluate(frameState, undefined)).toEqual(true);
-
-        expression = new Expression('!!color() == true');
         expect(expression.evaluate(frameState, undefined)).toEqual(true);
 
         expression = new Expression('color(\'green\') != color(\'green\')');
@@ -1152,9 +1396,6 @@ defineSuite([
         expect(expression.evaluate(frameState, undefined)).toEqual(true);
 
         expression = new Expression('vec4(1, 2, 3, 4) === vec4(1, 2, 3, 4)');
-        expect(expression.evaluate(frameState, undefined)).toEqual(true);
-
-        expression = new Expression('!!vec4(1.0) == true');
         expect(expression.evaluate(frameState, undefined)).toEqual(true);
 
         expression = new Expression('vec2(1, 2) != vec2(1, 2)');
@@ -1304,6 +1545,14 @@ defineSuite([
     it('throws if getExactClassName takes an invalid number of arguments', function() {
         expect(function() {
             return new Expression('getExactClassName("door")');
+        }).toThrowDeveloperError();
+    });
+
+    it('throws if built-in unary function is given an invalid argument', function() {
+        // Argument must be a number or vector
+        var expression = new Expression('abs("-1")');
+        expect(function() {
+            expression.evaluate(frameState, undefined);
         }).toThrowDeveloperError();
     });
 
@@ -2335,12 +2584,6 @@ defineSuite([
 
         expression = new Expression('[1+2, "hello", 2 < 3, color("blue"), ${property}]');
         expect(expression.evaluate(frameState, feature)).toEqual([3, 'hello', true, Cartesian4.fromColor(Color.BLUE), 'value']);
-
-        expression = new Expression('[1, 2, 3] * 4');
-        expect(expression.evaluate(frameState, undefined)).toEqual(NaN);
-
-        expression = new Expression('-[1, 2, 3]');
-        expect(expression.evaluate(frameState, undefined)).toEqual(NaN);
 
         expression = new Expression('${array[1]}');
         expect(expression.evaluate(frameState, feature)).toEqual(Cartesian4.UNIT_Y);

--- a/Specs/Scene/PointCloud3DTileContentSpec.js
+++ b/Specs/Scene/PointCloud3DTileContentSpec.js
@@ -551,6 +551,17 @@ defineSuite([
         });
     });
 
+    it('throws when shader style is invalid', function() {
+        return Cesium3DTilesTester.loadTileset(scene, pointCloudRGBUrl).then(function(tileset) {
+            var content = tileset._root.content;
+            expect(function() {
+                content.applyStyleWithShader(scene.frameState, new Cesium3DTileStyle({
+                    show : '1 < "2"'
+                }));
+            }).toThrowDeveloperError();
+        });
+    });
+
     it('destroys', function() {
         return Cesium3DTilesTester.tileDestroys(scene, pointCloudRGBUrl);
     });


### PR DESCRIPTION
Based on discussion here: https://github.com/AnalyticalGraphicsInc/3d-tiles/pull/166

To start this goes through the unary and binary operators and throws errors if the arguments are not the same type. There's a bit more work to be done with the math library, vector constructors, etc.

In some ways this PR is starting the process of changing the styling language to not be as dependent on JavaScript type-conversion rules. Is the end goal of the spec to not rely on JavaScript conventions at all?