### PR TITLE
Fix freezeRenderState test

### DIFF
--- a/Specs/Renderer/RenderStateSpec.js
+++ b/Specs/Renderer/RenderStateSpec.js
@@ -1,14 +1,16 @@
 defineSuite([
+        'Renderer/RenderState',
+        'Core/defined',
         'Core/WebGLConstants',
         'Core/WindingOrder',
         'Renderer/ContextLimits',
-        'Renderer/RenderState',
         'Specs/createContext'
     ], function(
+        RenderState,
+        defined,
         WebGLConstants,
         WindingOrder,
         ContextLimits,
-        RenderState,
         createContext) {
     'use strict';
 
@@ -408,6 +410,9 @@ defineSuite([
     });
 
     it('freezes render states', function(){
+        if (window.release) {
+            return;
+        }
         var rs = RenderState.fromCache();
         expect(function() {
             rs.depthRange = {};

--- a/Specs/customizeJasmine.js
+++ b/Specs/customizeJasmine.js
@@ -140,6 +140,10 @@ define([
             window.webglStub = true;
         }
 
+        if (release) {
+            window.release = true;
+        }
+
         //env.catchExceptions(true);
 
         env.beforeEach(function () {


### PR DESCRIPTION
Fixes #5924

The freezeRenderState code is wrapped in pragmas so it is removed from the release version.  This skips that test if the release flag is set.