### PR TITLE
Enable `global-require`, `no-buffer-constructor`, and `no-new-require`

### DIFF
--- a/Tools/eslint-config-cesium/CHANGES.md
+++ b/Tools/eslint-config-cesium/CHANGES.md
@@ -1,7 +1,7 @@
 Change Log
 ==========
 
-### 2.0.0
+### 2.0.0 - 2017-06-27
 
 * Enable [no-floating-decimal](http://eslint.org/docs/rules/no-floating-decimal).
 * Enable [no-use-before-define](http://eslint.org/docs/rules/no-use-before-define).
@@ -16,6 +16,10 @@ Change Log
 * Enable [no-unused-expressions](http://eslint.org/docs/rules/no-unused-expressions).
 * Enable [no-sequences](http://eslint.org/docs/rules/no-lonely-if).
 * Enable [block-scoped-var](http://eslint.org/docs/rules/block-scoped-var).
+* Enable Node-specific rules:
+  * [global-require](http://eslint.org/docs/rules/global-require)
+  * [no-buffer-constructor](http://eslint.org/docs/rules/no-buffer-constructor)
+  * [no-new-require](http://eslint.org/docs/rules/no-new-require)
 
 ### 1.0.0 - 2017-06-12
 

--- a/Tools/eslint-config-cesium/node.js
+++ b/Tools/eslint-config-cesium/node.js
@@ -4,5 +4,10 @@ module.exports = {
     extends: './index.js',
     env: {
         node: true
+    },
+    rules: {
+        'global-require' : 'error',
+        'no-buffer-constructor' : 'error',
+        'no-new-require' : 'error'
     }
 };

--- a/Tools/eslint-config-cesium/package.json
+++ b/Tools/eslint-config-cesium/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-cesium",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "ESLint shareable configs for Cesium",
   "homepage": "http://cesiumjs.org",
   "license": "Apache-2.0",


### PR DESCRIPTION
For #5456. Bump the version number in preparation to deploy version 2.0.0 of the [`eslint-config-cesium`](https://www.npmjs.com/package/eslint-config-cesium) package. 

The new rules pertaining to Node are:
* [global-require](http://eslint.org/docs/rules/global-require)
* [no-buffer-constructor](http://eslint.org/docs/rules/no-buffer-constructor)
* [no-new-require](http://eslint.org/docs/rules/no-new-require)
