### PR TITLE
3D Tiles Styling - change math constants and tileset time variable

### DIFF
--- a/Source/Scene/Expression.js
+++ b/Source/Scene/Expression.js
@@ -292,7 +292,7 @@ define([
         var result = '';
         var i = exp.indexOf('${');
         while (i >= 0) {
-            // check if string is inside quotes
+            // Check if string is inside quotes
             var openSingleQuote = exp.indexOf('\'');
             var openDoubleQuote = exp.indexOf('"');
             var closeQuote;
@@ -541,19 +541,18 @@ define([
 
     function parseKeywordsAndVariables(ast) {
         if (isVariable(ast.name)) {
-            return new Node(ExpressionNodeType.VARIABLE, getPropertyName(ast.name));
+            var name = getPropertyName(ast.name);
+            if (name.substr(0, 8) === 'tiles3d_') {
+                return new Node(ExpressionNodeType.GLOBAL_VARIABLE, name);
+            } else {
+                return new Node(ExpressionNodeType.VARIABLE, name);
+            }
         } else if (ast.name === 'NaN') {
             return new Node(ExpressionNodeType.LITERAL_NUMBER, NaN);
         } else if (ast.name === 'Infinity') {
             return new Node(ExpressionNodeType.LITERAL_NUMBER, Infinity);
         } else if (ast.name === 'undefined') {
             return new Node(ExpressionNodeType.LITERAL_UNDEFINED, undefined);
-        } else if (ast.name === 'PI') {
-            return new Node(ExpressionNodeType.LITERAL_NUMBER, Math.PI);
-        } else if (ast.name === 'E') {
-            return new Node(ExpressionNodeType.LITERAL_NUMBER, Math.E);
-        } else if (ast.name === 'TILES3D_TILESET_TIME') {
-            return new Node(ExpressionNodeType.LITERAL_GLOBAL, ast.name);
         }
 
         //>>includeStart('debug', pragmas.debug);
@@ -561,7 +560,20 @@ define([
         //>>includeEnd('debug');
     }
 
+    function parseMathConstant(ast) {
+        var name = ast.property.name;
+        if (name === 'PI') {
+            return new Node(ExpressionNodeType.LITERAL_NUMBER, Math.PI);
+        } else if (name === 'E') {
+            return new Node(ExpressionNodeType.LITERAL_NUMBER, Math.E);
+        }
+    }
+
     function parseMemberExpression(expression, ast) {
+        if (ast.object.name === 'Math') {
+            return parseMathConstant(ast);
+        }
+
         var val;
         var obj = createRuntimeAst(expression, ast.object);
         if (ast.computed) {
@@ -748,16 +760,16 @@ define([
             node.evaluate = node._evaluateLiteralString;
         } else if (node._type === ExpressionNodeType.REGEX) {
             node.evaluate = node._evaluateRegExp;
-        } else if (node._type === ExpressionNodeType.LITERAL_GLOBAL) {
-            if (node._value === 'TILES3D_TILESET_TIME') {
-                node.evaluate = evaluateTime;
+        } else if (node._type === ExpressionNodeType.GLOBAL_VARIABLE) {
+            if (node._value === 'tiles3d_tileset_time') {
+                node.evaluate = evaluateTilesetTime;
             }
         } else {
             node.evaluate = node._evaluateLiteral;
         }
     }
 
-    function evaluateTime(frameState, feature) {
+    function evaluateTilesetTime(frameState, feature) {
         return feature._content._tileset.timeSinceLoad;
     }
 
@@ -1619,8 +1631,8 @@ define([
                 //>>includeStart('debug', pragmas.debug);
                 throw new DeveloperError('Error generating style shader: undefined is not supported.');
                 //>>includeEnd('debug');
-            case ExpressionNodeType.LITERAL_GLOBAL:
-                if (value === 'TILES3D_TILESET_TIME') {
+            case ExpressionNodeType.GLOBAL_VARIABLE:
+                if (value === 'tiles3d_tileset_time') {
                     return 'u_tilesetTime';
                 }
         }

--- a/Source/Scene/ExpressionNodeType.js
+++ b/Source/Scene/ExpressionNodeType.js
@@ -27,7 +27,7 @@ define([
         LITERAL_VECTOR : 15,
         LITERAL_REGEX : 16,
         LITERAL_UNDEFINED : 17,
-        LITERAL_GLOBAL : 18
+        GLOBAL_VARIABLE : 18
     };
 
     return freezeObject(ExpressionNodeType);

--- a/Specs/Scene/ExpressionSpec.js
+++ b/Specs/Scene/ExpressionSpec.js
@@ -251,11 +251,13 @@ defineSuite([
 
         expression = new Expression('Infinity');
         expect(expression.evaluate(frameState, undefined)).toEqual(Infinity);
+    });
 
-        expression = new Expression('PI');
+    it('evaluates math constants', function() {
+        var expression = new Expression('Math.PI');
         expect(expression.evaluate(frameState, undefined)).toEqual(Math.PI);
 
-        expression = new Expression('E');
+        expression = new Expression('Math.E');
         expect(expression.evaluate(frameState, undefined)).toEqual(Math.E);
     });
 
@@ -1338,13 +1340,13 @@ defineSuite([
         var expression = new Expression('cos(0)');
         expect(expression.evaluate(frameState, undefined)).toEqual(1.0);
 
-        expression = new Expression('cos(vec2(0, PI))');
+        expression = new Expression('cos(vec2(0, Math.PI))');
         expect(expression.evaluate(frameState, undefined)).toEqualEpsilon(new Cartesian2(1.0, -1.0), CesiumMath.EPSILON7);
 
-        expression = new Expression('cos(vec3(0, PI, -PI)');
+        expression = new Expression('cos(vec3(0, Math.PI, -Math.PI)');
         expect(expression.evaluate(frameState, undefined)).toEqualEpsilon(new Cartesian3(1.0, -1.0, -1.0), CesiumMath.EPSILON7);
 
-        expression = new Expression('cos(vec4(0, PI, -PI, 0)');
+        expression = new Expression('cos(vec4(0, Math.PI, -Math.PI, 0)');
         expect(expression.evaluate(frameState, undefined)).toEqualEpsilon(new Cartesian4(1.0, -1.0, -1.0, 1.0), CesiumMath.EPSILON7);
     });
 
@@ -1362,13 +1364,13 @@ defineSuite([
         var expression = new Expression('sin(0)');
         expect(expression.evaluate(frameState, undefined)).toEqual(0);
 
-        expression = new Expression('sin(vec2(0, PI/2))');
+        expression = new Expression('sin(vec2(0, Math.PI/2))');
         expect(expression.evaluate(frameState, undefined)).toEqualEpsilon(new Cartesian2(0.0, 1.0), CesiumMath.EPSILON7);
 
-        expression = new Expression('sin(vec3(0, PI/2, -PI/2)');
+        expression = new Expression('sin(vec3(0, Math.PI/2, -Math.PI/2)');
         expect(expression.evaluate(frameState, undefined)).toEqualEpsilon(new Cartesian3(0.0, 1.0, -1.0), CesiumMath.EPSILON7);
 
-        expression = new Expression('sin(vec4(0, PI/2, -PI/2, 0)');
+        expression = new Expression('sin(vec4(0, Math.PI/2, -Math.PI/2, 0)');
         expect(expression.evaluate(frameState, undefined)).toEqualEpsilon(new Cartesian4(0.0, 1.0, -1.0, 0.0), CesiumMath.EPSILON7);
     });
 
@@ -1386,13 +1388,13 @@ defineSuite([
         var expression = new Expression('tan(0)');
         expect(expression.evaluate(frameState, undefined)).toEqual(0);
 
-        expression = new Expression('tan(vec2(0, PI/4))');
+        expression = new Expression('tan(vec2(0, Math.PI/4))');
         expect(expression.evaluate(frameState, undefined)).toEqualEpsilon(new Cartesian2(0.0, 1.0), CesiumMath.EPSILON7);
 
-        expression = new Expression('tan(vec3(0, PI/4, PI)');
+        expression = new Expression('tan(vec3(0, Math.PI/4, Math.PI)');
         expect(expression.evaluate(frameState, undefined)).toEqualEpsilon(new Cartesian3(0.0, 1.0, 0.0), CesiumMath.EPSILON7);
 
-        expression = new Expression('tan(vec4(0, PI/4, PI, -PI/4)');
+        expression = new Expression('tan(vec4(0, Math.PI/4, Math.PI, -Math.PI/4)');
         expect(expression.evaluate(frameState, undefined)).toEqualEpsilon(new Cartesian4(0.0, 1.0, 0.0, -1.0), CesiumMath.EPSILON7);
     });
 
@@ -1503,16 +1505,16 @@ defineSuite([
     });
 
     it('evaluates degrees function', function() {
-        var expression = new Expression('degrees(2 * PI)');
+        var expression = new Expression('degrees(2 * Math.PI)');
         expect(expression.evaluate(frameState, undefined)).toEqualEpsilon(360, CesiumMath.EPSILON10);
 
-        expression = new Expression('degrees(vec2(2 * PI, PI))');
+        expression = new Expression('degrees(vec2(2 * Math.PI, Math.PI))');
         expect(expression.evaluate(frameState, undefined)).toEqualEpsilon(new Cartesian2(360, 180), CesiumMath.EPSILON7);
 
-        expression = new Expression('degrees(vec3(2 * PI, PI, 2 * PI))');
+        expression = new Expression('degrees(vec3(2 * Math.PI, Math.PI, 2 * Math.PI))');
         expect(expression.evaluate(frameState, undefined)).toEqualEpsilon(new Cartesian3(360, 180, 360), CesiumMath.EPSILON7);
 
-        expression = new Expression('degrees(vec4(2 * PI, PI, 2 * PI, PI)');
+        expression = new Expression('degrees(vec4(2 * Math.PI, Math.PI, 2 * Math.PI, Math.PI)');
         expect(expression.evaluate(frameState, undefined)).toEqualEpsilon(new Cartesian4(360, 180, 360, 180), CesiumMath.EPSILON7);
     });
 
@@ -1740,13 +1742,13 @@ defineSuite([
         expression = new Expression('log(10.0)');
         expect(expression.evaluate(frameState, undefined)).toEqualEpsilon(2.302585092994046, CesiumMath.EPSILON7);
 
-        expression = new Expression('log(vec2(1.0, E))');
+        expression = new Expression('log(vec2(1.0, Math.E))');
         expect(expression.evaluate(frameState, undefined)).toEqual(new Cartesian2(0.0, 1.0));
 
-        expression = new Expression('log(vec3(1.0, E, 1.0))');
+        expression = new Expression('log(vec3(1.0, Math.E, 1.0))');
         expect(expression.evaluate(frameState, undefined)).toEqual(new Cartesian3(0.0, 1.0, 0.0));
 
-        expression = new Expression('log(vec4(1.0, E, 1.0, E))');
+        expression = new Expression('log(vec4(1.0, Math.E, 1.0, Math.E))');
         expect(expression.evaluate(frameState, undefined)).toEqual(new Cartesian4(0.0, 1.0, 0.0, 1.0));
     });
 
@@ -1877,7 +1879,7 @@ defineSuite([
         expect(expression.evaluate(frameState, undefined)).toEqualEpsilon(0.0, CesiumMath.EPSILON10);
 
         expression = new Expression('atan2(1,0)');
-        expect(expression.evaluate(frameState, undefined)).toEqualEpsilon(0.5*Math.PI, CesiumMath.EPSILON10);
+        expect(expression.evaluate(frameState, undefined)).toEqualEpsilon(0.5 * Math.PI, CesiumMath.EPSILON10);
     });
 
     it('throws if atan2 function takes an invalid number of arguments', function() {
@@ -2361,9 +2363,9 @@ defineSuite([
         expect(expression.evaluate(frameState, feature)).toEqual(70);
     });
 
-    it('evaluates TILES3D_TILESET_TIME expression', function() {
+    it('evaluates tiles3d_tileset_time expression', function() {
         var feature = new MockFeature();
-        var expression = new Expression('TILES3D_TILESET_TIME');
+        var expression = new Expression('${tiles3d_tileset_time}');
         expect(expression.evaluate(frameState, feature)).toEqual(0.0);
         feature._content._tileset.timeSinceLoad = 1.0;
         expect(expression.evaluate(frameState, feature)).toEqual(1.0);
@@ -2749,8 +2751,8 @@ defineSuite([
         expect(shaderExpression).toEqual(expected);
     });
 
-    it('gets shader expression for TILES3D_TILESET_TIME', function() {
-        var expression = new Expression('TILES3D_TILESET_TIME');
+    it('gets shader expression for tiles3d_tileset_time', function() {
+        var expression = new Expression('${tiles3d_tileset_time}');
         var shaderExpression = expression.getShaderExpression('', {});
         var expected = 'u_tilesetTime';
         expect(shaderExpression).toEqual(expected);


### PR DESCRIPTION
From the discussion here: https://github.com/AnalyticalGraphicsInc/3d-tiles/pull/169

* `PI` - `Math.PI`
* `E` - `Math.E`
* `TILES3D_TILESET_TIME` - `${tiles3d_tileset_time}`