### PR TITLE
Use defineProperties instead of Object.defineProperties

### DIFF
--- a/Source/Core/TileAvailability.js
+++ b/Source/Core/TileAvailability.js
@@ -4,6 +4,7 @@ define([
     './binarySearch',
     './Cartographic',
     './defined',
+    './defineProperties',
     './sampleTerrain',
     './DeveloperError',
     './Rectangle'
@@ -12,6 +13,7 @@ define([
     binarySearch,
     Cartographic,
     defined,
+    defineProperties,
     sampleTerrain,
     DeveloperError,
     Rectangle) {
@@ -29,7 +31,7 @@ define([
     function TileAvailability(tilingScheme, maximumLevel) {
         this._tilingScheme = tilingScheme;
         this._maximumLevel = maximumLevel;
-        
+
         this._rootNodes = [];
         for (var y = 0; y < tilingScheme.getNumberOfYTilesAtLevel(); ++y) {
             for (var x = 0; x < tilingScheme.getNumberOfXTilesAtLevel(); ++x) {
@@ -75,7 +77,7 @@ define([
      * Determines the level of the most detailed tile covering the position.  This function
      * usually completes in time logarithmic to the number of rectangles added with
      * {@link TileAvailability#addAvailableTileRange}.
-     * 
+     *
      * @param {Cartographic} position The position for which to determine the maximum available level.  The height component is ignored.
      * @return {Number} The level of the most detailed tile covering the position.
      * @throws {DeveloperError} If position is outside any tile according to the tiling scheme.
@@ -212,7 +214,7 @@ define([
         this._ne = undefined;
     }
 
-    Object.defineProperties(QuadtreeNode.prototype, {
+    defineProperties(QuadtreeNode.prototype, {
         nw: {
             get: function() {
                 if (!this._nw) {


### PR DESCRIPTION
`Object.defineProperties` causes old versions of IE to crash