### PR TITLE
Fix bug in streamToPromise

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1251,6 +1251,7 @@ function requirejsOptimize(name, config) {
 function streamToPromise(stream) {
     return new Promise(function(resolve, reject) {
         stream.on('finish', resolve);
-        stream.on('end', reject);
+        stream.on('end', resolve);
+        stream.on('error', reject);
     });
 }


### PR DESCRIPTION
I don't know how we never noticed this, but unless I'm missing something, the `streamToPromise` helper we use in `gulpfile.js` would actually trigger failure in some cases instead of success.  I think this might be why we have been seeing sporadic requirejs failures in travis builds but only on a very rare basis.