### PR TITLE
loadWithXhr resolve undefined for status code 204

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,0 +1,19 @@
+<component name="ProjectCodeStyleConfiguration">
+  <code_scheme name="Project" version="173">
+    <JSCodeStyleSettings>
+      <option name="SPACE_BEFORE_PROPERTY_COLON" value="true" />
+      <option name="SPACE_BEFORE_FUNCTION_LEFT_PARENTH" value="false" />
+    </JSCodeStyleSettings>
+    <XML>
+      <option name="XML_LEGACY_SETTINGS_IMPORTED" value="true" />
+    </XML>
+    <codeStyleSettings language="JavaScript">
+      <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
+      <option name="ALIGN_MULTILINE_BINARY_OPERATION" value="true" />
+      <option name="ALIGN_MULTILINE_TERNARY_OPERATION" value="true" />
+      <option name="ALIGN_MULTILINE_ARRAY_INITIALIZER_EXPRESSION" value="true" />
+      <option name="METHOD_PARAMETERS_LPAREN_ON_NEXT_LINE" value="true" />
+      <option name="IF_BRACE_FORCE" value="3" />
+    </codeStyleSettings>
+  </code_scheme>
+</component>

--- a/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/codeStyles/codeStyleConfig.xml
@@ -1,0 +1,5 @@
+<component name="ProjectCodeStyleConfiguration">
+  <state>
+    <option name="USE_PER_PROJECT_SETTINGS" value="true" />
+  </state>
+</component>

--- a/Source/Core/loadCRN.js
+++ b/Source/Core/loadCRN.js
@@ -67,6 +67,9 @@ define([
         }
 
         return loadPromise.then(function(data) {
+            if (!defined(data)) {
+                return;
+            }
             var transferrableObjects = [];
             if (data instanceof ArrayBuffer) {
                 transferrableObjects.push(data);

--- a/Source/Core/loadImageViaBlob.js
+++ b/Source/Core/loadImageViaBlob.js
@@ -70,6 +70,9 @@ define([
         }
 
         return blobPromise.then(function(blob) {
+            if (!defined(blob)) {
+                return;
+            }
             var blobUrl = window.URL.createObjectURL(blob);
 
             return loadImage(blobUrl, false).then(function(image) {

--- a/Source/Core/loadJson.js
+++ b/Source/Core/loadJson.js
@@ -65,6 +65,9 @@ define([
         }
 
         return textPromise.then(function(value) {
+            if (!defined(value)) {
+                return;
+            }
             return JSON.parse(value);
         });
     }

--- a/Source/Core/loadKTX.js
+++ b/Source/Core/loadKTX.js
@@ -86,7 +86,9 @@ define([
         }
 
         return loadPromise.then(function(data) {
-            return parseKTX(data);
+            if (defined(data)) {
+                return parseKTX(data);
+            }
         });
     }
 

--- a/Source/Core/loadWithXhr.js
+++ b/Source/Core/loadWithXhr.js
@@ -192,6 +192,8 @@ define([
             //or do not support the xhr.response property.
             if (defined(response) && (!defined(responseType) || (browserResponseType === responseType))) {
                 deferred.resolve(response);
+            } else if (xhr.status === 204) { // accept no content
+                deferred.resolve();
             } else if ((responseType === 'json') && typeof response === 'string') {
                 try {
                     deferred.resolve(JSON.parse(response));

--- a/Specs/Core/loadCRNSpec.js
+++ b/Specs/Core/loadCRNSpec.js
@@ -19,11 +19,7 @@ defineSuite([
     beforeEach(function() {
         fakeXHR = jasmine.createSpyObj('XMLHttpRequest', ['send', 'open', 'setRequestHeader', 'abort', 'getAllResponseHeaders']);
         fakeXHR.simulateLoad = function(response) {
-            fakeXHR.status = 200;
-            fakeXHR.response = response;
-            if (typeof fakeXHR.onload === 'function') {
-                fakeXHR.onload();
-            }
+            fakeXHR.simulateHttpResponse(200, response);
         };
         fakeXHR.simulateError = function() {
             fakeXHR.response = '';
@@ -31,7 +27,7 @@ defineSuite([
                 fakeXHR.onerror();
             }
         };
-        fakeXHR.simulateHttpError = function(statusCode, response) {
+        fakeXHR.simulateHttpResponse = function(statusCode, response) {
             fakeXHR.status = statusCode;
             fakeXHR.response = response;
             if (typeof fakeXHR.onload === 'function') {
@@ -113,11 +109,36 @@ defineSuite([
         expect(rejectedError).toBeUndefined();
 
         var error = 'some error';
-        fakeXHR.simulateHttpError(404, error);
+        fakeXHR.simulateHttpResponse(404, error);
         expect(resolvedValue).toBeUndefined();
         expect(rejectedError instanceof RequestErrorEvent).toBe(true);
         expect(rejectedError.statusCode).toEqual(404);
         expect(rejectedError.response).toEqual(error);
+    });
+
+    it('returns a promise that resolves with undefined when statusCode is 204', function() {
+        var testUrl = 'http://example.invalid/testuri';
+        var promise = loadCRN(testUrl);
+
+        expect(promise).toBeDefined();
+
+        var resolved = false;
+        var resolvedValue;
+        var rejectedError;
+        promise.then(function(value) {
+            resolved = true;
+            resolvedValue = value;
+        }, function(error) {
+            rejectedError = error;
+        });
+
+        expect(resolvedValue).toBeUndefined();
+        expect(rejectedError).toBeUndefined();
+
+        fakeXHR.simulateHttpResponse(204);
+        expect(resolved).toBe(true);
+        expect(resolvedValue).toBeUndefined();
+        expect(rejectedError).toBeUndefined();
     });
 
     it('returns a promise that resolves to a compressed texture when the request loads', function() {

--- a/Specs/Core/loadJsonSpec.js
+++ b/Specs/Core/loadJsonSpec.js
@@ -15,11 +15,7 @@ defineSuite([
     beforeEach(function() {
         fakeXHR = jasmine.createSpyObj('XMLHttpRequest', ['send', 'open', 'setRequestHeader', 'abort', 'getAllResponseHeaders']);
         fakeXHR.simulateLoad = function(response) {
-            fakeXHR.status = 200;
-            fakeXHR.response = response;
-            if (typeof fakeXHR.onload === 'function') {
-                fakeXHR.onload();
-            }
+            fakeXHR.simulateHttpResponse(200, response);
         };
         fakeXHR.simulateError = function() {
             fakeXHR.response = '';
@@ -27,7 +23,7 @@ defineSuite([
                 fakeXHR.onerror();
             }
         };
-        fakeXHR.simulateHttpError = function(statusCode, response) {
+        fakeXHR.simulateHttpResponse = function(statusCode, response) {
             fakeXHR.status = statusCode;
             fakeXHR.response = response;
             if (typeof fakeXHR.onload === 'function') {
@@ -136,11 +132,36 @@ defineSuite([
         expect(rejectedError).toBeUndefined();
 
         var error = 'some error';
-        fakeXHR.simulateHttpError(404, error);
+        fakeXHR.simulateHttpResponse(404, error);
         expect(resolvedValue).toBeUndefined();
         expect(rejectedError instanceof RequestErrorEvent).toBe(true);
         expect(rejectedError.statusCode).toEqual(404);
         expect(rejectedError.response).toEqual(error);
+    });
+
+    it('returns a promise that resolves with undefined when the status code ise 204', function() {
+        var testUrl = 'http://example.invalid/testuri';
+        var promise = loadJson(testUrl);
+
+        expect(promise).toBeDefined();
+
+        var resolved = false;
+        var resolvedValue;
+        var rejectedError;
+        promise.then(function(value) {
+            resolved = true;
+            resolvedValue = value;
+        }, function(error) {
+            rejectedError = error;
+        });
+
+        expect(resolvedValue).toBeUndefined();
+        expect(rejectedError).toBeUndefined();
+
+        fakeXHR.simulateHttpResponse(204);
+        expect(resolved).toBe(true);
+        expect(resolvedValue).toBeUndefined();
+        expect(rejectedError).toBeUndefined();
     });
 
     it('returns undefined if the request is throttled', function() {

--- a/Specs/Core/loadWithXhrSpec.js
+++ b/Specs/Core/loadWithXhrSpec.js
@@ -242,7 +242,7 @@ defineSuite([
                     fakeXHR.onerror();
                 }
             };
-            fakeXHR.simulateHttpError = function(statusCode, response) {
+            fakeXHR.simulateHttpResponse = function(statusCode, response) {
                 fakeXHR.status = statusCode;
                 fakeXHR.response = response;
                 if (typeof fakeXHR.onload === 'function') {
@@ -257,11 +257,7 @@ defineSuite([
                 }
             };
             fakeXHR.simulateResponseTextLoad = function(responseText) {
-                fakeXHR.status = 200;
-                fakeXHR.responseText = responseText;
-                if (typeof fakeXHR.onload === 'function') {
-                    fakeXHR.onload();
-                }
+                fakeXHR.simulateHttpResponse(200, responseText);
             };
 
             spyOn(window, 'XMLHttpRequest').and.returnValue(fakeXHR);
@@ -309,7 +305,7 @@ defineSuite([
                 expect(resolvedValue).toBeUndefined();
                 expect(rejectedError).toBeUndefined();
 
-                fakeXHR.simulateHttpError(199);
+                fakeXHR.simulateHttpResponse(199);
                 expect(resolvedValue).toBeUndefined();
                 expect(rejectedError instanceof RequestErrorEvent).toBe(true);
             });
@@ -334,7 +330,7 @@ defineSuite([
                 expect(resolvedValue).toBeUndefined();
                 expect(rejectedError).toBeUndefined();
 
-                fakeXHR.simulateHttpError(204);
+                fakeXHR.simulateHttpResponse(204);
                 expect(resolved).toBe(true);
                 expect(resolvedValue).toBeUndefined();
                 expect(rejectedError).toBeUndefined();

--- a/Specs/Core/loadWithXhrSpec.js
+++ b/Specs/Core/loadWithXhrSpec.js
@@ -313,6 +313,32 @@ defineSuite([
                 expect(resolvedValue).toBeUndefined();
                 expect(rejectedError instanceof RequestErrorEvent).toBe(true);
             });
+
+            it('resolves undefined for status code 204', function() {
+                var promise = loadWithXhr({
+                    url : 'http://example.invalid'
+                });
+
+                expect(promise).toBeDefined();
+
+                var resolved = false;
+                var resolvedValue;
+                var rejectedError;
+                promise.then(function(value) {
+                    resolved = true;
+                    resolvedValue = value;
+                }).otherwise(function (error) {
+                    rejectedError = error;
+                });
+
+                expect(resolvedValue).toBeUndefined();
+                expect(rejectedError).toBeUndefined();
+
+                fakeXHR.simulateHttpError(204);
+                expect(resolved).toBe(true);
+                expect(resolvedValue).toBeUndefined();
+                expect(rejectedError).toBeUndefined();
+            });
         });
 
         describe('returns a promise that resolves when the request loads', function() {


### PR DESCRIPTION
`loadWithXhr` tries to resolve content for status code 2XX.  However, if the status code is 204 that means that there shouldn't be any content in the response so we should resolve(undefined) instead.

Also, I updated WebStorm and it added new project files

@mramato 
