### PR TITLE
Build with the latest version of Node 6.x instead of 4.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - '4.3'
+  - '4'
 sudo: false
 before_script:
   - export DISPLAY=:99.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - '4'
+  - "6"
 sudo: false
 before_script:
   - export DISPLAY=:99.0


### PR DESCRIPTION
`eslint` or one of the modules it depends on no longer works on 4.3 (we should have always just been using `4` instead of `4.3` to begin with.)

We should merge this ASAP since all branches are currently broken.

CC @ggetz @tfili 