### PR TITLE
Changed behavior of JulianDate.fromIso8601 to match Javascript's Date specification

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,8 @@ Change Log
 
 ### 1.35 - 2017-07-05
 
+* Breaking changes
+  * `JulianDate.fromIso8601` will default to midnight UTC if no time is provided to match the Javascript [`Date` specification](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date). You must specify a local time of midnight to achieve the old behavior.
 * Deprecated
    * `GoogleEarthImageryProvider` has been deprecated and will be removed in Cesium 1.37, use `GoogleEarthEnterpriseMapsProvider` instead.
    * The `throttleRequest` parameter for `TerrainProvider.requestTileGeometry`, `CesiumTerrainProvider.requestTileGeometry`, `VRTheWorldTerrainProvider.requestTileGeometry`, and `EllipsoidTerrainProvider.requestTileGeometry` is deprecated and will be replaced with an optional `Request` object. The `throttleRequests` parameter will be removed in 1.37. Instead to throttle requests set the request's `throttle` property to `true`.

--- a/Source/Core/JulianDate.js
+++ b/Source/Core/JulianDate.js
@@ -353,7 +353,8 @@ define([
         }
         //>>includeEnd('debug')
 
-        //Not move onto the time string, which is much simpler.
+        //Now move onto the time string, which is much simpler.
+        //If no time is specified, it is considered the beginning of the day, UTC to match Javascript's implementation.
         var offsetIndex;
         if (defined(time)) {
             tokens = time.match(matchHoursMinutesSeconds);
@@ -425,9 +426,6 @@ define([
                 minute = minute + new Date(Date.UTC(year, month - 1, day, hour, minute)).getTimezoneOffset();
                 break;
             }
-        } else {
-            //If no time is specified, it is considered the beginning of the day, local time.
-            minute = minute + new Date(year, month - 1, day).getTimezoneOffset();
         }
 
         //ISO8601 denotes a leap second by any time having a seconds component of 60 seconds.

--- a/Specs/Core/JulianDateSpec.js
+++ b/Specs/Core/JulianDateSpec.js
@@ -166,67 +166,67 @@ defineSuite([
 
     it('Construct from ISO8601 local calendar date, basic format', function() {
         var expectedDate = JulianDate.fromDate(new Date(2009, 7, 1));
-        var computedDate = JulianDate.fromIso8601('20090801');
+        var computedDate = JulianDate.fromIso8601('20090801T00');
         expect(computedDate).toEqual(expectedDate);
     });
 
     it('Construct from ISO8601 local calendar date, extended format', function() {
         var expectedDate = JulianDate.fromDate(new Date(2009, 7, 1));
-        var computedDate = JulianDate.fromIso8601('2009-08-01');
+        var computedDate = JulianDate.fromIso8601('2009-08-01T00');
         expect(computedDate).toEqual(expectedDate);
     });
 
     it('Construct from ISO8601 local calendar date on Feb 29th, basic format', function() {
         var expectedDate = JulianDate.fromDate(new Date(2000, 1, 29));
-        var computedDate = JulianDate.fromIso8601('20000229');
+        var computedDate = JulianDate.fromIso8601('20000229T00');
         expect(computedDate).toEqual(expectedDate);
     });
 
     it('Construct from ISO8601 local calendar date on Feb 29th, extended format', function() {
         var expectedDate = JulianDate.fromDate(new Date(2000, 1, 29));
-        var computedDate = JulianDate.fromIso8601('2000-02-29');
+        var computedDate = JulianDate.fromIso8601('2000-02-29T00');
         expect(computedDate).toEqual(expectedDate);
     });
 
     it('Construct from an ISO8601 local ordinal date, basic format', function() {
         var expectedDate = JulianDate.fromDate(new Date(1985, 3, 12));
-        var computedDate = JulianDate.fromIso8601('1985102');
+        var computedDate = JulianDate.fromIso8601('1985102T00');
         expect(computedDate).toEqual(expectedDate);
     });
 
     it('Construct from an ISO8601 local ordinal date, extended format', function() {
         var expectedDate = JulianDate.fromDate(new Date(1985, 3, 12));
-        var computedDate = JulianDate.fromIso8601('1985-102');
+        var computedDate = JulianDate.fromIso8601('1985-102T00');
         expect(computedDate).toEqual(expectedDate);
     });
 
     it('Construct an ISO8601 ordinal date on a leap year', function() {
         var expectedDate = JulianDate.fromDate(new Date(2000, 11, 31));
-        var computedDate = JulianDate.fromIso8601('2000-366');
+        var computedDate = JulianDate.fromIso8601('2000-366T00');
         expect(computedDate).toEqual(expectedDate);
     });
 
     it('Construct from an ISO8601 local week date, basic format', function() {
         var expectedDate = JulianDate.fromDate(new Date(1985, 3, 12));
-        var computedDate = JulianDate.fromIso8601('1985W155');
+        var computedDate = JulianDate.fromIso8601('1985W155T00');
         expect(computedDate).toEqual(expectedDate);
     });
 
     it('Construct from an ISO8601 local week date, extended format', function() {
         var expectedDate = JulianDate.fromDate(new Date(2008, 8, 27));
-        var computedDate = JulianDate.fromIso8601('2008-W39-6');
+        var computedDate = JulianDate.fromIso8601('2008-W39-6T00');
         expect(computedDate).toEqual(expectedDate);
     });
 
     it('Construct from an ISO8601 local calendar week date, basic format', function() {
         var expectedDate = JulianDate.fromDate(new Date(1985, 3, 7));
-        var computedDate = JulianDate.fromIso8601('1985W15');
+        var computedDate = JulianDate.fromIso8601('1985W15T00');
         expect(computedDate).toEqual(expectedDate);
     });
 
     it('Construct from an ISO8601 local calendar week date, extended format', function() {
         var expectedDate = JulianDate.fromDate(new Date(2008, 8, 21));
-        var computedDate = JulianDate.fromIso8601('2008-W39');
+        var computedDate = JulianDate.fromIso8601('2008-W39T00');
         expect(computedDate).toEqual(expectedDate);
     });
 
@@ -234,7 +234,7 @@ defineSuite([
     //would confuse is with old YYMMDD dates
     it('Construct from an ISO8601 local calendar month, basic format', function() {
         var expectedDate = JulianDate.fromDate(new Date(1985, 3, 1));
-        var computedDate = JulianDate.fromIso8601('1985-04');
+        var computedDate = JulianDate.fromIso8601('1985-04T00');
         expect(computedDate).toEqual(expectedDate);
     });
 
@@ -443,6 +443,18 @@ defineSuite([
     it('Construct from ISO8601 local calendar date and time with no seconds and UTC offset in extended format', function() {
         var expectedDate = JulianDate.fromDate(new Date(Date.UTC(2009, 7, 1, 12, 30, 0)));
         var computedDate = JulianDate.fromIso8601('2009-08-01T07:30-05:00');
+        expect(computedDate).toEqual(expectedDate);
+    });
+
+    it('Construct from ISO8601 with date only in basic format should be midnight UTC', function() {
+        var expectedDate = JulianDate.fromDate(new Date(Date.UTC(2009, 7, 1)));
+        var computedDate = JulianDate.fromIso8601('20090801');
+        expect(computedDate).toEqual(expectedDate);
+    });
+
+    it('Construct from ISO8601 with date only in extended format should be midnight UTC', function() {
+        var expectedDate = JulianDate.fromDate(new Date(Date.UTC(2009, 7, 1)));
+        var computedDate = JulianDate.fromIso8601('2009-08-01');
         expect(computedDate).toEqual(expectedDate);
     });
 

--- a/Specs/Core/JulianDateSpec.js
+++ b/Specs/Core/JulianDateSpec.js
@@ -164,77 +164,77 @@ defineSuite([
         }).toThrowDeveloperError();
     });
 
-    it('Construct from ISO8601 local calendar date, basic format', function() {
-        var expectedDate = JulianDate.fromDate(new Date(2009, 7, 1));
-        var computedDate = JulianDate.fromIso8601('20090801T00');
+    it('Construct from ISO8601 calendar date, basic format', function() {
+        var expectedDate = JulianDate.fromDate(new Date(Date.UTC(2009, 7, 1)));
+        var computedDate = JulianDate.fromIso8601('20090801');
         expect(computedDate).toEqual(expectedDate);
     });
 
-    it('Construct from ISO8601 local calendar date, extended format', function() {
-        var expectedDate = JulianDate.fromDate(new Date(2009, 7, 1));
-        var computedDate = JulianDate.fromIso8601('2009-08-01T00');
+    it('Construct from ISO8601 calendar date, extended format', function() {
+        var expectedDate = JulianDate.fromDate(new Date(Date.UTC(2009, 7, 1)));
+        var computedDate = JulianDate.fromIso8601('2009-08-01');
         expect(computedDate).toEqual(expectedDate);
     });
 
-    it('Construct from ISO8601 local calendar date on Feb 29th, basic format', function() {
-        var expectedDate = JulianDate.fromDate(new Date(2000, 1, 29));
-        var computedDate = JulianDate.fromIso8601('20000229T00');
+    it('Construct from ISO8601 calendar date on Feb 29th, basic format', function() {
+        var expectedDate = JulianDate.fromDate(new Date(Date.UTC(2000, 1, 29)));
+        var computedDate = JulianDate.fromIso8601('20000229');
         expect(computedDate).toEqual(expectedDate);
     });
 
-    it('Construct from ISO8601 local calendar date on Feb 29th, extended format', function() {
-        var expectedDate = JulianDate.fromDate(new Date(2000, 1, 29));
-        var computedDate = JulianDate.fromIso8601('2000-02-29T00');
+    it('Construct from ISO8601 calendar date on Feb 29th, extended format', function() {
+        var expectedDate = JulianDate.fromDate(new Date(Date.UTC(2000, 1, 29)));
+        var computedDate = JulianDate.fromIso8601('2000-02-29');
         expect(computedDate).toEqual(expectedDate);
     });
 
-    it('Construct from an ISO8601 local ordinal date, basic format', function() {
-        var expectedDate = JulianDate.fromDate(new Date(1985, 3, 12));
-        var computedDate = JulianDate.fromIso8601('1985102T00');
+    it('Construct from an ISO8601 ordinal date, basic format', function() {
+        var expectedDate = JulianDate.fromDate(new Date(Date.UTC(1985, 3, 12)));
+        var computedDate = JulianDate.fromIso8601('1985102');
         expect(computedDate).toEqual(expectedDate);
     });
 
-    it('Construct from an ISO8601 local ordinal date, extended format', function() {
-        var expectedDate = JulianDate.fromDate(new Date(1985, 3, 12));
-        var computedDate = JulianDate.fromIso8601('1985-102T00');
+    it('Construct from an ISO8601 ordinal date, extended format', function() {
+        var expectedDate = JulianDate.fromDate(new Date(Date.UTC(1985, 3, 12)));
+        var computedDate = JulianDate.fromIso8601('1985-102');
         expect(computedDate).toEqual(expectedDate);
     });
 
     it('Construct an ISO8601 ordinal date on a leap year', function() {
-        var expectedDate = JulianDate.fromDate(new Date(2000, 11, 31));
-        var computedDate = JulianDate.fromIso8601('2000-366T00');
+        var expectedDate = JulianDate.fromDate(new Date(Date.UTC(2000, 11, 31)));
+        var computedDate = JulianDate.fromIso8601('2000-366');
         expect(computedDate).toEqual(expectedDate);
     });
 
-    it('Construct from an ISO8601 local week date, basic format', function() {
-        var expectedDate = JulianDate.fromDate(new Date(1985, 3, 12));
-        var computedDate = JulianDate.fromIso8601('1985W155T00');
+    it('Construct from an ISO8601 week date, basic format', function() {
+        var expectedDate = JulianDate.fromDate(new Date(Date.UTC(1985, 3, 12)));
+        var computedDate = JulianDate.fromIso8601('1985W155');
         expect(computedDate).toEqual(expectedDate);
     });
 
-    it('Construct from an ISO8601 local week date, extended format', function() {
-        var expectedDate = JulianDate.fromDate(new Date(2008, 8, 27));
-        var computedDate = JulianDate.fromIso8601('2008-W39-6T00');
+    it('Construct from an ISO8601 week date, extended format', function() {
+        var expectedDate = JulianDate.fromDate(new Date(Date.UTC(2008, 8, 27)));
+        var computedDate = JulianDate.fromIso8601('2008-W39-6');
         expect(computedDate).toEqual(expectedDate);
     });
 
-    it('Construct from an ISO8601 local calendar week date, basic format', function() {
-        var expectedDate = JulianDate.fromDate(new Date(1985, 3, 7));
-        var computedDate = JulianDate.fromIso8601('1985W15T00');
+    it('Construct from an ISO8601 calendar week date, basic format', function() {
+        var expectedDate = JulianDate.fromDate(new Date(Date.UTC(1985, 3, 7)));
+        var computedDate = JulianDate.fromIso8601('1985W15');
         expect(computedDate).toEqual(expectedDate);
     });
 
-    it('Construct from an ISO8601 local calendar week date, extended format', function() {
-        var expectedDate = JulianDate.fromDate(new Date(2008, 8, 21));
-        var computedDate = JulianDate.fromIso8601('2008-W39T00');
+    it('Construct from an ISO8601 calendar week date, extended format', function() {
+        var expectedDate = JulianDate.fromDate(new Date(Date.UTC(2008, 8, 21)));
+        var computedDate = JulianDate.fromIso8601('2008-W39');
         expect(computedDate).toEqual(expectedDate);
     });
 
     //Note, there is no 'extended format' for calendar month because eliminating the
     //would confuse is with old YYMMDD dates
-    it('Construct from an ISO8601 local calendar month, basic format', function() {
-        var expectedDate = JulianDate.fromDate(new Date(1985, 3, 1));
-        var computedDate = JulianDate.fromIso8601('1985-04T00');
+    it('Construct from an ISO8601 calendar month, basic format', function() {
+        var expectedDate = JulianDate.fromDate(new Date(Date.UTC(1985, 3, 1)));
+        var computedDate = JulianDate.fromIso8601('1985-04');
         expect(computedDate).toEqual(expectedDate);
     });
 
@@ -443,18 +443,6 @@ defineSuite([
     it('Construct from ISO8601 local calendar date and time with no seconds and UTC offset in extended format', function() {
         var expectedDate = JulianDate.fromDate(new Date(Date.UTC(2009, 7, 1, 12, 30, 0)));
         var computedDate = JulianDate.fromIso8601('2009-08-01T07:30-05:00');
-        expect(computedDate).toEqual(expectedDate);
-    });
-
-    it('Construct from ISO8601 with date only in basic format should be midnight UTC', function() {
-        var expectedDate = JulianDate.fromDate(new Date(Date.UTC(2009, 7, 1)));
-        var computedDate = JulianDate.fromIso8601('20090801');
-        expect(computedDate).toEqual(expectedDate);
-    });
-
-    it('Construct from ISO8601 with date only in extended format should be midnight UTC', function() {
-        var expectedDate = JulianDate.fromDate(new Date(Date.UTC(2009, 7, 1)));
-        var computedDate = JulianDate.fromIso8601('2009-08-01');
         expect(computedDate).toEqual(expectedDate);
     });
 


### PR DESCRIPTION
In the Date spec (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date), under the description of `dateString` you'll see this note
```
Note: parsing of date strings with the Date constructor (and Date.parse, they are equivalent)
is strongly discouraged due to browser differences and inconsistencies. Support for RFC 2822
format strings is by convention only. Support for ISO 8601 formats differs in that date-only
strings (e.g. "1970-01-01") are treated as UTC, not local.
```

Also fixed/added tests and updated CHANGES.md with the breaking change.