### PR TITLE
Fix for dynamic polylines with polyline dash material

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -32,6 +32,7 @@ Change Log
 * Added `FrustumGeometry` and `FrustumOutlineGeometry`. [#5649](https://github.com/AnalyticalGraphicsInc/cesium/pull/5649)
 * Added an `options` parameter to the constructors of `PerspectiveFrustum`, `PerspectiveOffCenterFrustum`, `OrthographicFrustum`, and `OrthographicOffCenterFrustum` to set properties. [#5649](https://github.com/AnalyticalGraphicsInc/cesium/pull/5649)
 * Added `ClassificationPrimitive` which defines a volume and draws the intersection of the volume and terrain or 3D Tiles. [#5625](https://github.com/AnalyticalGraphicsInc/cesium/pull/5625)
+* Fix for dynamic polylines with polyline dash material [#5681](https://github.com/AnalyticalGraphicsInc/cesium/pull/5681)
 
 ### 1.35.2 - 2017-07-11
 

--- a/Source/Scene/PolylineCollection.js
+++ b/Source/Scene/PolylineCollection.js
@@ -1144,14 +1144,22 @@ define([
         }
 
         var defines = ['DISTANCE_DISPLAY_CONDITION'];
+
+        var fs = new ShaderSource({
+            sources : [this.material.shaderSource, PolylineFS]
+        });
+
+        // Check for use of v_angle in material shader
+        if (this.material.shaderSource.search(/varying\s+float\s+v_angle;/g) !== -1) {
+            defines.push("POLYLINE_DASH");
+        }
+
         var vsSource = batchTable.getVertexShaderCallback()(PolylineVS);
         var vs = new ShaderSource({
             defines : defines,
             sources : [PolylineCommon, vsSource]
         });
-        var fs = new ShaderSource({
-            sources : [this.material.shaderSource, PolylineFS]
-        });
+
         var fsPick = new ShaderSource({
             sources : fs.sources,
             pickColorQualifier : 'varying'

--- a/Source/Scene/PolylineCollection.js
+++ b/Source/Scene/PolylineCollection.js
@@ -1151,7 +1151,7 @@ define([
 
         // Check for use of v_angle in material shader
         if (this.material.shaderSource.search(/varying\s+float\s+v_angle;/g) !== -1) {
-            defines.push("POLYLINE_DASH");
+            defines.push('POLYLINE_DASH');
         }
 
         var vsSource = batchTable.getVertexShaderCallback()(PolylineVS);

--- a/Source/Scene/PolylineCollection.js
+++ b/Source/Scene/PolylineCollection.js
@@ -1149,8 +1149,8 @@ define([
             sources : [this.material.shaderSource, PolylineFS]
         });
 
-        // Check for use of v_angle in material shader
-        if (this.material.shaderSource.search(/varying\s+float\s+v_angle;/g) !== -1) {
+        // Check for use of v_polylineAngle in material shader
+        if (this.material.shaderSource.search(/varying\s+float\s+v_polylineAngle;/g) !== -1) {
             defines.push('POLYLINE_DASH');
         }
 

--- a/Source/Scene/PolylineMaterialAppearance.js
+++ b/Source/Scene/PolylineMaterialAppearance.js
@@ -106,7 +106,7 @@ define([
         vertexShaderSource : {
             get : function() {
                 var vs = this._vertexShaderSource;
-                if (this.material.shaderSource.search(/varying\s+float\s+v_angle;/g) !== -1) {
+                if (this.material.shaderSource.search(/varying\s+float\s+v_polylineAngle;/g) !== -1) {
                     vs = '#define POLYLINE_DASH\n' + vs;
                 }
                 return vs;

--- a/Source/Shaders/Appearances/PolylineMaterialAppearanceVS.glsl
+++ b/Source/Shaders/Appearances/PolylineMaterialAppearanceVS.glsl
@@ -10,7 +10,7 @@ attribute float batchId;
 
 varying float v_width;
 varying vec2 v_st;
-varying float v_angle;
+varying float v_polylineAngle;
 
 void main()
 {
@@ -25,6 +25,6 @@ void main()
     v_width = width;
     v_st = st;
 
-    vec4 positionWC = getPolylineWindowCoordinates(p, prev, next, expandDir, width, usePrev, v_angle);
+    vec4 positionWC = getPolylineWindowCoordinates(p, prev, next, expandDir, width, usePrev, v_polylineAngle);
     gl_Position = czm_viewportOrthographic * positionWC;
 }

--- a/Source/Shaders/Materials/PolylineDashMaterial.glsl
+++ b/Source/Shaders/Materials/PolylineDashMaterial.glsl
@@ -2,7 +2,7 @@ uniform vec4 color;
 uniform vec4 gapColor;
 uniform float dashLength;
 uniform float dashPattern;
-varying float v_angle;
+varying float v_polylineAngle;
 
 const float maskLength = 16.0;
 
@@ -19,7 +19,7 @@ czm_material czm_getMaterial(czm_materialInput materialInput)
 {
     czm_material material = czm_getDefaultMaterial(materialInput);
 
-    vec2 pos = rotate(v_angle) * gl_FragCoord.xy;
+    vec2 pos = rotate(v_polylineAngle) * gl_FragCoord.xy;
 
     // Get the relative position within the dash from 0 to 1
     float dashPosition = fract(pos.x / dashLength);

--- a/Source/Shaders/PolylineVS.glsl
+++ b/Source/Shaders/PolylineVS.glsl
@@ -15,7 +15,7 @@ attribute vec4 texCoordExpandAndBatchIndex;
 varying vec2  v_st;
 varying float v_width;
 varying vec4  czm_pickColor;
-varying float v_angle;
+varying float v_polylineAngle;
 
 void main()
 {
@@ -90,7 +90,7 @@ void main()
         }
     #endif
 
-    vec4 positionWC = getPolylineWindowCoordinates(p, prev, next, expandDir, width, usePrev, v_angle);
+    vec4 positionWC = getPolylineWindowCoordinates(p, prev, next, expandDir, width, usePrev, v_polylineAngle);
     gl_Position = czm_viewportOrthographic * positionWC * show;
 
     v_st = vec2(texCoord, clamp(expandDir, 0.0, 1.0));


### PR DESCRIPTION
This fixes an issue where dynamic polylines (rendered with the PolylineCollection) weren't properly defining the POLYLINE_DASH define in the vertex shader and causing rendering issues b/c the v_angle wasn't being computed properly.

You can see an example of the issue here:  http://cesiumjs.org/Cesium/Apps/Sandcastle/?src=Hello%20World.html&label=Showcases&gist=1b4c2cf989ab0304020fdb3f94374e93

This fix looks for v_angle in the material shader and then adds the POLYLINE_DASH define if it finds it.