### PR TITLE
Add setter for KmlDataSource.name

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,7 +16,7 @@ Change Log
 * Added ability to show tile urls in the 3D Tiles Inspector. [#5592](https://github.com/AnalyticalGraphicsInc/cesium/pull/5592)
 * Added behavior to `Cesium3DTilesInspector` that selects the first tileset hovered over if no tilest is specified. [#5139](https://github.com/AnalyticalGraphicsInc/cesium/issues/5139)
 * Added ability to provide a `width` and `height` to `scene.pick`. [#5602](https://github.com/AnalyticalGraphicsInc/cesium/pull/5602)
-* Added setter for `KkmlDataSource.name` to specify a name for the datasource.
+* Added setter for `KmlDataSource.name` to specify a name for the datasource [#5660](https://github.com/AnalyticalGraphicsInc/cesium/pull/5660).
 * Fixed issue where scene would blink when labels were added. [#5537](https://github.com/AnalyticalGraphicsInc/cesium/issues/5537)
 * Fixed label positioning when height reference changes [#5609](https://github.com/AnalyticalGraphicsInc/cesium/issues/5609)
 * Fixed crash when using the `Cesium3DTilesInspectorViewModel` and removing a tileset [#5607](https://github.com/AnalyticalGraphicsInc/cesium/issues/5607)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,7 @@ Change Log
 * Added ability to show tile urls in the 3D Tiles Inspector. [#5592](https://github.com/AnalyticalGraphicsInc/cesium/pull/5592)
 * Added behavior to `Cesium3DTilesInspector` that selects the first tileset hovered over if no tilest is specified. [#5139](https://github.com/AnalyticalGraphicsInc/cesium/issues/5139)
 * Added ability to provide a `width` and `height` to `scene.pick`. [#5602](https://github.com/AnalyticalGraphicsInc/cesium/pull/5602)
+* Added setter for `KkmlDataSource.name` to specify a name for the datasource.
 * Fixed issue where scene would blink when labels were added. [#5537](https://github.com/AnalyticalGraphicsInc/cesium/issues/5537)
 * Fixed label positioning when height reference changes [#5609](https://github.com/AnalyticalGraphicsInc/cesium/issues/5609)
 * Fixed crash when using the `Cesium3DTilesInspectorViewModel` and removing a tileset [#5607](https://github.com/AnalyticalGraphicsInc/cesium/issues/5607)

--- a/Source/DataSources/KmlDataSource.js
+++ b/Source/DataSources/KmlDataSource.js
@@ -2356,6 +2356,7 @@ define([
             set : function(value) {
                 if(this._name !== value) {
                     this._name = value;
+                    this._changed.raiseEvent(this);
                 }
             }
         },

--- a/Source/DataSources/KmlDataSource.js
+++ b/Source/DataSources/KmlDataSource.js
@@ -2344,7 +2344,7 @@ define([
 
     defineProperties(KmlDataSource.prototype, {
         /**
-         * Gets a human-readable name for this instance.
+         * Gets or sets a human-readable name for this instance.
          * This will be automatically be set to the KML document name on load.
          * @memberof KmlDataSource.prototype
          * @type {String}
@@ -2352,6 +2352,11 @@ define([
         name : {
             get : function() {
                 return this._name;
+            },
+            set : function(value) {
+                if(this._name !== value) {
+                    this._name = value;
+                }
             }
         },
         /**

--- a/Source/DataSources/KmlDataSource.js
+++ b/Source/DataSources/KmlDataSource.js
@@ -2354,7 +2354,7 @@ define([
                 return this._name;
             },
             set : function(value) {
-                if(this._name !== value) {
+                if (this._name !== value) {
                     this._name = value;
                     this._changed.raiseEvent(this);
                 }

--- a/Specs/DataSources/KmlDataSourceSpec.js
+++ b/Specs/DataSources/KmlDataSourceSpec.js
@@ -152,7 +152,7 @@ defineSuite([
 
 
     it('setting name raises changed event', function() {
-        var dataSource = new KmlDataSource();
+        var dataSource = new KmlDataSource(options);
 
         var spy = jasmine.createSpy('changedEvent');
         dataSource.changedEvent.addEventListener(spy);

--- a/Specs/DataSources/KmlDataSourceSpec.js
+++ b/Specs/DataSources/KmlDataSourceSpec.js
@@ -150,6 +150,20 @@ defineSuite([
         expect(dataSource.show).toBe(true);
     });
 
+
+    it('setting name raises changed event', function() {
+        var dataSource = new KmlDataSource();
+
+        var spy = jasmine.createSpy('changedEvent');
+        dataSource.changedEvent.addEventListener(spy);
+
+        var newName = 'garfield';
+        dataSource.name = newName;
+        expect(dataSource.name).toEqual(newName);
+        expect(spy.calls.count()).toEqual(1);
+        expect(spy).toHaveBeenCalledWith(dataSource);
+    });
+
     it('show sets underlying entity collection show.', function() {
         var dataSource = new KmlDataSource(options);
 

--- a/Specs/DataSources/KmlDataSourceSpec.js
+++ b/Specs/DataSources/KmlDataSourceSpec.js
@@ -150,7 +150,6 @@ defineSuite([
         expect(dataSource.show).toBe(true);
     });
 
-
     it('setting name raises changed event', function() {
         var dataSource = new KmlDataSource(options);
 


### PR DESCRIPTION
Related to #5656.
This allows the ability to set the name of a `KmlDataSource`.