### PR TITLE
Change blending options in attempt to fix overlapping billboard fringes.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@ Change Log
 
 * Added the event `Viewer.trackedEntityChanged`, which is raised when the value of `viewer.trackedEntity` changes. [#5060](https://github.com/AnalyticalGraphicsInc/cesium/pull/5060)
 * Added `Camera.DEFAULT_OFFSET` for default view of objects with bounding spheres [#4936](https://github.com/AnalyticalGraphicsInc/cesium/pull/4936)
+* Changed billboard blending behavior [#5066](https://github.com/AnalyticalGraphicsInc/cesium/pull/5056)
 * Fix crunch compressed textures in IE11. [#5057](https://github.com/AnalyticalGraphicsInc/cesium/pull/5057)
 * Fixed a bug in `Quaternion.fromHeadingPitchRoll` that made it erroneously throw an exception when passed individual angles in an unminified / debug build.
 * Fix `GroundPrimitive` rendering in 2D and Columbus View [#5078](https://github.com/AnalyticalGraphicsInc/cesium/pull/5078)

--- a/Source/Scene/BillboardCollection.js
+++ b/Source/Scene/BillboardCollection.js
@@ -1461,14 +1461,19 @@ define([
                 this._rsOpaque = undefined;
             }
 
+            // If OPAQUE_AND_TRANSLUCENT is in use, only the opaque pass gets the benefit of the depth buffer,
+            // not the translucent pass.  Otherwise, if the TRANSLUCENT pass is on its own, it turns on
+            // a depthMask in lieu of full depth sorting (because it has opaque-ish fragments that look bad in OIT).
+            // When the TRANSLUCENT depth mask is in use, label backgrounds require the depth func to be LEQUAL.
+            var useTranslucentDepthMask = this._blendOption === BlendOption.TRANSLUCENT;
+
             if (this._blendOption === BlendOption.TRANSLUCENT || this._blendOption === BlendOption.OPAQUE_AND_TRANSLUCENT) {
                 this._rsTranslucent = RenderState.fromCache({
                     depthTest : {
                         enabled : true,
-                        // Allows label glyphs and billboards to overlap.
-                        func : ((this._blendOption === BlendOption.TRANSLUCENT) ? WebGLConstants.LEQUAL : WebGLConstants.LESS)
+                        func : (useTranslucentDepthMask ? WebGLConstants.LEQUAL : WebGLConstants.LESS)
                     },
-                    depthMask : this._blendOption === BlendOption.TRANSLUCENT,
+                    depthMask : useTranslucentDepthMask,
                     blending : BlendingState.ALPHA_BLEND
                 });
             } else {

--- a/Source/Scene/BillboardCollection.js
+++ b/Source/Scene/BillboardCollection.js
@@ -1453,7 +1453,7 @@ define([
                 this._rsOpaque = RenderState.fromCache({
                     depthTest : {
                         enabled : true,
-                        func : WebGLConstants.LEQUAL  // Allows label glyphs and billboards to overlap.
+                        func : WebGLConstants.LESS
                     },
                     depthMask : true
                 });
@@ -1465,7 +1465,8 @@ define([
                 this._rsTranslucent = RenderState.fromCache({
                     depthTest : {
                         enabled : true,
-                        func : WebGLConstants.LEQUAL  // Allows label glyphs and billboards to overlap.
+                        // Allows label glyphs and billboards to overlap.
+                        func : ((this._blendOption === BlendOption.TRANSLUCENT) ? WebGLConstants.LEQUAL : WebGLConstants.LESS)
                     },
                     depthMask : this._blendOption === BlendOption.TRANSLUCENT,
                     blending : BlendingState.ALPHA_BLEND


### PR DESCRIPTION
If this works, it should fix #5007.  Hopefully it whacks this mole without other ones popping up.

To see old behavior, compare [GeoJSON in 1.27](http://cesiumjs.org/releases/1.27/Apps/Sandcastle/index.html?src=GeoJSON%20simplestyle.html&label=Showcases) to [GeoJSON in 1.30](http://cesiumjs.org/releases/1.30/Apps/Sandcastle/index.html?src=GeoJSON%20simplestyle.html&label=Showcases).  The newer version is on the right:

![badblending1 27_1 30](https://cloud.githubusercontent.com/assets/1235080/23527730/15df6af8-ff65-11e6-8645-599c27bbeaf9.png)

This branch offers [this](http://cesium-dev.s3-website-us-east-1.amazonaws.com/cesium/blending-badness/Apps/Sandcastle/index.html?src=GeoJSON%20simplestyle.html&label=Showcases):

![maybefixedblending](https://cloud.githubusercontent.com/assets/1235080/23528125/b1e1c242-ff66-11e6-9a73-48b89182f197.png)

If you look closely at the 1.27 shot, you can see in the "rounded" corners of the billboard where the old bug was "punching holes" in the ones behind, making the corners appear more squared off.  In the 1.30 shot, everything is messed up, but the "punching holes" bug at least is gone.

On this branch, this demo appears more orderly.  ~~There's a slight issue remaining, where low-alpha fringes of the inset icons punch holes in the background color of the same icon.  This may actually be a bug with the alpha values coming out of the PinBuilder, since the output billboard should be calling for opaque fragments there in the interior, regardless of the inset graphic.~~ *Edit: Issue #5097, fixed in #5099.*

Anyway, I tested this with label backgrounds, and with non-backgrounded labels.  It seems to mostly work.  There's some strangeness where a non-background label that sticks into terrain will have its opaque fragments occluded at a slightly different depth from the translucent fragments.  *Edit: Issue #5083.* But mostly I think this is a big improvement.