### PR TITLE
Make sure camera world coordinate properties are normalized

### DIFF
--- a/Source/Scene/Camera.js
+++ b/Source/Scene/Camera.js
@@ -608,14 +608,17 @@ define([
 
         if (directionChanged || transformChanged) {
             camera._directionWC = Matrix4.multiplyByPointAsVector(transform, direction, camera._directionWC);
+            Cartesian3.normalize(camera._directionWC, camera._directionWC);
         }
 
         if (upChanged || transformChanged) {
             camera._upWC = Matrix4.multiplyByPointAsVector(transform, up, camera._upWC);
+            Cartesian3.normalize(camera._upWC, camera._upWC);
         }
 
         if (rightChanged || transformChanged) {
             camera._rightWC = Matrix4.multiplyByPointAsVector(transform, right, camera._rightWC);
+            Cartesian3.normalize(camera._rightWC, camera._rightWC);
         }
 
         if (positionChanged || directionChanged || upChanged || rightChanged || transformChanged) {

--- a/Specs/Scene/CameraSpec.js
+++ b/Specs/Scene/CameraSpec.js
@@ -2850,4 +2850,12 @@ defineSuite([
         camera.switchToPerspectiveFrustum();
         expect(camera.frustum instanceof OrthographicOffCenterFrustum).toEqual(true);
     });
+
+    it('normalizes WC members', function() {
+        var transform = Matrix4.fromScale(new Cartesian3(2, 2, 2));
+        camera.lookAtTransform(transform);
+        expect(Cartesian3.magnitude(camera.directionWC)).toEqualEpsilon(1.0, CesiumMath.EPSILON15);
+        expect(Cartesian3.magnitude(camera.rightWC)).toEqualEpsilon(1.0, CesiumMath.EPSILON15);
+        expect(Cartesian3.magnitude(camera.upWC)).toEqualEpsilon(1.0, CesiumMath.EPSILON15);
+    });
 });


### PR DESCRIPTION
The camera would not properly normalize the WC versions of up, right, and direction, which could lead to potential problems later in the frame.

Fixes #5439