### PR TITLE
Spec cleanup

### DIFF
--- a/Source/Scene/CreditDisplay.js
+++ b/Source/Scene/CreditDisplay.js
@@ -539,6 +539,7 @@ define([
     CreditDisplay.prototype.destroy = function() {
         this.container.removeChild(this._textContainer);
         this.container.removeChild(this._imageContainer);
+        this.container.removeChild(this._expandLink);
         this.viewport.removeChild(this._lightbox);
 
         return destroyObject(this);

--- a/Source/Scene/Scene.js
+++ b/Source/Scene/Scene.js
@@ -236,9 +236,9 @@ define([
             throw new DeveloperError('options and options.canvas are required.');
         }
         //>>includeEnd('debug');
-
+        var hasCreditContainer = defined(creditContainer);
         var context = new Context(canvas, contextOptions);
-        if (!defined(creditContainer)) {
+        if (!hasCreditContainer) {
             creditContainer = document.createElement('div');
             creditContainer.style.position = 'absolute';
             creditContainer.style.bottom = '0';
@@ -256,6 +256,8 @@ define([
         this._jobScheduler = new JobScheduler();
         this._frameState = new FrameState(context, new CreditDisplay(creditContainer, ' • ', creditViewport), this._jobScheduler);
         this._frameState.scene3DOnly = defaultValue(options.scene3DOnly, false);
+        this._removeCreditContainer = !hasCreditContainer;
+        this._creditContainer = creditContainer;
 
         var ps = new PassState(context);
         ps.viewport = new BoundingRectangle();
@@ -3518,6 +3520,9 @@ define([
 
         if (defined(this._globeDepth)) {
             this._globeDepth.destroy();
+        }
+        if (this._removeCreditContainer) {
+            this._canvas.parentNode.removeChild(this._creditContainer);
         }
 
         if (defined(this._oit)) {

--- a/Source/Widgets/CesiumWidget/CesiumWidget.js
+++ b/Source/Widgets/CesiumWidget/CesiumWidget.js
@@ -241,6 +241,7 @@ define([
         this._canvas = canvas;
         this._canvasWidth = 0;
         this._canvasHeight = 0;
+        this._creditContainerContainer = creditContainerContainer;
         this._creditContainer = creditContainer;
         this._canRender = false;
         this._renderLoopRunning = false;
@@ -654,6 +655,7 @@ define([
     CesiumWidget.prototype.destroy = function() {
         this._scene = this._scene && this._scene.destroy();
         this._container.removeChild(this._element);
+        this._creditContainerContainer.removeChild(this._creditContainer);
         destroyObject(this);
     };
 

--- a/Specs/Scene/Cesium3DTileSpec.js
+++ b/Specs/Scene/Cesium3DTileSpec.js
@@ -314,29 +314,34 @@ defineSuite([
     });
 
     describe('debug bounding volumes', function() {
+        var scene;
+        beforeEach(function() {
+            scene = createScene();
+        });
+
+        afterEach(function() {
+            scene.destroyForSpecs();
+        });
+
         it('can be a bounding region', function() {
-            var scene = createScene();
             var tile = new Cesium3DTile(mockTileset, '/some_url', tileWithBoundingRegion, undefined);
             tile.update(mockTileset, scene.frameState);
             expect(tile._debugBoundingVolume).toBeDefined();
         });
 
         it('can be an oriented bounding box', function() {
-            var scene = createScene();
             var tile = new Cesium3DTile(mockTileset, '/some_url', tileWithBoundingBox, undefined);
             tile.update(mockTileset, scene.frameState);
             expect(tile._debugBoundingVolume).toBeDefined();
         });
 
         it('can be a bounding sphere', function() {
-            var scene = createScene();
             var tile = new Cesium3DTile(mockTileset, '/some_url', tileWithBoundingSphere, undefined);
             tile.update(mockTileset, scene.frameState);
             expect(tile._debugBoundingVolume).toBeDefined();
         });
 
         it('creates debug bounding volume for viewer request volume', function() {
-            var scene = createScene();
             var tile = new Cesium3DTile(mockTileset, '/some_url', tileWithViewerRequestVolume, undefined);
             tile.update(mockTileset, scene.frameState);
             expect(tile._debugViewerRequestVolume).toBeDefined();

--- a/Specs/Scene/CreditDisplaySpec.js
+++ b/Specs/Scene/CreditDisplaySpec.js
@@ -1,8 +1,10 @@
 defineSuite([
         'Scene/CreditDisplay',
+        'Core/defined',
         'Core/Credit'
     ], function(
         CreditDisplay,
+        defined,
         Credit) {
     'use strict';
 
@@ -13,10 +15,18 @@ defineSuite([
     var image = 'cesium-credit-image';
     var imgSrc = 'imagesrc';
     var delimiter = 'cesium-credit-delimiter';
+    var creditDisplay;
 
     beforeEach(function() {
         container = document.createElement('div');
         container.id = 'credit-container';
+    });
+
+    afterEach(function(){
+        if (defined(creditDisplay)) {
+            creditDisplay.destroy();
+            creditDisplay = undefined;
+        }
     });
 
     it('credit display throws with no container', function() {
@@ -27,21 +37,21 @@ defineSuite([
 
     it('credit display addCredit throws when credit is undefined', function() {
         expect(function() {
-            var creditDisplay = new CreditDisplay(container);
+            creditDisplay = new CreditDisplay(container);
             creditDisplay.addCredit();
         }).toThrowDeveloperError();
     });
 
     it('credit display addDefaultCredit throws when credit is undefined', function() {
         expect(function() {
-            var creditDisplay = new CreditDisplay(container);
+            creditDisplay = new CreditDisplay(container);
             creditDisplay.addDefaultCredit();
         }).toThrowDeveloperError();
     });
 
     it('credit display removeDefaultCredit throws when credit is undefined', function() {
         expect(function() {
-            var creditDisplay = new CreditDisplay(container);
+            creditDisplay = new CreditDisplay(container);
             creditDisplay.removeDefaultCredit();
         }).toThrowDeveloperError();
     });
@@ -68,7 +78,7 @@ defineSuite([
     });
 
     it('credit display displays text credit', function() {
-        var creditDisplay = new CreditDisplay(container);
+        creditDisplay = new CreditDisplay(container);
         var credit = new Credit({
             text: 'credit1',
             showOnScreen: true
@@ -88,7 +98,7 @@ defineSuite([
     });
 
     it('credit display displays image credit', function() {
-        var creditDisplay = new CreditDisplay(container);
+        creditDisplay = new CreditDisplay(container);
         var credit = new Credit({
             imageUrl: imgSrc,
             showOnScreen: true
@@ -110,7 +120,7 @@ defineSuite([
     });
 
     it('credit display displays hyperlink credit', function() {
-        var creditDisplay = new CreditDisplay(container);
+        creditDisplay = new CreditDisplay(container);
         var link = 'http://cesiumjs.org/';
         var credit = new Credit({
             link: link,
@@ -143,7 +153,7 @@ defineSuite([
             showOnScreen: true
         });
 
-        var creditDisplay = new CreditDisplay(container);
+        creditDisplay = new CreditDisplay(container);
         creditDisplay.beginFrame();
         creditDisplay.addCredit(credit1);
         creditDisplay.endFrame();
@@ -192,7 +202,7 @@ defineSuite([
             text: 'credit2',
             showOnScreen: true
         });
-        var creditDisplay = new CreditDisplay(container, ', ');
+        creditDisplay = new CreditDisplay(container, ', ');
         creditDisplay.beginFrame();
         creditDisplay.addCredit(credit1);
         creditDisplay.addCredit(credit2);
@@ -226,7 +236,7 @@ defineSuite([
             showOnScreen: true
         });
 
-        var creditDisplay = new CreditDisplay(container, ', ');
+        creditDisplay = new CreditDisplay(container, ', ');
         creditDisplay.beginFrame();
         creditDisplay.addCredit(credit1);
         creditDisplay.addCredit(credit2);
@@ -281,7 +291,7 @@ defineSuite([
             imageUrl: imgSrc,
             showOnScreen: true
         });
-        var creditDisplay = new CreditDisplay(container);
+        creditDisplay = new CreditDisplay(container);
         creditDisplay.beginFrame();
         creditDisplay.addCredit(credit1);
         creditDisplay.endFrame();
@@ -303,7 +313,7 @@ defineSuite([
             link: 'link.com',
             showOnScreen: true
         });
-        var creditDisplay = new CreditDisplay(container);
+        creditDisplay = new CreditDisplay(container);
         creditDisplay.beginFrame();
         creditDisplay.addCredit(credit1);
         creditDisplay.endFrame();
@@ -330,7 +340,7 @@ defineSuite([
             showOnScreen: true
         });
 
-        var creditDisplay = new CreditDisplay(container, ', ');
+        creditDisplay = new CreditDisplay(container, ', ');
         creditDisplay.addDefaultCredit(defaultCredit);
         creditDisplay.beginFrame();
         creditDisplay.addCredit(credit1);
@@ -365,7 +375,7 @@ defineSuite([
             showOnScreen: true
         });
 
-        var creditDisplay = new CreditDisplay(container, ', ');
+        creditDisplay = new CreditDisplay(container, ', ');
         creditDisplay.addDefaultCredit(defaultCredit);
         creditDisplay.beginFrame();
         creditDisplay.addCredit(credit1);
@@ -400,7 +410,7 @@ defineSuite([
             text: 'credit1',
             showOnScreen: true
         });
-        var creditDisplay = new CreditDisplay(container, ', ');
+        creditDisplay = new CreditDisplay(container, ', ');
         creditDisplay.addDefaultCredit(defaultCredit);
         creditDisplay.beginFrame();
         creditDisplay.addCredit(credit1);
@@ -432,7 +442,7 @@ defineSuite([
             showOnScreen: true
         });
 
-        var creditDisplay = new CreditDisplay(container, ', ');
+        creditDisplay = new CreditDisplay(container, ', ');
         creditDisplay.addDefaultCredit(defaultCredit);
         creditDisplay.beginFrame();
         creditDisplay.addCredit(credit1);
@@ -465,7 +475,7 @@ defineSuite([
             imageUrl: imgSrc,
             showOnScreen: true
         });
-        var creditDisplay = new CreditDisplay(container);
+        creditDisplay = new CreditDisplay(container);
         creditDisplay.beginFrame();
         creditDisplay.addCredit(credit1);
         creditDisplay.addCredit(credit2);
@@ -492,7 +502,7 @@ defineSuite([
             text: 'credit1',
             showOnScreen: true
         });
-        var creditDisplay = new CreditDisplay(container);
+        creditDisplay = new CreditDisplay(container);
         creditDisplay.beginFrame();
         creditDisplay.addCredit(credit1);
         creditDisplay.addCredit(credit2);
@@ -511,7 +521,7 @@ defineSuite([
         var credit1 = new Credit({text: 'credit1'});
         var credit2 = new Credit({imageUrl: imgSrc});
 
-        var creditDisplay = new CreditDisplay(container);
+        creditDisplay = new CreditDisplay(container);
         var creditList = creditDisplay._creditList;
 
         creditDisplay.showLightbox();
@@ -552,7 +562,7 @@ defineSuite([
         var credit1 = new Credit({text: 'credit1'});
         var credit2 = new Credit({imageUrl: imgSrc});
 
-        var creditDisplay = new CreditDisplay(container);
+        creditDisplay = new CreditDisplay(container);
         var creditList = creditDisplay._creditList;
 
         creditDisplay.beginFrame();

--- a/Specs/Scene/EllipsoidPrimitiveSpec.js
+++ b/Specs/Scene/EllipsoidPrimitiveSpec.js
@@ -127,6 +127,7 @@ defineSuite([
         camera.up = Cartesian3.clone(Cartesian3.UNIT_Z);
 
         expect(scene).notToRender([0, 0, 0, 255]);
+        scene.destroyForSpecs();
     });
 
     it('does not render when show is false', function() {

--- a/Specs/Scene/SceneSpec.js
+++ b/Specs/Scene/SceneSpec.js
@@ -487,81 +487,85 @@ defineSuite([
         scene.destroyForSpecs();
     });
 
-    it('renders a globe', function() {
-        var s = createScene();
+    describe('render tests', function() {
+        var s;
 
-        s.globe = new Globe(Ellipsoid.UNIT_SPHERE);
-        s.camera.position = new Cartesian3(1.02, 0.0, 0.0);
-        s.camera.up = Cartesian3.clone(Cartesian3.UNIT_Z);
-        s.camera.direction = Cartesian3.negate(Cartesian3.normalize(s.camera.position, new Cartesian3()), new Cartesian3());
+        beforeEach(function() {
+            s = createScene();
+        });
 
-        // To avoid Jasmine's spec has no expectations error
-        expect(true).toEqual(true);
+        afterEach(function() {
+            s.destroyForSpecs();
+        });
 
-        return expect(s).toRenderAndCall(function() {
-            return pollToPromise(function() {
-                render(s.frameState, s.globe);
-                return !jasmine.matchersUtil.equals(s._context.readPixels(), [0, 0, 0, 0]);
+        it('renders a globe', function() {
+            s.globe = new Globe(Ellipsoid.UNIT_SPHERE);
+            s.camera.position = new Cartesian3(1.02, 0.0, 0.0);
+            s.camera.up = Cartesian3.clone(Cartesian3.UNIT_Z);
+            s.camera.direction = Cartesian3.negate(Cartesian3.normalize(s.camera.position, new Cartesian3()), new Cartesian3());
+
+            // To avoid Jasmine's spec has no expectations error
+            expect(true).toEqual(true);
+
+            return expect(s).toRenderAndCall(function() {
+                return pollToPromise(function() {
+                    render(s.frameState, s.globe);
+                    return !jasmine.matchersUtil.equals(s._context.readPixels(), [0, 0, 0, 0]);
+                });
             });
         });
-    });
 
-    it('renders a globe with an ElevationContour', function() {
-        var s = createScene();
+        it('renders a globe with an ElevationContour', function() {
+            s.globe = new Globe(Ellipsoid.UNIT_SPHERE);
+            s.globe.material = Material.fromType('ElevationContour');
+            s.camera.position = new Cartesian3(1.02, 0.0, 0.0);
+            s.camera.up = Cartesian3.clone(Cartesian3.UNIT_Z);
+            s.camera.direction = Cartesian3.negate(Cartesian3.normalize(s.camera.position, new Cartesian3()), new Cartesian3());
 
-        s.globe = new Globe(Ellipsoid.UNIT_SPHERE);
-        s.globe.material = Material.fromType('ElevationContour');
-        s.camera.position = new Cartesian3(1.02, 0.0, 0.0);
-        s.camera.up = Cartesian3.clone(Cartesian3.UNIT_Z);
-        s.camera.direction = Cartesian3.negate(Cartesian3.normalize(s.camera.position, new Cartesian3()), new Cartesian3());
+            // To avoid Jasmine's spec has no expectations error
+            expect(true).toEqual(true);
 
-        // To avoid Jasmine's spec has no expectations error
-        expect(true).toEqual(true);
-
-        return expect(s).toRenderAndCall(function() {
-            return pollToPromise(function() {
-                render(s.frameState, s.globe);
-                return !jasmine.matchersUtil.equals(s._context.readPixels(), [0, 0, 0, 0]);
+            return expect(s).toRenderAndCall(function() {
+                return pollToPromise(function() {
+                    render(s.frameState, s.globe);
+                    return !jasmine.matchersUtil.equals(s._context.readPixels(), [0, 0, 0, 0]);
+                });
             });
         });
-    });
 
-    it('renders a globe with a SlopeRamp', function() {
-        var s = createScene();
+        it('renders a globe with a SlopeRamp', function() {
+            s.globe = new Globe(Ellipsoid.UNIT_SPHERE);
+            s.globe.material = Material.fromType('SlopeRamp');
+            s.camera.position = new Cartesian3(1.02, 0.0, 0.0);
+            s.camera.up = Cartesian3.clone(Cartesian3.UNIT_Z);
+            s.camera.direction = Cartesian3.negate(Cartesian3.normalize(s.camera.position, new Cartesian3()), new Cartesian3());
 
-        s.globe = new Globe(Ellipsoid.UNIT_SPHERE);
-        s.globe.material = Material.fromType('SlopeRamp');
-        s.camera.position = new Cartesian3(1.02, 0.0, 0.0);
-        s.camera.up = Cartesian3.clone(Cartesian3.UNIT_Z);
-        s.camera.direction = Cartesian3.negate(Cartesian3.normalize(s.camera.position, new Cartesian3()), new Cartesian3());
+            // To avoid Jasmine's spec has no expectations error
+            expect(true).toEqual(true);
 
-        // To avoid Jasmine's spec has no expectations error
-        expect(true).toEqual(true);
-
-        return expect(s).toRenderAndCall(function() {
-            return pollToPromise(function() {
-                render(s.frameState, s.globe);
-                return !jasmine.matchersUtil.equals(s._context.readPixels(), [0, 0, 0, 0]);
+            return expect(s).toRenderAndCall(function() {
+                return pollToPromise(function() {
+                    render(s.frameState, s.globe);
+                    return !jasmine.matchersUtil.equals(s._context.readPixels(), [0, 0, 0, 0]);
+                });
             });
         });
-    });
 
-    it('renders a globe with a ElevationRamp', function() {
-        var s = createScene();
+        it('renders a globe with a ElevationRamp', function() {
+            s.globe = new Globe(Ellipsoid.UNIT_SPHERE);
+            s.globe.material = Material.fromType('ElevationRamp');
+            s.camera.position = new Cartesian3(1.02, 0.0, 0.0);
+            s.camera.up = Cartesian3.clone(Cartesian3.UNIT_Z);
+            s.camera.direction = Cartesian3.negate(Cartesian3.normalize(s.camera.position, new Cartesian3()), new Cartesian3());
 
-        s.globe = new Globe(Ellipsoid.UNIT_SPHERE);
-        s.globe.material = Material.fromType('ElevationRamp');
-        s.camera.position = new Cartesian3(1.02, 0.0, 0.0);
-        s.camera.up = Cartesian3.clone(Cartesian3.UNIT_Z);
-        s.camera.direction = Cartesian3.negate(Cartesian3.normalize(s.camera.position, new Cartesian3()), new Cartesian3());
+            // To avoid Jasmine's spec has no expectations error
+            expect(true).toEqual(true);
 
-        // To avoid Jasmine's spec has no expectations error
-        expect(true).toEqual(true);
-
-        return expect(s).toRenderAndCall(function() {
-            return pollToPromise(function() {
-                render(s.frameState, s.globe);
-                return !jasmine.matchersUtil.equals(s._context.readPixels(), [0, 0, 0, 0]);
+            return expect(s).toRenderAndCall(function() {
+                return pollToPromise(function() {
+                    render(s.frameState, s.globe);
+                    return !jasmine.matchersUtil.equals(s._context.readPixels(), [0, 0, 0, 0]);
+                });
             });
         });
     });
@@ -1190,6 +1194,8 @@ defineSuite([
 
         scene.globe = undefined;
         expect(scene.imageryLayers).toBeUndefined();
+
+        scene.destroyForSpecs();
     });
 
     it('Gets terrainProvider', function() {
@@ -1199,6 +1205,8 @@ defineSuite([
 
         scene.globe = undefined;
         expect(scene.terrainProvider).toBeUndefined();
+
+        scene.destroyForSpecs();
     });
 
     it('Sets terrainProvider', function() {
@@ -1216,6 +1224,8 @@ defineSuite([
                 url: '//newTerrain/tiles'
             });
         }).not.toThrow();
+
+        scene.destroyForSpecs();
     });
 
     it('Gets terrainProviderChanged', function() {
@@ -1225,6 +1235,8 @@ defineSuite([
 
         scene.globe = undefined;
         expect(scene.terrainProviderChanged).toBeUndefined();
+
+        scene.destroyForSpecs();
     });
 
 
@@ -1237,6 +1249,8 @@ defineSuite([
 
         globe.material = undefined;
         expect(globe.material).toBeUndefined();
+
+        scene.destroyForSpecs();
     });
 
 }, 'WebGL');

--- a/Specs/createFrameState.js
+++ b/Specs/createFrameState.js
@@ -18,7 +18,7 @@ define([
 
     function createFrameState(context, camera, frameNumber, time) {
         // Mock frame-state for testing.
-        var frameState = new FrameState(context, new CreditDisplay(document.createElement('div')), new JobScheduler());
+        var frameState = new FrameState(context, new CreditDisplay(document.createElement('div'), undefined, document.createElement('div')), new JobScheduler());
 
         var projection = new GeographicProjection();
         frameState.mapProjection = projection;

--- a/Specs/pick.js
+++ b/Specs/pick.js
@@ -35,7 +35,7 @@ define([
         var passState = pickFramebuffer.begin(rectangle);
 
         var oldPasses = frameState.passes;
-        frameState.passes = (new FrameState(new CreditDisplay(document.createElement('div')), new JobScheduler())).passes;
+        frameState.passes = (new FrameState(new CreditDisplay(document.createElement('div'), undefined, document.createElement('div')), new JobScheduler())).passes;
         frameState.passes.pick = true;
 
         primitives.update(frameState);


### PR DESCRIPTION
Fixes #6015

- Updated `CreditDisplay` `Scene` and `CesiumWidget` to properly remove elements they've added to the DOM
- Updated `CreditDisplaySpec` to destroy after each test
- Fixed a few spots where we we calling `createScene` but not `destroyForSpecs`

@emackey 