### PR TITLE
Fixed a crash when using Entity path visualization with references

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -45,6 +45,7 @@ Change Log
 * Fixed texture rotation for `RectangleGeometry`. [#2737](https://github.com/AnalyticalGraphicsInc/cesium/issues/2737)
 * Fixed issue where billboards on terrain had an incorrect offset. [#4598](https://github.com/AnalyticalGraphicsInc/cesium/issues/4598)
 * Fixed issue where `globe.getHeight` incorrectly returned `undefined`. [#3411](https://github.com/AnalyticalGraphicsInc/cesium/issues/3411)
+* Fixed a crash when using Entity path visualization with reference properties. [#4915](https://github.com/AnalyticalGraphicsInc/cesium/issues/4915)
 * Fixed a bug that caused `GroundPrimitive` to render incorrectly on systems without the `WEBGL_depth_texture` extension. [#4747](https://github.com/AnalyticalGraphicsInc/cesium/pull/4747)
 * Fixed default Mapbox token and added a watermark to notify users that they need to sign up for their own token.
 * Fixed glTF models with skinning that used `bindShapeMatrix`. [#4722](https://github.com/AnalyticalGraphicsInc/cesium/issues/4722)

--- a/Source/DataSources/PathVisualizer.js
+++ b/Source/DataSources/PathVisualizer.js
@@ -228,25 +228,22 @@ define([
     }
 
     function reallySubSample(property, start, stop, updateTime, referenceFrame, maximumStep, index, result) {
-        var innerProperty = property;
-
-        while (innerProperty instanceof ReferenceProperty || innerProperty instanceof ScaledPositionProperty) {
-            if (innerProperty instanceof ReferenceProperty) {
-                innerProperty = innerProperty.resolvedProperty;
-            }
-            if (innerProperty instanceof ScaledPositionProperty) {
-                innerProperty = innerProperty._value;
+        //Unwrap any references until we have the actual property.
+        while (property instanceof ReferenceProperty) {
+            if (property instanceof ReferenceProperty) {
+                property = property.resolvedProperty;
             }
         }
 
-        if (innerProperty instanceof SampledPositionProperty) {
-            var times = innerProperty._property._times;
+        if (property instanceof SampledPositionProperty) {
+            var times = property._property._times;
             index = subSampleSampledProperty(property, start, stop, times, updateTime, referenceFrame, maximumStep, index, result);
-        } else if (innerProperty instanceof CompositePositionProperty) {
+        } else if (property instanceof CompositePositionProperty) {
             index = subSampleCompositeProperty(property, start, stop, updateTime, referenceFrame, maximumStep, index, result);
-        } else if (innerProperty instanceof TimeIntervalCollectionPositionProperty) {
+        } else if (property instanceof TimeIntervalCollectionPositionProperty) {
             index = subSampleIntervalProperty(property, start, stop, updateTime, referenceFrame, maximumStep, index, result);
-        } else if (innerProperty instanceof ConstantPositionProperty) {
+        } else if (property instanceof ConstantPositionProperty ||
+                   (property instanceof ScaledPositionProperty && Property.isConstant(property))) {
             index = subSampleConstantProperty(property, start, stop, updateTime, referenceFrame, maximumStep, index, result);
         } else {
             //Fallback to generic sampling.

--- a/Specs/DataSources/PathVisualizerSpec.js
+++ b/Specs/DataSources/PathVisualizerSpec.js
@@ -556,7 +556,7 @@ defineSuite([
         expect(result).toEqual([sampledProperty.getValue(t1), sampledProperty.getValue(JulianDate.addSeconds(t1, maximumStep, new JulianDate())), sampledProperty.getValue(JulianDate.addSeconds(t1, maximumStep * 2, new JulianDate())), sampledProperty.getValue(updateTime), sampledProperty.getValue(JulianDate.addSeconds(t1, maximumStep * 3, new JulianDate())), sampledProperty.getValue(JulianDate.addSeconds(t1, maximumStep * 4, new JulianDate())), sampledProperty.getValue(JulianDate.addSeconds(t1, maximumStep * 5, new JulianDate())), sampledProperty.getValue(JulianDate.addSeconds(t1, maximumStep * 6, new JulianDate()))]);
     });
 
-    it('subSample works for composite properties', function() {
+    function createCompositeTest(useReferenceProperty){
         var t1 = new JulianDate(0, 0);
         var t2 = new JulianDate(1, 0);
         var t3 = new JulianDate(2, 0);
@@ -635,7 +635,15 @@ defineSuite([
         var referenceFrame = ReferenceFrame.FIXED;
         var maximumStep = 43200;
         var result = [];
-        PathVisualizer._subSample(property, t1, t6, updateTime, referenceFrame, maximumStep, result);
+
+        var propertyToTest = property;
+        if (useReferenceProperty) {
+            var testReference = entities.getOrCreateEntity('testReference');
+            testReference.position = property;
+            propertyToTest = new ReferenceProperty(entities, 'testReference', ['position']);
+        }
+
+        PathVisualizer._subSample(propertyToTest, t1, t6, updateTime, referenceFrame, maximumStep, result);
         expect(result).toEqual([intervalProperty.intervals.get(0).data,
                                 constantProperty.getValue(t1),
                                 sampledProperty.getValue(t3),
@@ -643,6 +651,14 @@ defineSuite([
                                 sampledProperty.getValue(t4),
                                 targetEntity.position.getValue(t5),
                                 scaledProperty.getValue(t6)]);
+    }
+
+    it('subSample works for composite properties', function() {
+        createCompositeTest(false);
+    });
+
+    it('subSample works for composite properties wrapped in reference properties', function() {
+        createCompositeTest(true);
     });
 
 }, 'WebGL');


### PR DESCRIPTION

Fixes #4915

There were several bugs here:

1. `PathVisualizer` was unwrapping a `ReferenceProperty`, finding a `CompositePositionProperty` inside, and then using the reference as if it was a composite instead of using the inner property.
2. Same was 1, but for `TimeIntervalCollectionPositionProperty`
3. We were unwrapping `ScaledPositionProperty` and using the inner property directly, but this prevented the value from actually being scaled properly. Now we use the `ScaledPositionProperty` which means it falls back to a generic sampling path but that's the best solution. (Not to mention that ScaledPositionProperty is private and will eventually go away).