### PR TITLE
Fix CorridorGeometry crash with same positions at different heights

### DIFF
--- a/Source/Core/CorridorGeometry.js
+++ b/Source/Core/CorridorGeometry.js
@@ -54,6 +54,13 @@ define([
     var scratch1 = new Cartesian3();
     var scratch2 = new Cartesian3();
 
+    function scaleToSurface(positions, ellipsoid) {
+        for (var i = 0; i < positions.length; i++) {
+            positions[i] = ellipsoid.scaleToGeodeticSurface(positions[i], positions[i]);
+        }
+        return positions;
+    }
+
     function addNormals(attr, normal, left, front, back, vertexFormat) {
         var normals = attr.normals;
         var tangents = attr.tangents;
@@ -698,6 +705,7 @@ define([
     var scratchCartographicMax = new Cartographic();
 
     function computeRectangle(positions, ellipsoid, width, cornerType) {
+        positions = scaleToSurface(positions, ellipsoid);
         var cleanPositions = arrayRemoveDuplicates(positions, Cartesian3.equalsEpsilon);
         var length = cleanPositions.length;
         if (length < 2 || width <= 0) {
@@ -964,14 +972,15 @@ define([
         var width = corridorGeometry._width;
         var extrudedHeight = corridorGeometry._extrudedHeight;
         var extrude = (height !== extrudedHeight);
+        var ellipsoid = corridorGeometry._ellipsoid;
 
+        positions = scaleToSurface(positions, ellipsoid);
         var cleanPositions = arrayRemoveDuplicates(positions, Cartesian3.equalsEpsilon);
 
         if ((cleanPositions.length < 2) || (width <= 0)) {
             return;
         }
 
-        var ellipsoid = corridorGeometry._ellipsoid;
         var vertexFormat = corridorGeometry._vertexFormat;
         var params = {
             ellipsoid : ellipsoid,

--- a/Source/Core/CorridorGeometryLibrary.js
+++ b/Source/Core/CorridorGeometryLibrary.js
@@ -150,13 +150,6 @@ define([
         }
     };
 
-    function scaleToSurface(positions, ellipsoid) {
-        for (var i = 0; i < positions.length; i++) {
-            positions[i] = ellipsoid.scaleToGeodeticSurface(positions[i], positions[i]);
-        }
-        return positions;
-    }
-
     var scratchForwardProjection = new Cartesian3();
     var scratchBackwardProjection = new Cartesian3();
 
@@ -167,7 +160,6 @@ define([
         var granularity = params.granularity;
         var positions = params.positions;
         var ellipsoid = params.ellipsoid;
-        positions = scaleToSurface(positions, ellipsoid);
         var width = params.width / 2;
         var cornerType = params.cornerType;
         var saveAttributes = params.saveAttributes;

--- a/Source/Core/CorridorOutlineGeometry.js
+++ b/Source/Core/CorridorOutlineGeometry.js
@@ -40,6 +40,13 @@ define([
     var cartesian2 = new Cartesian3();
     var cartesian3 = new Cartesian3();
 
+    function scaleToSurface(positions, ellipsoid) {
+        for (var i = 0; i < positions.length; i++) {
+            positions[i] = ellipsoid.scaleToGeodeticSurface(positions[i], positions[i]);
+        }
+        return positions;
+    }
+
     function combine(computedPositions, cornerType) {
         var wallIndices = [];
         var positions = computedPositions.positions;
@@ -462,14 +469,15 @@ define([
         var width = corridorOutlineGeometry._width;
         var extrudedHeight = corridorOutlineGeometry._extrudedHeight;
         var extrude = (height !== extrudedHeight);
+        var ellipsoid = corridorOutlineGeometry._ellipsoid;
 
+        positions = scaleToSurface(positions, ellipsoid);
         var cleanPositions = arrayRemoveDuplicates(positions, Cartesian3.equalsEpsilon);
 
         if ((cleanPositions.length < 2) || (width <= 0)) {
             return;
         }
 
-        var ellipsoid = corridorOutlineGeometry._ellipsoid;
         var params = {
             ellipsoid : ellipsoid,
             positions : cleanPositions,

--- a/Specs/Core/CorridorGeometrySpec.js
+++ b/Specs/Core/CorridorGeometrySpec.js
@@ -41,6 +41,13 @@ defineSuite([
             width: 10000
         }));
         expect(geometry).toBeUndefined();
+
+        geometry = CorridorGeometry.createGeometry(new CorridorGeometry({
+            positions :  [new Cartesian3(-1349511.388149118, -5063973.22857992, 3623141.6372688496), //same lon/lat, different height
+                          new Cartesian3(-1349046.4811926484, -5062228.688739784, 3621885.0521561056)],
+            width: 10000
+        }));
+        expect(geometry).toBeUndefined();
     });
 
     it('computes positions', function() {

--- a/Specs/Core/CorridorOutlineGeometrySpec.js
+++ b/Specs/Core/CorridorOutlineGeometrySpec.js
@@ -35,6 +35,13 @@ defineSuite([
             width: 10000
         }));
         expect(geometry).toBeUndefined();
+
+        geometry = CorridorOutlineGeometry.createGeometry(new CorridorOutlineGeometry({
+            positions :  [new Cartesian3(-1349511.388149118, -5063973.22857992, 3623141.6372688496), //same lon/lat, different height
+                          new Cartesian3(-1349046.4811926484, -5062228.688739784, 3621885.0521561056)],
+            width: 10000
+        }));
+        expect(geometry).toBeUndefined();
     });
 
     it('computes positions', function() {


### PR DESCRIPTION
Changed `CorridorGeometry` and `CorridorOutlintGeometry` to check for duplicate positions after scaling the positions to the surface instead of the other way around.  This keeps the following code from crashing with a 'normalized result is not a number' error

``` javascript
var viewer = new Cesium.Viewer('cesiumContainer');

viewer.entities.add({
    corridor : {
        positions : [new Cesium.Cartesian3(-1349511.388149118, -5063973.22857992, 3623141.6372688496),
                     new Cesium.Cartesian3(-1349046.4811926484, -5062228.688739784, 3621885.0521561056)],
        width : 200000.0,
        material : Cesium.Color.RED.withAlpha(0.5)
    }
});
```