### PR TITLE
Minor logic tweaks

### DIFF
--- a/Source/Core/BoundingSphere.js
+++ b/Source/Core/BoundingSphere.js
@@ -72,7 +72,7 @@ define([
      * The bounding sphere is computed by running two algorithms, a naive algorithm and
      * Ritter's algorithm. The smaller of the two spheres is used to ensure a tight fit.
      *
-     * @param {Cartesian3[]} positions An array of points that the bounding sphere will enclose.  Each point must have <code>x</code>, <code>y</code>, and <code>z</code> properties.
+     * @param {Cartesian3[]} [positions] An array of points that the bounding sphere will enclose.  Each point must have <code>x</code>, <code>y</code>, and <code>z</code> properties.
      * @param {BoundingSphere} [result] The object onto which to store the result.
      * @returns {BoundingSphere} The modified result parameter or a new BoundingSphere instance if one was not provided.
      *
@@ -223,7 +223,7 @@ define([
     /**
      * Computes a bounding sphere from a rectangle projected in 2D.
      *
-     * @param {Rectangle} rectangle The rectangle around which to create a bounding sphere.
+     * @param {Rectangle} [rectangle] The rectangle around which to create a bounding sphere.
      * @param {Object} [projection=GeographicProjection] The projection used to project the rectangle into 2D.
      * @param {BoundingSphere} [result] The object onto which to store the result.
      * @returns {BoundingSphere} The modified result parameter or a new BoundingSphere instance if none was provided.
@@ -236,7 +236,7 @@ define([
      * Computes a bounding sphere from a rectangle projected in 2D.  The bounding sphere accounts for the
      * object's minimum and maximum heights over the rectangle.
      *
-     * @param {Rectangle} rectangle The rectangle around which to create a bounding sphere.
+     * @param {Rectangle} [rectangle] The rectangle around which to create a bounding sphere.
      * @param {Object} [projection=GeographicProjection] The projection used to project the rectangle into 2D.
      * @param {Number} [minimumHeight=0.0] The minimum height over the rectangle.
      * @param {Number} [maximumHeight=0.0] The maximum height over the rectangle.
@@ -282,7 +282,7 @@ define([
      * Computes a bounding sphere from a rectangle in 3D. The bounding sphere is created using a subsample of points
      * on the ellipsoid and contained in the rectangle. It may not be accurate for all rectangles on all types of ellipsoids.
      *
-     * @param {Rectangle} rectangle The valid rectangle used to create a bounding sphere.
+     * @param {Rectangle} [rectangle] The valid rectangle used to create a bounding sphere.
      * @param {Ellipsoid} [ellipsoid=Ellipsoid.WGS84] The ellipsoid used to determine positions of the rectangle.
      * @param {Number} [surfaceHeight=0.0] The height above the surface of the ellipsoid.
      * @param {BoundingSphere} [result] The object onto which to store the result.
@@ -312,7 +312,7 @@ define([
      * algorithms, a naive algorithm and Ritter's algorithm. The smaller of the two spheres is used to
      * ensure a tight fit.
      *
-     * @param {Number[]} positions An array of points that the bounding sphere will enclose.  Each point
+     * @param {Number[]} [positions] An array of points that the bounding sphere will enclose.  Each point
      *        is formed from three elements in the array in the order X, Y, Z.
      * @param {Cartesian3} [center=Cartesian3.ZERO] The position to which the positions are relative, which need not be the
      *        origin of the coordinate system.  This is useful when the positions are to be used for
@@ -495,9 +495,9 @@ define([
      * algorithms, a naive algorithm and Ritter's algorithm. The smaller of the two spheres is used to
      * ensure a tight fit.
      *
-     * @param {Number[]} positionsHigh An array of high bits of the encoded cartesians that the bounding sphere will enclose.  Each point
+     * @param {Number[]} [positionsHigh] An array of high bits of the encoded cartesians that the bounding sphere will enclose.  Each point
      *        is formed from three elements in the array in the order X, Y, Z.
-     * @param {Number[]} positionsLow An array of low bits of the encoded cartesians that the bounding sphere will enclose.  Each point
+     * @param {Number[]} [positionsLow] An array of low bits of the encoded cartesians that the bounding sphere will enclose.  Each point
      *        is formed from three elements in the array in the order X, Y, Z.
      * @param {BoundingSphere} [result] The object onto which to store the result.
      * @returns {BoundingSphere} The modified result parameter or a new BoundingSphere instance if one was not provided.
@@ -706,7 +706,7 @@ define([
     /**
      * Computes a tight-fitting bounding sphere enclosing the provided array of bounding spheres.
      *
-     * @param {BoundingSphere[]} boundingSpheres The array of bounding spheres.
+     * @param {BoundingSphere[]} [boundingSpheres] The array of bounding spheres.
      * @param {BoundingSphere} [result] The object onto which to store the result.
      * @returns {BoundingSphere} The modified result parameter or a new BoundingSphere instance if none was provided.
      */

--- a/Source/Core/BoundingSphere.js
+++ b/Source/Core/BoundingSphere.js
@@ -292,11 +292,17 @@ define([
         ellipsoid = defaultValue(ellipsoid, Ellipsoid.WGS84);
         surfaceHeight = defaultValue(surfaceHeight, 0.0);
 
-        var positions;
-        if (defined(rectangle)) {
-            positions = Rectangle.subsample(rectangle, ellipsoid, surfaceHeight, fromRectangle3DScratch);
+        if (!defined(result)) {
+            result = new BoundingSphere();
         }
 
+        if (!defined(rectangle)) {
+            result.center = Cartesian3.clone(Cartesian3.ZERO, result.center);
+            result.radius = 0.0;
+            return result;
+        }
+
+        var positions = Rectangle.subsample(rectangle, ellipsoid, surfaceHeight, fromRectangle3DScratch);
         return BoundingSphere.fromPoints(positions, result);
     };
 

--- a/Source/DataSources/PointVisualizer.js
+++ b/Source/DataSources/PointVisualizer.js
@@ -144,7 +144,7 @@ define([
                 pointPrimitive.pixelSize = Property.getValueOrDefault(pointGraphics._pixelSize, time, defaultPixelSize);
                 pointPrimitive.distanceDisplayCondition = Property.getValueOrUndefined(pointGraphics._distanceDisplayCondition, time, distanceDisplayCondition);
                 pointPrimitive.disableDepthTestDistance = Property.getValueOrDefault(pointGraphics._disableDepthTestDistance, time, defaultDisableDepthTestDistance);
-            } else { // billboard
+            } else if (defined(billboard)) {
                 billboard.show = true;
                 billboard.position = position;
                 billboard.scaleByDistance = Property.getValueOrUndefined(pointGraphics._scaleByDistance, time, scaleByDistance);

--- a/Source/Scene/Expression.js
+++ b/Source/Scene/Expression.js
@@ -6,6 +6,7 @@ define([
         '../Core/Color',
         '../Core/defined',
         '../Core/defineProperties',
+        '../Core/DeveloperError',
         '../Core/isArray',
         '../Core/Math',
         '../Core/RuntimeError',
@@ -19,6 +20,7 @@ define([
         Color,
         defined,
         defineProperties,
+        DeveloperError,
         isArray,
         CesiumMath,
         RuntimeError,
@@ -1716,6 +1718,11 @@ define([
                 }
                 break;
             case ExpressionNodeType.LITERAL_VECTOR:
+                //>>includeStart('debug', pragmas.debug);
+                if (!defined(left)) {
+                    throw new DeveloperError('left should always be defined for type ExpressionNodeType.LITERAL_VECTOR');
+                }
+                //>>includeEnd('debug');
                 var length = left.length;
                 var vectorExpression = value + '(';
                 for (var i = 0; i < length; ++i) {

--- a/Source/Scene/GetFeatureInfoFormat.js
+++ b/Source/Scene/GetFeatureInfoFormat.js
@@ -238,7 +238,9 @@ define([
                 break;
             }
         }
-
+        if (!defined(layer)) {
+            throw new RuntimeError('Unable to find first child of the feature info xml document');
+        }
         var featureMembers = layer.childNodes;
         for (var featureIndex = 0; featureIndex < featureMembers.length; ++featureIndex) {
             var featureMember = featureMembers[featureIndex];

--- a/Source/Scene/createTileMapServiceImageryProvider.js
+++ b/Source/Scene/createTileMapServiceImageryProvider.js
@@ -129,8 +129,9 @@ define([
                 }
             }
 
+            var message;
             if (!defined(tilesets) || !defined(bbox)) {
-                var message = 'Unable to find expected tilesets or bbox attributes in ' + joinUrls(url, 'tilemapresource.xml') + '.';
+                message = 'Unable to find expected tilesets or bbox attributes in ' + joinUrls(url, 'tilemapresource.xml') + '.';
                 metadataError = TileProviderError.handleError(metadataError, imageryProvider, imageryProvider.errorEvent, message, undefined, undefined, undefined, requestMetadata);
                 if(!metadataError.retry) {
                     deferred.reject(new RuntimeError(message));
@@ -152,7 +153,7 @@ define([
                 } else if (tilingSchemeName === 'mercator' || tilingSchemeName === 'global-mercator') {
                     tilingScheme = new WebMercatorTilingScheme({ ellipsoid : options.ellipsoid });
                 } else {
-                    var message = joinUrls(url, 'tilemapresource.xml') + 'specifies an unsupported profile attribute, ' + tilingSchemeName + '.';
+                    message = joinUrls(url, 'tilemapresource.xml') + 'specifies an unsupported profile attribute, ' + tilingSchemeName + '.';
                     metadataError = TileProviderError.handleError(metadataError, imageryProvider, imageryProvider.errorEvent, message, undefined, undefined, undefined, requestMetadata);
                     if(!metadataError.retry) {
                         deferred.reject(new RuntimeError(message));

--- a/Source/Scene/createTileMapServiceImageryProvider.js
+++ b/Source/Scene/createTileMapServiceImageryProvider.js
@@ -129,6 +129,15 @@ define([
                 }
             }
 
+            if (!defined(tilesets) || !defined(bbox)) {
+                var message = 'Unable to find expected tilesets or bbox attributes in ' + joinUrls(url, 'tilemapresource.xml') + '.';
+                metadataError = TileProviderError.handleError(metadataError, imageryProvider, imageryProvider.errorEvent, message, undefined, undefined, undefined, requestMetadata);
+                if(!metadataError.retry) {
+                    deferred.reject(new RuntimeError(message));
+                }
+                return;
+            }
+
             var fileExtension = defaultValue(options.fileExtension, format.getAttribute('extension'));
             var tileWidth = defaultValue(options.tileWidth, parseInt(format.getAttribute('width'), 10));
             var tileHeight = defaultValue(options.tileHeight, parseInt(format.getAttribute('height'), 10));


### PR DESCRIPTION
There is no change in logic here, but I'm hoping these minor tweaks will make Coverity either not report errors or report errors that are aligned with a bug report I'm going to file.

- Make `BoundingSphere.fromRectangle3D` return the zero sphere if rectangle is undefined instead of letting `BoundingSphere.fromPoints` return when position is undefined
- Add and `else if ` condition to `PointVisualizer.update`
- Add a `DeveloperError` to `Expression` if for some reason `left` is undefined (in the current code it never will be)
- Add `RuntimeError` in `GetFeatureInfoFormat` and `createTileMapServiceImageryProvider` in case something goes catastrophically wrong with parsing the xml documents