### PR TITLE
Add prepush to run ESLint before pushing code.

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,10 +66,12 @@
     "karma-spec-reporter": "^0.0.31",
     "mime": "^1.3.4",
     "mkdirp": "^0.5.1",
+    "prepush": "^3.1.0",
     "request": "^2.79.0",
     "rimraf": "^2.6.1",
     "yargs": "^8.0.1"
   },
+  "prepush" : [ "gulp eslint --failTaskOnError" ],
   "scripts": {
     "start": "node server.js",
     "startPublic": "node server.js --public",


### PR DESCRIPTION
Runs `gulp eslint --failTaskOnError` before every `git push` using a client-side [git hook](https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks).

@pjcozzi is definitely right: when `eslint` is slow, the whole process of pushing drags. Therefore, this should be merged after #5469 (if at all).

Requires `npm install && ./node_modules/prepush/bin/cli.js install`, which installs the hook into .git/hooks.