### PR TITLE
Fix specs: remove test div when finished with it

### DIFF
--- a/Specs/Widgets/Geocoder/GeocoderSpec.js
+++ b/Specs/Widgets/Geocoder/GeocoderSpec.js
@@ -130,6 +130,7 @@ defineSuite([
         expect(viewModel._selectedSuggestion.displayName).toEqual('a');
         viewModel._handleArrowUp(viewModel);
         expect(viewModel._selectedSuggestion).toBeUndefined();
+        document.body.removeChild(container);
     });
 
 }, 'WebGL');


### PR DESCRIPTION
Fixes #4923

More than one test was using a div with this id, so when we added this one but forgot to remove it the other tests couldn't add a new div with the same id.  That's what was causing the tests to fail when they all ran, but not when they ran individually.