### PR TITLE
3D Tiles - Unloading fix

### DIFF
--- a/Source/Scene/Cesium3DTileset.js
+++ b/Source/Scene/Cesium3DTileset.js
@@ -1315,7 +1315,7 @@ define([
                         selectTile(tileset, t, fullyVisible, frameState);
 
                         if (outOfCore) {
-                            for (k = 0; (k < childrenLength) && t.canRequestContent(); ++k) {
+                            for (k = 0; k < childrenLength; ++k) {
                                 child = children[k];
                                 // PERFORMANCE_IDEA: we could spin a bit less CPU here by keeping separate lists for unloaded/ready children.
                                 if (child.contentUnloaded) {


### PR DESCRIPTION
Fixes https://github.com/AnalyticalGraphicsInc/cesium/issues/4673

Having the `t.canRequestContent()` check in the loop prevented some tiles from being touched when the request scheduler was full, causing them to be unloaded and continually reloaded.

@jbo023 this fixes the original bug you posted. Let me know if it also works from your end.