### PR TITLE
Fixed 3D Tiles refinement bug when skipLevelOfDetail is false

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,7 @@ Change Log
 * Fixed a 3D Tiles point cloud bug causing a stray point to appear at the center of the screen on certain hardware. [#5599](https://github.com/AnalyticalGraphicsInc/cesium/issues/5599)
 * Fixed removing multiple event listeners within event callbacks. [#5827](https://github.com/AnalyticalGraphicsInc/cesium/issues/5827)
 * Running `buildApps` now creates a built version of Sandcastle which uses the built version of Cesium for better performance.
+* Fixed a tileset traversal bug when the `skipLevelOfDetail` optimization is off. [#5869](https://github.com/AnalyticalGraphicsInc/cesium/issues/5869)
 
 ### 1.37 - 2017-09-01
 

--- a/Source/Scene/Cesium3DTilesetTraversal.js
+++ b/Source/Scene/Cesium3DTilesetTraversal.js
@@ -509,7 +509,7 @@ define([
         if (!tile.hasTilesetContent) {
             if (tile.refine === Cesium3DTileRefine.ADD) {
                 // Always load additive tiles
-                loadTile(tileset, tile, this.frameState);
+                loadTile(tileset, tile, this.frameState, true);
                 if (hasAdditiveContent(tile)) {
                     tileset._desiredTiles.push(tile);
                 }
@@ -635,9 +635,16 @@ define([
         }
     }
 
+    function checkAdditiveVisibility(tileset, tile, frameState) {
+        if (defined(tile.parent) && (tile.parent.refine === Cesium3DTileRefine.ADD)) {
+            return isVisibleAndMeetsSSE(tileset, tile, frameState);
+        }
+        return true;
+    }
+
     function loadTile(tileset, tile, frameState, checkVisibility) {
         if ((tile.contentUnloaded || tile.contentExpired) && tile._requestedFrame !== frameState.frameNumber) {
-            if (!checkVisibility || isVisibleAndMeetsSSE(tileset, tile, frameState)) {
+            if (!checkVisibility || checkAdditiveVisibility(tileset, tile, frameState)) {
                 tile._requestedFrame = frameState.frameNumber;
                 tileset._requestedTiles.push(tile);
             }

--- a/Specs/Scene/Cesium3DTilesetSpec.js
+++ b/Specs/Scene/Cesium3DTilesetSpec.js
@@ -720,6 +720,14 @@ defineSuite([
         });
     });
 
+    it('does not load additive tiles that are out of view', function() {
+        viewBottomLeft();
+        return Cesium3DTilesTester.loadTileset(scene, tilesetUrl).then(function(tileset) {
+            var statistics = tileset._statistics;
+            expect(statistics.numberOfTilesWithContentReady).toEqual(2);
+        });
+    });
+
     it('culls with content box', function() {
         // Root tile has a content box that is half the extents of its box
         // Expect to cull root tile and three child tiles


### PR DESCRIPTION
Fixes https://github.com/AnalyticalGraphicsInc/cesium/issues/5814

This bug was introduced in https://github.com/AnalyticalGraphicsInc/cesium/pull/5788/ which checks for a tile's visibility before loading it. This caused problems during the base-traversal step where it is expected that a replacement refinement tile loads all of its children, even if they are not visible. Otherwise the parent tile can never resolve.

This is not a problem with the internal-traversal (the skipping traversal), but since `skipLevelOfDetail=false` only uses the base-traversal it becomes a problem.

This PR limits the visibility check to additive tiles only. I think the visibility check would also work with replacement tiles during the skip traversal, but in practice this only saves a few requests and I don't want to mess with anything else.