### PR TITLE
Move `GoogleEarthImageryProvider` rename to next release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,11 +1,15 @@
 Change Log
 ==========
 
+### 1.35 - 2017-07-05
+* Deprecated
+   * `GoogleEarthImageryProvider` has been deprecated and will be removed in Cesium 1.37, use `GoogleEarthEnterpriseMapsProvider` instead. 
+* 
+
 ### 1.34 - 2017-06-01
 
 * Deprecated
    * Passing `options.clock` when creating a new `Viewer` instance has been deprecated and will be removed in Cesium 1.37, pass `options.clockViewModel` instead.
-   * `GoogleEarthImageryProvider` has been deprecated and will be removed in Cesium 1.37, use `GoogleEarthEnterpriseMapsProvider` instead. 
 * Fix issue where polylines in a `PolylineCollection` would ignore the far distance when updating the distance display condition. [#5283](https://github.com/AnalyticalGraphicsInc/cesium/pull/5283)
 * Fixed a crash when calling `Camera.pickEllipsoid` with a canvas of size 0.
 * Fix `BoundingSphere.fromOrientedBoundingBox`. [#5334](https://github.com/AnalyticalGraphicsInc/cesium/issues/5334)

--- a/Source/Scene/GoogleEarthImageryProvider.js
+++ b/Source/Scene/GoogleEarthImageryProvider.js
@@ -10,7 +10,7 @@ define([
     /**
      * Provides tiled imagery using the Google Earth Imagery API.
      *
-     * Notes: This imagery provider was deprecated in Cesium 1.34 and replaced with {@link GoogleEarthEnterpriseMapsProvider}.
+     * Notes: This imagery provider was deprecated in Cesium 1.35 and replaced with {@link GoogleEarthEnterpriseMapsProvider}.
      *        These are for use with the 2D Maps API. For 3D Earth API uses, see {@link GoogleEarthEngerpriseImageryProvider}.
      *        GoogleEarthImageryProvider will be removed in Cesium 1.37.
      *
@@ -27,7 +27,7 @@ define([
      * });
      */
     function GoogleEarthImageryProvider(options) {
-        deprecationWarning('GoogleEarthImageryProvider', 'GoogleEarthImageryProvider was deprecated in Cesium 1.34, it will be removed in 1.37. Use GoogleEarthEnterpriseMapsProvider instead.');
+        deprecationWarning('GoogleEarthImageryProvider', 'GoogleEarthImageryProvider was deprecated in Cesium 1.35, it will be removed in 1.37. Use GoogleEarthEnterpriseMapsProvider instead.');
 
         return new GoogleEarthEnterpriseMapsProvider(options);
     }


### PR DESCRIPTION
I merged #5399 but it didn't quite make the release.  This updates `CHANGES.md` and the `deprecationWarning` to say `1.35` instead of `1.34`