### PR TITLE
Fixed model cache bug

### DIFF
--- a/.idea/encodings.xml
+++ b/.idea/encodings.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="Encoding">
+    <file url="file://$PROJECT_DIR$/CHANGES.md" charset="UTF-8" />
     <file url="file://$PROJECT_DIR$/LICENSE.md" charset="UTF-8" />
     <file url="PROJECT" charset="UTF-8" />
   </component>

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@ Change Log
 
 * Fixed `replaceState` bug that was causing the `CesiumViewer` demo application to crash in Safari and iOS
 * Fixed issue where `Model` and `BillboardCollection` would throw an error if the globe is undefined [#5638](https://github.com/AnalyticalGraphicsInc/cesium/issues/5638)
+* Fixed issue where the `Model` glTF cache loses reference to the model's buffer data. [#5720](https://github.com/AnalyticalGraphicsInc/cesium/issues/5720)
 
 ### 1.36 - 2017-08-01
 

--- a/Source/Scene/Model.js
+++ b/Source/Scene/Model.js
@@ -4593,7 +4593,6 @@ define([
                 cachedResources.samplers = resources.samplers;
                 cachedResources.renderStates = resources.renderStates;
                 cachedResources.ready = true;
-                removePipelineExtras(this.gltf);
 
                 // The normal attribute name is required for silhouettes, so get it before the gltf JSON is released
                 this._normalAttributeName = getAttributeOrUniformBySemantic(this.gltf, 'NORMAL');

--- a/Specs/Scene/ModelSpec.js
+++ b/Specs/Scene/ModelSpec.js
@@ -429,38 +429,20 @@ defineSuite([
     });
 
     it('rejects readyPromise on error', function() {
-        var invalidGltf = clone(texturedBoxModel.gltf, true);
-        invalidGltf.shaders[0].uri = 'invalid.glsl';
+        return loadJson(boomBoxUrl).then(function(gltf) {
+            gltf.images[0].uri = 'invalid.png';
+            var model = primitives.add(new Model({
+                gltf : gltf
+            }));
 
-        var model = primitives.add(new Model({
-            gltf : invalidGltf
-        }));
+            scene.renderForSpecs();
 
-        scene.renderForSpecs();
-
-        return model.readyPromise.then(function(model) {
-            fail('should not resolve');
-        }).otherwise(function(error) {
-            expect(model.ready).toEqual(false);
-            primitives.remove(model);
-        });
-    });
-
-    it('rejects readyPromise on error', function() {
-        var invalidGltf = clone(texturedBoxModel.gltf, true);
-        invalidGltf.shaders[0].uri = 'invalid.glsl';
-
-        var model = primitives.add(new Model({
-            gltf : invalidGltf
-        }));
-
-        scene.renderForSpecs();
-
-        return model.readyPromise.then(function(model) {
-            fail('should not resolve');
-        }).otherwise(function(error) {
-            expect(model.ready).toEqual(false);
-            primitives.remove(model);
+            return model.readyPromise.then(function(model) {
+                fail('should not resolve');
+            }).otherwise(function(error) {
+                expect(model.ready).toEqual(false);
+                primitives.remove(model);
+            });
         });
     });
 


### PR DESCRIPTION
Fixes #5720 

While the discussion in #5720 is all valid, the fix was simpler. This prevents the pipeline extra's source buffer from being removed when loading completes. This allows any future models to reference that same buffer.

I had to restructure one test which was doing a `clone` on the `.gltf` property, since our `clone` function doesn't work for typed arrays.