### PR TITLE
Fix ESLint errors in Cesiumjs.org merge

### DIFF
--- a/Apps/CesiumViewer/index.html
+++ b/Apps/CesiumViewer/index.html
@@ -12,6 +12,7 @@
     <link rel="stylesheet" href="CesiumViewer.css" media="screen">
     <script data-main="CesiumViewerStartup" src="../../ThirdParty/requirejs-2.1.20/require.js"></script>
     <script type="text/javascript">
+    /* eslint-disable */
     if (window.location.host === "cesiumjs.org") {
         var _gaq = _gaq || [];
         _gaq.push(['_setAccount', 'UA-30040272-1']);
@@ -22,6 +23,7 @@
         var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
         })();
     }
+    /* eslint-enable */
 </script>
 </head>
 <body style="background: #000;">

--- a/Apps/Sandcastle/index.html
+++ b/Apps/Sandcastle/index.html
@@ -25,6 +25,7 @@
     <link rel="stylesheet" href="../../ThirdParty/codemirror-4.6/addon/hint/show-hint.css">
     <!-- End of autocomplete -->
     <script type="text/javascript">
+        /* eslint-disable */
         if (window.location.host === "cesiumjs.org") {
             var _gaq = _gaq || [];
             _gaq.push(['_setAccount', 'UA-30040272-1']);
@@ -38,6 +39,7 @@
                 s.parentNode.insertBefore(ga, s);
             })();
         }
+        /* eslint-enable */
     </script>
     <meta property="og:title" content="Cesium Sandcastle" />
     <meta property="og:description" content="The Cesium Sandcastle provides an interactive environment for testing Cesium code." />


### PR DESCRIPTION
Fixes #5587.

Just a few ESLint error fixes. I have no idea what the line `var _gaq = _gaq || [];` does (does it rely on a global variable being set?), so I've just disabled ESLint for it.