### PR TITLE
Update coding docs to include ESLint shareable config

### DIFF
--- a/Documentation/Contributors/CodingGuide/README.md
+++ b/Documentation/Contributors/CodingGuide/README.md
@@ -14,6 +14,7 @@ To some extent, this guide can be summarized as _make new code similar to existi
 
 * [Naming](#naming)
 * [Formatting](#formatting)
+* [Code Guidelines](#code-guidelines)
 * [Units](#units)
 * [Basic Code Construction](#basic-code-construction)
 * [Functions](#functions)
@@ -135,24 +136,11 @@ function Model(options) {
 
 * Text files, including JavaScript files, end with a newline to minimize the noise in diffs.
 
-## Code Linting
+## Code Guidelines
 
-We use [ESLint](http://eslint.org/) to check that our code adheres to syntax and style guidelines. In order to keep our ESLint guidelines
-the same across repositories, we use a [shareable config](http://eslint.org/docs/developer-guide/shareable-configs):
-[`eslint-config-cesium`](https://www.npmjs.com/package/eslint-config-cesium).
-
-The two common configurations defined in `eslint-config-cesium` are `browser` (used for Javascript and HTML which will run in the browser) and `node` (used
-for Node.js packages.) If we look inside [obj2gltf](https://github.com/AnalyticalGraphicsInc/obj2gltf)'s `.eslintrc.json`, we see:
-```json
-{
-    "extends": "cesium/node"
-}
-```
-`extends` tells ESLint that we inherit the `node` configuration from our shareable config. Now we can run
- ```bash
- $ npm run eslint
- ```
- to check if our changes adhere to the Cesium style and syntax guidelines.
+For syntax and style guidelines, we adhere to the common JavaScript "recommended" rules, according to [ESLint](http://eslint.org/docs/rules/). Some
+additions include enabling [`no-new`](http://eslint.org/docs/rules/no-new) and [`no-extend-native`](http://eslint.org/docs/rules/no-extend-native).
+For a complete list of what rules are enabled, look in `index.js`, `browser.js`, and `node.js` in the [`eslint-config-cesium`](https://github.com/AnalyticalGraphicsInc/cesium/tree/master/Tools/eslint-config-cesium) folder.
 
 * When [disabling rules with inline comments](http://eslint.org/docs/user-guide/configuring#disabling-rules-with-inline-comments), place the comments on new lines and as close to the associated code as possible:
 ```js

--- a/Documentation/Contributors/CodingGuide/README.md
+++ b/Documentation/Contributors/CodingGuide/README.md
@@ -138,11 +138,7 @@ function Model(options) {
 
 ## Linting
 
-For syntax and style guidelines, we use the [ESLint](http://eslint.org/docs/rules/) recommended settings as a base
-and extend it with additional rules. For a list of what rules are enabled, look in `index.js`, `browser.js`, and `node.js`
-in the [`eslint-config-cesium`](https://github.com/AnalyticalGraphicsInc/cesium/tree/master/Tools/eslint-config-cesium) folder.
-These are contained in the Node module [`eslint-config-cesium`](https://www.npmjs.com/package/eslint-config-cesium), which is maintained in the Cesium repository and is
-available for use on other projects as well.
+For syntax and style guidelines, we use the [ESLint](http://eslint.org/docs/rules/) recommended settings as a base and extend it with additional rules via a shared config Node module, [eslint-config-cesium](https://www.npmjs.com/package/eslint-config-cesium), which is maintained as part of the Cesium repository and also used throughout the Cesium ecosystem. For a list of which rules are enabled, look in [index.js](https://github.com/AnalyticalGraphicsInc/cesium/blob/master/Tools/eslint-config-cesium/index.js), [browser.js](https://github.com/AnalyticalGraphicsInc/cesium/blob/master/Tools/eslint-config-cesium/browser.js), and [node.js](https://github.com/AnalyticalGraphicsInc/cesium/blob/master/Tools/eslint-config-cesium/node.js). 
 
 * When disabling linting for one line, use `//eslint-disable-line`:
 ```js

--- a/Documentation/Contributors/CodingGuide/README.md
+++ b/Documentation/Contributors/CodingGuide/README.md
@@ -14,7 +14,7 @@ To some extent, this guide can be summarized as _make new code similar to existi
 
 * [Naming](#naming)
 * [Formatting](#formatting)
-* [Code Guidelines](#code-guidelines)
+* [Linting](#linting)
 * [Units](#units)
 * [Basic Code Construction](#basic-code-construction)
 * [Functions](#functions)
@@ -136,13 +136,22 @@ function Model(options) {
 
 * Text files, including JavaScript files, end with a newline to minimize the noise in diffs.
 
-## Code Guidelines
+## Linting
 
-For syntax and style guidelines, we adhere to the common JavaScript "recommended" rules, according to [ESLint](http://eslint.org/docs/rules/). Some
-additions include enabling [`no-new`](http://eslint.org/docs/rules/no-new) and [`no-extend-native`](http://eslint.org/docs/rules/no-extend-native).
-For a complete list of what rules are enabled, look in `index.js`, `browser.js`, and `node.js` in the [`eslint-config-cesium`](https://github.com/AnalyticalGraphicsInc/cesium/tree/master/Tools/eslint-config-cesium) folder.
+For syntax and style guidelines, we use the [ESLint](http://eslint.org/docs/rules/) recommended settings as a base
+and extend it with additional rules. For a list of what rules are enabled, look in `index.js`, `browser.js`, and `node.js`
+in the [`eslint-config-cesium`](https://github.com/AnalyticalGraphicsInc/cesium/tree/master/Tools/eslint-config-cesium) folder.
+These are contained in the Node module [`eslint-config-cesium`](https://www.npmjs.com/package/eslint-config-cesium), which is maintained in the Cesium repository and is
+available for use on other projects as well.
 
-* When [disabling rules with inline comments](http://eslint.org/docs/user-guide/configuring#disabling-rules-with-inline-comments), place the comments on new lines and as close to the associated code as possible:
+* When disabling linting for one line, use `//eslint-disable-line`:
+```js
+function exit(warningMessage) {
+    window.alert('Cannot exit: ' + warningMessage); //eslint-disable-line no-alert
+}
+```
+
+* When disabling linting for blocks of code, place `eslint-disable` comments on new lines and as close to the associated code as possible:
 ```js
 /*eslint-disable no-empty*/
 try {
@@ -152,13 +161,7 @@ try {
 /*eslint-enable no-empty*/
 ```
 
-* If possible, use `//eslint-disable-line` to disable specific rules for one line.
-```js
-fn multiplyByThree(foo) {
-    var unusedVar = 5; //eslint-disable-line no-unused-vars
-    return foo * 3;
-}
-```
+* See [Disabling Rules with Inline Comments](http://eslint.org/docs/user-guide/configuring#disabling-rules-with-inline-comments) for more examples.
 
 ## Units
 

--- a/Documentation/Contributors/CodingGuide/README.md
+++ b/Documentation/Contributors/CodingGuide/README.md
@@ -135,6 +135,25 @@ function Model(options) {
 
 * Text files, including JavaScript files, end with a newline to minimize the noise in diffs.
 
+## Code Linting
+
+We use [ESLint](http://eslint.org/) to check that our code adheres to syntax and style guidelines. In order to keep our ESLint guidelines
+the same across repositories, we use a [shareable config](http://eslint.org/docs/developer-guide/shareable-configs):
+[`eslint-config-cesium`](https://www.npmjs.com/package/eslint-config-cesium).
+
+The two common configurations defined in `eslint-config-cesium` are `browser` (used for Javascript and HTML which will run in the browser) and `node` (used
+for Node.js packages.) If we look inside [obj2gltf](https://github.com/AnalyticalGraphicsInc/obj2gltf)'s `.eslintrc.json`, we see:
+```json
+{
+    "extends": "cesium/node"
+}
+```
+`extends` tells ESLint that we inherit the `node` configuration from our shareable config. Now we can run
+ ```bash
+ $ npm run eslint
+ ```
+ to check if our changes adhere to the Cesium style and syntax guidelines.
+
 * When [disabling rules with inline comments](http://eslint.org/docs/user-guide/configuring#disabling-rules-with-inline-comments), place the comments on new lines and as close to the associated code as possible:
 ```js
 /*eslint-disable no-empty*/
@@ -143,6 +162,14 @@ try {
 } catch(ex) {
 }
 /*eslint-enable no-empty*/
+```
+
+* If possible, use `//eslint-disable-line` to disable specific rules for one line.
+```js
+fn multiplyByThree(foo) {
+    var unusedVar = 5; //eslint-disable-line no-unused-vars
+    return foo * 3;
+}
 ```
 
 ## Units


### PR DESCRIPTION
For #5449.

Small Coding Guide update to show how to use our ESLint shareable config. I did not include how to enable/disable global rules because a) it is clear in the ESLint docs and b) it should be generally discouraged.