### PR TITLE
Remove fcayre from individual CLA section

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -158,5 +158,4 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to Cesiu
 * [Rishabh Shah](https://github.com/rms13)
 * [Rudraksha Shah](https://github.com/Rudraksha20)
 * [Cody Guldner](https://github.com/burn123)
-* [Florent Cayré](https://github.com/fcayre)
 * [Nacho Carnicero](https://github.com/nacho-carnicero)


### PR DESCRIPTION
@fcayre was added to both the individual and corporate CLA sections in #5782

He should only be under the Corporate CLA section, right?