### PR TITLE
3D Tiles - WebGL stubs

### DIFF
--- a/Documentation/Contributors/TestingGuide/README.md
+++ b/Documentation/Contributors/TestingGuide/README.md
@@ -630,7 +630,7 @@ it('can create a billboard using a URL', function() {
     return pollToPromise(function() {
         return b.ready;
     }).then(function() {
-        expect(scene.renderForSpecs()).toEqual([0, 255, 0, 255]);
+        expect(scene).toRender([0, 255, 0, 255]);
     });
 });
 ```

--- a/Specs/Cesium3DTilesTester.js
+++ b/Specs/Cesium3DTilesTester.js
@@ -45,43 +45,50 @@ define([
         return string + whitespace;
     }
 
-    function expectRender(scene, tileset) {
+    Cesium3DTilesTester.expectRender = function(scene, tileset, callback) {
         tileset.show = false;
-        expect(scene.renderForSpecs()).toEqual([0, 0, 0, 255]);
+        expect(scene).toRender([0, 0, 0, 255]);
         tileset.show = true;
-        var pixelColor = scene.renderForSpecs();
-        expect(pixelColor).not.toEqual([0, 0, 0, 255]);
-        return pixelColor;
-    }
+        expect(scene).toRenderAndCall(function(rgba) {
+            expect(rgba).not.toEqual([0, 0, 0, 255]);
+            if (defined(callback)) {
+                callback(rgba);
+            }
+        });
+    };
 
-    function expectRenderBlank(scene, tileset) {
+    Cesium3DTilesTester.expectRenderBlank = function(scene, tileset) {
         tileset.show = false;
-        expect(scene.renderForSpecs()).toEqual([0, 0, 0, 255]);
+        expect(scene).toRender([0, 0, 0, 255]);
         tileset.show = true;
-        expect(scene.renderForSpecs()).toEqual([0, 0, 0, 255]);
-    }
+        expect(scene).toRender([0, 0, 0, 255]);
+    };
 
     Cesium3DTilesTester.expectRenderTileset = function(scene, tileset) {
         // Verify render before being picked
-        expectRender(scene, tileset);
+        Cesium3DTilesTester.expectRender(scene, tileset);
 
-        // Change the color of the picked feature to yellow
-        var picked = scene.pickForSpecs();
-        expect(picked).toBeDefined();
-        picked.color = Color.clone(Color.YELLOW, picked.color);
+        // Pick a feature
+        expect(scene).toPickAndCall(function(result) {
+            expect(result).toBeDefined();
 
-        // Expect the pixel color to be some shade of yellow
-        var pixelColor = expectRender(scene, tileset);
-        expect(pixelColor[0]).toBeGreaterThan(0);
-        expect(pixelColor[1]).toBeGreaterThan(0);
-        expect(pixelColor[2]).toEqual(0);
-        expect(pixelColor[3]).toEqual(255);
+            // Change the color of the picked feature to yellow
+            result.color = Color.clone(Color.YELLOW, result.color);
 
-        // Turn show off and on
-        picked.show = false;
-        expectRenderBlank(scene, tileset);
-        picked.show = true;
-        expectRender(scene, tileset);
+            // Expect the pixel color to be some shade of yellow
+            Cesium3DTilesTester.expectRender(scene, tileset, function(rgba) {
+                expect(rgba[0]).toBeGreaterThan(0);
+                expect(rgba[1]).toBeGreaterThan(0);
+                expect(rgba[2]).toEqual(0);
+                expect(rgba[3]).toEqual(255);
+            });
+
+            // Turn show off and on
+            result.show = false;
+            Cesium3DTilesTester.expectRenderBlank(scene, tileset);
+            result.show = true;
+            Cesium3DTilesTester.expectRender(scene, tileset);
+        });
     };
 
     Cesium3DTilesTester.waitForTilesLoaded = function(scene, tileset) {

--- a/Specs/Renderer/TextureSpec.js
+++ b/Specs/Renderer/TextureSpec.js
@@ -210,57 +210,69 @@ defineSuite([
     });
 
     it('draws the expected DXT compressed texture color', function() {
-        if (context.s3tc) {
-            texture = new Texture({
-                context : context,
-                pixelFormat : greenDXTImage.internalFormat,
-                source : {
-                    width : greenDXTImage.width,
-                    height : greenDXTImage.height,
-                    arrayBufferView : greenDXTImage.bufferView
-                }
-            });
-
-            var pixels = renderFragment(context);
-            expect(pixels).toEqual([0, 255, 0, 255]);
+        if (!context.s3tc) {
+            return;
         }
+
+        texture = new Texture({
+            context : context,
+            pixelFormat : greenDXTImage.internalFormat,
+            source : {
+                width : greenDXTImage.width,
+                height : greenDXTImage.height,
+                arrayBufferView : greenDXTImage.bufferView
+            }
+        });
+
+        expect({
+            context : context,
+            fragmentShader : fs,
+            uniformMap : uniformMap
+        }).contextToRender([0, 255, 0, 255]);
     });
 
     it('draws the expected PVR compressed texture color', function() {
-        if (context.pvrtc) {
-            texture = new Texture({
-                context : context,
-                pixelFormat : greenPVRImage.internalFormat,
-                source : {
-                    width : greenPVRImage.width,
-                    height : greenPVRImage.height,
-                    arrayBufferView : greenPVRImage.bufferView
-                }
-            });
-
-            var pixels = renderFragment(context);
-            expect(pixels).toEqual([0, 255, 0, 255]);
+        if (!context.pvrtc) {
+            return;
         }
+
+        texture = new Texture({
+            context : context,
+            pixelFormat : greenPVRImage.internalFormat,
+            source : {
+                width : greenPVRImage.width,
+                height : greenPVRImage.height,
+                arrayBufferView : greenPVRImage.bufferView
+            }
+        });
+
+        expect({
+            context : context,
+            fragmentShader : fs,
+            uniformMap : uniformMap
+        }).contextToRender([0, 255, 0, 255]);
     });
 
     it('draws the expected ETC1 compressed texture color', function() {
-        if (context.etc1) {
-            texture = new Texture({
-                context : context,
-                pixelFormat : greenETC1Image.internalFormat,
-                source : {
-                    width : greenETC1Image.width,
-                    height : greenETC1Image.height,
-                    arrayBufferView : greenETC1Image.bufferView
-                }
-            });
-
-            var pixels = renderFragment(context);
-            expect(pixels[0]).toEqual(0);
-            expect(pixels[1]).toBeGreaterThan(250);
-            expect(pixels[2]).toEqual(0);
-            expect(pixels[3]).toEqual(255);
+        if (!context.etc1) {
+            return;
         }
+
+        texture = new Texture({
+            context : context,
+            pixelFormat : greenETC1Image.internalFormat,
+            source : {
+                width : greenETC1Image.width,
+                height : greenETC1Image.height,
+                arrayBufferView : greenETC1Image.bufferView
+            }
+        });
+
+        expect({
+            context : context,
+            fragmentShader : fs,
+            uniformMap : uniformMap
+        }).contextToRender([0, 253, 0, 255]);
     });
 
     it('renders with premultiplied alpha', function() {

--- a/Specs/Scene/Composite3DTileContentSpec.js
+++ b/Specs/Scene/Composite3DTileContentSpec.js
@@ -37,54 +37,50 @@ defineSuite([
         scene.primitives.removeAll();
     });
 
-    function expectRender(tileset) {
-        tileset.show = false;
-        expect(scene.renderForSpecs()).toEqual([0, 0, 0, 255]);
-        tileset.show = true;
-        var pixelColor = scene.renderForSpecs();
-        expect(pixelColor).not.toEqual([0, 0, 0, 255]);
-        return pixelColor;
-    }
-
-    function expectRenderBlank(tileset) {
-        tileset.show = false;
-        expect(scene.renderForSpecs()).toEqual([0, 0, 0, 255]);
-        tileset.show = true;
-        expect(scene.renderForSpecs()).toEqual([0, 0, 0, 255]);
-    }
-
     function expectRenderComposite(tileset) {
-        expectRender(tileset);
+        Cesium3DTilesTester.expectRender(scene, tileset);
 
-        // Change the color of the picked building to yellow
-        var pickedBuilding = scene.pickForSpecs();
-        expect(pickedBuilding).toBeDefined();
-        pickedBuilding.color = Color.clone(Color.YELLOW, pickedBuilding.color);
+        expect(scene).toPickAndCall(function(result) {
+            // Pick a building
+            var pickedBuilding = result;
+            expect(pickedBuilding).toBeDefined();
 
-        // Expect building to be some shade of yellow
-        var pixelColor = expectRender(tileset);
-        expect(pixelColor[0]).toBeGreaterThan(0);
-        expect(pixelColor[1]).toBeGreaterThan(0);
-        expect(pixelColor[2]).toEqual(0);
-        expect(pixelColor[3]).toEqual(255);
+            // Change the color of the picked building to yellow
+            pickedBuilding.color = Color.clone(Color.YELLOW, pickedBuilding.color);
 
-        // Both a building and instance are located at the center, hide the building and pick the instance
-        pickedBuilding.show = false;
-        var pickedInstance = scene.pickForSpecs();
-        expect(pickedInstance).toBeDefined();
-        expect(pickedInstance).not.toEqual(pickedBuilding);
-        pickedInstance.color = Color.clone(Color.GREEN, pickedInstance.color);
+            // Expect the pixel color to be some shade of yellow
+            Cesium3DTilesTester.expectRender(scene, tileset, function(rgba) {
+                expect(rgba[0]).toBeGreaterThan(0);
+                expect(rgba[1]).toBeGreaterThan(0);
+                expect(rgba[2]).toEqual(0);
+                expect(rgba[3]).toEqual(255);
+            });
 
-        // Expect instance to be some shade of green
-        pixelColor = expectRender(tileset);
-        expect(pixelColor[0]).toEqual(0);
-        expect(pixelColor[1]).toBeGreaterThan(0);
-        expect(pixelColor[2]).toEqual(0);
-        expect(pixelColor[3]).toEqual(255);
+            // Both a building and instance are located at the center, hide the building and pick the instance
+            pickedBuilding.show = false;
 
-        // Hide the instance, and expect the render to be blank
-        pickedInstance.show = false;
-        expectRenderBlank(tileset);
+            var pickedInstance;
+            expect(scene).toPickAndCall(function(result) {
+                pickedInstance = result;
+                expect(pickedInstance).toBeDefined();
+                expect(pickedInstance).not.toEqual(pickedBuilding);
+            });
+
+            // Change the color of the picked instance to green
+            pickedInstance.color = Color.clone(Color.GREEN, pickedInstance.color);
+
+            // Expect the pixel color to be some shade of green
+            Cesium3DTilesTester.expectRender(scene, tileset, function(rgba) {
+                expect(rgba[0]).toEqual(0);
+                expect(rgba[1]).toBeGreaterThan(0);
+                expect(rgba[2]).toEqual(0);
+                expect(rgba[3]).toEqual(255);
+            });
+
+            // Hide the instance, and expect the render to be blank
+            pickedInstance.show = false;
+            Cesium3DTilesTester.expectRenderBlank(scene, tileset);
+        });
     }
 
     it('throws with invalid magic', function() {
@@ -130,7 +126,7 @@ defineSuite([
     it('rejects readyPromise on failed request', function() {
         return Cesium3DTilesTester.rejectsReadyPromiseOnFailedRequest('cmpt');
     });
-    
+
     it('renders composite', function() {
         return Cesium3DTilesTester.loadTileset(scene, compositeUrl).then(expectRenderComposite);
     });

--- a/Specs/Scene/ModelInstanceCollectionSpec.js
+++ b/Specs/Scene/ModelInstanceCollectionSpec.js
@@ -165,7 +165,7 @@ defineSuite([
         expectColor = defaultValue(expectColor, true);
 
         collection.show = false;
-        expect(scene.renderForSpecs(time)).toEqual([0, 0, 0, 255]);
+        expect(scene).toRender([0, 0, 0, 255]);
         collection.show = true;
 
         // Verify each instance
@@ -173,9 +173,15 @@ defineSuite([
         for (var i = 0; i < length; ++i) {
             zoomTo(collection, i);
             if (expectColor) {
-                expect(scene.renderForSpecs(time)).not.toEqual([0, 0, 0, 255]);
+                expect({
+                    scene : scene,
+                    time : time
+                }).notToRender([0, 0, 0, 255]);
             } else {
-                expect(scene.renderForSpecs(time)).toEqual([0, 0, 0, 255]);
+                expect({
+                    scene : scene,
+                    time : time
+                }).toRender([0, 0, 0, 255]);
             }
         }
     }
@@ -210,7 +216,10 @@ defineSuite([
             expect(collection._cull).toEqual(true);
             expect(collection._model).toBeDefined();
             expect(collection._model.ready).toEqual(true);
-            expect(collection._model.cacheKey).toEqual(boxUrl + '#instanced');
+
+            if (collection._instancingSupported) {
+                expect(collection._model.cacheKey).toEqual(boxUrl + '#instanced');
+            }
         });
     });
 
@@ -469,10 +478,12 @@ defineSuite([
                 }
             }
 
-            // Check that vertex arrays are different, since each collection has a unique vertex buffer for instanced attributes.
-            for (name in resourcesFirst.vertexArrays) {
-                if (resourcesFirst.vertexArrays.hasOwnProperty(name)) {
-                    expect(resourcesFirst.vertexArrays[name]).not.toEqual(resourcesSecond.vertexArrays[name]);
+            if (collections[0]._instancingSupported) {
+                // Check that vertex arrays are different, since each collection has a unique vertex buffer for instanced attributes.
+                for (name in resourcesFirst.vertexArrays) {
+                    if (resourcesFirst.vertexArrays.hasOwnProperty(name)) {
+                        expect(resourcesFirst.vertexArrays[name]).not.toEqual(resourcesSecond.vertexArrays[name]);
+                    }
                 }
             }
         });

--- a/Specs/Scene/PointCloud3DTileContentSpec.js
+++ b/Specs/Scene/PointCloud3DTileContentSpec.js
@@ -69,15 +69,6 @@ defineSuite([
         scene.primitives.removeAll();
     });
 
-    function expectRenderPointCloud(tileset) {
-        tileset.show = false;
-        expect(scene.renderForSpecs()).toEqual([0, 0, 0, 255]);
-        tileset.show = true;
-        var pixelColor = scene.renderForSpecs();
-        expect(pixelColor).not.toEqual([0, 0, 0, 255]);
-        return pixelColor;
-    }
-
     it('throws with invalid magic', function() {
         var arrayBuffer = Cesium3DTilesTester.generatePointCloudTileBuffer({
             magic : [120, 120, 120, 120]
@@ -178,56 +169,80 @@ defineSuite([
     });
 
     it('renders point cloud with rgb colors', function() {
-        return Cesium3DTilesTester.loadTileset(scene, pointCloudRGBUrl).then(expectRenderPointCloud);
+        return Cesium3DTilesTester.loadTileset(scene, pointCloudRGBUrl).then(function(tileset) {
+            Cesium3DTilesTester.expectRender(scene, tileset);
+        });
     });
 
     it('renders point cloud with rgba colors', function() {
-        return Cesium3DTilesTester.loadTileset(scene, pointCloudRGBAUrl).then(expectRenderPointCloud);
+        return Cesium3DTilesTester.loadTileset(scene, pointCloudRGBAUrl).then(function(tileset) {
+            Cesium3DTilesTester.expectRender(scene, tileset);
+        });
     });
 
     it('renders point cloud with rgb565 colors', function() {
-        return Cesium3DTilesTester.loadTileset(scene, pointCloudRGB565Url).then(expectRenderPointCloud);
+        return Cesium3DTilesTester.loadTileset(scene, pointCloudRGB565Url).then(function(tileset) {
+            Cesium3DTilesTester.expectRender(scene, tileset);
+        });
     });
 
     it('renders point cloud with no colors', function() {
-        return Cesium3DTilesTester.loadTileset(scene, pointCloudNoColorUrl).then(expectRenderPointCloud);
+        return Cesium3DTilesTester.loadTileset(scene, pointCloudNoColorUrl).then(function(tileset) {
+            Cesium3DTilesTester.expectRender(scene, tileset);
+        });
     });
 
     it('renders point cloud with constant colors', function() {
-        return Cesium3DTilesTester.loadTileset(scene, pointCloudConstantColorUrl).then(expectRenderPointCloud);
+        return Cesium3DTilesTester.loadTileset(scene, pointCloudConstantColorUrl).then(function(tileset) {
+            Cesium3DTilesTester.expectRender(scene, tileset);
+        });
     });
 
     it('renders point cloud with normals', function() {
-        return Cesium3DTilesTester.loadTileset(scene, pointCloudNormalsUrl).then(expectRenderPointCloud);
+        return Cesium3DTilesTester.loadTileset(scene, pointCloudNormalsUrl).then(function(tileset) {
+            Cesium3DTilesTester.expectRender(scene, tileset);
+        });
     });
 
     it('renders point cloud with oct encoded normals', function() {
-        return Cesium3DTilesTester.loadTileset(scene, pointCloudNormalsOctEncodedUrl).then(expectRenderPointCloud);
+        return Cesium3DTilesTester.loadTileset(scene, pointCloudNormalsOctEncodedUrl).then(function(tileset) {
+            Cesium3DTilesTester.expectRender(scene, tileset);
+        });
     });
 
     it('renders point cloud with quantized positions', function() {
-        return Cesium3DTilesTester.loadTileset(scene, pointCloudQuantizedUrl).then(expectRenderPointCloud);
+        return Cesium3DTilesTester.loadTileset(scene, pointCloudQuantizedUrl).then(function(tileset) {
+            Cesium3DTilesTester.expectRender(scene, tileset);
+        });
     });
 
     it('renders point cloud with quantized positions and oct-encoded normals', function() {
-        return Cesium3DTilesTester.loadTileset(scene, pointCloudQuantizedOctEncodedUrl).then(expectRenderPointCloud);
+        return Cesium3DTilesTester.loadTileset(scene, pointCloudQuantizedOctEncodedUrl).then(function(tileset) {
+            Cesium3DTilesTester.expectRender(scene, tileset);
+        });
     });
 
     it('renders point cloud that are not defined relative to center', function() {
-        return Cesium3DTilesTester.loadTileset(scene, pointCloudWGS84Url).then(expectRenderPointCloud);
+        return Cesium3DTilesTester.loadTileset(scene, pointCloudWGS84Url).then(function(tileset) {
+            Cesium3DTilesTester.expectRender(scene, tileset);
+        });
     });
 
     it('renders point cloud with batch table', function() {
-        return Cesium3DTilesTester.loadTileset(scene, pointCloudBatchedUrl).then(expectRenderPointCloud);
+        return Cesium3DTilesTester.loadTileset(scene, pointCloudBatchedUrl).then(function(tileset) {
+            Cesium3DTilesTester.expectRender(scene, tileset);
+        });
     });
 
     it('renders point cloud with per-point properties', function() {
-        return Cesium3DTilesTester.loadTileset(scene, pointCloudWithPerPointPropertiesUrl).then(expectRenderPointCloud);
+        return Cesium3DTilesTester.loadTileset(scene, pointCloudWithPerPointPropertiesUrl).then(function(tileset) {
+            Cesium3DTilesTester.expectRender(scene, tileset);
+        });
     });
 
     it('renders point cloud with tile transform', function() {
         return Cesium3DTilesTester.loadTileset(scene, pointCloudWithTransformUrl).then(function(tileset) {
-            expectRenderPointCloud(tileset);
+            Cesium3DTilesTester.expectRender(scene, tileset);
 
             var newLongitude = -1.31962;
             var newLatitude = 0.698874;
@@ -240,19 +255,20 @@ defineSuite([
 
             // Move the camera to the new location
             setCamera(newLongitude, newLatitude);
-            expectRenderPointCloud(tileset);
+            Cesium3DTilesTester.expectRender(scene, tileset);
         });
     });
 
     it('renders with debug color', function() {
         return Cesium3DTilesTester.loadTileset(scene, pointCloudRGBUrl).then(function(tileset) {
-            var color = expectRenderPointCloud(tileset);
+            var color;
+            expect(scene).toRenderAndCall(function(rgba) {
+                color = rgba;
+            });
             tileset.debugColorizeTiles = true;
-            var debugColor = expectRenderPointCloud(tileset);
-            expect(debugColor).not.toEqual(color);
+            expect(scene).notToRender(color);
             tileset.debugColorizeTiles = false;
-            debugColor = expectRenderPointCloud(tileset);
-            expect(debugColor).toEqual(color);
+            expect(scene).toRender(color);
         });
     });
 
@@ -260,7 +276,7 @@ defineSuite([
         return Cesium3DTilesTester.loadTileset(scene, pointCloudRGBUrl).then(function(tileset) {
             scene.morphToColumbusView(0.0);
             setCamera(centerLongitude, centerLatitude);
-            expectRenderPointCloud(tileset);
+            Cesium3DTilesTester.expectRender(scene, tileset);
         });
     });
 
@@ -269,7 +285,7 @@ defineSuite([
             scene.morphTo2D(0.0);
             setCamera(centerLongitude, centerLatitude);
             tileset.maximumScreenSpaceError = 3;
-            expectRenderPointCloud(tileset);
+            Cesium3DTilesTester.expectRender(scene, tileset);
         });
     });
 
@@ -277,33 +293,40 @@ defineSuite([
         return Cesium3DTilesTester.loadTileset(scene, pointCloudRGBUrl).then(function(tileset) {
             var content = tileset._root.content;
             tileset.show = false;
-            var picked = scene.pickForSpecs();
-            expect(picked).toBeUndefined();
+            expect(scene).toPickPrimitive(undefined);
             tileset.show = true;
-            picked = scene.pickForSpecs();
-            expect(picked).toBeDefined();
-            expect(picked.primitive).toBe(tileset);
-            expect(picked.content).toBe(content);
+            expect(scene).toPickAndCall(function(result) {
+                expect(result).toBeDefined();
+                expect(result.primitive).toBe(tileset);
+                expect(result.content).toBe(content);
+            });
         });
     });
 
     it('picks based on batchId', function() {
         return Cesium3DTilesTester.loadTileset(scene, pointCloudBatchedUrl).then(function(tileset) {
-            var pixelColor = scene.renderForSpecs();
+            // Get the original color
+            var color;
+            expect(scene).toRenderAndCall(function(rgba) {
+                color = rgba;
+            });
 
             // Change the color of the picked feature to yellow
-            var picked = scene.pickForSpecs();
-            expect(picked).toBeDefined();
-            picked.color = Color.clone(Color.YELLOW, picked.color);
+            expect(scene).toPickAndCall(function(first) {
+                expect(first).toBeDefined();
 
-            // Expect the pixel color to be some shade of yellow
-            var newPixelColor = scene.renderForSpecs();
-            expect(newPixelColor).not.toEqual(pixelColor);
+                first.color = Color.clone(Color.YELLOW, first.color);
 
-            // Turn show off. Expect a different feature to get picked.
-            picked.show = false;
-            var newPicked = scene.pickForSpecs();
-            expect(newPicked).not.toBe(picked);
+                // Expect the pixel color to be some shade of yellow
+                expect(scene).notToRender(color);
+
+                // Turn show off. Expect a different feature to get picked.
+                first.show = false;
+                expect(scene).toPickAndCall(function(second) {
+                    expect(second).toBeDefined();
+                    expect(second).not.toBe(first);
+                });
+            });
         });
     });
 
@@ -360,32 +383,52 @@ defineSuite([
             var content = tileset._root.content;
 
             // Get the number of picked sections with back face culling on
-            content.backFaceCulling = true;
-            var numberPickedCulling = 0;
-            var picked = scene.pickForSpecs();
-            while (defined(picked)) {
-                picked.show = false;
-                picked = scene.pickForSpecs();
-                ++numberPickedCulling;
-            }
-            content.backFaceCulling = false;
+            var pickedCountCulling = 0;
+            var pickedCount = 0;
+            var picked;
 
-            // Set the shows back to true
-            var length = content.featuresLength;
-            for (var i = 0; i < length; ++i) {
-                var feature = content.getFeature(i);
-                feature.show = true;
-            }
+            expect(scene).toPickAndCall(function(result) {
+                // Set culling to true
+                content.backFaceCulling = true;
 
-            // Get the number of picked sections with back face culling off
-            var numberPicked = 0;
-            picked = scene.pickForSpecs();
-            while (defined(picked)) {
-                picked.show = false;
-                picked = scene.pickForSpecs();
-                ++numberPicked;
-            }
-            expect(numberPicked).toBeGreaterThan(numberPickedCulling);
+                expect(scene).toPickAndCall(function(result) {
+                    picked = result;
+                });
+
+                /* jshint loopfunc: true */
+                while (defined(picked)) {
+                    picked.show = false;
+                    expect(scene).toPickAndCall(function(result) {
+                        picked = result;
+                    });
+                    ++pickedCountCulling;
+                }
+
+                // Set the shows back to true
+                var length = content.featuresLength;
+                for (var i = 0; i < length; ++i) {
+                    var feature = content.getFeature(i);
+                    feature.show = true;
+                }
+
+                // Set culling to false
+                content.backFaceCulling = false;
+
+                expect(scene).toPickAndCall(function(result) {
+                    picked = result;
+                });
+
+                /* jshint loopfunc: true */
+                while (defined(picked)) {
+                    picked.show = false;
+                    expect(scene).toPickAndCall(function(result) {
+                        picked = result;
+                    });
+                    ++pickedCount;
+                }
+
+                expect(pickedCount).toBeGreaterThan(pickedCountCulling);
+            });
         });
     });
 
@@ -397,29 +440,33 @@ defineSuite([
             tileset.style = new Cesium3DTileStyle({
                 color : 'color("red")'
             });
-            expect(scene.renderForSpecs()).toEqual([255, 0, 0, 255]);
+            expect(scene).toRender([255, 0, 0, 255]);
             expect(content._styleTranslucent).toBe(false);
 
             // Applies translucency
             tileset.style = new Cesium3DTileStyle({
                 color : 'rgba(255, 0, 0, 0.005)'
             });
-            var pixelColor = scene.renderForSpecs();
-            expect(pixelColor[0]).toBeLessThan(255);
-            expect(pixelColor[1]).toBe(0);
-            expect(pixelColor[2]).toBe(0);
-            expect(pixelColor[3]).toBe(255);
-            expect(content._styleTranslucent).toBe(true);
+            expect(scene).toRenderAndCall(function(rgba) {
+                // Pixel is a darker red
+                expect(rgba[0]).toBeLessThan(255);
+                expect(rgba[1]).toBe(0);
+                expect(rgba[2]).toBe(0);
+                expect(rgba[3]).toBe(255);
+                expect(content._styleTranslucent).toBe(true);
+            });
 
             // Style with property
             tileset.style = new Cesium3DTileStyle({
                 color : 'color() * ${temperature}'
             });
-            pixelColor = scene.renderForSpecs(); // Pixel color is some shade of gray
-            expect(pixelColor[0]).toBe(pixelColor[1]);
-            expect(pixelColor[0]).toBe(pixelColor[2]);
-            expect(pixelColor[0]).toBeGreaterThan(0);
-            expect(pixelColor[0]).toBeLessThan(255);
+            expect(scene).toRenderAndCall(function(rgba) {
+                // Pixel color is some shade of gray
+                expect(rgba[0]).toBe(rgba[1]);
+                expect(rgba[0]).toBe(rgba[2]);
+                expect(rgba[0]).toBeGreaterThan(0);
+                expect(rgba[0]).toBeLessThan(255);
+            });
 
             // When no conditions are met the default color is white
             tileset.style = new Cesium3DTileStyle({
@@ -429,7 +476,7 @@ defineSuite([
                     ]
                 }
             });
-            expect(scene.renderForSpecs()).toEqual([255, 255, 255, 255]);
+            expect(scene).toRender([255, 255, 255, 255]);
 
             // Apply style with conditions
             tileset.style = new Cesium3DTileStyle({
@@ -448,42 +495,42 @@ defineSuite([
                     ]
                 }
             });
-            expect(scene.renderForSpecs()).not.toEqual([0, 0, 0, 255]);
+            expect(scene).notToRender([0, 0, 0, 255]);
 
             // Apply show style
             tileset.style = new Cesium3DTileStyle({
                 show : true
             });
-            expect(scene.renderForSpecs()).not.toEqual([0, 0, 0, 255]);
+            expect(scene).notToRender([0, 0, 0, 255]);
 
             // Apply show style that hides all points
             tileset.style = new Cesium3DTileStyle({
                 show : false
             });
-            expect(scene.renderForSpecs()).toEqual([0, 0, 0, 255]);
+            expect(scene).toRender([0, 0, 0, 255]);
 
             // Apply show style with property
             tileset.style = new Cesium3DTileStyle({
                 show : '${temperature} > 0.1'
             });
-            expect(scene.renderForSpecs()).not.toEqual([0, 0, 0, 255]);
+            expect(scene).notToRender([0, 0, 0, 255]);
             tileset.style = new Cesium3DTileStyle({
                 show : '${temperature} > 0.9'
             });
-            expect(scene.renderForSpecs()).toEqual([0, 0, 0, 255]);
+            expect(scene).toRender([0, 0, 0, 255]);
 
             // Apply style with point cloud semantics
             tileset.style = new Cesium3DTileStyle({
                 color : '${COLOR} / 2.0',
                 show : '${POSITION}[0] > 0.5'
             });
-            expect(scene.renderForSpecs()).not.toEqual([0, 0, 0, 255]);
+            expect(scene).notToRender([0, 0, 0, 255]);
 
             // Apply pointSize style
             tileset.style = new Cesium3DTileStyle({
                 pointSize : 5.0
             });
-            expect(scene.renderForSpecs()).not.toEqual([0, 0, 0, 255]);
+            expect(scene).notToRender([0, 0, 0, 255]);
         });
     });
 
@@ -493,11 +540,11 @@ defineSuite([
             tileset.style = new Cesium3DTileStyle({
                 color : 'color("red")'
             });
-            expect(scene.renderForSpecs()).toEqual([255, 0, 0, 255]);
+            expect(scene).toRender([255, 0, 0, 255]);
 
             tileset.style.color = new Expression('color("lime")');
             tileset.makeStyleDirty();
-            expect(scene.renderForSpecs()).toEqual([0, 255, 0, 255]);
+            expect(scene).toRender([0, 255, 0, 255]);
         });
     });
 
@@ -506,9 +553,10 @@ defineSuite([
             tileset.style = new Cesium3DTileStyle({
                 color : 'color("red")'
             });
-            var red = scene.renderForSpecs()[0];
-            expect(red).toBeGreaterThan(0);
-            expect(red).toBeLessThan(255);
+            expect(scene).toRenderAndCall(function(rgba) {
+                expect(rgba[0]).toBeGreaterThan(0);
+                expect(rgba[0]).toBeLessThan(255);
+            });
         });
     });
 
@@ -517,7 +565,9 @@ defineSuite([
             tileset.style = new Cesium3DTileStyle({
                 color : 'color("red")'
             });
-            expect(scene.renderForSpecs()[0]).toBeGreaterThan(0);
+            expect(scene).toRenderAndCall(function(rgba) {
+                expect(rgba[0]).toBeGreaterThan(0);
+            });
         });
     });
 
@@ -526,7 +576,7 @@ defineSuite([
             tileset.style = new Cesium3DTileStyle({
                 color : 'color("red")'
             });
-            expect(scene.renderForSpecs()).toEqual([255, 0, 0, 255]);
+            expect(scene).toRender([255, 0, 0, 255]);
         });
     });
 
@@ -562,7 +612,7 @@ defineSuite([
             expect(content._drawCommand.shaderProgram).toBe(shaderProgram);
 
             // Point cloud is styled through the batch table
-            expect(scene.renderForSpecs()).not.toEqual([0, 0, 0, 255]);
+            expect(scene).notToRender([0, 0, 0, 255]);
         });
     });
 

--- a/Specs/createScene.js
+++ b/Specs/createScene.js
@@ -59,6 +59,10 @@ define([
             this.render(time);
         };
 
+        scene.pickForSpecs = function() {
+            this.pick(new Cartesian2(0, 0));
+        };
+
         scene.rethrowRenderErrors = defaultValue(options.rethrowRenderErrors, true);
 
         return scene;


### PR DESCRIPTION
Continuation of #4827 for 3d-tiles

Notes:

* Some tests for Texture are broken on 3d-tiles, but fixed in #4679 
* Cesium3DTileset has one test failure because the model appears black depending on the sun direction. We solve this elsewhere through adding some ambient color. This will be fixed in the 3d-tiles-tools generator.
* Added back `scene.pickForSpecs` just to force a pick to happen. It does not return the picked object. This simplifies some picking tests in `Cesium3DTilesetSpec`.

Otherwise the 3d-tiles code runs fine with webgl-stub on/off, and with browser vs command line.