### PR TITLE
3D Tiles - Fix point cloud drill pick

### DIFF
--- a/Source/Scene/PointCloud3DTileContent.js
+++ b/Source/Scene/PointCloud3DTileContent.js
@@ -699,7 +699,8 @@ define([
             pickUniformMap = batchTable.getPickUniformMapCallback()(uniformMap);
         } else {
             content._pickId = context.createPickId({
-                primitive : content
+                primitive : content._tileset,
+                content : content
             });
 
             pickUniformMap = combine(uniformMap, {

--- a/Specs/Scene/PointCloud3DTileContentSpec.js
+++ b/Specs/Scene/PointCloud3DTileContentSpec.js
@@ -268,7 +268,8 @@ defineSuite([
             tileset.show = true;
             picked = scene.pickForSpecs();
             expect(picked).toBeDefined();
-            expect(picked.primitive).toBe(content);
+            expect(picked.primitive).toBe(tileset);
+            expect(picked.content).toBe(content);
         });
     });
 


### PR DESCRIPTION
Fixes https://github.com/AnalyticalGraphicsInc/cesium/issues/4895

The pick primitive should reference the tileset instead of the content, in line with the rest of 3d-tiles (`Cesium3DTileFeature` for example).

I also added a content property as it may still be useful (like from this [forum post](https://groups.google.com/forum/#!searchin/cesium-dev/parsedcontent%7Csort:relevance/cesium-dev/PixND3vL0rA/pBnkwVHoAgAJ)) - however `PointCloud3DTileContent` is a private class, so I'm not sure about this.

> The problem here is that PointCloud3DTileContent does not have a show property.

This was better solved by using the tileset rather than adding a show property to `PointCloud3DTileContent`.