### PR TITLE
3D Tiles depth plane fix

### DIFF
--- a/Source/Scene/DepthPlane.js
+++ b/Source/Scene/DepthPlane.js
@@ -117,8 +117,7 @@ define([
                     enabled : true
                 },
                 depthTest : {
-                    enabled : true,
-                    func : DepthFunction.ALWAYS
+                    enabled : true
                 },
                 colorMask : {
                     red : false,


### PR DESCRIPTION
I noticed a problem with https://github.com/AnalyticalGraphicsInc/cesium/pull/5770 soon after merging where the depth plane was overwriting the depth of the tileset. This should fix that.

@bagnell can you review?

