### PR TITLE
Add Timer Queries

### DIFF
--- a/Source/Core/WebGLConstants.js
+++ b/Source/Core/WebGLConstants.js
@@ -329,6 +329,15 @@ define([
         // WEBGL_compressed_texture_etc1
         COMPRESSED_RGB_ETC1_WEBGL : 0x8D64,
 
+        // EXT_disjoint_timer_query
+        QUERY_COUNTER_BITS_EXT : 0x8864,
+        CURRENT_QUERY_EXT : 0x8865,
+        QUERY_RESULT_EXT : 0x8866,
+        QUERY_RESULT_AVAILABLE_EXT : 0x8867,
+        TIME_ELAPSED_EXT : 0x88BF,
+        TIMESTAMP_EXT : 0x8E28,
+        GPU_DISJOINT_EXT : 0x8FBB,
+
         // Desktop OpenGL
         DOUBLE : 0x140A,
 

--- a/Source/Renderer/Context.js
+++ b/Source/Renderer/Context.js
@@ -312,7 +312,7 @@ define([
         var endQuery;
         var queryCounter;
         var getQuery;
-        var getQueryObject;
+        var getQueryParameter;
 
         var vertexArrayObject;
         var instancedArrays;
@@ -330,6 +330,15 @@ define([
             glVertexAttribDivisor = function(index, divisor) { gl.vertexAttribDivisor(index, divisor); };
 
             glDrawBuffers = function(buffers) { gl.drawBuffers(buffers); };
+
+            createQuery = function() { return gl.createQuery(); };
+            deleteQuery = function(query) { return gl.deleteQuery(query); };
+            isQuery = function(query) { return gl.isQuery(query); };
+            beginQuery = function(target, query) { return gl.beginQuery(target, query); };
+            endQuery = function(target) { return gl.endQuery(target); };
+            queryCounter = function(query, target) { return webgl2TimerQuery.queryCounterEXT(query, target); };
+            getQuery = function(target, pname) { return gl.getQuery(target, pname); };
+            getQueryParameter = function(query, pname) { return gl.getQueryParameter(query, pname); };
         } else {
             vertexArrayObject = getExtension(gl, ['OES_vertex_array_object']);
             if (defined(vertexArrayObject)) {
@@ -354,10 +363,10 @@ define([
             deleteQuery = function(query) { return webgl1TimerQuery.deleteQueryEXT(query); };
             isQuery = function(query) { return webgl1TimerQuery.isQueryEXT(query); };
             beginQuery = function(target, query) { return webgl1TimerQuery.beginQueryEXT(target, query); };
-            endQuery = function(target, query) { return webgl1TimerQuery.endQueryEXT(target); };
+            endQuery = function(target) { return webgl1TimerQuery.endQueryEXT(target); };
             queryCounter = function(query, target) { return webgl1TimerQuery.queryCounterEXT(query, target); };
             getQuery = function(target, pname) { return webgl1TimerQuery.getQueryEXT(target, pname); };
-            getQueryObject = function(query, pname) { return webgl1TimerQuery.getQueryObjectEXT(query, pname); };
+            getQueryParameter = function(query, pname) { return webgl1TimerQuery.getQueryObjectEXT(query, pname); };
         }
 
         this.glCreateVertexArray = glCreateVertexArray;
@@ -377,7 +386,7 @@ define([
         this.endQuery = endQuery;
         this.queryCounter = queryCounter;
         this.getQuery = getQuery;
-        this.getQueryObject = getQueryObject;
+        this.getQueryParameter = getQueryParameter;
 
         this._vertexArrayObject = !!vertexArrayObject;
         this._instancedArrays = !!instancedArrays;

--- a/Source/Renderer/Context.js
+++ b/Source/Renderer/Context.js
@@ -277,11 +277,12 @@ define([
 
         var webgl1TimerQuery = getExtension(gl, ['EXT_disjoint_timer_query']);
         var webgl2TimerQuery = getExtension(gl, ['EXT_disjoint_timer_query_webgl2']);
+        if (!!webgl1TimerQuery && !webgl2TimerQuery) {
+            webgl2TimerQuery = webgl1TimerQuery;
+        }
 
         this._debugShaders = getExtension(gl, ['WEBGL_debug_shaders']);
-        this._timerQuery =
-            (!this._webgl2 && !!webgl1TimerQuery) ||
-            (this._webgl2 && !!webgl2TimerQuery);
+        this._timerQuery = !!webgl1TimerQuery || !!webgl2TimerQuery;
 
         this._colorBufferFloat = this._webgl2 && !!getExtension(gl, ['EXT_color_buffer_float']);
 

--- a/Source/Renderer/Context.js
+++ b/Source/Renderer/Context.js
@@ -350,14 +350,14 @@ define([
                 glDrawBuffers = function(buffers) { drawBuffers.drawBuffersWEBGL(buffers); };
             }
 
-            createQuery = function() { webgl1TimerQuery.createQueryEXT(); };
-            deleteQuery = function(query) { webgl1TimerQuery.deleteQueryEXT(query); };
-            isQuery = function(query) { webgl1TimerQuery.isQueryEXT(query); };
-            beginQuery = function(target, query) { webgl1TimerQuery.beginQueryEXT(target, query); };
-            endQuery = function(target, query) { webgl1TimerQuery.endQueryEXT(target); };
-            queryCounter = function(query, target) { webgl1TimerQuery.queryCounter(query, target); };
-            getQuery = function(target, pname) { webgl1TimerQuery.getQueryEXT(target, pname); };
-            getQueryObject = function(query, pname) { webgl1TimerQuery.getQueryObjectEXT(query, pname); };
+            createQuery = function() { return webgl1TimerQuery.createQueryEXT(); };
+            deleteQuery = function(query) { return webgl1TimerQuery.deleteQueryEXT(query); };
+            isQuery = function(query) { return webgl1TimerQuery.isQueryEXT(query); };
+            beginQuery = function(target, query) { return webgl1TimerQuery.beginQueryEXT(target, query); };
+            endQuery = function(target, query) { return webgl1TimerQuery.endQueryEXT(target); };
+            queryCounter = function(query, target) { return webgl1TimerQuery.queryCounterEXT(query, target); };
+            getQuery = function(target, pname) { return webgl1TimerQuery.getQueryEXT(target, pname); };
+            getQueryObject = function(query, pname) { return webgl1TimerQuery.getQueryObjectEXT(query, pname); };
         }
 
         this.glCreateVertexArray = glCreateVertexArray;

--- a/Source/Renderer/Context.js
+++ b/Source/Renderer/Context.js
@@ -293,6 +293,8 @@ define([
         this._textureFilterAnisotropic = textureFilterAnisotropic;
         ContextLimits._maximumTextureFilterAnisotropy = defined(textureFilterAnisotropic) ? gl.getParameter(textureFilterAnisotropic.MAX_TEXTURE_MAX_ANISOTROPY_EXT) : 1.0;
 
+        this._disjointTimerQuery = gl.getParameter(WebGLConstants.GPU_DISJOINT_EXT);
+
         var glCreateVertexArray;
         var glBindVertexArray;
         var glDeleteVertexArray;
@@ -713,6 +715,12 @@ define([
         timerQuery : {
             get : function() {
                 return this._timerQuery;
+            }
+        },
+
+        disjointTimerQuery : {
+            get : function() {
+                return this._disjointTimerQuery;
             }
         },
 

--- a/Source/Renderer/Context.js
+++ b/Source/Renderer/Context.js
@@ -274,7 +274,11 @@ define([
         this._depthTexture = !!getExtension(gl, ['WEBGL_depth_texture', 'WEBKIT_WEBGL_depth_texture']);
         this._textureFloat = !!getExtension(gl, ['OES_texture_float']);
         this._fragDepth = !!getExtension(gl, ['EXT_frag_depth']);
+
         this._debugShaders = getExtension(gl, ['WEBGL_debug_shaders']);
+        this._timerQuery =
+            (!this._webgl2 && !!getExtension(gl, ['EXT_disjoint_timer_query'])) ||
+            (this._webgl2 && !!getExtension(gl, ['EXT_disjoint_timer_query_webgl2']));
 
         this._colorBufferFloat = this._webgl2 && !!getExtension(gl, ['EXT_color_buffer_float']);
 
@@ -664,6 +668,21 @@ define([
         debugShaders : {
             get : function() {
                 return this._debugShaders;
+            }
+        },
+
+        /**
+         * <code>true</code> if either the EXT_disjoint_timer_query extension is supported in WebGL 1 or the
+         * EXT_disjoint_timer_query_webgl2 extension is supported in WebGL 2. This extension provides support
+         * for timer queries.
+         * @memberof Context.prototype
+         * @type {Boolean}
+         * @see {@link https://www.khronos.org/registry/webgl/extensions/EXT_disjoint_timer_query/}
+         * @see {@link https://www.khronos.org/registry/webgl/extensions/EXT_disjoint_timer_query_webgl2/}
+         */
+        timerQuery : {
+            get : function() {
+                return this._timerQuery;
             }
         },
 

--- a/Source/Renderer/Context.js
+++ b/Source/Renderer/Context.js
@@ -275,10 +275,13 @@ define([
         this._textureFloat = !!getExtension(gl, ['OES_texture_float']);
         this._fragDepth = !!getExtension(gl, ['EXT_frag_depth']);
 
+        var webgl1TimerQuery = getExtension(gl, ['EXT_disjoint_timer_query']);
+        var webgl2TimerQuery = getExtension(gl, ['EXT_disjoint_timer_query_webgl2']);
+
         this._debugShaders = getExtension(gl, ['WEBGL_debug_shaders']);
         this._timerQuery =
-            (!this._webgl2 && !!getExtension(gl, ['EXT_disjoint_timer_query'])) ||
-            (this._webgl2 && !!getExtension(gl, ['EXT_disjoint_timer_query_webgl2']));
+            (!this._webgl2 && !!webgl1TimerQuery) ||
+            (this._webgl2 && !!webgl2TimerQuery);
 
         this._colorBufferFloat = this._webgl2 && !!getExtension(gl, ['EXT_color_buffer_float']);
 
@@ -299,6 +302,15 @@ define([
         var glVertexAttribDivisor;
 
         var glDrawBuffers;
+
+        var createQuery;
+        var deleteQuery;
+        var isQuery;
+        var beginQuery;
+        var endQuery;
+        var queryCounter;
+        var getQuery;
+        var getQueryObject;
 
         var vertexArrayObject;
         var instancedArrays;
@@ -335,6 +347,15 @@ define([
             if (defined(drawBuffers)) {
                 glDrawBuffers = function(buffers) { drawBuffers.drawBuffersWEBGL(buffers); };
             }
+
+            createQuery = function() { webgl1TimerQuery.createQueryEXT(); };
+            deleteQuery = function(query) { webgl1TimerQuery.deleteQueryEXT(query); };
+            isQuery = function(query) { webgl1TimerQuery.isQueryEXT(query); };
+            beginQuery = function(target, query) { webgl1TimerQuery.beginQueryEXT(target, query); };
+            endQuery = function(target, query) { webgl1TimerQuery.endQueryEXT(target); };
+            queryCounter = function(query, target) { webgl1TimerQuery.queryCounter(query, target); };
+            getQuery = function(target, pname) { webgl1TimerQuery.getQueryEXT(target, pname); };
+            getQueryObject = function(query, pname) { webgl1TimerQuery.getQueryObjectEXT(query, pname); };
         }
 
         this.glCreateVertexArray = glCreateVertexArray;
@@ -346,6 +367,15 @@ define([
         this.glVertexAttribDivisor = glVertexAttribDivisor;
 
         this.glDrawBuffers = glDrawBuffers;
+
+        this.createQuery = createQuery;
+        this.deleteQuery = deleteQuery;
+        this.isQuery = isQuery;
+        this.beginQuery = beginQuery;
+        this.endQuery = endQuery;
+        this.queryCounter = queryCounter;
+        this.getQuery = getQuery;
+        this.getQueryObject = getQueryObject;
 
         this._vertexArrayObject = !!vertexArrayObject;
         this._instancedArrays = !!instancedArrays;

--- a/Source/Renderer/DrawCommand.js
+++ b/Source/Renderer/DrawCommand.js
@@ -503,7 +503,7 @@ define([
          var useTimerQuery = defined(this._timerQuery) && context.timerQuery;
 
          if (useTimerQuery) {
-             this._timerQuery.start();
+             this._timerQuery.begin();
          }
 
          context.draw(this, passState);

--- a/Source/Renderer/DrawCommand.js
+++ b/Source/Renderer/DrawCommand.js
@@ -294,6 +294,27 @@ define([
         },
 
         /**
+         * The timer query that this DrawCommand is using.
+         * If this value is defined, the timer query will be used to
+         * measure how long the DrawCommand takes to execute.
+         *
+         * @memberof DrawCommand.prototype
+         * @type {Object}
+         * @default undefined
+         */
+        timerQuery : {
+            get : function() {
+                return this._timerQuery;
+            },
+            set : function(value) {
+                if (this._timerQuery !== value) {
+                    this._timerQuery = value;
+                    this.dirty = true;
+                }
+            }
+        },
+
+        /**
          * An object with functions whose names match the uniforms in the shader program
          * and return values to set those uniforms.
          *

--- a/Source/Renderer/DrawCommand.js
+++ b/Source/Renderer/DrawCommand.js
@@ -38,6 +38,7 @@ define([
         this._debugOverlappingFrustums = 0;
         this._castShadows = defaultValue(options.castShadows, false);
         this._receiveShadows = defaultValue(options.receiveShadows, false);
+        this._timerQuery = options.timerQuery;
 
         this.dirty = true;
         this.lastDirtyTime = 0;
@@ -498,8 +499,18 @@ define([
      * @param {Context} context The renderer context in which to draw.
      * @param {PassState} [passState] The state for the current render pass.
      */
-    DrawCommand.prototype.execute = function(context, passState) {
-        context.draw(this, passState);
+     DrawCommand.prototype.execute = function(context, passState) {
+         var useTimerQuery = defined(this._timerQuery) && context.timerQuery;
+
+         if (useTimerQuery) {
+             this._timerQuery.start();
+         }
+
+         context.draw(this, passState);
+
+         if (useTimerQuery) {
+             this._timerQuery.end();
+         }
     };
 
     return DrawCommand;

--- a/Source/Renderer/TimerQuery.js
+++ b/Source/Renderer/TimerQuery.js
@@ -7,6 +7,9 @@ define([
     /**
      * Represents a timer query.
      *
+     *
+     * @param {Object} frameState The current FrameState.
+     * @param {Function} callback The callback to execute after the frame time is measured. Takes the frame time in millisecond as a parameter.
      * @private
      */
     function TimerQuery(frameState, callback) {

--- a/Source/Renderer/TimerQuery.js
+++ b/Source/Renderer/TimerQuery.js
@@ -26,6 +26,7 @@ define([
         frameState.afterRender.push(function() {
             var available = context.getQueryObject(endQuery, WebGLConstants.QUERY_RESULT_AVAILABLE_EXT);
             var disjoint = context.disjointTimerQuery;
+            console.log("Callback being called! Available: " + available + " disjoint: " + disjoint + " context: " + context);
             if (available && !disjoint) {
                 var timeStart = context.getQueryObject(startQuery, WebGLConstants.QUERY_RESULT_EXT);
                 var timeEnd = context.getQueryObject(endQuery, WebGLConstants.QUERY_RESULT_EXT);
@@ -45,4 +46,6 @@ define([
     TimerQuery.prototype.end = function() {
         this._context.queryCounter(this._endQuery, WebGLConstants.TIMESTAMP_EXT);
     };
+
+    return TimerQuery;
 });

--- a/Source/Renderer/TimerQuery.js
+++ b/Source/Renderer/TimerQuery.js
@@ -1,12 +1,6 @@
 define([
-        '../Core/defaultValue',
-        '../Core/defined',
-        '../Core/defineProperties',
         '../Core/WebGLConstants'
     ], function(
-        defaultValue,
-        defined,
-        defineProperties,
         WebGLConstants) {
     'use strict';
 
@@ -15,7 +9,8 @@ define([
      *
      * @private
      */
-    function TimerQuery(context, frameState, callback) {
+    function TimerQuery(frameState, callback) {
+        var context = frameState.context;
         var startQuery = context.createQuery();
         var endQuery = context.createQuery();
 
@@ -24,11 +19,11 @@ define([
         this._endQuery = endQuery;
 
         frameState.beforeRender.push(function() {
-            var available = context.getQueryObject(endQuery, WebGLConstants.QUERY_RESULT_AVAILABLE_EXT);
+            var available = context.getQueryParameter(endQuery, WebGLConstants.QUERY_RESULT_AVAILABLE_EXT);
             var disjoint = context.disjointTimerQuery;
             if (available && !disjoint) {
-                var timeStart = context.getQueryObject(startQuery, WebGLConstants.QUERY_RESULT_EXT);
-                var timeEnd = context.getQueryObject(endQuery, WebGLConstants.QUERY_RESULT_EXT);
+                var timeStart = context.getQueryParameter(startQuery, WebGLConstants.QUERY_RESULT_EXT);
+                var timeEnd = context.getQueryParameter(endQuery, WebGLConstants.QUERY_RESULT_EXT);
 
                 // Converts from nanoseconds to milliseconds
                 var timeElapsed = (timeEnd - timeStart) / 1e6;
@@ -43,7 +38,7 @@ define([
     };
 
     TimerQuery.prototype.end = function() {
-        this._context.queryCounter(this._endQuery, WebGLConstants.TIMESTAMP_EXT);
+        this._context.queryCounter(this._endQuery);
     };
 
     return TimerQuery;

--- a/Source/Renderer/TimerQuery.js
+++ b/Source/Renderer/TimerQuery.js
@@ -1,0 +1,48 @@
+define([
+        '../Core/defaultValue',
+        '../Core/defined',
+        '../Core/defineProperties',
+        '../Core/WebGLConstants'
+    ], function(
+        defaultValue,
+        defined,
+        defineProperties,
+        WebGLConstants) {
+    'use strict';
+
+    /**
+     * Represents a timer query.
+     *
+     * @private
+     */
+    function TimerQuery(context, frameState, callback) {
+        var startQuery = context.createQuery();
+        var endQuery = context.createQuery();
+
+        this._context = context;
+        this._startQuery = startQuery;
+        this._endQuery = endQuery;
+
+        frameState.afterRender.push(function() {
+            var available = context.getQueryObject(endQuery, WebGLConstants.QUERY_RESULT_AVAILABLE_EXT);
+            var disjoint = context.disjointTimerQuery;
+            if (available && !disjoint) {
+                var timeStart = context.getQueryObject(startQuery, WebGLConstants.QUERY_RESULT_EXT);
+                var timeEnd = context.getQueryObject(endQuery, WebGLConstants.QUERY_RESULT_EXT);
+
+                // Converts from nanoseconds to milliseconds
+                var timeElapsed = (timeEnd - timeStart) / 1e6;
+
+                callback(timeElapsed);
+            }
+        });
+    }
+
+    TimerQuery.prototype.begin = function() {
+        this._context.queryCounter(this._startQuery, WebGLConstants.TIMESTAMP_EXT);
+    };
+
+    TimerQuery.prototype.end = function() {
+        this._context.queryCounter(this._endQuery, WebGLConstants.TIMESTAMP_EXT);
+    };
+});

--- a/Source/Renderer/TimerQuery.js
+++ b/Source/Renderer/TimerQuery.js
@@ -23,10 +23,9 @@ define([
         this._startQuery = startQuery;
         this._endQuery = endQuery;
 
-        frameState.afterRender.push(function() {
+        frameState.beforeRender.push(function() {
             var available = context.getQueryObject(endQuery, WebGLConstants.QUERY_RESULT_AVAILABLE_EXT);
             var disjoint = context.disjointTimerQuery;
-            console.log("Callback being called! Available: " + available + " disjoint: " + disjoint + " context: " + context);
             if (available && !disjoint) {
                 var timeStart = context.getQueryObject(startQuery, WebGLConstants.QUERY_RESULT_EXT);
                 var timeEnd = context.getQueryObject(endQuery, WebGLConstants.QUERY_RESULT_EXT);

--- a/Source/Renderer/TimerQuery.js
+++ b/Source/Renderer/TimerQuery.js
@@ -38,7 +38,7 @@ define([
     };
 
     TimerQuery.prototype.end = function() {
-        this._context.queryCounter(this._endQuery);
+        this._context.queryCounter(this._endQuery, WebGLConstants.TIMESTAMP_EXT);
     };
 
     return TimerQuery;

--- a/Source/Renderer/TimerQuery.js
+++ b/Source/Renderer/TimerQuery.js
@@ -16,6 +16,8 @@ define([
      */
     function TimerQuery(frameState, callback) {
         var context = frameState.context;
+        this._context = context;
+
         if (!processingSupported(context)) {
             oneTimeWarning('TimerQuery', 'Timer queries are not supported -- missing extension!');
             return;
@@ -26,7 +28,6 @@ define([
 
         this._startQuery = startQuery;
         this._endQuery = endQuery;
-        this._context = context;
 
         frameState.beforeRender.push(function() {
             var available = context.getQueryParameter(endQuery, WebGLConstants.QUERY_RESULT_AVAILABLE_EXT);

--- a/Source/Scene/FrameState.js
+++ b/Source/Scene/FrameState.js
@@ -150,6 +150,19 @@ define([
         this.creditDisplay = creditDisplay;
 
         /**
+         * An array of functions to be called at the start of the frame.  This array
+         * will be cleared at the start of each frame.
+         *
+         * @type {FrameState~BeforeRenderCallback[]}
+         *
+         * @example
+         * frameState.beforeRender.push(function() {
+         *   // take some action, raise an event, etc.
+         * });
+         */
+        this.beforeRender = [];
+
+        /**
          * An array of functions to be called at the end of the frame.  This array
          * will be cleared after each frame.
          * <p>

--- a/Source/Scene/Scene.js
+++ b/Source/Scene/Scene.js
@@ -2540,6 +2540,14 @@ define([
         }
     }
 
+    function callBeforeRenderFunctions(frameState) {
+        var functions = frameState.beforeRender;
+        for (var i = 0, length = functions.length; i < length; ++i) {
+            functions[i]();
+        }
+        functions.length = 0;
+    }
+
     function callAfterRenderFunctions(frameState) {
         // Functions are queued up during primitive update and executed here in case
         // the function modifies scene state that should remain constant over the frame.
@@ -2591,12 +2599,13 @@ define([
             scene._cameraStartFired = false;
         }
 
-        scene._preRender.raiseEvent(scene, time);
-        scene._jobScheduler.resetBudgets();
-
         var context = scene.context;
         var us = context.uniformState;
         var frameState = scene._frameState;
+
+        callBeforeRenderFunctions(frameState);
+        scene._preRender.raiseEvent(scene, time);
+        scene._jobScheduler.resetBudgets();
 
         var frameNumber = CesiumMath.incrementWrap(frameState.frameNumber, 15000000.0, 1.0);
         updateFrameState(scene, frameNumber, time);


### PR DESCRIPTION
Implements timer queries for [WebGL 1](https://www.khronos.org/registry/webgl/extensions/EXT_disjoint_timer_query/) and [WebGL 2](https://www.khronos.org/registry/webgl/extensions/EXT_disjoint_timer_query_webgl2/) contexts.

The `TimerQuery` class can be used to profile WebGL calls. This PR also modifies `DrawCommand` so that individual `DrawCommands` can be monitored.