### PR TITLE
Prevent npm from creating package-lock.json

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false


### PR DESCRIPTION
We are already ignoring [package-lock.json](https://docs.npmjs.com/files/package-lock.json)
in git, this just stop npm from generating it altogether.

In case you're wondering why we don't just follow the suggestion of committing it to source control, it's because the file changes constantly and there's no reason to noise up our commits or create unecessary merge conflicts.  If we ever have a good reason to re-enable it, it's trivial to do so.