### PR TITLE
Order of operations fix in Expression

### DIFF
--- a/Source/Scene/Expression.js
+++ b/Source/Scene/Expression.js
@@ -434,7 +434,7 @@ define([
         for (var key in defines) {
             if (defines.hasOwnProperty(key)) {
                 var definePlaceholder = new RegExp('\\$\\{' + key + '\\}', 'g');
-                var defineReplace = defines[key];
+                var defineReplace = '(' + defines[key] + ')';
                 if (defined(defineReplace)) {
                     expression = expression.replace(definePlaceholder, defineReplace);
                 }

--- a/Specs/Scene/ExpressionSpec.js
+++ b/Specs/Scene/ExpressionSpec.js
@@ -137,6 +137,14 @@ defineSuite([
         expect(expression.evaluate(frameState, feature)).toEqual(5);
     });
 
+    it('evaluates with defines, honoring order of operations', function() {
+        var defines = {
+            value: '1 + 2'
+        };
+        var expression = new Expression('5.0 * ${value}', defines);
+        expect(expression.evaluate(frameState, undefined)).toEqual(15);
+    });
+
     it('evaluate takes result argument', function() {
         var expression = new Expression('vec3(1.0)');
         var result = new Cartesian3();


### PR DESCRIPTION
Fix so that the style below equals 15 instead of 7.

```json
{
    "defines" : {
        "value" : "1.0 + 2.0",
    },
    "pointSize" : "5.0 * ${value}"
}
```