### PR TITLE
Fix rotatable 2D crash

### DIFF
--- a/Source/Scene/Scene.js
+++ b/Source/Scene/Scene.js
@@ -1454,7 +1454,7 @@ define([
         }
 
         if (near !== Number.MAX_VALUE && (numFrustums !== numberOfFrustums || (frustumCommandsList.length !== 0 &&
-                (near < frustumCommandsList[0].near || far > frustumCommandsList[numberOfFrustums - 1].far)))) {
+                (near < frustumCommandsList[0].near || (far > frustumCommandsList[numberOfFrustums - 1].far && !CesiumMath.equalsEpsilon(far, frustumCommandsList[numberOfFrustums - 1].far, CesiumMath.EPSILON8)))))) {
             updateFrustums(near, far, farToNearRatio, numFrustums, frustumCommandsList, is2D, scene.nearToFarDistance2D);
             createPotentiallyVisibleSet(scene);
         }
@@ -2243,7 +2243,7 @@ define([
 
         if (defined(scene._debugFrustumPlanes)) {
             scene._debugFrustumPlanes.update(frameState);
-        } 
+        }
     }
 
     function updateShadowMaps(scene) {


### PR DESCRIPTION
Fixes #4619. Floating point error was causing the maximum far plane of the frustum to be greater than the far plane of the farthest frustum in the multi-frustum by 1e-10. Added an epsilon check to stop possibility of infinite recursion.