### PR TITLE
Fix 3D tiles tests failures related to HTMLNode

### DIFF
--- a/Specs/Widgets/CesiumInspector/Cesium3DTilesInspectorSpec.js
+++ b/Specs/Widgets/CesiumInspector/Cesium3DTilesInspectorSpec.js
@@ -65,8 +65,10 @@ defineSuite([
 
     describe('logging', function() {
         var widget;
+        var container;
+        
         beforeAll(function() {
-            var container = document.createElement('div');
+            container = document.createElement('div');
             container.id = 'testContainer';
             document.body.appendChild(container);
             widget = new Cesium3DTilesInspector('testContainer', scene);
@@ -75,15 +77,12 @@ defineSuite([
             viewModel.tileset = new Cesium3DTileset({
                 url: tilesetUrl
             });
-            var done = when.defer();
-            viewModel._tilesetLoaded.then(function() {
-                done.resolve();
-            });
-            return done;
+            return viewModel._tilesetLoaded;
         });
 
         afterAll(function() {
             widget.destroy();
+            document.body.removeChild(container);
         });
 
         it ('shows performance', function() {


### PR DESCRIPTION
Improper cleanup in Cesium3DTilesInspectorSpec.js was causing other tests to randomly fail because the container elements had the same id.