### PR TITLE
Clarify that the CLA applies to all AGI open-source projects, including Cesium

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,7 +55,7 @@ Before we can merge a pull request, we require a signed Contributor License Agre
 * [individuals](Documentation/Contributors/CLAs/individual-cla-agi-v1.0.txt) and
 * [corporations](Documentation/Contributors/CLAs/corporate-cla-agi-v1.0.txt).
 
-This only needs to be completed once.  The CLA ensures you retain copyright to your contributions, and we have the right to use them and incorporate them into Cesium using the [Apache 2.0 License](LICENSE.md).
+This only needs to be completed once, and enables contributions to all of the projects under the [Analytical Graphics Inc](https://github.com/AnalyticalGraphicsInc) organization, including Cesium.  The CLA ensures you retain copyright to your contributions, and provides us the right to use, modify, and redistribute your contributions using the [Apache 2.0 License](LICENSE.md).
 
 Please email a completed CLA with all fields filled in to [cla@agi.com](mailto:cla@agi.com).  Related questions are also welcome.
 


### PR DESCRIPTION
The helper text surrounding the Cesium CLA link is not very inclusive of AGI's other open-source projects.  I wonder if the powers that be would be willing to accept this change of wording?