### PR TITLE
Fix billboard clamping bug

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@ Change Log
 * Fixed a crash when calling `Camera.pickEllipsoid` with a canvas of size 0.
 * Fix `BoundingSphere.fromOrientedBoundingBox`. [#5334](https://github.com/AnalyticalGraphicsInc/cesium/issues/5334)
 * Fixed bug where polylines would not update when `PolylineCollection` model matrix was updated [#5327](https://github.com/AnalyticalGraphicsInc/cesium/pull/5327)
+* Fixed a bug where adding a ground clamped label without a position would show up at a previous label's clamped position. [#5338](https://github.com/AnalyticalGraphicsInc/cesium/issues/5338)
 * Fixed translucency bug for certain material types [#5335](https://github.com/AnalyticalGraphicsInc/cesium/pull/5335)
 * Fix picking polylines that use a depth fail appearance. [#5337](https://github.com/AnalyticalGraphicsInc/cesium/pull/5337)
 

--- a/Source/Scene/Billboard.js
+++ b/Source/Scene/Billboard.js
@@ -239,7 +239,6 @@ define([
                 if (!Cartesian3.equals(position, value)) {
                     Cartesian3.clone(value, position);
                     Cartesian3.clone(value, this._actualPosition);
-
                     this._updateClamping();
                     makeDirty(this, POSITION_INDEX);
                 }
@@ -956,6 +955,7 @@ define([
 
         var position = ellipsoid.cartesianToCartographic(owner._position);
         if (!defined(position)) {
+            owner._actualClampedPosition = undefined;
             return;
         }
 

--- a/Specs/Scene/BillboardCollectionSpec.js
+++ b/Specs/Scene/BillboardCollectionSpec.js
@@ -1877,6 +1877,10 @@ defineSuite([
             scene.globe.callback(Cartesian3.fromDegrees(-72.0, 40.0, 100.0));
             cartographic = scene.globe.ellipsoid.cartesianToCartographic(b._clampedPosition);
             expect(cartographic.height).toEqualEpsilon(100.0, CesiumMath.EPSILON9);
+
+            //Setting position to zero should clear the clamped position.
+            b.position = Cartesian3.ZERO;
+            expect(b._clampedPosition).toBeUndefined();
         });
 
         it('changing the terrain provider', function() {


### PR DESCRIPTION
Clear the current clamped position if the new position is not clampable.

In master, the below code has no effect when setting the billboard position to `Cartesian3.ZERO`, this branch properly updates the billboard:

```javascript
var viewer = new Cesium.Viewer('cesiumContainer');

var billboards = new Cesium.BillboardCollection({scene: viewer.scene});
viewer.scene.primitives.add(billboards);

var b = billboards.add({
    position : Cesium.Cartesian3.fromDegrees(-75, 45),
    image : '../images/facility.gif',
    heightReference : Cesium.HeightReference.CLAMP_TO_GROUND
});

Sandcastle.addToolbarButton('Set position', function(){
    b.position = Cesium.Cartesian3.ZERO;
});
```

Fixes #5338