### PR TITLE
Fix specular flickering in processModelMaterialsCommon

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@ Change Log
 * Fixed a bug that caused imagery splitting to work incorrectly when CSS pixels were not equivalent to WebGL drawing buffer pixels, such as on high DPI displays in Microsoft Edge and Internet Explorer.
 * Added `Cesium3DTileset.loadJson` to support overriding the default tileset loading behavior. [#5685](https://github.com/AnalyticalGraphicsInc/cesium/pull/5685)
 * Fixed loading of binary glTFs containing CRN or KTX textures. [#5753](https://github.com/AnalyticalGraphicsInc/cesium/pull/5753)
+* Fixed specular computation for certain models using the `KHR_materials_common` extension. [#5773](https://github.com/AnalyticalGraphicsInc/cesium/pull/5773)
 
 ### 1.36 - 2017-08-01
 

--- a/Source/ThirdParty/GltfPipeline/processModelMaterialsCommon.js
+++ b/Source/ThirdParty/GltfPipeline/processModelMaterialsCommon.js
@@ -452,7 +452,8 @@ define([
         }
 
         var hasSpecular = hasNormals && ((lightingModel === 'BLINN') || (lightingModel === 'PHONG')) &&
-            defined(techniqueParameters.specular) && defined(techniqueParameters.shininess);
+            defined(techniqueParameters.specular) && defined(techniqueParameters.shininess) &&
+            (techniqueParameters.shininess > 0.0);
 
         // Generate lighting code blocks
         var hasNonAmbientLights = false;


### PR DESCRIPTION
If a model uses the KHR_materials_common extension, sets its technique to "PHONG", but doesn't provide specular or shininess values in its material, default values are 0 are used. This causes something to go wrong in the shader math resulting in a flickery effect. This fix is just smarter about checking if the model really has specular.

This issue has come up on the forum a couple times now:
https://groups.google.com/forum/#!topic/cesium-dev/kR7u5R5wq5k
https://groups.google.com/forum/#!topic/cesium-dev/JtTnEncijn0