### PR TITLE
Resolve data uris the moment they are schedules.

### DIFF
--- a/Source/Core/RequestScheduler.js
+++ b/Source/Core/RequestScheduler.js
@@ -4,8 +4,8 @@ define([
         '../ThirdParty/when',
         './defaultValue',
         './defined',
-        './defineProperties',
         './DeveloperError',
+        './isDataUri',
         './Queue',
         './Request',
         './RequestType'
@@ -14,8 +14,8 @@ define([
         when,
         defaultValue,
         defined,
-        defineProperties,
         DeveloperError,
+        isDataUri,
         Queue,
         Request,
         RequestType) {
@@ -307,7 +307,7 @@ define([
 
         ++stats.numberOfRequestsThisFrame;
 
-        if (!RequestScheduler.throttle) {
+        if (!RequestScheduler.throttle || isDataUri(request.url)) {
             return request.requestFunction(request.url, request.parameters);
         }
 


### PR DESCRIPTION
I was seeing some strange "hangs" in Composer that resulted in a bunch of data uris being scheduled with the RequestScheduler, which didn't seem to know what to do with them.  This change just detects if the schedules url is a data uri and handles the load function immediately (Im not sure why we would ever throttle them).

@lilleyse if you think there's a different approach to take here, I'd be happy to implement it, I haven't really dug into the RequestScheduler yet to know all of the edge cases.