### PR TITLE
Fix model animation cache collision

### DIFF
--- a/Source/Scene/ModelAnimationCache.js
+++ b/Source/Scene/ModelAnimationCache.js
@@ -27,6 +27,8 @@ define([
     function ModelAnimationCache() {
     }
 
+    var dataUriRegex = /^data\:/i;
+
     function getAccessorKey(model, accessor) {
         var gltf = model.gltf;
         var buffers = gltf.buffers;
@@ -38,8 +40,8 @@ define([
         var byteOffset = bufferView.byteOffset + accessor.byteOffset;
         var byteLength = accessor.count * getBinaryAccessor(accessor).componentsPerAttribute;
 
-        // buffer.path will be undefined when animations are embedded.
-        return model.cacheKey + '//' + defaultValue(buffer.path, '') + '/' + byteOffset + '/' + byteLength;
+        var uriKey = dataUriRegex.test(buffer.uri) ? '' : buffer.uri;
+        return model.cacheKey + '//' + uriKey + '/' + byteOffset + '/' + byteLength;
     }
 
     var cachedAnimationParameters = {


### PR DESCRIPTION
Brought up on the forum: https://groups.google.com/forum/#!topic/cesium-dev/iKU4ORj0vNE

Since `buffer.path` is not defined for glTF 1.0 models (it was for 0.8), animations referencing different bin files could collide in the animation cache. This changes it to use `buffer.uri` instead, but only if it's not a data uri.