### PR TITLE
Enable four new ESLint rules

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,10 +1,6 @@
 {
     "extends": "./Tools/eslint-config-cesium/browser.js",
     "rules": {
-        "guard-for-in": ["error"],
-        "no-caller": ["error"],
-        "no-floating-decimal": ["error"],
-        "no-new": ["error"],
         "no-unused-vars": ["error", {"vars": "all", "args": "none"}]
     }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,6 +1,10 @@
 {
     "extends": "./Tools/eslint-config-cesium/browser.js",
     "rules": {
+        "guard-for-in": ["error"],
+        "no-caller": ["error"],
+        "no-floating-decimal": ["error"],
+        "no-new": ["error"],
         "no-unused-vars": ["error", {"vars": "all", "args": "none"}]
     }
 }

--- a/Tools/eslint-config-cesium/CHANGES.md
+++ b/Tools/eslint-config-cesium/CHANGES.md
@@ -1,5 +1,8 @@
 Change Log
 ==========
+### 2.0.0
+
+* Enable [`no-floating-decimal`](http://eslint.org/docs/rules/no-floating-decimal)
 
 ### 1.0.0 - 2017-06-12
 

--- a/Tools/eslint-config-cesium/index.js
+++ b/Tools/eslint-config-cesium/index.js
@@ -25,6 +25,7 @@ module.exports = {
         'no-empty': ['error'],
         'no-extend-native': ['error'],
         'no-extra-boolean-cast': 'off',
+        'no-floating-decimal': ['error'],
         'no-irregular-whitespace': ['error'],
         'no-new': ['error'],
         'no-undef': ['error'],


### PR DESCRIPTION
Add some rules that were likely lost during the transition from JSHint to ESLint. #5344 

These rules are the only of #5456 which do not require code changes in any way.

- [`guard-for-in`](http://eslint.org/docs/rules/guard-for-in)
- [`no-caller`](http://eslint.org/docs/rules/no-caller)
- [`no-floating-decimal`](http://eslint.org/docs/rules/no-floating-decimal)
- [`no-new`](http://eslint.org/docs/rules/no-new)