### PR TITLE
Parse binarygltf with dataView

### DIFF
--- a/Source/Scene/Batched3DModel3DTileContent.js
+++ b/Source/Scene/Batched3DModel3DTileContent.js
@@ -364,13 +364,10 @@ define([
             throw new RuntimeError('glTF byte length must be greater than 0.');
         }
 
-        var gltfView;
-        if (byteOffset % 4 === 0) {
-            gltfView = new Uint8Array(arrayBuffer, byteOffset, gltfByteLength);
-        } else {
-            // Create a copy of the glb so that it is 4-byte aligned
+        var gltfView = new Uint8Array(arrayBuffer, byteOffset, gltfByteLength);
+        if (byteOffset % 4 !== 0) {
+            // If glb is not 4-byte aligned print deprecation warning
             Batched3DModel3DTileContent._deprecationWarning('b3dm-glb-unaligned', 'The embedded glb is not aligned to a 4-byte boundary.');
-            gltfView = new Uint8Array(uint8Array.subarray(byteOffset, byteOffset + gltfByteLength));
         }
 
         var pickObject = {

--- a/Source/Scene/Instanced3DModel3DTileContent.js
+++ b/Source/Scene/Instanced3DModel3DTileContent.js
@@ -296,13 +296,10 @@ define([
             throw new RuntimeError('glTF byte length is zero, i3dm must have a glTF to instance.');
         }
 
-        var gltfView;
-        if (byteOffset % 4 === 0) {
-            gltfView = new Uint8Array(arrayBuffer, byteOffset, gltfByteLength);
-        } else {
-            // Create a copy of the glb so that it is 4-byte aligned
+        var gltfView = new Uint8Array(arrayBuffer, byteOffset, gltfByteLength);
+        if (byteOffset % 4 !== 0) {
+            // If glb is not 4-byte aligned print deprecation warning
             Instanced3DModel3DTileContent._deprecationWarning('i3dm-glb-unaligned', 'The embedded glb is not aligned to a 4-byte boundary.');
-            gltfView = new Uint8Array(uint8Array.subarray(byteOffset, byteOffset + gltfByteLength));
         }
 
         // Create model instance collection

--- a/Source/ThirdParty/GltfPipeline/parseBinaryGltf.js
+++ b/Source/ThirdParty/GltfPipeline/parseBinaryGltf.js
@@ -2,22 +2,18 @@ define([
         './addPipelineExtras',
         './removeExtensionsUsed',
         './updateVersion',
-        '../../Core/ComponentDatatype',
         '../../Core/defined',
         '../../Core/DeveloperError',
         '../../Core/getMagic',
-        '../../Core/getStringFromTypedArray',
-        '../../Core/WebGLConstants'
+        '../../Core/getStringFromTypedArray'
     ], function(
         addPipelineExtras,
         removeExtensionsUsed,
         updateVersion,
-        ComponentDatatype,
         defined,
         DeveloperError,
         getMagic,
-        getStringFromTypedArray,
-        WebGLConstants) {
+        getStringFromTypedArray) {
     'use strict';
 
     /**
@@ -27,7 +23,7 @@ define([
      * @returns {Object} The parsed binary glTF.
      */
     function parseBinaryGltf(data) {
-        var headerView = ComponentDatatype.createArrayBufferView(WebGLConstants.INT, data.buffer, data.byteOffset, 5);
+        var headerView = new DataView(data.buffer, data.byteOffset, 20);
 
         // Check that the magic string is present
         var magic = getMagic(data);
@@ -36,7 +32,7 @@ define([
         }
 
         // Check that the version is 1 or 2
-        var version = headerView[1];
+        var version = headerView.getInt32(4,true);
         if (version !== 1 && version !== 2) {
             throw new DeveloperError('Binary glTF version is not 1 or 2');
         }
@@ -46,9 +42,9 @@ define([
         var length;
         // Load binary glTF version 1
         if (version === 1) {
-            length = headerView[2];
-            var contentLength = headerView[3];
-            var contentFormat = headerView[4];
+            length = headerView.getInt32(8,true);
+            var contentLength = headerView.getInt32(12,true);
+            var contentFormat = headerView.getInt32(16, true);
 
             // Check that the content format is 0, indicating that it is JSON
             if (contentFormat !== 0) {
@@ -87,13 +83,13 @@ define([
 
         // Load binary glTF version 2
         if (version === 2) {
-            length = headerView[2];
+            length = headerView.getInt32(8);
             var byteOffset = 12;
             var binaryBuffer;
             while (byteOffset < length) {
-                var chunkHeaderView = ComponentDatatype.createArrayBufferView(WebGLConstants.INT, data.buffer, data.byteOffset + byteOffset, 2);
-                var chunkLength = chunkHeaderView[0];
-                var chunkType = chunkHeaderView[1];
+                var chunkHeaderView = new DataView(data.buffer, data.byteOffset + byteOffset, 8);
+                var chunkLength = chunkHeaderView.getInt32(0, true);
+                var chunkType = chunkHeaderView.getInt32(4, true);
                 byteOffset += 8;
                 var chunkBuffer = data.subarray(byteOffset, byteOffset + chunkLength);
                 byteOffset += chunkLength;

--- a/Source/ThirdParty/GltfPipeline/parseBinaryGltf.js
+++ b/Source/ThirdParty/GltfPipeline/parseBinaryGltf.js
@@ -83,7 +83,7 @@ define([
 
         // Load binary glTF version 2
         if (version === 2) {
-            length = headerView.getInt32(8);
+            length = headerView.getInt32(8, true);
             var byteOffset = 12;
             var binaryBuffer;
             while (byteOffset < length) {


### PR DESCRIPTION
- change parseBinaryGltf to use DataView instead of TypedArray, so we do not have to copy the TypedArray to assure the correct byte alignment. 
- change Batched/Instanced3DModel3DTileContent to not copy arraybuffer

As discussed in this PR https://github.com/AnalyticalGraphicsInc/cesium/pull/5784

TODOs
- [ ] Test with glb (Gltf 2.0) Model
- [ ] Check if parseBinaryGltf should be a PR in gltf-pipeline


Also at first I also wanted to change the typedarray copy of the batchTableBinary. But the batchTableBinary needs the correct byte-alignment and i couldn't find any reference in the 3D Tile spec that the batchTableBinary part should be byte aligned. Should this maybe part of the 3D Tiles Spec? Or do i just check the alignment(largest possible datatype) and only copy if its not aligned properly?