### PR TITLE
Fixed crash in Camera.pickEllipsoid when height or width is 0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@ Change Log
 ### 1.34 - 2017-06-01
 
 * Fix issue where polylines in a `PolylineCollection` would ignore the far distance when updating the distance display condition. [#5283](https://github.com/AnalyticalGraphicsInc/cesium/pull/5283)
+* Fixed a crash when calling `Camera.pickEllipsoid` with a canvas of size 0.
 
 ### 1.33 - 2017-05-01
 

--- a/Source/Scene/Camera.js
+++ b/Source/Scene/Camera.js
@@ -2395,6 +2395,11 @@ define([
         }
         //>>includeEnd('debug');
 
+        var canvas = this._scene.canvas;
+        if (canvas.clientWidth === 0 || canvas.clientHeight === 0) {
+            return undefined;
+        }
+
         if (!defined(result)) {
             result = new Cartesian3();
         }

--- a/Specs/Scene/CameraSpec.js
+++ b/Specs/Scene/CameraSpec.js
@@ -1890,10 +1890,20 @@ defineSuite([
         expect(camera.right).toEqual(right);
     });
 
-    it('pick ellipsoid thows without a position', function() {
+    it('pick ellipsoid throws without a position', function() {
         expect(function() {
             camera.pickEllipsoid();
         }).toThrowDeveloperError();
+    });
+
+    it('pick ellipsoid returns undefined if height is 0', function() {
+        scene.canvas.clientHeight = 0;
+        expect(camera.pickEllipsoid(Cartesian2.ZERO)).toBeUndefined();
+    });
+
+    it('pick ellipsoid returns undefined if width is 0', function() {
+        scene.canvas.clientWidth = 0;
+        expect(camera.pickEllipsoid(Cartesian2.ZERO)).toBeUndefined();
     });
 
     it('pick ellipsoid', function() {


### PR DESCRIPTION
There are cases where we programatically call `pickEllipsoid`, usually with the center or corner points of the screen. When the canvas is currently hidden via CSS or hasn't been added to the DOM yet, the canvas
has a length and width of 0.  Calling pickEllipsoid in these cases would lead to NaNs during Cartesian3.normalize.  The correct behavior is to simply return undefined, as we do in other cases where pickEllipsoid is not possible or fails.