### PR TITLE
Pipe through creditViewport argument to Viewer

### DIFF
--- a/Source/Scene/Scene.js
+++ b/Source/Scene/Scene.js
@@ -203,6 +203,7 @@ define([
      * @param {Canvas} options.canvas The HTML canvas element to create the scene for.
      * @param {Object} [options.contextOptions] Context and WebGL creation properties.  See details above.
      * @param {Element} [options.creditContainer] The HTML element in which the credits will be displayed.
+     * @param {Element} [options.creditViewport] The HTML element in which to display the credit popup.  If not specified, the viewport will be a added as a sibling of the canvas.
      * @param {MapProjection} [options.mapProjection=new GeographicProjection()] The map projection to use in 2D and Columbus View modes.
      * @param {Boolean} [options.orderIndependentTranslucency=true] If true and the configuration supports it, use order independent translucency.
      * @param {Boolean} [options.scene3DOnly=false] If true, optimizes memory use and performance for 3D mode but disables the ability to use 2D or Columbus View.

--- a/Source/Widgets/CesiumWidget/CesiumWidget.js
+++ b/Source/Widgets/CesiumWidget/CesiumWidget.js
@@ -159,6 +159,7 @@ define([
      * @param {Object} [options.contextOptions] Context and WebGL creation properties corresponding to <code>options</code> passed to {@link Scene}.
      * @param {Element|String} [options.creditContainer] The DOM element or ID that will contain the {@link CreditDisplay}.  If not specified, the credits are added
      *        to the bottom of the widget itself.
+     * @param {Element|String} [options.creditViewport] The DOM element or ID that will contain the credit pop up created by the {@link CreditDisplay}.  If not specified, it will appear over the widget itself.
      * @param {Number} [options.terrainExaggeration=1.0] A scalar used to exaggerate the terrain. Note that terrain exaggeration will not modify any other primitive as they are positioned relative to the ellipsoid.
      * @param {Boolean} [options.shadows=false] Determines if shadows are cast by the sun.
      * @param {ShadowMode} [options.terrainShadows=ShadowMode.RECEIVE_ONLY] Determines if the terrain casts or receives shadows from the sun.
@@ -228,11 +229,13 @@ define([
         };
         element.appendChild(canvas);
 
-        var creditContainer = document.createElement('div');
-        creditContainer.className = 'cesium-widget-credits';
+        var innerCreditContainer = document.createElement('div');
+        innerCreditContainer.className = 'cesium-widget-credits';
 
-        var creditContainerContainer = defined(options.creditContainer) ? getElement(options.creditContainer) : element;
-        creditContainerContainer.appendChild(creditContainer);
+        var creditContainer = defined(options.creditContainer) ? getElement(options.creditContainer) : element;
+        creditContainer.appendChild(innerCreditContainer);
+
+        var creditViewport = defined(options.creditViewport) ? getElement(options.creditViewport) : element;
 
         var showRenderLoopErrors = defaultValue(options.showRenderLoopErrors, true);
 
@@ -241,8 +244,9 @@ define([
         this._canvas = canvas;
         this._canvasWidth = 0;
         this._canvasHeight = 0;
-        this._creditContainerContainer = creditContainerContainer;
+        this._creditViewport = creditViewport;
         this._creditContainer = creditContainer;
+        this._innerCreditContainer = innerCreditContainer;
         this._canRender = false;
         this._renderLoopRunning = false;
         this._showRenderLoopErrors = showRenderLoopErrors;
@@ -256,7 +260,8 @@ define([
             var scene = new Scene({
                 canvas : canvas,
                 contextOptions : options.contextOptions,
-                creditContainer : creditContainer,
+                creditContainer : innerCreditContainer,
+                creditViewport: creditViewport,
                 mapProjection : options.mapProjection,
                 orderIndependentTranslucency : options.orderIndependentTranslucency,
                 scene3DOnly : defaultValue(options.scene3DOnly, false),
@@ -405,6 +410,18 @@ define([
         creditContainer: {
             get : function() {
                 return this._creditContainer;
+            }
+        },
+
+        /**
+         * Gets the credit viewport
+         * @memberof CesiumWidget.prototype
+         *
+         * @type {Element}
+         */
+        creditViewport: {
+            get: function() {
+                return this._creditViewport;
             }
         },
 
@@ -655,7 +672,7 @@ define([
     CesiumWidget.prototype.destroy = function() {
         this._scene = this._scene && this._scene.destroy();
         this._container.removeChild(this._element);
-        this._creditContainerContainer.removeChild(this._creditContainer);
+        this._creditContainer.removeChild(this._innerCreditContainer);
         destroyObject(this);
     };
 

--- a/Source/Widgets/Viewer/Viewer.js
+++ b/Source/Widgets/Viewer/Viewer.js
@@ -280,6 +280,7 @@ define([
      * @param {Globe} [options.globe=new Globe(mapProjection.ellipsoid)] The globe to use in the scene.  If set to <code>false</code>, no globe will be added.
      * @param {Boolean} [options.orderIndependentTranslucency=true] If true and the configuration supports it, use order independent translucency.
      * @param {Element|String} [options.creditContainer] The DOM element or ID that will contain the {@link CreditDisplay}.  If not specified, the credits are added to the bottom of the widget itself.
+     * @param {Element|String} [options.creditViewport] The DOM element or ID that will contain the credit pop up created by the {@link CreditDisplay}.  If not specified, it will appear over the widget itself.
      * @param {DataSourceCollection} [options.dataSources=new DataSourceCollection()] The collection of data sources visualized by the widget.  If this parameter is provided,
      *                               the instance is assumed to be owned by the caller and will not be destroyed when the viewer is destroyed.
      * @param {Number} [options.terrainExaggeration=1.0] A scalar used to exaggerate the terrain. Note that terrain exaggeration will not modify any other primitive as they are positioned relative to the ellipsoid.
@@ -430,6 +431,7 @@ Either specify options.terrainProvider instead or set options.baseLayerPicker to
             targetFrameRate : options.targetFrameRate,
             showRenderLoopErrors : options.showRenderLoopErrors,
             creditContainer : defined(options.creditContainer) ? options.creditContainer : bottomContainer,
+            creditViewport: options.creditViewport,
             scene3DOnly : scene3DOnly,
             terrainExaggeration : options.terrainExaggeration,
             shadows : options.shadows,

--- a/Specs/Widgets/CesiumWidget/CesiumWidgetSpec.js
+++ b/Specs/Widgets/CesiumWidget/CesiumWidgetSpec.js
@@ -68,6 +68,7 @@ defineSuite([
         expect(widget.container).toBeInstanceOf(HTMLElement);
         expect(widget.canvas).toBeInstanceOf(HTMLElement);
         expect(widget.creditContainer).toBeInstanceOf(HTMLElement);
+        expect(widget.creditViewport).toBeInstanceOf(HTMLElement);
         expect(widget.scene).toBeInstanceOf(Scene);
         expect(widget.imageryLayers).toBeInstanceOf(ImageryLayerCollection);
         expect(widget.terrainProvider).toBeInstanceOf(EllipsoidTerrainProvider);


### PR DESCRIPTION
When I added the credit popover, I added a `creditViewport` param to `CreditDisplay` and `Scene` for specifying the parent container for the credit popup overlay.  However, I missed piping it through `CesiumWidget` and `Viewer`.

- Add `creditViewport` option to `CesiumWidget` and `Viewer`.  If not specified, it defaults to the `CesiumWidget` element
- `CesiumWidget.creditContainer` was returning the wrong element, so I fixed that.  It was returning an element created by the `CesiumWidget` instead of the element that was passed in by the user.
- Add `creditViewport` to doc in `Scene`