### PR TITLE
Add a function for getting maximum level of detail in terrainProvider

### DIFF
--- a/Source/Core/CesiumTerrainProvider.js
+++ b/Source/Core/CesiumTerrainProvider.js
@@ -729,5 +729,21 @@ define([
         return this.availability.isTileAvailable(level, x, y);
     };
 
+    /**
+     * Determines the level of the most detailed tile covering the position.  This function
+     * usually completes in time logarithmic to the number of rectangles added with
+     * {@link TileAvailability#addAvailableTileRange}.
+     *
+     * @param {Cartographic} position The position for which to determine the maximum available level.  The height component is ignored.
+     * @return {Number} The level of the most detailed tile covering the position.
+     * @throws {DeveloperError} Undefined if not supported by the terrain provider or if position is outside any tile according to the tiling scheme.
+     */
+    CesiumTerrainProvider.prototype.getMaximumLevelAtPosition = function(position) {
+        if (!defined(this.availability)) {
+            return undefined;
+        }
+        return this.availability.computeMaximumLevelAtPosition(position);
+    };
+
     return CesiumTerrainProvider;
 });

--- a/Source/Core/TerrainProvider.js
+++ b/Source/Core/TerrainProvider.js
@@ -227,5 +227,16 @@ define([
      */
     TerrainProvider.prototype.getTileDataAvailable = DeveloperError.throwInstantiationError;
 
+    /**
+     * Determines the level of the most detailed tile covering the position.  This function
+     * usually completes in time logarithmic to the number of rectangles added with
+     * {@link TileAvailability#addAvailableTileRange}.
+     *
+     * @param {Cartographic} position The position for which to determine the maximum available level.  The height component is ignored.
+     * @return {Number} The level of the most detailed tile covering the position.
+     * @throws {DeveloperError} Undefined if not supported by the terrain provider or if position is outside any tile according to the tiling scheme.
+     */
+    TerrainProvider.prototype.getMaximumLevelAtPosition = DeveloperError.throwInstantiationError;
+
     return TerrainProvider;
 });

--- a/Source/Core/TerrainProvider.js
+++ b/Source/Core/TerrainProvider.js
@@ -231,6 +231,7 @@ define([
      * Determines the level of the most detailed tile covering the position.  This function
      * usually completes in time logarithmic to the number of rectangles added with
      * {@link TileAvailability#addAvailableTileRange}.
+     * @function
      *
      * @param {Cartographic} position The position for which to determine the maximum available level.  The height component is ignored.
      * @return {Number} The level of the most detailed tile covering the position.


### PR DESCRIPTION
This PR adds a method for getting the maximum level of detail for a specific zone of the globe from a terrainProvider instance. 

The reason for which I'm adding this is that it is very useful for getting the height of the terrain in a specific point. According to [this example](https://cesiumjs.org/Cesium/Build/Documentation/sampleTerrain.html) the following code can be used for sending a query to the terrain provider and getting back the height of the terrain:

```javascript
// Query the terrain height of two Cartographic positions
var terrainProvider = new Cesium.CesiumTerrainProvider({
    url : 'https://assets.agi.com/stk-terrain/v1/tilesets/world/tiles'
});
var positions = [
    Cesium.Cartographic.fromDegrees(86.925145, 27.988257),
    Cesium.Cartographic.fromDegrees(87.0, 28.0)
];
var promise = Cesium.sampleTerrain(terrainProvider, 11, positions);
Cesium.when(promise, function(updatedPositions) {
    // positions[0].height and positions[1].height have been updated.
    // updatedPositions is just a reference to positions.
});
```

Now as it can be seen the call to `sampleTerrain` needs to specify the level-of-detail (LOD) to be used for the query. Since the LOD varies from one region to another, it is not possible (nor suitable) to hard-code the maximum LOD in one region and hope that it will work for another region.

Thus, this PR enables to call `terrainProvider.getMaxigetMaximumLevelAtPosition(position)` in order to get the maximal LOD in the region of interest and then query the terrainProvider to get the most precise height of the terrain.
