### PR TITLE
Check regExp expresssions don't throw syntax errors

### DIFF
--- a/Specs/Scene/ExpressionSpec.js
+++ b/Specs/Scene/ExpressionSpec.js
@@ -2696,15 +2696,15 @@ defineSuite([
         expect(expression._runtimeAst._type).toEqual(ExpressionNodeType.REGEX);
     });
 
-    it('throws if regex constructor has invalid pattern', function() {
+    it('does not throw SyntaxError if regex constructor has invalid pattern', function() {
         var expression = new Expression('regExp("(?<=\\s)" + ".")');
         expect(function() {
             expression.evaluate(frameState, undefined);
-        }).toThrowRuntimeError();
+        }).not.toThrowSyntaxError();
 
         expect(function() {
             return new Expression('regExp("(?<=\\s)")');
-        }).toThrowRuntimeError();
+        }).not.toThrowSyntaxError();
     });
 
     it('throws if regex constructor has invalid flags', function() {

--- a/Specs/addDefaultMatchers.js
+++ b/Specs/addDefaultMatchers.js
@@ -412,7 +412,9 @@ define([
 
             toThrowDeveloperError : makeThrowFunction(debug, DeveloperError, 'DeveloperError'),
 
-            toThrowRuntimeError : makeThrowFunction(true, RuntimeError, 'RuntimeError')
+            toThrowRuntimeError : makeThrowFunction(true, RuntimeError, 'RuntimeError'),
+
+            toThrowSyntaxError : makeThrowFunction(true, SyntaxError, 'SyntaxError')
         };
     }
 


### PR DESCRIPTION
Fixes #5927

The important part was that invalid regExp doesn't throw a syntax error.

@hpinkos Can you test this in windows 10? 