### PR TITLE
Fix KML descriptions that link to relative paths

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@ Change Log
 * Fixed translucency bug for certain material types [#5335](https://github.com/AnalyticalGraphicsInc/cesium/pull/5335)
 * Fix picking polylines that use a depth fail appearance. [#5337](https://github.com/AnalyticalGraphicsInc/cesium/pull/5337)
 * Fixed a crash when morphing from Columbus view to 3D. [#5311](https://github.com/AnalyticalGraphicsInc/cesium/issues/5311)
+* Fixed a bug which prevented KML descriptions with relative paths from loading. [#5352](https://github.com/AnalyticalGraphicsInc/cesium/pull/5352)
 * Updated documentation for Quaternion.fromHeadingPitchRoll [#5264](https://github.com/AnalyticalGraphicsInc/cesium/issues/5264)
 
 ### 1.33 - 2017-05-01

--- a/Specs/DataSources/KmlDataSourceSpec.js
+++ b/Specs/DataSources/KmlDataSourceSpec.js
@@ -1832,6 +1832,28 @@ defineSuite([
         });
     });
 
+    it('BalloonStyle: relative description paths absolute to sourceUri', function() {
+        var kml = '<?xml version="1.0" encoding="UTF-8"?>\
+        <Placemark>\
+            <description><![CDATA[<img src="foo/bar.png"/>]]></description>\
+        </Placemark>';
+
+        return KmlDataSource.load(parser.parseFromString(kml, "text/xml"), {
+            camera : options.camera,
+            canvas : options.canvas,
+            sourceUri : 'http://test.invalid'
+        }).then(function(dataSource) {
+            var entity = dataSource.entities.values[0];
+
+            var element = document.createElement('div');
+            element.innerHTML = entity.description.getValue();
+
+            var a = element.firstChild.firstChild;
+            expect(a.localName).toEqual('img');
+            expect(a.getAttribute('src')).toEqual('http://test.invalid/foo/bar.png');
+        });
+    });
+
     it('BalloonStyle: description retargets existing links to _blank', function() {
         var kml = '<?xml version="1.0" encoding="UTF-8"?>\
         <Placemark>\


### PR DESCRIPTION
If a KML description included a relative path, the browser request would end up using whatever server the application was hosted on as the base path, this is because the KML HTML would be injected into the InfoBox as-is. The end result is that relative images and links inside of KML files would not load properly.

To fix this, we now expand all relative paths into absolute paths that use the KML's source Uri as the bas.

I added a test that fails in master and passes in this branch; but if you want to test this manually, you can unzip `gdpPerCapita2008.kmz` into it's own subdirectory and load the KML.  Click on any item and it will be missing images in master, but they properly show up in this branch (the KMZ itself always worked because it goes through a different code path).