### PR TITLE
Made czm_imagerySplitPosition use absolute coordinates.  Fixes #5106.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,6 +25,7 @@ Change Log
     * Set `projectionPicker` to `true` in the options when creating a `Viewer` to add a widget that will switch projections. [#5021](https://github.com/AnalyticalGraphicsInc/cesium/pull/5021)
     * Call `switchToOrthographicFrustum` or `switchToPerspectiveFrustum` on `Camera` to change projections.
 * Fix billboard, point and label clustering in 2D and Columbus view. [#5136](https://github.com/AnalyticalGraphicsInc/cesium/pull/5136)
+* Fixed issues with imagerySplitPosition and the international date line in 2D mode. [#5151](https://github.com/AnalyticalGraphicsInc/cesium/pull/5151)
 
 ### 1.31 - 2017-03-01
 

--- a/Source/Renderer/AutomaticUniforms.js
+++ b/Source/Renderer/AutomaticUniforms.js
@@ -1469,7 +1469,7 @@ define([
 
          /**
          * An automatic GLSL uniform representing the splitter position to use when rendering imagery layers with a splitter.
-         * This will be in the range 0.0 to 1.0 with 0.0 being the far left of the viewport and 1.0 being the far right of the viewport.
+         * This will be in pixel coordinates relative to the canvas.
          *
          * @alias czm_imagerySplitPosition
          * @glslUniform

--- a/Source/Renderer/UniformState.js
+++ b/Source/Renderer/UniformState.js
@@ -951,7 +951,8 @@ define([
         this._frameState = frameState;
         this._temeToPseudoFixed = Transforms.computeTemeToPseudoFixedMatrix(frameState.time, this._temeToPseudoFixed);
 
-        this._imagerySplitPosition = frameState.imagerySplitPosition;
+        // Convert the relative imagerySplitPosition to absolute pixel coordinates
+        this._imagerySplitPosition = frameState.imagerySplitPosition * canvas.clientWidth;
         var fov = camera.frustum.fov;
         var viewport = this._viewport;
         var pixelSizePerMeter;

--- a/Source/Shaders/GlobeFS.glsl
+++ b/Source/Shaders/GlobeFS.glsl
@@ -99,7 +99,7 @@ vec4 sampleAndBlend(
     float alpha = value.a;
 
 #ifdef APPLY_SPLIT
-    float splitPosition = czm_imagerySplitPosition * czm_viewport.z;
+    float splitPosition = czm_imagerySplitPosition;
     // Split to the left
     if (split < 0.0 && gl_FragCoord.x > splitPosition) {
        alpha = 0.0;


### PR DESCRIPTION
czm_imagerySplitPosition now computes absolute pixel coordinates from the relative public property during UniformState.update to fix issues with the date line.  The public imagerySplitPosition is still in relative coordinates.  I think this is a better fix than #5124 so users don't have to worry about the canvas being resized and it also avoids having to deprecate the imagerySplitPosition public property.