### PR TITLE
gltf-pipeline fix for _BATCHID semantic

### DIFF
--- a/Source/ThirdParty/GltfPipeline/processPbrMetallicRoughness.js
+++ b/Source/ThirdParty/GltfPipeline/processPbrMetallicRoughness.js
@@ -729,15 +729,16 @@ define([
                 if (!defined(techniqueParameterForSemantic(technique, semantic))) {
                     var accessorId = attributes[semantic];
                     var accessor = accessors[accessorId];
-                    if (semantic.charAt(0) === '_') {
-                        semantic = semantic.slice(1);
+                    var lowerCase = semantic.toLowerCase();
+                    if (lowerCase.charAt(0) === '_') {
+                        lowerCase = lowerCase.slice(1);
                     }
-                    var attributeName = 'a_' + semantic;
-                    technique.parameters[semantic] = {
-                        semantic : semantic,
-                        type : accessor.componentType
+                    var attributeName = 'a_' + lowerCase;
+                    technique.parameters[lowerCase] = {
+                        semantic: semantic,
+                        type: accessor.componentType
                     };
-                    technique.attributes[attributeName] = semantic;
+                    technique.attributes[attributeName] = lowerCase;
                     program.attributes.push(attributeName);
                     var pipelineExtras = vertexShader.extras._pipeline;
                     var shaderText = pipelineExtras.source;


### PR DESCRIPTION
This is a fix for when a gltf with PBR uses the _BATCHID semantic or other underscored semantics. It only affected loading a gltf model, not a b3dm.

The gltf-pipeline PR is here with a couple more notes: https://github.com/AnalyticalGraphicsInc/gltf-pipeline/pull/340

Bug reported on the forum: https://groups.google.com/forum/#!topic/cesium-dev/qMKvqBUGsoE