### PR TITLE
Fix 3d tiles inspector ThirdParty require path

### DIFF
--- a/Source/Widgets/CesiumInspector/Cesium3DTilesInspectorViewModel.js
+++ b/Source/Widgets/CesiumInspector/Cesium3DTilesInspectorViewModel.js
@@ -14,8 +14,8 @@ define([
         '../../Scene/PerformanceDisplay',
         '../../Core/ScreenSpaceEventHandler',
         '../../Core/ScreenSpaceEventType',
-        '../createCommand',
-        'ThirdParty/when'
+        '../../ThirdParty/when',
+        '../createCommand'
     ], function(
         Cartesian3,
         Cartographic,
@@ -31,8 +31,8 @@ define([
         PerformanceDisplay,
         ScreenSpaceEventHandler,
         ScreenSpaceEventType,
-        createCommand,
-        when) {
+        when,
+        createCommand) {
     'use strict';
 
     function createKnockoutBindings(viewModel, options) {


### PR DESCRIPTION
While working with the inspector I realized the require path was wrong. It worked with sandcastle and the tests because their base paths are different, but adding the 3d tiles inspector to CesiumViewer could not resolve ThirdParty/when