### PR TITLE
Fix depth fail material in Edge

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,7 @@ Change Log
 * Fixed a crash when morphing from Columbus view to 3D. [#5311](https://github.com/AnalyticalGraphicsInc/cesium/issues/5311)
 * Fixed a bug which prevented KML descriptions with relative paths from loading. [#5352](https://github.com/AnalyticalGraphicsInc/cesium/pull/5352)
 * Updated documentation for Quaternion.fromHeadingPitchRoll [#5264](https://github.com/AnalyticalGraphicsInc/cesium/issues/5264)
+* Fixed an issue where using the depth fail material for polylines would cause a crash in Edge. [#5359](https://github.com/AnalyticalGraphicsInc/cesium/pull/5359)
 
 ### 1.33 - 2017-05-01
 

--- a/Source/Scene/Primitive.js
+++ b/Source/Scene/Primitive.js
@@ -994,15 +994,11 @@ define([
     function depthClampVS(vertexShaderSource) {
         var modifiedVS = ShaderSource.replaceMain(vertexShaderSource, 'czm_non_depth_clamp_main');
         modifiedVS +=
-            '#ifdef GL_EXT_frag_depth\n' +
             'varying float v_WindowZ;\n' +
-            '#endif\n' +
             'void main() {\n' +
             '    czm_non_depth_clamp_main();\n' +
             '    vec4 position = gl_Position;\n' +
-            '#ifdef GL_EXT_frag_depth\n' +
             '    v_WindowZ = (0.5 * (position.z / position.w) + 0.5) * position.w;\n' +
-            '#endif\n' +
             '    position.z = min(position.z, position.w);\n' +
             '    gl_Position = position;' +
             '}\n';
@@ -1012,9 +1008,7 @@ define([
     function depthClampFS(fragmentShaderSource) {
         var modifiedFS = ShaderSource.replaceMain(fragmentShaderSource, 'czm_non_depth_clamp_main');
         modifiedFS +=
-            '#ifdef GL_EXT_frag_depth\n' +
             'varying float v_WindowZ;\n' +
-            '#endif\n' +
             'void main() {\n' +
             '    czm_non_depth_clamp_main();\n' +
             '#ifdef GL_EXT_frag_depth\n' +

--- a/Source/Scene/Primitive.js
+++ b/Source/Scene/Primitive.js
@@ -993,6 +993,9 @@ define([
 
     function depthClampVS(vertexShaderSource) {
         var modifiedVS = ShaderSource.replaceMain(vertexShaderSource, 'czm_non_depth_clamp_main');
+        // The varying should be surround by #ifdef GL_EXT_frag_depth as an optimization.
+        // It is not to workaround an issue with Edge:
+        //     https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/12120362/
         modifiedVS +=
             'varying float v_WindowZ;\n' +
             'void main() {\n' +


### PR DESCRIPTION
Always include frag depth varying even when not supported. Fixes #5357.