### PR TITLE
Adds support for R/RG/RGB/RGBA floating point textures for WebGL 2

### DIFF
--- a/Source/Renderer/Texture.js
+++ b/Source/Renderer/Texture.js
@@ -72,6 +72,23 @@ define([
                     internalFormat = WebGLConstants.DEPTH_COMPONENT24;
                 }
             }
+
+            if (pixelDatatype == PixelDatatype.FLOAT) {
+                switch (pixelFormat) {
+                case PixelFormat.RGBA:
+                    internalFormat = WebGLConstants.RGBA32F;
+                    break;
+		case PixelFormat.RGB:
+                    internalFormat = WebGLConstants.RGB32F;
+                    break;
+                case PixelFormat.RG:
+                    internalFormat = WebGLConstants.RG32F;
+                    break;
+                case PixelFormat.R:
+                    internalFormat = WebGLConstants.R32F;
+                    break;
+                }
+            }
         }
 
         //>>includeStart('debug', pragmas.debug);


### PR DESCRIPTION
In WebGL 2, we need to specify a certain internal format for textures that have the floating point type and the pixel formats RGBA, RGB, RG, and R. This change sets the internal format of R/RG/RGB/RGBA textures to the corresponding 32-bit floating-point internal format.