### PR TITLE
Fix eslint glob

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "requirejs": "gulp requirejs",
     "generateDocumentation": "gulp generateDocumentation",
     "instrumentForCoverage": "gulp instrumentForCoverage",
-    "eslint": "eslint ./**/*.js ./**/*.html --cache --quiet",
+    "eslint": "eslint \"./**/*.js\" \"./**/*.html\" --cache --quiet",
     "makeZipFile": "gulp makeZipFile",
     "minify": "gulp minify",
     "minifyRelease": "gulp minifyRelease",


### PR DESCRIPTION
Fix eslint glob issue, which prevented ESLint from expanding globs and instead left it up to the OS.

@mramato please merge soon!