### PR TITLE
Fix crash when using invert classification and resizing the window

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@ Change Log
     * Added `PlaneGeometry`, `PlaneOutlineGeometry`, `PlaneGeometryUpdater`, and `PlaneOutlineGeometryUpdater` classes to render plane primitives. [#5996](https://github.com/AnalyticalGraphicsInc/cesium/pull/5996)
     * Added `PlaneGraphics` class and `plane` property to `Entity`. [#5996](https://github.com/AnalyticalGraphicsInc/cesium/pull/5996)
 * Fixed point cloud crash in IE [#6051](https://github.com/AnalyticalGraphicsInc/cesium/pull/6051)
+* Fixed crash when `invertClassification` was enabled, the invert color had an alpha less than `1.0`, and the window was resized. [#6046](https://github.com/AnalyticalGraphicsInc/cesium/issues/6046)
 
 ### 1.40 - 2017-12-01
 

--- a/Source/Scene/InvertClassification.js
+++ b/Source/Scene/InvertClassification.js
@@ -220,7 +220,7 @@ define([
                 })
             });
 
-            if (previousFramebufferChanged && !defined(this._previousFramebuffer)) {
+            if (!defined(this._previousFramebuffer)) {
                 this._classifiedTexture = new Texture({
                     context : context,
                     width : width,

--- a/Source/Scene/Scene.js
+++ b/Source/Scene/Scene.js
@@ -2667,7 +2667,7 @@ define([
             clear.execute(context, passState);
         }
 
-        var useInvertClassification = environmentState.useInvertClassification = defined(passState.framebuffer) && scene.invertClassification;
+        var useInvertClassification = environmentState.useInvertClassification = !picking && defined(passState.framebuffer) && scene.invertClassification;
         if (useInvertClassification) {
             var depthFramebuffer;
             if (scene.frameState.invertClassificationColor.alpha === 1.0) {


### PR DESCRIPTION
* Fix crash when resizing window and invert classification in enabled.
* Do not update FBOs when picking as they are not used.

Fixes #6046.