### PR TITLE
3D Tiles - small b3dm picking fix

### DIFF
--- a/Source/Scene/Batched3DModel3DTileContent.js
+++ b/Source/Scene/Batched3DModel3DTileContent.js
@@ -321,6 +321,7 @@ define([
             shadows: this._tileset.shadows,
             debugWireframe: this._tileset.debugWireframe,
             incrementallyLoadTextures : false,
+            pickPrimitive : this._tileset,
             vertexShaderLoaded : getVertexShaderCallback(this),
             fragmentShaderLoaded : getFragmentShaderCallback(this),
             uniformMapLoaded : batchTable.getUniformMapCallback(),

--- a/Specs/Scene/Cesium3DTileBatchTableSpec.js
+++ b/Specs/Scene/Cesium3DTileBatchTableSpec.js
@@ -37,7 +37,7 @@ defineSuite([
 
     var withBatchTableUrl = './Data/Cesium3DTiles/Batched/BatchedWithBatchTable/';
     var withoutBatchTableUrl = './Data/Cesium3DTiles/Batched/BatchedWithoutBatchTable/';
-    var batchLengthZeroUrl = './Data/Cesium3DTiles/Batched/BatchedNoBatchIds/';
+    var noBatchIdsUrl = './Data/Cesium3DTiles/Batched/BatchedNoBatchIds/';
     var batchTableHierarchyUrl = './Data/Cesium3DTiles/Hierarchy/BatchTableHierarchy/';
     var batchTableHierarchyBinaryUrl = './Data/Cesium3DTiles/Hierarchy/BatchTableHierarchyBinary/';
     var batchTableHierarchyMultipleParentsUrl = './Data/Cesium3DTiles/Hierarchy/BatchTableHierarchyMultipleParents/';
@@ -570,12 +570,12 @@ defineSuite([
     });
 
     it('renders with featuresLength of zero', function() {
-        return Cesium3DTilesTester.loadTileset(scene, batchLengthZeroUrl).then(function(tileset) {
+        return Cesium3DTilesTester.loadTileset(scene, noBatchIdsUrl).then(function(tileset) {
             Cesium3DTilesTester.expectRender(scene, tileset);
 
             expect(scene).toPickAndCall(function(result) {
                 expect(result).toBeDefined();
-                expect(result.primitive).toBe(tileset._root.content._model);
+                expect(result.primitive).toBe(tileset);
             });
         });
     });


### PR DESCRIPTION
For #3241 

For a b3dm with a `batchLength` of 0 the picked primitive should be the tileset instead of the model.