### PR TITLE
Improve check errors

### DIFF
--- a/Documentation/Contributors/CodingGuide/README.md
+++ b/Documentation/Contributors/CodingGuide/README.md
@@ -389,7 +389,7 @@ Use the functions of Cesium's [Check](https://github.com/AnalyticalGraphicsInc/c
 ```javascript
 Cartesian3.maximumComponent = function(cartesian) {
     //>>includeStart('debug', pragmas.debug);
-    Check.typeOf.object(cartesian, 'cartesian');
+    Check.typeOf.object('cartesian', cartesian);
     //>>includeEnd('debug');
 
     return Math.max(cartesian.x, cartesian.y, cartesian.z);
@@ -400,8 +400,8 @@ Cartesian3.maximumComponent = function(cartesian) {
 ```javascript
 Cartesian3.unpackArray = function(array, result) {
     //>>includeStart('debug', pragmas.debug);
-    Check.defined(array, 'array');
-    Check.numeric.minimum(array.length, 3);
+    Check.defined('array', array);
+    Check.typeOf.number.greaterThanOrEquals('array.length', array.length, 3);
     if (array.length % 3 !== 0) {
         throw new DeveloperError('array length must be a multiple of 3.');
     }
@@ -416,7 +416,7 @@ Cartesian3.unpackArray = function(array, result) {
 Cartesian3.maximumComponent = function(cartesian) {
     //>>includeStart('debug', pragmas.debug);
     var c = cartesian;
-    Check.typeOf.object(cartesian, 'cartesian');
+    Check.typeOf.object('cartesian', cartesian);
     //>>includeEnd('debug');
 
     // Works in debug. Fails in release since c is optimized out!

--- a/Source/Core/BoundingRectangle.js
+++ b/Source/Core/BoundingRectangle.js
@@ -79,8 +79,8 @@ define([
      */
     BoundingRectangle.pack = function(value, array, startingIndex) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(value, 'value');
-        Check.defined(array, 'array');
+        Check.typeOf.object('value', value);
+        Check.defined('array', array);
         //>>includeEnd('debug');
 
         startingIndex = defaultValue(startingIndex, 0);
@@ -103,7 +103,7 @@ define([
      */
     BoundingRectangle.unpack = function(array, startingIndex, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.defined(array, 'array');
+        Check.defined('array', array);
         //>>includeEnd('debug');
 
         startingIndex = defaultValue(startingIndex, 0);
@@ -236,8 +236,8 @@ define([
      */
     BoundingRectangle.union = function(left, right, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(left, 'left');
-        Check.typeOf.object(right, 'right');
+        Check.typeOf.object('left', left);
+        Check.typeOf.object('right', right);
         //>>includeEnd('debug');
 
         if (!defined(result)) {
@@ -266,8 +266,8 @@ define([
      */
     BoundingRectangle.expand = function(rectangle, point, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(rectangle, 'rectangle');
-        Check.typeOf.object(point, 'point');
+        Check.typeOf.object('rectangle', rectangle);
+        Check.typeOf.object('point', point);
         //>>includeEnd('debug');
 
         result = BoundingRectangle.clone(rectangle, result);
@@ -301,8 +301,8 @@ define([
      */
     BoundingRectangle.intersect = function(left, right) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(left, 'left');
-        Check.typeOf.object(right, 'right');
+        Check.typeOf.object('left', left);
+        Check.typeOf.object('right', right);
         //>>includeEnd('debug');
 
         var leftX = left.x;

--- a/Source/Core/BoundingSphere.js
+++ b/Source/Core/BoundingSphere.js
@@ -348,7 +348,7 @@ define([
         stride = defaultValue(stride, 3);
 
         //>>includeStart('debug', pragmas.debug);
-        Check.numeric.minimum(stride, 3);
+        Check.typeOf.number.greaterThanOrEquals('stride', stride, 3);
         //>>includeEnd('debug');
 
         var currentPos = fromPointsCurrentPos;
@@ -654,8 +654,8 @@ define([
      */
     BoundingSphere.fromCornerPoints = function(corner, oppositeCorner, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(corner, 'corner');
-        Check.typeOf.object(oppositeCorner, 'oppositeCorner');
+        Check.typeOf.object('corner', corner);
+        Check.typeOf.object('oppositeCorner', oppositeCorner);
         //>>includeEnd('debug');
 
         if (!defined(result)) {
@@ -681,7 +681,7 @@ define([
      */
     BoundingSphere.fromEllipsoid = function(ellipsoid, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(ellipsoid, 'ellipsoid');
+        Check.typeOf.object('ellipsoid', ellipsoid);
         //>>includeEnd('debug');
 
         if (!defined(result)) {
@@ -809,8 +809,8 @@ define([
      */
     BoundingSphere.pack = function(value, array, startingIndex) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(value, 'value');
-        Check.defined(array, 'array');
+        Check.typeOf.object('value', value);
+        Check.defined('array', array);
         //>>includeEnd('debug');
 
         startingIndex = defaultValue(startingIndex, 0);
@@ -834,7 +834,7 @@ define([
      */
     BoundingSphere.unpack = function(array, startingIndex, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.defined(array, 'array');
+        Check.defined('array', array);
         //>>includeEnd('debug');
 
         startingIndex = defaultValue(startingIndex, 0);
@@ -863,8 +863,8 @@ define([
      */
     BoundingSphere.union = function(left, right, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(left, 'left');
-        Check.typeOf.object(right, 'right');
+        Check.typeOf.object('left', left);
+        Check.typeOf.object('right', right);
         //>>includeEnd('debug');
 
         if (!defined(result)) {
@@ -915,8 +915,8 @@ define([
      */
     BoundingSphere.expand = function(sphere, point, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(sphere, 'sphere');
-        Check.typeOf.object(point, 'point');
+        Check.typeOf.object('sphere', sphere);
+        Check.typeOf.object('point', point);
         //>>includeEnd('debug');
 
         result = BoundingSphere.clone(sphere, result);
@@ -941,8 +941,8 @@ define([
      */
     BoundingSphere.intersectPlane = function(sphere, plane) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(sphere, 'sphere');
-        Check.typeOf.object(plane, 'plane');
+        Check.typeOf.object('sphere', sphere);
+        Check.typeOf.object('plane', plane);
         //>>includeEnd('debug');
 
         var center = sphere.center;
@@ -970,8 +970,8 @@ define([
      */
     BoundingSphere.transform = function(sphere, transform, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(sphere, 'sphere');
-        Check.typeOf.object(transform, 'transform');
+        Check.typeOf.object('sphere', sphere);
+        Check.typeOf.object('transform', transform);
         //>>includeEnd('debug');
 
         if (!defined(result)) {
@@ -1001,8 +1001,8 @@ define([
      */
     BoundingSphere.distanceSquaredTo = function(sphere, cartesian) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(sphere, 'sphere');
-        Check.typeOf.object(cartesian, 'cartesian');
+        Check.typeOf.object('sphere', sphere);
+        Check.typeOf.object('cartesian', cartesian);
         //>>includeEnd('debug');
 
         var diff = Cartesian3.subtract(sphere.center, cartesian, distanceSquaredToScratch);
@@ -1026,8 +1026,8 @@ define([
      */
     BoundingSphere.transformWithoutScale = function(sphere, transform, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(sphere, 'sphere');
-        Check.typeOf.object(transform, 'transform');
+        Check.typeOf.object('sphere', sphere);
+        Check.typeOf.object('transform', transform);
         //>>includeEnd('debug');
 
         if (!defined(result)) {
@@ -1056,9 +1056,9 @@ define([
      */
     BoundingSphere.computePlaneDistances = function(sphere, position, direction, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(sphere, 'sphere');
-        Check.typeOf.object(position, 'position');
-        Check.typeOf.object(direction, 'direction');
+        Check.typeOf.object('sphere', sphere);
+        Check.typeOf.object('position', position);
+        Check.typeOf.object('direction', direction);
         //>>includeEnd('debug');
 
         if (!defined(result)) {
@@ -1095,7 +1095,7 @@ define([
      */
     BoundingSphere.projectTo2D = function(sphere, projection, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(sphere, 'sphere');
+        Check.typeOf.object('sphere', sphere);
         //>>includeEnd('debug');
 
         projection = defaultValue(projection, projectTo2DProjection);
@@ -1192,8 +1192,8 @@ define([
      */
     BoundingSphere.isOccluded = function(sphere, occluder) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(sphere, 'sphere');
-        Check.typeOf.object(occluder, 'occluder');
+        Check.typeOf.object('sphere', sphere);
+        Check.typeOf.object('occluder', occluder);
         //>>includeEnd('debug');
         return !occluder.isBoundingSphereVisible(sphere);
     };

--- a/Source/Core/Cartesian2.js
+++ b/Source/Core/Cartesian2.js
@@ -120,8 +120,8 @@ define([
      */
     Cartesian2.pack = function(value, array, startingIndex) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(value, 'value');
-        Check.defined(array, 'array');
+        Check.typeOf.object('value', value);
+        Check.defined('array', array);
         //>>includeEnd('debug');
 
         startingIndex = defaultValue(startingIndex, 0);
@@ -142,7 +142,7 @@ define([
      */
     Cartesian2.unpack = function(array, startingIndex, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.defined(array, 'array');
+        Check.defined('array', array);
         //>>includeEnd('debug');
 
         startingIndex = defaultValue(startingIndex, 0);
@@ -164,7 +164,7 @@ define([
      */
     Cartesian2.packArray = function(array, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.defined(array, 'array');
+        Check.defined('array', array);
         //>>includeEnd('debug');
 
         var length = array.length;
@@ -189,7 +189,7 @@ define([
      */
     Cartesian2.unpackArray = function(array, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.defined(array, 'array');
+        Check.defined('array', array);
         //>>includeEnd('debug');
 
         var length = array.length;
@@ -234,7 +234,7 @@ define([
      */
     Cartesian2.maximumComponent = function(cartesian) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(cartesian, 'cartesian');
+        Check.typeOf.object('cartesian', cartesian);
         //>>includeEnd('debug');
 
         return Math.max(cartesian.x, cartesian.y);
@@ -248,7 +248,7 @@ define([
      */
     Cartesian2.minimumComponent = function(cartesian) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(cartesian, 'cartesian');
+        Check.typeOf.object('cartesian', cartesian);
         //>>includeEnd('debug');
 
         return Math.min(cartesian.x, cartesian.y);
@@ -264,9 +264,9 @@ define([
      */
     Cartesian2.minimumByComponent = function(first, second, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(first, 'first');
-        Check.typeOf.object(second, 'second');
-        Check.typeOf.object(result, 'result');
+        Check.typeOf.object('first', first);
+        Check.typeOf.object('second', second);
+        Check.typeOf.object('result', result);
         //>>includeEnd('debug');
 
 
@@ -286,9 +286,9 @@ define([
      */
     Cartesian2.maximumByComponent = function(first, second, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(first, 'first');
-        Check.typeOf.object(second, 'second');
-        Check.typeOf.object(result, 'result');
+        Check.typeOf.object('first', first);
+        Check.typeOf.object('second', second);
+        Check.typeOf.object('result', result);
         //>>includeEnd('debug');
 
         result.x = Math.max(first.x, second.x);
@@ -304,7 +304,7 @@ define([
      */
     Cartesian2.magnitudeSquared = function(cartesian) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(cartesian, 'cartesian');
+        Check.typeOf.object('cartesian', cartesian);
         //>>includeEnd('debug');
 
         return cartesian.x * cartesian.x + cartesian.y * cartesian.y;
@@ -376,8 +376,8 @@ define([
      */
     Cartesian2.normalize = function(cartesian, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(cartesian, 'cartesian');
-        Check.typeOf.object(result, 'result');
+        Check.typeOf.object('cartesian', cartesian);
+        Check.typeOf.object('result', result);
         //>>includeEnd('debug');
 
         var magnitude = Cartesian2.magnitude(cartesian);
@@ -403,8 +403,8 @@ define([
      */
     Cartesian2.dot = function(left, right) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(left, 'left');
-        Check.typeOf.object(right, 'right');
+        Check.typeOf.object('left', left);
+        Check.typeOf.object('right', right);
         //>>includeEnd('debug');
 
         return left.x * right.x + left.y * right.y;
@@ -420,9 +420,9 @@ define([
      */
     Cartesian2.multiplyComponents = function(left, right, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(left, 'left');
-        Check.typeOf.object(right, 'right');
-        Check.typeOf.object(result, 'result');
+        Check.typeOf.object('left', left);
+        Check.typeOf.object('right', right);
+        Check.typeOf.object('result', result);
         //>>includeEnd('debug');
 
         result.x = left.x * right.x;
@@ -440,9 +440,9 @@ define([
      */
     Cartesian2.divideComponents = function(left, right, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(left, 'left');
-        Check.typeOf.object(right, 'right');
-        Check.typeOf.object(result, 'result');
+        Check.typeOf.object('left', left);
+        Check.typeOf.object('right', right);
+        Check.typeOf.object('result', result);
         //>>includeEnd('debug');
 
         result.x = left.x / right.x;
@@ -460,9 +460,9 @@ define([
      */
     Cartesian2.add = function(left, right, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(left, 'left');
-        Check.typeOf.object(right, 'right');
-        Check.typeOf.object(result, 'result');
+        Check.typeOf.object('left', left);
+        Check.typeOf.object('right', right);
+        Check.typeOf.object('result', result);
         //>>includeEnd('debug');
 
         result.x = left.x + right.x;
@@ -480,9 +480,9 @@ define([
      */
     Cartesian2.subtract = function(left, right, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(left, 'left');
-        Check.typeOf.object(right, 'right');
-        Check.typeOf.object(result, 'result');
+        Check.typeOf.object('left', left);
+        Check.typeOf.object('right', right);
+        Check.typeOf.object('result', result);
         //>>includeEnd('debug');
 
         result.x = left.x - right.x;
@@ -500,9 +500,9 @@ define([
      */
     Cartesian2.multiplyByScalar = function(cartesian, scalar, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(cartesian, 'cartesian');
-        Check.typeOf.number(scalar, 'scalar');
-        Check.typeOf.object(result, 'result');
+        Check.typeOf.object('cartesian', cartesian);
+        Check.typeOf.number('scalar', scalar);
+        Check.typeOf.object('result', result);
         //>>includeEnd('debug');
 
         result.x = cartesian.x * scalar;
@@ -520,9 +520,9 @@ define([
      */
     Cartesian2.divideByScalar = function(cartesian, scalar, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(cartesian, 'cartesian');
-        Check.typeOf.number(scalar, 'scalar');
-        Check.typeOf.object(result, 'result');
+        Check.typeOf.object('cartesian', cartesian);
+        Check.typeOf.number('scalar', scalar);
+        Check.typeOf.object('result', result);
         //>>includeEnd('debug');
 
         result.x = cartesian.x / scalar;
@@ -539,8 +539,8 @@ define([
      */
     Cartesian2.negate = function(cartesian, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(cartesian, 'cartesian');
-        Check.typeOf.object(result, 'result');
+        Check.typeOf.object('cartesian', cartesian);
+        Check.typeOf.object('result', result);
         //>>includeEnd('debug');
 
         result.x = -cartesian.x;
@@ -557,8 +557,8 @@ define([
      */
     Cartesian2.abs = function(cartesian, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(cartesian, 'cartesian');
-        Check.typeOf.object(result, 'result');
+        Check.typeOf.object('cartesian', cartesian);
+        Check.typeOf.object('result', result);
         //>>includeEnd('debug');
 
         result.x = Math.abs(cartesian.x);
@@ -578,10 +578,10 @@ define([
      */
     Cartesian2.lerp = function(start, end, t, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(start, 'start');
-        Check.typeOf.object(end, 'end');
-        Check.typeOf.number(t, 't');
-        Check.typeOf.object(result, 'result');
+        Check.typeOf.object('start', start);
+        Check.typeOf.object('end', end);
+        Check.typeOf.number('t', t);
+        Check.typeOf.object('result', result);
         //>>includeEnd('debug');
 
         Cartesian2.multiplyByScalar(end, t, lerpScratch);
@@ -600,8 +600,8 @@ define([
      */
     Cartesian2.angleBetween = function(left, right) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(left, 'left');
-        Check.typeOf.object(right, 'right');
+        Check.typeOf.object('left', left);
+        Check.typeOf.object('right', right);
         //>>includeEnd('debug');
 
         Cartesian2.normalize(left, angleBetweenScratch);
@@ -619,8 +619,8 @@ define([
      */
     Cartesian2.mostOrthogonalAxis = function(cartesian, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(cartesian, 'cartesian');
-        Check.typeOf.object(result, 'result');
+        Check.typeOf.object('cartesian', cartesian);
+        Check.typeOf.object('result', result);
         //>>includeEnd('debug');
 
         var f = Cartesian2.normalize(cartesian, mostOrthogonalAxisScratch);

--- a/Source/Core/Cartesian3.js
+++ b/Source/Core/Cartesian3.js
@@ -60,7 +60,7 @@ define([
      */
     Cartesian3.fromSpherical = function(spherical, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(spherical, 'spherical');
+        Check.typeOf.object('spherical', spherical);
         //>>includeEnd('debug');
 
         if (!defined(result)) {
@@ -146,8 +146,8 @@ define([
      */
     Cartesian3.pack = function(value, array, startingIndex) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(value, 'value');
-        Check.defined(array, 'array');
+        Check.typeOf.object('value', value);
+        Check.defined('array', array);
         //>>includeEnd('debug');
 
         startingIndex = defaultValue(startingIndex, 0);
@@ -169,7 +169,7 @@ define([
      */
     Cartesian3.unpack = function(array, startingIndex, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.defined(array, 'array');
+        Check.defined('array', array);
         //>>includeEnd('debug');
 
         startingIndex = defaultValue(startingIndex, 0);
@@ -192,7 +192,7 @@ define([
      */
     Cartesian3.packArray = function(array, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.defined(array, 'array');
+        Check.defined('array', array);
         //>>includeEnd('debug');
 
         var length = array.length;
@@ -217,8 +217,8 @@ define([
      */
     Cartesian3.unpackArray = function(array, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.defined(array, 'array');
-        Check.numeric.minimum(array.length, 3);
+        Check.defined('array', array);
+        Check.typeOf.number.greaterThanOrEquals('array.length', array.length, 3);
         if (array.length % 3 !== 0) {
             throw new DeveloperError('array length must be a multiple of 3.');
         }
@@ -266,7 +266,7 @@ define([
      */
     Cartesian3.maximumComponent = function(cartesian) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(cartesian, 'cartesian');
+        Check.typeOf.object('cartesian', cartesian);
         //>>includeEnd('debug');
 
         return Math.max(cartesian.x, cartesian.y, cartesian.z);
@@ -280,7 +280,7 @@ define([
      */
     Cartesian3.minimumComponent = function(cartesian) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(cartesian, 'cartesian');
+        Check.typeOf.object('cartesian', cartesian);
         //>>includeEnd('debug');
 
         return Math.min(cartesian.x, cartesian.y, cartesian.z);
@@ -296,9 +296,9 @@ define([
      */
     Cartesian3.minimumByComponent = function(first, second, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(first, 'first');
-        Check.typeOf.object(second, 'second');
-        Check.typeOf.object(result, 'result');
+        Check.typeOf.object('first', first);
+        Check.typeOf.object('second', second);
+        Check.typeOf.object('result', result);
         //>>includeEnd('debug');
 
         result.x = Math.min(first.x, second.x);
@@ -318,9 +318,9 @@ define([
      */
     Cartesian3.maximumByComponent = function(first, second, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(first, 'first');
-        Check.typeOf.object(second, 'second');
-        Check.typeOf.object(result, 'result');
+        Check.typeOf.object('first', first);
+        Check.typeOf.object('second', second);
+        Check.typeOf.object('result', result);
         //>>includeEnd('debug');
 
         result.x = Math.max(first.x, second.x);
@@ -337,7 +337,7 @@ define([
      */
     Cartesian3.magnitudeSquared = function(cartesian) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(cartesian, 'cartesian');
+        Check.typeOf.object('cartesian', cartesian);
         //>>includeEnd('debug');
 
         return cartesian.x * cartesian.x + cartesian.y * cartesian.y + cartesian.z * cartesian.z;
@@ -368,8 +368,8 @@ define([
      */
     Cartesian3.distance = function(left, right) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(left, 'left');
-        Check.typeOf.object(right, 'right');
+        Check.typeOf.object('left', left);
+        Check.typeOf.object('right', right);
         //>>includeEnd('debug');
 
         Cartesian3.subtract(left, right, distanceScratch);
@@ -390,8 +390,8 @@ define([
      */
     Cartesian3.distanceSquared = function(left, right) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(left, 'left');
-        Check.typeOf.object(right, 'right');
+        Check.typeOf.object('left', left);
+        Check.typeOf.object('right', right);
         //>>includeEnd('debug');
 
         Cartesian3.subtract(left, right, distanceScratch);
@@ -407,8 +407,8 @@ define([
      */
     Cartesian3.normalize = function(cartesian, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(cartesian, 'cartesian');
-        Check.typeOf.object(result, 'result');
+        Check.typeOf.object('cartesian', cartesian);
+        Check.typeOf.object('result', result);
         //>>includeEnd('debug');
 
         var magnitude = Cartesian3.magnitude(cartesian);
@@ -435,8 +435,8 @@ define([
      */
     Cartesian3.dot = function(left, right) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(left, 'left');
-        Check.typeOf.object(right, 'right');
+        Check.typeOf.object('left', left);
+        Check.typeOf.object('right', right);
         //>>includeEnd('debug');
 
         return left.x * right.x + left.y * right.y + left.z * right.z;
@@ -452,9 +452,9 @@ define([
      */
     Cartesian3.multiplyComponents = function(left, right, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(left, 'left');
-        Check.typeOf.object(right, 'right');
-        Check.typeOf.object(result, 'result');
+        Check.typeOf.object('left', left);
+        Check.typeOf.object('right', right);
+        Check.typeOf.object('result', result);
         //>>includeEnd('debug');
 
         result.x = left.x * right.x;
@@ -500,9 +500,9 @@ define([
      */
     Cartesian3.add = function(left, right, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(left, 'left');
-        Check.typeOf.object(right, 'right');
-        Check.typeOf.object(result, 'result');
+        Check.typeOf.object('left', left);
+        Check.typeOf.object('right', right);
+        Check.typeOf.object('result', result);
         //>>includeEnd('debug');
 
         result.x = left.x + right.x;
@@ -521,9 +521,9 @@ define([
      */
     Cartesian3.subtract = function(left, right, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(left, 'left');
-        Check.typeOf.object(right, 'right');
-        Check.typeOf.object(result, 'result');
+        Check.typeOf.object('left', left);
+        Check.typeOf.object('right', right);
+        Check.typeOf.object('result', result);
         //>>includeEnd('debug');
 
         result.x = left.x - right.x;
@@ -542,9 +542,9 @@ define([
      */
     Cartesian3.multiplyByScalar = function(cartesian, scalar, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(cartesian, 'cartesian');
-        Check.typeOf.number(scalar, 'scalar');
-        Check.typeOf.object(result, 'result');
+        Check.typeOf.object('cartesian', cartesian);
+        Check.typeOf.number('scalar', scalar);
+        Check.typeOf.object('result', result);
         //>>includeEnd('debug');
 
         result.x = cartesian.x * scalar;
@@ -563,9 +563,9 @@ define([
      */
     Cartesian3.divideByScalar = function(cartesian, scalar, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(cartesian, 'cartesian');
-        Check.typeOf.number(scalar, 'scalar');
-        Check.typeOf.object(result, 'result');
+        Check.typeOf.object('cartesian', cartesian);
+        Check.typeOf.number('scalar', scalar);
+        Check.typeOf.object('result', result);
         //>>includeEnd('debug');
 
         result.x = cartesian.x / scalar;
@@ -583,8 +583,8 @@ define([
      */
     Cartesian3.negate = function(cartesian, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(cartesian, 'cartesian');
-        Check.typeOf.object(result, 'result');
+        Check.typeOf.object('cartesian', cartesian);
+        Check.typeOf.object('result', result);
         //>>includeEnd('debug');
 
         result.x = -cartesian.x;
@@ -602,8 +602,8 @@ define([
      */
     Cartesian3.abs = function(cartesian, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(cartesian, 'cartesian');
-        Check.typeOf.object(result, 'result');
+        Check.typeOf.object('cartesian', cartesian);
+        Check.typeOf.object('result', result);
         //>>includeEnd('debug');
 
         result.x = Math.abs(cartesian.x);
@@ -624,10 +624,10 @@ define([
      */
     Cartesian3.lerp = function(start, end, t, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(start, 'start');
-        Check.typeOf.object(end, 'end');
-        Check.typeOf.number(t, 't');
-        Check.typeOf.object(result, 'result');
+        Check.typeOf.object('start', start);
+        Check.typeOf.object('end', end);
+        Check.typeOf.number('t', t);
+        Check.typeOf.object('result', result);
         //>>includeEnd('debug');
 
         Cartesian3.multiplyByScalar(end, t, lerpScratch);
@@ -646,8 +646,8 @@ define([
      */
     Cartesian3.angleBetween = function(left, right) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(left, 'left');
-        Check.typeOf.object(right, 'right');
+        Check.typeOf.object('left', left);
+        Check.typeOf.object('right', right);
         //>>includeEnd('debug');
 
         Cartesian3.normalize(left, angleBetweenScratch);
@@ -667,8 +667,8 @@ define([
      */
     Cartesian3.mostOrthogonalAxis = function(cartesian, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(cartesian, 'cartesian');
-        Check.typeOf.object(result, 'result');
+        Check.typeOf.object('cartesian', cartesian);
+        Check.typeOf.object('result', result);
         //>>includeEnd('debug');
 
         var f = Cartesian3.normalize(cartesian, mostOrthogonalAxisScratch);
@@ -747,9 +747,9 @@ define([
      */
     Cartesian3.cross = function(left, right, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(left, 'left');
-        Check.typeOf.object(right, 'right');
-        Check.typeOf.object(result, 'result');
+        Check.typeOf.object('left', left);
+        Check.typeOf.object('right', right);
+        Check.typeOf.object('result', result);
         //>>includeEnd('debug');
 
         var leftX = left.x;
@@ -784,8 +784,8 @@ define([
      */
     Cartesian3.fromDegrees = function(longitude, latitude, height, ellipsoid, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.number(longitude, 'longitude');
-        Check.typeOf.number(latitude, 'latitude');
+        Check.typeOf.number('longitude', longitude);
+        Check.typeOf.number('latitude', latitude);
         //>>includeEnd('debug');
 
         longitude = CesiumMath.toRadians(longitude);
@@ -812,8 +812,8 @@ define([
      */
     Cartesian3.fromRadians = function(longitude, latitude, height, ellipsoid, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.number(longitude, 'longitude');
-        Check.typeOf.number(latitude, 'latitude');
+        Check.typeOf.number('longitude', longitude);
+        Check.typeOf.number('latitude', latitude);
         //>>includeEnd('debug');
 
         height = defaultValue(height, 0.0);
@@ -849,7 +849,7 @@ define([
      */
     Cartesian3.fromDegreesArray = function(coordinates, ellipsoid, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.defined(coordinates, 'coordinates');
+        Check.defined('coordinates', coordinates);
         if (coordinates.length < 2 || coordinates.length % 2 !== 0) {
             throw new DeveloperError('the number of coordinates must be a multiple of 2 and at least 2');
         }
@@ -885,7 +885,7 @@ define([
      */
     Cartesian3.fromRadiansArray = function(coordinates, ellipsoid, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.defined(coordinates, 'coordinates');
+        Check.defined('coordinates', coordinates);
         if (coordinates.length < 2 || coordinates.length % 2 !== 0) {
             throw new DeveloperError('the number of coordinates must be a multiple of 2 and at least 2');
         }
@@ -921,7 +921,7 @@ define([
      */
     Cartesian3.fromDegreesArrayHeights = function(coordinates, ellipsoid, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.defined(coordinates, 'coordinates');
+        Check.defined('coordinates', coordinates);
         if (coordinates.length < 3 || coordinates.length % 3 !== 0) {
             throw new DeveloperError('the number of coordinates must be a multiple of 3 and at least 3');
         }
@@ -958,7 +958,7 @@ define([
      */
     Cartesian3.fromRadiansArrayHeights = function(coordinates, ellipsoid, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.defined(coordinates, 'coordinates');
+        Check.defined('coordinates', coordinates);
         if (coordinates.length < 3 || coordinates.length % 3 !== 0) {
             throw new DeveloperError('the number of coordinates must be a multiple of 3 and at least 3');
         }

--- a/Source/Core/Cartesian4.js
+++ b/Source/Core/Cartesian4.js
@@ -91,7 +91,7 @@ define([
      */
     Cartesian4.fromColor = function(color, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(color, 'color');
+        Check.typeOf.object('color', color);
         //>>includeEnd('debug');
         if (!defined(result)) {
             return new Cartesian4(color.red, color.green, color.blue, color.alpha);
@@ -145,8 +145,8 @@ define([
      */
     Cartesian4.pack = function(value, array, startingIndex) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(value, 'value');
-        Check.defined(array, 'array');
+        Check.typeOf.object('value', value);
+        Check.defined('array', array);
         //>>includeEnd('debug');
 
         startingIndex = defaultValue(startingIndex, 0);
@@ -169,7 +169,7 @@ define([
      */
     Cartesian4.unpack = function(array, startingIndex, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.defined(array, 'array');
+        Check.defined('array', array);
         //>>includeEnd('debug');
 
         startingIndex = defaultValue(startingIndex, 0);
@@ -193,7 +193,7 @@ define([
      */
     Cartesian4.packArray = function(array, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.defined(array, 'array');
+        Check.defined('array', array);
         //>>includeEnd('debug');
 
         var length = array.length;
@@ -218,7 +218,7 @@ define([
      */
     Cartesian4.unpackArray = function(array, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.defined(array, 'array');
+        Check.defined('array', array);
         //>>includeEnd('debug');
 
         var length = array.length;
@@ -263,7 +263,7 @@ define([
      */
     Cartesian4.maximumComponent = function(cartesian) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(cartesian, 'cartesian');
+        Check.typeOf.object('cartesian', cartesian);
         //>>includeEnd('debug');
 
         return Math.max(cartesian.x, cartesian.y, cartesian.z, cartesian.w);
@@ -277,7 +277,7 @@ define([
      */
     Cartesian4.minimumComponent = function(cartesian) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(cartesian, 'cartesian');
+        Check.typeOf.object('cartesian', cartesian);
         //>>includeEnd('debug');
 
         return Math.min(cartesian.x, cartesian.y, cartesian.z, cartesian.w);
@@ -293,9 +293,9 @@ define([
      */
     Cartesian4.minimumByComponent = function(first, second, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(first, 'first');
-        Check.typeOf.object(second, 'second');
-        Check.typeOf.object(result, 'result');
+        Check.typeOf.object('first', first);
+        Check.typeOf.object('second', second);
+        Check.typeOf.object('result', result);
         //>>includeEnd('debug');
 
         result.x = Math.min(first.x, second.x);
@@ -316,9 +316,9 @@ define([
      */
     Cartesian4.maximumByComponent = function(first, second, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(first, 'first');
-        Check.typeOf.object(second, 'second');
-        Check.typeOf.object(result, 'result');
+        Check.typeOf.object('first', first);
+        Check.typeOf.object('second', second);
+        Check.typeOf.object('result', result);
         //>>includeEnd('debug');
 
         result.x = Math.max(first.x, second.x);
@@ -337,7 +337,7 @@ define([
      */
     Cartesian4.magnitudeSquared = function(cartesian) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(cartesian, 'cartesian');
+        Check.typeOf.object('cartesian', cartesian);
         //>>includeEnd('debug');
 
         return cartesian.x * cartesian.x + cartesian.y * cartesian.y + cartesian.z * cartesian.z + cartesian.w * cartesian.w;
@@ -370,8 +370,8 @@ define([
      */
     Cartesian4.distance = function(left, right) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(left, 'left');
-        Check.typeOf.object(right, 'right');
+        Check.typeOf.object('left', left);
+        Check.typeOf.object('right', right);
         //>>includeEnd('debug');
 
         Cartesian4.subtract(left, right, distanceScratch);
@@ -394,8 +394,8 @@ define([
      */
     Cartesian4.distanceSquared = function(left, right) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(left, 'left');
-        Check.typeOf.object(right, 'right');
+        Check.typeOf.object('left', left);
+        Check.typeOf.object('right', right);
         //>>includeEnd('debug');
 
         Cartesian4.subtract(left, right, distanceScratch);
@@ -411,8 +411,8 @@ define([
      */
     Cartesian4.normalize = function(cartesian, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(cartesian, 'cartesian');
-        Check.typeOf.object(result, 'result');
+        Check.typeOf.object('cartesian', cartesian);
+        Check.typeOf.object('result', result);
         //>>includeEnd('debug');
 
         var magnitude = Cartesian4.magnitude(cartesian);
@@ -440,8 +440,8 @@ define([
      */
     Cartesian4.dot = function(left, right) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(left, 'left');
-        Check.typeOf.object(right, 'right');
+        Check.typeOf.object('left', left);
+        Check.typeOf.object('right', right);
         //>>includeEnd('debug');
 
         return left.x * right.x + left.y * right.y + left.z * right.z + left.w * right.w;
@@ -457,9 +457,9 @@ define([
      */
     Cartesian4.multiplyComponents = function(left, right, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(left, 'left');
-        Check.typeOf.object(right, 'right');
-        Check.typeOf.object(result, 'result');
+        Check.typeOf.object('left', left);
+        Check.typeOf.object('right', right);
+        Check.typeOf.object('result', result);
         //>>includeEnd('debug');
 
         result.x = left.x * right.x;
@@ -479,9 +479,9 @@ define([
      */
     Cartesian4.divideComponents = function(left, right, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(left, 'left');
-        Check.typeOf.object(right, 'right');
-        Check.typeOf.object(result, 'result');
+        Check.typeOf.object('left', left);
+        Check.typeOf.object('right', right);
+        Check.typeOf.object('result', result);
         //>>includeEnd('debug');
 
         result.x = left.x / right.x;
@@ -501,9 +501,9 @@ define([
      */
     Cartesian4.add = function(left, right, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(left, 'left');
-        Check.typeOf.object(right, 'right');
-        Check.typeOf.object(result, 'result');
+        Check.typeOf.object('left', left);
+        Check.typeOf.object('right', right);
+        Check.typeOf.object('result', result);
         //>>includeEnd('debug');
 
         result.x = left.x + right.x;
@@ -523,9 +523,9 @@ define([
      */
     Cartesian4.subtract = function(left, right, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(left, 'left');
-        Check.typeOf.object(right, 'right');
-        Check.typeOf.object(result, 'result');
+        Check.typeOf.object('left', left);
+        Check.typeOf.object('right', right);
+        Check.typeOf.object('result', result);
         //>>includeEnd('debug');
 
         result.x = left.x - right.x;
@@ -545,9 +545,9 @@ define([
      */
     Cartesian4.multiplyByScalar = function(cartesian, scalar, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(cartesian, 'cartesian');
-        Check.typeOf.number(scalar, 'scalar');
-        Check.typeOf.object(result, 'result');
+        Check.typeOf.object('cartesian', cartesian);
+        Check.typeOf.number('scalar', scalar);
+        Check.typeOf.object('result', result);
         //>>includeEnd('debug');
 
         result.x = cartesian.x * scalar;
@@ -567,9 +567,9 @@ define([
      */
     Cartesian4.divideByScalar = function(cartesian, scalar, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(cartesian, 'cartesian');
-        Check.typeOf.number(scalar, 'scalar');
-        Check.typeOf.object(result, 'result');
+        Check.typeOf.object('cartesian', cartesian);
+        Check.typeOf.number('scalar', scalar);
+        Check.typeOf.object('result', result);
         //>>includeEnd('debug');
 
         result.x = cartesian.x / scalar;
@@ -588,8 +588,8 @@ define([
      */
     Cartesian4.negate = function(cartesian, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(cartesian, 'cartesian');
-        Check.typeOf.object(result, 'result');
+        Check.typeOf.object('cartesian', cartesian);
+        Check.typeOf.object('result', result);
         //>>includeEnd('debug');
 
         result.x = -cartesian.x;
@@ -608,8 +608,8 @@ define([
      */
     Cartesian4.abs = function(cartesian, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(cartesian, 'cartesian');
-        Check.typeOf.object(result, 'result');
+        Check.typeOf.object('cartesian', cartesian);
+        Check.typeOf.object('result', result);
         //>>includeEnd('debug');
 
         result.x = Math.abs(cartesian.x);
@@ -631,10 +631,10 @@ define([
      */
     Cartesian4.lerp = function(start, end, t, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(start, 'start');
-        Check.typeOf.object(end, 'end');
-        Check.typeOf.number(t, 't');
-        Check.typeOf.object(result, 'result');
+        Check.typeOf.object('start', start);
+        Check.typeOf.object('end', end);
+        Check.typeOf.number('t', t);
+        Check.typeOf.object('result', result);
         //>>includeEnd('debug');
 
         Cartesian4.multiplyByScalar(end, t, lerpScratch);
@@ -652,8 +652,8 @@ define([
      */
     Cartesian4.mostOrthogonalAxis = function(cartesian, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(cartesian, 'cartesian');
-        Check.typeOf.object(result, 'result');
+        Check.typeOf.object('cartesian', cartesian);
+        Check.typeOf.object('result', result);
         //>>includeEnd('debug');
 
         var f = Cartesian4.normalize(cartesian, mostOrthogonalAxisScratch);

--- a/Source/Core/Check.js
+++ b/Source/Core/Check.js
@@ -1,7 +1,7 @@
 /*global define*/
 define([
-    './defined',
-    './DeveloperError'
+        './defined',
+        './DeveloperError'
     ], function(
         defined,
         DeveloperError) {

--- a/Source/Core/Check.js
+++ b/Source/Core/Check.js
@@ -49,15 +49,17 @@ define([
      * Throws if test is greater than maximum
      *
      * @param {Number} test The value to test
+     * @param {String} name The name of the variable being tested
      * @param {Number} maximum The maximum allowed value
      * @exception {DeveloperError} test must not be greater than maximum
      * @exception {DeveloperError} Both test and maximum must be typeof 'number'
      */
-    Check.numeric.maximum = function (test, maximum) {
-        Check.typeOf.number(test);
-        Check.typeOf.number(maximum);
+    Check.numeric.maximum = function (test, name, maximum) {
+        Check.typeOf.number(test, 'test');
+        Check.typeOf.string(name, 'name');
+        Check.typeOf.number(maximum, 'maximum');
         if (test > maximum) {
-            throw new DeveloperError('Expected ' + test + ' to be at most ' + maximum);
+            throw new DeveloperError('Expected ' + name + ' to be at most ' + maximum + ', actual value was ' + test);
         }
     };
 
@@ -65,15 +67,17 @@ define([
      * Throws if test is less than minimum
      *
      * @param {Number} test The value to test
+     * @param {String} name The name of the variable being tested
      * @param {Number} minimum The minimum allowed value
      * @exception {DeveloperError} test must not be less than mininum
      * @exception {DeveloperError} Both test and maximum must be typeof 'number'
      */
-    Check.numeric.minimum = function (test, minimum) {
-        Check.typeOf.number(test);
-        Check.typeOf.number(minimum);
+    Check.numeric.minimum = function (test, name, minimum) {
+        Check.typeOf.number(test, 'test');
+        Check.typeOf.string(name, 'name');
+        Check.typeOf.number(minimum, 'minimum');
         if (test < minimum) {
-            throw new DeveloperError('Expected ' + test + ' to be at least ' + minimum);
+            throw new DeveloperError('Expected ' + name + ' to be at least ' + minimum + ', actual value was ' + test);
         }
     };
 

--- a/Source/Core/Check.js
+++ b/Source/Core/Check.js
@@ -19,11 +19,6 @@ define([
      */
     Check.typeOf = {};
 
-    /**
-     * Contains functions for checking numeric conditions such as minimum and maximum values
-     */
-    Check.numeric = {};
-
     function getUndefinedErrorMessage(name) {
         return name + ' is required, actual value was undefined';
     }
@@ -35,52 +30,24 @@ define([
     /**
      * Throws if test is not defined
      *
-     * @param {*} test The value that is to be checked
      * @param {String} name The name of the variable being tested
+     * @param {*} test The value that is to be checked
      * @exception {DeveloperError} test must be defined
      */
-    Check.defined = function (test, name) {
+    Check.defined = function (name, test) {
         if (!defined(test)) {
             throw new DeveloperError(getUndefinedErrorMessage(name));
         }
     };
 
     /**
-     * Throws if test is greater than maximum
-     *
-     * @param {Number} test The value to test
-     * @param {String} name The name of the variable being tested
-     * @param {Number} maximum The maximum allowed value
-     * @exception {DeveloperError} test must not be greater than maximum
-     */
-    Check.numeric.maximum = function (test, name, maximum) {
-        if (test > maximum) {
-            throw new DeveloperError('Expected ' + name + ' to be at most ' + maximum + ', actual value was ' + test);
-        }
-    };
-
-    /**
-     * Throws if test is less than minimum
-     *
-     * @param {Number} test The value to test
-     * @param {String} name The name of the variable being tested
-     * @param {Number} minimum The minimum allowed value
-     * @exception {DeveloperError} test must not be less than mininum
-     */
-    Check.numeric.minimum = function (test, name, minimum) {
-        if (test < minimum) {
-            throw new DeveloperError('Expected ' + name + ' to be at least ' + minimum + ', actual value was ' + test);
-        }
-    };
-
-    /**
      * Throws if test is not typeof 'function'
      *
-     * @param {*} test The value to test
      * @param {String} name The name of the variable being tested
+     * @param {*} test The value to test
      * @exception {DeveloperError} test must be typeof 'function'
      */
-    Check.typeOf.func = function (test, name) {
+    Check.typeOf.func = function (name, test) {
         if (typeof test !== 'function') {
             throw new DeveloperError(getFailedTypeErrorMessage(typeof test, 'function', name));
         }
@@ -89,11 +56,11 @@ define([
     /**
      * Throws if test is not typeof 'string'
      *
-     * @param {*} test The value to test
      * @param {String} name The name of the variable being tested
+     * @param {*} test The value to test
      * @exception {DeveloperError} test must be typeof 'string'
      */
-    Check.typeOf.string = function (test, name) {
+    Check.typeOf.string = function (name, test) {
         if (typeof test !== 'string') {
             throw new DeveloperError(getFailedTypeErrorMessage(typeof test, 'string', name));
         }
@@ -102,24 +69,84 @@ define([
     /**
      * Throws if test is not typeof 'number'
      *
-     * @param {*} test The value to test
      * @param {String} name The name of the variable being tested
+     * @param {*} test The value to test
      * @exception {DeveloperError} test must be typeof 'number'
      */
-    Check.typeOf.number = function (test, name) {
+    Check.typeOf.number = function (name, test) {
         if (typeof test !== 'number') {
             throw new DeveloperError(getFailedTypeErrorMessage(typeof test, 'number', name));
         }
     };
 
     /**
+     * Throws if test is not typeof 'number' and less than limit
+     *
+     * @param {String} name The name of the variable being tested
+     * @param {*} test The value to test
+     * @param {Number} limit The limit value to compare against
+     * @exception {DeveloperError} test must be typeof 'number' and less than limit
+     */
+    Check.typeOf.number.lessThan = function (name, test, limit) {
+        Check.typeOf.number(name, test);
+        if (test >= limit) {
+            throw new DeveloperError('Expected ' + name + ' to be less than ' + limit + ', actual value was ' + test);
+        }
+    };
+
+    /**
+     * Throws if test is not typeof 'number' and less than or equal to limit
+     *
+     * @param {String} name The name of the variable being tested
+     * @param {*} test The value to test
+     * @param {Number} limit The limit value to compare against
+     * @exception {DeveloperError} test must be typeof 'number' and less than or equal to limit
+     */
+    Check.typeOf.number.lessThanOrEquals = function (name, test, limit) {
+        Check.typeOf.number(name, test);
+        if (test > limit) {
+            throw new DeveloperError('Expected ' + name + ' to be less than or equal to ' + limit + ', actual value was ' + test);
+        }
+    };
+
+    /**
+     * Throws if test is not typeof 'number' and greater than limit
+     *
+     * @param {String} name The name of the variable being tested
+     * @param {*} test The value to test
+     * @param {Number} limit The limit value to compare against
+     * @exception {DeveloperError} test must be typeof 'number' and greater than limit
+     */
+    Check.typeOf.number.greaterThan = function (name, test, limit) {
+        Check.typeOf.number(name, test);
+        if (test <= limit) {
+            throw new DeveloperError('Expected ' + name + ' to be greater than ' + limit + ', actual value was ' + test);
+        }
+    };
+
+    /**
+     * Throws if test is not typeof 'number' and greater than or equal to limit
+     *
+     * @param {String} name The name of the variable being tested
+     * @param {*} test The value to test
+     * @param {Number} limit The limit value to compare against
+     * @exception {DeveloperError} test must be typeof 'number' and greater than or equal to limit
+     */
+    Check.typeOf.number.greaterThanOrEquals = function (name, test, limit) {
+        Check.typeOf.number(name, test);
+        if (test < limit) {
+            throw new DeveloperError('Expected ' + name + ' to be greater than or equal to' + limit + ', actual value was ' + test);
+        }
+    };
+
+    /**
      * Throws if test is not typeof 'object'
      *
-     * @param {*} test The value to test
      * @param {String} name The name of the variable being tested
+     * @param {*} test The value to test
      * @exception {DeveloperError} test must be typeof 'object'
      */
-    Check.typeOf.object = function (test, name) {
+    Check.typeOf.object = function (name, test) {
         if (typeof test !== 'object') {
             throw new DeveloperError(getFailedTypeErrorMessage(typeof test, 'object', name));
         }
@@ -128,11 +155,11 @@ define([
     /**
      * Throws if test is not typeof 'boolean'
      *
-     * @param {*} test The value to test
      * @param {String} name The name of the variable being tested
+     * @param {*} test The value to test
      * @exception {DeveloperError} test must be typeof 'boolean'
      */
-    Check.typeOf.bool = function (test, name) {
+    Check.typeOf.bool = function (name, test) {
         if (typeof test !== 'boolean') {
             throw new DeveloperError(getFailedTypeErrorMessage(typeof test, 'boolean', name));
         }

--- a/Source/Core/Check.js
+++ b/Source/Core/Check.js
@@ -25,11 +25,11 @@ define([
     Check.numeric = {};
 
     function getUndefinedErrorMessage(name) {
-        return name + ' was required but undefined.';
+        return name + ' is required, actual value was undefined';
     }
 
     function getFailedTypeErrorMessage(actual, expected, name) {
-        return 'Expected ' + name + ' to be typeof ' + expected + ', got ' + actual;
+        return 'Expected ' + name + ' to be typeof ' + expected + ', actual typeof was ' + actual;
     }
 
     /**

--- a/Source/Core/Check.js
+++ b/Source/Core/Check.js
@@ -52,12 +52,8 @@ define([
      * @param {String} name The name of the variable being tested
      * @param {Number} maximum The maximum allowed value
      * @exception {DeveloperError} test must not be greater than maximum
-     * @exception {DeveloperError} Both test and maximum must be typeof 'number'
      */
     Check.numeric.maximum = function (test, name, maximum) {
-        Check.typeOf.number(test, 'test');
-        Check.typeOf.string(name, 'name');
-        Check.typeOf.number(maximum, 'maximum');
         if (test > maximum) {
             throw new DeveloperError('Expected ' + name + ' to be at most ' + maximum + ', actual value was ' + test);
         }
@@ -70,12 +66,8 @@ define([
      * @param {String} name The name of the variable being tested
      * @param {Number} minimum The minimum allowed value
      * @exception {DeveloperError} test must not be less than mininum
-     * @exception {DeveloperError} Both test and maximum must be typeof 'number'
      */
     Check.numeric.minimum = function (test, name, minimum) {
-        Check.typeOf.number(test, 'test');
-        Check.typeOf.string(name, 'name');
-        Check.typeOf.number(minimum, 'minimum');
         if (test < minimum) {
             throw new DeveloperError('Expected ' + name + ' to be at least ' + minimum + ', actual value was ' + test);
         }

--- a/Source/Core/CircleGeometry.js
+++ b/Source/Core/CircleGeometry.js
@@ -56,7 +56,7 @@ define([
         var radius = options.radius;
 
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.number(radius, 'radius');
+        Check.typeOf.number('radius', radius);
         //>>includeEnd('debug');
 
         var ellipseGeometryOptions = {
@@ -92,7 +92,7 @@ define([
      */
     CircleGeometry.pack = function(value, array, startingIndex) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(value, 'value');
+        Check.typeOf.object('value', value);
         //>>includeEnd('debug');
         return EllipseGeometry.pack(value._ellipseGeometry, array, startingIndex);
     };

--- a/Source/Core/CircleOutlineGeometry.js
+++ b/Source/Core/CircleOutlineGeometry.js
@@ -51,7 +51,7 @@ define([
         var radius = options.radius;
 
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.number(radius, 'radius');
+        Check.typeOf.number('radius', radius);
         //>>includeEnd('debug');
 
         var ellipseGeometryOptions = {
@@ -85,7 +85,7 @@ define([
      */
     CircleOutlineGeometry.pack = function(value, array, startingIndex) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(value, 'value');
+        Check.typeOf.object('value', value);
         //>>includeEnd('debug');
         return EllipseOutlineGeometry.pack(value._ellipseGeometry, array, startingIndex);
     };

--- a/Source/Core/Matrix2.js
+++ b/Source/Core/Matrix2.js
@@ -59,8 +59,8 @@ define([
      */
     Matrix2.pack = function(value, array, startingIndex) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(value, 'value');
-        Check.defined(array, 'array');
+        Check.typeOf.object('value', value);
+        Check.defined('array', array);
         //>>includeEnd('debug');
 
         startingIndex = defaultValue(startingIndex, 0);
@@ -83,7 +83,7 @@ define([
      */
     Matrix2.unpack = function(array, startingIndex, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.defined(array, 'array');
+        Check.defined('array', array);
         //>>includeEnd('debug');
 
         startingIndex = defaultValue(startingIndex, 0);
@@ -143,7 +143,7 @@ define([
      */
     Matrix2.fromArray = function(array, startingIndex, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.defined(array, 'array');
+        Check.defined('array', array);
         //>>includeEnd('debug');
 
         startingIndex = defaultValue(startingIndex, 0);
@@ -168,7 +168,7 @@ define([
      */
     Matrix2.fromColumnMajorArray = function(values, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.defined(values, 'values');
+        Check.defined('values', values);
         //>>includeEnd('debug');
 
         return Matrix2.clone(values, result);
@@ -184,7 +184,7 @@ define([
      */
     Matrix2.fromRowMajorArray = function(values, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.defined(values, 'values');
+        Check.defined('values', values);
         //>>includeEnd('debug');
 
         if (!defined(result)) {
@@ -213,7 +213,7 @@ define([
      */
     Matrix2.fromScale = function(scale, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(scale, 'scale');
+        Check.typeOf.object('scale', scale);
         //>>includeEnd('debug');
 
         if (!defined(result)) {
@@ -244,7 +244,7 @@ define([
      */
     Matrix2.fromUniformScale = function(scale, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.number(scale, 'scale');
+        Check.typeOf.number('scale', scale);
         //>>includeEnd('debug');
 
         if (!defined(result)) {
@@ -275,7 +275,7 @@ define([
      */
     Matrix2.fromRotation = function(angle, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.number(angle, 'angle');
+        Check.typeOf.number('angle', angle);
         //>>includeEnd('debug');
 
         var cosAngle = Math.cos(angle);
@@ -303,7 +303,7 @@ define([
      */
     Matrix2.toArray = function(matrix, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(matrix, 'matrix');
+        Check.typeOf.object('matrix', matrix);
         //>>includeEnd('debug');
 
         if (!defined(result)) {
@@ -334,13 +334,11 @@ define([
      */
     Matrix2.getElementIndex = function(column, row) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.number(row, 'row');
-        Check.numeric.minimum(row, 0);
-        Check.numeric.maximum(row, 1);
+        Check.typeOf.number.greaterThanOrEquals('row', row, 0);
+        Check.typeOf.number.lessThanOrEquals('row', row, 1);
 
-        Check.typeOf.number(column, 'column');
-        Check.numeric.minimum(column, 0);
-        Check.numeric.maximum(column, 1);
+        Check.typeOf.number.greaterThanOrEquals('column', column, 0);
+        Check.typeOf.number.lessThanOrEquals('column', column, 1);
         //>>includeEnd('debug');
 
         return column * 2 + row;
@@ -358,13 +356,12 @@ define([
      */
     Matrix2.getColumn = function(matrix, index, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(matrix, 'matrix');
+        Check.typeOf.object('matrix', matrix);
 
-        Check.typeOf.number(index, 'index');
-        Check.numeric.minimum(index, 0);
-        Check.numeric.maximum(index, 1);
+        Check.typeOf.number.greaterThanOrEquals('index', index, 0);
+        Check.typeOf.number.lessThanOrEquals('index', index, 1);
 
-        Check.typeOf.object(result, 'result');
+        Check.typeOf.object('result', result);
         //>>includeEnd('debug');
 
         var startIndex = index * 2;
@@ -389,14 +386,13 @@ define([
      */
     Matrix2.setColumn = function(matrix, index, cartesian, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(matrix, 'matrix');
+        Check.typeOf.object('matrix', matrix);
 
-        Check.typeOf.number(index, 'index');
-        Check.numeric.minimum(index, 0);
-        Check.numeric.maximum(index, 1);
+        Check.typeOf.number.greaterThanOrEquals('index', index, 0);
+        Check.typeOf.number.lessThanOrEquals('index', index, 1);
 
-        Check.typeOf.object(cartesian, 'cartesian');
-        Check.typeOf.object(result, 'result');
+        Check.typeOf.object('cartesian', cartesian);
+        Check.typeOf.object('result', result);
         //>>includeEnd('debug');
 
         result = Matrix2.clone(matrix, result);
@@ -418,13 +414,12 @@ define([
      */
     Matrix2.getRow = function(matrix, index, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(matrix, 'matrix');
+        Check.typeOf.object('matrix', matrix);
 
-        Check.typeOf.number(index, 'index');
-        Check.numeric.minimum(index, 0);
-        Check.numeric.maximum(index, 1);
+        Check.typeOf.number.greaterThanOrEquals('index', index, 0);
+        Check.typeOf.number.lessThanOrEquals('index', index, 1);
 
-        Check.typeOf.object(result, 'result');
+        Check.typeOf.object('result', result);
         //>>includeEnd('debug');
 
         var x = matrix[index];
@@ -448,14 +443,13 @@ define([
      */
     Matrix2.setRow = function(matrix, index, cartesian, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(matrix, 'matrix');
+        Check.typeOf.object('matrix', matrix);
 
-        Check.typeOf.number(index, 'index');
-        Check.numeric.minimum(index, 0);
-        Check.numeric.maximum(index, 1);
+        Check.typeOf.number.greaterThanOrEquals('index', index, 0);
+        Check.typeOf.number.lessThanOrEquals('index', index, 1);
 
-        Check.typeOf.object(cartesian, 'cartesian');
-        Check.typeOf.object(result, 'result');
+        Check.typeOf.object('cartesian', cartesian);
+        Check.typeOf.object('result', result);
         //>>includeEnd('debug');
 
         result = Matrix2.clone(matrix, result);
@@ -475,8 +469,8 @@ define([
      */
     Matrix2.getScale = function(matrix, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(matrix, 'matrix');
-        Check.typeOf.object(result, 'result');
+        Check.typeOf.object('matrix', matrix);
+        Check.typeOf.object('result', result);
         //>>includeEnd('debug');
 
         result.x = Cartesian2.magnitude(Cartesian2.fromElements(matrix[0], matrix[1], scratchColumn));
@@ -508,9 +502,9 @@ define([
      */
     Matrix2.multiply = function(left, right, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(left, 'left');
-        Check.typeOf.object(right, 'right');
-        Check.typeOf.object(result, 'result');
+        Check.typeOf.object('left', left);
+        Check.typeOf.object('right', right);
+        Check.typeOf.object('result', result);
         //>>includeEnd('debug');
 
         var column0Row0 = left[0] * right[0] + left[2] * right[1];
@@ -535,9 +529,9 @@ define([
      */
     Matrix2.add = function(left, right, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(left, 'left');
-        Check.typeOf.object(right, 'right');
-        Check.typeOf.object(result, 'result');
+        Check.typeOf.object('left', left);
+        Check.typeOf.object('right', right);
+        Check.typeOf.object('result', result);
         //>>includeEnd('debug');
 
         result[0] = left[0] + right[0];
@@ -557,9 +551,9 @@ define([
      */
     Matrix2.subtract = function(left, right, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(left, 'left');
-        Check.typeOf.object(right, 'right');
-        Check.typeOf.object(result, 'result');
+        Check.typeOf.object('left', left);
+        Check.typeOf.object('right', right);
+        Check.typeOf.object('result', result);
         //>>includeEnd('debug');
 
         result[0] = left[0] - right[0];
@@ -579,9 +573,9 @@ define([
      */
     Matrix2.multiplyByVector = function(matrix, cartesian, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(matrix, 'matrix');
-        Check.typeOf.object(cartesian, 'cartesian');
-        Check.typeOf.object(result, 'result');
+        Check.typeOf.object('matrix', matrix);
+        Check.typeOf.object('cartesian', cartesian);
+        Check.typeOf.object('result', result);
         //>>includeEnd('debug');
 
         var x = matrix[0] * cartesian.x + matrix[2] * cartesian.y;
@@ -602,9 +596,9 @@ define([
      */
     Matrix2.multiplyByScalar = function(matrix, scalar, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(matrix, 'matrix');
-        Check.typeOf.number(scalar, 'scalar');
-        Check.typeOf.object(result, 'result');
+        Check.typeOf.object('matrix', matrix);
+        Check.typeOf.number('scalar', scalar);
+        Check.typeOf.object('result', result);
         //>>includeEnd('debug');
 
         result[0] = matrix[0] * scalar;
@@ -632,9 +626,9 @@ define([
      */
     Matrix2.multiplyByScale = function(matrix, scale, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(matrix, 'matrix');
-        Check.typeOf.object(scale, 'scale');
-        Check.typeOf.object(result, 'result');
+        Check.typeOf.object('matrix', matrix);
+        Check.typeOf.object('scale', scale);
+        Check.typeOf.object('result', result);
         //>>includeEnd('debug');
 
         result[0] = matrix[0] * scale.x;
@@ -653,8 +647,8 @@ define([
      */
     Matrix2.negate = function(matrix, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(matrix, 'matrix');
-        Check.typeOf.object(result, 'result');
+        Check.typeOf.object('matrix', matrix);
+        Check.typeOf.object('result', result);
         //>>includeEnd('debug');
 
         result[0] = -matrix[0];
@@ -673,8 +667,8 @@ define([
      */
     Matrix2.transpose = function(matrix, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(matrix, 'matrix');
-        Check.typeOf.object(result, 'result');
+        Check.typeOf.object('matrix', matrix);
+        Check.typeOf.object('result', result);
         //>>includeEnd('debug');
 
         var column0Row0 = matrix[0];
@@ -698,8 +692,8 @@ define([
      */
     Matrix2.abs = function(matrix, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(matrix, 'matrix');
-        Check.typeOf.object(result, 'result');
+        Check.typeOf.object('matrix', matrix);
+        Check.typeOf.object('result', result);
         //>>includeEnd('debug');
 
         result[0] = Math.abs(matrix[0]);
@@ -750,7 +744,7 @@ define([
      */
     Matrix2.equalsEpsilon = function(left, right, epsilon) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.number(epsilon, 'epsilon');
+        Check.typeOf.number('epsilon', epsilon);
         //>>includeEnd('debug');
 
         return (left === right) ||

--- a/Source/Core/Matrix3.js
+++ b/Source/Core/Matrix3.js
@@ -74,8 +74,8 @@ define([
      */
     Matrix3.pack = function(value, array, startingIndex) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(value, 'value');
-        Check.defined(array, 'array');
+        Check.typeOf.object('value', value);
+        Check.defined('array', array);
         //>>includeEnd('debug');
 
         startingIndex = defaultValue(startingIndex, 0);
@@ -103,7 +103,7 @@ define([
      */
     Matrix3.unpack = function(array, startingIndex, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.defined(array, 'array');
+        Check.defined('array', array);
         //>>includeEnd('debug');
 
         startingIndex = defaultValue(startingIndex, 0);
@@ -175,7 +175,7 @@ define([
      */
     Matrix3.fromArray = function(array, startingIndex, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.defined(array, 'array');
+        Check.defined('array', array);
         //>>includeEnd('debug');
 
         startingIndex = defaultValue(startingIndex, 0);
@@ -205,7 +205,7 @@ define([
      */
     Matrix3.fromColumnMajorArray = function(values, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.defined(values, 'values');
+        Check.defined('values', values);
         //>>includeEnd('debug');
 
         return Matrix3.clone(values, result);
@@ -221,7 +221,7 @@ define([
      */
     Matrix3.fromRowMajorArray = function(values, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.defined(values, 'values');
+        Check.defined('values', values);
         //>>includeEnd('debug');
 
         if (!defined(result)) {
@@ -250,7 +250,7 @@ define([
      */
     Matrix3.fromQuaternion = function(quaternion, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(quaternion, 'quaternion');
+        Check.typeOf.object('quaternion', quaternion);
         //>>includeEnd('debug');
 
         var x2 = quaternion.x * quaternion.x;
@@ -302,7 +302,7 @@ define([
      */
     Matrix3.fromHeadingPitchRoll = function(headingPitchRoll, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(headingPitchRoll, 'headingPitchRoll');
+        Check.typeOf.object('headingPitchRoll', headingPitchRoll);
         //>>includeEnd('debug');
 
         var cosTheta = Math.cos(-headingPitchRoll.pitch);
@@ -357,7 +357,7 @@ define([
      */
     Matrix3.fromScale = function(scale, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(scale, 'scale');
+        Check.typeOf.object('scale', scale);
         //>>includeEnd('debug');
 
         if (!defined(result)) {
@@ -395,7 +395,7 @@ define([
      */
     Matrix3.fromUniformScale = function(scale, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.number(scale, 'scale');
+        Check.typeOf.number('scale', scale);
         //>>includeEnd('debug');
 
         if (!defined(result)) {
@@ -433,7 +433,7 @@ define([
      */
     Matrix3.fromCrossProduct = function(vector, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(vector, 'vector');
+        Check.typeOf.object('vector', vector);
         //>>includeEnd('debug');
 
         if (!defined(result)) {
@@ -470,7 +470,7 @@ define([
      */
     Matrix3.fromRotationX = function(angle, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.number(angle, 'angle');
+        Check.typeOf.number('angle', angle);
         //>>includeEnd('debug');
 
         var cosAngle = Math.cos(angle);
@@ -511,7 +511,7 @@ define([
      */
     Matrix3.fromRotationY = function(angle, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.number(angle, 'angle');
+        Check.typeOf.number('angle', angle);
         //>>includeEnd('debug');
 
         var cosAngle = Math.cos(angle);
@@ -552,7 +552,7 @@ define([
      */
     Matrix3.fromRotationZ = function(angle, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.number(angle, 'angle');
+        Check.typeOf.number('angle', angle);
         //>>includeEnd('debug');
 
         var cosAngle = Math.cos(angle);
@@ -588,7 +588,7 @@ define([
      */
     Matrix3.toArray = function(matrix, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(matrix, 'matrix');
+        Check.typeOf.object('matrix', matrix);
         //>>includeEnd('debug');
 
         if (!defined(result)) {
@@ -624,12 +624,10 @@ define([
      */
     Matrix3.getElementIndex = function(column, row) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.number(column, 'column');
-        Check.typeOf.number(row, 'row');
-        Check.numeric.minimum(row, 0);
-        Check.numeric.maximum(row, 2);
-        Check.numeric.minimum(column, 0);
-        Check.numeric.maximum(column, 2);
+        Check.typeOf.number.greaterThanOrEquals('row', row, 0);
+        Check.typeOf.number.lessThanOrEquals('row', row, 2);
+        Check.typeOf.number.greaterThanOrEquals('column', column, 0);
+        Check.typeOf.number.lessThanOrEquals('column', column, 2);
         //>>includeEnd('debug');
 
         return column * 3 + row;
@@ -647,11 +645,10 @@ define([
      */
     Matrix3.getColumn = function(matrix, index, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(matrix, 'matrix');
-        Check.typeOf.number(index, 'index');
-        Check.numeric.minimum(index, 0);
-        Check.numeric.maximum(index, 2);
-        Check.typeOf.object(result, 'result');
+        Check.typeOf.object('matrix', matrix);
+        Check.typeOf.number.greaterThanOrEquals('index', index, 0);
+        Check.typeOf.number.lessThanOrEquals('index', index, 2);
+        Check.typeOf.object('result', result);
         //>>includeEnd('debug');
 
         var startIndex = index * 3;
@@ -678,12 +675,11 @@ define([
      */
     Matrix3.setColumn = function(matrix, index, cartesian, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(matrix, 'matrix');
-        Check.typeOf.number(index, 'index');
-        Check.numeric.minimum(index, 0);
-        Check.numeric.maximum(index, 2);
-        Check.typeOf.object(cartesian, 'cartesian');
-        Check.typeOf.object(result, 'result');
+        Check.typeOf.object('matrix', matrix);
+        Check.typeOf.number.greaterThanOrEquals('index', index, 0);
+        Check.typeOf.number.lessThanOrEquals('index', index, 2);
+        Check.typeOf.object('cartesian', cartesian);
+        Check.typeOf.object('result', result);
         //>>includeEnd('debug');
 
         result = Matrix3.clone(matrix, result);
@@ -706,11 +702,10 @@ define([
      */
     Matrix3.getRow = function(matrix, index, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(matrix, 'matrix');
-        Check.typeOf.number(index, 'index');
-        Check.numeric.minimum(index, 0);
-        Check.numeric.maximum(index, 2);
-        Check.typeOf.object(result, 'result');
+        Check.typeOf.object('matrix', matrix);
+        Check.typeOf.number.greaterThanOrEquals('index', index, 0);
+        Check.typeOf.number.lessThanOrEquals('index', index, 2);
+        Check.typeOf.object('result', result);
         //>>includeEnd('debug');
 
         var x = matrix[index];
@@ -736,12 +731,11 @@ define([
      */
     Matrix3.setRow = function(matrix, index, cartesian, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(matrix, 'matrix');
-        Check.typeOf.number(index, 'index');
-        Check.numeric.minimum(index, 0);
-        Check.numeric.maximum(index, 2);
-        Check.typeOf.object(cartesian, 'cartesian');
-        Check.typeOf.object(result, 'result');
+        Check.typeOf.object('matrix', matrix);
+        Check.typeOf.number.greaterThanOrEquals('index', index, 0);
+        Check.typeOf.number.lessThanOrEquals('index', index, 2);
+        Check.typeOf.object('cartesian', cartesian);
+        Check.typeOf.object('result', result);
         //>>includeEnd('debug');
 
         result = Matrix3.clone(matrix, result);
@@ -762,8 +756,8 @@ define([
      */
     Matrix3.getScale = function(matrix, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(matrix, 'matrix');
-        Check.typeOf.object(result, 'result');
+        Check.typeOf.object('matrix', matrix);
+        Check.typeOf.object('result', result);
         //>>includeEnd('debug');
 
         result.x = Cartesian3.magnitude(Cartesian3.fromElements(matrix[0], matrix[1], matrix[2], scratchColumn));
@@ -796,9 +790,9 @@ define([
      */
     Matrix3.multiply = function(left, right, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(left, 'left');
-        Check.typeOf.object(right, 'right');
-        Check.typeOf.object(result, 'result');
+        Check.typeOf.object('left', left);
+        Check.typeOf.object('right', right);
+        Check.typeOf.object('result', result);
         //>>includeEnd('debug');
 
         var column0Row0 = left[0] * right[0] + left[3] * right[1] + left[6] * right[2];
@@ -835,9 +829,9 @@ define([
      */
     Matrix3.add = function(left, right, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(left, 'left');
-        Check.typeOf.object(right, 'right');
-        Check.typeOf.object(result, 'result');
+        Check.typeOf.object('left', left);
+        Check.typeOf.object('right', right);
+        Check.typeOf.object('result', result);
         //>>includeEnd('debug');
 
         result[0] = left[0] + right[0];
@@ -862,9 +856,9 @@ define([
      */
     Matrix3.subtract = function(left, right, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(left, 'left');
-        Check.typeOf.object(right, 'right');
-        Check.typeOf.object(result, 'result');
+        Check.typeOf.object('left', left);
+        Check.typeOf.object('right', right);
+        Check.typeOf.object('result', result);
         //>>includeEnd('debug');
 
         result[0] = left[0] - right[0];
@@ -889,9 +883,9 @@ define([
      */
     Matrix3.multiplyByVector = function(matrix, cartesian, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(matrix, 'matrix');
-        Check.typeOf.object(cartesian, 'cartesian');
-        Check.typeOf.object(result, 'result');
+        Check.typeOf.object('matrix', matrix);
+        Check.typeOf.object('cartesian', cartesian);
+        Check.typeOf.object('result', result);
         //>>includeEnd('debug');
 
         var vX = cartesian.x;
@@ -918,9 +912,9 @@ define([
      */
     Matrix3.multiplyByScalar = function(matrix, scalar, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(matrix, 'matrix');
-        Check.typeOf.number(scalar, 'scalar');
-        Check.typeOf.object(result, 'result');
+        Check.typeOf.object('matrix', matrix);
+        Check.typeOf.number('scalar', scalar);
+        Check.typeOf.object('result', result);
         //>>includeEnd('debug');
 
         result[0] = matrix[0] * scalar;
@@ -953,9 +947,9 @@ define([
      */
     Matrix3.multiplyByScale = function(matrix, scale, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(matrix, 'matrix');
-        Check.typeOf.object(scale, 'scale');
-        Check.typeOf.object(result, 'result');
+        Check.typeOf.object('matrix', matrix);
+        Check.typeOf.object('scale', scale);
+        Check.typeOf.object('result', result);
         //>>includeEnd('debug');
 
         result[0] = matrix[0] * scale.x;
@@ -979,8 +973,8 @@ define([
      */
     Matrix3.negate = function(matrix, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(matrix, 'matrix');
-        Check.typeOf.object(result, 'result');
+        Check.typeOf.object('matrix', matrix);
+        Check.typeOf.object('result', result);
         //>>includeEnd('debug');
 
         result[0] = -matrix[0];
@@ -1004,8 +998,8 @@ define([
      */
     Matrix3.transpose = function(matrix, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(matrix, 'matrix');
-        Check.typeOf.object(result, 'result');
+        Check.typeOf.object('matrix', matrix);
+        Check.typeOf.object('result', result);
         //>>includeEnd('debug');
 
         var column0Row0 = matrix[0];
@@ -1147,7 +1141,7 @@ define([
      */
     Matrix3.computeEigenDecomposition = function(matrix, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(matrix, 'matrix');
+        Check.typeOf.object('matrix', matrix);
         //>>includeEnd('debug');
 
         // This routine was created based upon Matrix Computations, 3rd ed., by Golub and Van Loan,
@@ -1193,8 +1187,8 @@ define([
      */
     Matrix3.abs = function(matrix, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(matrix, 'matrix');
-        Check.typeOf.object(result, 'result');
+        Check.typeOf.object('matrix', matrix);
+        Check.typeOf.object('result', result);
         //>>includeEnd('debug');
 
         result[0] = Math.abs(matrix[0]);
@@ -1218,7 +1212,7 @@ define([
      */
     Matrix3.determinant = function(matrix) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(matrix, 'matrix');
+        Check.typeOf.object('matrix', matrix);
         //>>includeEnd('debug');
 
         var m11 = matrix[0];
@@ -1245,8 +1239,8 @@ define([
      */
     Matrix3.inverse = function(matrix, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(matrix, 'matrix');
-        Check.typeOf.object(result, 'result');
+        Check.typeOf.object('matrix', matrix);
+        Check.typeOf.object('result', result);
         //>>includeEnd('debug');
 
         var m11 = matrix[0];
@@ -1316,7 +1310,7 @@ define([
      */
     Matrix3.equalsEpsilon = function(left, right, epsilon) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.number(epsilon, 'epsilon');
+        Check.typeOf.number('epsilon', epsilon);
         //>>includeEnd('debug');
 
         return (left === right) ||

--- a/Source/Core/Matrix4.js
+++ b/Source/Core/Matrix4.js
@@ -630,18 +630,10 @@ define([
       */
     Matrix4.computePerspectiveFieldOfView = function(fovY, aspectRatio, near, far, result) {
         //>>includeStart('debug', pragmas.debug);
-        if (fovY <= 0.0 || fovY > Math.PI) {
-            throw new DeveloperError('fovY must be in (0, PI].');
-        }
-        if (aspectRatio <= 0.0) {
-            throw new DeveloperError('aspectRatio must be greater than zero.');
-        }
-        if (near <= 0.0) {
-            throw new DeveloperError('near must be greater than zero.');
-        }
-        if (far <= 0.0) {
-            throw new DeveloperError('far must be greater than zero.');
-        }
+        Check.typeOf.number.greaterThan('fovY', fovY, 0.0);
+        Check.typeOf.number.lessThan('fovY', fovY, Math.PI);
+        Check.typeOf.number.greaterThan('near', near, 0.0);
+        Check.typeOf.number.greaterThan('far', far, 0.0);
         Check.typeOf.object('result', result);
         //>>includeEnd('debug');
 

--- a/Source/Core/Matrix4.js
+++ b/Source/Core/Matrix4.js
@@ -106,8 +106,8 @@ define([
      */
     Matrix4.pack = function(value, array, startingIndex) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(value, 'value');
-        Check.defined(array, 'array');
+        Check.typeOf.object('value', value);
+        Check.defined('array', array);
         //>>includeEnd('debug');
 
         startingIndex = defaultValue(startingIndex, 0);
@@ -142,7 +142,7 @@ define([
      */
     Matrix4.unpack = function(array, startingIndex, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.defined(array, 'array');
+        Check.defined('array', array);
         //>>includeEnd('debug');
 
         startingIndex = defaultValue(startingIndex, 0);
@@ -240,7 +240,7 @@ define([
      */
     Matrix4.fromColumnMajorArray = function(values, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.defined(values, 'values');
+        Check.defined('values', values);
         //>>includeEnd('debug');
 
         return Matrix4.clone(values, result);
@@ -256,7 +256,7 @@ define([
      */
     Matrix4.fromRowMajorArray = function(values, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.defined(values, 'values');
+        Check.defined('values', values);
         //>>includeEnd('debug');
 
         if (!defined(result)) {
@@ -295,7 +295,7 @@ define([
      */
     Matrix4.fromRotationTranslation = function(rotation, translation, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(rotation, 'rotation');
+        Check.typeOf.object('rotation', rotation);
         //>>includeEnd('debug');
 
         translation = defaultValue(translation, Cartesian3.ZERO);
@@ -345,9 +345,9 @@ define([
      */
     Matrix4.fromTranslationQuaternionRotationScale = function(translation, rotation, scale, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(translation, 'translation');
-        Check.typeOf.object(rotation, 'rotation');
-        Check.typeOf.object(scale, 'scale');
+        Check.typeOf.object('translation', translation);
+        Check.typeOf.object('rotation', rotation);
+        Check.typeOf.object('scale', scale);
         //>>includeEnd('debug');
 
         if (!defined(result)) {
@@ -410,7 +410,7 @@ define([
      */
     Matrix4.fromTranslationRotationScale = function(translationRotationScale, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(translationRotationScale, 'translationRotationScale');
+        Check.typeOf.object('translationRotationScale', translationRotationScale);
         //>>includeEnd('debug');
 
         return Matrix4.fromTranslationQuaternionRotationScale(translationRotationScale.translation, translationRotationScale.rotation, translationRotationScale.scale, result);
@@ -427,7 +427,7 @@ define([
      */
     Matrix4.fromTranslation = function(translation, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(translation, 'translation');
+        Check.typeOf.object('translation', translation);
         //>>includeEnd('debug');
 
         return Matrix4.fromRotationTranslation(Matrix3.IDENTITY, translation, result);
@@ -450,7 +450,7 @@ define([
      */
     Matrix4.fromScale = function(scale, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(scale, 'scale');
+        Check.typeOf.object('scale', scale);
         //>>includeEnd('debug');
 
         if (!defined(result)) {
@@ -497,7 +497,7 @@ define([
      */
     Matrix4.fromUniformScale = function(scale, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.number(scale, 'scale');
+        Check.typeOf.number('scale', scale);
         //>>includeEnd('debug');
 
         if (!defined(result)) {
@@ -539,7 +539,7 @@ define([
      */
     Matrix4.fromCamera = function(camera, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(camera, 'camera');
+        Check.typeOf.object('camera', camera);
         //>>includeEnd('debug');
 
         var position = camera.position;
@@ -547,9 +547,9 @@ define([
         var up = camera.up;
 
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(position, 'camera.position');
-        Check.typeOf.object(direction, 'camera.direction');
-        Check.typeOf.object(up, 'camera.up');
+        Check.typeOf.object('camera.position', position);
+        Check.typeOf.object('camera.direction', direction);
+        Check.typeOf.object('camera.up', up);
         //>>includeEnd('debug');
 
         Cartesian3.normalize(direction, fromCameraF);
@@ -642,7 +642,7 @@ define([
         if (far <= 0.0) {
             throw new DeveloperError('far must be greater than zero.');
         }
-        Check.typeOf.object(result, 'result');
+        Check.typeOf.object('result', result);
         //>>includeEnd('debug');
 
         var bottom = Math.tan(fovY * 0.5);
@@ -685,13 +685,13 @@ define([
     */
     Matrix4.computeOrthographicOffCenter = function(left, right, bottom, top, near, far, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.number(left, 'left');
-        Check.typeOf.number(right, 'right');
-        Check.typeOf.number(bottom, 'bottom');
-        Check.typeOf.number(top, 'top');
-        Check.typeOf.number(near, 'near');
-        Check.typeOf.number(far, 'far');
-        Check.typeOf.object(result, 'result');
+        Check.typeOf.number('left', left);
+        Check.typeOf.number('right', right);
+        Check.typeOf.number('bottom', bottom);
+        Check.typeOf.number('top', top);
+        Check.typeOf.number('near', near);
+        Check.typeOf.number('far', far);
+        Check.typeOf.object('result', result);
         //>>includeEnd('debug');
 
         var a = 1.0 / (right - left);
@@ -738,13 +738,13 @@ define([
      */
     Matrix4.computePerspectiveOffCenter = function(left, right, bottom, top, near, far, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.number(left, 'left');
-        Check.typeOf.number(right, 'right');
-        Check.typeOf.number(bottom, 'bottom');
-        Check.typeOf.number(top, 'top');
-        Check.typeOf.number(near, 'near');
-        Check.typeOf.number(far, 'far');
-        Check.typeOf.object(result, 'result');
+        Check.typeOf.number('left', left);
+        Check.typeOf.number('right', right);
+        Check.typeOf.number('bottom', bottom);
+        Check.typeOf.number('top', top);
+        Check.typeOf.number('near', near);
+        Check.typeOf.number('far', far);
+        Check.typeOf.object('result', result);
         //>>includeEnd('debug');
 
         var column0Row0 = 2.0 * near / (right - left);
@@ -787,12 +787,12 @@ define([
      */
     Matrix4.computeInfinitePerspectiveOffCenter = function(left, right, bottom, top, near, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.number(left, 'left');
-        Check.typeOf.number(right, 'right');
-        Check.typeOf.number(bottom, 'bottom');
-        Check.typeOf.number(top, 'top');
-        Check.typeOf.number(near, 'near');
-        Check.typeOf.object(result, 'result');
+        Check.typeOf.number('left', left);
+        Check.typeOf.number('right', right);
+        Check.typeOf.number('bottom', bottom);
+        Check.typeOf.number('top', top);
+        Check.typeOf.number('near', near);
+        Check.typeOf.object('result', result);
         //>>includeEnd('debug');
 
         var column0Row0 = 2.0 * near / (right - left);
@@ -842,7 +842,7 @@ define([
      */
     Matrix4.computeViewportTransformation = function(viewport, nearDepthRange, farDepthRange, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(result, 'result');
+        Check.typeOf.object('result', result);
         //>>includeEnd('debug');
 
         viewport = defaultValue(viewport, defaultValue.EMPTY_OBJECT);
@@ -896,11 +896,11 @@ define([
      */
     Matrix4.computeView = function(position, direction, up, right, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(position, 'position');
-        Check.typeOf.object(direction, 'direction');
-        Check.typeOf.object(up, 'up');
-        Check.typeOf.object(right, 'right');
-        Check.typeOf.object(result, 'result');
+        Check.typeOf.object('position', position);
+        Check.typeOf.object('direction', direction);
+        Check.typeOf.object('up', up);
+        Check.typeOf.object('right', right);
+        Check.typeOf.object('result', result);
         //>>includeEnd('debug');
 
         result[0] = right.x;
@@ -943,7 +943,7 @@ define([
      */
     Matrix4.toArray = function(matrix, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(matrix, 'matrix');
+        Check.typeOf.object('matrix', matrix);
         //>>includeEnd('debug');
 
         if (!defined(result)) {
@@ -989,13 +989,11 @@ define([
      */
     Matrix4.getElementIndex = function(column, row) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.number(row, 'row');
-        Check.numeric.minimum(row, 0);
-        Check.numeric.maximum(row, 3);
+        Check.typeOf.number.greaterThanOrEquals('row', row, 0);
+        Check.typeOf.number.lessThanOrEquals('row', row, 3);
 
-        Check.typeOf.number(column, 'column');
-        Check.numeric.minimum(column, 0);
-        Check.numeric.maximum(column, 3);
+        Check.typeOf.number.greaterThanOrEquals('column', column, 0);
+        Check.typeOf.number.lessThanOrEquals('column', column, 3);
         //>>includeEnd('debug');
 
         return column * 4 + row;
@@ -1030,13 +1028,12 @@ define([
      */
     Matrix4.getColumn = function(matrix, index, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(matrix, 'matrix');
+        Check.typeOf.object('matrix', matrix);
 
-        Check.typeOf.number(index, 'index');
-        Check.numeric.minimum(index, 0);
-        Check.numeric.maximum(index, 3);
+        Check.typeOf.number.greaterThanOrEquals('index', index, 0);
+        Check.typeOf.number.lessThanOrEquals('index', index, 3);
 
-        Check.typeOf.object(result, 'result');
+        Check.typeOf.object('result', result);
         //>>includeEnd('debug');
 
         var startIndex = index * 4;
@@ -1080,14 +1077,13 @@ define([
      */
     Matrix4.setColumn = function(matrix, index, cartesian, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(matrix, 'matrix');
+        Check.typeOf.object('matrix', matrix);
 
-        Check.typeOf.number(index, 'index');
-        Check.numeric.minimum(index, 0);
-        Check.numeric.maximum(index, 3);
+        Check.typeOf.number.greaterThanOrEquals('index', index, 0);
+        Check.typeOf.number.lessThanOrEquals('index', index, 3);
 
-        Check.typeOf.object(cartesian, 'cartesian');
-        Check.typeOf.object(result, 'result');
+        Check.typeOf.object('cartesian', cartesian);
+        Check.typeOf.object('result', result);
         //>>includeEnd('debug');
 
         result = Matrix4.clone(matrix, result);
@@ -1110,9 +1106,9 @@ define([
      */
     Matrix4.setTranslation = function(matrix, translation, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(matrix, 'matrix');
-        Check.typeOf.object(translation, 'translation');
-        Check.typeOf.object(result, 'result');
+        Check.typeOf.object('matrix', matrix);
+        Check.typeOf.object('translation', translation);
+        Check.typeOf.object('result', result);
         //>>includeEnd('debug');
 
         result[0] = matrix[0];
@@ -1167,13 +1163,12 @@ define([
      */
     Matrix4.getRow = function(matrix, index, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(matrix, 'matrix');
+        Check.typeOf.object('matrix', matrix);
 
-        Check.typeOf.number(index, 'index');
-        Check.numeric.minimum(index, 0);
-        Check.numeric.maximum(index, 3);
+        Check.typeOf.number.greaterThanOrEquals('index', index, 0);
+        Check.typeOf.number.lessThanOrEquals('index', index, 3);
 
-        Check.typeOf.object(result, 'result');
+        Check.typeOf.object('result', result);
         //>>includeEnd('debug');
 
         var x = matrix[index];
@@ -1216,14 +1211,13 @@ define([
      */
     Matrix4.setRow = function(matrix, index, cartesian, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(matrix, 'matrix');
+        Check.typeOf.object('matrix', matrix);
 
-        Check.typeOf.number(index, 'index');
-        Check.numeric.minimum(index, 0);
-        Check.numeric.maximum(index, 3);
+        Check.typeOf.number.greaterThanOrEquals('index', index, 0);
+        Check.typeOf.number.lessThanOrEquals('index', index, 3);
 
-        Check.typeOf.object(cartesian, 'cartesian');
-        Check.typeOf.object(result, 'result');
+        Check.typeOf.object('cartesian', cartesian);
+        Check.typeOf.object('result', result);
         //>>includeEnd('debug');
 
         result = Matrix4.clone(matrix, result);
@@ -1245,8 +1239,8 @@ define([
      */
     Matrix4.getScale = function(matrix, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(matrix, 'matrix');
-        Check.typeOf.object(result, 'result');
+        Check.typeOf.object('matrix', matrix);
+        Check.typeOf.object('result', result);
         //>>includeEnd('debug');
 
         result.x = Cartesian3.magnitude(Cartesian3.fromElements(matrix[0], matrix[1], matrix[2], scratchColumn));
@@ -1280,9 +1274,9 @@ define([
      */
     Matrix4.multiply = function(left, right, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(left, 'left');
-        Check.typeOf.object(right, 'right');
-        Check.typeOf.object(result, 'result');
+        Check.typeOf.object('left', left);
+        Check.typeOf.object('right', right);
+        Check.typeOf.object('result', result);
         //>>includeEnd('debug');
 
         var left0 = left[0];
@@ -1368,9 +1362,9 @@ define([
      */
     Matrix4.add = function(left, right, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(left, 'left');
-        Check.typeOf.object(right, 'right');
-        Check.typeOf.object(result, 'result');
+        Check.typeOf.object('left', left);
+        Check.typeOf.object('right', right);
+        Check.typeOf.object('result', result);
         //>>includeEnd('debug');
 
         result[0] = left[0] + right[0];
@@ -1402,9 +1396,9 @@ define([
      */
     Matrix4.subtract = function(left, right, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(left, 'left');
-        Check.typeOf.object(right, 'right');
-        Check.typeOf.object(result, 'result');
+        Check.typeOf.object('left', left);
+        Check.typeOf.object('right', right);
+        Check.typeOf.object('result', result);
         //>>includeEnd('debug');
 
         result[0] = left[0] - right[0];
@@ -1447,9 +1441,9 @@ define([
      */
     Matrix4.multiplyTransformation = function(left, right, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(left, 'left');
-        Check.typeOf.object(right, 'right');
-        Check.typeOf.object(result, 'result');
+        Check.typeOf.object('left', left);
+        Check.typeOf.object('right', right);
+        Check.typeOf.object('result', result);
         //>>includeEnd('debug');
 
         var left0 = left[0];
@@ -1529,9 +1523,9 @@ define([
      */
     Matrix4.multiplyByMatrix3 = function(matrix, rotation, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(matrix, 'matrix');
-        Check.typeOf.object(rotation, 'rotation');
-        Check.typeOf.object(result, 'result');
+        Check.typeOf.object('matrix', matrix);
+        Check.typeOf.object('rotation', rotation);
+        Check.typeOf.object('result', result);
         //>>includeEnd('debug');
 
         var left0 = matrix[0];
@@ -1601,9 +1595,9 @@ define([
      */
     Matrix4.multiplyByTranslation = function(matrix, translation, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(matrix, 'matrix');
-        Check.typeOf.object(translation, 'translation');
-        Check.typeOf.object(result, 'result');
+        Check.typeOf.object('matrix', matrix);
+        Check.typeOf.object('translation', translation);
+        Check.typeOf.object('result', result);
         //>>includeEnd('debug');
 
         var x = translation.x;
@@ -1657,9 +1651,9 @@ define([
      */
     Matrix4.multiplyByUniformScale = function(matrix, scale, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(matrix, 'matrix');
-        Check.typeOf.number(scale, 'scale');
-        Check.typeOf.object(result, 'result');
+        Check.typeOf.object('matrix', matrix);
+        Check.typeOf.number('scale', scale);
+        Check.typeOf.object('result', result);
         //>>includeEnd('debug');
 
         uniformScaleScratch.x = scale;
@@ -1690,9 +1684,9 @@ define([
      */
     Matrix4.multiplyByScale = function(matrix, scale, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(matrix, 'matrix');
-        Check.typeOf.object(scale, 'scale');
-        Check.typeOf.object(result, 'result');
+        Check.typeOf.object('matrix', matrix);
+        Check.typeOf.object('scale', scale);
+        Check.typeOf.object('result', result);
         //>>includeEnd('debug');
 
         var scaleX = scale.x;
@@ -1733,9 +1727,9 @@ define([
      */
     Matrix4.multiplyByVector = function(matrix, cartesian, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(matrix, 'matrix');
-        Check.typeOf.object(cartesian, 'cartesian');
-        Check.typeOf.object(result, 'result');
+        Check.typeOf.object('matrix', matrix);
+        Check.typeOf.object('cartesian', cartesian);
+        Check.typeOf.object('result', result);
         //>>includeEnd('debug');
 
         var vX = cartesian.x;
@@ -1773,9 +1767,9 @@ define([
      */
     Matrix4.multiplyByPointAsVector = function(matrix, cartesian, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(matrix, 'matrix');
-        Check.typeOf.object(cartesian, 'cartesian');
-        Check.typeOf.object(result, 'result');
+        Check.typeOf.object('matrix', matrix);
+        Check.typeOf.object('cartesian', cartesian);
+        Check.typeOf.object('result', result);
         //>>includeEnd('debug');
 
         var vX = cartesian.x;
@@ -1807,9 +1801,9 @@ define([
      */
     Matrix4.multiplyByPoint = function(matrix, cartesian, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(matrix, 'matrix');
-        Check.typeOf.object(cartesian, 'cartesian');
-        Check.typeOf.object(result, 'result');
+        Check.typeOf.object('matrix', matrix);
+        Check.typeOf.object('cartesian', cartesian);
+        Check.typeOf.object('result', result);
         //>>includeEnd('debug');
 
         var vX = cartesian.x;
@@ -1851,9 +1845,9 @@ define([
      */
     Matrix4.multiplyByScalar = function(matrix, scalar, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(matrix, 'matrix');
-        Check.typeOf.number(scalar, 'scalar');
-        Check.typeOf.object(result, 'result');
+        Check.typeOf.object('matrix', matrix);
+        Check.typeOf.number('scalar', scalar);
+        Check.typeOf.object('result', result);
         //>>includeEnd('debug');
 
         result[0] = matrix[0] * scalar;
@@ -1899,8 +1893,8 @@ define([
      */
     Matrix4.negate = function(matrix, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(matrix, 'matrix');
-        Check.typeOf.object(result, 'result');
+        Check.typeOf.object('matrix', matrix);
+        Check.typeOf.object('result', result);
         //>>includeEnd('debug');
 
         result[0] = -matrix[0];
@@ -1946,8 +1940,8 @@ define([
      */
     Matrix4.transpose = function(matrix, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(matrix, 'matrix');
-        Check.typeOf.object(result, 'result');
+        Check.typeOf.object('matrix', matrix);
+        Check.typeOf.object('result', result);
         //>>includeEnd('debug');
 
         var matrix1 = matrix[1];
@@ -1985,8 +1979,8 @@ define([
      */
     Matrix4.abs = function(matrix, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(matrix, 'matrix');
-        Check.typeOf.object(result, 'result');
+        Check.typeOf.object('matrix', matrix);
+        Check.typeOf.object('result', result);
         //>>includeEnd('debug');
 
         result[0] = Math.abs(matrix[0]);
@@ -2102,7 +2096,7 @@ define([
      */
     Matrix4.equalsEpsilon = function(left, right, epsilon) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.number(epsilon, 'epsilon');
+        Check.typeOf.number('epsilon', epsilon);
         //>>includeEnd('debug');
 
         return (left === right) ||
@@ -2135,8 +2129,8 @@ define([
      */
     Matrix4.getTranslation = function(matrix, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(matrix, 'matrix');
-        Check.typeOf.object(result, 'result');
+        Check.typeOf.object('matrix', matrix);
+        Check.typeOf.object('result', result);
         //>>includeEnd('debug');
 
         result.x = matrix[12];
@@ -2169,8 +2163,8 @@ define([
      */
     Matrix4.getRotation = function(matrix, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(matrix, 'matrix');
-        Check.typeOf.object(result, 'result');
+        Check.typeOf.object('matrix', matrix);
+        Check.typeOf.object('result', result);
         //>>includeEnd('debug');
 
         result[0] = matrix[0];
@@ -2204,8 +2198,8 @@ define([
       */
     Matrix4.inverse = function(matrix, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(matrix, 'matrix');
-        Check.typeOf.object(result, 'result');
+        Check.typeOf.object('matrix', matrix);
+        Check.typeOf.object('result', result);
         //>>includeEnd('debug');
 
         // Special case for a zero scale matrix that can occur, for example,
@@ -2345,8 +2339,8 @@ define([
      */
     Matrix4.inverseTransformation = function(matrix, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(matrix, 'matrix');
-        Check.typeOf.object(result, 'result');
+        Check.typeOf.object('matrix', matrix);
+        Check.typeOf.object('result', result);
         //>>includeEnd('debug');
 
         //This function is an optimized version of the below 4 lines.

--- a/Source/Core/Quaternion.js
+++ b/Source/Core/Quaternion.js
@@ -75,8 +75,8 @@ define([
      */
     Quaternion.fromAxisAngle = function(axis, angle, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(axis, 'axis');
-        Check.typeOf.number(angle, 'angle');
+        Check.typeOf.object('axis', axis);
+        Check.typeOf.number('angle', angle);
         //>>includeEnd('debug');
 
         var halfAngle = angle / 2.0;
@@ -110,7 +110,7 @@ define([
      */
     Quaternion.fromRotationMatrix = function(matrix, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(matrix, 'matrix');
+        Check.typeOf.object('matrix', matrix);
         //>>includeEnd('debug');
 
         var root;
@@ -186,9 +186,9 @@ define([
      */
     Quaternion.fromHeadingPitchRoll = function(heading, pitch, roll, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.number(heading, 'heading');
-        Check.typeOf.number(pitch, 'pitch');
-        Check.typeOf.number(roll, 'roll');
+        Check.typeOf.number('heading', heading);
+        Check.typeOf.number('pitch', pitch);
+        Check.typeOf.number('roll', roll);
         //>>includeEnd('debug');
 
         var rollQuaternion = Quaternion.fromAxisAngle(Cartesian3.UNIT_X, roll, scratchHPRQuaternion);
@@ -221,8 +221,8 @@ define([
      */
     Quaternion.pack = function(value, array, startingIndex) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(value, 'value');
-        Check.defined(array, 'array');
+        Check.typeOf.object('value', value);
+        Check.defined('array', array);
         //>>includeEnd('debug');
 
         startingIndex = defaultValue(startingIndex, 0);
@@ -245,7 +245,7 @@ define([
      */
     Quaternion.unpack = function(array, startingIndex, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.defined(array, 'array');
+        Check.defined('array', array);
         //>>includeEnd('debug');
 
         startingIndex = defaultValue(startingIndex, 0);
@@ -356,8 +356,8 @@ define([
      */
     Quaternion.conjugate = function(quaternion, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(quaternion, 'quaternion');
-        Check.typeOf.object(result, 'result');
+        Check.typeOf.object('quaternion', quaternion);
+        Check.typeOf.object('result', result);
         //>>includeEnd('debug');
 
         result.x = -quaternion.x;
@@ -375,7 +375,7 @@ define([
      */
     Quaternion.magnitudeSquared = function(quaternion) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(quaternion, 'quaternion');
+        Check.typeOf.object('quaternion', quaternion);
         //>>includeEnd('debug');
 
         return quaternion.x * quaternion.x + quaternion.y * quaternion.y + quaternion.z * quaternion.z + quaternion.w * quaternion.w;
@@ -400,7 +400,7 @@ define([
      */
     Quaternion.normalize = function(quaternion, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(result, 'result');
+        Check.typeOf.object('result', result);
         //>>includeEnd('debug');
 
         var inverseMagnitude = 1.0 / Quaternion.magnitude(quaternion);
@@ -425,7 +425,7 @@ define([
      */
     Quaternion.inverse = function(quaternion, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(result, 'result');
+        Check.typeOf.object('result', result);
         //>>includeEnd('debug');
 
         var magnitudeSquared = Quaternion.magnitudeSquared(quaternion);
@@ -443,9 +443,9 @@ define([
      */
     Quaternion.add = function(left, right, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(left, 'left');
-        Check.typeOf.object(right, 'right');
-        Check.typeOf.object(result, 'result');
+        Check.typeOf.object('left', left);
+        Check.typeOf.object('right', right);
+        Check.typeOf.object('result', result);
         //>>includeEnd('debug');
 
         result.x = left.x + right.x;
@@ -465,9 +465,9 @@ define([
      */
     Quaternion.subtract = function(left, right, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(left, 'left');
-        Check.typeOf.object(right, 'right');
-        Check.typeOf.object(result, 'result');
+        Check.typeOf.object('left', left);
+        Check.typeOf.object('right', right);
+        Check.typeOf.object('result', result);
         //>>includeEnd('debug');
 
         result.x = left.x - right.x;
@@ -486,8 +486,8 @@ define([
      */
     Quaternion.negate = function(quaternion, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(quaternion, 'quaternion');
-        Check.typeOf.object(result, 'result');
+        Check.typeOf.object('quaternion', quaternion);
+        Check.typeOf.object('result', result);
         //>>includeEnd('debug');
 
         result.x = -quaternion.x;
@@ -506,8 +506,8 @@ define([
      */
     Quaternion.dot = function(left, right) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(left, 'left');
-        Check.typeOf.object(right, 'right');
+        Check.typeOf.object('left', left);
+        Check.typeOf.object('right', right);
         //>>includeEnd('debug');
 
         return left.x * right.x + left.y * right.y + left.z * right.z + left.w * right.w;
@@ -523,9 +523,9 @@ define([
      */
     Quaternion.multiply = function(left, right, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(left, 'left');
-        Check.typeOf.object(right, 'right');
-        Check.typeOf.object(result, 'result');
+        Check.typeOf.object('left', left);
+        Check.typeOf.object('right', right);
+        Check.typeOf.object('result', result);
         //>>includeEnd('debug');
 
         var leftX = left.x;
@@ -560,9 +560,9 @@ define([
      */
     Quaternion.multiplyByScalar = function(quaternion, scalar, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(quaternion, 'quaternion');
-        Check.typeOf.number(scalar, 'scalar');
-        Check.typeOf.object(result, 'result');
+        Check.typeOf.object('quaternion', quaternion);
+        Check.typeOf.number('scalar', scalar);
+        Check.typeOf.object('result', result);
         //>>includeEnd('debug');
 
         result.x = quaternion.x * scalar;
@@ -582,9 +582,9 @@ define([
      */
     Quaternion.divideByScalar = function(quaternion, scalar, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(quaternion, 'quaternion');
-        Check.typeOf.number(scalar, 'scalar');
-        Check.typeOf.object(result, 'result');
+        Check.typeOf.object('quaternion', quaternion);
+        Check.typeOf.number('scalar', scalar);
+        Check.typeOf.object('result', result);
         //>>includeEnd('debug');
 
         result.x = quaternion.x / scalar;
@@ -603,8 +603,8 @@ define([
      */
     Quaternion.computeAxis = function(quaternion, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(quaternion, 'quaternion');
-        Check.typeOf.object(result, 'result');
+        Check.typeOf.object('quaternion', quaternion);
+        Check.typeOf.object('result', result);
         //>>includeEnd('debug');
 
         var w = quaternion.w;
@@ -629,7 +629,7 @@ define([
      */
     Quaternion.computeAngle = function(quaternion) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(quaternion, 'quaternion');
+        Check.typeOf.object('quaternion', quaternion);
         //>>includeEnd('debug');
 
         if (Math.abs(quaternion.w - 1.0) < CesiumMath.EPSILON6) {
@@ -650,10 +650,10 @@ define([
      */
     Quaternion.lerp = function(start, end, t, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(start, 'start');
-        Check.typeOf.object(end, 'end');
-        Check.typeOf.number(t, 't');
-        Check.typeOf.object(result, 'result');
+        Check.typeOf.object('start', start);
+        Check.typeOf.object('end', end);
+        Check.typeOf.number('t', t);
+        Check.typeOf.object('result', result);
         //>>includeEnd('debug');
 
         lerpScratch = Quaternion.multiplyByScalar(end, t, lerpScratch);
@@ -677,10 +677,10 @@ define([
      */
     Quaternion.slerp = function(start, end, t, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(start, 'start');
-        Check.typeOf.object(end, 'end');
-        Check.typeOf.number(t, 't');
-        Check.typeOf.object(result, 'result');
+        Check.typeOf.object('start', start);
+        Check.typeOf.object('end', end);
+        Check.typeOf.number('t', t);
+        Check.typeOf.object('result', result);
         //>>includeEnd('debug');
 
         var dot = Quaternion.dot(start, end);
@@ -715,8 +715,8 @@ define([
      */
     Quaternion.log = function(quaternion, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(quaternion, 'quaternion');
-        Check.typeOf.object(result, 'result');
+        Check.typeOf.object('quaternion', quaternion);
+        Check.typeOf.object('result', result);
         //>>includeEnd('debug');
 
         var theta = CesiumMath.acosClamped(quaternion.w);
@@ -738,8 +738,8 @@ define([
      */
     Quaternion.exp = function(cartesian, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(cartesian, 'cartesian');
-        Check.typeOf.object(result, 'result');
+        Check.typeOf.object('cartesian', cartesian);
+        Check.typeOf.object('result', result);
         //>>includeEnd('debug');
 
         var theta = Cartesian3.magnitude(cartesian);
@@ -776,10 +776,10 @@ define([
      */
     Quaternion.computeInnerQuadrangle = function(q0, q1, q2, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(q0, 'q0');
-        Check.typeOf.object(q1, 'q1');
-        Check.typeOf.object(q2, 'q2');
-        Check.typeOf.object(result, 'result');
+        Check.typeOf.object('q0', q0);
+        Check.typeOf.object('q1', q1);
+        Check.typeOf.object('q2', q2);
+        Check.typeOf.object('result', result);
         //>>includeEnd('debug');
 
         var qInv = Quaternion.conjugate(q1, squadScratchQuaternion0);
@@ -823,12 +823,12 @@ define([
      */
     Quaternion.squad = function(q0, q1, s0, s1, t, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(q0, 'q0');
-        Check.typeOf.object(q1, 'q1');
-        Check.typeOf.object(s0, 's0');
-        Check.typeOf.object(s1, 's1');
-        Check.typeOf.number(t, 't');
-        Check.typeOf.object(result, 'result');
+        Check.typeOf.object('q0', q0);
+        Check.typeOf.object('q1', q1);
+        Check.typeOf.object('s0', s0);
+        Check.typeOf.object('s1', s1);
+        Check.typeOf.number('t', t);
+        Check.typeOf.object('result', result);
         //>>includeEnd('debug');
 
         var slerp0 = Quaternion.slerp(q0, q1, t, squadScratchQuaternion0);
@@ -867,10 +867,10 @@ define([
      */
     Quaternion.fastSlerp = function(start, end, t, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(start, 'start');
-        Check.typeOf.object(end, 'end');
-        Check.typeOf.number(t, 't');
-        Check.typeOf.object(result, 'result');
+        Check.typeOf.object('start', start);
+        Check.typeOf.object('end', end);
+        Check.typeOf.number('t', t);
+        Check.typeOf.object('result', result);
         //>>includeEnd('debug');
 
         var x = Quaternion.dot(start, end);
@@ -921,12 +921,12 @@ define([
      */
     Quaternion.fastSquad = function(q0, q1, s0, s1, t, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(q0, 'q0');
-        Check.typeOf.object(q1, 'q1');
-        Check.typeOf.object(s0, 's0');
-        Check.typeOf.object(s1, 's1');
-        Check.typeOf.number(t, 't');
-        Check.typeOf.object(result, 'result');
+        Check.typeOf.object('q0', q0);
+        Check.typeOf.object('q1', q1);
+        Check.typeOf.object('s0', s0);
+        Check.typeOf.object('s1', s1);
+        Check.typeOf.number('t', t);
+        Check.typeOf.object('result', result);
         //>>includeEnd('debug');
 
         var slerp0 = Quaternion.fastSlerp(q0, q1, t, squadScratchQuaternion0);
@@ -964,7 +964,7 @@ define([
      */
     Quaternion.equalsEpsilon = function(left, right, epsilon) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.number(epsilon, 'epsilon');
+        Check.typeOf.number('epsilon', epsilon);
         //>>includeEnd('debug');
 
         return (left === right) ||

--- a/Source/Core/Rectangle.js
+++ b/Source/Core/Rectangle.js
@@ -109,8 +109,8 @@ define([
      */
     Rectangle.pack = function(value, array, startingIndex) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(value, 'value');
-        Check.defined(array, 'array');
+        Check.typeOf.object('value', value);
+        Check.defined('array', array);
         //>>includeEnd('debug');
 
         startingIndex = defaultValue(startingIndex, 0);
@@ -133,7 +133,7 @@ define([
      */
     Rectangle.unpack = function(array, startingIndex, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.defined(array, 'array');
+        Check.defined('array', array);
         //>>includeEnd('debug');
 
         startingIndex = defaultValue(startingIndex, 0);
@@ -156,7 +156,7 @@ define([
      */
     Rectangle.computeWidth = function(rectangle) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(rectangle, 'rectangle');
+        Check.typeOf.object('rectangle', rectangle);
         //>>includeEnd('debug');
         var east = rectangle.east;
         var west = rectangle.west;
@@ -173,7 +173,7 @@ define([
      */
     Rectangle.computeHeight = function(rectangle) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(rectangle, 'rectangle');
+        Check.typeOf.object('rectangle', rectangle);
         //>>includeEnd('debug');
         return rectangle.north - rectangle.south;
     };
@@ -218,7 +218,7 @@ define([
      */
     Rectangle.fromCartographicArray = function(cartographics, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.defined(cartographics, 'cartographics');
+        Check.defined('cartographics', cartographics);
         //>>includeEnd('debug');
 
         var west = Number.MAX_VALUE;
@@ -273,7 +273,7 @@ define([
      */
     Rectangle.fromCartesianArray = function(cartesians, ellipsoid, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.defined(cartesians, 'cartesians');
+        Check.defined('cartesians', cartesians);
         //>>includeEnd('debug');
 
         var west = Number.MAX_VALUE;
@@ -391,7 +391,7 @@ define([
      */
     Rectangle.prototype.equalsEpsilon = function(other, epsilon) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.number(epsilon, 'epsilon');
+        Check.typeOf.number('epsilon', epsilon);
         //>>includeEnd('debug');
 
         return defined(other) &&
@@ -413,27 +413,23 @@ define([
      */
     Rectangle.validate = function(rectangle) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(rectangle, 'rectangle');
+        Check.typeOf.object('rectangle', rectangle);
 
         var north = rectangle.north;
-        Check.typeOf.number(north, 'north');
-        Check.numeric.minimum(north, -CesiumMath.PI_OVER_TWO);
-        Check.numeric.maximum(north, CesiumMath.PI_OVER_TWO);
+        Check.typeOf.number.greaterThanOrEquals('north', north, -CesiumMath.PI_OVER_TWO);
+        Check.typeOf.number.lessThanOrEquals('north', north, CesiumMath.PI_OVER_TWO);
 
         var south = rectangle.south;
-        Check.typeOf.number(south, 'south');
-        Check.numeric.minimum(south, -CesiumMath.PI_OVER_TWO);
-        Check.numeric.maximum(south, CesiumMath.PI_OVER_TWO);
+        Check.typeOf.number.greaterThanOrEquals('south', south, -CesiumMath.PI_OVER_TWO);
+        Check.typeOf.number.lessThanOrEquals('south', south, CesiumMath.PI_OVER_TWO);
 
         var west = rectangle.west;
-        Check.typeOf.number(west, 'west');
-        Check.numeric.minimum(west, -Math.PI);
-        Check.numeric.maximum(west, Math.PI);
+        Check.typeOf.number.greaterThanOrEquals('west', west, -Math.PI);
+        Check.typeOf.number.lessThanOrEquals('west', west, Math.PI);
 
         var east = rectangle.east;
-        Check.typeOf.number(east, 'east');
-        Check.numeric.minimum(east, -Math.PI);
-        Check.numeric.maximum(east, Math.PI);
+        Check.typeOf.number.greaterThanOrEquals('east', east, -Math.PI);
+        Check.typeOf.number.lessThanOrEquals('east', east, Math.PI);
         //>>includeEnd('debug');
     };
 
@@ -446,7 +442,7 @@ define([
      */
     Rectangle.southwest = function(rectangle, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(rectangle, 'rectangle');
+        Check.typeOf.object('rectangle', rectangle);
         //>>includeEnd('debug');
 
         if (!defined(result)) {
@@ -467,7 +463,7 @@ define([
      */
     Rectangle.northwest = function(rectangle, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(rectangle, 'rectangle');
+        Check.typeOf.object('rectangle', rectangle);
         //>>includeEnd('debug');
 
         if (!defined(result)) {
@@ -488,7 +484,7 @@ define([
      */
     Rectangle.northeast = function(rectangle, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(rectangle, 'rectangle');
+        Check.typeOf.object('rectangle', rectangle);
         //>>includeEnd('debug');
 
         if (!defined(result)) {
@@ -509,7 +505,7 @@ define([
      */
     Rectangle.southeast = function(rectangle, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(rectangle, 'rectangle');
+        Check.typeOf.object('rectangle', rectangle);
         //>>includeEnd('debug');
 
         if (!defined(result)) {
@@ -530,7 +526,7 @@ define([
      */
     Rectangle.center = function(rectangle, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(rectangle, 'rectangle');
+        Check.typeOf.object('rectangle', rectangle);
         //>>includeEnd('debug');
 
         var east = rectangle.east;
@@ -567,8 +563,8 @@ define([
      */
     Rectangle.intersection = function(rectangle, otherRectangle, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(rectangle, 'rectangle');
-        Check.typeOf.object(otherRectangle, 'otherRectangle');
+        Check.typeOf.object('rectangle', rectangle);
+        Check.typeOf.object('otherRectangle', otherRectangle);
         //>>includeEnd('debug');
 
         var rectangleEast = rectangle.east;
@@ -626,8 +622,8 @@ define([
      */
     Rectangle.simpleIntersection = function(rectangle, otherRectangle, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(rectangle, 'rectangle');
-        Check.typeOf.object(otherRectangle, 'otherRectangle');
+        Check.typeOf.object('rectangle', rectangle);
+        Check.typeOf.object('otherRectangle', otherRectangle);
         //>>includeEnd('debug');
 
         var west = Math.max(rectangle.west, otherRectangle.west);
@@ -660,8 +656,8 @@ define([
      */
     Rectangle.union = function(rectangle, otherRectangle, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(rectangle, 'rectangle');
-        Check.typeOf.object(otherRectangle, 'otherRectangle');
+        Check.typeOf.object('rectangle', rectangle);
+        Check.typeOf.object('otherRectangle', otherRectangle);
         //>>includeEnd('debug');
 
         if (!defined(result)) {
@@ -707,8 +703,8 @@ define([
      */
     Rectangle.expand = function(rectangle, cartographic, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(rectangle, 'rectangle');
-        Check.typeOf.object(cartographic, 'cartographic');
+        Check.typeOf.object('rectangle', rectangle);
+        Check.typeOf.object('cartographic', cartographic);
         //>>includeEnd('debug');
 
         if (!defined(result)) {
@@ -732,8 +728,8 @@ define([
      */
     Rectangle.contains = function(rectangle, cartographic) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(rectangle, 'rectangle');
-        Check.typeOf.object(cartographic, 'cartographic');
+        Check.typeOf.object('rectangle', rectangle);
+        Check.typeOf.object('cartographic', cartographic);
         //>>includeEnd('debug');
 
         var longitude = cartographic.longitude;
@@ -768,7 +764,7 @@ define([
      */
     Rectangle.subsample = function(rectangle, ellipsoid, surfaceHeight, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(rectangle, 'rectangle');
+        Check.typeOf.object('rectangle', rectangle);
         //>>includeEnd('debug');
 
         ellipsoid = defaultValue(ellipsoid, Ellipsoid.WGS84);

--- a/Source/Core/RectangleGeometry.js
+++ b/Source/Core/RectangleGeometry.js
@@ -649,9 +649,9 @@ define([
         var rectangle = options.rectangle;
 
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(rectangle, 'rectangle');
+        Check.typeOf.object('rectangle', rectangle);
         Rectangle.validate(rectangle);
-        Check.numeric.minimum(rectangle.north, rectangle.south);
+        Check.typeOf.number.greaterThanOrEquals('rectangle.north', rectangle.north, rectangle.south);
         //>>includeEnd('debug');
 
         var rotation = defaultValue(options.rotation, 0.0);
@@ -688,8 +688,8 @@ define([
      */
     RectangleGeometry.pack = function(value, array, startingIndex) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(value, 'value');
-        Check.defined(array, 'array');
+        Check.typeOf.object('value', value);
+        Check.defined('array', array);
         //>>includeEnd('debug');
 
         startingIndex = defaultValue(startingIndex, 0);
@@ -746,7 +746,7 @@ define([
      */
     RectangleGeometry.unpack = function(array, startingIndex, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.defined(array, 'array');
+        Check.defined('array', array);
         //>>includeEnd('debug');
 
         startingIndex = defaultValue(startingIndex, 0);

--- a/Source/Core/RectangleGeometry.js
+++ b/Source/Core/RectangleGeometry.js
@@ -651,7 +651,9 @@ define([
         //>>includeStart('debug', pragmas.debug);
         Check.typeOf.object('rectangle', rectangle);
         Rectangle.validate(rectangle);
-        Check.typeOf.number.greaterThanOrEquals('rectangle.north', rectangle.north, rectangle.south);
+        if (rectangle.north < rectangle.south) {
+            throw new DeveloperError('options.rectangle.north must be greater than or equal to options.rectangle.south');
+        }
         //>>includeEnd('debug');
 
         var rotation = defaultValue(options.rotation, 0.0);

--- a/Source/Core/SphereGeometry.js
+++ b/Source/Core/SphereGeometry.js
@@ -72,7 +72,7 @@ define([
      */
     SphereGeometry.pack = function(value, array, startingIndex) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(value, 'value');
+        Check.typeOf.object('value', value);
         //>>includeEnd('debug');
 
         return EllipsoidGeometry.pack(value._ellipsoidGeometry, array, startingIndex);

--- a/Source/Core/SphereOutlineGeometry.js
+++ b/Source/Core/SphereOutlineGeometry.js
@@ -70,7 +70,7 @@ define([
      */
     SphereOutlineGeometry.pack = function(value, array, startingIndex) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(value, 'value');
+        Check.typeOf.object('value', value);
         //>>includeEnd('debug');
 
         return EllipsoidOutlineGeometry.pack(value._ellipsoidGeometry, array, startingIndex);

--- a/Source/Core/Spherical.js
+++ b/Source/Core/Spherical.js
@@ -36,7 +36,7 @@ define([
      */
     Spherical.fromCartesian3 = function(cartesian3, result) {
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(cartesian3, 'cartesian3');
+        Check.typeOf.object('cartesian3', cartesian3);
         //>>includeEnd('debug');
 
         var x = cartesian3.x;
@@ -85,7 +85,7 @@ define([
      */
     Spherical.normalize = function(spherical, result) {
       //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.object(spherical, 'spherical');
+        Check.typeOf.object('spherical', spherical);
         //>>includeEnd('debug');
 
         if (!defined(result)) {

--- a/Source/Core/Transforms.js
+++ b/Source/Core/Transforms.js
@@ -474,7 +474,7 @@ define([
      * var transform = Cesium.Transforms.headingPitchRollToFixedFrame(center, hpr);
      */
     Transforms.headingPitchRollToFixedFrame = function(origin, headingPitchRoll, ellipsoid, result) {
-        Check.typeOf.object(headingPitchRoll, 'headingPitchRoll');
+        Check.typeOf.object('headingPitchRoll', headingPitchRoll);
         var heading = headingPitchRoll.heading;
         var pitch = headingPitchRoll.pitch;
         var roll = headingPitchRoll.roll;
@@ -512,7 +512,7 @@ define([
      */
     Transforms.headingPitchRollQuaternion = function(origin, headingPitchRoll, ellipsoid, result) {
         // checks for required parameters happen in the called functions
-        Check.typeOf.object(headingPitchRoll, 'headingPitchRoll');
+        Check.typeOf.object('headingPitchRoll', headingPitchRoll);
         var transform = Transforms.headingPitchRollToFixedFrame(origin, headingPitchRoll, ellipsoid, scratchENUMatrix4);
         var rotation = Matrix4.getRotation(transform, scratchHPRMatrix3);
         return Quaternion.fromRotationMatrix(rotation, result);

--- a/Specs/Core/CheckSpec.js
+++ b/Specs/Core/CheckSpec.js
@@ -8,55 +8,55 @@ defineSuite([
     describe('type checks', function () {
         it('Check.typeOf.bool does not throw when passed a boolean', function () {
             expect(function () {
-                Check.typeOf.bool(true);
+                Check.typeOf.bool('bool', true);
             }).not.toThrowDeveloperError();
         });
 
-        it('Check.typeOf.boolean throws when passed a non-boolean', function () {
+        it('Check.typeOf.bool throws when passed a non-boolean', function () {
             expect(function () {
-                Check.typeOf.bool({}, 'mockName');
+                Check.typeOf.bool('mockName', {});
             }).toThrowDeveloperError();
             expect(function () {
-                Check.typeOf.bool([], 'mockName');
+                Check.typeOf.bool('mockName', []);
             }).toThrowDeveloperError();
             expect(function () {
-                Check.typeOf.bool(1, 'mockName');
+                Check.typeOf.bool('mockName', 1);
             }).toThrowDeveloperError();
             expect(function () {
                 Check.typeOf.bool('snth', 'mockName');
             }).toThrowDeveloperError();
             expect(function () {
-                Check.typeOf.bool(function () {return true;}, 'mockName');
+                Check.typeOf.bool('mockName', function () {return true;});
             }).toThrowDeveloperError();
         });
 
         it('Check.typeOf.func does not throw when passed a function', function () {
             expect(function () {
-                Check.typeOf.func(function () {return true;}, 'mockName');
+                Check.typeOf.func('mockName', function () {return true;});
             }).not.toThrowDeveloperError();
         });
 
         it('Check.typeOf.func throws when passed a non-function', function () {
             expect(function () {
-                Check.typeOf.func({}, 'mockName');
+                Check.typeOf.func('mockName', {});
             }).toThrowDeveloperError();
             expect(function () {
-                Check.typeOf.func([], 'mockName');
+                Check.typeOf.func('mockName', [2]);
             }).toThrowDeveloperError();
             expect(function () {
-                Check.typeOf.func(1, 'mockName');
+                Check.typeOf.func('mockName', 1);
             }).toThrowDeveloperError();
             expect(function () {
                 Check.typeOf.func('snth', 'mockName');
             }).toThrowDeveloperError();
             expect(function () {
-                Check.typeOf.func(true, 'mockName');
+                Check.typeOf.func('mockName', true);
             }).toThrowDeveloperError();
         });
 
         it('Check.typeOf.object does not throw when passed object', function() {
             expect(function () {
-                Check.typeOf.object({}, 'mockName');
+                Check.typeOf.object('mockName', {});
             }).not.toThrowDeveloperError();
         });
 
@@ -65,19 +65,19 @@ defineSuite([
                 Check.typeOf.object('snth', 'mockName');
             }).toThrowDeveloperError();
             expect(function () {
-                Check.typeOf.object(true, 'mockName');
+                Check.typeOf.object('mockName', true);
             }).toThrowDeveloperError();
             expect(function () {
-                Check.typeOf.object(1, 'mockName');
+                Check.typeOf.object('mockName', 1);
             }).toThrowDeveloperError();
             expect(function () {
-                Check.typeOf.object(function () {return true;}, 'mockName');
+                Check.typeOf.object('mockName', function () {return true;});
             }).toThrowDeveloperError();
         });
 
         it('Check.typeOf.number does not throw when passed number', function() {
             expect(function () {
-                Check.typeOf.number(2, 'mockName');
+                Check.typeOf.number('mockName', 2);
             }).not.toThrowDeveloperError();
         });
 
@@ -86,16 +86,16 @@ defineSuite([
                 Check.typeOf.number('snth', 'mockName');
             }).toThrowDeveloperError();
             expect(function () {
-                Check.typeOf.number(true, 'mockName');
+                Check.typeOf.number('mockName', true);
             }).toThrowDeveloperError();
             expect(function () {
-                Check.typeOf.number({}, 'mockName');
+                Check.typeOf.number('mockName', {});
             }).toThrowDeveloperError();
             expect(function () {
-                Check.typeOf.number([2], 'mockName');
+                Check.typeOf.number('mockName', [2]);
             }).toThrowDeveloperError();
             expect(function () {
-                Check.typeOf.number(function () {return true;}, 'mockName');
+                Check.typeOf.number('mockName', function () {return true;});
             }).toThrowDeveloperError();
         });
 
@@ -107,68 +107,36 @@ defineSuite([
 
         it('Check.typeOf.string throws on non-string', function () {
             expect(function () {
-                Check.typeOf.string({}, 'mockName');
+                Check.typeOf.string('mockName', {});
             }).toThrowDeveloperError();
             expect(function () {
-                Check.typeOf.string(true, 'mockName');
+                Check.typeOf.string('mockName', true);
             }).toThrowDeveloperError();
             expect(function () {
-                Check.typeOf.string(1, 'mockName');
+                Check.typeOf.string('mockName', 1);
             }).toThrowDeveloperError();
             expect(function () {
-                Check.typeOf.string([2], 'mockName');
+                Check.typeOf.string('mockName', [2]);
             }).toThrowDeveloperError();
             expect(function () {
-                Check.typeOf.string(function () {return true;}, 'mockName');
+                Check.typeOf.string('mockName', function () {return true;});
             }).toThrowDeveloperError();
-        });
-    });
-
-    describe('Check.numeric', function () {
-        it('minimum throws on value less than minimum', function () {
-            var test = 4;
-            var minimum = 5;
-            expect(function () {
-                Check.numeric.minimum(test, 'test', minimum);
-            }).toThrowDeveloperError();
-        });
-        it('minimum does not throw on value at least as big as minimum', function () {
-            var test = 4;
-            expect(function () {
-                Check.numeric.minimum(test, 'test', 4);
-                Check.numeric.minimum(test, 'test', 3);
-            }).not.toThrowDeveloperError();
-        });
-
-        it('maximum throws on value greater than maximum', function () {
-            var test = 6;
-            expect(function () {
-                Check.numeric.maximum(test, 'test', 5);
-            }).toThrowDeveloperError();
-        });
-        it('maximum does not throw on value at most as big as maximum', function () {
-            expect(function () {
-                var test = 5;
-                Check.numeric.maximum(test, 'test', 5);
-                test = 4;
-                Check.numeric.maximum(test, 'test', 5);
-            }).not.toThrowDeveloperError();
         });
     });
 
     describe('Check.defined', function () {
         it('does not throw unless passed value that is undefined or null', function () {
             expect(function () {
-                Check.defined({}, 'mockName');
+                Check.defined('mockName', {});
             }).not.toThrowDeveloperError();
             expect(function () {
-                Check.defined([], 'mockName');
+                Check.defined('mockName', []);
             }).not.toThrowDeveloperError();
             expect(function () {
-                Check.defined(2, 'mockName');
+                Check.defined('mockName', 2);
             }).not.toThrowDeveloperError();
             expect(function () {
-                Check.defined(function() {return true;}, 'mockName');
+                Check.defined('mockName', function () {return true;});
             }).not.toThrowDeveloperError();
             expect(function () {
                 Check.defined('snt', 'mockName');
@@ -177,8 +145,88 @@ defineSuite([
 
         it('throws when passed undefined', function () {
             expect(function () {
-                Check.defined(undefined, 'mockName');
+                Check.defined('mockName', undefined);
             }).toThrowDeveloperError();
+        });
+    });
+
+    describe('Check.typeOf.number.lessThan', function () {
+        it('throws if test is equal to limit', function () {
+            expect(function () {
+                Check.typeOf.number.lessThan('mockName', 3, 3);
+            }).toThrowDeveloperError();
+        });
+
+        it('throws if test is greater than limit', function () {
+            expect(function () {
+                Check.typeOf.number.lessThan('mockName', 4, 3);
+            }).toThrowDeveloperError();
+        });
+
+        it('does not throw if test is less than limit', function () {
+            expect(function () {
+                Check.typeOf.number.lessThan('mockName', 2, 3);
+            }).not.toThrowDeveloperError();
+        });
+    });
+
+    describe('Check.typeOf.number.lessThanOrEquals', function () {
+        it('throws if test is greater than limit', function () {
+            expect(function () {
+                Check.typeOf.number.lessThanOrEquals('mockName', 4, 3);
+            }).toThrowDeveloperError();
+        });
+
+        it('does not throw if test is equal to limit', function () {
+            expect(function () {
+                Check.typeOf.number.lessThanOrEquals('mockName', 3, 3);
+            }).not.toThrowDeveloperError();
+        });
+
+        it('does not throw if test is less than limit', function () {
+            expect(function () {
+                Check.typeOf.number.lessThanOrEquals('mockName', 2, 3);
+            }).not.toThrowDeveloperError();
+        });
+    });
+
+    describe('Check.typeOf.number.greaterThan', function () {
+        it('throws if test is equal to limit', function () {
+            expect(function () {
+                Check.typeOf.number.greaterThan('mockName', 3, 3);
+            }).toThrowDeveloperError();
+        });
+
+        it('throws if test is less than limit', function () {
+            expect(function () {
+                Check.typeOf.number.greaterThan('mockName', 2, 3);
+            }).toThrowDeveloperError();
+        });
+
+        it('does not throw if test is greater than limit', function () {
+            expect(function () {
+                Check.typeOf.number.greaterThan('mockName', 4, 3);
+            }).not.toThrowDeveloperError();
+        });
+    });
+
+    describe('Check.typeOf.number.greaterThanOrEquals', function () {
+        it('throws if test is less than limit', function () {
+            expect(function () {
+                Check.typeOf.number.greaterThanOrEquals('mockName', 2, 3);
+            }).toThrowDeveloperError();
+        });
+
+        it('does not throw if test is equal to limit', function () {
+            expect(function () {
+                Check.typeOf.number.greaterThanOrEquals('mockName', 3, 3);
+            }).not.toThrowDeveloperError();
+        });
+
+        it('does not throw if test is greater than limit', function () {
+            expect(function () {
+                Check.typeOf.number.greaterThanOrEquals('mockName', 4, 3);
+            }).not.toThrowDeveloperError();
         });
     });
 });

--- a/Specs/Core/CheckSpec.js
+++ b/Specs/Core/CheckSpec.js
@@ -1,6 +1,6 @@
 /*global defineSuite*/
 defineSuite([
-    'Core/Check'
+        'Core/Check'
     ], function(
         Check) {
     'use strict';
@@ -23,7 +23,7 @@ defineSuite([
                 Check.typeOf.bool('mockName', 1);
             }).toThrowDeveloperError();
             expect(function () {
-                Check.typeOf.bool('snth', 'mockName');
+                Check.typeOf.bool('mockName', 'snth');
             }).toThrowDeveloperError();
             expect(function () {
                 Check.typeOf.bool('mockName', function () {return true;});
@@ -47,7 +47,7 @@ defineSuite([
                 Check.typeOf.func('mockName', 1);
             }).toThrowDeveloperError();
             expect(function () {
-                Check.typeOf.func('snth', 'mockName');
+                Check.typeOf.func('mockName', 'snth');
             }).toThrowDeveloperError();
             expect(function () {
                 Check.typeOf.func('mockName', true);
@@ -62,7 +62,7 @@ defineSuite([
 
         it('Check.typeOf.object throws when passed non-object', function() {
             expect(function () {
-                Check.typeOf.object('snth', 'mockName');
+                Check.typeOf.object('mockName', 'snth');
             }).toThrowDeveloperError();
             expect(function () {
                 Check.typeOf.object('mockName', true);
@@ -83,7 +83,7 @@ defineSuite([
 
         it('Check.typeOf.number throws when passed non-number', function() {
             expect(function () {
-                Check.typeOf.number('snth', 'mockName');
+                Check.typeOf.number('mockName', 'snth');
             }).toThrowDeveloperError();
             expect(function () {
                 Check.typeOf.number('mockName', true);
@@ -101,7 +101,7 @@ defineSuite([
 
         it('Check.typeOf.string does not throw when passed a string', function () {
             expect(function () {
-                Check.typeOf.string('s', 'mockName');
+                Check.typeOf.string('mockName', 's');
             }).not.toThrowDeveloperError();
         });
 
@@ -139,7 +139,7 @@ defineSuite([
                 Check.defined('mockName', function () {return true;});
             }).not.toThrowDeveloperError();
             expect(function () {
-                Check.defined('snt', 'mockName');
+                Check.defined('mockName', 'snt');
             }).not.toThrowDeveloperError();
         });
 

--- a/Specs/Core/CheckSpec.js
+++ b/Specs/Core/CheckSpec.js
@@ -126,52 +126,59 @@ defineSuite([
 
     describe('Check.numeric', function () {
         it('minimum throws on value less than minimum', function () {
+            var test = 4;
+            var minimum = 5;
             expect(function () {
-                Check.numeric.minimum(4, 5);
+                Check.numeric.minimum(test, 'test', minimum);
             }).toThrowDeveloperError();
         });
         it('minimum does not throw on value at least as big as minimum', function () {
+            var test = 4;
             expect(function () {
-                Check.numeric.minimum(4, 4);
-                Check.numeric.minimum(4, 3);
+                Check.numeric.minimum(test, 'test', 4);
+                Check.numeric.minimum(test, 'test', 3);
             }).not.toThrowDeveloperError();
         });
 
         it('maximum throws on value greater than maximum', function () {
+            var test = 6;
             expect(function () {
-                Check.numeric.maximum(6, 5);
+                Check.numeric.maximum(test, 'test', 5);
             }).toThrowDeveloperError();
         });
         it('maximum does not throw on value at most as big as maximum', function () {
             expect(function () {
-                Check.numeric.maximum(5, 5);
-                Check.numeric.maximum(4, 5);
+                var test = 5;
+                Check.numeric.maximum(test, 'test', 5);
+                test = 4;
+                Check.numeric.maximum(test, 'test', 5);
             }).not.toThrowDeveloperError();
         });
     });
 
-    it('Check.defined does not throw unless passed value that is undefined or null', function () {
-        expect(function () {
-            Check.defined({}, 'mockName');
-        }).not.toThrowDeveloperError();
-        expect(function () {
-            Check.defined([], 'mockName');
-        }).not.toThrowDeveloperError();
-        expect(function () {
-            Check.defined(2, 'mockName');
-        }).not.toThrowDeveloperError();
-        expect(function () {
-            Check.defined(function() {return true;}, 'mockName');
-        }).not.toThrowDeveloperError();
-        expect(function () {
-            Check.defined('snt', 'mockName');
-        }).not.toThrowDeveloperError();
-    });
+    describe('Check.defined', function () {
+        it('does not throw unless passed value that is undefined or null', function () {
+            expect(function () {
+                Check.defined({}, 'mockName');
+            }).not.toThrowDeveloperError();
+            expect(function () {
+                Check.defined([], 'mockName');
+            }).not.toThrowDeveloperError();
+            expect(function () {
+                Check.defined(2, 'mockName');
+            }).not.toThrowDeveloperError();
+            expect(function () {
+                Check.defined(function() {return true;}, 'mockName');
+            }).not.toThrowDeveloperError();
+            expect(function () {
+                Check.defined('snt', 'mockName');
+            }).not.toThrowDeveloperError();
+        });
 
-    it('Check.defined throws when passed undefined', function () {
-        expect(function () {
-            Check.defined(undefined, 'mockName');
-        }).toThrowDeveloperError();
+        it('throws when passed undefined', function () {
+            expect(function () {
+                Check.defined(undefined, 'mockName');
+            }).toThrowDeveloperError();
+        });
     });
-
 });


### PR DESCRIPTION
Fixes #4882.

In addition it improves a few of the other error messages.

The changes to `Check.numeric.minimum` and `Check.numeric.maximum` breaks the existing usage of these, so this needs to be fixed before merging. 

In hindsight I think it would have been better to make the name the first parameter of all of the `Check` methods, but to keep parameter order consistent with what we already have in all `typeOf` methods I put the `name` parameter after the variable being tested.  