### PR TITLE
Fix point cloud crash in IE

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@ Change Log
     * Added `Plane.transformPlane` function to apply a transformation to a plane. [#5966](https://github.com/AnalyticalGraphicsInc/cesium/pull/5966)
     * Added `PlaneGeometry`, `PlaneOutlineGeometry`, `PlaneGeometryUpdater`, and `PlaneOutlineGeometryUpdater` classes to render plane primitives. [#5996](https://github.com/AnalyticalGraphicsInc/cesium/pull/5996)
     * Added `PlaneGraphics` class and `plane` property to `Entity`. [#5996](https://github.com/AnalyticalGraphicsInc/cesium/pull/5996)
+* Fixed point cloud crash in IE [#6047](https://github.com/AnalyticalGraphicsInc/cesium/pull/6047)
 
 ### 1.40 - 2017-12-01
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,7 +9,7 @@ Change Log
     * Added `Plane.transformPlane` function to apply a transformation to a plane. [#5966](https://github.com/AnalyticalGraphicsInc/cesium/pull/5966)
     * Added `PlaneGeometry`, `PlaneOutlineGeometry`, `PlaneGeometryUpdater`, and `PlaneOutlineGeometryUpdater` classes to render plane primitives. [#5996](https://github.com/AnalyticalGraphicsInc/cesium/pull/5996)
     * Added `PlaneGraphics` class and `plane` property to `Entity`. [#5996](https://github.com/AnalyticalGraphicsInc/cesium/pull/5996)
-* Fixed point cloud crash in IE [#6047](https://github.com/AnalyticalGraphicsInc/cesium/pull/6047)
+* Fixed point cloud crash in IE [#6051](https://github.com/AnalyticalGraphicsInc/cesium/pull/6051)
 
 ### 1.40 - 2017-12-01
 

--- a/Source/Scene/Cesium3DTileBatchTable.js
+++ b/Source/Scene/Cesium3DTileBatchTable.js
@@ -1008,7 +1008,6 @@ define([
                     '    tile_color(tile_featureColor); \n' +
                     '}';
             } else {
-                source += '';
                 if (handleTranslucent) {
                     source += 'uniform bool tile_translucentCommand; \n';
                 }

--- a/Source/Scene/Cesium3DTileBatchTable.js
+++ b/Source/Scene/Cesium3DTileBatchTable.js
@@ -858,9 +858,12 @@ define([
 
             if (ContextLimits.maximumVertexTextureImageUnits > 0) {
                 // When VTF is supported, perform per-feature show/hide in the vertex shader
-                newMain =
+                newMain = '';
+                if (handleTranslucent) {
+                    newMain += 'uniform bool tile_translucentCommand; \n';
+                }
+                newMain +=
                     'uniform sampler2D tile_batchTexture; \n' +
-                    'uniform bool tile_translucentCommand; \n' +
                     'varying vec4 tile_featureColor; \n' +
                     'void main() \n' +
                     '{ \n' +
@@ -1005,9 +1008,12 @@ define([
                     '    tile_color(tile_featureColor); \n' +
                     '}';
             } else {
+                source += '';
+                if (handleTranslucent) {
+                    source += 'uniform bool tile_translucentCommand; \n';
+                }
                 source +=
                     'uniform sampler2D tile_batchTexture; \n' +
-                    'uniform bool tile_translucentCommand; \n' +
                     'varying vec2 tile_featureSt; \n' +
                     'void main() \n' +
                     '{ \n' +


### PR DESCRIPTION
This fixes a crash in IE where the `tile_translucentCommand` uniform is discovered by `gl.getActiveUniform` but is not included in the uniform map. The fix is to to not declare `tile_translucentCommand` if `handleTranslucent` is false, which is the case for point clouds.

Chrome and Firefox must be smarter about realizing the uniform was not actually being used, so this bug did not surface on those browsers.