### PR TITLE
debugColorizeTiles works with no features

### DIFF
--- a/Source/Scene/Batched3DModel3DTileContent.js
+++ b/Source/Scene/Batched3DModel3DTileContent.js
@@ -377,7 +377,11 @@ define([
      */
     Batched3DModel3DTileContent.prototype.applyDebugSettings = function(enabled, color) {
         color = enabled ? color : Color.WHITE;
-        this.batchTable.setAllColor(color);
+        if (this.featuresLength === 0) {
+            this._model.color = color;
+        } else {
+            this.batchTable.setAllColor(color);
+        }
     };
 
     /**

--- a/Source/Scene/Cesium3DTile.js
+++ b/Source/Scene/Cesium3DTile.js
@@ -602,6 +602,8 @@ define([
         this.lastSelectedFrameNumber = 0;
         this.lastStyleTime = 0;
 
+        this._debugColorizeTiles = false;
+
         this._debugBoundingVolume = this._debugBoundingVolume && this._debugBoundingVolume.destroy();
         this._debugContentBoundingVolume = this._debugContentBoundingVolume && this._debugContentBoundingVolume.destroy();
         this._debugViewerRequestVolume = this._debugViewerRequestVolume && this._debugViewerRequestVolume.destroy();

--- a/Specs/Scene/Cesium3DTileBatchTableSpec.js
+++ b/Specs/Scene/Cesium3DTileBatchTableSpec.js
@@ -581,28 +581,6 @@ defineSuite([
         });
     });
 
-    it('renders with debug color', function() {
-        return Cesium3DTilesTester.loadTileset(scene, withoutBatchTableUrl).then(function(tileset) {
-            // Get initial color
-            var color;
-            Cesium3DTilesTester.expectRender(scene, tileset, function(rgba) {
-                color = rgba;
-            });
-
-            // Check for debug color
-            tileset.debugColorizeTiles = true;
-            Cesium3DTilesTester.expectRender(scene, tileset, function(rgba) {
-                expect(rgba).not.toEqual(color);
-            });
-
-            // Check for original color
-            tileset.debugColorizeTiles = false;
-            Cesium3DTilesTester.expectRender(scene, tileset, function(rgba) {
-                expect(rgba).toEqual(color);
-            });
-        });
-    });
-
     function expectRenderTranslucent(tileset) {
         var batchTable = tileset._root.content.batchTable;
 


### PR DESCRIPTION
Fixes #5290 

When `debugColorizeTiles` is on and the b3dm has no features, set the model's color.

Plus some cleanup for the camera settings in `Cesium3DTileset`