### PR TITLE
Expose getStats function in Cesium3DTilesInspectorViewModel

### DIFF
--- a/Source/Widgets/Cesium3DTilesInspector/Cesium3DTilesInspectorViewModel.js
+++ b/Source/Widgets/Cesium3DTilesInspector/Cesium3DTilesInspectorViewModel.js
@@ -984,7 +984,7 @@ define([
     /**
      * Generates an HTML string of the statistics
      * @param {Cesium3DTileset} tileset The tileset
-     * @param {Boolean} isPick Whether this is getting the statistics for a picked feature
+     * @param {Boolean} isPick Whether this is getting the statistics for the pick pass
      * @returns {String} The formatted statistics
      */
     Cesium3DTilesInspectorViewModel.getStats = getStats;

--- a/Source/Widgets/Cesium3DTilesInspector/Cesium3DTilesInspectorViewModel.js
+++ b/Source/Widgets/Cesium3DTilesInspector/Cesium3DTilesInspectorViewModel.js
@@ -981,5 +981,13 @@ define([
         return destroyObject(this);
     };
 
+    /**
+     * Generates an HTML string of the statistics
+     * @param {Cesium3DTileset} tileset The tileset
+     * @param {Boolean} isPick Whether this is getting the statistics for a picked feature
+     * @returns {String} The formatted statistics
+     */
+    Cesium3DTilesInspectorViewModel.getStats = getStats;
+
     return Cesium3DTilesInspectorViewModel;
 });


### PR DESCRIPTION
I'm overriding the default picking functionality in the `Cesium3DTilesInspector` and I need a way to call this function from my custom view