### PR TITLE
Show point cloud tests under the correct heading

### DIFF
--- a/Specs/Scene/PointCloud3DTileContentSpec.js
+++ b/Specs/Scene/PointCloud3DTileContentSpec.js
@@ -16,7 +16,7 @@ defineSuite([
         'Specs/Cesium3DTilesTester',
         'Specs/createScene',
         'ThirdParty/when'
-    ], function(
+    ], 'Scene/PointCloud3DTileContent', function(
         Cartesian3,
         ClippingPlaneCollection,
         Color,


### PR DESCRIPTION
Point clouds tests were accidentally running under the `Cartesian3` header because that is the first require. Now they run under the proper heading.

Thanks @bagnell for catching this.