### PR TITLE
Fix jsDoc

### DIFF
--- a/Tools/jsdoc/conf.json
+++ b/Tools/jsdoc/conf.json
@@ -8,7 +8,7 @@
         "includePattern": ".+\\.js(doc)?$",
         "excludePattern": "(^|\\/|\\\\)_"
     },
-    "plugins": ["cesiumTags"],
+    "plugins": ["./Tools/jsdoc/cesiumTags"],
     "templates": {
         "cleverLinks": true,
         "default": {
@@ -18,7 +18,7 @@
     },
     "opts": {
         "destination": "Build/Documentation",
-        "template": "cesium_template",
+        "template": "./Tools/jsdoc/cesium_template",
         "recurse": true
     }
 }


### PR DESCRIPTION
Apparently the paths to plugins/templates were "fixed" in the latest version of jsDoc, which means our paths were now wrong and needed to be updated.