### PR TITLE
3D Tiles - i3dm external url fix

### DIFF
--- a/Source/Scene/Instanced3DModel3DTileContent.js
+++ b/Source/Scene/Instanced3DModel3DTileContent.js
@@ -323,8 +323,7 @@ define([
 
         if (gltfFormat === 0) {
             var gltfUrl = getStringFromTypedArray(gltfView);
-            var baseUrl = defaultValue(this._tileset.baseUrl, '');
-            collectionOptions.url = joinUrls(baseUrl, gltfUrl);
+            collectionOptions.url = joinUrls(getBaseUri(this._url), gltfUrl);
         } else {
             collectionOptions.gltf = gltfView;
             collectionOptions.basePath = getBaseUri(this._url);


### PR DESCRIPTION
This makes the url inside the i3dm tile relative to the tile rather than the tileset.