### PR TITLE
Fix travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ script:
 
   - echo 'makeZipFile' && echo -en 'travis_fold:start:script.makeZipFile\\r'
   - npm run clean
-  - npm run makeZipFile
+  - npm run makeZipFile -- --concurrency 2
   - npm pack
   - echo -en 'travis_fold:end:script.makeZipFile\\r'
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -46,8 +46,10 @@ var noDevelopmentGallery = taskName === 'release' || taskName === 'makeZipFile';
 var buildingRelease = noDevelopmentGallery;
 var minifyShaders = taskName === 'minify' || taskName === 'minifyRelease' || taskName === 'release' || taskName === 'makeZipFile' || taskName === 'buildApps';
 
-//travis reports 32 cores but only has 3GB of memory, which causes the VM to run out.  Limit to 8 cores instead.
-var concurrency = Math.min(os.cpus().length, 8);
+var concurrency = yargs.argv.concurrency;
+if (!concurrency) {
+    concurrency = os.cpus().length;
+}
 
 //Since combine and minify run in parallel already, split concurrency in half when building both.
 //This can go away when gulp 4 comes out because it allows for synchronous tasks.


### PR DESCRIPTION
The problem was that travis itself was killing our build process because we were trying to run 8 requirejs processes at once, leading us to run out of memory (only 3GB available on travis).  This adds a command line to specify concurrency and updates travis to do at most 2 (one for each core).

Travis recently switched over to a new trusty-based images, and I'm guessing there's slightly less free memory available (and perhaps quite a bit more code on our end after merging 3D Tiles) leading to the memory issues.

CC @bagnell 