### PR TITLE
Update package.json with 'main'

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "map",
     "globe"
   ],
+  "main": "Build/Cesium/Cesium.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/AnalyticalGraphicsInc/cesium.git"


### PR DESCRIPTION
Added 'main' property to package.json pointing to minified build main script 'Build/Cesium/Cesium.js'.

This is required to load external library when using angular2+.

#5048
https://docs.npmjs.com/files/package.json#main