### PR TITLE
Fix loading of Iau2006Xys data when stopIndex is negative

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,6 +23,7 @@ Change Log
 * Added support for WMS version 1.3 by using CRS vice SRS query string parameter to request projection. SRS is still used for older versions.
 * The attribute `perInstanceAttribute` of `DebugAppearance` has been made optional and defaults to `false`.
 * Fixed a bug that would cause a crash when `debugShowFrustums` is enabled with OIT [#4864](https://github.com/AnalyticalGraphicsInc/cesium/pull/4864)
+* Fixed a bug in `Iau2006XysData.preload` that would cause incorrect indices to load and result in unkept promises. [#4368](https://github.com/AnalyticalGraphicsInc/cesium/issues/4638)
 
 ### 1.29 - 2017-01-02
 * Improved 3D Models

--- a/Source/Core/Iau2006XysData.js
+++ b/Source/Core/Iau2006XysData.js
@@ -104,18 +104,16 @@ define([
         var startDaysSinceEpoch = getDaysSinceEpoch(this, startDayTT, startSecondTT);
         var stopDaysSinceEpoch = getDaysSinceEpoch(this, stopDayTT, stopSecondTT);
 
-        var startIndex = (startDaysSinceEpoch / this._stepSizeDays - this._interpolationOrder / 2) | 0;
-        if (startIndex < 0) {
-            startIndex = 0;
-        }
+        var startIndex = (startDaysSinceEpoch / this._stepSizeDays - this._interpolationOrder / 2);
+        startIndex = Math.max(0, startIndex);
 
-        var stopIndex = (stopDaysSinceEpoch / this._stepSizeDays - this._interpolationOrder / 2) | 0 + this._interpolationOrder;
-        if (stopIndex >= this._totalSamples) {
+        var stopIndex = (stopDaysSinceEpoch / this._stepSizeDays - this._interpolationOrder / 2) + this._interpolationOrder;
+        if ((stopIndex < 0) || (stopIndex > this._totalSamples - 1)) {
             stopIndex = this._totalSamples - 1;
         }
 
-        var startChunk = (startIndex / this._samplesPerXysFile) | 0;
-        var stopChunk = (stopIndex / this._samplesPerXysFile) | 0;
+        var startChunk = (startIndex / this._samplesPerXysFile);
+        var stopChunk = (stopIndex / this._samplesPerXysFile);
 
         var promises = [];
         for ( var i = startChunk; i <= stopChunk; ++i) {

--- a/Source/Core/Iau2006XysData.js
+++ b/Source/Core/Iau2006XysData.js
@@ -104,16 +104,16 @@ define([
         var startDaysSinceEpoch = getDaysSinceEpoch(this, startDayTT, startSecondTT);
         var stopDaysSinceEpoch = getDaysSinceEpoch(this, stopDayTT, stopSecondTT);
 
-        var startIndex = (startDaysSinceEpoch / this._stepSizeDays - this._interpolationOrder / 2);
+        var startIndex = (startDaysSinceEpoch / this._stepSizeDays - this._interpolationOrder / 2) | 0;
         startIndex = Math.max(0, startIndex);
 
-        var stopIndex = (stopDaysSinceEpoch / this._stepSizeDays - this._interpolationOrder / 2) + this._interpolationOrder;
+        var stopIndex = (stopDaysSinceEpoch / this._stepSizeDays - this._interpolationOrder / 2) | 0 + this._interpolationOrder;
         if ((stopIndex < 0) || (stopIndex > this._totalSamples - 1)) {
             stopIndex = this._totalSamples - 1;
         }
 
-        var startChunk = (startIndex / this._samplesPerXysFile);
-        var stopChunk = (stopIndex / this._samplesPerXysFile);
+        var startChunk = (startIndex / this._samplesPerXysFile) | 0;
+        var stopChunk = (stopIndex / this._samplesPerXysFile) | 0;
 
         var promises = [];
         for ( var i = startChunk; i <= stopChunk; ++i) {


### PR DESCRIPTION
Fixes #4638 

This fixes the problem when `stopIndex < 0`. In this case, `stopIndex` will be set to `totalSamples` which will let it run through all the files.

I'm not sure if this is a particularly good thing wrt to performance, but given the fact that it's a `preload` function that returns promises, I think it should be fine.

The other change I made in this PR is to remove the ` x | 0` ops which doesn't change `x` in any way. Unless there is a more significant reason that these are around, I think removing this should be fine.