### PR TITLE
Check for typed array support in BatchTable

### DIFF
--- a/Source/Scene/BatchTable.js
+++ b/Source/Scene/BatchTable.js
@@ -9,6 +9,7 @@ define([
         '../Core/defineProperties',
         '../Core/destroyObject',
         '../Core/DeveloperError',
+        '../Core/FeatureDetection',
         '../Core/Math',
         '../Core/PixelFormat',
         '../Core/RuntimeError',
@@ -28,6 +29,7 @@ define([
         defineProperties,
         destroyObject,
         DeveloperError,
+        FeatureDetection,
         CesiumMath,
         PixelFormat,
         RuntimeError,
@@ -273,6 +275,9 @@ define([
         return Cartesian4.fromElements(x, y, z, w, result);
     }
 
+    if (!FeatureDetection.supportsTypedArrays()) {
+        return;
+    }
     var scratchFloatArray = new Float32Array(1);
 
     function packFloat(value, result) {


### PR DESCRIPTION
We were creating a `new Float32Array` without checking if the browser has typed array support.  This caused IE9 to crash instead of displaying a 'no webgl support' error message.

@mramato 