### PR TITLE
editorconfig tweak

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,3 +10,6 @@ insert_final_newline = true
 
 [*.md]
 trim_trailing_whitespace = false
+
+[package.json]
+indent_size = 2


### PR DESCRIPTION
When package.json is formatted by ide (according to .editorconfig), package.json is indented by 4. But npm indents by 2 when `npm install --save blabla` kind of command is executed. This micro PR solves this mismatch.