### PR TITLE
Fix GroundPrimitive in 2D

### DIFF
--- a/Source/Shaders/ShadowVolumeVS.glsl
+++ b/Source/Shaders/ShadowVolumeVS.glsl
@@ -23,6 +23,7 @@ void main()
 
     vec4 position = czm_computePosition();
     float delta = min(u_globeMinimumAltitude, czm_geometricToleranceOverMeter * length(position.xyz));
+    delta *= czm_sceneMode == czm_sceneMode3D ? 1.0 : 0.0;
 
     //extrudeDirection is zero for the top layer
     position = position + vec4(extrudeDirection * delta, 0.0);


### PR DESCRIPTION
Do not extrude volumes further in 2D or columbus view. Fixes #5075.

This is also a partial fix for #5026. If you zoom in to the polygons in the GeoJSON attached to that issue, the frame rate goes up. There is still a problem with low frame rates for the global view which I'm still looking into.