### PR TITLE
Firefox test failure fix - draws with multiple render targets

### DIFF
--- a/Specs/Renderer/FramebufferSpec.js
+++ b/Specs/Renderer/FramebufferSpec.js
@@ -527,15 +527,22 @@ defineSuite([
             return;
         }
 
+        var source = new Uint8Array(4);
         var colorTexture0 = new Texture({
             context : context,
-            width : 1,
-            height : 1
+            source : {
+                arrayBufferView : source,
+                width : 1,
+                height : 1
+            }
         });
         var colorTexture1 = new Texture({
             context : context,
-            width : 1,
-            height : 1
+            source : {
+                arrayBufferView : source,
+                width : 1,
+                height : 1
+            }
         });
         framebuffer = new Framebuffer({
             context : context,


### PR DESCRIPTION
Related to the same bug from here: #4762 