### PR TITLE
Changes for Node 8

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 # Auto detect text files and perform LF normalization
 * text=auto
+package.json text eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ Thumbs.db
 /node_modules
 npm-debug.log
 npm-debug.log.*
+package-lock.json
 
 # WebStorm user-specific
 .idea/workspace.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "6"
+  - "8"
 sudo: false
 before_script:
   - export DISPLAY=:99.0


### PR DESCRIPTION
Node 8 and npm 5 introduce some changes that required some .gitignore and .gitattributes updates.  It will be LTS at the end of this month, so I figured it was a good time to switch over.  Our build system will continue to work with 6.x for the foreseeable future, so no need for any devs to do anything locally. (But I recommend everyone update to Node 8 once it's LTS).

1. Start building on travis with Node 8 since it will be LTS soon (it should slightly speed up builds as well)
2. Add package-lock.json to .gitignore, this is a new npm-generated file that we won't be submitting to GitHub (it changes almost every time you run `npm install`).
3. Add package.json to .gitattributes to fix line endings caused by this npm bug: https://github.com/npm/npm/issues/17161