### PR TITLE
Fix Material translucency 

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,6 +25,7 @@ Change Log
 * Upgrade FXAA to version 3.11. [#5200](https://github.com/AnalyticalGraphicsInc/cesium/pull/5200)
 * `Scene.pickPosition` now caches results per frame to increase performance. [#5117](https://github.com/AnalyticalGraphicsInc/cesium/issues/5117)
 * Fixed bug where polylines would not update when `PolylineCollection` model matrix was updated [#5327](https://github.com/AnalyticalGraphicsInc/cesium/pull/5327)
+* Fixed translucency bug for certain material types [#5335](https://github.com/AnalyticalGraphicsInc/cesium/pull/5335)
 
 ### 1.32 - 2017-04-03
 

--- a/Source/Scene/Material.js
+++ b/Source/Scene/Material.js
@@ -1268,7 +1268,7 @@ define([
         },
         translucent : function(material) {
             var uniforms = material.uniforms;
-            return (uniforms.evenColor.alpha < 1.0) || (uniforms.oddColor.alpha < 0.0);
+            return (uniforms.evenColor.alpha < 1.0) || (uniforms.oddColor.alpha < 1.0);
         }
     });
 
@@ -1290,7 +1290,7 @@ define([
         },
         translucent : function(material) {
             var uniforms = material.uniforms;
-            return (uniforms.lightColor.alpha < 1.0) || (uniforms.darkColor.alpha < 0.0);
+            return (uniforms.lightColor.alpha < 1.0) || (uniforms.darkColor.alpha < 1.0);
         }
     });
 
@@ -1312,7 +1312,7 @@ define([
         },
         translucent : function(material) {
             var uniforms = material.uniforms;
-            return (uniforms.lightColor.alpha < 1.0) || (uniforms.darkColor.alpha < 0.0);
+            return (uniforms.lightColor.alpha < 1.0) || (uniforms.darkColor.alpha < 1.0);
         }
     });
 
@@ -1340,7 +1340,7 @@ define([
         },
         translucent : function(material) {
             var uniforms = material.uniforms;
-            return (uniforms.baseWaterColor.alpha < 1.0) || (uniforms.blendColor.alpha < 0.0);
+            return (uniforms.baseWaterColor.alpha < 1.0) || (uniforms.blendColor.alpha < 1.0);
         }
     });
 
@@ -1362,7 +1362,7 @@ define([
         },
         translucent : function(material) {
             var uniforms = material.uniforms;
-            return (uniforms.color.alpha < 1.0) || (uniforms.rimColor.alpha < 0.0);
+            return (uniforms.color.alpha < 1.0) || (uniforms.rimColor.alpha < 1.0);
         }
     });
 


### PR DESCRIPTION
Fix translucency for dot, checkerboard, stripe, water and rim lighting materials

Before:
![image](https://cloud.githubusercontent.com/assets/3451886/26164854/f88e0f86-3afb-11e7-9b4d-c66aef9acc4f.png)

After:
![image](https://cloud.githubusercontent.com/assets/3451886/26164856/fa953570-3afb-11e7-9350-438fdc41fe6e.png)
