### PR TITLE
Polyline Crash on Undefined Globe Fix

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@ Change Log
 ### 1.35 - 2017-07-05
 * Deprecated
    * `GoogleEarthImageryProvider` has been deprecated and will be removed in Cesium 1.37, use `GoogleEarthEnterpriseMapsProvider` instead. 
-* 
+* Fixed bug where if polylines were set to follow the surface of an undefined globe, Cesium would crash [#5413] https://github.com/AnalyticalGraphicsInc/cesium/pull/5413
 
 ### 1.34 - 2017-06-01
 

--- a/Source/DataSources/PolylineGeometryUpdater.js
+++ b/Source/DataSources/PolylineGeometryUpdater.js
@@ -516,7 +516,6 @@ define([
         this._geometryUpdater = geometryUpdater;
         this._positions = [];
 
-        generateCartesianArcOptions.ellipsoid = geometryUpdater._scene.globe.ellipsoid;
     }
     DynamicGeometryUpdater.prototype.update = function(time) {
         var geometryUpdater = this._geometryUpdater;
@@ -537,10 +536,12 @@ define([
         }
 
         var followSurface = Property.getValueOrDefault(polyline._followSurface, time, true);
-        if (followSurface) {
+        var globe = geometryUpdater._scene.globe;
+        if (followSurface && defined(globe)) {
+            generateCartesianArcOptions.ellipsoid = globe.ellipsoid;
             generateCartesianArcOptions.positions = positions;
             generateCartesianArcOptions.granularity = Property.getValueOrUndefined(polyline._granularity, time);
-            generateCartesianArcOptions.height = PolylinePipeline.extractHeights(positions, this._geometryUpdater._scene.globe.ellipsoid);
+            generateCartesianArcOptions.height = PolylinePipeline.extractHeights(positions, globe.ellipsoid);
             positions = PolylinePipeline.generateCartesianArc(generateCartesianArcOptions);
         }
 

--- a/Specs/DataSources/PolylineGeometryUpdaterSpec.js
+++ b/Specs/DataSources/PolylineGeometryUpdaterSpec.js
@@ -8,6 +8,7 @@ defineSuite([
         'Core/DistanceDisplayCondition',
         'Core/DistanceDisplayConditionGeometryInstanceAttribute',
         'Core/JulianDate',
+        'Core/PolylinePipeline',
         'Core/ShowGeometryInstanceAttribute',
         'Core/TimeInterval',
         'Core/TimeIntervalCollection',
@@ -34,6 +35,7 @@ defineSuite([
         DistanceDisplayCondition,
         DistanceDisplayConditionGeometryInstanceAttribute,
         JulianDate,
+        PolylinePipeline,
         ShowGeometryInstanceAttribute,
         TimeInterval,
         TimeIntervalCollection,
@@ -575,5 +577,19 @@ defineSuite([
 
         updater.destroy();
         scene.primitives.removeAll();
+    });
+
+    it('followSurface true with undefined globe does not call generateCartesianArc', function() {
+        var entity = createBasicPolyline();
+        entity.polyline.width = createDynamicProperty(1);
+        scene.globe = undefined;
+        var updater = new PolylineGeometryUpdater(entity, scene);
+        var dynamicUpdater = updater.createDynamicUpdater(scene.primitives);
+        spyOn(PolylinePipeline, 'generateCartesianArc').and.callThrough();
+        dynamicUpdater.update(time);
+        expect(PolylinePipeline.generateCartesianArc).not.toHaveBeenCalled();
+        updater.destroy();
+        scene.primitives.removeAll();
+        scene.globe = new Globe();
     });
 }, 'WebGL');


### PR DESCRIPTION
For #5146. Ellipsoid assignment moved to `update` and check added for globe. Without the globe the polyline is drawn as a straight line segment. Hopefully this is appropriate behavior?