### PR TITLE
3D Tiles - Inspector picking fix

### DIFF
--- a/Source/Widgets/CesiumInspector/Cesium3DTilesInspectorViewModel.js
+++ b/Source/Widgets/CesiumInspector/Cesium3DTilesInspectorViewModel.js
@@ -2,6 +2,7 @@
 define([
         '../../Core/Cartesian3',
         '../../Core/Cartographic',
+        '../../Scene/Cesium3DTileFeature',
         '../../Scene/Cesium3DTileset',
         '../../Scene/Cesium3DTileStyle',
         '../../Scene/Cesium3DTileColorBlendMode',
@@ -19,6 +20,7 @@ define([
     ], function(
         Cartesian3,
         Cartographic,
+        Cesium3DTileFeature,
         Cesium3DTileset,
         Cesium3DTileStyle,
         Cesium3DTileColorBlendMode,
@@ -153,8 +155,11 @@ define([
                     return function(val) {
                         if (val) {
                             that._eventHandler.setInputAction(function(e) {
-                                that._feature = scene.pick(e.endPosition);
-                                that._updateStats(true);
+                                var picked = scene.pick(e.endPosition);
+                                if (picked instanceof Cesium3DTileFeature) {
+                                    that._feature = picked;
+                                    that._updateStats(true);
+                                }
                             }, ScreenSpaceEventType.MOUSE_MOVE);
                         } else {
                             that._feature = undefined;
@@ -438,7 +443,6 @@ define([
             _feature: {
                 default: undefined,
                 subscribe: (function() {
-
                     var current;
                     var scratchColor = new Color();
                     var oldColor = new Color();


### PR DESCRIPTION
For #3241 

Small fix that prevents the 3d tiles inspector from doing mouse over picking of things that aren't features, uncovered on the forum: https://groups.google.com/forum/#!topic/cesium-dev/1Rl2cW6tXbo/discussion