### PR TITLE
Fix Mapbox default token warning showing up all the time

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -76,6 +76,8 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to Cesiu
    * [Dmitry Kiselev](https://github.com/kiselev-dv)
 * [Bentley Systems, Inc.](https://www.bentley.com)
    * [Paul Connelly](https://github.com/pmconne)
+* [Flightradar24 AB](https://www.flightradar24.com)
+   * [Aleksei Kalmykov](https://github.com/kalmykov)
 
 ## [Individual CLA](http://www.agi.com/licenses/individual-cla-agi-v1.0.txt)
 * [Victor Berchet](https://github.com/vicb)

--- a/Source/Scene/MapboxImageryProvider.js
+++ b/Source/Scene/MapboxImageryProvider.js
@@ -65,7 +65,7 @@ define([
         this._url = url;
         this._mapId = mapId;
         this._accessToken = MapboxApi.getAccessToken(options.accessToken);
-        this._accessTokenErrorCredit = MapboxApi.getErrorCredit(options.key);
+        this._accessTokenErrorCredit = MapboxApi.getErrorCredit(options.accessToken);
         var format = defaultValue(options.format, 'png');
         if (!/\./.test(format)) {
             format = '.' + format;


### PR DESCRIPTION
This PR fixes an error made in #4749 : `MapboxImageryProvider` checks for parameter `options.key` instead of `options.accessToken` (this is probably just copy-paste from `BingImageryProvider`) for detecting usage of default access token. This results in permanent access token warning, no matter which token you use.

Temporary workaround for this is to pass 2 parameters, both `accessToken` and `key` , with same value.

I've sent CLA back in January 2016. I can re-send it if you need.