### PR TITLE
Update CodeReviewGuide README with `hub` info.

### DIFF
--- a/Documentation/Contributors/CodeReviewGuide/README.md
+++ b/Documentation/Contributors/CodeReviewGuide/README.md
@@ -114,6 +114,20 @@ git rebase -i upstream/target
 git push -f origin mybranch # Requires force push as it is changing existing history on remote
 ```
 
+### You want to checkout a pull-request for review
+
+GitHub's [hub](https://hub.github.com) makes checking-out PR's simple. For example, run:
+
+ ```hub checkout https://github.com/AnalyticalGraphicsInc/cesium/pull/3941```
+ 
+ This will create a new branch with the contents of the pull request. Also, you can easily add remote
+ forks with:
+ 
+ ```hub fetch boomer_jones,pjcozzi```
+ 
+ which will automatically add these repos as remotes and fetch them. See the hub [open-source maintainer section](https://hub.github.com/#maintainer)
+ for more info.
+ 
 ## Resources
 
 * [Practice Conspicuous Code Review](http://producingoss.com/en/producingoss.html#code-review) in [Producing Open Source Software](http://producingoss.com/).


### PR DESCRIPTION
Fixes #4943.

Add a couple GitHub `hub` commands to the README.