### PR TITLE
Add .eslintcache to .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,4 @@
+/.eslintcache
 /.externalToolBuilders
 /.gitattributes
 /.github


### PR DESCRIPTION
It shouldn't be part of our npm package.