### PR TITLE
Fixed version directive when combining shaders

### DIFF
--- a/Source/Renderer/ShaderSource.js
+++ b/Source/Renderer/ShaderSource.js
@@ -202,7 +202,7 @@ define([
         // #version must be first
         // defaults to #version 100 if not specified
         if (defined(version)) {
-            result = '#version ' + version;
+            result = '#version ' + version + '\n';
         }
 
         if (isFragmentShader) {

--- a/Specs/Renderer/ShaderSourceSpec.js
+++ b/Specs/Renderer/ShaderSourceSpec.js
@@ -65,4 +65,12 @@ defineSuite([
             });
         }).toThrowDeveloperError();
     });
+
+    it('combines #version to shader', function() {
+        var source = new ShaderSource({
+            sources : ['#version 300 es\nvoid main() {gl_FragColor = vec4(1.0); }']
+        });
+        var shaderText = source.createCombinedVertexShader();
+        expect(shaderText).toStartWith('#version 300 es\n');
+    });
 });


### PR DESCRIPTION
Previously, the version directive wouldn't be followed by a new line character, causing the resulting shader to be invalid.