### PR TITLE
Fixed the home button to work with 2D view

### DIFF
--- a/Source/Scene/Camera.js
+++ b/Source/Scene/Camera.js
@@ -1276,7 +1276,7 @@ define([
 
         if (mode === SceneMode.SCENE2D) {
             this.flyTo({
-                destination : Rectangle.MAX_VALUE,
+                destination : Camera.DEFAULT_VIEW_RECTANGLE,
                 duration : duration,
                 endTransform : Matrix4.IDENTITY
             });

--- a/Specs/Scene/CameraSpec.js
+++ b/Specs/Scene/CameraSpec.js
@@ -2473,7 +2473,7 @@ defineSuite([
             destination: destination
         });
         camera.flyHome(0);
-        expect(camera.position).toEqualEpsilon(Cartesian3.UNIT_Z, CesiumMath.EPSILON8);
+        expect(camera.position).toEqualEpsilon(new Cartesian3(-9183857.990445068, 3896182.1777645755, 1.0), CesiumMath.EPSILON8);
         expect(camera.direction).toEqualEpsilon(new Cartesian3(0, 0, -1), CesiumMath.EPSILON8);
         expect(camera.up).toEqualEpsilon(Cartesian3.UNIT_Y, CesiumMath.EPSILON8);
     });


### PR DESCRIPTION
Solves issue #4933. 

#4971 was a correct solution, but was failing a test. The test was equating the center of the map with the position. It now compares the position with the correct home position.