### PR TITLE
Use the drawing buffer width instead of the canvas width for imagery splitting

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@ Change Log
 * Fixed issue where the `Model` glTF cache loses reference to the model's buffer data. [#5720](https://github.com/AnalyticalGraphicsInc/cesium/issues/5720)
 * Fixed some issues with `disableDepthTestDistance` [#5501](https://github.com/AnalyticalGraphicsInc/cesium/issues/5501) [#5331](https://github.com/AnalyticalGraphicsInc/cesium/issues/5331) [#5621](https://github.com/AnalyticalGraphicsInc/cesium/issues/5621)
 * Added several new Bing Maps styles: `CANVAS_DARK`, `CANVAS_LIGHT`, and `CANVAS_GRAY`.
+* Fixed a bug that could cause imagery splitting to work incorrectly when CSS pixels are not equivalent to WebGL drawing buffer pixels, such as on high DPI displays in Microsoft Edge and Internet Explorer.
 
 ### 1.36 - 2017-08-01
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,7 +8,7 @@ Change Log
 * Fixed issue where the `Model` glTF cache loses reference to the model's buffer data. [#5720](https://github.com/AnalyticalGraphicsInc/cesium/issues/5720)
 * Fixed some issues with `disableDepthTestDistance` [#5501](https://github.com/AnalyticalGraphicsInc/cesium/issues/5501) [#5331](https://github.com/AnalyticalGraphicsInc/cesium/issues/5331) [#5621](https://github.com/AnalyticalGraphicsInc/cesium/issues/5621)
 * Added several new Bing Maps styles: `CANVAS_DARK`, `CANVAS_LIGHT`, and `CANVAS_GRAY`.
-* Fixed a bug that could cause imagery splitting to work incorrectly when CSS pixels are not equivalent to WebGL drawing buffer pixels, such as on high DPI displays in Microsoft Edge and Internet Explorer.
+* Fixed a bug that caused imagery splitting to work incorrectly when CSS pixels were not equivalent to WebGL drawing buffer pixels, such as on high DPI displays in Microsoft Edge and Internet Explorer.
 
 ### 1.36 - 2017-08-01
 

--- a/Source/Renderer/UniformState.js
+++ b/Source/Renderer/UniformState.js
@@ -1016,7 +1016,7 @@ define([
         this._temeToPseudoFixed = Transforms.computeTemeToPseudoFixedMatrix(frameState.time, this._temeToPseudoFixed);
 
         // Convert the relative imagerySplitPosition to absolute pixel coordinates
-        this._imagerySplitPosition = frameState.imagerySplitPosition * canvas.clientWidth;
+        this._imagerySplitPosition = frameState.imagerySplitPosition * frameState.context.drawingBufferWidth;
         var fov = camera.frustum.fov;
         var viewport = this._viewport;
         var pixelSizePerMeter;


### PR DESCRIPTION
On systems where the drawing buffer width is not equal to the canvas width in CSS pixels, imagery splitting happens at the wrong position.  To see what I mean, visit this URL in Microsoft Edge on a machine with a high DPI display:
http://cesiumjs.org/Cesium/Apps/Sandcastle/index.html?src=Imagery%20Layers%20Split.html&label=All

If you can see the split at all, it won't be in the center of the screen as it is on other systems, and it won't line up with the divider line.

Edge:
![image](https://user-images.githubusercontent.com/924374/29262486-1edd289a-8118-11e7-9258-ff3a0aeb7af7.png)

Chrome:
![image](https://user-images.githubusercontent.com/924374/29262502-372d7300-8118-11e7-99bd-66086c9cb44e.png)

In case you're wondering what Edge has to do with this: not much.  Edge is missing support for the `image-rendering` CSS style, so Cesium chooses to ignore the `devicePixelRatio` and render the canvas with full device pixels, which guarantees and CSS pixels and drawing buffer pixels are not the same, triggering the bug.  IMO this `imagery-rendering` behavior is pretty questionable - it would be better for Cesium to be slightly blurry on IE/Edge rather than unusably slow - but that's a separate issue.