### PR TITLE
Support instanced models in 2D

### DIFF
--- a/Apps/Sandcastle/gallery/development/3D Models Instancing.html
+++ b/Apps/Sandcastle/gallery/development/3D Models Instancing.html
@@ -55,7 +55,6 @@ var height = 50.0;
 function orientCamera(center, radius) {
     var controller = scene.screenSpaceCameraController;
     var r = Math.max(radius, camera.frustum.near);
-    controller.minimumZoomDistance = r * 0.5;
 
     var heading = Cesium.Math.toRadians(230.0);
     var pitch = Cesium.Math.toRadians(-20.0);

--- a/Apps/Sandcastle/gallery/development/3D Models Instancing.html
+++ b/Apps/Sandcastle/gallery/development/3D Models Instancing.html
@@ -48,9 +48,9 @@ var spacing = 0.0002;
 var url = '../../SampleData/models/CesiumAir/Cesium_Air.gltf';
 var useCollection = true;
 
-var centerLongitude = -123.0744619;
-var centerLatitude = 44.0503706;
-var height = 5000.0;
+var centerLongitude = -75.61209431;
+var centerLatitude = 40.042530612;
+var height = 50.0;
 
 function orientCamera(center, radius) {
     var controller = scene.screenSpaceCameraController;
@@ -60,6 +60,7 @@ function orientCamera(center, radius) {
     var heading = Cesium.Math.toRadians(230.0);
     var pitch = Cesium.Math.toRadians(-20.0);
     camera.lookAt(center, new Cesium.HeadingPitchRange(heading, pitch, r * 2.0));
+    camera.lookAtTransform(Cesium.Matrix4.IDENTITY);
 }
 
 function createCollection(instances) {
@@ -76,7 +77,7 @@ function createCollection(instances) {
             speedup : 0.5,
             loop : Cesium.ModelAnimationLoop.REPEAT
         });
-        orientCamera(collection._boundingVolume.center, collection._boundingVolume.radius);
+        orientCamera(collection._boundingSphere.center, collection._boundingSphere.radius);
     }).otherwise(function(error){
         window.alert(error);
     });
@@ -222,7 +223,6 @@ Sandcastle.addToolbarMenu([ {
     }
 }]);
 
-
 Sandcastle.addToolbarMenu([ {
     text : 'Instancing Enabled',
     onselect : function() {
@@ -244,6 +244,18 @@ Sandcastle.addToolbarMenu([ {
         reset();
     }
 }]);
+
+Sandcastle.addToolbarButton('2D', function() {
+    scene.morphTo2D(0.0);
+});
+
+Sandcastle.addToolbarButton('CV', function() {
+    scene.morphToColumbusView(0.0);
+});
+
+Sandcastle.addToolbarButton('3D', function() {
+    scene.morphTo3D(0.0);
+});
 
 //Sandcastle_End
 Sandcastle.finishedLoading();

--- a/Source/Core/Transforms.js
+++ b/Source/Core/Transforms.js
@@ -796,14 +796,17 @@ define([
         return result;
     };
 
+    var swizzleMatrix = new Matrix4(
+        0.0, 0.0, 1.0, 0.0,
+        1.0, 0.0, 0.0, 0.0,
+        0.0, 1.0, 0.0, 0.0,
+        0.0, 0.0, 0.0, 1.0
+    );
+
     var scratchCartographic = new Cartographic();
     var scratchCartesian3Projection = new Cartesian3();
-    var scratchCartesian3 = new Cartesian3();
-    var scratchCartesian4Origin = new Cartesian4();
-    var scratchCartesian4NewOrigin = new Cartesian4();
-    var scratchCartesian4NewXAxis = new Cartesian4();
-    var scratchCartesian4NewYAxis = new Cartesian4();
-    var scratchCartesian4NewZAxis = new Cartesian4();
+    var scratchCenter = new Cartesian3();
+    var scratchRotation = new Matrix3();
     var scratchFromENU = new Matrix4();
     var scratchToENU = new Matrix4();
 
@@ -823,59 +826,24 @@ define([
         }
         //>>includeEnd('debug');
 
+        var rtcCenter = Matrix4.getTranslation(matrix, scratchCenter);
         var ellipsoid = projection.ellipsoid;
 
-        var origin = Matrix4.getColumn(matrix, 3, scratchCartesian4Origin);
-        var cartographic = ellipsoid.cartesianToCartographic(origin, scratchCartographic);
-
-        var fromENU = Transforms.eastNorthUpToFixedFrame(origin, ellipsoid, scratchFromENU);
-        var toENU = Matrix4.inverseTransformation(fromENU, scratchToENU);
-
+        // Get the 2D Center
+        var cartographic = ellipsoid.cartesianToCartographic(rtcCenter, scratchCartographic);
         var projectedPosition = projection.project(cartographic, scratchCartesian3Projection);
-        var newOrigin = scratchCartesian4NewOrigin;
-        newOrigin.x = projectedPosition.z;
-        newOrigin.y = projectedPosition.x;
-        newOrigin.z = projectedPosition.y;
-        newOrigin.w = 1.0;
+        Cartesian3.fromElements(projectedPosition.z, projectedPosition.x, projectedPosition.y, projectedPosition);
 
-        var xAxis = Matrix4.getColumn(matrix, 0, scratchCartesian3);
-        var xScale = Cartesian3.magnitude(xAxis);
-        var newXAxis = Matrix4.multiplyByVector(toENU, xAxis, scratchCartesian4NewXAxis);
-        Cartesian4.fromElements(newXAxis.z, newXAxis.x, newXAxis.y, 0.0, newXAxis);
-
-        var yAxis = Matrix4.getColumn(matrix, 1, scratchCartesian3);
-        var yScale = Cartesian3.magnitude(yAxis);
-        var newYAxis = Matrix4.multiplyByVector(toENU, yAxis, scratchCartesian4NewYAxis);
-        Cartesian4.fromElements(newYAxis.z, newYAxis.x, newYAxis.y, 0.0, newYAxis);
-
-        var zAxis = Matrix4.getColumn(matrix, 2, scratchCartesian3);
-        var zScale = Cartesian3.magnitude(zAxis);
-
-        var newZAxis = scratchCartesian4NewZAxis;
-        Cartesian3.cross(newXAxis, newYAxis, newZAxis);
-        Cartesian3.normalize(newZAxis, newZAxis);
-        Cartesian3.cross(newYAxis, newZAxis, newXAxis);
-        Cartesian3.normalize(newXAxis, newXAxis);
-        Cartesian3.cross(newZAxis, newXAxis, newYAxis);
-        Cartesian3.normalize(newYAxis, newYAxis);
-
-        Cartesian3.multiplyByScalar(newXAxis, xScale, newXAxis);
-        Cartesian3.multiplyByScalar(newYAxis, yScale, newYAxis);
-        Cartesian3.multiplyByScalar(newZAxis, zScale, newZAxis);
-
-        Matrix4.setColumn(result, 0, newXAxis, result);
-        Matrix4.setColumn(result, 1, newYAxis, result);
-        Matrix4.setColumn(result, 2, newZAxis, result);
-        Matrix4.setColumn(result, 3, newOrigin, result);
+        // Assuming the instance are positioned in WGS84, invert the WGS84 transform to get the local transform and then convert to 2D
+        var fromENU = Transforms.eastNorthUpToFixedFrame(rtcCenter, ellipsoid, scratchFromENU);
+        var toENU = Matrix4.inverseTransformation(fromENU, scratchToENU);
+        var rotation = Matrix4.getRotation(matrix, scratchRotation);
+        var local = Matrix4.multiplyByMatrix3(toENU, rotation, result);
+        Matrix4.multiply(swizzleMatrix, local, result); // Swap x, y, z for 2D
+        Matrix4.setTranslation(result, projectedPosition, result); // Use the projected center
 
         return result;
     };
-
-    var swizzleMatrix = new Matrix4(
-        0.0, 0.0, 1.0, 0.0,
-        1.0, 0.0, 0.0, 0.0,
-        0.0, 1.0, 0.0, 0.0,
-        0.0, 0.0, 0.0, 1.0);
 
     /**
      * @private
@@ -900,13 +868,9 @@ define([
 
         var cartographic = ellipsoid.cartesianToCartographic(center, scratchCartographic);
         var projectedPosition = projection.project(cartographic, scratchCartesian3Projection);
-        var newOrigin = scratchCartesian4NewOrigin;
-        newOrigin.x = projectedPosition.z;
-        newOrigin.y = projectedPosition.x;
-        newOrigin.z = projectedPosition.y;
-        newOrigin.w = 1.0;
+        Cartesian3.fromElements(projectedPosition.z, projectedPosition.x, projectedPosition.y, projectedPosition);
 
-        var translation = Matrix4.fromTranslation(newOrigin, scratchFromENU);
+        var translation = Matrix4.fromTranslation(projectedPosition, scratchFromENU);
         Matrix4.multiply(swizzleMatrix, toENU, result);
         Matrix4.multiply(translation, result, result);
 

--- a/Source/Scene/Instanced3DModel3DTileContent.js
+++ b/Source/Scene/Instanced3DModel3DTileContent.js
@@ -243,7 +243,7 @@ define([
 
         var batchTableBinaryByteLength = view.getUint32(byteOffset, true);
         byteOffset += sizeOfUint32;
-        
+
         var gltfFormat = view.getUint32(byteOffset, true);
         //>>includeStart('debug', pragmas.debug);
         if (gltfFormat !== 1 && gltfFormat !== 0) {
@@ -300,9 +300,6 @@ define([
         var collectionOptions = {
             instances : new Array(instancesLength),
             batchTable : this.batchTable,
-            boundingVolume : this._tile.contentBoundingVolume.boundingVolume,
-            center : undefined,
-            transform : this._tile.computedTransform,
             cull : false, // Already culled by 3D Tiles
             url : undefined,
             requestType : RequestType.TILES3D,
@@ -321,8 +318,6 @@ define([
         }
 
         var eastNorthUp = featureTable.getGlobalProperty('EAST_NORTH_UP');
-
-        var center = new Cartesian3();
 
         var instances = collectionOptions.instances;
         var instancePosition = new Cartesian3();
@@ -364,7 +359,6 @@ define([
             }
             Cartesian3.unpack(position, 0, instancePosition);
             instanceTranslationRotationScale.translation = instancePosition;
-            Cartesian3.add(center, instancePosition, center);
 
             // Get the instance rotation
             var normalUp = featureTable.getProperty('NORMAL_UP', i, ComponentDatatype.FLOAT, 3);
@@ -443,9 +437,6 @@ define([
             };
         }
 
-        center = Cartesian3.divideByScalar(center, instancesLength, center);
-        collectionOptions.center = center;
-
         var modelInstanceCollection = new ModelInstanceCollection(collectionOptions);
         this._modelInstanceCollection = modelInstanceCollection;
         this.state = Cesium3DTileContentState.PROCESSING;
@@ -490,7 +481,7 @@ define([
         // the content's resource loading.  In the READY state, it will
         // actually generate commands.
         this.batchTable.update(tileset, frameState);
-        this._modelInstanceCollection.transform = this._tile.computedTransform;
+        this._modelInstanceCollection.modelMatrix = this._tile.computedTransform;
         this._modelInstanceCollection.shadows = this._tileset.shadows;
         this._modelInstanceCollection.debugWireframe = this._tileset.debugWireframe;
         this._modelInstanceCollection.update(frameState);

--- a/Source/Scene/Model.js
+++ b/Source/Scene/Model.js
@@ -3627,7 +3627,7 @@ define([
         var nodeStack = scratchNodeStack;
         var computedModelMatrix = model._computedModelMatrix;
 
-        if (model._mode !== SceneMode.SCENE3D) {
+        if ((model._mode !== SceneMode.SCENE3D) && !model._ignoreCommands) {
             var translation = Matrix4.getColumn(computedModelMatrix, 3, scratchComputedTranslation);
             if (!Cartesian4.equals(translation, Cartesian4.UNIT_W)) {
                 computedModelMatrix = Transforms.basisTo2D(projection, computedModelMatrix, scratchComputedMatrixIn2D);

--- a/Source/Scene/ModelInstanceCollection.js
+++ b/Source/Scene/ModelInstanceCollection.js
@@ -69,6 +69,9 @@ define([
     /**
      * A 3D model instance collection. All instances reference the same underlying model, but have unique
      * per-instance properties like model matrix, pick id, etc.
+     * 
+     * Instances are rendered relative-to-center and for best results instances should be positioned close to one another.
+     * Otherwise there may be precision issues if, for example, instances are placed on opposite sides of the globe.
      *
      * @alias ModelInstanceCollection
      * @constructor

--- a/Source/Scene/ModelInstanceCollection.js
+++ b/Source/Scene/ModelInstanceCollection.js
@@ -2,6 +2,8 @@
 define([
         '../Core/BoundingSphere',
         '../Core/Cartesian3',
+        '../Core/Cartesian4',
+        '../Core/Cartographic',
         '../Core/clone',
         '../Core/Color',
         '../Core/ComponentDatatype',
@@ -11,9 +13,11 @@ define([
         '../Core/destroyObject',
         '../Core/DeveloperError',
         '../Core/Math',
+        '../Core/Matrix3',
         '../Core/Matrix4',
         '../Core/oneTimeWarning',
         '../Core/PrimitiveType',
+        '../Core/Transforms',
         '../Renderer/Buffer',
         '../Renderer/BufferUsage',
         '../Renderer/DrawCommand',
@@ -27,6 +31,8 @@ define([
     ], function(
         BoundingSphere,
         Cartesian3,
+        Cartesian4,
+        Cartographic,
         clone,
         Color,
         ComponentDatatype,
@@ -36,9 +42,11 @@ define([
         destroyObject,
         DeveloperError,
         CesiumMath,
+        Matrix3,
         Matrix4,
         oneTimeWarning,
         PrimitiveType,
+        Transforms,
         Buffer,
         BufferUsage,
         DrawCommand,
@@ -68,9 +76,6 @@ define([
      * @param {Object} options Object with the following properties:
      * @param {Object[]} [options.instances] An array of instances, where each instance contains a modelMatrix and optional batchId when options.batchTable is defined.
      * @param {Cesium3DTileBatchTable} [options.batchTable] The batch table of the instanced 3D Tile.
-     * @param {Object} [options.boundingVolume] The bounding volume, typically the bounding volume of the instanced 3D Tile.
-     * @param {Cartesian3} [options.center] The center point of the instances, typically only passed in by the instanced 3D Tile.
-     * @param {Matrix4} [options.transform=Matrix4.IDENTITY] An additional transform to apply to all instances, typically the transform of the 3D Tile.
      * @param {String} [options.url] The url to the .gltf file.
      * @param {Object} [options.headers] HTTP headers to send with the request.
      * @param {Object} [options.requestType] The request type, used for budget scheduling in {@link RequestScheduler}.
@@ -130,12 +135,15 @@ define([
         this._pickCommands = [];
         this._modelCommands = undefined;
 
-        this._boundingVolume = defined(options.boundingVolume) ? options.boundingVolume : createBoundingSphere(this);
-        this._boundingVolumeExpand = !defined(options.boundingVolume); // Expand the bounding volume by the radius of the loaded model
+        this._boundingSphere = createBoundingSphere(this);
+        this._center = Cartesian3.clone(this._boundingSphere.center);
+        this._rtcTransform = new Matrix4();
+        this._rtcModelView = new Matrix4(); // Holds onto uniform
 
-        this._center = defaultValue(options.center, this._boundingVolume.center);
-        this.transform = defined(options.transform) ? options.transform : Matrix4.clone(Matrix4.IDENTITY);
-        this._rtcViewTransform = new Matrix4(); // Holds onto uniform
+        this._mode = undefined;
+
+        this.modelMatrix = Matrix4.clone(Matrix4.IDENTITY);
+        this._modelMatrix = Matrix4.clone(this.modelMatrix);
 
         // Passed on to Model
         this._url = options.url;
@@ -207,13 +215,9 @@ define([
         return BoundingSphere.fromPoints(points);
     }
 
-    var scratchCartesian = new Cartesian3();
-
     ModelInstanceCollection.prototype.expandBoundingSphere = function(instanceModelMatrix) {
-        if (this._boundingVolumeExpand) {
-            var translation = Matrix4.getTranslation(instanceModelMatrix, scratchCartesian);
-            BoundingSphere.expand(this._boundingVolume, translation, this._boundingVolume);
-        }
+        var translation = Matrix4.getTranslation(instanceModelMatrix, scratchCartesian);
+        BoundingSphere.expand(this._boundingSphere, translation, this._boundingSphere);
     };
 
     function getInstancedUniforms(collection, programName) {
@@ -384,8 +388,7 @@ define([
 
     function createModifiedModelView(collection, context) {
         return function() {
-            var rtcTransform = Matrix4.multiplyByTranslation(collection.transform, collection._center, scratchMatrix);
-            return Matrix4.multiply(context.uniformState.view, rtcTransform, collection._rtcViewTransform);
+            return Matrix4.multiply(context.uniformState.view, collection._rtcTransform, collection._rtcModelView);
         };
     }
 
@@ -471,8 +474,6 @@ define([
             return uniformMap;
         };
     }
-
-    var scratchMatrix = new Matrix4();
 
     function getVertexBufferData(collection, context) {
         var instances = collection._instances;
@@ -736,20 +737,20 @@ define([
         var commandsLength = drawCommands.length;
         var instancesLength = collection.length;
         var allowPicking = collection.allowPicking;
-        var boundingVolume = collection._boundingVolume;
+        var boundingSphere = collection._boundingSphere;
         var cull = collection._cull;
 
         for (var i = 0; i < commandsLength; ++i) {
             var drawCommand = DrawCommand.shallowClone(drawCommands[i]);
             drawCommand.instanceCount = instancesLength;
-            drawCommand.boundingVolume = boundingVolume;
+            drawCommand.boundingVolume = boundingSphere;
             drawCommand.cull = cull;
             collection._drawCommands.push(drawCommand);
 
             if (allowPicking) {
                 var pickCommand = DrawCommand.shallowClone(pickCommands[i]);
                 pickCommand.instanceCount = instancesLength;
-                pickCommand.boundingVolume = boundingVolume;
+                pickCommand.boundingVolume = boundingSphere;
                 pickCommand.cull = cull;
                 collection._pickCommands.push(pickCommand);
             }
@@ -812,14 +813,18 @@ define([
         var commandsLength = modelCommands.length;
         var instancesLength = collection.length;
         var allowPicking = collection.allowPicking;
+        var collectionTransform = collection._rtcTransform;
+        var collectionCenter = collection._center;
 
         for (var i = 0; i < commandsLength; ++i) {
             var modelCommand = modelCommands[i];
             for (var j = 0; j < instancesLength; ++j) {
                 var commandIndex = i * instancesLength + j;
                 var drawCommand = collection._drawCommands[commandIndex];
-                var collectionTransform = collection.transform;
-                var instanceMatrix = collection._instances[j]._modelMatrix;
+                var instanceMatrix = Matrix4.clone(collection._instances[j]._modelMatrix, scratchMatrix);
+                instanceMatrix[12] -= collectionCenter.x;
+                instanceMatrix[13] -= collectionCenter.y;
+                instanceMatrix[14] -= collectionCenter.z;
                 instanceMatrix = Matrix4.multiply(collectionTransform, instanceMatrix, scratchMatrix);
                 var nodeMatrix = modelCommand.modelMatrix;
                 var modelMatrix = drawCommand.modelMatrix;
@@ -876,12 +881,42 @@ define([
         }
     }
 
-    ModelInstanceCollection.prototype.update = function(frameState) {
-        if (frameState.mode !== SceneMode.SCENE3D) {
-            oneTimeWarning('Instanced models in 2D', 'Instanced models are only supported in 3D.');
-            return;
-        }
+    var swizzleMatrix = new Matrix4(
+        0.0, 0.0, 1.0, 0.0,
+        1.0, 0.0, 0.0, 0.0,
+        0.0, 1.0, 0.0, 0.0,
+        0.0, 0.0, 0.0, 1.0
+    );
 
+    var scratchCartographic = new Cartographic();
+    var scratchCartesian = new Cartesian3();
+    var scratchCenter = new Cartesian3();
+    var scratchMatrix = new Matrix4();
+    var scratchRotation = new Matrix3();
+
+    function getRtcTransform2D(frameState, rtcTransform, result) {
+        var rtcCenter = Matrix4.getTranslation(rtcTransform, scratchCenter);
+
+        var projection = frameState.mapProjection;
+        var ellipsoid = projection.ellipsoid;
+
+        // Get the 2D Center
+        var cartographic = ellipsoid.cartesianToCartographic(rtcCenter, scratchCartographic);
+        var projectedPosition = projection.project(cartographic, scratchCartesian);
+        Cartesian3.fromElements(projectedPosition.z, projectedPosition.x, projectedPosition.y, projectedPosition);
+
+        // Assuming the instance are positioned in WGS84, invert the WGS84 transform to get the local transform and then convert to 2D
+        var fromENU = Transforms.eastNorthUpToFixedFrame(rtcCenter, ellipsoid, scratchMatrix);
+        var toENU = Matrix4.inverseTransformation(fromENU, scratchMatrix);
+        var rotation = Matrix4.getRotation(rtcTransform, scratchRotation);
+        var local = Matrix4.multiplyByMatrix3(toENU, rotation, scratchMatrix);
+        Matrix4.multiply(swizzleMatrix, local, result); // Swap x, y, z for 2D
+        Matrix4.setTranslation(result, projectedPosition, result); // Use the projected center
+
+        return result;
+    }
+
+    ModelInstanceCollection.prototype.update = function(frameState) {
         if (!this.show) {
             return;
         }
@@ -912,9 +947,7 @@ define([
             this._ready = true;
 
             // Expand bounding volume to fit the radius of the loaded model
-            if (this._boundingVolumeExpand) {
-                this._boundingVolume.radius += model.boundingSphere.radius;
-            }
+            this._boundingSphere.radius += model.boundingSphere.radius;
 
             var modelCommands = getModelCommands(model);
             this._modelCommands = modelCommands.draw;
@@ -934,11 +967,18 @@ define([
             return;
         }
 
-        // If any node changes due to an animation, update the commands. This could be inefficient if the model is
-        // composed of many nodes and only one changes, however it is probably fine in the general use case.
-        // Only applies when instancing is disabled. The instanced shader automatically handles node transformations.
-        if (!instancingSupported && (model.dirty || this._dirty)) {
-            updateCommandsNonInstanced(this);
+        var modeChanged = (frameState.mode !== this._mode);
+        var modelMatrix = this.modelMatrix;
+        var modelMatrixChanged = !Matrix4.equals(this._modelMatrix, modelMatrix);
+
+        if (modeChanged || modelMatrixChanged) {
+            this._mode = frameState.mode;
+            Matrix4.clone(modelMatrix, this._modelMatrix);
+            var rtcTransform = Matrix4.multiplyByTranslation(this._modelMatrix, this._center, this._rtcTransform);
+            if (this._mode !== SceneMode.SCENE3D) {
+                rtcTransform = getRtcTransform2D(frameState, rtcTransform, rtcTransform);
+            }
+            Matrix4.getTranslation(rtcTransform, this._boundingSphere.center);
         }
 
         if (instancingSupported && this._dirty) {
@@ -948,6 +988,13 @@ define([
 
             // PERFORMANCE_IDEA: only update dirty sub-sections instead of the whole collection
             updateVertexBuffer(this, context);
+        }
+
+        // If any node changes due to an animation, update the commands. This could be inefficient if the model is
+        // composed of many nodes and only one changes, however it is probably fine in the general use case.
+        // Only applies when instancing is disabled. The instanced shader automatically handles node transformations.
+        if (!instancingSupported && (model.dirty || this._dirty || modeChanged || modelMatrixChanged)) {
+            updateCommandsNonInstanced(this);
         }
 
         updateShadows(this);

--- a/Specs/Scene/Instanced3DModel3DTileContentSpec.js
+++ b/Specs/Scene/Instanced3DModel3DTileContentSpec.js
@@ -49,6 +49,7 @@ defineSuite([
     });
 
     beforeEach(function() {
+        scene.morphTo3D(0.0);
         setCamera(centerLongitude, centerLatitude);
     });
 
@@ -211,10 +212,43 @@ defineSuite([
 
             // Update tile transform
             tileset._root.transform = newTransform;
-            scene.renderForSpecs();
 
             // Move the camera to the new location
             setCamera(newLongitude, newLatitude);
+            Cesium3DTilesTester.expectRenderTileset(scene, tileset);
+        });
+    });
+
+    it('renders in 2D', function() {
+        return Cesium3DTilesTester.loadTileset(scene, gltfExternalUrl).then(function(tileset) {
+            Cesium3DTilesTester.expectRenderTileset(scene, tileset);
+            tileset.maximumScreenSpaceError = 2.0;
+            scene.morphTo2D(0.0);
+            Cesium3DTilesTester.expectRenderTileset(scene, tileset);
+        });
+    });
+
+    it('renders in 2D with tile transform', function() {
+        return Cesium3DTilesTester.loadTileset(scene, withTransformUrl).then(function(tileset) {
+            Cesium3DTilesTester.expectRenderTileset(scene, tileset);
+            tileset.maximumScreenSpaceError = 2.0;
+            scene.morphTo2D(0.0);
+            Cesium3DTilesTester.expectRenderTileset(scene, tileset);
+        });
+    });
+
+    it('renders in CV', function() {
+        return Cesium3DTilesTester.loadTileset(scene, gltfExternalUrl).then(function(tileset) {
+            Cesium3DTilesTester.expectRenderTileset(scene, tileset);
+            scene.morphToColumbusView(0.0);
+            Cesium3DTilesTester.expectRenderTileset(scene, tileset);
+        });
+    });
+
+    it('renders in CV with tile transform', function() {
+        return Cesium3DTilesTester.loadTileset(scene, withTransformUrl).then(function(tileset) {
+            Cesium3DTilesTester.expectRenderTileset(scene, tileset);
+            scene.morphToColumbusView(0.0);
             Cesium3DTilesTester.expectRenderTileset(scene, tileset);
         });
     });


### PR DESCRIPTION
For #3241 

I tested out a variety of cases like regular i3dm tiles, i3dm with tile transform / changing the transform dynamically, `3D Models Instancing` sandcastle with instancing on/off.

The approach here transforms the instances to 2D with a transform derived from the collection's center.

I think this approach will be fine for most uses cases, like most i3dm tiles, but will definitely break down if instances are located all across the globe. For that the `getRtcTransform2D` function would have to be on an instance-by-instance basis and the vertex buffer would need to be updated when switching to 2D. Since it is a one time operation it may be worth just doing that.

![2d](https://cloud.githubusercontent.com/assets/915398/22865799/1dce1730-f139-11e6-8c90-f5e9ccd15b1b.png)
