### PR TITLE
do not clone gltf binary data

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -86,6 +86,8 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to Cesiu
    * [Jason Crow](https://github.com/jason-crow)
 * [Flightradar24 AB](https://www.flightradar24.com)
    * [Aleksei Kalmykov](https://github.com/kalmykov)
+* [virtualcitySYSTEMS GmbH](https://www.virtualcitysystems.de)
+   * [Jannes Bolling](https://github.com/jbo023)
 
 ## [Individual CLA](Documentation/Contributors/CLAs/individual-cla-agi-v1.0.txt)
 * [Victor Berchet](https://github.com/vicb)

--- a/Source/Scene/ModelAnimationCache.js
+++ b/Source/Scene/ModelAnimationCache.js
@@ -78,9 +78,9 @@ define([
 
             values = new Array(count);
             var accessorByteOffset = defaultValue(accessor.byteOffset, 0);
-            var byteOffset = bufferView.byteOffset + accessorByteOffset + source.byteOffset;
+            var byteOffset = bufferView.byteOffset + accessorByteOffset;
             for (var i = 0; i < count; i++) {
-                var typedArrayView = ComponentDatatype.createArrayBufferView(componentType, source.buffer, byteOffset, numberOfComponents);
+                var typedArrayView = ComponentDatatype.createArrayBufferView(componentType, source.buffer, source.byteOffset + byteOffset, numberOfComponents);
                 if (type === 'SCALAR') {
                     values[i] = typedArrayView[0];
                 } else if (type === 'VEC3') {
@@ -177,14 +177,14 @@ define([
             var type = accessor.type;
             var count = accessor.count;
             var byteStride = getAccessorByteStride(gltf, accessor);
-            var byteOffset = bufferView.byteOffset + accessor.byteOffset + source.byteOffset;
+            var byteOffset = bufferView.byteOffset + accessor.byteOffset;
             var numberOfComponents = numberOfComponentsForType(type);
 
             matrices = new Array(count);
 
             if ((componentType === WebGLConstants.FLOAT) && (type === AttributeType.MAT4)) {
                 for (var i = 0; i < count; ++i) {
-                    var typedArrayView = ComponentDatatype.createArrayBufferView(componentType, source.buffer, byteOffset, numberOfComponents);
+                    var typedArrayView = ComponentDatatype.createArrayBufferView(componentType, source.buffer, source.byteOffset + byteOffset, numberOfComponents);
                     matrices[i] = Matrix4.fromArray(typedArrayView);
                     byteOffset += byteStride;
                 }

--- a/Source/Scene/ModelAnimationCache.js
+++ b/Source/Scene/ModelAnimationCache.js
@@ -78,7 +78,7 @@ define([
 
             values = new Array(count);
             var accessorByteOffset = defaultValue(accessor.byteOffset, 0);
-            var byteOffset = bufferView.byteOffset + accessorByteOffset;
+            var byteOffset = bufferView.byteOffset + accessorByteOffset + source.byteOffset;
             for (var i = 0; i < count; i++) {
                 var typedArrayView = ComponentDatatype.createArrayBufferView(componentType, source.buffer, byteOffset, numberOfComponents);
                 if (type === 'SCALAR') {
@@ -177,7 +177,7 @@ define([
             var type = accessor.type;
             var count = accessor.count;
             var byteStride = getAccessorByteStride(gltf, accessor);
-            var byteOffset = bufferView.byteOffset + accessor.byteOffset;
+            var byteOffset = bufferView.byteOffset + accessor.byteOffset + source.byteOffset;
             var numberOfComponents = numberOfComponentsForType(type);
 
             matrices = new Array(count);

--- a/Source/ThirdParty/GltfPipeline/parseBinaryGltf.js
+++ b/Source/ThirdParty/GltfPipeline/parseBinaryGltf.js
@@ -60,9 +60,9 @@ define([
 
             var contentString = getStringFromTypedArray(data, jsonStart, contentLength);
             gltf = JSON.parse(contentString);
-
-            // Clone just the binary chunk so the underlying buffer can be freed
-            var binaryData = new Uint8Array(data.subarray(binaryStart, length));
+            
+            // do not clone, TypedArray copies are a major performance bottleneck in IE11
+            var binaryData = data.subarray(binaryStart, length);
 
             buffers = gltf.buffers;
             if (defined(buffers) && Object.keys(buffers).length > 0) {

--- a/Source/ThirdParty/GltfPipeline/parseBinaryGltf.js
+++ b/Source/ThirdParty/GltfPipeline/parseBinaryGltf.js
@@ -60,8 +60,7 @@ define([
 
             var contentString = getStringFromTypedArray(data, jsonStart, contentLength);
             gltf = JSON.parse(contentString);
-            
-            // do not clone, TypedArray copies are a major performance bottleneck in IE11
+
             var binaryData = data.subarray(binaryStart, length);
 
             buffers = gltf.buffers;
@@ -107,7 +106,7 @@ define([
                 // Load Binary chunk
                 else if (chunkType === 0x004E4942) {
                     // Clone just the binary chunk so the underlying buffer can be freed
-                    binaryBuffer = new Uint8Array(chunkBuffer);
+                    binaryBuffer = chunkBuffer;
                 }
             }
             if (defined(gltf) && defined(binaryBuffer)) {


### PR DESCRIPTION
change parseBinaryGltf to not clone the typedarray. Typedarray operations are really slow in internet explorer 11. 

Advantages: 
- much better gltf loading characteristics in ie11

Disadvantages
- the underlying buffer has to stay in main memory until the b3dm gets unloaded

After updating to Cesium 1.36 we saw much worse performance in ie11 with 3d-tilesets during tile loading, this change helps a lot. 
