### PR TITLE
Blur input field on enter/geocode

### DIFF
--- a/Source/Widgets/Geocoder/GeocoderViewModel.js
+++ b/Source/Widgets/Geocoder/GeocoderViewModel.js
@@ -117,6 +117,7 @@ define([
 
         this._searchCommand = createCommand(function() {
             that.hideSuggestions();
+            that._focusTextbox = false;
             if (defined(that._selectedSuggestion)) {
                 that.activateSuggestion(that._selectedSuggestion);
                 return false;


### PR DESCRIPTION
Fixes #4916.

This fix makes sure that the input box is unfocused after hitting enter to geocode. Previously this was not the case in Firefox.

@hpinkos can you review and merge?