### PR TITLE
Add translucencyByDistanceXXX and distanceDisplayConditionXXX to tile styling for labels

### DIFF
--- a/Apps/Sandcastle/gallery/3D Tiles.html
+++ b/Apps/Sandcastle/gallery/3D Tiles.html
@@ -168,7 +168,13 @@ Cesium.knockout.getObservable(viewModel, 'selectedTileset').subscribe(function(o
             "scaleByDistanceNearRange" : "1000.0",
             "scaleByDistanceNearValue" : "2.0",
             "scaleByDistanceFarRange" : " 10000.0",
-            "scaleByDistanceFarValue" : "0.5"
+            "scaleByDistanceFarValue" : "0.5",
+            "translucencyByDistanceNearRange" : "10000.0",
+            "translucencyByDistanceNearValue" : "1.0",
+            "translucencyByDistanceFarRange" : " 20000.0",
+            "translucencyByDistanceFarValue" : "0.1",
+            "distanceDisplayConditionNear" : "0",
+            "distanceDisplayConditionFar" : "30000.0"
         });
     });
 });

--- a/Source/Scene/Cesium3DTileFeature.js
+++ b/Source/Scene/Cesium3DTileFeature.js
@@ -266,6 +266,22 @@ define([
                     label.scaleByDistance = value;
                 }
             }
+        },
+
+        translucencyByDistance : {
+            get : function() {
+                if (defined(this._labelCollection)) {
+                    var label = this._labelCollection.get(this._batchId);
+                    return label.translucencyByDistance;
+                }
+                return undefined;
+            },
+            set : function(value) {
+                if (defined(this._labelCollection)) {
+                    var label = this._labelCollection.get(this._batchId);
+                    label.translucencyByDistance = value;
+                }
+            }
         }
     });
 

--- a/Source/Scene/Cesium3DTileFeature.js
+++ b/Source/Scene/Cesium3DTileFeature.js
@@ -282,6 +282,22 @@ define([
                     label.translucencyByDistance = value;
                 }
             }
+        },
+
+        distanceDisplayCondition : {
+            get : function() {
+                if (defined(this._labelCollection)) {
+                    var label = this._labelCollection.get(this._batchId);
+                    return label.distanceDisplayCondition;
+                }
+                return undefined;
+            },
+            set : function(value) {
+                if (defined(this._labelCollection)) {
+                    var label = this._labelCollection.get(this._batchId);
+                    label.distanceDisplayCondition = value;
+                }
+            }
         }
     });
 

--- a/Source/Scene/Cesium3DTileStyle.js
+++ b/Source/Scene/Cesium3DTileStyle.js
@@ -83,6 +83,10 @@ define([
         this._scaleByDistanceNearValue = undefined;
         this._scaleByDistanceFarRange = undefined;
         this._scaleByDistanceFarValue = undefined;
+        this._translucencyByDistanceNearRange = undefined;
+        this._translucencyByDistanceNearValue = undefined;
+        this._translucencyByDistanceFarRange = undefined;
+        this._translucencyByDistanceFarValue = undefined;
         this._meta = undefined;
 
         this._colorShaderFunction = undefined;
@@ -140,6 +144,10 @@ define([
         var scaleByDistanceNearValueExpression = styleJson.scaleByDistanceNearValue;
         var scaleByDistanceFarRangeExpression = styleJson.scaleByDistanceFarRange;
         var scaleByDistanceFarValueExpression = styleJson.scaleByDistanceFarValue;
+        var translucencyByDistanceNearRangeExpression = styleJson.translucencyByDistanceNearRange;
+        var translucencyByDistanceNearValueExpression = styleJson.translucencyByDistanceNearValue;
+        var translucencyByDistanceFarRangeExpression = styleJson.translucencyByDistanceFarRange;
+        var translucencyByDistanceFarValueExpression = styleJson.translucencyByDistanceFarValue;
 
         var color;
         if (typeof colorExpression === 'string') {
@@ -297,6 +305,50 @@ define([
         }
 
         that._scaleByDistanceFarValue = scaleByDistanceFarValue;
+
+        var translucencyByDistanceNearRange;
+        if (typeof translucencyByDistanceNearRangeExpression === 'number') {
+            translucencyByDistanceNearRange = new Expression(String(translucencyByDistanceNearRangeExpression));
+        } else if (typeof translucencyByDistanceNearRangeExpression === 'string') {
+            translucencyByDistanceNearRange = new Expression(translucencyByDistanceNearRangeExpression);
+        } else if (defined(translucencyByDistanceNearRangeExpression) && defined(translucencyByDistanceNearRangeExpression.conditions)) {
+            translucencyByDistanceNearRange = new ConditionsExpression(translucencyByDistanceNearRangeExpression);
+        }
+
+        that._translucencyByDistanceNearRange = translucencyByDistanceNearRange;
+
+        var translucencyByDistanceNearValue;
+        if (typeof translucencyByDistanceNearValueExpression === 'number') {
+            translucencyByDistanceNearValue = new Expression(String(translucencyByDistanceNearValueExpression));
+        } else if (typeof translucencyByDistanceNearValueExpression === 'string') {
+            translucencyByDistanceNearValue = new Expression(translucencyByDistanceNearValueExpression);
+        } else if (defined(translucencyByDistanceNearValueExpression) && defined(translucencyByDistanceNearValueExpression.conditions)) {
+            translucencyByDistanceNearValue = new ConditionsExpression(translucencyByDistanceNearValueExpression);
+        }
+
+        that._translucencyByDistanceNearValue = translucencyByDistanceNearValue;
+
+        var translucencyByDistanceFarRange;
+        if (typeof translucencyByDistanceFarRangeExpression === 'number') {
+            translucencyByDistanceFarRange = new Expression(String(translucencyByDistanceFarRangeExpression));
+        } else if (typeof translucencyByDistanceFarRangeExpression === 'string') {
+            translucencyByDistanceFarRange = new Expression(translucencyByDistanceFarRangeExpression);
+        } else if (defined(translucencyByDistanceFarRangeExpression) && defined(translucencyByDistanceFarRangeExpression.conditions)) {
+            translucencyByDistanceFarRange = new ConditionsExpression(translucencyByDistanceFarRangeExpression);
+        }
+
+        that._translucencyByDistanceFarRange = translucencyByDistanceFarRange;
+
+        var translucencyByDistanceFarValue;
+        if (typeof translucencyByDistanceFarValueExpression === 'number') {
+            translucencyByDistanceFarValue = new Expression(String(translucencyByDistanceFarValueExpression));
+        } else if (typeof translucencyByDistanceFarValueExpression === 'string') {
+            translucencyByDistanceFarValue = new Expression(translucencyByDistanceFarValueExpression);
+        } else if (defined(translucencyByDistanceFarValueExpression) && defined(translucencyByDistanceFarValueExpression.conditions)) {
+            translucencyByDistanceFarValue = new ConditionsExpression(translucencyByDistanceFarValueExpression);
+        }
+
+        that._translucencyByDistanceFarValue = translucencyByDistanceFarValue;
 
         var meta = {};
         if (defined(styleJson.meta)) {
@@ -682,6 +734,66 @@ define([
             },
             set : function(value) {
                 this._scaleByDistanceFarValue = value;
+            }
+        },
+
+        translucencyByDistanceNearRange : {
+            get : function() {
+                //>>includeStart('debug', pragmas.debug);
+                if (!this._ready) {
+                    throw new DeveloperError('The style is not loaded.  Use Cesium3DTileStyle.readyPromise or wait for Cesium3DTileStyle.ready to be true.');
+                }
+                //>>includeEnd('debug');
+
+                return this._translucencyByDistanceNearRange;
+            },
+            set : function(value) {
+                this._translucencyByDistanceNearRange = value;
+            }
+        },
+
+        translucencyByDistanceNearValue : {
+            get : function() {
+                //>>includeStart('debug', pragmas.debug);
+                if (!this._ready) {
+                    throw new DeveloperError('The style is not loaded.  Use Cesium3DTileStyle.readyPromise or wait for Cesium3DTileStyle.ready to be true.');
+                }
+                //>>includeEnd('debug');
+
+                return this._translucencyByDistanceNearValue;
+            },
+            set : function(value) {
+                this._translucencyByDistanceNearValue = value;
+            }
+        },
+
+        translucencyByDistanceFarRange : {
+            get : function() {
+                //>>includeStart('debug', pragmas.debug);
+                if (!this._ready) {
+                    throw new DeveloperError('The style is not loaded.  Use Cesium3DTileStyle.readyPromise or wait for Cesium3DTileStyle.ready to be true.');
+                }
+                //>>includeEnd('debug');
+
+                return this._translucencyByDistanceFarRange;
+            },
+            set : function(value) {
+                this._translucencyByDistanceFarRange = value;
+            }
+        },
+
+        translucencyByDistanceFarValue : {
+            get : function() {
+                //>>includeStart('debug', pragmas.debug);
+                if (!this._ready) {
+                    throw new DeveloperError('The style is not loaded.  Use Cesium3DTileStyle.readyPromise or wait for Cesium3DTileStyle.ready to be true.');
+                }
+                //>>includeEnd('debug');
+
+                return this._translucencyByDistanceFarValue;
+            },
+            set : function(value) {
+                this._translucencyByDistanceFarValue = value;
             }
         },
 

--- a/Source/Scene/Cesium3DTileStyle.js
+++ b/Source/Scene/Cesium3DTileStyle.js
@@ -148,6 +148,8 @@ define([
         var translucencyByDistanceNearValueExpression = styleJson.translucencyByDistanceNearValue;
         var translucencyByDistanceFarRangeExpression = styleJson.translucencyByDistanceFarRange;
         var translucencyByDistanceFarValueExpression = styleJson.translucencyByDistanceFarValue;
+        var distanceDisplayConditionNearExpression = styleJson.distanceDisplayConditionNear;
+        var distanceDisplayConditionFarExpression = styleJson.distanceDisplayConditionFar;
 
         var color;
         if (typeof colorExpression === 'string') {
@@ -349,6 +351,28 @@ define([
         }
 
         that._translucencyByDistanceFarValue = translucencyByDistanceFarValue;
+
+        var distanceDisplayConditionNear;
+        if (typeof distanceDisplayConditionNearExpression === 'number') {
+            distanceDisplayConditionNear = new Expression(String(distanceDisplayConditionNearExpression));
+        } else if (typeof distanceDisplayConditionNearExpression === 'string') {
+            distanceDisplayConditionNear = new Expression(distanceDisplayConditionNearExpression);
+        } else if (defined(distanceDisplayConditionNearExpression) && defined(distanceDisplayConditionNearExpression.conditions)) {
+            distanceDisplayConditionNear = new ConditionsExpression(distanceDisplayConditionNearExpression);
+        }
+
+        that._distanceDisplayConditionNear = distanceDisplayConditionNear;
+
+        var distanceDisplayConditionFar;
+        if (typeof distanceDisplayConditionFarExpression === 'number') {
+            distanceDisplayConditionFar = new Expression(String(distanceDisplayConditionFarExpression));
+        } else if (typeof distanceDisplayConditionFarExpression === 'string') {
+            distanceDisplayConditionFar = new Expression(distanceDisplayConditionFarExpression);
+        } else if (defined(distanceDisplayConditionFarExpression) && defined(distanceDisplayConditionFarExpression.conditions)) {
+            distanceDisplayConditionFar = new ConditionsExpression(distanceDisplayConditionFarExpression);
+        }
+
+        that._distanceDisplayConditionFar = distanceDisplayConditionFar;
 
         var meta = {};
         if (defined(styleJson.meta)) {
@@ -794,6 +818,36 @@ define([
             },
             set : function(value) {
                 this._translucencyByDistanceFarValue = value;
+            }
+        },
+
+        distanceDisplayConditionNear : {
+            get : function() {
+                //>>includeStart('debug', pragmas.debug);
+                if (!this._ready) {
+                    throw new DeveloperError('The style is not loaded.  Use Cesium3DTileStyle.readyPromise or wait for Cesium3DTileStyle.ready to be true.');
+                }
+                //>>includeEnd('debug');
+
+                return this._distanceDisplayConditionNear;
+            },
+            set : function(value) {
+                this._distanceDisplayConditionNear = value;
+            }
+        },
+
+        distanceDisplayConditionFar : {
+            get : function() {
+                //>>includeStart('debug', pragmas.debug);
+                if (!this._ready) {
+                    throw new DeveloperError('The style is not loaded.  Use Cesium3DTileStyle.readyPromise or wait for Cesium3DTileStyle.ready to be true.');
+                }
+                //>>includeEnd('debug');
+
+                return this._distanceDisplayConditionFar;
+            },
+            set : function(value) {
+                this._distanceDisplayConditionFar = value;
             }
         },
 

--- a/Source/Scene/Cesium3DTileStyleEngine.js
+++ b/Source/Scene/Cesium3DTileStyleEngine.js
@@ -3,12 +3,14 @@ define([
         '../Core/Color',
         '../Core/defined',
         '../Core/defineProperties',
+        '../Core/DistanceDisplayCondition',
         '../Core/NearFarScalar',
         './LabelStyle'
     ], function(
         Color,
         defined,
         defineProperties,
+        DistanceDisplayCondition,
         NearFarScalar,
         LabelStyle) {
     'use strict';
@@ -167,6 +169,16 @@ define([
             } else {
                 feature.translucencyByDistance = undefined;
             }
+
+            var distanceDisplayConditionNear = style.distanceDisplayConditionNear;
+            var distanceDisplayConditionFar = style.distanceDisplayConditionFar;
+
+            if (defined(distanceDisplayConditionNear) && defined(distanceDisplayConditionFar)) {
+                var near = distanceDisplayConditionNear.evaluate(frameState, feature);
+                var far = distanceDisplayConditionFar.evaluate(frameState, feature);
+
+                feature.distanceDisplayCondition = new DistanceDisplayCondition(near, far);
+            }
         }
     }
 
@@ -185,6 +197,7 @@ define([
             feature.backgroundYPadding = 5.0;
             feature.backgroundEnabled = false;
             feature.scaleByDistance = undefined;
+            feature.translucencyByDistance = undefined;
         }
     }
 

--- a/Source/Scene/Cesium3DTileStyleEngine.js
+++ b/Source/Scene/Cesium3DTileStyleEngine.js
@@ -150,6 +150,23 @@ define([
             } else {
                 feature.scaleByDistance = undefined;
             }
+
+            var translucencyByDistanceNearRange = style.translucencyByDistanceNearRange;
+            var translucencyByDistanceNearValue = style.translucencyByDistanceNearValue;
+            var translucencyByDistanceFarRange = style.translucencyByDistanceFarRange;
+            var translucencyByDistanceFarValue = style.translucencyByDistanceFarValue;
+
+            if (defined(translucencyByDistanceNearRange) && defined(translucencyByDistanceNearValue) &&
+                defined(translucencyByDistanceFarRange) && defined(translucencyByDistanceFarValue)) {
+                var nearRange = translucencyByDistanceNearRange.evaluate(frameState, feature);
+                var nearValue = translucencyByDistanceNearValue.evaluate(frameState, feature);
+                var farRange = translucencyByDistanceFarRange.evaluate(frameState, feature);
+                var farValue = translucencyByDistanceFarValue.evaluate(frameState, feature);
+
+                feature.translucencyByDistance = new NearFarScalar(nearRange, nearValue, farRange, farValue);
+            } else {
+                feature.translucencyByDistance = undefined;
+            }
         }
     }
 

--- a/Source/Scene/Cesium3DTileStyleEngine.js
+++ b/Source/Scene/Cesium3DTileStyleEngine.js
@@ -160,12 +160,12 @@ define([
 
             if (defined(translucencyByDistanceNearRange) && defined(translucencyByDistanceNearValue) &&
                 defined(translucencyByDistanceFarRange) && defined(translucencyByDistanceFarValue)) {
-                var nearRange = translucencyByDistanceNearRange.evaluate(frameState, feature);
-                var nearValue = translucencyByDistanceNearValue.evaluate(frameState, feature);
-                var farRange = translucencyByDistanceFarRange.evaluate(frameState, feature);
-                var farValue = translucencyByDistanceFarValue.evaluate(frameState, feature);
+                var tNearRange = translucencyByDistanceNearRange.evaluate(frameState, feature);
+                var tNearValue = translucencyByDistanceNearValue.evaluate(frameState, feature);
+                var tFarRange = translucencyByDistanceFarRange.evaluate(frameState, feature);
+                var tFarValue = translucencyByDistanceFarValue.evaluate(frameState, feature);
 
-                feature.translucencyByDistance = new NearFarScalar(nearRange, nearValue, farRange, farValue);
+                feature.translucencyByDistance = new NearFarScalar(tNearRange, tNearValue, tFarRange, tFarValue);
             } else {
                 feature.translucencyByDistance = undefined;
             }


### PR DESCRIPTION
As @bagnell has added the scaleByDistanceXXX options recently in vector-tiles-labels branch, I would like to also add the translucencyByDistanceXXX and distanceDisplayConditionXXX options.

Any objections?