### PR TITLE
fixes #5943 geocoder selects wrong list item with key press

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -166,3 +166,4 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to Cesiu
 * [Rudraksha Shah](https://github.com/Rudraksha20)
 * [Cody Guldner](https://github.com/burn123)
 * [Nacho Carnicero](https://github.com/nacho-carnicero)
+* [Y.Selim Abidin](https://github.com/SelimAbidin)

--- a/Source/Widgets/Geocoder/GeocoderViewModel.js
+++ b/Source/Widgets/Geocoder/GeocoderViewModel.js
@@ -80,12 +80,12 @@ define([
         });
 
         this._searchCommand = createCommand(function() {
-            that.hideSuggestions();
             that._focusTextbox = false;
             if (defined(that._selectedSuggestion)) {
                 that.activateSuggestion(that._selectedSuggestion);
                 return false;
             }
+            that.hideSuggestions();
             if (that.isSearchInProgress) {
                 cancelGeocode(that);
             } else {


### PR DESCRIPTION
Search command in `Source/Widgets/Geocoder/GeocoderViewModel.js ` hides suggestions first and then tries to activate the selected item which is already defined `undefined`

Moving `hideSuggestions` under `activateSuggestion` will have no impact since `activateSuggestion'` also calls it.

