### PR TITLE
Viewer clock improvements

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,8 @@ Change Log
 
 ### 1.34 - 2017-06-01
 
+* Breaking changes
+   * Passing `options.clock` when creating a new `Viewer` instance has been deprecated and will be removed in Cesium 1.37, pass `options.clockViewModel` instead.
 * Fix issue where polylines in a `PolylineCollection` would ignore the far distance when updating the distance display condition. [#5283](https://github.com/AnalyticalGraphicsInc/cesium/pull/5283)
 * Fixed a crash when calling `Camera.pickEllipsoid` with a canvas of size 0.
 

--- a/Source/Widgets/Viewer/Viewer.js
+++ b/Source/Widgets/Viewer/Viewer.js
@@ -2,9 +2,11 @@
 define([
         '../../Core/BoundingSphere',
         '../../Core/Cartesian3',
+        '../../Core/Clock',
         '../../Core/defaultValue',
         '../../Core/defined',
         '../../Core/defineProperties',
+        '../../Core/deprecationWarning',
         '../../Core/destroyObject',
         '../../Core/DeveloperError',
         '../../Core/Event',
@@ -46,9 +48,11 @@ define([
     ], function(
         BoundingSphere,
         Cartesian3,
+        Clock,
         defaultValue,
         defined,
         defineProperties,
+        deprecationWarning,
         destroyObject,
         DeveloperError,
         Event,
@@ -259,7 +263,7 @@ define([
      * @param {Boolean} [options.navigationHelpButton=true] If set to false, the navigation help button will not be created.
      * @param {Boolean} [options.navigationInstructionsInitiallyVisible=true] True if the navigation instructions should initially be visible, or false if the should not be shown until the user explicitly clicks the button.
      * @param {Boolean} [options.scene3DOnly=false] When <code>true</code>, each geometry instance will only be rendered in 3D to save GPU memory.
-     * @param {Clock} [options.clock=new Clock()] The clock to use to control current time.
+     * @param {ClockViewModel} [options.clockViewModel=new ClockViewModel(options.clock)] The clock view model to use to control current time.
      * @param {ProviderViewModel} [options.selectedImageryProviderViewModel] The view model for the current base imagery layer, if not supplied the first available base layer is used.  This value is only valid if options.baseLayerPicker is set to true.
      * @param {ProviderViewModel[]} [options.imageryProviderViewModels=createDefaultImageryProviderViewModels()] The array of ProviderViewModels to be selectable from the BaseLayerPicker.  This value is only valid if options.baseLayerPicker is set to true.
      * @param {ProviderViewModel} [options.selectedTerrainProviderViewModel] The view model for the current base terrain layer, if not supplied the first available base layer is used.  This value is only valid if options.baseLayerPicker is set to true.
@@ -401,11 +405,27 @@ Either specify options.terrainProvider instead or set options.baseLayerPicker to
 
         var scene3DOnly = defaultValue(options.scene3DOnly, false);
 
+        if (defined(options.clock)) {
+            deprecationWarning('Viewer.options.clock', 'Passing options.clock when creating a new Viewer instance was deprecated in Cesium 1.34 and will be removed in Cesium 1.37, pass options.clockViewModel instead.');
+        }
+
+        var clock;
+        var clockViewModel;
+        var destroyClockViewModel = false;
+        if (defined(options.clockViewModel)) {
+            clockViewModel = options.clockViewModel;
+            clock = clockViewModel.clock;
+        } else {
+            clock = new Clock();
+            clockViewModel = new ClockViewModel(clock);
+            destroyClockViewModel = true;
+        }
+
         // Cesium widget
         var cesiumWidget = new CesiumWidget(cesiumWidgetContainer, {
             terrainProvider : options.terrainProvider,
             imageryProvider : createBaseLayerPicker ? false : options.imageryProvider,
-            clock : options.clock,
+            clock : clock,
             skyBox : options.skyBox,
             skyAtmosphere : options.skyAtmosphere,
             sceneMode : options.sceneMode,
@@ -436,8 +456,6 @@ Either specify options.terrainProvider instead or set options.baseLayerPicker to
             dataSourceCollection : dataSourceCollection
         });
 
-        var clock = cesiumWidget.clock;
-        var clockViewModel = new ClockViewModel(clock);
         var eventHelper = new EventHelper();
 
         eventHelper.add(clock.onTick, Viewer.prototype._onTick, this);
@@ -649,6 +667,7 @@ Either specify options.terrainProvider instead or set options.baseLayerPicker to
         this._destroyDataSourceCollection = destroyDataSourceCollection;
         this._dataSourceDisplay = dataSourceDisplay;
         this._clockViewModel = clockViewModel;
+        this._destroyClockViewModel = destroyClockViewModel;
         this._toolbar = toolbar;
         this._homeButton = homeButton;
         this._sceneModePicker = sceneModePicker;
@@ -1067,7 +1086,19 @@ Either specify options.terrainProvider instead or set options.baseLayerPicker to
          */
         clock : {
             get : function() {
-                return this._cesiumWidget.clock;
+                return this._clockViewModel.clock;
+            }
+        },
+
+        /**
+         * Gets the clock view model.
+         * @memberof Viewer.prototype
+         * @type {ClockViewModel}
+         * @readonly
+         */
+        clockViewModel : {
+            get : function() {
+                return this._clockViewModel;
             }
         },
 
@@ -1492,7 +1523,9 @@ Either specify options.terrainProvider instead or set options.baseLayerPicker to
             this._selectionIndicator = this._selectionIndicator.destroy();
         }
 
-        this._clockViewModel = this._clockViewModel.destroy();
+        if (this._destroyClockViewModel) {
+            this._clockViewModel = this._clockViewModel.destroy();
+        }
         this._dataSourceDisplay = this._dataSourceDisplay.destroy();
         this._cesiumWidget = this._cesiumWidget.destroy();
 

--- a/Source/Widgets/Viewer/Viewer.js
+++ b/Source/Widgets/Viewer/Viewer.js
@@ -405,7 +405,8 @@ Either specify options.terrainProvider instead or set options.baseLayerPicker to
 
         var scene3DOnly = defaultValue(options.scene3DOnly, false);
 
-        if (defined(options.clock)) {
+        var deprecatedClock = options.clock;
+        if (defined(deprecatedClock)) {
             deprecationWarning('Viewer.options.clock', 'Passing options.clock when creating a new Viewer instance was deprecated in Cesium 1.34 and will be removed in Cesium 1.37, pass options.clockViewModel instead.');
         }
 
@@ -416,7 +417,7 @@ Either specify options.terrainProvider instead or set options.baseLayerPicker to
             clockViewModel = options.clockViewModel;
             clock = clockViewModel.clock;
         } else {
-            clock = new Clock();
+            clock = defined(deprecatedClock) ? deprecatedClock : new Clock();
             clockViewModel = new ClockViewModel(clock);
             destroyClockViewModel = true;
         }

--- a/Specs/Widgets/Viewer/ViewerSpec.js
+++ b/Specs/Widgets/Viewer/ViewerSpec.js
@@ -26,6 +26,7 @@ defineSuite([
         'Widgets/BaseLayerPicker/BaseLayerPicker',
         'Widgets/BaseLayerPicker/ProviderViewModel',
         'Widgets/CesiumWidget/CesiumWidget',
+        'Widgets/ClockViewModel',
         'Widgets/FullscreenButton/FullscreenButton',
         'Widgets/Geocoder/Geocoder',
         'Widgets/HomeButton/HomeButton',
@@ -60,6 +61,7 @@ defineSuite([
         BaseLayerPicker,
         ProviderViewModel,
         CesiumWidget,
+        ClockViewModel,
         FullscreenButton,
         Geocoder,
         HomeButton,
@@ -114,6 +116,8 @@ defineSuite([
         expect(viewer.baseLayerPicker).toBeInstanceOf(BaseLayerPicker);
         expect(viewer.navigationHelpButton).toBeInstanceOf(NavigationHelpButton);
         expect(viewer.animation).toBeInstanceOf(Animation);
+        expect(viewer.clockViewModel).toBeInstanceOf(ClockViewModel);
+        expect(viewer.animation.viewModel.clockViewModel).toBe(viewer.clockViewModel);
         expect(viewer.timeline).toBeInstanceOf(Timeline);
         expect(viewer.fullscreenButton).toBeInstanceOf(FullscreenButton);
         expect(viewer.selectionIndicator).toBeInstanceOf(SelectionIndicator);
@@ -128,6 +132,16 @@ defineSuite([
         expect(viewer.isDestroyed()).toEqual(false);
         viewer.destroy();
         expect(viewer.isDestroyed()).toEqual(true);
+    });
+
+    it('can specify custom clockViewModel', function() {
+        var clockViewModel = new ClockViewModel();
+        viewer = createViewer(container, {clockViewModel : clockViewModel});
+        expect(viewer.clockViewModel).toBe(clockViewModel);
+        expect(viewer.animation.viewModel.clockViewModel).toBe(viewer.clockViewModel);
+        viewer.destroy();
+        expect(clockViewModel.isDestroyed()).toBe(false);
+        clockViewModel.destroy();
     });
 
     it('renders without errors', function() {


### PR DESCRIPTION
In master, it's impossible specify the `clockViewModel` instance to use for any child widgets that need it.  Viewer also doesn't expose the `ClockViewModel` and you have to dig into `animation.viewModel.clockViewModel` to get to it.  This makes it hard to write custom widgets that need to share the same `ClockViewModel` and are not directly tied to the lifetime of the 
 clockViewModel` created by Viewer (which gets destroyed when the Viewer is destroyed).

This change deprecates the Viewer `clock` constructor option and replaces it with `clockViewModel`.  If a custom `clockViewModel` is specified, it is passed through to any child widgets that need it and it is not destroyed on destruction.

We didn't have tests for the old functionality, but I added a test for the new parameter.