### PR TITLE
Add automatic uniform for scene background color

### DIFF
--- a/Source/Renderer/AutomaticUniforms.js
+++ b/Source/Renderer/AutomaticUniforms.js
@@ -1421,7 +1421,7 @@ define([
          * // Example: In fragment shader, if frag color matches background, invert frag color.
          * if (czm_backgroundColor.rgb == gl_FragColor.rgb)
          * {
-         *    gl_FragColor = vec4(1.0-gl_FragColor.r, 1.0-gl_FragColor.g, 1.0-gl_FragColor.b, gl_FragColor.a);
+         *    gl_FragColor.rgb = vec3(1.0) - gl_FragColor.rgb;
          * }
          */
         czm_backgroundColor : new AutomaticUniform({

--- a/Source/Renderer/AutomaticUniforms.js
+++ b/Source/Renderer/AutomaticUniforms.js
@@ -1409,6 +1409,24 @@ define([
         }),
 
         /**
+         * An automatic GLSL uniform representing the current scene background color.
+         *
+         * @alias czm_backgroundColor
+         * @glslUniform
+         *
+         * @example
+         * // GLSL declaration
+         * uniform vec4 czm_pass;
+         */
+        czm_backgroundColor : new AutomaticUniform({
+            size : 1,
+            datatype : WebGLConstants.FLOAT_VEC4,
+            getValue : function(uniformState) {
+                return uniformState.backgroundColor;
+            }
+        }),
+
+        /**
          * An automatic GLSL uniform representing a 3x3 rotation matrix that transforms
          * from True Equator Mean Equinox (TEME) axes to the pseudo-fixed axes at the current scene time.
          *

--- a/Source/Renderer/AutomaticUniforms.js
+++ b/Source/Renderer/AutomaticUniforms.js
@@ -1416,7 +1416,13 @@ define([
          *
          * @example
          * // GLSL declaration
-         * uniform vec4 czm_pass;
+         * uniform vec4 czm_backgroundColor;
+         *
+         * // Example: In fragment shader, if frag color matches background, invert frag color.
+         * if (czm_backgroundColor.rgb == gl_FragColor.rgb)
+         * {
+         *    gl_FragColor = vec4(1.0-gl_FragColor.r, 1.0-gl_FragColor.g, 1.0-gl_FragColor.b, gl_FragColor.a);
+         * }
          */
         czm_backgroundColor : new AutomaticUniform({
             size : 1,

--- a/Source/Renderer/AutomaticUniforms.js
+++ b/Source/Renderer/AutomaticUniforms.js
@@ -1422,7 +1422,9 @@ define([
          * vec4 adjustColorForContrast(vec4 color)
          * {
          *     if (czm_backgroundColor.rgb == color.rgb)
+         *     {
          *         color.rgb = vec3(1.0) - color.rgb;
+         *     }
          *
          *     return color;
          * }

--- a/Source/Renderer/AutomaticUniforms.js
+++ b/Source/Renderer/AutomaticUniforms.js
@@ -1418,10 +1418,13 @@ define([
          * // GLSL declaration
          * uniform vec4 czm_backgroundColor;
          *
-         * // Example: In fragment shader, if frag color matches background, invert frag color.
-         * if (czm_backgroundColor.rgb == gl_FragColor.rgb)
+         * // Example: If the given color's RGB matches the background color, invert it.
+         * vec4 adjustColorForContrast(vec4 color)
          * {
-         *    gl_FragColor.rgb = vec3(1.0) - gl_FragColor.rgb;
+         *     if (czm_backgroundColor.rgb == color.rgb)
+         *         color.rgb = vec3(1.0) - color.rgb;
+         *
+         *     return color;
          * }
          */
         czm_backgroundColor : new AutomaticUniform({

--- a/Source/Renderer/UniformState.js
+++ b/Source/Renderer/UniformState.js
@@ -5,6 +5,7 @@ define([
         '../Core/Cartesian3',
         '../Core/Cartesian4',
         '../Core/Cartographic',
+        '../Core/Color',
         '../Core/defined',
         '../Core/defineProperties',
         '../Core/EncodedCartesian3',
@@ -21,6 +22,7 @@ define([
         Cartesian3,
         Cartesian4,
         Cartographic,
+        Color,
         defined,
         defineProperties,
         EncodedCartesian3,
@@ -147,7 +149,7 @@ define([
         this._eyeHeight2D = new Cartesian2();
         this._resolutionScale = 1.0;
         this._orthographicIn3D = false;
-        this._backgroundColor = undefined;
+        this._backgroundColor = new Color();
 
         this._fogDensity = undefined;
 
@@ -928,10 +930,6 @@ define([
         this._pass = pass;
     };
 
-    UniformState.prototype.updateBackgroundColor = function(color) {
-        this._backgroundColor = color;
-    };
-
     /**
      * Synchronizes frame state with the uniform state.  This is called
      * by the {@link Scene} when rendering to ensure that automatic GLSL uniforms
@@ -977,6 +975,7 @@ define([
         }
 
         this._geometricToleranceOverMeter = pixelSizePerMeter * frameState.maximumScreenSpaceError;
+        Color.clone(frameState.backgroundColor, this._backgroundColor);
     };
 
     function cleanViewport(uniformState) {

--- a/Source/Renderer/UniformState.js
+++ b/Source/Renderer/UniformState.js
@@ -785,6 +785,7 @@ define([
         },
 
         /**
+         * The current background color
          * @memberof UniformState.prototype
          * @type {Color}
          */

--- a/Source/Renderer/UniformState.js
+++ b/Source/Renderer/UniformState.js
@@ -147,6 +147,7 @@ define([
         this._eyeHeight2D = new Cartesian2();
         this._resolutionScale = 1.0;
         this._orthographicIn3D = false;
+        this._backgroundColor = undefined;
 
         this._fogDensity = undefined;
 
@@ -783,6 +784,16 @@ define([
 
         /**
          * @memberof UniformState.prototype
+         * @type {Color}
+         */
+        backgroundColor : {
+            get : function() {
+                return this._backgroundColor;
+            }
+        },
+
+        /**
+         * @memberof UniformState.prototype
          * @type {Number}
          */
         imagerySplitPosition : {
@@ -915,6 +926,10 @@ define([
 
     UniformState.prototype.updatePass = function(pass) {
         this._pass = pass;
+    };
+
+    UniformState.prototype.updateBackgroundColor = function(color) {
+        this._backgroundColor = color;
     };
 
     /**

--- a/Source/Scene/FrameState.js
+++ b/Source/Scene/FrameState.js
@@ -271,6 +271,13 @@ define([
          * @default []
          */
         this.frustumSplits = [];
+
+        /**
+         * The current scene background color
+         *
+         * @type {Color}
+         */
+        this.backgroundColor = undefined;
     }
 
     FrameState.prototype.addCommand = function(command) {

--- a/Source/Scene/Scene.js
+++ b/Source/Scene/Scene.js
@@ -2562,6 +2562,9 @@ define([
 
         us.update(frameState);
 
+        var backgroundColor = defaultValue(scene.backgroundColor, Color.BLACK);
+        us.updateBackgroundColor(backgroundColor);
+
         var shadowMap = scene.shadowMap;
         if (defined(shadowMap) && shadowMap.enabled) {
             // Update the sun's direction
@@ -2582,7 +2585,7 @@ define([
         }
 
         updateEnvironment(scene);
-        updateAndExecuteCommands(scene, passState, defaultValue(scene.backgroundColor, Color.BLACK));
+        updateAndExecuteCommands(scene, passState, backgroundColor);
         resolveFramebuffers(scene, passState);
         executeOverlayCommands(scene, passState);
 

--- a/Source/Scene/Scene.js
+++ b/Source/Scene/Scene.js
@@ -2556,14 +2556,15 @@ define([
         var frameNumber = CesiumMath.incrementWrap(frameState.frameNumber, 15000000.0, 1.0);
         updateFrameState(scene, frameNumber, time);
         frameState.passes.render = true;
+
+        var backgroundColor = defaultValue(scene.backgroundColor, Color.BLACK);
+        frameState.backgroundColor = backgroundColor;
+
         frameState.creditDisplay.beginFrame();
 
         scene.fog.update(frameState);
 
         us.update(frameState);
-
-        var backgroundColor = defaultValue(scene.backgroundColor, Color.BLACK);
-        us.updateBackgroundColor(backgroundColor);
 
         var shadowMap = scene.shadowMap;
         if (defined(shadowMap) && shadowMap.enabled) {

--- a/Specs/Renderer/AutomaticUniformSpec.js
+++ b/Specs/Renderer/AutomaticUniformSpec.js
@@ -2,6 +2,7 @@
 defineSuite([
         'Core/Cartesian2',
         'Core/Cartesian3',
+        'Core/Color',
         'Core/defaultValue',
         'Core/Matrix4',
         'Renderer/Pass',
@@ -15,6 +16,7 @@ defineSuite([
     ], 'Renderer/AutomaticUniforms', function(
         Cartesian2,
         Cartesian3,
+        Color,
         defaultValue,
         Matrix4,
         Pass,
@@ -1230,6 +1232,21 @@ defineSuite([
         var fs =
             'void main() { ' +
             '  gl_FragColor = vec4(czm_imagerySplitPosition == 0.0); ' +
+            '}';
+        expect({
+            context : context,
+            fragmentShader : fs
+        }).contextToRender();
+    });
+
+    it('has czm_backgroundColor', function() {
+        var frameState = createFrameState(context, createMockCamera());
+        frameState.backgroundColor = new Color(0.0, 0.25, 0.75, 1.0);
+        context.uniformState.update(frameState);
+
+        var fs =
+            'void main() { ' +
+            '  gl_FragColor = vec4(czm_backgroundColor.r == 0.0, czm_backgroundColor.g == 0.25, czm_backgroundColor.b == 0.75, czm_backgroundColor.a == 1.0); ' +
             '}';
         expect({
             context : context,


### PR DESCRIPTION
Our app sometimes changes the scene's background color. We want our shaders to be able to adjust fragment color based on the background color in order to ensure proper contrast.