### PR TITLE
Fix some math used by disableDepthDistance

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ Change Log
 * Fixed `replaceState` bug that was causing the `CesiumViewer` demo application to crash in Safari and iOS
 * Fixed issue where `Model` and `BillboardCollection` would throw an error if the globe is undefined [#5638](https://github.com/AnalyticalGraphicsInc/cesium/issues/5638)
 * Fixed issue where the `Model` glTF cache loses reference to the model's buffer data. [#5720](https://github.com/AnalyticalGraphicsInc/cesium/issues/5720)
+* Fixed some issues with `disableDepthTestDistance` [#5501](https://github.com/AnalyticalGraphicsInc/cesium/issues/5501) [#5331](https://github.com/AnalyticalGraphicsInc/cesium/issues/5331) [#5621](https://github.com/AnalyticalGraphicsInc/cesium/issues/5621)
 
 ### 1.36 - 2017-08-01
 

--- a/Source/Shaders/BillboardCollectionVS.glsl
+++ b/Source/Shaders/BillboardCollectionVS.glsl
@@ -265,11 +265,12 @@ void main()
 
     if (disableDepthTestDistance != 0.0)
     {
-        gl_Position.z = min(gl_Position.z, gl_Position.w);
-
-        bool clipped = gl_Position.z < -gl_Position.w || gl_Position.z > gl_Position.w;
+        // Don't try to "multiply both sides" by w.  Greater/less-than comparisons won't work for negative values of w.
+        float zclip = gl_Position.z / gl_Position.w;
+        bool clipped = (zclip < -1.0 || zclip > 1.0);
         if (!clipped && (disableDepthTestDistance < 0.0 || (lengthSq > 0.0 && lengthSq < disableDepthTestDistance)))
         {
+            // Position z on the near plane.
             gl_Position.z = -gl_Position.w;
         }
     }

--- a/Source/Shaders/PointPrimitiveCollectionVS.glsl
+++ b/Source/Shaders/PointPrimitiveCollectionVS.glsl
@@ -160,11 +160,12 @@ void main()
 
     if (disableDepthTestDistance != 0.0)
     {
-        gl_Position.z = min(gl_Position.z, gl_Position.w);
-
-        bool clipped = gl_Position.z < -gl_Position.w || gl_Position.z > gl_Position.w;
+        // Don't try to "multiply both sides" by w.  Greater/less-than comparisons won't work for negative values of w.
+        float zclip = gl_Position.z / gl_Position.w;
+        bool clipped = (zclip < -1.0 || zclip > 1.0);
         if (!clipped && (disableDepthTestDistance < 0.0 || (lengthSq > 0.0 && lengthSq < disableDepthTestDistance)))
         {
+            // Position z on the near plane.
             gl_Position.z = -gl_Position.w;
         }
     }


### PR DESCRIPTION
Fixes #5501, fixes #5331, fixes #5621.

This closes 3 issues, but somehow still doesn't feel perfect.  In particular, `Number.POSITIVE_INFINITY` tends to show through the globe very reliably now, whereas before it was spotty.

The original math error was along these lines:

```
    (z/w) < -1 || (z/w) > 1
```

This had been "simplified" by multiplying both sides by `w`, like so:

```
    z < -w || z > w
```

This simplification only works for positive values of `w` (the greater-than/less-than sense gets swapped for negative values of `w`).

/cc @bagnell @rahwang @tfili 
