### PR TITLE
Add link to sampleTerrainMostDetailed in sampleTerrain documentation

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -159,4 +159,4 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to Cesiu
 * [Rudraksha Shah](https://github.com/Rudraksha20)
 * [Cody Guldner](https://github.com/burn123)
 * [Florent Cayré](https://github.com/fcayre)
-
+* [Nacho Carnicero](https://github.com/nacho-carnicero)

--- a/Source/Core/sampleTerrain.js
+++ b/Source/Core/sampleTerrain.js
@@ -16,7 +16,9 @@ define([
      * or another error occurs, the height is set to undefined.  As is typical of the
      * {@link Cartographic} type, the supplied height is a height above the reference ellipsoid
      * (such as {@link Ellipsoid.WGS84}) rather than an altitude above mean sea level.  In other
-     * words, it will not necessarily be 0.0 if sampled in the ocean.
+     * words, it will not necessarily be 0.0 if sampled in the ocean. This function needs the
+     * terrain level of detail as input, if you need to get the altitude of the terrain as precisely
+     * as possible (i.e. with maximum level of detail) use {@link sampleTerrainMostDetailed}.
      *
      * @exports sampleTerrain
      *
@@ -24,6 +26,8 @@ define([
      * @param {Number} level The terrain level-of-detail from which to query terrain heights.
      * @param {Cartographic[]} positions The positions to update with terrain heights.
      * @returns {Promise.<Cartographic[]>} A promise that resolves to the provided list of positions when terrain the query has completed.
+     *
+     * @see sampleTerrainMostDetailed
      *
      * @example
      * // Query the terrain height of two Cartographic positions


### PR DESCRIPTION
This adds a link to sampleTerrainMostDetailed in the sampleTerrain documentation as discussed with @kring in #5849. 