### PR TITLE
ModelInstanceCollection picking

### DIFF
--- a/Apps/Sandcastle/gallery/development/3D Models Instancing.html
+++ b/Apps/Sandcastle/gallery/development/3D Models Instancing.html
@@ -46,7 +46,6 @@ var instancedArraysExtension = context._instancedArrays;
 var count = 1024;
 var spacing = 0.0002;
 var url = '../../SampleData/models/CesiumAir/Cesium_Air.gltf';
-var dynamic = false;
 var useCollection = true;
 
 var centerLongitude = -123.0744619;
@@ -67,7 +66,6 @@ function createCollection(instances) {
     var collection = scene.primitives.add(new Cesium.ModelInstanceCollection({
         url : url,
         instances : instances,
-        dynamic : dynamic,
         debugShowBoundingVolume : debugShowBoundingVolume,
         debugWireframe : debugWireframe
     }));
@@ -148,6 +146,19 @@ function reset() {
 
     useCollection ? createCollection(instances) : createModels(instances);
 }
+
+// Scale picked instances
+var handler = new Cesium.ScreenSpaceEventHandler(viewer.canvas);
+handler.setInputAction(function(movement) {
+    var pickedInstance = scene.pick(movement.position);
+    if (Cesium.defined(pickedInstance)) {
+        console.log(pickedInstance);
+        var instance = useCollection ? pickedInstance : pickedInstance.primitive;
+        var scaleMatrix = Cesium.Matrix4.fromUniformScale(1.1);
+        var modelMatrix = Cesium.Matrix4.multiply(instance.modelMatrix, scaleMatrix, new Cesium.Matrix4());
+        instance.modelMatrix = modelMatrix;
+    }
+}, Cesium.ScreenSpaceEventType.LEFT_CLICK);
 
 Sandcastle.addToolbarMenu([ {
     text : '1024 instances',
@@ -230,20 +241,6 @@ Sandcastle.addToolbarMenu([ {
     text : 'Individual models',
     onselect : function() {
         useCollection = false;
-        reset();
-    }
-}]);
-
-Sandcastle.addToolbarMenu([ {
-    text : 'Static',
-    onselect : function() {
-        dynamic = false;
-        reset();
-    }
-}, {
-    text : 'Dynamic',
-    onselect : function() {
-        dynamic = true;
         reset();
     }
 }]);

--- a/Source/Renderer/ShaderSource.js
+++ b/Source/Renderer/ShaderSource.js
@@ -280,7 +280,7 @@ define([
         this.pickColorQualifier = pickColorQualifier;
         this.includeBuiltIns = defaultValue(options.includeBuiltIns, true);
     }
-    
+
     ShaderSource.prototype.clone = function() {
         return new ShaderSource({
             sources : this.sources,

--- a/Source/Scene/Model.js
+++ b/Source/Scene/Model.js
@@ -2307,21 +2307,32 @@ define([
         // Retrieve the compiled shader program to assign index values to attributes
         var attributeLocations = {};
 
+        var index;
         var technique = techniques[materials[primitive.material].technique];
         var parameters = technique.parameters;
         var attributes = technique.attributes;
-        var programAttributeLocations = model._rendererResources.programs[technique.program].vertexAttributes;
+        var program = model._rendererResources.programs[technique.program];
+        var programVertexAttributes = program.vertexAttributes;
+        var programAttributeLocations = program._attributeLocations;
 
         // Note: WebGL shader compiler may have optimized and removed some attributes from programAttributeLocations
         for (var location in programAttributeLocations){
             if (programAttributeLocations.hasOwnProperty(location)) {
                 var attribute = attributes[location];
-                var index = programAttributeLocations[location].index;
                 if (defined(attribute)) {
-                    var parameter = parameters[attribute];
-                    attributeLocations[parameter.semantic] = index;
+                    var vertexAttribute = programVertexAttributes[location];
+                    if (defined(vertexAttribute)) {
+                        index = vertexAttribute.index;
+                        var parameter = parameters[attribute];
+                        attributeLocations[parameter.semantic] = index;
+                    }
                 } else {
-                    // Pre-created attributes
+                    // Pre-created attributes.
+                    // Some pre-created attributes, like per-instance pickIds, may be compiled out of the draw program
+                    // but should be included in the list of attribute locations for the pick program.
+                    // This is safe to do since programVertexAttributes and programAttributeLocations are equivalent except
+                    // that programVertexAttributes optimizes out unused attributes.
+                    index = programAttributeLocations[location];
                     attributeLocations[location] = index;
                 }
             }

--- a/Source/Scene/ModelInstance.js
+++ b/Source/Scene/ModelInstance.js
@@ -1,0 +1,43 @@
+/*global define*/
+define([
+        '../Core/defineProperties',
+        '../Core/Matrix4'
+], function(
+        defineProperties,
+        Matrix4) {
+    'use strict';
+
+    /**
+     * @private
+     */
+    function ModelInstance(collection, modelMatrix, instanceId) {
+        this.primitive = collection;
+        this._modelMatrix = Matrix4.clone(modelMatrix);
+        this._instanceId = instanceId;
+    }
+
+    defineProperties(ModelInstance.prototype, {
+        instanceId : {
+            get : function() {
+                return this._instanceId;
+            }
+        },
+        model : {
+            get : function() {
+                return this.primitive._model;
+            }
+        },
+        modelMatrix : {
+            get : function() {
+                return Matrix4.clone(this._modelMatrix);
+            },
+            set : function(value) {
+                Matrix4.clone(value, this._modelMatrix);
+                this.primitive.expandBoundingSphere(this._modelMatrix);
+                this.primitive._dirty = true;
+            }
+        }
+    });
+
+    return ModelInstance;
+});

--- a/Source/Scene/ModelInstanceCollection.js
+++ b/Source/Scene/ModelInstanceCollection.js
@@ -21,6 +21,7 @@ define([
         '../ThirdParty/when',
         './getAttributeOrUniformBySemantic',
         './Model',
+        './ModelInstance',
         './SceneMode',
         './ShadowMode'
     ], function(
@@ -45,6 +46,7 @@ define([
         when,
         getAttributeOrUniformBySemantic,
         Model,
+        ModelInstance,
         SceneMode,
         ShadowMode) {
     'use strict';
@@ -55,34 +57,6 @@ define([
         LOADED : 2,
         FAILED : 3
     };
-
-    function ModelInstance(collection, modelMatrix, instanceId) {
-        this.primitive = collection;
-        this._modelMatrix = Matrix4.clone(modelMatrix);
-        this._instanceId = instanceId;
-    }
-
-    defineProperties(ModelInstance.prototype, {
-        instanceId : {
-            get : function() {
-                return this._instanceId;
-            }
-        },
-        model : {
-            get : function() {
-                return this.primitive._model;
-            }
-        },
-        modelMatrix : {
-            get : function() {
-                return Matrix4.clone(this._modelMatrix);
-            },
-            set : function(value) {
-                Matrix4.clone(value, this._modelMatrix);
-                this.primitive._dirty = true;
-            }
-        }
-    });
 
     /**
      * A 3D model instance collection. All instances reference the same underlying model, but have unique
@@ -232,6 +206,15 @@ define([
 
         return BoundingSphere.fromPoints(points);
     }
+
+    var scratchCartesian = new Cartesian3();
+
+    ModelInstanceCollection.prototype.expandBoundingSphere = function(instanceModelMatrix) {
+        if (this._boundingVolumeExpand) {
+            var translation = Matrix4.getTranslation(instanceModelMatrix, scratchCartesian);
+            BoundingSphere.expand(this._boundingVolume, translation, this._boundingVolume);
+        }
+    };
 
     function getInstancedUniforms(collection, programName) {
         if (defined(collection._instancedUniformsByProgram)) {

--- a/Source/Scene/ModelInstanceCollection.js
+++ b/Source/Scene/ModelInstanceCollection.js
@@ -376,7 +376,7 @@ define([
             // Use the vertex shader that was generated earlier
             vs = vertexShaderCached;
             var usesBatchTable = defined(collection._batchTable);
-            var allowPicking = defined(collection._allowPicking);
+            var allowPicking = collection._allowPicking;
             if (usesBatchTable) {
                 vs = collection._batchTable.getPickVertexShaderCallback('a_batchId')(vs);
             } else if (allowPicking) {
@@ -389,7 +389,7 @@ define([
     function getPickFragmentShaderCallback(collection) {
         return function(fs) {
             var usesBatchTable = defined(collection._batchTable);
-            var allowPicking = defined(collection._allowPicking);
+            var allowPicking = collection._allowPicking;
             if (usesBatchTable) {
                 fs = collection._batchTable.getPickFragmentShaderCallback()(fs);
             } else if (allowPicking) {
@@ -469,7 +469,7 @@ define([
     function getPickFragmentShaderNonInstancedCallback(collection) {
         return function(fs) {
             var usesBatchTable = defined(collection._batchTable);
-            var allowPicking = defined(collection._allowPicking);
+            var allowPicking = collection._allowPicking;
             if (usesBatchTable) {
                 fs = collection._batchTable.getPickFragmentShaderCallback()(fs);
             } else if (allowPicking) {

--- a/Specs/Scene/ModelInstanceCollectionSpec.js
+++ b/Specs/Scene/ModelInstanceCollectionSpec.js
@@ -608,8 +608,10 @@ defineSuite([
             zoomTo(collection, 1);
             expect(scene).toPickAndCall(function(result) {
                 var originalMatrix = result.modelMatrix;
+                var originalRadius = collection._boundingVolume.radius;
                 result.modelMatrix = Matrix4.IDENTITY;
                 expect(scene).notToPick();
+                expect(collection._boundingVolume.radius).toBeGreaterThan(originalRadius);
                 result.modelMatrix = originalMatrix;
                 expect(scene).toPickPrimitive(collection);
             });


### PR DESCRIPTION
This fixes picking for `ModelInstanceCollection`. This doesn't affect i3dm picking which continues to work fine.

The picked object that is returned is a `ModelInstance` object which contains the instance's modelMatrix, the underlying collection, the underlying model, and its instance id.

You can set the modelMatrix to move the instance dynamically.

@freder Is this the sort of functionality you had in mind?

