### PR TITLE
Allow applications to control terrain adjustment suspension

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,6 +25,7 @@ Change Log
    * Only one node is supported.
    * Only one mesh per node is supported.
    * Only one primitive per mesh is supported.
+* Added `Camera.enableTerrainAdjustmentWhenLoading` to enable/disable suspension of camera position adjustment when terrain is loading [#5999](https://github.com/AnalyticalGraphicsInc/cesium/issues/5999).
 
 ### 1.41 - 2018-01-02
 

--- a/Source/Scene/Camera.js
+++ b/Source/Scene/Camera.js
@@ -199,6 +199,14 @@ define([
          */
         this.maximumZoomFactor = 1.5;
 
+        /**
+         * Allows or disallows camera position adjustment while terrain is loading.
+         * When <code>false</code> the camera position will only be adjusted when all terrain has been loaded.
+         * @type {Boolean}
+         * @default false
+         */
+        this.enableTerrainAdjustmentWhenLoading = false;
+
         this._moveStart = new Event();
         this._moveEnd = new Event();
 
@@ -367,7 +375,7 @@ define([
         var minimumCollisionTerrainHeight = screenSpaceCameraController.minimumCollisionTerrainHeight;
         var minimumZoomDistance = screenSpaceCameraController.minimumZoomDistance;
 
-        if (this._suspendTerrainAdjustment || !enableCollisionDetection) {
+        if ((!this.enableTerrainAdjustmentWhenLoading && this._suspendTerrainAdjustment) || !enableCollisionDetection) {
             return;
         }
 


### PR DESCRIPTION
Fixes: #5999.
Fixes: #5837.

With this simple change, terrain adjustment suspension can be activated/disactivated at will by the application. The default behaviour stays unchanged.

In sandcastle, the code can be tested with:

```js
var viewer = new Cesium.Viewer('cesiumContainer');
var scene = viewer.scene;
var globe = scene.globe;

var controller = scene.screenSpaceCameraController;
controller.minimumZoomDistance = 3000;

var cesiumTerrainProviderMeshes = new Cesium.CesiumTerrainProvider({
    url : 'https://assets.agi.com/stk-terrain/v1/tilesets/world/tiles'
});
viewer.terrainProvider = cesiumTerrainProviderMeshes;

setInterval(function() {
    var carto = Cesium.Cartographic.fromCartesian(scene.camera.position);
    console.log(carto.height - globe.getHeight(carto));
}, 10);

scene.camera.enableTerrainAdjustmentWhenLoading = true;
```

This PR fixes issues where the camera sinks under the terrain, and after (a long) time jumps above the terrain.
  