### PR TITLE
Fix Orthographic canvas resize

### DIFF
--- a/Source/Scene/OrthographicFrustum.js
+++ b/Source/Scene/OrthographicFrustum.js
@@ -87,11 +87,7 @@ define([
             frustum._far = frustum.far;
 
             if (!frustum._useDeprecated) {
-                var ratio = frustum.aspectRatio;
-                if (ratio > 1.0) {
-                    ratio = 1.0 / frustum.aspectRatio;
-                }
-
+                var ratio = 1.0 / frustum.aspectRatio;
                 f.right = frustum.width * 0.5;
                 f.left = -f.right;
                 f.top = ratio * f.right;


### PR DESCRIPTION
Fix resizing the canvas when height > width with an orthographic projection.
Before:
![image](https://cloud.githubusercontent.com/assets/1494815/24262542/b9c5ee8c-0fd0-11e7-8e5e-bfc4d1243583.png)
After:
![image](https://cloud.githubusercontent.com/assets/1494815/24262567/d398eb2a-0fd0-11e7-92e6-72bafbedaff1.png)
