### PR TITLE
Darken fog when terrain lighting is enabled.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,7 +16,7 @@ Change Log
 * Added `customTags` property to the UrlTemplateImageryProvider to allow custom keywords in the template URL. [#5696](https://github.com/AnalyticalGraphicsInc/cesium/pull/5696)
 * Improved CZML Reference Properties example [#5754](https://github.com/AnalyticalGraphicsInc/cesium/pull/5754)
 * Fixed bug with placemarks in imported KML: placemarks with no specified icon would be displayed with default icon. [#5819](https://github.com/AnalyticalGraphicsInc/cesium/issues/5819)
-* Fix bright fog when terrain lighting is enabled. [#5934](https://github.com/AnalyticalGraphicsInc/cesium/pull/5934)
+* Fixed bright fog when terrain lighting is enabled and added `Fog.minimumBrightness` to affect how bright the fog will be when in complete darkness. [#5934](https://github.com/AnalyticalGraphicsInc/cesium/pull/5934)
 
 ### 1.38 - 2017-10-02
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,7 @@ Change Log
 * Added `eyeSeparation` and `focalLength` properties to `Scene` to configure VR settings. [#5917](https://github.com/AnalyticalGraphicsInc/cesium/pull/5917)
 * Added `customTags` property to the UrlTemplateImageryProvider to allow custom keywords in the template URL. [#5696](https://github.com/AnalyticalGraphicsInc/cesium/pull/5696)
 * Improved CZML Reference Properties example [#5754](https://github.com/AnalyticalGraphicsInc/cesium/pull/5754)
+* Fix bright fog when terrain lighting is enabled. [#5934](https://github.com/AnalyticalGraphicsInc/cesium/pull/5934)
 
 ### 1.38 - 2017-10-02
 

--- a/Source/Scene/Fog.js
+++ b/Source/Scene/Fog.js
@@ -24,7 +24,6 @@ define([
          * @default true
          */
         this.enabled = true;
-
         /**
          * A scalar that determines the density of the fog. Terrain that is in full fog are culled.
          * The density of the fog increases as this number approaches 1.0 and becomes less dense as it approaches zero.
@@ -44,6 +43,13 @@ define([
          * @default 2.0
          */
         this.screenSpaceErrorFactor = 2.0;
+        /**
+         * The minimum brightness of the fog color from lighting. A value of 0.0 can cause the fog to be completely black. A value of 1.0 will not affect
+         * the brightness at all.
+         * @type {Number}
+         * @default 0.1
+         */
+        this.minimumBrightness = 0.1;
     }
 
     // These values were found by sampling the density at certain views and finding at what point culled tiles impacted the view at the horizon.
@@ -135,6 +141,7 @@ define([
 
         frameState.fog.density = density;
         frameState.fog.sse = this.screenSpaceErrorFactor;
+        frameState.fog.minimumBrightness = this.minimumBrightness;
     };
 
     return Fog;

--- a/Source/Scene/FrameState.js
+++ b/Source/Scene/FrameState.js
@@ -208,7 +208,14 @@ define([
              * @type {Number}
              * @default undefined
              */
-            sse : undefined
+            sse : undefined,
+            /**
+             * The minimum brightness of terrain with fog applied.
+             *
+             * @type {Number}
+             * @default undefined
+             */
+            minimumBrightness : undefined
         };
 
         /**

--- a/Source/Scene/GlobeSurfaceTileProvider.js
+++ b/Source/Scene/GlobeSurfaceTileProvider.js
@@ -849,6 +849,9 @@ define([
             u_dayTextureSplit : function() {
                 return this.properties.dayTextureSplit;
             },
+            u_minimumBrightness : function() {
+                return frameState.fog.minimumBrightness;
+            },
 
             // make a separate object so that changes to the properties are seen on
             // derived commands that combine another uniform map with this one.

--- a/Source/Shaders/GlobeFS.glsl
+++ b/Source/Shaders/GlobeFS.glsl
@@ -52,6 +52,10 @@ uniform sampler2D u_oceanNormalMap;
 uniform vec2 u_lightingFadeDistance;
 #endif
 
+#if defined(FOG) && (defined(ENABLE_VERTEX_LIGHTING) || defined(ENABLE_DAYNIGHT_SHADING))
+uniform float u_minimumBrightness;
+#endif
+
 varying vec3 v_positionMC;
 varying vec3 v_positionEC;
 varying vec3 v_textureCoordinates;
@@ -201,8 +205,8 @@ void main()
     fogColor = vec3(1.0) - exp(-fExposure * fogColor);
 
 #if defined(ENABLE_VERTEX_LIGHTING) || defined(ENABLE_DAYNIGHT_SHADING)
-    float darken = clamp(dot(normalize(czm_viewerPositionWC), normalize(czm_sunPositionWC)), 0.1, 1.0);
-    fogColor = mix(vec3(0.0), fogColor, darken);
+    float darken = clamp(dot(normalize(czm_viewerPositionWC), normalize(czm_sunPositionWC)), u_minimumBrightness, 1.0);
+    fogColor *= darken;
 #endif
 
     gl_FragColor = vec4(czm_fog(v_distance, finalColor.rgb, fogColor), finalColor.a);

--- a/Source/Shaders/GlobeFS.glsl
+++ b/Source/Shaders/GlobeFS.glsl
@@ -195,11 +195,15 @@ void main()
     vec4 finalColor = color;
 #endif
 
-
 #ifdef FOG
     const float fExposure = 2.0;
     vec3 fogColor = v_mieColor + finalColor.rgb * v_rayleighColor;
     fogColor = vec3(1.0) - exp(-fExposure * fogColor);
+
+#if defined(ENABLE_VERTEX_LIGHTING) || defined(ENABLE_DAYNIGHT_SHADING)
+    float darken = clamp(dot(normalize(czm_viewerPositionWC), normalize(czm_sunPositionWC)), 0.1, 1.0);
+    fogColor = mix(vec3(0.0), fogColor, darken);
+#endif
 
     gl_FragColor = vec4(czm_fog(v_distance, finalColor.rgb, fogColor), finalColor.a);
 #else


### PR DESCRIPTION
Darkens the fog when `viewer.scene.globe.enableLighting = true`. Here is a Sandcastle example for testing:
```javascript
var viewer = new Cesium.Viewer('cesiumContainer');

viewer.terrainProvider = new Cesium.CesiumTerrainProvider({
    url : 'https://assets.agi.com/stk-terrain/v1/tilesets/world/tiles',
    requestVertexNormals : true
});

viewer.scene.globe.enableLighting = true;

var camera = viewer.scene.camera;
camera.position = new Cesium.Cartesian3(305111.15252842277, 5635080.182335396, 2980739.393793938);
camera.direction = new Cesium.Cartesian3(-0.8922165975346716, 0.21339304915721466, -0.39801124312642266);
camera.up = new Cesium.Cartesian3(0.012013291290700188, 0.8922235826513757, 0.4514341141219929);
camera.right = Cesium.Cartesian3.cross(camera.direction, camera.up, new Cesium.Cartesian3());
viewer.clock.currentTime = new Cesium.JulianDate(2458052, 45720.28193048129);
```

CC @emackey