### PR TITLE
Add `options.query` to KMLDataSource

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@ Change Log
 * Reduced the amount of Sun bloom post-process effect near the horizon. [#5381](https://github.com/AnalyticalGraphicsInc/cesium/issues/5381)
 * Added Sandcastle demo for ArcticDEM data. [#5224](https://github.com/AnalyticalGraphicsInc/cesium/issues/5224)
 * `CzmlDataSource` load functions now take an optional `query` object, which will append query parameters to all network requests. [#5419](https://github.com/AnalyticalGraphicsInc/cesium/pull/5419)
+* `KmlDataSource` load functions now take an optional `query` object. which will append query parameters to all network requests. [#5434](https://github.com/AnalyticalGraphicsInc/cesium/pull/5434)
 
 ### 1.34 - 2017-06-01
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,8 +9,7 @@ Change Log
 * Fixed a bug where picking clusters would return undefined instead of a list of the clustered entities. [#5286](https://github.com/AnalyticalGraphicsInc/cesium/issues/5286)
 * Reduced the amount of Sun bloom post-process effect near the horizon. [#5381](https://github.com/AnalyticalGraphicsInc/cesium/issues/5381)
 * Added Sandcastle demo for ArcticDEM data. [#5224](https://github.com/AnalyticalGraphicsInc/cesium/issues/5224)
-* `CzmlDataSource` load functions now take an optional `query` object, which will append query parameters to all network requests. [#5419](https://github.com/AnalyticalGraphicsInc/cesium/pull/5419)
-* `KmlDataSource` load functions now take an optional `query` object. which will append query parameters to all network requests. [#5434](https://github.com/AnalyticalGraphicsInc/cesium/pull/5434)
+* `CzmlDataSource` and `KmlDataSource` load functions now take an optional `query` object, which will append query parameters to all network requests. [#5419](https://github.com/AnalyticalGraphicsInc/cesium/pull/5419), [#5434](https://github.com/AnalyticalGraphicsInc/cesium/pull/5434)
 
 ### 1.34 - 2017-06-01
 

--- a/Source/DataSources/KmlDataSource.js
+++ b/Source/DataSources/KmlDataSource.js
@@ -2333,6 +2333,7 @@ define([
      * @param {DefaultProxy} [options.proxy] A proxy to be used for loading external data.
      * @param {String} [options.sourceUri] Overrides the url to use for resolving relative links and other KML network features.
      * @param {Boolean} [options.clampToGround=false] true if we want the geometry features (Polygons, LineStrings and LinearRings) clamped to the ground. If true, lines will use corridors so use Entity.corridor instead of Entity.polyline.
+     * @param {Object} [options.query] Key-value pairs which are appended to all URIs in the CZML.
      *
      * @returns {Promise.<KmlDataSource>} A promise that will resolve to a new KmlDataSource instance once the KML is loaded.
      */
@@ -2479,6 +2480,7 @@ define([
      * @param {Number} [options.sourceUri] Overrides the url to use for resolving relative links and other KML network features.
      * @returns {Promise.<KmlDataSource>} A promise that will resolve to this instances once the KML is loaded.
      * @param {Boolean} [options.clampToGround=false] true if we want the geometry features (Polygons, LineStrings and LinearRings) clamped to the ground. If true, lines will use corridors so use Entity.corridor instead of Entity.polyline.
+     * @param {Object} [options.query] Key-value pairs which are appended to all URIs in the CZML.
      */
     KmlDataSource.prototype.load = function(data, options) {
         //>>includeStart('debug', pragmas.debug);

--- a/Specs/DataSources/KmlDataSourceSpec.js
+++ b/Specs/DataSources/KmlDataSourceSpec.js
@@ -3205,6 +3205,56 @@ defineSuite([
         });
     });
 
+    it('NetworkLink: Appends query tokens to source URL', function() {
+        var requestNetworkLink = when.defer();
+        spyOn(loadWithXhr, 'load').and.callFake(function(url, responseType, method, data, headers, deferred, overrideMimeType) {
+            requestNetworkLink.resolve(url);
+            deferred.reject();
+        });
+
+        KmlDataSource.load('Data/KML/networkLink.kml', {
+            camera : options.camera,
+            canvas : options.canvas,
+            query : {
+                password: "PassW0rd",
+                token: 229432
+            }
+        });
+
+        return requestNetworkLink.promise.then(function(url) {
+            expect(url).toEqual('Data/KML/networkLink.kml?password=PassW0rd&token=229432');
+        });
+    });
+
+    it('NetworkLink: Appends query tokens to all URI', function() {
+        var kml = '<?xml version="1.0" encoding="UTF-8"?>\
+          <NetworkLink id="link">\
+            <Link>\
+              <href>./Data/KML/refresh.kml</href>\
+              <viewRefreshMode>onStop</viewRefreshMode>\
+            </Link>\
+          </NetworkLink>';
+
+        var requestNetworkLink = when.defer();
+        spyOn(loadWithXhr, 'load').and.callFake(function(url, responseType, method, data, headers, deferred, overrideMimeType) {
+            requestNetworkLink.resolve(url);
+            deferred.reject();
+        });
+
+        KmlDataSource.load(parser.parseFromString(kml, "text/xml"), {
+            camera: options.camera,
+            canvas: options.canvas,
+            query: {
+                password: "Passw0rd",
+                token: 32940
+            }
+        });
+
+        return requestNetworkLink.promise.then(function(url) {
+            expect(url).toEqual('./Data/KML/refresh.kml?password=Passw0rd&token=32940&BBOX=-180,-90,180,90');
+        });
+    });
+
     it('NetworkLink: onInterval', function() {
         var kml = '<?xml version="1.0" encoding="UTF-8"?>\
           <NetworkLink id="link">\
@@ -3445,6 +3495,65 @@ defineSuite([
         });
     });
 
+    it('NetworkLink: Url is correct on initial load with httpQuery without a ? and options.query', function() {
+        var kml = '<?xml version="1.0" encoding="UTF-8"?>\
+          <NetworkLink id="link">\
+            <Link>\
+              <href>./Data/KML/refresh.kml</href>\
+              <viewRefreshMode>onInterval</viewRefreshMode>\
+              <httpQuery>client=[clientName]-v[clientVersion]&amp;v=[kmlVersion]&amp;lang=[language]</httpQuery>\
+            </Link>\
+          </NetworkLink>';
+
+        var requestNetworkLink = when.defer();
+        spyOn(loadWithXhr, 'load').and.callFake(function(url, responseType, method, data, headers, deferred, overrideMimeType) {
+            requestNetworkLink.resolve(url);
+            deferred.reject();
+        });
+
+        KmlDataSource.load(parser.parseFromString(kml, "text/xml"), {
+            camera: options.camera,
+            canvas: options.canvas,
+            query: {
+                "test": false,
+                "token": 39
+            }
+        });
+
+        return requestNetworkLink.promise.then(function(url) {
+            expect(url).toEqual('./Data/KML/refresh.kml?test=false&token=39&client=Cesium-v1&v=2.2&lang=English');
+        });
+    });
+
+    it('NetworkLink: Url is correct on initial load with httpQuery with a ? and options.query', function() {
+        var kml = '<?xml version="1.0" encoding="UTF-8"?>\
+          <NetworkLink id="link">\
+            <Link>\
+              <href>./Data/KML/refresh.kml</href>\
+              <viewRefreshMode>onInterval</viewRefreshMode>\
+              <httpQuery>?client=[clientName]-v[clientVersion]&amp;v=[kmlVersion]&amp;lang=[language]</httpQuery>\
+            </Link>\
+          </NetworkLink>';
+
+        var requestNetworkLink = when.defer();
+        spyOn(loadWithXhr, 'load').and.callFake(function(url, responseType, method, data, headers, deferred, overrideMimeType) {
+            requestNetworkLink.resolve(url);
+            deferred.reject();
+        });
+
+        KmlDataSource.load(parser.parseFromString(kml, "text/xml"), {
+            camera: options.camera,
+            canvas: options.canvas,
+            query: {
+                "test": true
+            }
+        });
+
+        return requestNetworkLink.promise.then(function(url) {
+            expect(url).toEqual('./Data/KML/refresh.kml?test=true&client=Cesium-v1&v=2.2&lang=English');
+        });
+    });
+
     it('NetworkLink: Url is correct on initial load with viewFormat without a ?', function() {
         var kml = '<?xml version="1.0" encoding="UTF-8"?>\
           <NetworkLink id="link">\
@@ -3495,6 +3604,68 @@ defineSuite([
         });
     });
 
+    it('NetworkLink: Url is correct on initial load with viewFormat without a ? and options.query', function() {
+        var kml = '<?xml version="1.0" encoding="UTF-8"?>\
+          <NetworkLink id="link">\
+            <Link>\
+              <href>./Data/KML/refresh.kml</href>\
+              <viewRefreshMode>onInterval</viewRefreshMode>\
+              <viewFormat>BBOX=[bboxWest],[bboxSouth],[bboxEast],[bboxNorth];CAMERA=\
+[lookatLon],[lookatLat],[lookatRange],[lookatTilt],[lookatHeading];VIEW=\
+[horizFov],[vertFov],[horizPixels],[vertPixels],[terrainEnabled]</viewFormat>\
+            </Link>\
+          </NetworkLink>';
+
+        var requestNetworkLink = when.defer();
+        spyOn(loadWithXhr, 'load').and.callFake(function(url, responseType, method, data, headers, deferred, overrideMimeType) {
+            requestNetworkLink.resolve(url);
+            deferred.reject();
+        });
+
+        KmlDataSource.load(parser.parseFromString(kml, "text/xml"), {
+            camera: options.camera,
+            canvas: options.canvas,
+            query: {
+                "test": true
+            }
+        });
+
+        return requestNetworkLink.promise.then(function(url) {
+            expect(url).toEqual('./Data/KML/refresh.kml?test=true&BBOX=-180,-90,180,90;CAMERA=0,0,6378137,0,0;VIEW=45,45,512,512,1');
+        });
+    });
+
+    it('NetworkLink: Url is correct on initial load with viewFormat with a ? and options.query', function() {
+        var kml = '<?xml version="1.0" encoding="UTF-8"?>\
+          <NetworkLink id="link">\
+            <Link>\
+              <href>./Data/KML/refresh.kml</href>\
+              <viewRefreshMode>onInterval</viewRefreshMode>\
+              <viewFormat>?BBOX=[bboxWest],[bboxSouth],[bboxEast],[bboxNorth];CAMERA=\
+[lookatLon],[lookatLat],[lookatRange],[lookatTilt],[lookatHeading];VIEW=\
+[horizFov],[vertFov],[horizPixels],[vertPixels],[terrainEnabled]</viewFormat>\
+            </Link>\
+          </NetworkLink>';
+
+        var requestNetworkLink = when.defer();
+        spyOn(loadWithXhr, 'load').and.callFake(function(url, responseType, method, data, headers, deferred, overrideMimeType) {
+            requestNetworkLink.resolve(url);
+            deferred.reject();
+        });
+
+        KmlDataSource.load(parser.parseFromString(kml, "text/xml"), {
+            camera: options.camera,
+            canvas: options.canvas,
+            query: {
+                "test": true
+            }
+        });
+
+        return requestNetworkLink.promise.then(function(url) {
+            expect(url).toEqual('./Data/KML/refresh.kml?test=true&BBOX=-180,-90,180,90;CAMERA=0,0,6378137,0,0;VIEW=45,45,512,512,1');
+        });
+    });
+
     it('NetworkLink: Url is correct on initial load with viewFormat and httpQuery', function() {
         var kml = '<?xml version="1.0" encoding="UTF-8"?>\
           <NetworkLink id="link">\
@@ -3516,6 +3687,36 @@ defineSuite([
 
         return requestNetworkLink.promise.then(function(url) {
             expect(url).toEqual('./Data/KML/refresh.kml?vf=1&hq=1');
+        });
+    });
+
+    it('NetworkLink: Url is correct on initial load with viewFormat and httpQuery and options.query', function() {
+        var kml = '<?xml version="1.0" encoding="UTF-8"?>\
+          <NetworkLink id="link">\
+            <Link>\
+              <href>./Data/KML/refresh.kml</href>\
+              <viewRefreshMode>onInterval</viewRefreshMode>\
+              <viewFormat>vf=1</viewFormat>\
+              <httpQuery>hq=1</httpQuery>\
+            </Link>\
+          </NetworkLink>';
+
+        var requestNetworkLink = when.defer();
+        spyOn(loadWithXhr, 'load').and.callFake(function(url, responseType, method, data, headers, deferred, overrideMimeType) {
+            requestNetworkLink.resolve(url);
+            deferred.reject();
+        });
+
+        KmlDataSource.load(parser.parseFromString(kml, "text/xml"), {
+            camera: options.camera,
+            canvas: options.canvas,
+            query: {
+                "test": true
+            }
+        });
+
+        return requestNetworkLink.promise.then(function(url) {
+            expect(url).toEqual('./Data/KML/refresh.kml?test=true&vf=1&hq=1');
         });
     });
 

--- a/Specs/DataSources/KmlDataSourceSpec.js
+++ b/Specs/DataSources/KmlDataSourceSpec.js
@@ -1555,6 +1555,32 @@ defineSuite([
         });
     });
 
+    it('IconStyle: Sets billboard image with query', function() {
+        var kml = '<?xml version="1.0" encoding="UTF-8"?>\
+          <Placemark>\
+              <Style>\
+                  <IconStyle>\
+                      <Icon>\
+                          <href>image.png</href>\
+                      </Icon>\
+                  </IconStyle>\
+              </Style>\
+          </Placemark>';
+        debugger;
+        return KmlDataSource.load(parser.parseFromString(kml, "text/xml"), {
+            camera : options.camera,
+            canvas : options.canvas,
+            sourceUri : 'http://test.invalid',
+            query : {
+                "test": true
+            }
+        }).then(function(dataSource) {
+            var entities = dataSource.entities.values;
+            var billboard = entities[0].billboard;
+            expect(billboard.image.getValue()).toEqual('http://test.invalid/image.png?test=true');
+        });
+    });
+
     it('IconStyle: Sets billboard image with subregion', function() {
         var kml = '<?xml version="1.0" encoding="UTF-8"?>\
           <Placemark xmlns="http://www.opengis.net/kml/2.2"\

--- a/Specs/DataSources/KmlDataSourceSpec.js
+++ b/Specs/DataSources/KmlDataSourceSpec.js
@@ -1566,7 +1566,7 @@ defineSuite([
                   </IconStyle>\
               </Style>\
           </Placemark>';
-        debugger;
+
         return KmlDataSource.load(parser.parseFromString(kml, "text/xml"), {
             camera : options.camera,
             canvas : options.canvas,


### PR DESCRIPTION
Fixes #5408 

Pass around a `query` parameter which eventually gets blobbed onto the various uri in `KMLDataSource`. I've added like 6 unit tests, but am unconvinced about the thoroughness of this implementation. @mramato please test elsewhere? :)

One problem: using `proxyUrl` to append `query` means that `processNetworkLinkQueryString` will be using the already-formatted `href` ([LINE](https://github.com/AnalyticalGraphicsInc/cesium/compare/master...omh1280:kml_query?expand=1#diff-0aabbb637a10ce9c28e4d24c9f73a99eR1953)). Therefore, it will be used throughout the text-replacement process of `processNetworkLinkQueryString`. I don't think this will (ever) be a problem, unless some authentication token contains `[bboxWest]` or something.

I've also moved a [function call](https://github.com/AnalyticalGraphicsInc/cesium/compare/master...omh1280:kml_query?expand=1#diff-0aabbb637a10ce9c28e4d24c9f73a99eL492) out of an `if` block, so now the behavior is that `proxyUrl` is run for every URI. This is ok because if either `proxy` or `query` are `undefined`, `proxyUrl` doesn't do anything.

Ottavio