### PR TITLE
Auto-reset the zoom after zooming past a target.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,8 +2,9 @@ Change Log
 ==========
 
 ### 1.31 - 2017-03-01
+
 * Breaking changes
-  * Corrected spelling of `Color.FUCHSIA` from `Color.FUSCHIA`
+   * Corrected spelling of `Color.FUCHSIA` from `Color.FUSCHIA`. [#4977](https://github.com/AnalyticalGraphicsInc/cesium/pull/4977)
 * Added support to `DebugCameraPrimitive` to draw multifrustum planes. The attribute `debugShowFrustumPlanes` of `Scene` and `frustumPlanes` of `CesiumInspector` toggles this. `FrameState` has been augmented to include `frustumSplits` which is a `Number[]` of the near/far planes of the camera frustums.
 * Enable rendering `GroundPrimitives` on hardware without the `EXT_frag_depth` extension; however, this could cause artifacts for certain viewing angles.
 * Added compressed texture support. [#4758](https://github.com/AnalyticalGraphicsInc/cesium/pull/4758)
@@ -12,6 +13,7 @@ Change Log
    * Added new `PixelFormat` and `WebGLConstants` enums from WebGL extensions `WEBGL_compressed_s3tc`, `WEBGL_compressed_texture_pvrtc`, and `WEBGL_compressed_texture_etc1`.
    * Added `CompressedTextureBuffer`.
 * Improved `RectangleGeometry` by skipping unecessary logic in the code [#4948](https://github.com/AnalyticalGraphicsInc/cesium/pull/4948)
+* Fixed an issue where the camera would zoom past an object and flip to the other side of the globe. [#4967](https://github.com/AnalyticalGraphicsInc/cesium/pull/4967) and [#4982](https://github.com/AnalyticalGraphicsInc/cesium/pull/4982)
 
 ### 1.30 - 2017-02-01
 

--- a/Source/Scene/ScreenSpaceCameraController.js
+++ b/Source/Scene/ScreenSpaceCameraController.js
@@ -576,6 +576,9 @@ define([
 
                         var alphaDot = Cartesian3.dot(cameraPositionNormal, positionToTargetNormal);
                         if (alphaDot >= 0.0) {
+                            // We zoomed past the target, and this zoom is not valid anymore.
+                            // This line causes the next zoom movement to pick a new starting point.
+                            object._zoomMouseStart.x = -1;
                             return;
                         }
                         var alpha = Math.acos(-alphaDot);


### PR DESCRIPTION
Per suggestions from @duvifn and @kring in PR #4967.  This is an enhancement to an already-merged fix for #4855.

This prevents the camera zoom from "locking up" by automatically selecting a new zoom start point.  I tried this with the 3D model sandcastle demo, and it works well.