### PR TITLE
Fix broken deploy when branch name uses non-NPM-safe characters.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -327,7 +327,7 @@ gulp.task('deploy-s3', function(done) {
         return;
     }
 
-    var argv = yargs.usage('Usage: delpoy -b [Bucket Name] -d [Upload Directory]')
+    var argv = yargs.usage('Usage: deploy-s3 -b [Bucket Name] -d [Upload Directory]')
         .demand(['b', 'd']).argv;
 
     var uploadDirectory = argv.d;
@@ -570,7 +570,8 @@ function listAll(s3, bucketName, prefix, files, marker) {
 gulp.task('deploy-set-version', function() {
     var version = yargs.argv.version;
     if (version) {
-        packageJson.version += '-' + version;
+        // NPM versions can only contain alphanumeric and hyphen characters
+        packageJson.version += '-' + version.replace(/[^[0-9A-Za-z-]/g, '');
         fs.writeFileSync('package.json', JSON.stringify(packageJson, undefined, 2));
     }
 });


### PR DESCRIPTION
The deploy script dumps the branch name into the NPM version.  Only certain characters are allowed in package.json versions.  Specifically, only hyphens and alphanumerics are allowed.  This breaks deploy from any branch that doesn't meet that criteria.  For example, branches with underscore in the name crash during deploy.

This PR removes non-valid characters from the version.