### PR TITLE
Remove `eslint-plugin-html` from shareable config

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,5 +1,8 @@
 {
     "extends": "./Tools/eslint-config-cesium/browser.js",
+    "plugins": [
+        "html"
+    ],
     "rules": {
         "no-unused-vars": ["error", {"vars": "all", "args": "none"}]
     }

--- a/Tools/eslint-config-cesium/CHANGES.md
+++ b/Tools/eslint-config-cesium/CHANGES.md
@@ -1,6 +1,9 @@
 Change Log
 ==========
 
+### 2.0.1 - 2017-06-28
+* Remove [eslint-plugin-html](https://www.npmjs.com/package/eslint-plugin-html) peerDependency from `browser` config.
+
 ### 2.0.0 - 2017-06-27
 
 * Enable [no-floating-decimal](http://eslint.org/docs/rules/no-floating-decimal).

--- a/Tools/eslint-config-cesium/browser.js
+++ b/Tools/eslint-config-cesium/browser.js
@@ -6,9 +6,6 @@ module.exports = {
         amd: true,
         browser: true
     },
-    plugins: [
-        'html'
-    ],
     rules: {
         'no-implicit-globals': 'error'
     }

--- a/Tools/eslint-config-cesium/package.json
+++ b/Tools/eslint-config-cesium/package.json
@@ -19,7 +19,6 @@
     "cesium"
   ],
   "peerDependencies": {
-    "eslint": ">= 4",
-    "eslint-plugin-html": ">= 3"
+    "eslint": ">= 4"
   }
 }


### PR DESCRIPTION
@mramato and I talked offline about how few of our repositories need [`eslint-plugin-html`](https://www.npmjs.com/package/eslint-plugin-html), so I've removed it for the next version of our shareable config. 

This has the added benefit of removing the npm warning that `eslint-plugin-html` is not installed every time someone runs `npm install` (since it was defined as a peerDependency).