### PR TITLE
Helper function for adding cesium.com assets

### DIFF
--- a/Source/Core/ComposerApi.js
+++ b/Source/Core/ComposerApi.js
@@ -1,0 +1,46 @@
+define([
+    './Credit',
+    './defined',
+    './DeveloperError'
+], function(
+    Credit,
+    defined,
+    DeveloperError) {
+    'use strict';
+
+    /**
+     * Object for setting and retrieving the default Composer API access token.
+     *
+     * @exports ComposerApi
+     */
+    var ComposerApi = {
+    };
+
+    /**
+     * The default cesium.com access token to use if one is not provided to the
+     * constructor of an object that uses the Composer API.
+     * @type {String}
+     */
+    ComposerApi.defaultToken = undefined;
+
+    /**
+     * Returns the provided token, or the default token if none was provided
+     * @param {String} [token] A cesium.com access token
+     * @return {String} A cesium.com access token
+     */
+    ComposerApi.getToken = function(token) {
+        if (defined(token)) {
+            return token;
+        }
+
+        //>>includeStart('debug', pragmas.debug);
+        if (!defined(ComposerApi.defaultToken)) {
+            throw new DeveloperError('Assign your cesium.com token to ComposerApi.defaultToken before using the cesium.com asset type');
+        }
+        //>>includeEnd('debug');
+
+        return ComposerApi.defaultKey;
+    };
+
+    return ComposerApi;
+});

--- a/Source/Scene/ComposerAssetType.js
+++ b/Source/Scene/ComposerAssetType.js
@@ -1,0 +1,14 @@
+define([
+    '../Core/freezeObject'
+], function (freezeObject) {
+    'use strict';
+
+    return freezeObject({
+        IMAGERY: 'IMAGERY',
+        TERRAIN: 'TERRAIN',
+        '3DTILES': '3DTILES',
+        MODEL: 'MODEL',
+        CZML: 'CZML',
+        KML: 'KML'
+    });
+});

--- a/Source/Scene/ComposerExternalImageryType.js
+++ b/Source/Scene/ComposerExternalImageryType.js
@@ -41,29 +41,29 @@ define([
 
     /**
      * Creates an imagery provider from the external imagery type
-     * @param {ComposerExternalImageryType} type The imagery provider type
-     * @param {Object} metadata The asset metadata
+     * @param {Object} configuration The asset configuration
      * @return {ImageryProvider}
      */
-    ComposerExternalImageryType.getProvider = function(type, metadata) {
+    ComposerExternalImageryType.getProvider = function(configuration) {
+        var type = configuration.type;
         if (type === ComposerExternalImageryType.ARCGIS_MAPSERVER) {
-            return new ArcGisMapServerImageryProvider(metadata);
+            return new ArcGisMapServerImageryProvider(configuration);
         } else if (type === ComposerExternalImageryType.BING) {
-            return new BingMapsImageryProvider(metadata);
+            return new BingMapsImageryProvider(configuration);
         } else if (type === ComposerExternalImageryType.GOOGLE_EARTH) {
-            return new GoogleEarthEnterpriseMapsProvider(metadata);
+            return new GoogleEarthEnterpriseMapsProvider(configuration);
         } else if (type === ComposerExternalImageryType.MAPBOX) {
-            return new MapboxImageryProvider(metadata);
+            return new MapboxImageryProvider(configuration);
         } else if (type === ComposerExternalImageryType.SINGLE_TILE) {
-            return new SingleTileImageryProvider(metadata);
+            return new SingleTileImageryProvider(configuration);
         } else if (type === ComposerExternalImageryType.TMS) {
-            return createTileMapServiceImageryProvider(metadata);
+            return createTileMapServiceImageryProvider(configuration);
         } else if (type === ComposerExternalImageryType.URL_TEMPLATE) {
-            return new UrlTemplateImageryProvider(metadata);
+            return new UrlTemplateImageryProvider(configuration);
         } else if (type === ComposerExternalImageryType.WMS) {
-            return new WebMapServiceImageryProvider(metadata);
+            return new WebMapServiceImageryProvider(configuration);
         } else if (type === ComposerExternalImageryType.WMTS) {
-            return new WebMapTileServiceImageryProvider(metadata);
+            return new WebMapTileServiceImageryProvider(configuration);
         }
         //>>includeStart('debug', pragmas.debug);
         throw new DeveloperError('Unrecognized external imagery type: ' + type);
@@ -72,4 +72,3 @@ define([
 
     return freezeObject(ComposerExternalImageryType);
 });
-

--- a/Source/Scene/ComposerExternalImageryType.js
+++ b/Source/Scene/ComposerExternalImageryType.js
@@ -1,0 +1,75 @@
+define([
+    '../Core/freezeObject',
+    '../Core/DeveloperError',
+    './createTileMapServiceImageryProvider',
+    './ArcGisMapServerImageryProvider',
+    './BingMapsImageryProvider',
+    './GoogleEarthEnterpriseMapsProvider',
+    './MapboxImageryProvider',
+    './SingleTileImageryProvider',
+    './UrlTemplateImageryProvider',
+    './WebMapServiceImageryProvider',
+    './WebMapTileServiceImageryProvider'
+], function (freezeObject,
+             DeveloperError,
+             createTileMapServiceImageryProvider,
+             ArcGisMapServerImageryProvider,
+             BingMapsImageryProvider,
+             GoogleEarthEnterpriseMapsProvider,
+             MapboxImageryProvider,
+             SingleTileImageryProvider,
+             UrlTemplateImageryProvider,
+             WebMapServiceImageryProvider,
+             WebMapTileServiceImageryProvider) {
+    'use strict';
+
+    /**
+     * Aliases of available imagery providers.
+     * @exports ComposerExternalImageryType
+     */
+    var ComposerExternalImageryType = {
+        ARCGIS_MAPSERVER: 'ARCGIS_MAPSERVER',
+        BING: 'BING',
+        GOOGLE_EARTH: 'GOOGLE_EARTH',
+        MAPBOX: 'MAPBOX',
+        SINGLE_TILE: 'SINGLE_TILE',
+        TMS: 'TMS',
+        URL_TEMPLATE: 'TEMPLATE',
+        WMS: 'WMS',
+        WMTS: 'WMTS'
+    };
+
+    /**
+     * Creates an imagery provider from the external imagery type
+     * @param {ComposerExternalImageryType} type The imagery provider type
+     * @param {Object} metadata The asset metadata
+     * @return {ImageryProvider}
+     */
+    ComposerExternalImageryType.getProvider = function(type, metadata) {
+        if (type === ComposerExternalImageryType.ARCGIS_MAPSERVER) {
+            return new ArcGisMapServerImageryProvider(metadata);
+        } else if (type === ComposerExternalImageryType.BING) {
+            return new BingMapsImageryProvider(metadata);
+        } else if (type === ComposerExternalImageryType.GOOGLE_EARTH) {
+            return new GoogleEarthEnterpriseMapsProvider(metadata);
+        } else if (type === ComposerExternalImageryType.MAPBOX) {
+            return new MapboxImageryProvider(metadata);
+        } else if (type === ComposerExternalImageryType.SINGLE_TILE) {
+            return new SingleTileImageryProvider(metadata);
+        } else if (type === ComposerExternalImageryType.TMS) {
+            return createTileMapServiceImageryProvider(metadata);
+        } else if (type === ComposerExternalImageryType.URL_TEMPLATE) {
+            return new UrlTemplateImageryProvider(metadata);
+        } else if (type === ComposerExternalImageryType.WMS) {
+            return new WebMapServiceImageryProvider(metadata);
+        } else if (type === ComposerExternalImageryType.WMTS) {
+            return new WebMapTileServiceImageryProvider(metadata);
+        }
+        //>>includeStart('debug', pragmas.debug);
+        throw new DeveloperError('Unrecognized external imagery type: ' + type);
+        //>>includeEnd('debug');
+    };
+
+    return freezeObject(ComposerExternalImageryType);
+});
+

--- a/Source/Scene/createComposerAsset.js
+++ b/Source/Scene/createComposerAsset.js
@@ -1,0 +1,84 @@
+define([
+    './createTileMapServiceImageryProvider',
+    './ComposerAssetType',
+    './ComposerExternalImageryType',
+    './Cesium3DTileset',
+    '../Core/loadJson',
+    '../Core/CesiumTerrainProvider',
+    '../DataSources/CzmlDataSource',
+    '../DataSources/Entity',
+    '../DataSources/KmlDataSource'
+], function(
+    createTileMapServiceImageryProvider,
+    ComposerAssetType,
+    ComposerExternalImageryType,
+    Cesium3DTileset,
+    loadJson,
+    CesiumTerrainProvider,
+    CzmlDataSource,
+    Entity,
+    KmlDataSource) {
+    'use strict';
+
+    /**
+     *
+     * @param assetId
+     * @param token
+     * @param {Object} options
+     * @return {*}
+     */
+    function createComposerAsset(assetId, token, options) {
+        return loadJson('beta.cesium.com/api/assets/' + assetId + '?access_token=' + token)
+            .then(function(metadata) {
+                var type = metadata.type;
+                if (type === ComposerAssetType.MODEL) {
+                    return new Entity({
+                        name : metadata.name,
+                        description : metadata.description,
+                        position : options.position,
+                        orientation : options.orientation,
+                        model : {
+                            uri : metadata.url,
+                            show : options.show,
+                            scale : options.scale,
+                            minimumPixelSize : options.minimumPixelSize,
+                            maximumScale : options.maximumScale,
+                            incrementallyLoadTextures : options.incrementallyLoadTextures,
+                            shadows : options.shadows,
+                            runAnimations : options.runAnimations,
+                            heightReference : options.heightReference,
+                            distanceDisplayCondition : options.distanceDisplayCondition,
+                            silhouetteColor : options.silhouetteColor,
+                            silhouetteSize : options.silhouetteSize,
+                            color : options.color,
+                            colorBlendMode : options.colorBlendMode,
+                            colorBlendAmount : options.colorBlendAmount
+                        }
+                    });
+                } else if (type === ComposerAssetType['3DTILES']) {
+                    return new Cesium3DTileset(metadata);
+                } else if (type === ComposerAssetType.CZML) {
+                    return CzmlDataSource.load(metadata.url);
+                } else if (type === ComposerAssetType.KML) {
+                    return KmlDataSource.load(metadata.url, {
+                        camera : options.scene.camera,
+                        canvas : options.scene.canvas,
+                        clampToGround : true
+                    });
+                } else if (type === ComposerAssetType.IMAGERY) {
+                    if (!metadata.isExternal) {
+                        return createTileMapServiceImageryProvider(metadata);
+                    }
+                    return ComposerExternalImageryType.getProvider(metadata.externalType, metadata.externalConfiguration);
+                } else if (type === ComposerAssetType.TERRAIN) {
+                    return new CesiumTerrainProvider({
+                        url : metadata.url,
+                        requestWaterMask : true,
+                        requestVertexNormals : true
+                    });
+                }
+            });
+    }
+
+    return createComposerAsset;
+});

--- a/Source/Scene/createComposerAsset.js
+++ b/Source/Scene/createComposerAsset.js
@@ -37,9 +37,10 @@ define([
         //>>includeEnd('debug');
 
         token = ComposerApi.getToken(token);
-        return loadJson('beta.cesium.com/api/assets/' + assetId + '?access_token=' + token)
+        return loadJson('//api.composer.dev:8081/api/assets/' + assetId + '?access_token=' + token)
             .then(function(metadata) {
                 var type = metadata.type;
+                metadata.url = metadata.url + '?access_token=' + token;
                 if (type === ComposerAssetType.MODEL) {
                     return new Entity({
                         name : metadata.name,


### PR DESCRIPTION
Added the helper function `createComposerAsset` for adding assets hosted on cesium.com to a cesium application.

@mramato ready for early review.  I haven't written any tests yet, and I know we'll have to rename all of the functions, but is this generally what you had in mind?