### PR TITLE
Use console.warn for oneTimeWarning

### DIFF
--- a/Source/Core/oneTimeWarning.js
+++ b/Source/Core/oneTimeWarning.js
@@ -42,7 +42,7 @@ define([
 
         if (!defined(warnings[identifier])) {
             warnings[identifier] = true;
-            console.log(defaultValue(message, identifier));
+            console.warn(defaultValue(message, identifier));
         }
     }
 

--- a/Specs/Core/deprecationWarningSpec.js
+++ b/Specs/Core/deprecationWarningSpec.js
@@ -6,15 +6,15 @@ defineSuite([
     'use strict';
 
     it('logs a warning', function() {
-        spyOn(console, 'log');
+        spyOn(console, 'warn');
 
         deprecationWarning('deprecation-identifier', 'message');
         deprecationWarning('deprecation-identifier', 'message');
         deprecationWarning('another deprecation-identifier', 'another message');
 
-        expect(console.log.calls.count()).toEqual(2);
-        expect(console.log.calls.argsFor(0)[0]).toBe('message');
-        expect(console.log.calls.argsFor(1)[0]).toBe('another message');
+        expect(console.warn.calls.count()).toEqual(2);
+        expect(console.warn.calls.argsFor(0)[0]).toBe('message');
+        expect(console.warn.calls.argsFor(1)[0]).toBe('another message');
     });
 
     it('throws without identifier', function() {

--- a/Specs/Core/oneTimeWarningSpec.js
+++ b/Specs/Core/oneTimeWarningSpec.js
@@ -6,15 +6,15 @@ defineSuite([
     "use strict";
 
     it('logs a warning', function() {
-        spyOn(console, 'log');
+        spyOn(console, 'warn');
 
         oneTimeWarning('oneTime-identifier', 'message');
         oneTimeWarning('oneTime-identifier');
         oneTimeWarning('another oneTime-identifier');
 
-        expect(console.log.calls.count()).toEqual(2);
-        expect(console.log.calls.argsFor(0)[0]).toBe('message');
-        expect(console.log.calls.argsFor(1)[0]).toBe('another oneTime-identifier');
+        expect(console.warn.calls.count()).toEqual(2);
+        expect(console.warn.calls.argsFor(0)[0]).toBe('message');
+        expect(console.warn.calls.argsFor(1)[0]).toBe('another oneTime-identifier');
     });
 
     it('throws without identifier', function() {


### PR DESCRIPTION
[oneTimeWarning](https://github.com/AnalyticalGraphicsInc/cesium/blob/master/Source/Core/oneTimeWarning.js#L45) uses `console.log` to warn developers of changes.

I think we should use `console.warn` instead so these message stand out a little more from regular console logs.  Some applications spit out a lot of log messages and this warning could get lost in the mix.