### PR TITLE
Don't reject the whole KML Data load on Network Link failure

### DIFF
--- a/Source/DataSources/KmlDataSource.js
+++ b/Source/DataSources/KmlDataSource.js
@@ -2188,6 +2188,8 @@ define([
                     } else if (viewRefreshMode === 'onRegion') {
                         oneTimeWarning('kml-refrehMode-onRegion', 'KML - Unsupported viewRefreshMode: onRegion');
                     }
+                }).otherwise(function(error) {
+                    oneTimeWarning('An error occured during loading ' + linkUrl);
                 });
 
                 promises.push(promise);


### PR DESCRIPTION
GoogleEarth warns user when the link isn't available, but loads the rest of the KML.

This patch makes Cesium behave the same way, if NetworkLink promise will be rejected it will warn the user, but still loads the rest of the KML and resolves the whole KMLDataSource.load promise.