### PR TITLE
Update requestAnimationFrame doc link

### DIFF
--- a/Source/Core/requestAnimationFrame.js
+++ b/Source/Core/requestAnimationFrame.js
@@ -62,7 +62,7 @@ define([
      * }
      * tick();
      *
-     * @see {@link http://www.w3.org/TR/animation-timing/#the-WindowAnimationTiming-interface|The WindowAnimationTiming interface}
+     * @see {@link https://www.w3.org/TR/html51/webappapis.html#animation-frames|The Web API Animation Frames interface}
      */
     function requestAnimationFrame(callback) {
         // we need this extra wrapper function because the native requestAnimationFrame


### PR DESCRIPTION
`requestAnimationFrame` was linking to an outdated specification. Updated with the new link.