### PR TITLE
Fix polyline collection update when model matrix changes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,6 +24,7 @@ Change Log
 * Fixed bug in conversion formula in `Matrix3.fromHeadingPitchRoll`. [#5195](https://github.com/AnalyticalGraphicsInc/cesium/issues/5195)
 * Upgrade FXAA to version 3.11. [#5200](https://github.com/AnalyticalGraphicsInc/cesium/pull/5200)
 * `Scene.pickPosition` now caches results per frame to increase performance. [#5117](https://github.com/AnalyticalGraphicsInc/cesium/issues/5117)
+* Fixed bug where polylines would not update when `PolylineCollection` model matrix was updated [#5327](https://github.com/AnalyticalGraphicsInc/cesium/pull/5327)
 
 ### 1.32 - 2017-04-03
 

--- a/Source/Core/PolylinePipeline.js
+++ b/Source/Core/PolylinePipeline.js
@@ -152,9 +152,9 @@ define([
             var inverseModelMatrix = Matrix4.inverseTransformation(modelMatrix, wrapLongitudeInversMatrix);
 
             var origin = Matrix4.multiplyByPoint(inverseModelMatrix, Cartesian3.ZERO, wrapLongitudeOrigin);
-            var xzNormal = Matrix4.multiplyByPointAsVector(inverseModelMatrix, Cartesian3.UNIT_Y, wrapLongitudeXZNormal);
+            var xzNormal = Cartesian3.normalize(Matrix4.multiplyByPointAsVector(inverseModelMatrix, Cartesian3.UNIT_Y, wrapLongitudeXZNormal), wrapLongitudeXZNormal);
             var xzPlane = Plane.fromPointNormal(origin, xzNormal, wrapLongitudeXZPlane);
-            var yzNormal = Matrix4.multiplyByPointAsVector(inverseModelMatrix, Cartesian3.UNIT_X, wrapLongitudeYZNormal);
+            var yzNormal = Cartesian3.normalize(Matrix4.multiplyByPointAsVector(inverseModelMatrix, Cartesian3.UNIT_X, wrapLongitudeYZNormal), wrapLongitudeYZNormal);
             var yzPlane = Plane.fromPointNormal(origin, yzNormal, wrapLongitudeYZPlane);
 
             var count = 1;

--- a/Source/Scene/Polyline.js
+++ b/Source/Scene/Polyline.js
@@ -335,7 +335,7 @@ define([
             this._boundingVolumeWC = BoundingSphere.transform(this._boundingVolume, modelMatrix, this._boundingVolumeWC);
         }
 
-        this._modelMatrix = modelMatrix;
+        this._modelMatrix = Matrix4.clone(modelMatrix, this._modelMatrix);
 
         if (this._segments.positions.length !== segmentPositionsLength) {
             // number of positions changed

--- a/Specs/Scene/PolylineCollectionSpec.js
+++ b/Specs/Scene/PolylineCollectionSpec.js
@@ -7,6 +7,7 @@ defineSuite([
         'Core/DistanceDisplayCondition',
         'Core/HeadingPitchRange',
         'Core/Math',
+        'Core/Matrix4',
         'Scene/Camera',
         'Scene/Material',
         'Scene/SceneMode',
@@ -19,6 +20,7 @@ defineSuite([
         DistanceDisplayCondition,
         HeadingPitchRange,
         CesiumMath,
+        Matrix4,
         Camera,
         Material,
         SceneMode,
@@ -1369,6 +1371,26 @@ defineSuite([
         p1.width = 1;
         expect(scene).notToRender([0, 0, 0, 255]);
 
+    });
+
+    it('renders with model matrix', function() {
+        polylines.add({
+            positions : [{
+                x : 0.0,
+                y : 0.0,
+                z : 0.0
+            }, {
+                x : 0.0,
+                y : 1.0,
+                z : 0.0
+            }]
+        });
+
+        expect(scene).toRender([0, 0, 0, 255]);
+        scene.primitives.add(polylines);
+        expect(scene).toRender([0, 0, 0, 255]);
+        polylines.modelMatrix = Matrix4.fromUniformScale(1000000.0, polylines.modelMatrix);
+        expect(scene).notToRender([0, 0, 0, 255]);
     });
 
     it('is picked', function() {


### PR DESCRIPTION
`Polyline` wasn't updating properly when the `PolylineCollection` model matrix values changed because it was copying the reference to `PolylineCollection.modelMatrix` instead of copying the values.

Here is an example that doesn't update in master but updates in this branch.

``` javascript
var viewer = new Cesium.Viewer('cesiumContainer');
var localPolylines = viewer.scene.primitives.add(new Cesium.PolylineCollection());

var lon = -125;
var lat = 35;
var center = new Cesium.Cartesian3();

var localPolyline = localPolylines.add({
    positions : [
        new Cesium.Cartesian3(0.0, 0.0, 0.0),
        new Cesium.Cartesian3(1000000.0, 0.0, 0.0)
    ],
    width : 10.0,
    material : Cesium.Material.fromType(Cesium.Material.PolylineArrowType)
});

setInterval(function() {
    lon += 0.3;
    center = Cesium.Cartesian3.fromDegrees(lon, lat, 0, undefined, center);
    localPolylines.modelMatrix = Cesium.Transforms.eastNorthUpToFixedFrame(center, undefined, localPolylines.modelMatrix);
}, 100);
```