### PR TITLE
Halt camera zoom

### DIFF
--- a/Source/Scene/ScreenSpaceCameraController.js
+++ b/Source/Scene/ScreenSpaceCameraController.js
@@ -568,14 +568,17 @@ define([
                         Cartesian3.clone(camera.direction, forward);
                         Cartesian3.add(cameraPosition, Cartesian3.multiplyByScalar(forward, 1000, scratchCartesian), center);
 
-
                         var positionToTarget = scratchPositionToTarget;
                         var positionToTargetNormal = scratchPositionToTargetNormal;
                         Cartesian3.subtract(target, cameraPosition, positionToTarget);
 
                         Cartesian3.normalize(positionToTarget, positionToTargetNormal);
 
-                        var alpha = Math.acos( -Cartesian3.dot( cameraPositionNormal, positionToTargetNormal ) );
+                        var alphaDot = Cartesian3.dot(cameraPositionNormal, positionToTargetNormal);
+                        if (alphaDot >= 0.0) {
+                            return;
+                        }
+                        var alpha = Math.acos(-alphaDot);
                         var cameraDistance = Cartesian3.magnitude( cameraPosition );
                         var targetDistance = Cartesian3.magnitude( target );
                         var remainingDistance = cameraDistance - distance;
@@ -632,7 +635,9 @@ define([
                         Cartesian3.cross(camera.right, camera.direction, camera.up);
 
                         return;
-                    } else if (defined(centerPosition)) {
+                    }
+
+                    if (defined(centerPosition)) {
                         var positionNormal = Cartesian3.normalize(centerPosition, scratchPositionNormal);
                         var pickedNormal = Cartesian3.normalize(object._zoomWorldPosition, scratchPickNormal);
                         var dotProduct = Cartesian3.dot(pickedNormal, positionNormal);


### PR DESCRIPTION
This is the dumbest possible fix for #4855, much hackier than @kring's abandoned fix, but hear me out.

Basically, the camera "target" is decided when the zoom begins, and is not recalculated every frame of the zoom (for UX reasons).  As such it is possible to get the camera into a situation where it is zooming close to and then past a small entity, such as the Aircraft model in the 3D models sandcastle demo.

@duvifn deserves the credit for [finding the spot where the problem begins](https://github.com/AnalyticalGraphicsInc/cesium/issues/4855#issuecomment-273616112).  He isolates a place where a dot product flips over, this indicates that the camera has already zoomed past its own target in the previous frame of zoom, and is about to flip to the other side of the planet (due to Math.acos being applied to the flipped dot product).

When this "error condition" is detected, the camera is already just barely past its target, and a decision needs to be made:  Other than flipping to the opposite side of the Earth, what can we do?

* Move the camera backwards, to be in front of the target again?  No, that leads to bounce.
* Call `Math.abs` and pretend that the target is still in front of us?  No, that leads to Earthquake Cam.
* Stop.  Just stop the camera from zooming, until the user selects a new zoom target by releasing the right mouse or pinch action and starting a new one.

This PR takes the last option above, so the camera halts one frame after passing the target, and waits for the user to start a new zoom action.