### PR TITLE
3D Tiles - HeadingPitchRoll fix

### DIFF
--- a/Apps/Sandcastle/gallery/development/3D Models Instancing.html
+++ b/Apps/Sandcastle/gallery/development/3D Models Instancing.html
@@ -137,7 +137,7 @@ function reset() {
             var roll = Math.random();
             var scale = (Math.random() + 1.0)/2.0;
 
-            var modelMatrix = Cesium.Transforms.headingPitchRollToFixedFrame(position, heading, pitch, roll);
+            var modelMatrix = Cesium.Transforms.headingPitchRollToFixedFrame(position, new Cesium.HeadingPitchRoll(heading, pitch, roll));
             Cesium.Matrix4.multiplyByUniformScale(modelMatrix, scale, modelMatrix);
 
             instances.push({


### PR DESCRIPTION
Seems like this is the only occurrence of the old HeadingPitchRoll syntax on the 3d-tiles branch.