### PR TITLE
Suggest Node 6.x instead of 4.x

### DIFF
--- a/Documentation/Contributors/BuildGuide/README.md
+++ b/Documentation/Contributors/BuildGuide/README.md
@@ -27,7 +27,7 @@
 ## Build the Code
 
 Prerequisites:
- * Install [Node.js](http://nodejs.org/) on your system.  Building Cesium requires Node 4.x or newer.
+ * Install [Node.js](http://nodejs.org/) on your system.  Building Cesium requires Node 6.x or newer.
 
 Cesium uses [npm modules](https://docs.npmjs.com/getting-started/what-is-npm) for development, so after syncing, you need to run `npm install` from the Cesium root directory:
 


### PR DESCRIPTION
The latest server changes do not work with Node 4.x since `Buffer.from` is required.