### PR TITLE
Use associative array key type for entity collection ids

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@ Change Log
 ==========
 ### 1.37 - 2017-09-01
 
+* Fixed `Entity` id type to be `String` in `EntityCollection` and `CompositeEntityCollection` [#5791](https://github.com/AnalyticalGraphicsInc/cesium/pull/579)
 * Fixed `replaceState` bug that was causing the `CesiumViewer` demo application to crash in Safari and iOS
 * Fixed issue where `Model` and `BillboardCollection` would throw an error if the globe is undefined [#5638](https://github.com/AnalyticalGraphicsInc/cesium/issues/5638)
 * Fixed issue where the `Model` glTF cache loses reference to the model's buffer data. [#5720](https://github.com/AnalyticalGraphicsInc/cesium/issues/5720)

--- a/Source/DataSources/CompositeEntityCollection.js
+++ b/Source/DataSources/CompositeEntityCollection.js
@@ -449,7 +449,7 @@ define([
     /**
      * Gets an entity with the specified id.
      *
-     * @param {Object} id The id of the entity to retrieve.
+     * @param {String} id The id of the entity to retrieve.
      * @returns {Entity} The entity with the provided id or undefined if the id did not exist in the collection.
      */
     CompositeEntityCollection.prototype.getById = function(id) {

--- a/Source/DataSources/EntityCollection.js
+++ b/Source/DataSources/EntityCollection.js
@@ -325,7 +325,7 @@ define([
     /**
      * Removes an entity with the provided id from the collection.
      *
-     * @param {Object} id The id of the entity to remove.
+     * @param {String} id The id of the entity to remove.
      * @returns {Boolean} true if the item was removed, false if no item with the provided id existed in the collection.
      */
     EntityCollection.prototype.removeById = function(id) {
@@ -382,7 +382,7 @@ define([
     /**
      * Gets an entity with the specified id.
      *
-     * @param {Object} id The id of the entity to retrieve.
+     * @param {String} id The id of the entity to retrieve.
      * @returns {Entity} The entity with the provided id or undefined if the id did not exist in the collection.
      */
     EntityCollection.prototype.getById = function(id) {
@@ -398,7 +398,7 @@ define([
     /**
      * Gets an entity with the specified id or creates it and adds it to the collection if it does not exist.
      *
-     * @param {Object} id The id of the entity to retrieve or create.
+     * @param {String} id The id of the entity to retrieve or create.
      * @returns {Entity} The new or existing object.
      */
     EntityCollection.prototype.getOrCreateEntity = function(id) {


### PR DESCRIPTION
The previous type: Object is too broad, thus not compatible with the associative array key: String|Number.

As a side note, I noticed the documentation is broken: click on the link to the source code of https://cesiumjs.org/Cesium/Build/Documentation/EntityCollection.html#getById and you will get a 404 error.