### PR TITLE
Changed loadJson to support loading from string if string is valid JSON

### DIFF
--- a/Source/Core/loadJson.js
+++ b/Source/Core/loadJson.js
@@ -3,12 +3,14 @@ define([
         './clone',
         './defined',
         './DeveloperError',
-        './loadText'
+        './loadText',
+        '../ThirdParty/when'
     ], function(
         clone,
         defined,
         DeveloperError,
-        loadText) {
+        loadText,
+        when) {
     'use strict';
 
     var defaultHeaders = {
@@ -70,9 +72,7 @@ define([
         }
 
         if(jsonData){
-            return new Promise(function(resolve, reject){
-                resolve(jsonData);
-            });
+            return when.resolve(jsonData);
         }else{
             return loadText(url, headers).then(function(value) {
                 return JSON.parse(value);

--- a/Source/Core/loadJson.js
+++ b/Source/Core/loadJson.js
@@ -17,7 +17,7 @@ define([
 
     // note: &#42;&#47;&#42; below is */* but that ends the comment block early
     /**
-     * Asynchronously loads the given URL as JSON.  Returns a promise that will resolve to
+     * Asynchronously loads the given URL or JSON string as JSON.  Returns a promise that will resolve to
      * a JSON object once loaded, or reject if the URL failed to load.  The data is loaded
      * using XMLHttpRequest, which means that in order to make requests to another origin,
      * the server must have Cross-Origin Resource Sharing (CORS) headers enabled. This function
@@ -26,7 +26,7 @@ define([
      *
      * @exports loadJson
      *
-     * @param {String|Promise.<String>} url The URL to request, or a promise for the URL.
+     * @param {String|Promise.<String>} url The URL to request, a JSON string, or a promise for the URL.
      * @param {Object} [headers] HTTP headers to send with the request.
      * 'Accept: application/json,&#42;&#47;&#42;;q=0.01' is added to the request headers automatically
      * if not specified.
@@ -39,7 +39,7 @@ define([
      * }).otherwise(function(error) {
      *     // an error occurred
      * });
-     * 
+     *
      * @see loadText
      * @see {@link http://www.w3.org/TR/cors/|Cross-Origin Resource Sharing}
      * @see {@link http://wiki.commonjs.org/wiki/Promises/A|CommonJS Promises/A}
@@ -59,9 +59,26 @@ define([
             headers.Accept = defaultHeaders.Accept;
         }
 
-        return loadText(url, headers).then(function(value) {
-            return JSON.parse(value);
-        });
+        var jsonData = false;
+
+        if(typeof url === 'string'){
+            try{
+                jsonData = JSON.parse(url);
+            }catch(e){
+
+            }
+        }
+
+        if(jsonData){
+            return new Promise(function(resolve, reject){
+                resolve(jsonData);
+            });
+        }else{
+            return loadText(url, headers).then(function(value) {
+                return JSON.parse(value);
+            });
+        }
+
     }
 
     return loadJson;


### PR DESCRIPTION
I think this is cleaner than mixing Cesium.loadJson and manually wrapping JSON.parse in a promise.