### PR TITLE
Don't crash when inspecting a tile that is not loaded.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@ Change Log
 * Fix crunch compressed textures in IE11. [#5057](https://github.com/AnalyticalGraphicsInc/cesium/pull/5057)
 * Fixed a bug in `Quaternion.fromHeadingPitchRoll` that made it erroneously throw an exception when passed individual angles in an unminified / debug build.
 * Fix `GroundPrimitive` rendering in 2D and Columbus View [#5078](https://github.com/AnalyticalGraphicsInc/cesium/pull/5078)
+* Fixed a bug that caused an exception in `CesiumInspectorViewModel` when using the NW / NE / SW / SE / Parent buttons to navigate to a terrain tile that is not yet loaded.
 
 ### 1.31 - 2017-03-01
 

--- a/Source/Widgets/CesiumInspector/CesiumInspectorViewModel.js
+++ b/Source/Widgets/CesiumInspector/CesiumInspectorViewModel.js
@@ -895,7 +895,7 @@ define([
                         this.tileText += '<br>NE corner: ' + newTile.rectangle.east + ', ' + newTile.rectangle.north;
                         var data = newTile.data;
                         if (defined(data)) {
-                            this.tileText += '<br>Min: ' + newTile.data.minimumHeight + ' Max: ' + newTile.data.maximumHeight;
+                            this.tileText += '<br>Min: ' + data.minimumHeight + ' Max: ' + data.maximumHeight;
                         } else {
                             this.tileText += '<br>(Tile is not loaded)';
                         }

--- a/Source/Widgets/CesiumInspector/CesiumInspectorViewModel.js
+++ b/Source/Widgets/CesiumInspector/CesiumInspectorViewModel.js
@@ -493,7 +493,7 @@ define([
 
                 globe._surface._tilesToRender = [];
 
-                if (defined(that._tile)) {
+                if (defined(that._tile) && that._tile.renderable) {
                     globe._surface._tilesToRender.push(that._tile);
                 }
             }

--- a/Source/Widgets/CesiumInspector/CesiumInspectorViewModel.js
+++ b/Source/Widgets/CesiumInspector/CesiumInspectorViewModel.js
@@ -893,7 +893,12 @@ define([
                         this.tileText = 'L: ' + newTile.level + ' X: ' + newTile.x + ' Y: ' + newTile.y;
                         this.tileText += '<br>SW corner: ' + newTile.rectangle.west + ', ' + newTile.rectangle.south;
                         this.tileText += '<br>NE corner: ' + newTile.rectangle.east + ', ' + newTile.rectangle.north;
-                        this.tileText += '<br>Min: ' + newTile.data.minimumHeight + ' Max: ' + newTile.data.maximumHeight;
+                        var data = newTile.data;
+                        if (defined(data)) {
+                            this.tileText += '<br>Min: ' + newTile.data.minimumHeight + ' Max: ' + newTile.data.maximumHeight;
+                        } else {
+                            this.tileText += '<br>(Tile is not loaded)';
+                        }
                     }
                     this._tile = newTile;
                     this.showTileBoundingSphere();

--- a/Specs/Widgets/CesiumInspector/CesiumInspectorViewModelSpec.js
+++ b/Specs/Widgets/CesiumInspector/CesiumInspectorViewModelSpec.js
@@ -216,6 +216,7 @@ defineSuite([
         var viewModel = new CesiumInspectorViewModel(scene, performanceContainer);
         var tile = new QuadtreeTile({tilingScheme : new WebMercatorTilingScheme(), x : 0, y : 0, level : 0});
         tile.data = new GlobeSurfaceTile();
+        tile.renderable = true;
         viewModel.tile = tile;
 
         viewModel.filterTile  = true;

--- a/Specs/Widgets/CesiumInspector/CesiumInspectorViewModelSpec.js
+++ b/Specs/Widgets/CesiumInspector/CesiumInspectorViewModelSpec.js
@@ -227,4 +227,18 @@ defineSuite([
         expect(viewModel.suspendUpdates).toBe(false);
     });
 
+    it('does not try to render a non-renderable tile', function() {
+        var viewModel = new CesiumInspectorViewModel(scene, performanceContainer);
+        var tile = new QuadtreeTile({tilingScheme : new WebMercatorTilingScheme(), x : 0, y : 0, level : 0});
+        tile.data = new GlobeSurfaceTile();
+        viewModel.tile = tile;
+
+        viewModel.filterTile  = true;
+        expect(viewModel.scene.globe._surface._tilesToRender.length).toBe(0);
+        expect(viewModel.suspendUpdates).toBe(true);
+
+        viewModel.filterTile = false;
+        expect(viewModel.suspendUpdates).toBe(false);
+    });
+
 }, 'WebGL');


### PR DESCRIPTION
Instead, just tell the user it's not loaded.

Fixes #5055 
