### PR TITLE
Use new DomOrientationEvent constructor when available.

### DIFF
--- a/Specs/DomEventSimulator.js
+++ b/Specs/DomEventSimulator.js
@@ -215,8 +215,18 @@ define([
         var gamma = defaultValue(options.gamma, 0.0);
         var absolute = defaultValue(options.absolute, false);
 
-        var event = document.createEvent('DeviceOrientationEvent');
-        event.initDeviceOrientationEvent(type, canBubble, cancelable, alpha, beta, gamma, absolute);
+        var event;
+        event = document.createEvent('DeviceOrientationEvent');
+        if (typeof event.initDeviceOrientationEvent === 'function') {
+            event.initDeviceOrientationEvent(type, canBubble, cancelable, alpha, beta, gamma, absolute);
+        } else {
+            event = new DeviceOrientationEvent('deviceorientation', {
+                alpha : alpha,
+                beta : beta,
+                gamma : gamma,
+                absolute : absolute
+            });
+        }
         return event;
     }
 


### PR DESCRIPTION
Chrome 59 removed `event.initDeviceOrientationEvent` in favor of a `DeviceOrientationEvent` constructor, but the former is required for other browsers.  This is a test-only change.

Fixes #5430