### PR TITLE
Call QuadtreePrimitive.tileLoadProgressEvent after rendering frame state

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,6 @@
 Change Log
 ==========
+* `QuadtreePrimitive` now uses `frameState.afterRender` to fire `tileLoadProgressEvent` [3450](https://github.com/AnalyticalGraphicsInc/cesium/issues/3450)
 * Fixed an issue with `TileBoundingBox` that caused the terrain to disappear in certain places [4032](https://github.com/AnalyticalGraphicsInc/cesium/issues/4032)
 
 ### 1.32 - 2017-04-03

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,7 @@
 Change Log
 ==========
 
-* `QuadtreePrimitive` now uses `frameState.afterRender` to fire `tileLoadProgressEvent` [3450](https://github.com/AnalyticalGraphicsInc/cesium/issues/3450)
+* `QuadtreePrimitive` now uses `frameState.afterRender` to fire `tileLoadProgressEvent` [#3450](https://github.com/AnalyticalGraphicsInc/cesium/issues/3450)
 
 ### 1.32 - 2017-04-03
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,8 +1,6 @@
 Change Log
 ==========
 
-* `QuadtreePrimitive` now uses `frameState.afterRender` to fire `tileLoadProgressEvent` [#3450](https://github.com/AnalyticalGraphicsInc/cesium/issues/3450)
-
 ### 1.32 - 2017-04-03
 
 * Deprecated
@@ -32,6 +30,7 @@ Change Log
 * Fix billboard, point and label clustering in 2D and Columbus view. [#5136](https://github.com/AnalyticalGraphicsInc/cesium/pull/5136)
 * Fixed issues with imagerySplitPosition and the international date line in 2D mode. [#5151](https://github.com/AnalyticalGraphicsInc/cesium/pull/5151)
 * Fixed an issue with `TileBoundingBox` that caused the terrain to disappear in certain places [4032](https://github.com/AnalyticalGraphicsInc/cesium/issues/4032)
+* `QuadtreePrimitive` now uses `frameState.afterRender` to fire `tileLoadProgressEvent` [#3450](https://github.com/AnalyticalGraphicsInc/cesium/issues/3450)
 
 ### 1.31 - 2017-03-01
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,6 @@ Change Log
 ==========
 
 * `QuadtreePrimitive` now uses `frameState.afterRender` to fire `tileLoadProgressEvent` [3450](https://github.com/AnalyticalGraphicsInc/cesium/issues/3450)
-* Fixed an issue with `TileBoundingBox` that caused the terrain to disappear in certain places [4032](https://github.com/AnalyticalGraphicsInc/cesium/issues/4032)
 
 ### 1.32 - 2017-04-03
 

--- a/Source/Scene/QuadtreePrimitive.js
+++ b/Source/Scene/QuadtreePrimitive.js
@@ -496,7 +496,13 @@ define([
             }
         }
 
-        raiseTileLoadProgressEvent(primitive);
+        frameState.afterRender.push(createTileProgressFunction(primitive));
+    }
+
+    function createTileProgressFunction(primitive) {
+        return function() {
+            raiseTileLoadProgressEvent(primitive);
+        };
     }
 
     function visitTile(primitive, frameState, tile) {

--- a/Specs/Scene/QuadtreePrimitiveSpec.js
+++ b/Specs/Scene/QuadtreePrimitiveSpec.js
@@ -179,6 +179,8 @@ defineSuite([
         quadtree.update(scene.frameState);
         quadtree.endFrame(scene.frameState);
 
+        scene.renderForSpecs();
+
         // There will now be two zero-level tiles in the load queue.
         expect(progressEventSpy.calls.mostRecent().args[0]).toEqual(2);
 
@@ -189,6 +191,8 @@ defineSuite([
         quadtree.update(scene.frameState);
         quadtree.endFrame(scene.frameState);
 
+        scene.renderForSpecs();
+
         // Now there should only be one left in the update queue
         expect(progressEventSpy.calls.mostRecent().args[0]).toEqual(1);
 
@@ -198,6 +202,8 @@ defineSuite([
         quadtree.beginFrame(scene.frameState);
         quadtree.update(scene.frameState);
         quadtree.endFrame(scene.frameState);
+
+        scene.renderForSpecs();
 
         // Now that tile's four children should be in the load queue.
         expect(progressEventSpy.calls.mostRecent().args[0]).toEqual(4);
@@ -372,7 +378,7 @@ defineSuite([
         expect(quadtree._tileLoadQueueHigh).toContain(quadtree._levelZeroTiles[1]);
         expect(quadtree._tileLoadQueueMedium.length).toBe(0);
         expect(quadtree._tileLoadQueueLow.length).toBe(0);
-        
+
         // Mark the first root tile renderable (but not done loading)
         quadtree._levelZeroTiles[0].renderable = true;
 
@@ -420,7 +426,7 @@ defineSuite([
         quadtree._levelZeroTiles[0].children[1].upsampledFromParent = true;
         quadtree._levelZeroTiles[0].children[2].upsampledFromParent = true;
         quadtree._levelZeroTiles[0].children[3].upsampledFromParent = true;
-        
+
         quadtree.beginFrame(scene.frameState);
         quadtree.update(scene.frameState);
         quadtree.endFrame(scene.frameState);


### PR DESCRIPTION
Closes #3450. References #5134