### PR TITLE
Fix for stray point in center of screen

### DIFF
--- a/Source/Scene/PointCloud3DTileContent.js
+++ b/Source/Scene/PointCloud3DTileContent.js
@@ -1018,11 +1018,13 @@ define([
 
         if (hasNormals && backFaceCulling) {
             vs += '    float visible = step(-normal.z, 0.0); \n' +
-                  '    gl_Position *= visible; \n';
+                  '    gl_Position *= visible; \n' +
+                  '    gl_PointSize *= visible; \n';
         }
 
         if (hasShowStyle) {
-            vs += '    gl_PointSize *= show; \n';
+            vs += '    gl_Position *= show; \n' +
+                  '    gl_PointSize *= show; \n';
         }
 
         vs += '} \n';

--- a/Source/Scene/PointCloud3DTileContent.js
+++ b/Source/Scene/PointCloud3DTileContent.js
@@ -1022,7 +1022,7 @@ define([
         }
 
         if (hasShowStyle) {
-            vs += '    gl_Position *= show; \n';
+            vs += '    gl_PointSize *= show; \n';
         }
 
         vs += '} \n';


### PR DESCRIPTION
A stray point appeared in the center of screen instead of discarding under some systems when there were points with show = false style.
This should fix the issue.
See https://github.com/AnalyticalGraphicsInc/cesium/issues/5598