### PR TITLE
Add outline to polyline walls

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@ Change Log
 ### 1.31 - 2017-03-01
 * Added support to `DebugCameraPrimitive` to draw multifrustum planes. The attribute `debugShowFrustumPlanes` of `Scene` and `frustumPlanes` of `CesiumInspector` toggles this. `FrameState` has been augmented to include `frustumSplits` which is a `Number[]` of the near/far planes of the camera frustums.
 * Enable rendering `GroundPrimitives` on hardware without the `EXT_frag_depth` extension; however, this could cause artifacts for certain viewing angles.
+* Always outline KML line extrusions so that they show up properly in 2D and other straight down views.
 * Added compressed texture support. [#4758](https://github.com/AnalyticalGraphicsInc/cesium/pull/4758)
    * glTF models and imagery layers can now reference [KTX](https://www.khronos.org/opengles/sdk/tools/KTX/) textures and textures compressed with [crunch](https://github.com/BinomialLLC/crunch).
    * Added `loadKTX`, to load KTX textures, and `loadCRN` to load crunch compressed textures.

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -49,6 +49,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to Cesiu
    * [Ákos Maróy](https://github.com/akosmaroy)
 * [Raytheon Intelligence and Information Systems](http://www.raytheon.com/)
    * [David Hudlow](https://github.com/DavidHudlow)
+   * [Ashley Mort](https://github.com/mortac8)
 * [Evax Software](http://www.evax.fr)
    * [Evax Software](https://github.com/evax)
 * [Aviture](http://aviture.us.com)

--- a/Source/DataSources/KmlDataSource.js
+++ b/Source/DataSources/KmlDataSource.js
@@ -1156,14 +1156,16 @@ define([
 
             if (defined(polygon)) {
                 wall.fill = polygon.fill;
-                wall.outline = polygon.outline;
                 wall.material = polygon.material;
             }
 
+            //Always outline walls so they show up in 2D.
+            wall.outline = true;
             if (defined(polyline)) {
-                wall.outline = true;
                 wall.outlineColor = defined(polyline.material) ? polyline.material.color : Color.WHITE;
                 wall.outlineWidth = polyline.width;
+            } else if (defined(polygon)) {
+                wall.outlineColor = defined(polygon.material) ? polygon.material.color : Color.WHITE;
             }
         } else {
             if (dataSource._clampToGround && !canExtrude && tessellate) {

--- a/Source/DataSources/KmlDataSource.js
+++ b/Source/DataSources/KmlDataSource.js
@@ -1161,6 +1161,7 @@ define([
             }
 
             if (defined(polyline)) {
+                wall.outline = true;
                 wall.outlineColor = defined(polyline.material) ? polyline.material.color : Color.WHITE;
                 wall.outlineWidth = polyline.width;
             }

--- a/Specs/DataSources/KmlDataSourceSpec.js
+++ b/Specs/DataSources/KmlDataSourceSpec.js
@@ -1142,7 +1142,7 @@ defineSuite([
             expect(entity.wall.material).toBeInstanceOf(ColorMaterialProperty);
             expect(entity.wall.material.color.getValue()).toEqual(uberPolyColor);
             expect(entity.wall.fill.getValue()).toEqual(uberPolyFill);
-            expect(entity.wall.outline.getValue()).toEqual(uberPolyOutline);
+            expect(entity.wall.outline.getValue()).toEqual(true);
             expect(entity.wall.outlineColor.getValue()).toEqual(uberLineColor);
             expect(entity.wall.outlineWidth.getValue()).toEqual(uberLineWidth);
 


### PR DESCRIPTION
This fixes the issue referenced in where KML polylines/walls would not be visible when viewing them directly from above

https://groups.google.com/forum/#!topic/cesium-dev/ZGV9jpxMSIE