### PR TITLE
deprecated ArcGisImageServerTerrainProvider

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@ Change Log
 ==========
 
 ### 1.31 - 2017-03-01
+* Deprecated
+  * `ArcGisImageServerTerrainProvider` will be removed in 1.32 due to missing TIFF support in web browsers.
 * Breaking changes
   * Corrected spelling of `Color.FUCHSIA` from `Color.FUSCHIA`
 * Added support to `DebugCameraPrimitive` to draw multifrustum planes. The attribute `debugShowFrustumPlanes` of `Scene` and `frustumPlanes` of `CesiumInspector` toggles this. `FrameState` has been augmented to include `frustumSplits` which is a `Number[]` of the near/far planes of the camera frustums.

--- a/Source/Core/ArcGisImageServerTerrainProvider.js
+++ b/Source/Core/ArcGisImageServerTerrainProvider.js
@@ -5,6 +5,7 @@ define([
         './defaultValue',
         './defined',
         './defineProperties',
+        './deprecationWarning',
         './DeveloperError',
         './Ellipsoid',
         './Event',
@@ -21,6 +22,7 @@ define([
         defaultValue,
         defined,
         defineProperties,
+        deprecationWarning,
         DeveloperError,
         Ellipsoid,
         Event,
@@ -62,6 +64,8 @@ define([
      * viewer.terrainProvider = terrainProvider;
      *
      *  @see TerrainProvider
+     *
+     *  @deprecated
      */
     function ArcGisImageServerTerrainProvider(options) {
         //>>includeStart('debug', pragmas.debug);
@@ -69,6 +73,8 @@ define([
             throw new DeveloperError('options.url is required.');
         }
         //>>includeEnd('debug');
+
+        deprecationWarning('ArcGisImageServerTerrainProvider', 'ArcGisImageServerTerrainProvider was deprecated in Cesium 1.31.  It will be removed in 1.32.');
 
         this._url = options.url;
         this._token = options.token;


### PR DESCRIPTION
Resolves https://github.com/AnalyticalGraphicsInc/cesium/issues/4955.

Do we know if there is anything roadmapped for browser TIFF support? Or, out of curiosity for someone who knows very little about how imagery servers work, how impractical is in-engine TIFF -> RGBA PNG conversion if the TIFF can just be fetched as a binary or something?