### PR TITLE
Support Animation widget construction outside of the DOM

### DIFF
--- a/Source/Widgets/Animation/Animation.js
+++ b/Source/Widgets/Animation/Animation.js
@@ -713,16 +713,12 @@ define([
                 return;
             }
             var that = this;
-            that._observer = new MutationObserver(function(mutations) {
-                mutations.forEach(function(mutation) {
-                    for (var i = 0; i < mutation.addedNodes.length; i++) {
-                        if (mutation.addedNodes[i].contains(that._container)) {
-                            that._observer.disconnect();
-                            that._observer = undefined;
-                            that.applyThemeChanges();
-                        }
-                    }
-                });
+            that._observer = new MutationObserver(function() {
+                if (document.body.contains(that._container)) {
+                    that._observer.disconnect();
+                    that._observer = undefined;
+                    that.applyThemeChanges();
+                }
             });
             that._observer.observe(document, {childList : true, subtree : true});
             return;

--- a/Source/Widgets/Animation/Animation.js
+++ b/Source/Widgets/Animation/Animation.js
@@ -611,6 +611,11 @@ define([
      * removing the widget from layout.
      */
     Animation.prototype.destroy = function() {
+        if (defined(this._observer)) {
+            this._observer.disconnect();
+            this._observer = undefined;
+        }
+
         var mouseCallback = this._mouseCallback;
         this._shuttleRingBackPanel.removeEventListener('mousedown', mouseCallback, true);
         this._shuttleRingBackPanel.removeEventListener('touchstart', mouseCallback, true);
@@ -698,6 +703,31 @@ define([
      * animation.applyThemeChanges();
      */
     Animation.prototype.applyThemeChanges = function() {
+        // Since we rely on computed styles for themeing, we can't actually
+        // do anything if the container has not yet been added to the DOM.
+        // Set up an observer to be notified when it is added and apply
+        // the changes at that time.
+        if (!document.body.contains(this._container)) {
+            if (defined(this._observer)) {
+                //Already listening.
+                return;
+            }
+            var that = this;
+            that._observer = new MutationObserver(function(mutations) {
+                mutations.forEach(function(mutation) {
+                    for (var i = 0; i < mutation.addedNodes.length; i++) {
+                        if (mutation.addedNodes[i].contains(that._container)) {
+                            that._observer.disconnect();
+                            that._observer = undefined;
+                            that.applyThemeChanges();
+                        }
+                    }
+                });
+            });
+            that._observer.observe(document, {childList : true, subtree : true});
+            return;
+        }
+
         var buttonNormalBackColor = getElementColor(this._themeNormal);
         var buttonHoverBackColor = getElementColor(this._themeHover);
         var buttonToggledBackColor = getElementColor(this._themeSelect);

--- a/Specs/Widgets/Animation/AnimationSpec.js
+++ b/Specs/Widgets/Animation/AnimationSpec.js
@@ -1,19 +1,55 @@
 /*global defineSuite*/
 defineSuite([
         'Widgets/Animation/Animation',
+        'Core/defined',
         'Widgets/Animation/AnimationViewModel',
         'Widgets/ClockViewModel'
     ], function(
         Animation,
+        defined,
         AnimationViewModel,
         ClockViewModel) {
     'use strict';
 
-    it('sanity check', function() {
+    var container;
+    var animation;
+    afterEach(function() {
+        if (defined(animation)) {
+            animation = animation.destroy();
+        }
+        if (defined(container) && defined(container.parentNode)) {
+            container.parentNode.removeChild(container);
+        }
+    });
+
+    it('Can create and destroy', function() {
         var clockViewModel = new ClockViewModel();
         var animationViewModel = new AnimationViewModel(clockViewModel);
-        var animation = new Animation(document.body, animationViewModel);
-        animation.applyThemeChanges();
-        animation.destroy();
+        animation = new Animation(document.body, animationViewModel);
+    });
+
+    it('Can create with container not in the DOM', function(done) {
+        container = document.createElement('div');
+        var clockViewModel = new ClockViewModel();
+        var animationViewModel = new AnimationViewModel(clockViewModel);
+        var animation = new Animation(container, animationViewModel);
+
+        //Verify applyThemeChanges is called when we add the container to the DOM.
+        spyOn(animation, 'applyThemeChanges').and.callThrough();
+        document.body.appendChild(container);
+
+        // setTimeout is needed because the MutationObserver used by Animation
+        // will not be called before next tick.
+        setTimeout(function() {
+            expect(animation.applyThemeChanges).toHaveBeenCalled();
+            done();
+        }, 0);
+    });
+
+    it('Can destroy without container ever being in the DOM', function() {
+        container = document.createElement('div');
+        var clockViewModel = new ClockViewModel();
+        var animationViewModel = new AnimationViewModel(clockViewModel);
+        animation = new Animation(container, animationViewModel);
     });
 });


### PR DESCRIPTION
Creating a new `Animation` instance would crash if provided container was not currently in the DOM. This is because we use computed styles for themeing and computed styles return undefined if the element isn't in the DOM.  Since we call `applyThemeChanges` during construction, this would lead to a crash.

The solution is check if the container is in the DOM, and if not, use `MutationObserver` to delay the style application until the element is added.