### PR TITLE
Support access of some tile constants with Cesium3DTileStyle

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -135,3 +135,4 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to Cesiu
 * [Prasanna Natarajan](https://github.com/PrasannaNatarajan)
 * [Joseph Klinger](https://github.com/klingerj)
 * [Grace Lee](https://github.com/glee2244)
+* [Heiko Thiel](https://github.com/SunBlack)

--- a/Source/Scene/PointCloud3DTileContent.js
+++ b/Source/Scene/PointCloud3DTileContent.js
@@ -939,13 +939,13 @@ define([
         }
         if (hasShowStyle) {
             getStyleableProperties(showStyleFunction, styleableProperties);
-            getStyleableTileConstants(colorStyleFunction, styleableTileConstants);
+            getStyleableTileConstants(showStyleFunction, styleableTileConstants);
             getStyleableSemantics(showStyleFunction, styleableSemantics);
             showStyleFunction = modifyStyleFunction(showStyleFunction);
         }
         if (hasPointSizeStyle) {
             getStyleableProperties(pointSizeStyleFunction, styleableProperties);
-            getStyleableTileConstants(colorStyleFunction, styleableTileConstants);
+            getStyleableTileConstants(pointSizeStyleFunction, styleableTileConstants);
             getStyleableSemantics(pointSizeStyleFunction, styleableSemantics);
             pointSizeStyleFunction = modifyStyleFunction(pointSizeStyleFunction);
         }

--- a/Source/Scene/PointCloud3DTileContent.js
+++ b/Source/Scene/PointCloud3DTileContent.js
@@ -913,7 +913,7 @@ define([
         var usesNormalSemantic = styleableProperties.indexOf('NORMAL') >= 0;
 		
 		// Split default properties from user properties
-        var userProperties = styleableProperties.filter(function(property) { defaultProperties.includes(property); });
+        var userProperties = styleableProperties.filter(function(property) { return !defaultProperties.includes(property); });
 		
         //>>includeStart('debug', pragmas.debug);
         if (usesNormalSemantic && !hasNormals) {

--- a/Source/Scene/PointCloud3DTileContent.js
+++ b/Source/Scene/PointCloud3DTileContent.js
@@ -811,7 +811,7 @@ define([
 
     function getStyleableProperties(source, properties) {
         // Get all the properties used by this style
-        var regex = /czm_tiles3d_style_([\w_]+)/g;
+        var regex = /czm_tiles3d_style_(\w+)/g;
         var matches = regex.exec(source);
         while (matches !== null) {
             var name = matches[1];
@@ -839,7 +839,7 @@ define([
             var property = defaultProperties[i];
             var styleName = 'czm_tiles3d_style_' + property;
             var replaceName = property.toLowerCase();
-            source = source.replace(new RegExp(styleName + "([^\w_$])", 'g'), replaceName + "$1");
+            source = source.replace(new RegExp(styleName + '(\\W)', 'g'), replaceName + '$1');
         }
 
         // Edit the function header to accept the point position, color, and normal
@@ -911,10 +911,10 @@ define([
 
         var usesColorSemantic = styleableProperties.indexOf('COLOR') >= 0;
         var usesNormalSemantic = styleableProperties.indexOf('NORMAL') >= 0;
-		
-		// Split default properties from user properties
-        var userProperties = styleableProperties.filter(function(property) { return !defaultProperties.includes(property); });
-		
+
+        // Split default properties from user properties
+        var userProperties = styleableProperties.filter(function(property) { return defaultProperties.indexOf(property) === -1; });
+
         //>>includeStart('debug', pragmas.debug);
         if (usesNormalSemantic && !hasNormals) {
             throw new DeveloperError('Style references the NORMAL semantic but the point cloud does not have normals');

--- a/Source/Scene/PointCloud3DTileContent.js
+++ b/Source/Scene/PointCloud3DTileContent.js
@@ -807,7 +807,7 @@ define([
         });
     }
 
-    var semantics = ['POSITION', 'COLOR', 'NORMAL', 'ABSOLUTE_POSITION'];
+    var semantics = ['POSITION', 'COLOR', 'NORMAL', 'POSITION_ABSOLUTE'];
 
     function getStyleableProperties(source, properties) {
         // Get all the properties used by this style
@@ -855,7 +855,7 @@ define([
         }
 
         // Edit the function header to accept the point position, color, and normal
-        return source.replace('()', '(vec3 position, vec3 absolute_position, vec4 color, vec3 normal)');
+        return source.replace('()', '(vec3 position, vec3 position_absolute, vec4 color, vec3 normal)');
     }
 
     function createShaders(content, frameState, style) {
@@ -1069,7 +1069,7 @@ define([
         } else {
             vs += '    vec3 position = a_position; \n';
         }
-        vs += '    vec3 absolute_position = vec3(czm_model * vec4(position, 1.0)); \n';
+        vs += '    vec3 position_absolute = vec3(czm_model * vec4(position, 1.0)); \n';
 
         if (hasNormals) {
             if (isOctEncoded16P) {
@@ -1082,15 +1082,15 @@ define([
         }
 
         if (hasColorStyle) {
-            vs += '    color = getColorFromStyle(position, absolute_position, color, normal); \n';
+            vs += '    color = getColorFromStyle(position, position_absolute, color, normal); \n';
         }
 
         if (hasShowStyle) {
-            vs += '    float show = float(getShowFromStyle(position, absolute_position, color, normal)); \n';
+            vs += '    float show = float(getShowFromStyle(position, position_absolute, color, normal)); \n';
         }
 
         if (hasPointSizeStyle) {
-            vs += '    gl_PointSize = getPointSizeFromStyle(position, absolute_position, color, normal); \n';
+            vs += '    gl_PointSize = getPointSizeFromStyle(position, position_absolute, color, normal); \n';
         } else {
             vs += '    gl_PointSize = u_pointSize; \n';
         }


### PR DESCRIPTION
Support access of RTC_CENTER, QUANTIZED_VOLUME_SCALE and QUANTIZED_VOLUME_OFFSET by Cesium3DTileStyle.

Example:
```
new Cesium3DTileStyle({
	"color": "rgb((${RTC_CENTER}.z + ${POSITION}.z) % 255, 0, 0)"
});
```

Related issue: #4654