### PR TITLE
Fix viewer.flyTo ignoring and resetting minimumZoomDistance

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,7 +23,7 @@ Change Log
 * Fixed crash when using the `Cesium3DTilesInspectorViewModel` and removing a tileset [#5607](https://github.com/AnalyticalGraphicsInc/cesium/issues/5607)
 * Fixed polygon outline in Polygon Sandcastle demo [#5642](https://github.com/AnalyticalGraphicsInc/cesium/issues/5642)
 * Fixed label positioning when using `HeightReference.CLAMP_TO_GROUND` and no position [#5648](https://github.com/AnalyticalGraphicsInc/cesium/pull/5648)
-* Fixed `viewer.flyTo` not respecting zoom limits, and resetting minimumZoomDistance if the camera zoomed past the minimumZoomDistance. [5573](https://github.com/AnalyticalGraphicsInc/cesium/issues/5573)
+* Fixed `Viewer.flyTo` not respecting zoom limits, and resetting minimumZoomDistance if the camera zoomed past the minimumZoomDistance. [5573](https://github.com/AnalyticalGraphicsInc/cesium/issues/5573)
 * Updated `Billboard`, `Label` and `PointPrimitive` constructors to clone `NearFarScale` parameters [#5654](https://github.com/AnalyticalGraphicsInc/cesium/pull/5654)
 * Added `FrustumGeometry` and `FrustumOutlineGeometry`. [#5649](https://github.com/AnalyticalGraphicsInc/cesium/pull/5649)
 * Added an `options` parameter to the constructors of `PerspectiveFrustum`, `PerspectiveOffCenterFrustum`, `OrthographicFrustum`, and `OrthographicOffCenterFrustum` to set properties. [#5649](https://github.com/AnalyticalGraphicsInc/cesium/pull/5649)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,6 +23,7 @@ Change Log
 * Fixed crash when using the `Cesium3DTilesInspectorViewModel` and removing a tileset [#5607](https://github.com/AnalyticalGraphicsInc/cesium/issues/5607)
 * Fixed polygon outline in Polygon Sandcastle demo [#5642](https://github.com/AnalyticalGraphicsInc/cesium/issues/5642)
 * Fixed label positioning when using `HeightReference.CLAMP_TO_GROUND` and no position [#5648](https://github.com/AnalyticalGraphicsInc/cesium/pull/5648)
+* Fixed `viewer.flyTo` not respecting zoom limits, and resetting minimumZoomDistance if the camera zoomed past the minimumZoomDistance. [5573](https://github.com/AnalyticalGraphicsInc/cesium/issues/5573)
 * Updated `Billboard`, `Label` and `PointPrimitive` constructors to clone `NearFarScale` parameters [#5654](https://github.com/AnalyticalGraphicsInc/cesium/pull/5654)
 * Added `FrustumGeometry` and `FrustumOutlineGeometry`. [#5649](https://github.com/AnalyticalGraphicsInc/cesium/pull/5649)
 * Added an `options` parameter to the constructors of `PerspectiveFrustum`, `PerspectiveOffCenterFrustum`, `OrthographicFrustum`, and `OrthographicOffCenterFrustum` to set properties. [#5649](https://github.com/AnalyticalGraphicsInc/cesium/pull/5649)

--- a/Source/DataSources/EntityView.js
+++ b/Source/DataSources/EntityView.js
@@ -317,9 +317,6 @@ define([
             var hasViewFrom = defined(viewFromProperty);
 
             if (!hasViewFrom && defined(boundingSphere)) {
-                var controller = scene.screenSpaceCameraController;
-                controller.minimumZoomDistance = Math.min(controller.minimumZoomDistance, boundingSphere.radius * 0.5);
-
                 //The default HPR is not ideal for high altitude objects so
                 //we scale the pitch as we get further from the earth for a more
                 //downward view.

--- a/Source/Scene/Camera.js
+++ b/Source/Scene/Camera.js
@@ -2858,19 +2858,19 @@ define([
             offset = HeadingPitchRange.clone(Camera.DEFAULT_OFFSET);
         }
 
-        var DEFAULT_ZOOM = 100.0;
-        var MINIMUM_ZOOM = camera._scene.screenSpaceCameraController.minimumZoomDistance;
-        var MAXIMUM_ZOOM = camera._scene.screenSpaceCameraController.maximumZoomDistance;
+        var defaultZoom = 100.0;
+        var minimumZoom = camera._scene.screenSpaceCameraController.minimumZoomDistance;
+        var maximumZoom = camera._scene.screenSpaceCameraController.maximumZoomDistance;
         var range = offset.range;
         if (!defined(range) || range === 0.0) {
             var radius = boundingSphere.radius;
             // If the minimumZoomDistance hasn't been set yet, it is equal to 1,
-            if (radius < MINIMUM_ZOOM && MINIMUM_ZOOM > 1) {
-                offset.range = MINIMUM_ZOOM;
-            } else if(radius > MAXIMUM_ZOOM) {
-                offset.range = MAXIMUM_ZOOM;
+            if (radius < minimumZoom && minimumZoom > 1) {
+                offset.range = minimumZoom;
+            } else if(radius > maximumZoom) {
+                offset.range = maximumZoom;
             } else if(radius === 0) {
-                offset.range = DEFAULT_ZOOM;
+                offset.range = defaultZoom;
             } else if (camera.frustum instanceof OrthographicFrustum || camera._mode === SceneMode.SCENE2D) {
                 offset.range = distanceToBoundingSphere2D(camera, radius);
             } else {

--- a/Source/Scene/Camera.js
+++ b/Source/Scene/Camera.js
@@ -2853,19 +2853,20 @@ define([
         return Math.max(right, top) * 1.50;
     }
 
+    var MINIMUM_ZOOM = 100.0;
+
     function adjustBoundingSphereOffset(camera, boundingSphere, offset) {
         if (!defined(offset)) {
             offset = HeadingPitchRange.clone(Camera.DEFAULT_OFFSET);
         }
 
-        var defaultZoom = 100.0;
         var minimumZoom = camera._scene.screenSpaceCameraController.minimumZoomDistance;
         var maximumZoom = camera._scene.screenSpaceCameraController.maximumZoomDistance;
         var range = offset.range;
         if (!defined(range) || range === 0.0) {
             var radius = boundingSphere.radius;
-            if(radius === 0) {
-                offset.range = defaultZoom;
+            if (radius === 0) {
+                offset.range = MINIMUM_ZOOM;
             } else if (camera.frustum instanceof OrthographicFrustum || camera._mode === SceneMode.SCENE2D) {
                 offset.range = distanceToBoundingSphere2D(camera, radius);
             } else {

--- a/Source/Scene/Camera.js
+++ b/Source/Scene/Camera.js
@@ -2853,12 +2853,12 @@ define([
         return Math.max(right, top) * 1.50;
     }
 
-    var MINIMUM_ZOOM = 100.0;
-
     function adjustBoundingSphereOffset(camera, boundingSphere, offset) {
         if (!defined(offset)) {
             offset = HeadingPitchRange.clone(Camera.DEFAULT_OFFSET);
         }
+        
+        var MINIMUM_ZOOM = camera._scene.screenSpaceCameraController.minimumZoomDistance;
 
         var range = offset.range;
         if (!defined(range) || range === 0.0) {

--- a/Source/Scene/Camera.js
+++ b/Source/Scene/Camera.js
@@ -2864,18 +2864,14 @@ define([
         var range = offset.range;
         if (!defined(range) || range === 0.0) {
             var radius = boundingSphere.radius;
-            // If the minimumZoomDistance hasn't been set yet, it is equal to 1,
-            if (radius < minimumZoom && minimumZoom > 1) {
-                offset.range = minimumZoom;
-            } else if(radius > maximumZoom) {
-                offset.range = maximumZoom;
-            } else if(radius === 0) {
+            if(radius === 0) {
                 offset.range = defaultZoom;
             } else if (camera.frustum instanceof OrthographicFrustum || camera._mode === SceneMode.SCENE2D) {
                 offset.range = distanceToBoundingSphere2D(camera, radius);
             } else {
                 offset.range = distanceToBoundingSphere3D(camera, radius);
             }
+            offset.range = CesiumMath.clamp(offset.range, minimumZoom, maximumZoom);
         }
 
         return offset;

--- a/Source/Scene/Camera.js
+++ b/Source/Scene/Camera.js
@@ -2865,7 +2865,7 @@ define([
         var range = offset.range;
         if (!defined(range) || range === 0.0) {
             var radius = boundingSphere.radius;
-            if (radius === 0) {
+            if (radius === 0.0) {
                 offset.range = MINIMUM_ZOOM;
             } else if (camera.frustum instanceof OrthographicFrustum || camera._mode === SceneMode.SCENE2D) {
                 offset.range = distanceToBoundingSphere2D(camera, radius);

--- a/Source/Scene/Camera.js
+++ b/Source/Scene/Camera.js
@@ -2857,14 +2857,20 @@ define([
         if (!defined(offset)) {
             offset = HeadingPitchRange.clone(Camera.DEFAULT_OFFSET);
         }
-        
-        var MINIMUM_ZOOM = camera._scene.screenSpaceCameraController.minimumZoomDistance;
 
+        var DEFAULT_ZOOM = 100.0;
+        var MINIMUM_ZOOM = camera._scene.screenSpaceCameraController.minimumZoomDistance;
+        var MAXIMUM_ZOOM = camera._scene.screenSpaceCameraController.maximumZoomDistance;
         var range = offset.range;
         if (!defined(range) || range === 0.0) {
             var radius = boundingSphere.radius;
-            if (radius === 0.0) {
+            // If the minimumZoomDistance hasn't been set yet, it is equal to 1,
+            if (radius < MINIMUM_ZOOM && MINIMUM_ZOOM > 1) {
                 offset.range = MINIMUM_ZOOM;
+            } else if(radius > MAXIMUM_ZOOM) {
+                offset.range = MAXIMUM_ZOOM;
+            } else if(radius === 0) {
+                offset.range = DEFAULT_ZOOM;
             } else if (camera.frustum instanceof OrthographicFrustum || camera._mode === SceneMode.SCENE2D) {
                 offset.range = distanceToBoundingSphere2D(camera, radius);
             } else {
@@ -2950,7 +2956,6 @@ define([
         //>>includeEnd('debug');
 
         options = defaultValue(options, defaultValue.EMPTY_OBJECT);
-
         var scene2D = this._mode === SceneMode.SCENE2D || this._mode === SceneMode.COLUMBUS_VIEW;
         this._setTransform(Matrix4.IDENTITY);
         var offset = adjustBoundingSphereOffset(this, boundingSphere, options.offset);

--- a/Source/Widgets/Viewer/Viewer.js
+++ b/Source/Widgets/Viewer/Viewer.js
@@ -1870,6 +1870,7 @@ Either specify options.terrainProvider instead or set options.baseLayerPicker to
         var zoomPromise = viewer._zoomPromise;
         var zoomOptions = defaultValue(viewer._zoomOptions, {});
 
+console.log('hey');
         //If zoomTarget was an ImageryLayer
         if (entities instanceof Rectangle) {
             var options = {
@@ -1915,7 +1916,6 @@ Either specify options.terrainProvider instead or set options.baseLayerPicker to
 
         var boundingSphere = BoundingSphere.fromBoundingSpheres(boundingSpheres);
         var controller = scene.screenSpaceCameraController;
-        controller.minimumZoomDistance = Math.min(controller.minimumZoomDistance, boundingSphere.radius * 0.5);
 
         if (!viewer._zoomIsFlight) {
             camera.viewBoundingSphere(boundingSphere, viewer._zoomOptions);

--- a/Source/Widgets/Viewer/Viewer.js
+++ b/Source/Widgets/Viewer/Viewer.js
@@ -1914,7 +1914,6 @@ Either specify options.terrainProvider instead or set options.baseLayerPicker to
         viewer.trackedEntity = undefined;
 
         var boundingSphere = BoundingSphere.fromBoundingSpheres(boundingSpheres);
-        var controller = scene.screenSpaceCameraController;
 
         if (!viewer._zoomIsFlight) {
             camera.viewBoundingSphere(boundingSphere, viewer._zoomOptions);

--- a/Source/Widgets/Viewer/Viewer.js
+++ b/Source/Widgets/Viewer/Viewer.js
@@ -1870,7 +1870,6 @@ Either specify options.terrainProvider instead or set options.baseLayerPicker to
         var zoomPromise = viewer._zoomPromise;
         var zoomOptions = defaultValue(viewer._zoomOptions, {});
 
-console.log('hey');
         //If zoomTarget was an ImageryLayer
         if (entities instanceof Rectangle) {
             var options = {

--- a/Specs/Scene/CameraSpec.js
+++ b/Specs/Scene/CameraSpec.js
@@ -2605,6 +2605,36 @@ defineSuite([
         expect(distance).toBeLessThan(sphere.radius * 3.0);
     });
 
+    it('flyToBoundingSphere does not zoom closer than minimumZoomDistance', function() {
+        scene.mode = SceneMode.SCENE3D;
+        var MIN_VALUE = 1000;
+        scene.screenSpaceCameraController.minimumZoomDistance = MIN_VALUE;
+
+        var sphere = new BoundingSphere(Cartesian3.fromDegrees(-117.16, 32.71, 0.0), 10.0);
+
+        camera.flyToBoundingSphere(sphere, {
+            duration : 0.0
+        });
+
+        var distance = Cartesian3.distance(camera.position, sphere.center);
+        expect(CesiumMath.equalsEpsilon(distance, MIN_VALUE, 0.1)).toBe(true);
+    });
+
+    it('flyToBoundingSphere does not zoom further than maximumZoomDistance', function() {
+        scene.mode = SceneMode.SCENE3D;
+        var MAX_VALUE = 10000;
+        scene.screenSpaceCameraController.maximumZoomDistance = MAX_VALUE;
+
+        var sphere = new BoundingSphere(Cartesian3.fromDegrees(-117.16, 32.71, 0.0), 100000);
+
+        camera.flyToBoundingSphere(sphere, {
+            duration : 0.0
+        });
+
+        var distance = Cartesian3.distance(camera.position, sphere.center);
+        expect(CesiumMath.equalsEpsilon(distance, MAX_VALUE, 0.1)).toBe(true);
+    });
+
     it('distanceToBoundingSphere', function() {
         scene.mode = SceneMode.SCENE3D;
 

--- a/Specs/Scene/CameraSpec.js
+++ b/Specs/Scene/CameraSpec.js
@@ -2607,8 +2607,8 @@ defineSuite([
 
     it('flyToBoundingSphere does not zoom closer than minimumZoomDistance', function() {
         scene.mode = SceneMode.SCENE3D;
-        var MIN_VALUE = 1000;
-        scene.screenSpaceCameraController.minimumZoomDistance = MIN_VALUE;
+        var minValue = 1000;
+        scene.screenSpaceCameraController.minimumZoomDistance = minValue;
 
         var sphere = new BoundingSphere(Cartesian3.fromDegrees(-117.16, 32.71, 0.0), 10.0);
 
@@ -2617,13 +2617,13 @@ defineSuite([
         });
 
         var distance = Cartesian3.distance(camera.position, sphere.center);
-        expect(CesiumMath.equalsEpsilon(distance, MIN_VALUE, 0.1)).toBe(true);
+        expect(CesiumMath.equalsEpsilon(distance, minValue, 0.1)).toBe(true);
     });
 
     it('flyToBoundingSphere does not zoom further than maximumZoomDistance', function() {
         scene.mode = SceneMode.SCENE3D;
-        var MAX_VALUE = 10000;
-        scene.screenSpaceCameraController.maximumZoomDistance = MAX_VALUE;
+        var maxValue = 10000;
+        scene.screenSpaceCameraController.maximumZoomDistance = maxValue;
 
         var sphere = new BoundingSphere(Cartesian3.fromDegrees(-117.16, 32.71, 0.0), 100000);
 
@@ -2632,7 +2632,7 @@ defineSuite([
         });
 
         var distance = Cartesian3.distance(camera.position, sphere.center);
-        expect(CesiumMath.equalsEpsilon(distance, MAX_VALUE, 0.1)).toBe(true);
+        expect(CesiumMath.equalsEpsilon(distance, maxValue, 0.1)).toBe(true);
     });
 
     it('distanceToBoundingSphere', function() {


### PR DESCRIPTION
This fixes #5573.
I might have messed something up by doing this, but here goes my best shot!

For some reason, the `screenSpaceCameraController.minimumZoomDistance` was being set to the radius of the bounding sphere, which happened to be always zero, when zooming to an entity or billboard. As the `maximumZoomDistance` is never set in this way, and [this was the commit message](https://github.com/AnalyticalGraphicsInc/cesium/commit/245af6784a38350cf0fa19d8a21956465dfc731b) when that block of code was added. So I figured that wasn't particularly necessary anymore.

If nothing else, you could probably keep the tests!