### PR TITLE
Fix sporadic build/test failures.

### DIFF
--- a/Specs/karma.conf.js
+++ b/Specs/karma.conf.js
@@ -6,6 +6,9 @@ module.exports = function(config) {
         // base path that will be used to resolve all patterns (eg. files, exclude)
         basePath : '..',
 
+        // Disable module load timeout
+        waitSeconds : 0,
+
         // frameworks to use
         // available frameworks: https://npmjs.org/browse/keyword/karma-adapter
         frameworks : ['jasmine', 'requirejs', 'detectBrowsers'],

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -123,6 +123,10 @@ gulp.task('clean', function(done) {
 
 gulp.task('requirejs', function(done) {
     var config = JSON.parse(new Buffer(process.argv[3].substring(2), 'base64').toString('utf8'));
+
+    // Disable module load timeout
+    config.waitSeconds = 0;
+
     requirejs.optimize(config, function() {
         done();
     }, done);


### PR DESCRIPTION
The default load timeout for AMD modules is 7 seconds, when running the tests so many modules get loaded at once that it can time out. This fixes the karma configuration under Node so that timeout is indefinite.

Because we've also seen sporadic build failures, I also added the timeout option to `requirejs.optimize` as well, I'm not sure if this has any effect, but if we stop seeing sporadic requirejs.optimize failures, we'll know it did.

CC @hpinkos @bagnell 