### PR TITLE
Allow optional `options` for SampledProperty.setInterpolationOptions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,7 @@ Change Log
 * Fixed an issue where billboards were not properly aligned. [#2487](https://github.com/AnalyticalGraphicsInc/cesium/issues/2487)
 * Fixed an issue where translucent objects could flicker when picking on mouse move. [#5307](https://github.com/AnalyticalGraphicsInc/cesium/issues/5307)
 * Fixed a bug where billboards with sizeInMeters set to true would move upwards when zooming out. [#5373](https://github.com/AnalyticalGraphicsInc/cesium/issues/5373)
+* Fixed a bug where `SampledProperty.setInterpolationOptions` does not ignore undefined `options`. [#3575](https://github.com/AnalyticalGraphicsInc/cesium/issues/3575)
 
 ### 1.33 - 2017-05-01
 

--- a/Source/DataSources/SampledProperty.js
+++ b/Source/DataSources/SampledProperty.js
@@ -136,11 +136,11 @@ define([
      * var property = new Cesium.SampledProperty(Cesium.Cartesian2);
      *
      * //Populate it with data
-     * property.addSample(Cesium.JulianDate.fromIso8601(`2012-08-01T00:00:00.00Z`), new Cesium.Cartesian2(0, 0));
-     * property.addSample(Cesium.JulianDate.fromIso8601(`2012-08-02T00:00:00.00Z`), new Cesium.Cartesian2(4, 7));
+     * property.addSample(Cesium.JulianDate.fromIso8601('2012-08-01T00:00:00.00Z'), new Cesium.Cartesian2(0, 0));
+     * property.addSample(Cesium.JulianDate.fromIso8601('2012-08-02T00:00:00.00Z'), new Cesium.Cartesian2(4, 7));
      *
      * //Retrieve an interpolated value
-     * var result = property.getValue(Cesium.JulianDate.fromIso8601(`2012-08-01T12:00:00.00Z`));
+     * var result = property.getValue(Cesium.JulianDate.fromIso8601('2012-08-01T12:00:00.00Z'));
      *
      * @example
      * //Create a simple numeric SampledProperty that uses third degree Hermite Polynomial Approximation
@@ -151,18 +151,18 @@ define([
      * });
      *
      * //Populate it with data
-     * property.addSample(Cesium.JulianDate.fromIso8601(`2012-08-01T00:00:00.00Z`), 1.0);
-     * property.addSample(Cesium.JulianDate.fromIso8601(`2012-08-01T00:01:00.00Z`), 6.0);
-     * property.addSample(Cesium.JulianDate.fromIso8601(`2012-08-01T00:02:00.00Z`), 12.0);
-     * property.addSample(Cesium.JulianDate.fromIso8601(`2012-08-01T00:03:30.00Z`), 5.0);
-     * property.addSample(Cesium.JulianDate.fromIso8601(`2012-08-01T00:06:30.00Z`), 2.0);
+     * property.addSample(Cesium.JulianDate.fromIso8601('2012-08-01T00:00:00.00Z'), 1.0);
+     * property.addSample(Cesium.JulianDate.fromIso8601('2012-08-01T00:01:00.00Z'), 6.0);
+     * property.addSample(Cesium.JulianDate.fromIso8601('2012-08-01T00:02:00.00Z'), 12.0);
+     * property.addSample(Cesium.JulianDate.fromIso8601('2012-08-01T00:03:30.00Z'), 5.0);
+     * property.addSample(Cesium.JulianDate.fromIso8601('2012-08-01T00:06:30.00Z'), 2.0);
      *
      * //Samples can be added in any order.
-     * property.addSample(Cesium.JulianDate.fromIso8601(`2012-08-01T00:00:30.00Z`), 6.2);
+     * property.addSample(Cesium.JulianDate.fromIso8601('2012-08-01T00:00:30.00Z'), 6.2);
      *
      * //Retrieve an interpolated value
-     * var result = property.getValue(Cesium.JulianDate.fromIso8601(`2012-08-01T00:02:34.00Z`));
-     * 
+     * var result = property.getValue(Cesium.JulianDate.fromIso8601('2012-08-01T00:02:34.00Z'));
+     *
      * @see SampledPositionProperty
      */
     function SampledProperty(type, derivativeTypes) {
@@ -506,23 +506,21 @@ define([
      * @param {Number} [options.interpolationDegree] The new interpolation degree.  If undefined, the existing property will be unchanged.
      */
     SampledProperty.prototype.setInterpolationOptions = function(options) {
-        //>>includeStart('debug', pragmas.debug);
         if (!defined(options)) {
-            throw new DeveloperError('options is required.');
+            return;
         }
-        //>>includeEnd('debug');
 
         var valuesChanged = false;
 
         var interpolationAlgorithm = options.interpolationAlgorithm;
         var interpolationDegree = options.interpolationDegree;
 
-        if (this._interpolationAlgorithm !== interpolationAlgorithm) {
+        if (defined(interpolationAlgorithm) && this._interpolationAlgorithm !== interpolationAlgorithm) {
             this._interpolationAlgorithm = interpolationAlgorithm;
             valuesChanged = true;
         }
 
-        if (this._interpolationDegree !== interpolationDegree) {
+        if (defined(interpolationDegree) && this._interpolationDegree !== interpolationDegree) {
             this._interpolationDegree = interpolationDegree;
             valuesChanged = true;
         }

--- a/Specs/DataSources/SampledPropertySpec.js
+++ b/Specs/DataSources/SampledPropertySpec.js
@@ -222,6 +222,18 @@ defineSuite([
         expect(property.getValue(JulianDate.addSeconds(time, 4, new JulianDate()))).toBeUndefined();
     });
 
+    it('Allows empty options object without failing', function() {
+        var property = new SampledProperty(Number);
+
+        var interpolationAlgorithm = property.interpolationAlgorithm;
+        var interpolationDegree = property.interpolationDegree;
+
+        property.setInterpolationOptions({});
+
+        expect(property.interpolationAlgorithm).toEqual(interpolationAlgorithm);
+        expect(property.interpolationDegree).toEqual(interpolationDegree);
+    });
+
     it('mergeNewSamples works with huge data sets.', function() {
         var times = [];
         var values = [];


### PR DESCRIPTION
Fixes #3575

Also add test and change backticks to single-quotes.