### PR TITLE
Fix tile continually expiring when expireDate is set

### DIFF
--- a/Source/Scene/Cesium3DTile.js
+++ b/Source/Scene/Cesium3DTile.js
@@ -249,7 +249,6 @@ define([
          * The time in seconds after the tile's content is ready when the content expires and new content is requested.
          *
          * @type {Number}
-         * @readonly
          */
         this.expireDuration = expireDuration;
 
@@ -257,7 +256,6 @@ define([
          * The date when the content expires and new content is requested.
          *
          * @type {JulianDate}
-         * @readonly
          */
         this.expireDate = expireDate;
 

--- a/Source/Scene/Cesium3DTile.js
+++ b/Source/Scene/Cesium3DTile.js
@@ -552,7 +552,6 @@ define([
             if (JulianDate.lessThan(this.expireDate, now)) {
                 this._contentState = Cesium3DTileContentState.EXPIRED;
                 this._expiredContent = this._content;
-                this.expireDate = undefined;
             }
         }
     };
@@ -592,7 +591,8 @@ define([
         }
 
         var url = this._contentUrl;
-        if (defined(this.expireDate)) {
+        var expired = this.contentExpired;
+        if (expired) {
             // Append a query parameter of the tile expiration date to prevent caching
             var timestampQuery = '?expired=' + this.expireDate.toString();
             url = joinUrls(url, timestampQuery, false);
@@ -614,6 +614,10 @@ define([
         this._contentState = Cesium3DTileContentState.LOADING;
         this._contentReadyToProcessPromise = when.defer();
         this._contentReadyPromise = when.defer();
+
+        if (expired) {
+            this.expireDate = undefined;
+        }
 
         promise.then(function(arrayBuffer) {
             if (that.isDestroyed()) {

--- a/Source/Scene/Cesium3DTile.js
+++ b/Source/Scene/Cesium3DTile.js
@@ -552,6 +552,7 @@ define([
             if (JulianDate.lessThan(this.expireDate, now)) {
                 this._contentState = Cesium3DTileContentState.EXPIRED;
                 this._expiredContent = this._content;
+                this.expireDate = undefined;
             }
         }
     };

--- a/Specs/Scene/Cesium3DTilesetSpec.js
+++ b/Specs/Scene/Cesium3DTilesetSpec.js
@@ -2607,7 +2607,6 @@ defineSuite([
                 scene.renderForSpecs();
                 expect(statistics.numberOfCommands).toBe(1); // Still renders expired content
                 return tile.contentReady;
-
             }).then(function() {
                 scene.renderForSpecs();
 
@@ -2713,6 +2712,28 @@ defineSuite([
             expect(tile._contentState).toBe(Cesium3DTileContentState.FAILED);
             expect(statistics.numberOfCommands).toBe(0);
             expect(statistics.numberTotal).toBe(1);
+        });
+    });
+
+    it('tile expiration date', function() {
+        return Cesium3DTilesTester.loadTileset(scene, tilesetUrl).then(function(tileset) {
+            var tile = tileset._root;
+
+            // Trigger expiration to happen next frame
+            tile.expireDate = JulianDate.addSeconds(JulianDate.now(), -1.0, new JulianDate());
+
+            // Stays in the expired state until the request goes through
+            scene.renderForSpecs();
+            expect(tile.contentExpired).toBe(true);
+            expect(tile.expireDate).toBeUndefined();
+
+            return pollToPromise(function() {
+                scene.renderForSpecs();
+                return tile.contentReady;
+            }).then(function() {
+                scene.renderForSpecs();
+                expect(tile._expiredContent).toBeUndefined();
+            });
         });
     });
 

--- a/Specs/Scene/Cesium3DTilesetSpec.js
+++ b/Specs/Scene/Cesium3DTilesetSpec.js
@@ -2725,7 +2725,6 @@ defineSuite([
             // Stays in the expired state until the request goes through
             scene.renderForSpecs();
             expect(tile.contentExpired).toBe(true);
-            expect(tile.expireDate).toBeUndefined();
 
             return pollToPromise(function() {
                 scene.renderForSpecs();
@@ -2733,6 +2732,7 @@ defineSuite([
             }).then(function() {
                 scene.renderForSpecs();
                 expect(tile._expiredContent).toBeUndefined();
+                expect(tile.expireDate).toBeUndefined();
             });
         });
     });


### PR DESCRIPTION
For some reason I had not tested setting just `expireDate` without `expireDuration`.

This fix prevents the tile from thinking it is expired every frame.