### PR TITLE
Disable tests that require an extension

### DIFF
--- a/Specs/Renderer/ContextSpec.js
+++ b/Specs/Renderer/ContextSpec.js
@@ -189,6 +189,10 @@ defineSuite([
     });
 
     it('get the fragment depth extension', function() {
+        if (context.fragmentDepth && !context.webgl2) {
+            return;
+        }
+
         var fs =
             'void main()\n' +
             '{\n' +
@@ -201,17 +205,13 @@ defineSuite([
             depth : 0.5
         }).contextToRender([255, 0, 0, 255]);
 
-        var fsFragDepth = '';
-        
-        if (context.fragmentDepth && !context.webgl2) {
-            fsFragDepth += '#extension GL_EXT_frag_depth : enable\n';
-        }
-        
+        var fsFragDepth = '#extension GL_EXT_frag_depth : enable\n';
+
         fsFragDepth +=
             'void main()\n' +
             '{\n' +
             '    gl_FragColor = vec4(0.0, 1.0, 0.0, 1.0);\n';
-        
+
         if (context.fragmentDepth) {
             fsFragDepth += '    gl_FragDepth';
             if (!context.webgl2) {
@@ -219,10 +219,10 @@ defineSuite([
             }
             fsFragDepth += ' = 0.0;\n';
         }
-        
+
         fsFragDepth += '}\n';
 
-        var expected = context.fragmentDepth ? [0, 255, 0, 255] : [255, 0, 0, 255];
+        var expected = [0, 255, 0, 255];
         expect({
             context : context,
             fragmentShader : fsFragDepth,

--- a/Specs/Scene/BillboardCollectionSpec.js
+++ b/Specs/Scene/BillboardCollectionSpec.js
@@ -917,6 +917,10 @@ defineSuite([
     });
 
     it('renders more than 16K billboards', function() {
+        if(!context.instancedArrays) {
+            return;
+        }
+
         for ( var i = 0; i < 16 * 1024; ++i) {
             billboards.add({
                 position : Cartesian3.ZERO,

--- a/Specs/Scene/GroundPrimitiveSpec.js
+++ b/Specs/Scene/GroundPrimitiveSpec.js
@@ -493,6 +493,10 @@ defineSuite([
     });
 
     it('renders with distance display condition per instance attribute', function() {
+        if (!context.floatingPointTexture) {
+            return;
+        }
+
         if (!GroundPrimitive.isSupported(scene)) {
             return;
         }

--- a/Specs/Scene/PrimitiveSpec.js
+++ b/Specs/Scene/PrimitiveSpec.js
@@ -723,6 +723,10 @@ defineSuite([
     });
 
     it('renders with distance display condition per instance attribute', function() {
+        if (!context.floatingPointTexture) {
+            return;
+        }
+
         var near = 10000.0;
         var far = 1000000.0;
         var rect = Rectangle.fromDegrees(-1.0, -1.0, 1.0, 1.0);


### PR DESCRIPTION
The following tests are skipped:
* Scene/Primitive renders with distance display condition per instance attribute (floatingPointTextures)
* Scene/GroundPrimitive renders with distance display condition per instance attribute (floatingPointTextures)
* Scene/BillboardCollection renders more than 16k billboards (instancedArray)
* Renderer/Context get the frame depth extension (frameDepth)

Fixes #4711 along with #4980.