### PR TITLE
3D Tiles in 2D/CV

### DIFF
--- a/Apps/Sandcastle/gallery/3D Tiles Batch Table Hierarchy.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Batch Table Hierarchy.html
@@ -227,6 +227,10 @@ var HIGHLIGHT_COLOR = new Cesium.Color(1.0, 1.0, 0.0, 0.4);
 
 // Highlight feature on mouse over
 handler.setInputAction(function(movement) {
+    if (scene.mode === Cesium.SceneMode.MORPHING) {
+        return;
+    }
+
     if (!pickingEnabled) {
         return;
     }

--- a/Apps/Sandcastle/gallery/3D Tiles Batch Table Hierarchy.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Batch Table Hierarchy.html
@@ -81,9 +81,7 @@ function startup(Cesium) {
 //     * doorknob_size
 //     * doorknob_name
 
-var viewer = new Cesium.Viewer('cesiumContainer', {
-    scene3DOnly : true
-});
+var viewer = new Cesium.Viewer('cesiumContainer');
 
 var scene = viewer.scene;
 var tilesetUrl = '../../../Specs/Data/Cesium3DTiles/Hierarchy/BatchTableHierarchy';
@@ -91,11 +89,14 @@ var tileset = scene.primitives.add(new Cesium.Cesium3DTileset({
     url : tilesetUrl
 }));
 
-tileset.readyPromise.then(function(tileset) {
+function zoomToTileset() {
     var boundingSphere = tileset.boundingSphere;
     viewer.camera.viewBoundingSphere(boundingSphere, new Cesium.HeadingPitchRange(0, -2.0, 0));
     viewer.camera.lookAtTransform(Cesium.Matrix4.IDENTITY);
-});
+}
+
+tileset.readyPromise.then(zoomToTileset);
+scene.morphComplete.addEventListener(zoomToTileset);
 
 var styles = [];
 function addStyle(name, style) {

--- a/Apps/Sandcastle/gallery/3D Tiles Point Cloud Styling.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Point Cloud Styling.html
@@ -29,9 +29,7 @@ function startup(Cesium) {
     'use strict';
 //Sandcastle_Begin
 
-var viewer = new Cesium.Viewer('cesiumContainer', {
-    scene3DOnly : true
-});
+var viewer = new Cesium.Viewer('cesiumContainer');
 
 var scene = viewer.scene;
 var url = '../../../Specs/Data/Cesium3DTiles/PointCloud/PointCloudWithPerPointProperties/';

--- a/Apps/Sandcastle/gallery/3D Tiles Point Cloud Styling.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Point Cloud Styling.html
@@ -38,10 +38,14 @@ var tileset = scene.primitives.add(new Cesium.Cesium3DTileset({
     url : url
 }));
 
-tileset.readyPromise.then(function(tileset) {
+function zoomToTileset() {
     var boundingSphere = tileset.boundingSphere;
     viewer.camera.viewBoundingSphere(boundingSphere, new Cesium.HeadingPitchRange(0, -2.0, 0));
-});
+    viewer.camera.lookAtTransform(Cesium.Matrix4.IDENTITY);
+}
+
+tileset.readyPromise.then(zoomToTileset);
+scene.morphComplete.addEventListener(zoomToTileset);
 
 var styles = [];
 function addStyle(name, style) {

--- a/Apps/Sandcastle/gallery/3D Tiles.html
+++ b/Apps/Sandcastle/gallery/3D Tiles.html
@@ -30,7 +30,6 @@ function startup(Cesium) {
 //Sandcastle_Begin
 
 var viewer = new Cesium.Viewer('cesiumContainer', {
-    scene3DOnly : true,
     shadows : true
 });
 

--- a/Apps/Sandcastle/gallery/3D Tiles.html
+++ b/Apps/Sandcastle/gallery/3D Tiles.html
@@ -187,6 +187,10 @@ var HIGHLIGHT_COLOR = new Cesium.Color(1.0, 1.0, 0.0, 0.4);
 
 // Highlight feature on mouse over
 handler.setInputAction(function(movement) {
+    if (scene.mode === Cesium.SceneMode.MORPHING) {
+        return;
+    }
+
     if (!pickingEnabled) {
         return;
     }

--- a/Apps/Sandcastle/gallery/development/3D Models Instancing.html
+++ b/Apps/Sandcastle/gallery/development/3D Models Instancing.html
@@ -137,7 +137,8 @@ function reset() {
             var roll = Math.random();
             var scale = (Math.random() + 1.0)/2.0;
 
-            var modelMatrix = Cesium.Transforms.headingPitchRollToFixedFrame(position, heading, pitch, roll);
+            var hpr = new Cesium.HeadingPitchRoll(heading, pitch, roll);
+            var modelMatrix = Cesium.Transforms.headingPitchRollToFixedFrame(position, hpr);
             Cesium.Matrix4.multiplyByUniformScale(modelMatrix, scale, modelMatrix);
 
             instances.push({

--- a/Source/Scene/Cesium3DTile.js
+++ b/Source/Scene/Cesium3DTile.js
@@ -529,7 +529,7 @@ define([
      */
     Cesium3DTile.prototype.visibility = function(frameState, parentVisibilityPlaneMask) {
         var cullingVolume = frameState.cullingVolume;
-        var boundingVolume = getBoundingVolume(this, frameState)
+        var boundingVolume = getBoundingVolume(this, frameState);
         return cullingVolume.computeVisibilityWithPlaneMask(boundingVolume, parentVisibilityPlaneMask);
     };
 

--- a/Source/Scene/Cesium3DTile.js
+++ b/Source/Scene/Cesium3DTile.js
@@ -1,5 +1,6 @@
 /*global define*/
 define([
+        '../Core/BoundingSphere',
         '../Core/BoxOutlineGeometry',
         '../Core/Cartesian3',
         '../Core/Color',
@@ -27,11 +28,12 @@ define([
         './Empty3DTileContent',
         './PerInstanceColorAppearance',
         './Primitive',
+        './SceneMode',
         './TileBoundingRegion',
         './TileBoundingSphere',
-        './TileOrientedBoundingBox',
-        './Tileset3DTileContent'
+        './TileOrientedBoundingBox'
     ], function(
+        BoundingSphere,
         BoxOutlineGeometry,
         Cartesian3,
         Color,
@@ -59,10 +61,10 @@ define([
         Empty3DTileContent,
         PerInstanceColorAppearance,
         Primitive,
+        SceneMode,
         TileBoundingRegion,
         TileBoundingSphere,
-        TileOrientedBoundingBox,
-        Tileset3DTileContent) {
+        TileOrientedBoundingBox) {
     'use strict';
 
     /**
@@ -98,6 +100,7 @@ define([
         this._transformDirty = true;
 
         this._boundingVolume = this.createBoundingVolume(header.boundingVolume, computedTransform);
+        this._boundingVolume2D = undefined;
 
         var contentBoundingVolume;
 
@@ -110,6 +113,7 @@ define([
             contentBoundingVolume = this.createBoundingVolume(contentHeader.boundingVolume, computedTransform);
         }
         this._contentBoundingVolume = contentBoundingVolume;
+        this._contentBoundingVolume2D = undefined;
 
         var viewerRequestVolume;
         if (defined(header.viewerRequestVolume)) {
@@ -505,34 +509,48 @@ define([
     /**
      * Determines whether the tile's bounding volume intersects the culling volume.
      *
-     * @param {CullingVolume} cullingVolume The culling volume whose intersection with the tile is to be tested.
+     * @param {FrameState} frameState The frame state.
      * @param {Number} parentVisibilityPlaneMask The parent's plane mask to speed up the visibility check.
      * @returns {Number} A plane mask as described above in {@link CullingVolume#computeVisibilityWithPlaneMask}.
      *
      * @private
      */
-    Cesium3DTile.prototype.visibility = function(cullingVolume, parentVisibilityPlaneMask) {
-        return cullingVolume.computeVisibilityWithPlaneMask(this._boundingVolume, parentVisibilityPlaneMask);
+    Cesium3DTile.prototype.visibility = function(frameState, parentVisibilityPlaneMask) {
+        if (frameState.mode !== SceneMode.SCENE3D && !defined(this._boundingVolume2D)) {
+            var boundingSphere = this._boundingVolume.boundingSphere;
+            this._boundingVolume2D = BoundingSphere.projectTo2D(boundingSphere);
+        }
+
+        var cullingVolume = frameState.cullingVolume;
+        var boundingVolume = frameState.mode !== SceneMode.SCENE3D ? this._boundingVolume2D : this._boundingVolume;
+        return cullingVolume.computeVisibilityWithPlaneMask(boundingVolume, parentVisibilityPlaneMask);
     };
 
     /**
      * Assuming the tile's bounding volume intersects the culling volume, determines
      * whether the tile's content's bounding volume intersects the culling volume.
      *
-     * @param {CullingVolume} cullingVolume The culling volume whose intersection with the tile's content is to be tested.
+     * @param {FrameState} frameState The frame state.
      * @returns {Intersect} The result of the intersection: the tile's content is completely outside, completely inside, or intersecting the culling volume.
      *
      * @private
      */
-    Cesium3DTile.prototype.contentsVisibility = function(cullingVolume) {
+    Cesium3DTile.prototype.contentsVisibility = function(frameState) {
         // Assumes the tile's bounding volume intersects the culling volume already, so
         // just return Intersect.INSIDE if there is no content bounding volume.
-        var boundingVolume = this._contentBoundingVolume;
-        if (!defined(boundingVolume)) {
+        if (!defined(this._contentBoundingVolume)) {
             return Intersect.INSIDE;
         }
+
+        if (frameState.mode !== SceneMode.SCENE3D && !defined(this._contentBoundingVolume2D)) {
+            var boundingSphere = this._contentBoundingVolume2D.boundingSphere;
+            this._contentBoundingVolume2D = BoundingSphere.projectTo2D(boundingSphere);
+        }
+
         // PERFORMANCE_IDEA: is it possible to burn less CPU on this test since we know the
         // tile's (not the content's) bounding volume intersects the culling volume?
+        var cullingVolume = frameState.cullingVolume;
+        var boundingVolume = frameState.mode !== SceneMode.SCENE3D ? this._contentBoundingVolume2D : this._contentBoundingVolume;
         return cullingVolume.computeVisibility(boundingVolume);
     };
 

--- a/Source/Scene/Cesium3DTile.js
+++ b/Source/Scene/Cesium3DTile.js
@@ -543,7 +543,7 @@ define([
         }
 
         if (frameState.mode !== SceneMode.SCENE3D && !defined(this._contentBoundingVolume2D)) {
-            var boundingSphere = this._contentBoundingVolume2D.boundingSphere;
+            var boundingSphere = this._contentBoundingVolume.boundingSphere;
             this._contentBoundingVolume2D = BoundingSphere.projectTo2D(boundingSphere);
         }
 

--- a/Source/Scene/Cesium3DTileset.js
+++ b/Source/Scene/Cesium3DTileset.js
@@ -1076,8 +1076,7 @@ define([
             var sseDenominator = camera.frustum.sseDenominator;
             error = (geometricError * height) / (distance * sseDenominator);
 
-            // TODO: fix in 2D
-            if (tileset.dynamicScreenSpaceError && frameState.mode === SceneMode.SCENE3D) {
+            if (tileset.dynamicScreenSpaceError) {
                 var density = tileset._dynamicScreenSpaceErrorComputedDensity;
                 var factor = tileset.dynamicScreenSpaceErrorFactor;
                 var dynamicError = CesiumMath.fog(distance, density) * factor;

--- a/Source/Scene/Cesium3DTileset.js
+++ b/Source/Scene/Cesium3DTileset.js
@@ -1179,7 +1179,6 @@ define([
         }
 
         var maximumScreenSpaceError = tileset._maximumScreenSpaceError;
-        var cullingVolume = frameState.cullingVolume;
 
         tileset._selectedTiles.length = 0;
         tileset._selectedTilesToStyle.length = 0;

--- a/Source/Scene/Model.js
+++ b/Source/Scene/Model.js
@@ -3601,14 +3601,12 @@ define([
                             if (defined(command) && model._mode === SceneMode.SCENE2D) {
                                 Matrix4.clone(nodeMatrix, command.modelMatrix);
                                 command.modelMatrix[13] -= CesiumMath.sign(command.modelMatrix[13]) * 2.0 * CesiumMath.PI * projection.ellipsoid.maximumRadius;
-                                //BoundingSphere.transform(primitiveCommand.boundingSphere, command.modelMatrix, command.boundingVolume);
-                                command.boundingVolume = undefined;
+                                BoundingSphere.transform(primitiveCommand.boundingSphere, command.modelMatrix, command.boundingVolume);
 
                                 if (allowPicking) {
                                     var pickCommand2D = primitiveCommand.pickCommand2D;
                                     Matrix4.clone(command.modelMatrix, pickCommand2D.modelMatrix);
-                                    //BoundingSphere.clone(command.boundingVolume, pickCommand2D.boundingVolume);
-                                    pickCommand2D.boundingVolume = undefined;
+                                    BoundingSphere.clone(command.boundingVolume, pickCommand2D.boundingVolume);
                                 }
                             }
                         }

--- a/Source/Scene/Model.js
+++ b/Source/Scene/Model.js
@@ -3527,6 +3527,7 @@ define([
     }
 
     var scratchNodeStack = [];
+    var scratchComputedTranslation = new Cartesian4();
     var scratchComputedMatrixIn2D = new Matrix4();
 
     function updateNodeHierarchyModelMatrix(model, modelTransformChanged, justLoaded, projection) {
@@ -3540,7 +3541,14 @@ define([
         var computedModelMatrix = model._computedModelMatrix;
 
         if (model._mode !== SceneMode.SCENE3D) {
-            computedModelMatrix = Transforms.basisTo2D(projection, computedModelMatrix, scratchComputedMatrixIn2D);
+            var translation = Matrix4.getColumn(computedModelMatrix, 3, scratchComputedTranslation);
+            if (!Cartesian4.equals(translation, Cartesian4.UNIT_W)) {
+                computedModelMatrix = Transforms.basisTo2D(projection, computedModelMatrix, scratchComputedMatrixIn2D);
+            } else {
+                var center = model.boundingSphere.center;
+                var to2D = Transforms.wgs84To2DModelMatrix(projection, center, scratchComputedMatrixIn2D);
+                computedModelMatrix = Matrix4.multiply(to2D, computedModelMatrix, scratchComputedMatrixIn2D);
+            }
         }
 
         for (var i = 0; i < length; ++i) {

--- a/Source/Scene/ModelInstanceCollection.js
+++ b/Source/Scene/ModelInstanceCollection.js
@@ -11,6 +11,7 @@ define([
         '../Core/DeveloperError',
         '../Core/Math',
         '../Core/Matrix4',
+        '../Core/oneTimeWarning',
         '../Core/PrimitiveType',
         '../Renderer/Buffer',
         '../Renderer/BufferUsage',
@@ -33,6 +34,7 @@ define([
         DeveloperError,
         CesiumMath,
         Matrix4,
+        oneTimeWarning,
         PrimitiveType,
         Buffer,
         BufferUsage,
@@ -78,7 +80,7 @@ define([
      * @param {ShadowMode} [options.shadows=ShadowMode.ENABLED] Determines whether the collection casts or receives shadows from each light source.
      * @param {Boolean} [options.debugShowBoundingVolume=false] For debugging only. Draws the bounding sphere for the collection.
      * @param {Boolean} [options.debugWireframe=false] For debugging only. Draws the instances in wireframe.
-     * 
+     *
      * @exception {DeveloperError} Must specify either <options.gltf> or <options.url>, but not both.
      * @exception {DeveloperError} Shader program cannot be optimized for instancing. Parameters cannot have any of the following semantics: MODEL, MODELINVERSE, MODELVIEWINVERSE, MODELVIEWPROJECTIONINVERSE, MODELINVERSETRANSPOSE.
      *
@@ -766,6 +768,7 @@ define([
 
     ModelInstanceCollection.prototype.update = function(frameState) {
         if (frameState.mode !== SceneMode.SCENE3D) {
+            oneTimeWarning('Instanced models in 2D', 'Instanced models are only supported in 3D.');
             return;
         }
 

--- a/Source/Scene/PointCloud3DTileContent.js
+++ b/Source/Scene/PointCloud3DTileContent.js
@@ -1,6 +1,7 @@
 /*global define*/
 define([
         '../Core/Cartesian3',
+        '../Core/Cartesian4',
         '../Core/Color',
         '../Core/combine',
         '../Core/ComponentDatatype',
@@ -19,6 +20,7 @@ define([
         '../Core/Request',
         '../Core/RequestScheduler',
         '../Core/RequestType',
+        '../Core/Transforms',
         '../Core/WebGLConstants',
         '../Renderer/Buffer',
         '../Renderer/BufferUsage',
@@ -34,9 +36,11 @@ define([
         './Cesium3DTileColorBlendMode',
         './Cesium3DTileContentState',
         './Cesium3DTileFeature',
-        './Cesium3DTileFeatureTable'
+        './Cesium3DTileFeatureTable',
+        './SceneMode'
     ], function(
         Cartesian3,
+        Cartesian4,
         Color,
         combine,
         ComponentDatatype,
@@ -55,6 +59,7 @@ define([
         Request,
         RequestScheduler,
         RequestType,
+        Transforms,
         WebGLConstants,
         Buffer,
         BufferUsage,
@@ -70,7 +75,8 @@ define([
         Cesium3DTileColorBlendMode,
         Cesium3DTileContentState,
         Cesium3DTileFeature,
-        Cesium3DTileFeatureTable) {
+        Cesium3DTileFeatureTable,
+        SceneMode) {
     'use strict';
 
     /**
@@ -120,6 +126,8 @@ define([
         this._pointSize = 1.0;
         this._quantizedVolumeScale = undefined;
         this._quantizedVolumeOffset = undefined;
+
+        this._mode = undefined;
 
         /**
          * The following properties are part of the {@link Cesium3DTileContent} interface.
@@ -1141,11 +1149,15 @@ define([
         return false;
     };
 
+    var scratchComputedTranslation = new Cartesian4();
+    var scratchComputedMatrixIn2D = new Matrix4();
+
     /**
      * Part of the {@link Cesium3DTileContent} interface.
      */
     PointCloud3DTileContent.prototype.update = function(tileset, frameState) {
-        var updateModelMatrix = this._tile.transformDirty;
+        var updateModelMatrix = this._tile.transformDirty || this._mode !== frameState.mode;
+        this._mode = frameState.mode;
 
         if (!defined(this._drawCommand)) {
             createResources(this, frameState);
@@ -1166,7 +1178,31 @@ define([
             } else {
                 Matrix4.clone(this._tile.computedTransform, this._drawCommand.modelMatrix);
             }
+
+            if (frameState.mode !== SceneMode.SCENE3D) {
+                var projection = frameState.mapProjection;
+                var modelMatrix = this._drawCommand.modelMatrix;
+                var translation = Matrix4.getColumn(modelMatrix, 3, scratchComputedTranslation);
+                if (!Cartesian4.equals(translation, Cartesian4.UNIT_W)) {
+                    Transforms.basisTo2D(projection, modelMatrix, modelMatrix);
+                } else {
+                    var center = this._tile.boundingSphere.center;
+                    var to2D = Transforms.wgs84To2DModelMatrix(projection, center, scratchComputedMatrixIn2D);
+                    Matrix4.multiply(to2D, modelMatrix, modelMatrix);
+                }
+            }
+
             Matrix4.clone(this._drawCommand.modelMatrix, this._pickCommand.modelMatrix);
+
+            var boundingVolume;
+            if (defined(this._tile._contentBoundingVolume)) {
+                boundingVolume = this._mode === SceneMode.SCENE3D ? this._tile._contentBoundingVolume.boundingSphere : this._tile._contentBoundingVolume2D.boundingSphere;
+            } else {
+                boundingVolume = this._mode === SceneMode.SCENE3D ? this._tile._boundingVolume.boundingSphere : this._tile._boundingVolume2D.boundingSphere;
+            }
+
+            this._drawCommand.boundingVolume = boundingVolume;
+            this._pickCommand.boundingVolume = boundingVolume;
         }
 
         if (this.backFaceCulling !== this._backFaceCulling) {

--- a/Specs/Cesium3DTilesTester.js
+++ b/Specs/Cesium3DTilesTester.js
@@ -21,6 +21,7 @@ define([
 
     var mockTile = {
         contentBoundingVolume : new TileBoundingSphere(),
+        _contentBoundingVolume : new TileBoundingSphere(),
         _header : {
             content : {
                 boundingVolume : {

--- a/Specs/Scene/Cesium3DTilesetSpec.js
+++ b/Specs/Scene/Cesium3DTilesetSpec.js
@@ -110,6 +110,7 @@ defineSuite([
     });
 
     beforeEach(function() {
+        scene.morphTo3D(0.0);
         originalMaximumRequests = RequestScheduler.maximumRequests;
         viewAllTiles();
     });
@@ -305,6 +306,27 @@ defineSuite([
         });
     });
 
+    it('renders tileset in CV', function() {
+        return Cesium3DTilesTester.loadTileset(scene, tilesetUrl).then(function(tileset) {
+            scene.morphToColumbusView(0.0);
+            scene.renderForSpecs();
+            var stats = tileset._statistics;
+            expect(stats.visited).toEqual(5);
+            expect(stats.numberOfCommands).toEqual(5);
+        });
+    });
+
+    it('renders tileset in 2D', function() {
+        return Cesium3DTilesTester.loadTileset(scene, tilesetUrl).then(function(tileset) {
+            scene.morphTo2D(0.0);
+            tileset.maximumScreenSpaceError = 3;
+            scene.renderForSpecs();
+            var stats = tileset._statistics;
+            expect(stats.visited).toEqual(5);
+            expect(stats.numberOfCommands).toEqual(10);
+        });
+    });
+
     it('renders tileset with empty root tile', function() {
         return Cesium3DTilesTester.loadTileset(scene, tilesetEmptyRootUrl).then(function(tileset) {
             scene.renderForSpecs();
@@ -380,7 +402,7 @@ defineSuite([
             scene.renderForSpecs();
             expect(stats.visited).toEqual(0);
             expect(stats.numberOfCommands).toEqual(0);
-            expect(tileset._root.visibility(scene.frameState.cullingVolume, CullingVolume.MASK_INDETERMINATE)).toEqual(CullingVolume.MASK_OUTSIDE);
+            expect(tileset._root.visibility(scene.frameState, CullingVolume.MASK_INDETERMINATE)).toEqual(CullingVolume.MASK_OUTSIDE);
         });
     });
 
@@ -1110,7 +1132,7 @@ defineSuite([
             var spyUpdate = jasmine.createSpy('listener');
             tileset.tileVisible.addEventListener(spyUpdate);
             scene.renderForSpecs();
-            expect(tileset._root.visibility(scene.frameState.cullingVolume, CullingVolume.MASK_INDETERMINATE)).not.toEqual(CullingVolume.MASK_OUTSIDE);
+            expect(tileset._root.visibility(scene.frameState, CullingVolume.MASK_INDETERMINATE)).not.toEqual(CullingVolume.MASK_OUTSIDE);
             expect(spyUpdate.calls.count()).toEqual(1);
             expect(spyUpdate.calls.argsFor(0)[0]).toBe(tileset._root);
         });
@@ -1814,7 +1836,7 @@ defineSuite([
             tileset.tileUnload.addEventListener(spyUpdate);
             scene.renderForSpecs();
 
-            expect(tileset._root.visibility(scene.frameState.cullingVolume, CullingVolume.MASK_INDETERMINATE)).not.toEqual(CullingVolume.MASK_OUTSIDE);
+            expect(tileset._root.visibility(scene.frameState, CullingVolume.MASK_INDETERMINATE)).not.toEqual(CullingVolume.MASK_OUTSIDE);
             expect(spyUpdate.calls.count()).toEqual(4);
             expect(spyUpdate.calls.argsFor(0)[0]).toBe(tileset._root.children[0]);
             expect(spyUpdate.calls.argsFor(1)[0]).toBe(tileset._root.children[1]);

--- a/Specs/Scene/PointCloud3DTileContentSpec.js
+++ b/Specs/Scene/PointCloud3DTileContentSpec.js
@@ -52,11 +52,7 @@ defineSuite([
     }
 
     beforeAll(function() {
-        // Point tiles use RTC, which for now requires scene3DOnly to be true
-        scene = createScene({
-            scene3DOnly : true
-        });
-
+        scene = createScene();
         scene.frameState.passes.render = true;
     });
 
@@ -65,6 +61,7 @@ defineSuite([
     });
 
     beforeEach(function() {
+        scene.morphTo3D(0.0);
         setCamera(centerLongitude, centerLatitude);
     });
 
@@ -256,6 +253,23 @@ defineSuite([
             tileset.debugColorizeTiles = false;
             debugColor = expectRenderPointCloud(tileset);
             expect(debugColor).toEqual(color);
+        });
+    });
+
+    it('renders in CV', function() {
+        return Cesium3DTilesTester.loadTileset(scene, pointCloudRGBUrl).then(function(tileset) {
+            scene.morphToColumbusView(0.0);
+            setCamera(centerLongitude, centerLatitude);
+            expectRenderPointCloud(tileset);
+        });
+    });
+
+    it('renders in 2D', function() {
+        return Cesium3DTilesTester.loadTileset(scene, pointCloudRGBUrl).then(function(tileset) {
+            scene.morphTo2D(0.0);
+            setCamera(centerLongitude, centerLatitude);
+            tileset.maximumScreenSpaceError = 3;
+            expectRenderPointCloud(tileset);
         });
     });
 


### PR DESCRIPTION
Add 3D Tiles support for 2D and Columbus View.

The majority of this change was for models using RTC or are positioned in ECF (model matrix is identity). I'll open a PR for those changes in master. @lilleyse Can you create two simple glTF models from the tilesets you made for me for testing?

- [x] Add tests.