### PR TITLE
Enable `no-sequences` ESLint rule

### DIFF
--- a/Tools/eslint-config-cesium/CHANGES.md
+++ b/Tools/eslint-config-cesium/CHANGES.md
@@ -12,6 +12,7 @@ Change Log
 * Enable [no-implicit-globals](http://eslint.org/docs/rules/no-implicit-globals).
 * Enable [no-trailing-spaces](http://eslint.org/docs/rules/no-trailing-spaces).
 * Enable [no-lonely-if](http://eslint.org/docs/rules/no-lonely-if).
+* Enable [no-sequences](http://eslint.org/docs/rules/no-lonely-if).
 
 ### 1.0.0 - 2017-06-12
 

--- a/Tools/eslint-config-cesium/index.js
+++ b/Tools/eslint-config-cesium/index.js
@@ -32,6 +32,7 @@ module.exports = {
         'no-lonely-if': 'error',
         'no-loop-func': 'error',
         'no-new': 'error',
+        'no-sequences': 'error',
         'no-trailing-spaces': ['error'],
         'no-undef': 'error',
         'no-undef-init': 'error',


### PR DESCRIPTION
For #5369. Enable the [`no-sequences`](http://eslint.org/docs/rules/no-sequences) rule. Nothing needed to be changed.