### PR TITLE
Webpack Changes

### DIFF
--- a/Source/Core/TaskProcessor.js
+++ b/Source/Core/TaskProcessor.js
@@ -137,7 +137,7 @@ define([
 
         if (defined(TaskProcessor._loaderConfig)) {
             bootstrapMessage.loaderConfig = TaskProcessor._loaderConfig;
-        } else if (defined(require.toUrl)) {
+        } else if (defined(define.amd) && !define.amd.toUrlUndefined && defined(require.toUrl)) {
             bootstrapMessage.loaderConfig.baseUrl =
                 getAbsoluteUri('..', buildModuleUrl('Workers/cesiumWorkerBootstrapper.js'));
         } else {

--- a/Source/Core/buildModuleUrl.js
+++ b/Source/Core/buildModuleUrl.js
@@ -74,7 +74,7 @@ define([
     function buildModuleUrl(moduleID) {
         if (!defined(implementation)) {
             //select implementation
-            if (defined(require.toUrl)) {
+            if (defined(define.amd) && !define.amd.toUrlUndefined && defined(require.toUrl)) {
                 implementation = buildModuleUrlFromRequireToUrl;
             } else {
                 implementation = buildModuleUrlFromBaseUrl;


### PR DESCRIPTION
Part of #5816

Compiles with the configuration here: https://github.com/ggetz/cesium-webpack-example

Assets, Workers, and Widgets files can be served as is, using the pre-built workers.

So, really the only change needed in Cesium itself In `buidModuleUrl` and `TaskProcessor`, we needed to avoid `require.toUrl`, because although it confirms to AMD, webpack doesn't parse it correctly. So instead I check for `define.amd` to be defined and add a check for a custom `define.amd.toUrlUndefined`. You can then avoid the `toUrl` by adding the following to a webpack config file: 
```
amd: {
    toUrlUndefined: true
}
```
And we can rename that if desired.