### PR TITLE
Incremental renderer updates for multiple viewports

### DIFF
--- a/Source/Scene/FXAA.js
+++ b/Source/Scene/FXAA.js
@@ -54,7 +54,7 @@ define([
         this._viewport = new BoundingRectangle();
         this._rs = undefined;
 
-        this._useScissorTest = undefined;
+        this._useScissorTest = false;
         this._scissorRectangle = undefined;
 
         var clearCommand = new ClearCommand({

--- a/Source/Scene/FXAA.js
+++ b/Source/Scene/FXAA.js
@@ -54,6 +54,9 @@ define([
         this._viewport = new BoundingRectangle();
         this._rs = undefined;
 
+        this._useScissorTest = undefined;
+        this._scissorRectangle = undefined;
+
         var clearCommand = new ClearCommand({
             color : new Color(0.0, 0.0, 0.0, 0.0),
             depth : 1.0,
@@ -81,7 +84,7 @@ define([
         }
     }
 
-    FXAA.prototype.update = function(context) {
+    FXAA.prototype.update = function(context, passState) {
         var width = context.drawingBufferWidth;
         var height = context.drawingBufferHeight;
 
@@ -150,9 +153,22 @@ define([
         this._viewport.width = width;
         this._viewport.height = height;
 
-        if (!defined(this._rs) || !BoundingRectangle.equals(this._rs.viewport, this._viewport)) {
+        var useScissorTest = !BoundingRectangle.equals(this._viewport, passState.viewport);
+        var updateScissor = useScissorTest !== this._useScissorTest;
+        this._useScissorTest = useScissorTest;
+
+        if (!BoundingRectangle.equals(this._scissorRectangle, passState.viewport)) {
+            this._scissorRectangle = BoundingRectangle.clone(passState.viewport, this._scissorRectangle);
+            updateScissor = true;
+        }
+
+        if (!defined(this._rs) || !BoundingRectangle.equals(this._rs.viewport, this._viewport) || updateScissor) {
             this._rs = RenderState.fromCache({
-                viewport : this._viewport
+                viewport : this._viewport,
+                scissorTest : {
+                    enabled : this._useScissorTest,
+                    rectangle : this._scissorRectangle
+                }
             });
         }
 

--- a/Source/Scene/GlobeDepth.js
+++ b/Source/Scene/GlobeDepth.js
@@ -43,6 +43,9 @@ define([
         this._viewport = new BoundingRectangle();
         this._rs = undefined;
 
+        this._useScissorTest = undefined;
+        this._scissorRectangle = undefined;
+
         this._debugGlobeDepthViewportCommand = undefined;
     }
 
@@ -111,7 +114,7 @@ define([
         });
     }
 
-    function createFramebuffers(globeDepth, context, width, height) {
+    function createFramebuffers(globeDepth, context) {
         globeDepth.framebuffer = new Framebuffer({
             context : context,
             colorTextures : [globeDepth._colorTexture],
@@ -133,17 +136,30 @@ define([
             destroyTextures(globeDepth);
             destroyFramebuffers(globeDepth);
             createTextures(globeDepth, context, width, height);
-            createFramebuffers(globeDepth, context, width, height);
+            createFramebuffers(globeDepth, context);
         }
     }
 
-    function updateCopyCommands(globeDepth, context, width, height) {
+    function updateCopyCommands(globeDepth, context, width, height, passState) {
         globeDepth._viewport.width = width;
         globeDepth._viewport.height = height;
 
-        if (!defined(globeDepth._rs) || !BoundingRectangle.equals(globeDepth._viewport, globeDepth._rs.viewport)) {
+        var useScissorTest = !BoundingRectangle.equals(globeDepth._viewport, passState.viewport);
+        var updateScissor = useScissorTest !== globeDepth._useScissorTest;
+        globeDepth._useScissorTest = useScissorTest;
+
+        if (!BoundingRectangle.equals(globeDepth._scissorRectangle, passState.viewport)) {
+            globeDepth._scissorRectangle = BoundingRectangle.clone(passState.viewport, globeDepth._scissorRectangle);
+            updateScissor = true;
+        }
+
+        if (!defined(globeDepth._rs) || !BoundingRectangle.equals(globeDepth._viewport, globeDepth._rs.viewport) || updateScissor) {
             globeDepth._rs = RenderState.fromCache({
-                viewport : globeDepth._viewport
+                viewport : globeDepth._viewport,
+                scissorTest : {
+                    enabled : globeDepth._useScissorTest,
+                    rectangle : globeDepth._scissorRectangle
+                }
             });
         }
 
@@ -196,12 +212,12 @@ define([
         executeDebugGlobeDepth(this, context, passState);
     };
 
-    GlobeDepth.prototype.update = function(context) {
+    GlobeDepth.prototype.update = function(context, passState) {
         var width = context.drawingBufferWidth;
         var height = context.drawingBufferHeight;
 
         updateFramebuffers(this, context, width, height);
-        updateCopyCommands(this, context, width, height);
+        updateCopyCommands(this, context, width, height, passState);
         context.uniformState.globeDepthTexture = undefined;
     };
 

--- a/Source/Scene/GlobeDepth.js
+++ b/Source/Scene/GlobeDepth.js
@@ -43,7 +43,7 @@ define([
         this._viewport = new BoundingRectangle();
         this._rs = undefined;
 
-        this._useScissorTest = undefined;
+        this._useScissorTest = false;
         this._scissorRectangle = undefined;
 
         this._debugGlobeDepthViewportCommand = undefined;

--- a/Source/Scene/OIT.js
+++ b/Source/Scene/OIT.js
@@ -88,7 +88,7 @@ define([
         this._viewport = new BoundingRectangle();
         this._rs = undefined;
 
-        this._useScissorTest = undefined;
+        this._useScissorTest = false;
         this._scissorRectangle = undefined;
     }
 

--- a/Source/Scene/OIT.js
+++ b/Source/Scene/OIT.js
@@ -87,6 +87,9 @@ define([
 
         this._viewport = new BoundingRectangle();
         this._rs = undefined;
+
+        this._useScissorTest = undefined;
+        this._scissorRectangle = undefined;
     }
 
     function destroyTextures(oit) {
@@ -200,7 +203,7 @@ define([
         return supported;
     }
 
-    OIT.prototype.update = function(context, framebuffer) {
+    OIT.prototype.update = function(context, passState, framebuffer) {
         if (!this.isSupported()) {
             return;
         }
@@ -312,9 +315,22 @@ define([
         this._viewport.width = width;
         this._viewport.height = height;
 
-        if (!defined(this._rs) || !BoundingRectangle.equals(this._viewport, this._rs.viewport)) {
+        var useScissorTest = !BoundingRectangle.equals(this._viewport, passState.viewport);
+        var updateScissor = useScissorTest !== this._useScissorTest;
+        this._useScissorTest = useScissorTest;
+
+        if (!BoundingRectangle.equals(this._scissorRectangle, passState.viewport)) {
+            this._scissorRectangle = BoundingRectangle.clone(passState.viewport, this._scissorRectangle);
+            updateScissor = true;
+        }
+
+        if (!defined(this._rs) || !BoundingRectangle.equals(this._viewport, this._rs.viewport) || updateScissor) {
             this._rs = RenderState.fromCache({
-                viewport : this._viewport
+                viewport : this._viewport,
+                scissorTest : {
+                    enabled : this._useScissorTest,
+                    rectangle : this._scissorRectangle
+                }
             });
         }
 

--- a/Source/Scene/Scene.js
+++ b/Source/Scene/Scene.js
@@ -2071,6 +2071,10 @@ define([
         var context = scene._context;
 
         var viewport = passState.viewport;
+        viewport.x = 0;
+        viewport.y = 0;
+        viewport.width = context.drawingBufferWidth;
+        viewport.height = context.drawingBufferHeight;
 
         var frameState = scene._frameState;
         var camera = frameState.camera;
@@ -2078,12 +2082,13 @@ define([
         var depthOnly = frameState.passes.depth;
 
         if (scene._useWebVR && mode !== SceneMode.SCENE2D) {
+            updateAndClearFramebuffers(scene, passState, backgroundColor);
+
             if (!depthOnly) {
                 updatePrimitives(scene);
             }
 
             createPotentiallyVisibleSet(scene);
-            updateAndClearFramebuffers(scene, passState, backgroundColor);
 
             if (!depthOnly) {
                 executeComputeCommands(scene);
@@ -2123,13 +2128,7 @@ define([
 
             Camera.clone(savedCamera, camera);
         } else {
-            viewport.x = 0;
-            viewport.y = 0;
-            viewport.width = context.drawingBufferWidth;
-            viewport.height = context.drawingBufferHeight;
-
             updateAndClearFramebuffers(scene, passState, backgroundColor);
-
             if (mode !== SceneMode.SCENE2D || scene._mapMode2D === MapMode2D.ROTATE) {
                 executeCommandsInViewport(true, scene, passState);
             } else {

--- a/Source/Scene/Sun.js
+++ b/Source/Scene/Sun.js
@@ -139,11 +139,7 @@ define([
     /**
      * @private
      */
-    Sun.prototype.update = function(scene) {
-        var passState = scene._passState;
-        var frameState = scene.frameState;
-        var context = scene.context;
-
+    Sun.prototype.update = function(frameState, passState) {
         if (!this.show) {
             return undefined;
         }
@@ -157,6 +153,7 @@ define([
             return undefined;
         }
 
+        var context = frameState.context;
         var drawingBufferWidth = passState.viewport.width;
         var drawingBufferHeight = passState.viewport.height;
 
@@ -289,7 +286,7 @@ define([
 
         var position = SceneTransforms.computeActualWgs84Position(frameState, sunPosition, scratchCartesian4);
 
-        var dist = Cartesian3.magnitude(Cartesian3.subtract(position, scene.camera.position, scratchCartesian4));
+        var dist = Cartesian3.magnitude(Cartesian3.subtract(position, frameState.camera.position, scratchCartesian4));
         var projMatrix = context.uniformState.projection;
 
         var positionEC = scratchPositionEC;

--- a/Specs/Scene/SunSpec.js
+++ b/Specs/Scene/SunSpec.js
@@ -87,7 +87,7 @@ defineSuite([
 
         viewSun(scene.camera, scene.context.uniformState);
         scene.frameState.passes.render = false;
-        var command = scene.sun.update(scene);
+        var command = scene.sun.update(scene.frameState, scene._passState);
         expect(command).not.toBeDefined();
     });
 


### PR DESCRIPTION
2D is rendered with either one or two viewports depending on whether the longitude line at 180 degrees is visible. This computes the two viewports from the pass state viewport instead of the canvas dimensions.

All commands that copy from a post process framebuffer now use the scissor test to only copy the portion of the texture written to. The idea is that multiple scenes/viewports can use the same post process resources (textures, fbos, etc.) and just change the render state. The alternative was to create a viewport sized texture for each viewport.