### PR TITLE
Support b3dm files without a batchId attribute

### DIFF
--- a/Source/Scene/Cesium3DTileBatchTable.js
+++ b/Source/Scene/Cesium3DTileBatchTable.js
@@ -854,7 +854,7 @@ define([
                     'void main() \n' +
                     '{ \n' +
                     '    tile_main(); \n' +
-                    '    vec2 st = computeSt(' + batchIdAttributeName + '); \n' +
+                    '    vec2 st = computeSt(' + (batchIdAttributeName ? batchIdAttributeName : '0.0') + '); \n' +
                     '    vec4 featureProperties = texture2D(tile_batchTexture, st); \n' +
                     '    float show = ceil(featureProperties.a); \n' +      // 0 - false, non-zeo - true
                     '    gl_Position *= show; \n';                          // Per-feature show/hide
@@ -887,7 +887,7 @@ define([
                     'void main() \n' +
                     '{ \n' +
                     '    tile_main(); \n' +
-                    '    tile_featureSt = computeSt(' + batchIdAttributeName + '); \n' +
+                    '    tile_featureSt = computeSt(' + (batchIdAttributeName ? batchIdAttributeName : '0.0') + '); \n' +
                     '}';
             }
 
@@ -1088,7 +1088,7 @@ define([
                     'void main() \n' +
                     '{ \n' +
                     '    tile_main(); \n' +
-                    '    vec2 st = computeSt(' + batchIdAttributeName + '); \n' +
+                    '    vec2 st = computeSt(' + (batchIdAttributeName ? batchIdAttributeName : '0.0') + '); \n' +
                     '    vec4 featureProperties = texture2D(tile_batchTexture, st); \n' +
                     '    float show = ceil(featureProperties.a); \n' +    // 0 - false, non-zero - true
                     '    gl_Position *= show; \n' +                       // Per-feature show/hide
@@ -1100,7 +1100,7 @@ define([
                     'void main() \n' +
                     '{ \n' +
                     '    tile_main(); \n' +
-                    '    tile_featureSt = computeSt(' + batchIdAttributeName + '); \n' +
+                    '    tile_featureSt = computeSt(' + (batchIdAttributeName ? batchIdAttributeName : '0.0') + '); \n' +
                     '}';
             }
 


### PR DESCRIPTION
I'm using b3dm for basically massive model rendering, so there's conceptually only one feature and no reason to have a batch table or a `batchId` attribute.  The b3dm spec leads me to believe it's ok to leave out the attribute:

> When a Batch Table is present, the batchId attribute (with the parameter semantic _BATCHID) is required; otherwise, it is not.

However, this leads to a vertex shader compilation failure because the section of the shader generated by `Cesium3DTileBatchTable.prototype.getVertexShaderCallback` contains `vec2 st = computeSt(undefined);`. 

This PR is basically the simplest possible fix for this (if there's no batch ID, assume 0), after which b3dms without a batch table or batchId attribute work fine.