### PR TITLE
Prevent normalizing zero vector

### DIFF
--- a/Source/Core/GeometryPipeline.js
+++ b/Source/Core/GeometryPipeline.js
@@ -1178,7 +1178,13 @@ define([
                 for (j = 0; j < vertexNormalData.count; j++) {
                     Cartesian3.add(normal, normalsPerTriangle[normalIndices[vertexNormalData.indexOffset + j]], normal);
                 }
-                Cartesian3.normalize(normal, normal);
+
+                if (Cartesian3.equalsEpsilon(normal, Cartesian3.ZERO, CesiumMath.EPSILON7)) {
+                    Cartesian3.clone(Cartesian3.UNIT_X, normal);
+                } else {
+                    Cartesian3.normalize(normal, normal);
+                }
+
                 normalValues[i3] = normal.x;
                 normalValues[i3 + 1] = normal.y;
                 normalValues[i3 + 2] = normal.z;


### PR DESCRIPTION
`GeometryPipeline.computeNormal` is used by gltf-pipeline and will fail on some models when generating normals. This just checks if the normal is zero before trying to normalize. Maybe not the best fix, but definitely the easiest.

Some more discussion here: https://github.com/AnalyticalGraphicsInc/cesium/issues/4863#issuecomment-274016146