### PR TITLE
Implement expression for length

### DIFF
--- a/Source/Scene/Expression.js
+++ b/Source/Scene/Expression.js
@@ -105,7 +105,7 @@ define([
         log : Math.log,
         log2 : log2,
         fract : fract,
-        length : length // Dummy function so length is a known function (requires different implementations for Cartesian2, Cartesian3 and Cartesian4)
+        length : Math.abs
     };
 
     var ternaryFunctions = {
@@ -776,14 +776,16 @@ define([
             var left = this._left.evaluate(feature);
 
             if (call === 'length') {
-                if (left instanceof Cartesian2) {
+                if (typeof left === 'number') {
+                    return evaluate(left);
+                } else if (left instanceof Cartesian2) {
                     return Cartesian2.magnitude(left);
                 } else if (left instanceof Cartesian3) {
                     return Cartesian3.magnitude(left);
                 } else if (left instanceof Cartesian4) {
                     return Cartesian4.magnitude(left);
                 } else {
-                    throw new DeveloperError('Function "' + call + '" requires a vector argument. Argument is ' + left + '.');
+                    throw new DeveloperError('Function "' + call + '" requires a vector or number argument. Argument is ' + left + '.');
                 }
             }
 

--- a/Source/Scene/Expression.js
+++ b/Source/Scene/Expression.js
@@ -104,7 +104,8 @@ define([
         exp2 : exp2,
         log : Math.log,
         log2 : log2,
-        fract : fract
+        fract : fract,
+        length : length // Dummy function so length is a known function (requires different implementations for Cartesian2, Cartesian3 and Cartesian4)
     };
 
     var ternaryFunctions = {
@@ -121,7 +122,7 @@ define([
     }
 
     function log2(number) {
-    	return CesiumMath.logBase(number, 2.0);
+        return CesiumMath.logBase(number, 2.0);
     }
 
     /**
@@ -773,6 +774,19 @@ define([
         var evaluate = unaryFunctions[call];
         return function(feature) {
             var left = this._left.evaluate(feature);
+
+            if (call === 'length') {
+                if (left instanceof Cartesian2) {
+                    return Cartesian2.magnitude(left);
+                } else if (left instanceof Cartesian3) {
+                    return Cartesian3.magnitude(left);
+                } else if (left instanceof Cartesian4) {
+                    return Cartesian4.magnitude(left);
+                } else {
+                    throw new DeveloperError('Function "' + call + '" requires a vector argument. Argument is ' + left + '.');
+                }
+            }
+
             if (typeof left === 'number') {
                 return evaluate(left);
             } else if (left instanceof Cartesian2) {
@@ -1557,7 +1571,7 @@ define([
                 } else if (value === 'Number') {
                     return 'float(' + left + ')';
                 } else if (value === 'round') {
-                	return 'floor(' + left + ' + 0.5)';
+                    return 'floor(' + left + ' + 0.5)';
                 } else if (defined(unaryFunctions[value])) {
                     return value + '(' + left + ')';
                 } else if ((value === 'isNaN') || (value === 'isFinite') || (value === 'String') || (value === 'isExactClass') || (value === 'isClass') || (value === 'getExactClassName')) {

--- a/Specs/Scene/ExpressionSpec.js
+++ b/Specs/Scene/ExpressionSpec.js
@@ -2143,6 +2143,34 @@ defineSuite([
         }).toThrowDeveloperError();
     });
 
+    it('evaluates length function', function() {
+        var expression = new Expression('length(vec2(-3.0, 4.0))');
+        expect(expression.evaluate(frameState, undefined)).toEqual(5.0);
+
+        var expression = new Expression('length(vec3(2.0, 3.0, 6.0))');
+        expect(expression.evaluate(frameState, undefined)).toEqual(7.0);
+        
+        var expression = new Expression('length(vec4(2.0, 4.0, 7.0, 10.0))');
+        expect(expression.evaluate(frameState, undefined)).toEqual(13.0);
+    });
+
+    it('throws if length function takes an invalid type of argument', function() {
+        expect(function() {
+            var expression = new Expression('length(1.0)');
+            expression.evaluate(frameState, undefined);
+        }).toThrowDeveloperError();
+    });
+    
+    it('throws if length function takes an invalid number of arguments', function() {
+        expect(function() {
+            return new Expression('length()');			
+        }).toThrowDeveloperError();
+
+        expect(function() {
+            return new Expression('length(vec2(0.0, 1.0), vec2(0.0, 1.0))');
+        }).toThrowDeveloperError();
+    });
+
     it('evaluates ternary conditional', function() {
         var expression = new Expression('true ? "first" : "second"');
         expect(expression.evaluate(frameState, undefined)).toEqual('first');

--- a/Specs/Scene/ExpressionSpec.js
+++ b/Specs/Scene/ExpressionSpec.js
@@ -2144,6 +2144,9 @@ defineSuite([
     });
 
     it('evaluates length function', function() {
+        var expression = new Expression('length(-3.0)');
+        expect(expression.evaluate(frameState, undefined)).toEqual(3.0);
+
         var expression = new Expression('length(vec2(-3.0, 4.0))');
         expect(expression.evaluate(frameState, undefined)).toEqual(5.0);
 
@@ -2154,13 +2157,6 @@ defineSuite([
         expect(expression.evaluate(frameState, undefined)).toEqual(13.0);
     });
 
-    it('throws if length function takes an invalid type of argument', function() {
-        expect(function() {
-            var expression = new Expression('length(1.0)');
-            expression.evaluate(frameState, undefined);
-        }).toThrowDeveloperError();
-    });
-    
     it('throws if length function takes an invalid number of arguments', function() {
         expect(function() {
             return new Expression('length()');			


### PR DESCRIPTION
Implemented length command. Unlike in mentioned in #4865 I have just implemented it for Cartesian, because I don't know what the result of `length(float x)` should be (`x`?). Even [glsl](https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/length.xhtml) does support it only with a vector, so I think we are getting more trouble if we implement it for float.