### PR TITLE
Add a pass for 3D Tiles

### DIFF
--- a/Source/Renderer/Pass.js
+++ b/Source/Renderer/Pass.js
@@ -21,11 +21,12 @@ define([
         ENVIRONMENT : 0,
         COMPUTE : 1,
         GLOBE : 2,
-        GROUND : 3,
-        OPAQUE : 4,
-        TRANSLUCENT : 5,
-        OVERLAY : 6,
-        NUMBER_OF_PASSES : 7
+        CESIUM_3D_TILE : 3,
+        GROUND : 4,
+        OPAQUE : 5,
+        TRANSLUCENT : 6,
+        OVERLAY : 7,
+        NUMBER_OF_PASSES : 8
     };
 
     return freezeObject(Pass);

--- a/Source/Scene/Cesium3DTileBatchTable.js
+++ b/Source/Scene/Cesium3DTileBatchTable.js
@@ -1315,6 +1315,7 @@ define([
 
     function deriveCommand(command) {
         var derivedCommand = DrawCommand.shallowClone(command);
+        derivedCommand.pass = Pass.CESIUM_3D_TILE;
 
         // Add a uniform to indicate if the original command was translucent so
         // the shader knows not to cull vertices that were originally transparent

--- a/Source/Scene/PointCloud3DTileContent.js
+++ b/Source/Scene/PointCloud3DTileContent.js
@@ -797,7 +797,7 @@ define([
             shaderProgram : undefined, // Updated in createShaders
             uniformMap : drawUniformMap,
             renderState : isTranslucent ? content._translucentRenderState : content._opaqueRenderState,
-            pass : isTranslucent ? Pass.TRANSLUCENT : Pass.OPAQUE,
+            pass : isTranslucent ? Pass.TRANSLUCENT : Pass.CESIUM_3D_TILE,
             owner : content
         });
 
@@ -811,7 +811,7 @@ define([
             shaderProgram : undefined, // Updated in createShaders
             uniformMap : pickUniformMap,
             renderState : isTranslucent ? content._translucentRenderState : content._opaqueRenderState,
-            pass : isTranslucent ? Pass.TRANSLUCENT : Pass.OPAQUE,
+            pass : isTranslucent ? Pass.TRANSLUCENT : Pass.CESIUM_3D_TILE,
             owner : content
         });
     }
@@ -1259,7 +1259,7 @@ define([
         // Update the render state
         var isTranslucent = (this._highlightColor.alpha < 1.0) || (this._constantColor.alpha < 1.0) || this._styleTranslucent;
         this._drawCommand.renderState = isTranslucent ? this._translucentRenderState : this._opaqueRenderState;
-        this._drawCommand.pass = isTranslucent ? Pass.TRANSLUCENT : Pass.OPAQUE;
+        this._drawCommand.pass = isTranslucent ? Pass.TRANSLUCENT : Pass.CESIUM_3D_TILE;
 
         if (defined(this.batchTable)) {
             this.batchTable.update(tileset, frameState);

--- a/Source/Scene/Scene.js
+++ b/Source/Scene/Scene.js
@@ -1884,6 +1884,13 @@ define([
                 passState.framebuffer = fb;
             }
 
+            us.updatePass(Pass.CESIUM_3D_TILE);
+            commands = frustumCommands.commands[Pass.CESIUM_3D_TILE];
+            length = frustumCommands.indices[Pass.CESIUM_3D_TILE];
+            for (j = 0; j < length; ++j) {
+                executeCommand(commands[j], scene, context, passState);
+            }
+
             us.updatePass(Pass.GROUND);
             commands = frustumCommands.commands[Pass.GROUND];
             length = frustumCommands.indices[Pass.GROUND];
@@ -1896,12 +1903,15 @@ define([
                 scene._stencilClearCommand.execute(context, passState);
             }
 
+            // TODO: need 3D tile depth
+            /*
             if (clearGlobeDepth) {
                 clearDepth.execute(context, passState);
                 if (useDepthPlane) {
                     depthPlane.execute(context, passState);
                 }
             }
+            */
 
             // Execute commands in order by pass up to the translucent pass.
             // Translucent geometry needs special handling (sorting/OIT).
@@ -1976,7 +1986,7 @@ define([
             var command = commandList[i];
             updateDerivedCommands(scene, command);
 
-            if (command.castShadows && (command.pass === Pass.GLOBE || command.pass === Pass.OPAQUE || command.pass === Pass.TRANSLUCENT)) {
+            if (command.castShadows && (command.pass === Pass.GLOBE || command.pass === Pass.CESIUM_3D_TILE || command.pass === Pass.OPAQUE || command.pass === Pass.TRANSLUCENT)) {
                 if (isVisible(command, shadowVolume)) {
                     if (isPointLight) {
                         for (var k = 0; k < numberOfPasses; ++k) {

--- a/Source/Scene/Scene.js
+++ b/Source/Scene/Scene.js
@@ -1884,13 +1884,6 @@ define([
                 passState.framebuffer = fb;
             }
 
-            us.updatePass(Pass.CESIUM_3D_TILE);
-            commands = frustumCommands.commands[Pass.CESIUM_3D_TILE];
-            length = frustumCommands.indices[Pass.CESIUM_3D_TILE];
-            for (j = 0; j < length; ++j) {
-                executeCommand(commands[j], scene, context, passState);
-            }
-
             us.updatePass(Pass.GROUND);
             commands = frustumCommands.commands[Pass.GROUND];
             length = frustumCommands.indices[Pass.GROUND];
@@ -1903,15 +1896,19 @@ define([
                 scene._stencilClearCommand.execute(context, passState);
             }
 
-            // TODO: need 3D tile depth
-            /*
             if (clearGlobeDepth) {
                 clearDepth.execute(context, passState);
                 if (useDepthPlane) {
                     depthPlane.execute(context, passState);
                 }
             }
-            */
+
+            us.updatePass(Pass.CESIUM_3D_TILE);
+            commands = frustumCommands.commands[Pass.CESIUM_3D_TILE];
+            length = frustumCommands.indices[Pass.CESIUM_3D_TILE];
+            for (j = 0; j < length; ++j) {
+                executeCommand(commands[j], scene, context, passState);
+            }
 
             // Execute commands in order by pass up to the translucent pass.
             // Translucent geometry needs special handling (sorting/OIT).

--- a/Source/Scene/Scene.js
+++ b/Source/Scene/Scene.js
@@ -1345,7 +1345,7 @@ define([
                 break;
             }
 
-            var pass = command instanceof ClearCommand ? Pass.OPAQUE : command.pass;
+            var pass = command.pass;
             var index = frustumCommands.indices[pass]++;
             frustumCommands.commands[pass][index] = command;
 

--- a/Source/Shaders/Builtin/Constants/passCesium3DTile.glsl
+++ b/Source/Shaders/Builtin/Constants/passCesium3DTile.glsl
@@ -1,0 +1,9 @@
+/**
+ * The automatic GLSL constant for {@link Pass#CESIUM_3D_TILE}
+ *
+ * @name czm_passCesium3DTile
+ * @glslConstant
+ *
+ * @see czm_pass
+ */
+const float czm_passCesium3DTile = 3.0;

--- a/Source/Shaders/Builtin/Constants/passGround.glsl
+++ b/Source/Shaders/Builtin/Constants/passGround.glsl
@@ -6,4 +6,4 @@
  *
  * @see czm_pass
  */
-const float czm_passGround = 3.0;
+const float czm_passGround = 4.0;

--- a/Source/Shaders/Builtin/Constants/passOpaque.glsl
+++ b/Source/Shaders/Builtin/Constants/passOpaque.glsl
@@ -6,4 +6,4 @@
  *
  * @see czm_pass
  */
-const float czm_passOpaque = 4.0;
+const float czm_passOpaque = 5.0;

--- a/Source/Shaders/Builtin/Constants/passOverlay.glsl
+++ b/Source/Shaders/Builtin/Constants/passOverlay.glsl
@@ -6,4 +6,4 @@
  *
  * @see czm_pass
  */
-const float czm_passOverlay = 6.0;
+const float czm_passOverlay = 7.0;

--- a/Source/Shaders/Builtin/Constants/passTranslucent.glsl
+++ b/Source/Shaders/Builtin/Constants/passTranslucent.glsl
@@ -6,4 +6,4 @@
  *
  * @see czm_pass
  */
-const float czm_passTranslucent = 5.0;
+const float czm_passTranslucent = 6.0;


### PR DESCRIPTION
Adds a `CESIUM_3D_TILE` pass for rendering 3D Tiles (name suggestions are welcome). I occurs after the `ENVIRONMENT` and `GLOBE` passes but before the `GROUND` pass. Because it happens before the `GROUND` pass, I had to disable the depth clear for terrain. If we aren't concerned about `GroundPrimitive`s on 3D Tiles yet, I can move the pass after the depth clear.