### PR TITLE
Fix billboards not initially clustering.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@ Change Log
 * Fixed issue with displaying `MapboxImageryProvider` default token error message [#5191](https://github.com/AnalyticalGraphicsInc/cesium/pull/5191)
 * Added a `depthFailMaterial` property to line entities, which is the material used to render the line when it fails the depth test. [#5160](https://github.com/AnalyticalGraphicsInc/cesium/pull/5160)
 * Upgrade FXAA to version 3.11. [#5200](https://github.com/AnalyticalGraphicsInc/cesium/pull/5200)
+* Fix billboards not initially clustering. [#5208](https://github.com/AnalyticalGraphicsInc/cesium/pull/5208)
 
 ### 1.32 - 2017-04-03
 

--- a/Source/DataSources/EntityCluster.js
+++ b/Source/DataSources/EntityCluster.js
@@ -723,10 +723,21 @@ define([
         // If clustering is enabled before the label collection is updated,
         // the glyphs haven't been created so the screen space bounding boxes
         // are incorrect.
+        var commandList;
         if (defined(this._labelCollection) && this._labelCollection.length > 0 && this._labelCollection.get(0)._glyphs.length === 0) {
-            var commandList = frameState.commandList;
+            commandList = frameState.commandList;
             frameState.commandList = [];
             this._labelCollection.update(frameState);
+            frameState.commandList = commandList;
+        }
+
+        // If clustering is enabled before the billboard collection is updated,
+        // the images haven't been added to the image atlas so the screen space bounding boxes
+        // are incorrect.
+        if (defined(this._billboardCollection) && this._billboardCollection.length > 0 && !defined(this._billboardCollection.get(0).width)) {
+            commandList = frameState.commandList;
+            frameState.commandList = [];
+            this._billboardCollection.update(frameState);
             frameState.commandList = commandList;
         }
 

--- a/Specs/DataSources/EntityClusterSpec.js
+++ b/Specs/DataSources/EntityClusterSpec.js
@@ -175,6 +175,29 @@ defineSuite([
         expect(cluster._clusterLabelCollection).not.toBeDefined();
     });
 
+    it('clusters billboards on first update', function() {
+        cluster = new EntityCluster();
+        cluster._initialize(scene);
+
+        var entity = new Entity();
+        var billboard = cluster.getBillboard(entity);
+        billboard.id = entity;
+        billboard.image = createBillboardImage();
+        billboard.position = SceneTransforms.drawingBufferToWgs84Coordinates(scene, new Cartesian2(0.0, 0.0), 0.5);
+
+        entity = new Entity();
+        billboard = cluster.getBillboard(entity);
+        billboard.id = entity;
+        billboard.image = createBillboardImage();
+        billboard.position = SceneTransforms.drawingBufferToWgs84Coordinates(scene, new Cartesian2(scene.canvas.clientWidth, scene.canvas.clientHeight), 0.5);
+
+        cluster.enabled = true;
+        cluster.update(scene.frameState);
+
+        expect(cluster._clusterLabelCollection).toBeDefined();
+        expect(cluster._clusterLabelCollection.length).toEqual(1);
+    });
+
     it('clusters labels', function() {
         cluster = new EntityCluster();
         cluster._initialize(scene);
@@ -208,6 +231,29 @@ defineSuite([
         expect(cluster._clusterLabelCollection).not.toBeDefined();
     });
 
+    it('clusters labels on first update', function() {
+        cluster = new EntityCluster();
+        cluster._initialize(scene);
+
+        var entity = new Entity();
+        var label = cluster.getLabel(entity);
+        label.id = entity;
+        label.text = 'a';
+        label.position = SceneTransforms.drawingBufferToWgs84Coordinates(scene, new Cartesian2(0.0, 0.0), 0.5);
+
+        entity = new Entity();
+        label = cluster.getLabel(entity);
+        label.id = entity;
+        label.text = 'b';
+        label.position = SceneTransforms.drawingBufferToWgs84Coordinates(scene, new Cartesian2(scene.canvas.clientWidth, scene.canvas.clientHeight), 0.5);
+
+        cluster.enabled = true;
+        cluster.update(scene.frameState);
+
+        expect(cluster._clusterLabelCollection).toBeDefined();
+        expect(cluster._clusterLabelCollection.length).toEqual(1);
+    });
+
     it('clusters points', function() {
         cluster = new EntityCluster();
         cluster._initialize(scene);
@@ -239,6 +285,29 @@ defineSuite([
         cluster.update(frameState);
 
         expect(cluster._clusterLabelCollection).not.toBeDefined();
+    });
+
+    it('clusters points on first update', function() {
+        cluster = new EntityCluster();
+        cluster._initialize(scene);
+
+        var entity = new Entity();
+        var point = cluster.getPoint(entity);
+        point.id = entity;
+        point.pixelSize = 1;
+        point.position = SceneTransforms.drawingBufferToWgs84Coordinates(scene, new Cartesian2(0.0, 0.0), 0.5);
+
+        entity = new Entity();
+        point = cluster.getPoint(entity);
+        point.id = entity;
+        point.pixelSize = 1;
+        point.position = SceneTransforms.drawingBufferToWgs84Coordinates(scene, new Cartesian2(scene.canvas.clientWidth, scene.canvas.clientHeight), 0.5);
+
+        cluster.enabled = true;
+        cluster.update(scene.frameState);
+
+        expect(cluster._clusterLabelCollection).toBeDefined();
+        expect(cluster._clusterLabelCollection.length).toEqual(1);
     });
 
     it('clusters points that have labels', function() {


### PR DESCRIPTION
Fixes #4536.

If billboards aren't updated before the first cluster update, the images haven't been added to the atlas and the screen space bounding boxes are invalid.