### PR TITLE
Clear clamp to ground callback for label glyphs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,7 @@ Change Log
 * Fixed label positioning when height reference changes [#5609](https://github.com/AnalyticalGraphicsInc/cesium/issues/5609)
 * Fixed crash when using the `Cesium3DTilesInspectorViewModel` and removing a tileset [#5607](https://github.com/AnalyticalGraphicsInc/cesium/issues/5607)
 * Fixed polygon outline in Polygon Sandcastle demo [#5642](https://github.com/AnalyticalGraphicsInc/cesium/issues/5642)
+* Fixed label positioning when using `HeightReference.CLAMP_TO_GROUND` and no position [#5648](https://github.com/AnalyticalGraphicsInc/cesium/pull/5648)
 
 ### 1.35.2 - 2017-07-11
 

--- a/Source/Scene/LabelCollection.js
+++ b/Source/Scene/LabelCollection.js
@@ -106,6 +106,10 @@ define([
         if (defined(billboard)) {
             billboard.show = false;
             billboard.image = undefined;
+            if (defined(billboard._removeCallbackFunc)) {
+                billboard._removeCallbackFunc();
+                billboard._removeCallbackFunc = undefined;
+            }
             labelCollection._spareBillboards.push(billboard);
             glyph.billboard = undefined;
         }

--- a/Specs/Scene/LabelCollectionSpec.js
+++ b/Specs/Scene/LabelCollectionSpec.js
@@ -2227,6 +2227,23 @@ defineSuite([
             expect(l._clampedPosition).toBeUndefined();
             expect(l._glyphs[0].billboard._clampedPosition).toBeUndefined();
         });
+
+        it('clears the billboard height reference callback when the label is removed', function() {
+            scene.globe = createGlobe();
+            spyOn(scene.camera, 'update');
+            var l = labelsWithHeight.add({
+                heightReference : HeightReference.CLAMP_TO_GROUND,
+                text: 't',
+                position : Cartesian3.fromDegrees(-72.0, 40.0)
+            });
+            scene.renderForSpecs();
+            var billboard = l._glyphs[0].billboard;
+            expect(billboard._removeCallbackFunc).toBeDefined();
+            var spy = spyOn(billboard, '_removeCallbackFunc');
+            labelsWithHeight.remove(l);
+            expect(spy).toHaveBeenCalled();
+            expect(labelsWithHeight._spareBillboards[0]._removeCallbackFunc).not.toBeDefined();
+        });
     });
 
 }, 'WebGL');


### PR DESCRIPTION
Fixes #5647
Fixes #4716 

When a label is removed, the label collection hangs onto the billboard glyphs to re-use them in new labels.  However, the height reference callback for these billboards wasn't properly removed so if the new label didn't have a defined position, the glyphs would ground clamp to whatever the old labels position was.