### PR TITLE
Upgrade gltf-pipeline

### DIFF
--- a/Source/ThirdParty/GltfPipeline/addDefaults.js
+++ b/Source/ThirdParty/GltfPipeline/addDefaults.js
@@ -219,6 +219,9 @@ define([
             emission : [
                 0.5, 0.5, 0.5, 1.0
             ]
+        },
+        extras : {
+            _pipeline: {}
         }
     };
 
@@ -357,7 +360,6 @@ define([
                 }
                 material.technique = defaultTechniqueId;
             }
-
         }
     }
 

--- a/Source/ThirdParty/GltfPipeline/processPbrMetallicRoughness.js
+++ b/Source/ThirdParty/GltfPipeline/processPbrMetallicRoughness.js
@@ -49,23 +49,16 @@ define([
             // Pre-processing to assign skinning info and address incompatibilities
             splitIncompatibleSkins(gltf);
 
-            if (!defined(gltf.techniques)) {
-                gltf.techniques = [];
-            }
-            var materials = [];
             ForEach.material(gltf, function(material) {
-                if (defined(material.pbrMetallicRoughness)) {
-                    var pbrMetallicRoughness = material.pbrMetallicRoughness;
+                var pbrMetallicRoughness = material.pbrMetallicRoughness;
+                if (defined(pbrMetallicRoughness)) {
                     var technique = generateTechnique(gltf, material, options);
 
-                    var newMaterial = {
-                        values : pbrMetallicRoughness,
-                        technique : technique
-                    };
-                    materials.push(newMaterial);
+                    material.values = pbrMetallicRoughness;
+                    material.technique = technique;
+                    delete material.pbrMetallicRoughness;
                 }
             });
-            gltf.materials = materials;
 
             // If any primitives have semantics that aren't declared in the generated
             // shaders, we want to preserve them.


### PR DESCRIPTION
Contains a fix for models that use default materials and pbr materials. From https://github.com/AnalyticalGraphicsInc/gltf-pipeline/pull/336/.