### PR TITLE
Fixed removing multiple listeners within event callbacks #5827

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,7 @@ Change Log
 * Fixed CZML processing of `velocityReference` within an interval. [#5738](https://github.com/AnalyticalGraphicsInc/cesium/issues/5738)
 * Zoom about mouse now maintains camera heading, pitch, and roll [#4639](https://github.com/AnalyticalGraphicsInc/cesium/pull/5603)
 * Fixed a bug in `PolylineCollection` preventing the display of more than 16K points in a single collection [#5538](https://github.com/AnalyticalGraphicsInc/cesium/pull/5782)
+* Fixed removing multiple event listeners within event callbacks. [#5827](https://github.com/AnalyticalGraphicsInc/cesium/issues/5827)
 
 ### 1.37 - 2017-09-01
 

--- a/Source/Core/Event.js
+++ b/Source/Core/Event.js
@@ -120,6 +120,10 @@ define([
         return false;
     };
 
+    function compareNumber(a,b) {
+        return b - a;
+    }
+
     /**
      * Raises the event by calling each registered listener with all supplied arguments.
      *
@@ -146,12 +150,15 @@ define([
         //Actually remove items removed in removeEventListener.
         var toRemove = this._toRemove;
         length = toRemove.length;
-        for (i = 0; i < length; i++) {
-            var index = toRemove[i];
-            listeners.splice(index, 1);
-            scopes.splice(index, 1);
+        if (length > 0) {
+            toRemove.sort(compareNumber);
+            for (i = 0; i < length; i++) {
+                var index = toRemove[i];
+                listeners.splice(index, 1);
+                scopes.splice(index, 1);
+            }
+            toRemove.length = 0;
         }
-        toRemove.length = 0;
 
         this._insideRaiseEvent = false;
     };

--- a/Specs/Core/EventSpec.js
+++ b/Specs/Core/EventSpec.js
@@ -45,7 +45,7 @@ defineSuite([
         expect(spyListener).not.toHaveBeenCalled();
     });
 
-    it('can remove from withing a callback', function() {
+    it('can remove from within a callback', function() {
         var doNothing = function(evt) {
         };
 
@@ -65,6 +65,25 @@ defineSuite([
         event.removeEventListener(doNothing);
         event.removeEventListener(doNothing2);
         expect(event.numberOfListeners).toEqual(0);
+    });
+
+    it('can remove multiple listeners within a callback', function() {
+        var removeEvent0 =  event.addEventListener(function() { removeEvent0(); });
+                            event.addEventListener(function() {});
+        var removeEvent2 =  event.addEventListener(function() { removeEvent2(); });
+                            event.addEventListener(function() {});
+        var removeEvent4 =  event.addEventListener(function() { removeEvent4(); });
+                            event.addEventListener(function() {});
+        var removeEvent6 =  event.addEventListener(function() { removeEvent6(); });
+                            event.addEventListener(function() {});
+        var removeEvent8 =  event.addEventListener(function() { removeEvent8(); });
+                            event.addEventListener(function() {});
+
+        expect(event.numberOfListeners).toEqual(10);
+        event.raiseEvent();
+        expect(event.numberOfListeners).toEqual(5);
+        event.raiseEvent();
+        expect(event.numberOfListeners).toEqual(5);
     });
 
     it('addEventListener and removeEventListener works with same function of different scopes', function() {


### PR DESCRIPTION
Fixed a bug that occurs when removing multiple event listeners within an event callback (see #5827). Added a test case to EventSpec. 