### PR TITLE
Remove gulpfile from release

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -251,7 +251,6 @@ gulp.task('makeZipFile', ['release'], function() {
         'Specs/**',
         'ThirdParty/**',
         'favicon.ico',
-        'gulpfile.js',
         'server.js',
         'package.json',
         'LICENSE.md',


### PR DESCRIPTION
Fixes #3911

The release zips are only meant for using Cesium, not building it, so there's no need to include the `gulpfile`.