### PR TITLE
Fix link to CLAs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,8 +52,8 @@ We love pull requests.  We strive to promptly review them, provide feedback, and
 
 Before we can merge a pull request, we require a signed Contributor License Agreement.  There is a CLA for:
 
-* [individuals](http://www.agi.com/licenses/individual-cla-agi-v1.0.txt) and 
-* [corporations](http://www.agi.com/licenses/corporate-cla-agi-v1.0.txt).
+* [individuals](Documentation/Contributors/CLAs/individual-cla-agi-v1.0.txt) and 
+* [corporations](Documentation/Contributors/CLAs/corporate-cla-agi-v1.0.txt).
 
 This only needs to be completed once.  The CLA ensures you retain copyright to your contributions, and we have the right to use them and incorporate them into Cesium using the [Apache 2.0 License](LICENSE.md).
 

--- a/Documentation/Contributors/CLAs/corporate-cla-agi-v1.0.txt
+++ b/Documentation/Contributors/CLAs/corporate-cla-agi-v1.0.txt
@@ -1,0 +1,147 @@
+                      Analytical Graphics, Inc.
+  Software Grant and Corporate Contributor License Agreement ("Agreement")
+           http://www.agi.com/licenses/corporate-cla-agi-v1.0.txt
+                                 v1.0
+
+In order to clarify the intellectual property license granted with
+Contributions from any person or entity, Analytical Graphics, Inc.
+("AGI") must have a Contributor License Agreement (CLA) on file that has
+been signed by each Contributor, indicating agreement to the license
+terms below. This license is for your protection as a Contributor as well
+as the protection of AGI and its users; it does not change your rights to
+use your own Contributions for any other purpose.
+
+This version of the Agreement allows an entity (the "Corporation") to
+submit Contributions to AGI, to authorize Contributions submitted by its
+designated employees to AGI, and to grant copyright and patent licenses thereto.
+
+Please send complete forms to cla@agi.com.
+
+Please read this document carefully before signing and keep a copy 
+for your records.
+
+   Corporation name:    ________________________________________________
+
+   Corporation address: ________________________________________________
+
+                        ________________________________________________
+
+                        ________________________________________________
+
+   Point of Contact:    ________________________________________________
+
+          E-Mail:       ________________________________________________
+
+          Telephone:    _____________________ Fax: _____________________
+
+
+You accept and agree to the following terms and conditions for Your present
+and future Contributions submitted to AGI. Except for the license granted
+herein to AGI and recipients of software distributed by AGI, You reserve
+all right, title, and interest in and to Your Contributions.
+
+   1. Definitions.
+
+      "You" (or "Your") shall mean the copyright owner or legal entity
+      authorized by the copyright owner that is making this Agreement
+      with AGI. For legal entities, the entity making a Contribution and
+      all other entities that control, are controlled by, or are under
+      common control with that entity are considered to be a single
+      Contributor. For the purposes of this definition, "control" means
+      (i) the power, direct or indirect, to cause the direction or
+      management of such entity, whether by contract or otherwise, or
+      (ii) ownership of fifty percent (50%) or more of the outstanding
+      shares, or (iii) beneficial ownership of such entity.
+
+      "Contribution" shall mean the code, documentation or other original
+      works of authorship expressly identified in Schedule B, as well as
+      any original work of authorship, including any modifications or
+      additions to an existing work, that is intentionally submitted by
+      You to AGI for inclusion in, or documentation of, any of the
+      products owned or managed by AGI (the "Work"). For the purposes of
+      this definition, "submitted" means any form of electronic, verbal,
+      or written communication sent to AGI or its representatives,
+      including but not limited to communication on electronic mailing
+      lists, source code control systems, and issue tracking systems
+      that are managed by, or on behalf of, AGI for the purpose of
+      discussing and improving the Work, but excluding communication
+      that is conspicuously marked or otherwise designated in writing by
+      You as "Not a Contribution."
+
+   2. Grant of Copyright License. Subject to the terms and conditions
+      of this Agreement, You hereby grant to AGI and to recipients of
+      software distributed by AGI a perpetual, worldwide, non-exclusive,
+      no-charge, royalty-free, irrevocable copyright license to reproduce,
+      prepare derivative works of, publicly display, publicly perform,
+      sublicense, and distribute Your Contributions and such derivative
+      works.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this Agreement, You hereby grant to AGI and to recipients of
+      software distributed by AGI a perpetual, worldwide, non-exclusive,
+      no-charge, royalty-free, irrevocable (except as stated in this
+      section) patent license to make, have made, use, offer to sell,
+      sell, import, and otherwise transfer the Work, where such license
+      applies only to those patent claims licensable by You that are 
+      necessarily infringed by Your Contribution(s) alone or by combination
+      of Your Contribution(s) with the Work to which such Contribution(s)
+      were submitted. If any entity institutes patent litigation against
+      You or any other entity (including a cross-claim or counterclaim in a 
+      awsuit) alleging that your Contribution, or the Work to which you
+      have contributed, constitutes direct or contributory patent
+      infringement, then any patent licenses granted to that entity under
+      this Agreement for that Contribution or Work shall terminate as of
+      the date such litigation is filed.
+
+   4. You represent that You are legally entitled to grant the above
+      license. You represent further that each employee of the
+      Corporation designated on Schedule A below (or in a subsequent
+      written modification to that Schedule) is authorized to submit
+      Contributions on behalf of the Corporation.
+
+   5. You represent that each of Your Contributions is Your original
+      creation (see section 7 for submissions on behalf of others).
+
+   6. You are not expected to provide support for Your Contributions,
+      except to the extent You desire to provide support. You may provide
+      support for free, for a fee, or not at all. Unless required by
+      applicable law or agreed to in writing, You provide Your
+      Contributions on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+      OF ANY KIND, either express or implied, including, without
+      limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT,
+      MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE.
+
+   7. Should You wish to submit work that is not Your original creation,
+      You may submit it to AGI separately from any Contribution, identifying
+      the complete details of its source and of any license or other
+      restriction (including, but not limited to, related patents, trademarks,
+      and license agreements) of which you are personally aware, and
+      conspicuously marking the work as "Submitted on behalf of a third-
+      party: [named here]".
+
+   8. It is your responsibility to notify AGI when any change is required
+      to the list of designated employees authorized to submit Contributions
+      on behalf of the Corporation, or to the Corporation's Point of Contact
+      with AGI.
+
+Sign by typing your full name.
+
+   Please sign: __________________________________ Date: _______________
+
+   Title:       __________________________________
+
+   Corporation: __________________________________
+
+
+Schedule A
+
+   [Initial list of designated employees.  NB: authorization is not
+    tied to particular Contributions.]
+
+
+
+
+Schedule B
+
+   [Identification of optional concurrent software grant.  Would be
+    left blank or omitted if there is no concurrent software grant.]

--- a/Documentation/Contributors/CLAs/individual-cla-agi-v1.0.txt
+++ b/Documentation/Contributors/CLAs/individual-cla-agi-v1.0.txt
@@ -1,0 +1,128 @@
+                      Analytical Graphics, Inc.
+     Individual Contributor License Agreement ("Agreement") v1.0
+       http://www.agi.com/licenses/individual-cla-agi-v1.0.txt
+
+In order to clarify the intellectual property license granted with
+Contributions from any person or entity, Analytical Graphics, Inc.
+("AGI") must have a Contributor License Agreement ("CLA") on file
+that has been signed by each Contributor, indicating agreement to
+the license terms below. This license is for your protection as a
+Contributor as well as the protection of AGI; it does not change
+your rights to use your own Contributions for any other purpose.
+
+Please send complete forms to cla@agi.com.
+
+Please read this document carefully before signing and keep a copy 
+for your records.
+
+  Full name: ______________________________________________________
+
+  Mailing Address: ________________________________________________
+
+                   ________________________________________________
+
+  Country:   ______________________________________________________
+
+  Telephone: ______________________________________________________
+
+  E-Mail:    ______________________________________________________
+
+  GitHub username: ________________________________________________
+
+You accept and agree to the following terms and conditions for Your
+present and future Contributions submitted to AGI. Except for the
+license granted herein to AGI and recipients of software distributed
+by AGI, You reserve all right, title, and interest in and to Your 
+Contributions.
+
+1. Definitions.
+
+   "You" (or "Your") shall mean the copyright owner or legal entity
+   authorized by the copyright owner that is making this Agreement
+   with AGI. For legal entities, the entity making a Contribution 
+   and all other entities that control, are controlled by, or are
+   under common control with that entity are considered to be a
+   single Contributor. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "Contribution" shall mean any original work of authorship,
+   including any modifications or additions to an existing work, that
+   is intentionally submitted by You to AGI for inclusion in, or
+   documentation of, any of the products owned or managed by the
+   AGI (the "Work"). For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication
+   sent to AGI or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control
+   systems, and issue tracking systems that are managed by, or on
+   behalf of, AGI for the purpose of discussing and improving the
+   Work, but excluding communication that is conspicuously marked or
+   otherwise designated in writing by You as "Not a Contribution."
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this Agreement, You hereby grant to AGI and to recipients of
+   software distributed by AGI a perpetual, worldwide, non-exclusive,
+   no-charge, royalty-free, irrevocable copyright license to
+   reproduce, prepare derivative works of, publicly display, publicly
+   perform, sublicense, and distribute Your Contributions and such
+   derivative works.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this Agreement, You hereby grant to AGI and to recipients of
+   software distributed by AGI a perpetual, worldwide, non-exclusive, 
+   no-charge, royalty-free, irrevocable (except as stated in this
+   section) patent license to make, have made, use, offer to sell,
+   sell, import, and otherwise transfer the Work, where such license
+   applies only to those patent claims licensable by You that are
+   necessarily infringed by Your Contribution(s) alone or by
+   combination of Your Contribution(s) with the Work to which such
+   Contribution(s) was submitted. If any entity institutes patent
+   litigation against You or any other entity (including a cross-claim
+   or counterclaim in a lawsuit) alleging that your Contribution, or
+   the Work to which you have contributed, constitutes direct or
+   contributory patent infringement, then any patent licenses granted
+   to that entity under this Agreement for that Contribution or Work
+   shall terminate as of the date such litigation is filed.
+
+4. You represent that you are legally entitled to grant the above
+   license. If your employer(s) has rights to intellectual property
+   that you create that includes your Contributions, you represent
+   that you have received permission to make Contributions on behalf
+   of that employer, that your employer has waived such rights for
+   your Contributions to AGI, or that your employer has executed a
+   separate Corporate CLA with AGI.
+
+5. You represent that each of Your Contributions is Your original
+   creation (see section 7 for submissions on behalf of others).  You
+   represent that Your Contribution submissions include complete
+   details of any third-party license or other restriction (including,
+   but not limited to, related patents and trademarks) of which you
+   are personally aware and which are associated with any part of Your
+   Contributions.
+
+6. You are not expected to provide support for Your Contributions,
+   except to the extent You desire to provide support. You may provide
+   support for free, for a fee, or not at all. Unless required by
+   applicable law or agreed to in writing, You provide Your
+   Contributions on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+   OF ANY KIND, either express or implied, including, without
+   limitation, any warranties or conditions of TITLE, NON-
+   INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE.
+
+7. Should You wish to submit work that is not Your original creation,
+   You may submit it to AGI separately from any Contribution, identifying
+   the complete details of its source and of any license or other
+   restriction (including, but not limited to, related patents, trademarks,
+   and license agreements) of which you are personally aware, and 
+   conspicuously marking the work as "Submitted on behalf of a third-
+   party: [named here]".
+
+8. You agree to notify AGI of any facts or circumstances of which you
+   become aware that would make these representations inaccurate in any
+   respect.
+
+Sign by typing your full name.
+
+Please sign: __________________________________ Date: ________________


### PR DESCRIPTION
With the new AGI website, the links to the CLAs no longer worked.  I moved them to this repo for easier maintenance.