### PR TITLE
Fix occluded level zero tile when there is only one.

### DIFF
--- a/Source/Scene/GlobeSurfaceTileProvider.js
+++ b/Source/Scene/GlobeSurfaceTileProvider.js
@@ -504,7 +504,7 @@ define([
         }
 
         var ortho3D = frameState.mode === SceneMode.SCENE3D && frameState.camera.frustum instanceof OrthographicFrustum;
-        if (frameState.mode === SceneMode.SCENE3D && !ortho3D) {
+        if (frameState.mode === SceneMode.SCENE3D && !ortho3D && defined(occluders)) {
             var occludeePointInScaledSpace = surfaceTile.occludeePointInScaledSpace;
             if (!defined(occludeePointInScaledSpace)) {
                 return intersection;

--- a/Source/Scene/QuadtreePrimitive.js
+++ b/Source/Scene/QuadtreePrimitive.js
@@ -427,11 +427,11 @@ define([
 
         primitive._occluders.ellipsoid.cameraPosition = frameState.camera.positionWC;
 
-        var tileProvider = primitive._tileProvider;
-        var occluders = primitive._occluders;
-
         var tile;
         var levelZeroTiles = primitive._levelZeroTiles;
+
+        var tileProvider = primitive._tileProvider;
+        var occluders = levelZeroTiles.length > 1 ? primitive._occluders : undefined;
 
         // Sort the level zero tiles by the distance from the center to the camera.
         // The level zero tiles aren't necessarily a nice neat quad, so we can use the


### PR DESCRIPTION
In master, if the occludee point isn't visible the level zero tile isn't rendered. Running this code example in master doesn't render the globe until the camera is rotated.
```javascript
var viewer = new Cesium.Viewer('cesiumContainer');
viewer.terrainProvider = new Cesium.EllipsoidTerrainProvider({
    tilingScheme : new Cesium.WebMercatorTilingScheme({ ellipsoid : Cesium.Ellipsoid.WGS84 })
});
viewer.camera.lookAtTransform(Cesium.Matrix4.IDENTITY, new Cesium.Cartesian3(-29598857.314114936, 607177.0813790036, -4502364.106523662));
```
Noticed while testing #5780.