### PR TITLE
Merge v1.39 into vector tiles

### DIFF
--- a/.concierge/templates/pullRequestOpened.hbs
+++ b/.concierge/templates/pullRequestOpened.hbs
@@ -1,0 +1,24 @@
+{{#if claEnabled}}
+{{#if askForCla}}
+[![Please sign the CLA before we review this PR.](https://img.shields.io/badge/CLA-required-red.svg)](https://github.com/AnalyticalGraphicsInc/cesium/blob/master/CONTRIBUTING.md#contributor-license-agreement-cla)
+
+Welcome to the Cesium community @{{ userName }}!
+
+Can you please send in a [Contributor License Agreement](https://github.com/AnalyticalGraphicsInc/cesium/blob/master/CONTRIBUTING.md#contributor-license-agreement-cla) (CLA) so that we can review and merge this pull request?
+{{else}}
+![Signed CLA is on file.](https://img.shields.io/badge/CLA-signed-brightgreen.svg)
+
+@{{ userName }}, thanks for the pull request! Maintainers, we have a signed CLA from @{{ userName }}, so you can review this at any time.
+{{/if}}
+{{else}}
+@{{ userName }}, thanks for the pull request!
+{{/if}}
+
+{{#if askAboutChanges}}
+:warning: I noticed that [CHANGES.md]({{ repository_url }}/blob/master/CHANGES.md) has not been updated. If this change updates the public API in any way, fixes a bug, or makes any non-trivial update, please add a bullet point to `CHANGES.md` and comment on this pull request so we know it was updated. For more info, see the [Pull Request Guidelines]( https://github.com/AnalyticalGraphicsInc/cesium/blob/master/CONTRIBUTING.md#pull-request-guidelines).
+
+{{/if}}
+{{#if askAboutThirdParty}}
+:warning: I noticed that a file in one of our ThirdParty folders (`{{ thirdPartyFolders }}`) has been added or modified. Please verify that it has a section in [LICENSE.md]({{ repository_url }}/blob/master/LICENSE.md) and that its license information is up to date with this new version. Once you do, please confirm by commenting on this pull request.
+
+{{/if}}

--- a/.concierge/templates/signature.hbs
+++ b/.concierge/templates/signature.hbs
@@ -1,0 +1,5 @@
+---
+
+__I am a bot who helps you make Cesium awesome! [Contributions to my configuration are welcome.](https://github.com/AnalyticalGraphicsInc/cesium/tree/master/.concierge)__
+
+:earth_africa: :earth_americas: :earth_asia:

--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,4 @@
+/.concierge
 /.eslintcache
 /.externalToolBuilders
 /.gitattributes

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,19 +3,22 @@ Change Log
 
 ### 1.39 - 2017-11-01
 
-* Added support for right-to-left languages in labels. [#5771](https://github.com/AnalyticalGraphicsInc/cesium/pull/5771)
-* Added the ability to load Cesium's assets from the local file system if security permissions allow it. [#5830](https://github.com/AnalyticalGraphicsInc/cesium/issues/5830)
-* Added function that inserts missing namespace declarations into KML files. [#5860](https://github.com/AnalyticalGraphicsInc/cesium/pull/5860)
-* Added support for the layer.json `parentUrl` property in `CesiumTerrainProvider` to allow for compositing of tilesets.
+* Cesium now officially supports webpack. See our [Integrating Cesium and webpack blog post](https://cesium.com/blog/2017/10/18/cesium-and-webpack/) for more details.
+* Added support for right-to-left language detection in labels, currently Hebrew and Arabic are supported. To enable it, set `Cesium.Label.enableRightToLeftDetection = true` at the start of your application. [#5771](https://github.com/AnalyticalGraphicsInc/cesium/pull/5771)
+* Fixed handling of KML files with missing `xsi` namespace declarations. [#5860](https://github.com/AnalyticalGraphicsInc/cesium/pull/5860)
 * Fixed a bug that caused KML ground overlays to appear distorted when rotation was applied. [#5914](https://github.com/AnalyticalGraphicsInc/cesium/issues/5914)
-* Added two new properties to `ImageryLayer` that allow for adjusting the texture sampler used for up- and down-sampling of image tiles, namely `minificationFilter` and `magnificationFilter` with possible values `LINEAR` (the default) and `NEAREST` defined in `TextureMinificationFilter` and `TextureMagnificationFilter`. [#5846](https://github.com/AnalyticalGraphicsInc/cesium/issues/5846)
-* The enums `TextureMinificationFilter` and `TextureMagnificationFilter` have been made public to support the new texture filter properties mentioned above. 
-* KML files load when a Network Link fails [#5871](https://github.com/AnalyticalGraphicsInc/cesium/pull/5871)
-* Adds `invertClassification` and `invertClassificationColor` to `Scene`. When `invertClassification` is `true`, any 3D Tiles geometry that is not classified by a `ClassificationPrimitive` or `GroundPrimitive` will have its color multiplied by `invertClassificationColor`. [#5836](https://github.com/AnalyticalGraphicsInc/cesium/pull/5836)
-* Added `eyeSeparation` and `focalLength` properties to `Scene` to configure VR settings. [#5917](https://github.com/AnalyticalGraphicsInc/cesium/pull/5917)
+* Fixed a bug where KML placemarks with no specified icon would be displayed with default icon. [#5819](https://github.com/AnalyticalGraphicsInc/cesium/issues/5819)
+* Changed KML loading to ignore NetworkLink failures and continue to load the rest of the document. [#5871](https://github.com/AnalyticalGraphicsInc/cesium/pull/5871)
+* Added the ability to load Cesium's assets from the local file system if security permissions allow it. [#5830](https://github.com/AnalyticalGraphicsInc/cesium/issues/5830)
+* Added two new properties to `ImageryLayer` that allow for adjusting the texture sampler used for up and down-sampling of imagery tiles, namely `minificationFilter` and `magnificationFilter` with possible values `LINEAR` (the default) and `NEAREST` defined in `TextureMinificationFilter` and `TextureMagnificationFilter`. [#5846](https://github.com/AnalyticalGraphicsInc/cesium/issues/5846)
+* Fixed flickering artifacts with 3D Tiles tilesets with thin walls. [#5940](https://github.com/AnalyticalGraphicsInc/cesium/pull/5940)
+* Fixed bright fog when terrain lighting is enabled and added `Fog.minimumBrightness` to affect how bright the fog will be when in complete darkness. [#5934](https://github.com/AnalyticalGraphicsInc/cesium/pull/5934)
+* Fixed using arrow keys in geocoder widget to select search suggestions. [#5943](https://github.com/AnalyticalGraphicsInc/cesium/issues/5943)
+* Added support for the layer.json `parentUrl` property in `CesiumTerrainProvider` to allow for compositing of tilesets. [#5864](https://github.com/AnalyticalGraphicsInc/cesium/pull/5864)
+* Added `invertClassification` and `invertClassificationColor` to `Scene`. When `invertClassification` is `true`, any 3D Tiles geometry that is not classified by a `ClassificationPrimitive` or `GroundPrimitive` will have its color multiplied by `invertClassificationColor`. [#5836](https://github.com/AnalyticalGraphicsInc/cesium/pull/5836)
 * Added `customTags` property to the UrlTemplateImageryProvider to allow custom keywords in the template URL. [#5696](https://github.com/AnalyticalGraphicsInc/cesium/pull/5696)
+* Added `eyeSeparation` and `focalLength` properties to `Scene` to configure VR settings. [#5917](https://github.com/AnalyticalGraphicsInc/cesium/pull/5917)
 * Improved CZML Reference Properties example [#5754](https://github.com/AnalyticalGraphicsInc/cesium/pull/5754)
-* Fixed bug with placemarks in imported KML: placemarks with no specified icon would be displayed with default icon. [#5819](https://github.com/AnalyticalGraphicsInc/cesium/issues/5819)
 
 ### 1.38 - 2017-10-02
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -166,3 +166,4 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to Cesiu
 * [Rudraksha Shah](https://github.com/Rudraksha20)
 * [Cody Guldner](https://github.com/burn123)
 * [Nacho Carnicero](https://github.com/nacho-carnicero)
+* [Y.Selim Abidin](https://github.com/SelimAbidin)

--- a/Source/Scene/Batched3DModel3DTileContent.js
+++ b/Source/Scene/Batched3DModel3DTileContent.js
@@ -451,7 +451,8 @@ define([
         // If any commands were pushed, add derived commands
         var commandEnd = frameState.commandList.length;
         if ((commandStart < commandEnd) && frameState.passes.render) {
-            this._batchTable.addDerivedCommands(frameState, commandStart);
+            var finalResolution = this._tile._finalResolution;
+            this._batchTable.addDerivedCommands(frameState, commandStart, finalResolution);
         }
    };
 

--- a/Source/Scene/Fog.js
+++ b/Source/Scene/Fog.js
@@ -24,7 +24,6 @@ define([
          * @default true
          */
         this.enabled = true;
-
         /**
          * A scalar that determines the density of the fog. Terrain that is in full fog are culled.
          * The density of the fog increases as this number approaches 1.0 and becomes less dense as it approaches zero.
@@ -44,6 +43,13 @@ define([
          * @default 2.0
          */
         this.screenSpaceErrorFactor = 2.0;
+        /**
+         * The minimum brightness of the fog color from lighting. A value of 0.0 can cause the fog to be completely black. A value of 1.0 will not affect
+         * the brightness at all.
+         * @type {Number}
+         * @default 0.1
+         */
+        this.minimumBrightness = 0.1;
     }
 
     // These values were found by sampling the density at certain views and finding at what point culled tiles impacted the view at the horizon.
@@ -135,6 +141,7 @@ define([
 
         frameState.fog.density = density;
         frameState.fog.sse = this.screenSpaceErrorFactor;
+        frameState.fog.minimumBrightness = this.minimumBrightness;
     };
 
     return Fog;

--- a/Source/Scene/FrameState.js
+++ b/Source/Scene/FrameState.js
@@ -208,7 +208,14 @@ define([
              * @type {Number}
              * @default undefined
              */
-            sse : undefined
+            sse : undefined,
+            /**
+             * The minimum brightness of terrain with fog applied.
+             *
+             * @type {Number}
+             * @default undefined
+             */
+            minimumBrightness : undefined
         };
 
         /**

--- a/Source/Scene/GlobeSurfaceTileProvider.js
+++ b/Source/Scene/GlobeSurfaceTileProvider.js
@@ -849,6 +849,9 @@ define([
             u_dayTextureSplit : function() {
                 return this.properties.dayTextureSplit;
             },
+            u_minimumBrightness : function() {
+                return frameState.fog.minimumBrightness;
+            },
 
             // make a separate object so that changes to the properties are seen on
             // derived commands that combine another uniform map with this one.

--- a/Source/Scene/Instanced3DModel3DTileContent.js
+++ b/Source/Scene/Instanced3DModel3DTileContent.js
@@ -516,7 +516,7 @@ define([
         // If any commands were pushed, add derived commands
         var commandEnd = frameState.commandList.length;
         if ((commandStart < commandEnd) && frameState.passes.render) {
-            this._batchTable.addDerivedCommands(frameState, commandStart);
+            this._batchTable.addDerivedCommands(frameState, commandStart, false);
         }
     };
 

--- a/Source/Scene/Label.js
+++ b/Source/Scene/Label.js
@@ -1311,6 +1311,11 @@ define([
         }
     }
 
+    //To add another language, simply add it's Unicode block range(s) to the below regex.
+    var hebrew = '\u05D0-\u05EA';
+    var arabic = '\u0600-\u06FF\u0750–\u077F\u08A0–\u08FF';
+    var rtlChars = new RegExp('[' + hebrew + arabic + ']');
+
     /**
      *
      * @param {String} value the text to parse and reorder
@@ -1318,7 +1323,6 @@ define([
      * @private
      */
     function reverseRtl(value) {
-        var rtlChars = /[\u05D0-\u05EA]/;
         var texts = value.split('\n');
         var result = '';
         for (var i = 0; i < texts.length; i++) {

--- a/Source/Shaders/GlobeFS.glsl
+++ b/Source/Shaders/GlobeFS.glsl
@@ -52,6 +52,10 @@ uniform sampler2D u_oceanNormalMap;
 uniform vec2 u_lightingFadeDistance;
 #endif
 
+#if defined(FOG) && (defined(ENABLE_VERTEX_LIGHTING) || defined(ENABLE_DAYNIGHT_SHADING))
+uniform float u_minimumBrightness;
+#endif
+
 varying vec3 v_positionMC;
 varying vec3 v_positionEC;
 varying vec3 v_textureCoordinates;
@@ -195,11 +199,15 @@ void main()
     vec4 finalColor = color;
 #endif
 
-
 #ifdef FOG
     const float fExposure = 2.0;
     vec3 fogColor = v_mieColor + finalColor.rgb * v_rayleighColor;
     fogColor = vec3(1.0) - exp(-fExposure * fogColor);
+
+#if defined(ENABLE_VERTEX_LIGHTING) || defined(ENABLE_DAYNIGHT_SHADING)
+    float darken = clamp(dot(normalize(czm_viewerPositionWC), normalize(czm_sunPositionWC)), u_minimumBrightness, 1.0);
+    fogColor *= darken;
+#endif
 
     gl_FragColor = vec4(czm_fog(v_distance, finalColor.rgb, fogColor), finalColor.a);
 #else

--- a/Source/Widgets/Geocoder/GeocoderViewModel.js
+++ b/Source/Widgets/Geocoder/GeocoderViewModel.js
@@ -80,12 +80,12 @@ define([
         });
 
         this._searchCommand = createCommand(function() {
-            that.hideSuggestions();
             that._focusTextbox = false;
             if (defined(that._selectedSuggestion)) {
                 that.activateSuggestion(that._selectedSuggestion);
                 return false;
             }
+            that.hideSuggestions();
             if (that.isSearchInProgress) {
                 cancelGeocode(that);
             } else {

--- a/Specs/Scene/Cesium3DTilesetSpec.js
+++ b/Specs/Scene/Cesium3DTilesetSpec.js
@@ -2492,8 +2492,9 @@ defineSuite([
 
             scene.renderForSpecs();
 
-            // 2 for root tile, 2 for child, 1 for stencil clear
-            expect(statistics.numberOfCommands).toEqual(5);
+            // 2 for root tile, 1 for child, 1 for stencil clear
+            // Tiles that are marked as finalResolution, including leaves, do not create back face commands
+            expect(statistics.numberOfCommands).toEqual(4);
             expect(root.selected).toBe(true);
             expect(root._finalResolution).toBe(false);
             expect(root.children[0].children[0].children[3].selected).toBe(true);
@@ -2504,6 +2505,7 @@ defineSuite([
             var rs = commandList[1].renderState;
             expect(rs.cull.enabled).toBe(true);
             expect(rs.cull.face).toBe(CullFace.FRONT);
+            expect(rs.polygonOffset.enabled).toBe(true);
         });
     });
 

--- a/Specs/Scene/ExpressionSpec.js
+++ b/Specs/Scene/ExpressionSpec.js
@@ -2696,15 +2696,15 @@ defineSuite([
         expect(expression._runtimeAst._type).toEqual(ExpressionNodeType.REGEX);
     });
 
-    it('throws if regex constructor has invalid pattern', function() {
+    it('does not throw SyntaxError if regex constructor has invalid pattern', function() {
         var expression = new Expression('regExp("(?<=\\s)" + ".")');
         expect(function() {
             expression.evaluate(frameState, undefined);
-        }).toThrowRuntimeError();
+        }).not.toThrowSyntaxError();
 
         expect(function() {
             return new Expression('regExp("(?<=\\s)")');
-        }).toThrowRuntimeError();
+        }).not.toThrowSyntaxError();
     });
 
     it('throws if regex constructor has invalid flags', function() {

--- a/Specs/Scene/LabelCollectionSpec.js
+++ b/Specs/Scene/LabelCollectionSpec.js
@@ -1861,7 +1861,7 @@ defineSuite([
             Label.enableRightToLeftDetection = false;
         });
 
-        it('should not modify text when rightToLeft is true and there is no hebrew characters', function() {
+        it('should not modify text when rightToLeft is true and there are no RTL characters', function() {
             var text = 'bla bla bla';
             var label = labels.add({
                 text : text
@@ -1870,9 +1870,20 @@ defineSuite([
             expect(label.text).toEqual(text);
         });
 
-        it('should reverse text when there is only hebrew characters and rightToLeft is true', function() {
+        it('should reverse text when there are only hebrew characters and rightToLeft is true', function() {
             var text = 'שלום';
             var expectedText = 'םולש';
+            var label = labels.add({
+                text : text
+            });
+
+            expect(label.text).toEqual(text);
+            expect(label._renderedText).toEqual(expectedText);
+        });
+
+        it('should reverse text when there are only arabic characters and rightToLeft is true', function() {
+            var text = 'مرحبا';
+            var expectedText = 'ابحرم';
             var label = labels.add({
                 text : text
             });

--- a/Specs/addDefaultMatchers.js
+++ b/Specs/addDefaultMatchers.js
@@ -412,7 +412,9 @@ define([
 
             toThrowDeveloperError : makeThrowFunction(debug, DeveloperError, 'DeveloperError'),
 
-            toThrowRuntimeError : makeThrowFunction(true, RuntimeError, 'RuntimeError')
+            toThrowRuntimeError : makeThrowFunction(true, RuntimeError, 'RuntimeError'),
+
+            toThrowSyntaxError : makeThrowFunction(true, SyntaxError, 'SyntaxError')
         };
     }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cesium",
-  "version": "1.38.0",
+  "version": "1.39.0",
   "description": "Cesium is a JavaScript library for creating 3D globes and 2D maps in a web browser without a plugin.",
   "homepage": "http://cesiumjs.org",
   "license": "Apache-2.0",


### PR DESCRIPTION
Merge the newly released v1.39 into vector tiles.
This merge allows people relying on the vector-tiles branch to publish their own packages.
This is similar to #5875 and #5810.