### PR TITLE
Fix incorrect call to Check.typeOf.number in Quaternion.fromHeadingPitchRoll

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ Change Log
 * Added the event `Viewer.trackedEntityChanged`, which is raised when the value of `viewer.trackedEntity` changes. [#5060](https://github.com/AnalyticalGraphicsInc/cesium/pull/5060)
 * Added `Camera.DEFAULT_OFFSET` for default view of objects with bounding spheres [#4936](https://github.com/AnalyticalGraphicsInc/cesium/pull/4936)
 * Fix crunch compressed textures in IE11. [#5057](https://github.com/AnalyticalGraphicsInc/cesium/pull/5057)
+* Fixed a bug in `Quaternion.fromHeadingPitchRoll` that made it erroneously throw an exception for correct inputs in an unminified / debug build.
 
 ### 1.31 - 2017-03-01
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,7 +6,7 @@ Change Log
 * Added the event `Viewer.trackedEntityChanged`, which is raised when the value of `viewer.trackedEntity` changes. [#5060](https://github.com/AnalyticalGraphicsInc/cesium/pull/5060)
 * Added `Camera.DEFAULT_OFFSET` for default view of objects with bounding spheres [#4936](https://github.com/AnalyticalGraphicsInc/cesium/pull/4936)
 * Fix crunch compressed textures in IE11. [#5057](https://github.com/AnalyticalGraphicsInc/cesium/pull/5057)
-* Fixed a bug in `Quaternion.fromHeadingPitchRoll` that made it erroneously throw an exception for correct inputs in an unminified / debug build.
+* Fixed a bug in `Quaternion.fromHeadingPitchRoll` that made it erroneously throw an exception when passed individual angles in an unminified / debug build.
 
 ### 1.31 - 2017-03-01
 

--- a/Source/Core/Quaternion.js
+++ b/Source/Core/Quaternion.js
@@ -194,9 +194,9 @@ define([
         if (headingOrHeadingPitchRoll instanceof HeadingPitchRoll) {
             Check.typeOf.object('headingPitchRoll', headingOrHeadingPitchRoll);
         } else {
-            Check.typeOf.number(headingOrHeadingPitchRoll, 'heading');
-            Check.typeOf.number(pitchOrResult, 'pitch');
-            Check.typeOf.number(roll, 'roll');
+            Check.typeOf.number('heading', headingOrHeadingPitchRoll);
+            Check.typeOf.number('pitch', pitchOrResult);
+            Check.typeOf.number('roll', roll);
         }
         //>>includeEnd('debug');
         var hpr;

--- a/Specs/Core/QuaternionSpec.js
+++ b/Specs/Core/QuaternionSpec.js
@@ -158,6 +158,16 @@ defineSuite([
         expect(quaternion).toEqualEpsilon(expected, CesiumMath.EPSILON11);
     });
 
+    it('fromHeadingPitchRoll works with individual angle parameters', function() {
+        var heading =  CesiumMath.toRadians(180.0);
+        var pitch = CesiumMath.toRadians(-45.0);
+        var roll = CesiumMath.toRadians(45.0);
+        var hpr = new HeadingPitchRoll( heading, pitch, roll);
+        var quaternion1 = Quaternion.fromHeadingPitchRoll(hpr);
+        var quaternion2 = Quaternion.fromHeadingPitchRoll(heading, pitch, roll);
+        expect(quaternion1).toEqual(quaternion2);
+    });
+
     it('clone without a result parameter', function() {
         var quaternion = new Quaternion(1.0, 2.0, 3.0, 4.0);
         var result = quaternion.clone();


### PR DESCRIPTION
This bug made it impossible to call the function with individual angle parameters in a debug build of Cesium.

I used a regular expression to try to find other occurrences of this bug and didn't find any.