### PR TITLE
Fix string->number conversion in 3D Tiles inspector

### DIFF
--- a/Source/Widgets/Cesium3DTilesInspector/Cesium3DTilesInspectorViewModel.js
+++ b/Source/Widgets/Cesium3DTilesInspector/Cesium3DTilesInspectorViewModel.js
@@ -536,6 +536,7 @@ define([
                 return maximumScreenSpaceError();
             },
             set : function(value) {
+                value = parseFloat(value);
                 maximumScreenSpaceError(value);
                 if (that._tileset) {
                     that._tileset.maximumScreenSpaceError = value;
@@ -556,6 +557,7 @@ define([
                 return dynamicScreenSpaceErrorDensity();
             },
             set : function(value) {
+                value = parseFloat(value);
                 dynamicScreenSpaceErrorDensity(value);
                 if (that._tileset) {
                     that._tileset.dynamicScreenSpaceErrorDensity = value;
@@ -594,6 +596,7 @@ define([
                 return dynamicScreenSpaceErrorFactor();
             },
             set : function(value) {
+                value = parseFloat(value);
                 dynamicScreenSpaceErrorFactor(value);
                 if (that._tileset) {
                     that._tileset.dynamicScreenSpaceErrorFactor = value;

--- a/Source/Widgets/Cesium3DTilesInspector/Cesium3DTilesInspectorViewModel.js
+++ b/Source/Widgets/Cesium3DTilesInspector/Cesium3DTilesInspectorViewModel.js
@@ -536,10 +536,12 @@ define([
                 return maximumScreenSpaceError();
             },
             set : function(value) {
-                value = parseFloat(value);
-                maximumScreenSpaceError(value);
-                if (that._tileset) {
-                    that._tileset.maximumScreenSpaceError = value;
+                value = Number(value);
+                if (!isNaN(value)) {
+                    maximumScreenSpaceError(value);
+                    if (that._tileset) {
+                        that._tileset.maximumScreenSpaceError = value;
+                    }
                 }
             }
         });
@@ -557,10 +559,12 @@ define([
                 return dynamicScreenSpaceErrorDensity();
             },
             set : function(value) {
-                value = parseFloat(value);
-                dynamicScreenSpaceErrorDensity(value);
-                if (that._tileset) {
-                    that._tileset.dynamicScreenSpaceErrorDensity = value;
+                value = Number(value);
+                if (!isNaN(value)) {
+                    dynamicScreenSpaceErrorDensity(value);
+                    if (that._tileset) {
+                        that._tileset.dynamicScreenSpaceErrorDensity = value;
+                    }
                 }
             }
         });
@@ -596,10 +600,12 @@ define([
                 return dynamicScreenSpaceErrorFactor();
             },
             set : function(value) {
-                value = parseFloat(value);
-                dynamicScreenSpaceErrorFactor(value);
-                if (that._tileset) {
-                    that._tileset.dynamicScreenSpaceErrorFactor = value;
+                value = Number(value);
+                if (!isNaN(value)) {
+                    dynamicScreenSpaceErrorFactor(value);
+                    if (that._tileset) {
+                        that._tileset.dynamicScreenSpaceErrorFactor = value;
+                    }
                 }
             }
         });


### PR DESCRIPTION
Values were being sent as strings rather than numbers, causing the sliders not to work.

@hpinkos could you look at this? I'm not sure if this is the correct thing to do.