### PR TITLE
Add event for trackedEntity changes.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,10 @@
 Change Log
 ==========
 
+### 1.32 - 2017-04-03
+
+* Added the event `Viewer.trackedEntityChanged`, which is raised when the value of `viewer.trackedEntity` changes. [#5060](https://github.com/AnalyticalGraphicsInc/cesium/pull/5060)
+
 ### 1.31 - 2017-03-01
 
 * Deprecated

--- a/Source/Widgets/Viewer/Viewer.js
+++ b/Source/Widgets/Viewer/Viewer.js
@@ -664,6 +664,7 @@ Either specify options.terrainProvider instead or set options.baseLayerPicker to
         this._zoomPromise = undefined;
         this._zoomOptions = undefined;
         this._selectedEntityChanged = new Event();
+        this._trackedEntityChanged = new Event();
 
         knockout.track(this, ['_trackedEntity', '_selectedEntity', '_clockTrackedDataSource']);
 
@@ -1171,12 +1172,13 @@ Either specify options.terrainProvider instead or set options.baseLayerPicker to
 
                         this._entityView = undefined;
                         this.camera.lookAtTransform(Matrix4.IDENTITY);
-                        return;
+                    } else {
+                        //We can't start tracking immediately, so we set a flag and start tracking
+                        //when the bounding sphere is ready (most likely next frame).
+                        this._needTrackedEntityUpdate = true;
                     }
 
-                    //We can't start tracking immediately, so we set a flag and start tracking
-                    //when the bounding sphere is ready (most likely next frame).
-                    this._needTrackedEntityUpdate = true;
+                    this._trackedEntityChanged.raiseEvent(value);
                 }
             }
         },
@@ -1216,6 +1218,17 @@ Either specify options.terrainProvider instead or set options.baseLayerPicker to
         selectedEntityChanged : {
             get : function() {
                 return this._selectedEntityChanged;
+            }
+        },
+        /**
+         * Gets the event that is raised when the tracked entity chages
+         * @memberof Viewer.prototype
+         * @type {Event}
+         * @readonly
+         */
+        trackedEntityChanged : {
+            get : function() {
+                return this._trackedEntityChanged;
             }
         },
         /**

--- a/Specs/Widgets/Viewer/ViewerSpec.js
+++ b/Specs/Widgets/Viewer/ViewerSpec.js
@@ -33,7 +33,7 @@ defineSuite([
         'Widgets/SceneModePicker/SceneModePicker',
         'Widgets/SelectionIndicator/SelectionIndicator',
         'Widgets/Timeline/Timeline'
-    ], function(
+    ], 'Widgets/Viewer/Viewer', function(
         Cartesian3,
         ClockRange,
         ClockStep,
@@ -845,6 +845,30 @@ defineSuite([
         expect(myEntity).toBe(entity);
 
         viewer.selectedEntity = undefined;
+        expect(myEntity).toBeUndefined();
+
+        viewer.destroy();
+    });
+
+    it('raises an event when the tracked entity changes', function() {
+        var viewer = createViewer(container);
+
+        var dataSource = new MockDataSource();
+        viewer.dataSources.add(dataSource);
+
+        var entity = new Entity();
+        entity.position = new ConstantPositionProperty(new Cartesian3(123456, 123456, 123456));
+
+        dataSource.entities.add(entity);
+
+        var myEntity;
+        viewer.trackedEntityChanged.addEventListener(function(newValue) {
+            myEntity = newValue;
+        });
+        viewer.trackedEntity = entity;
+        expect(myEntity).toBe(entity);
+
+        viewer.trackedEntity = undefined;
         expect(myEntity).toBeUndefined();
 
         viewer.destroy();


### PR DESCRIPTION
This PR consists of 99.5% recycled code lines from @hpinkos selectedEntityChanged event in #5043.