### PR TITLE
Possibly hacky fix for the zoom to nowhere bug.

### DIFF
--- a/Source/Scene/ScreenSpaceCameraController.js
+++ b/Source/Scene/ScreenSpaceCameraController.js
@@ -504,6 +504,16 @@ define([
 
             zoomingOnVector = object._zoomingOnVector = false;
             rotatingZoom = object._rotatingZoom = false;
+        } else {
+            if (defined(object._globe)) {
+                pickedPosition = mode !== SceneMode.SCENE2D ? pickGlobe(object, startPosition, scratchPickCartesian) : camera.getPickRay(startPosition, scratchZoomPickRay).origin;
+            }
+            if (defined(pickedPosition)) {
+                object._useZoomWorldPosition = true;
+                object._zoomWorldPosition = Cartesian3.clone(pickedPosition, object._zoomWorldPosition);
+            } else {
+                object._useZoomWorldPosition = false;
+            }
         }
 
         if (!object._useZoomWorldPosition) {


### PR DESCRIPTION
Fixes #4855 

I haven't updated CHANGES.md or even thought about writing a test for this yet, because I'm not confident in it.  It'd be good if @bagnell could take a quick look first.

The story is, there's a (slow) system in a demo lab here that I can reproduce #4855 on every single time.  I just pan over to Australia and zoom in to Cradle Mountain in Tasmania using right-click drag.  Before I manage to zoom in close, I'll suddenly end up somewhere in the Atlantic.

@duvifn noted that on his system, this happens when the `target` position that we're zooming toward is behind the camera.  Same thing on my system (thanks for that @duvifn, saved me a lot of time!).  That `target` comes from `_zoomWorldPosition`, and in the frame where this happens, `_zoomWorldPosition` is not updated because the mouse hasn't moved.

So I think what is happening is this:
* I'm zooming in, and there's inertia.
* Since the last frame, the mouse hasn't moved but (due to inertia) the camera has.  Because the system is super slow, the frame rate is low and the camera has actually moved quite a lot since the last frame.
* Because the mouse position hasn't moved, `handleZoom` doesn't think it needs to update `_zoomWorldPosition`, but actually it does because the target point last frame was somewhere much different because the camera moved so much.

So my solution in this PR is to recompute `_zoomWorldPosition` even if the mouse didn't move.  Fixes it on my slow system.