### PR TITLE
Clarify globe materials sandcastle example 'change color' button

### DIFF
--- a/Apps/Sandcastle/gallery/Globe Materials.html
+++ b/Apps/Sandcastle/gallery/Globe Materials.html
@@ -52,7 +52,7 @@
             Line Width <input style="width: 125px" type="range" min="1.0" max="10.0" step="1.0" data-bind="value: contourWidth, valueUpdate: 'input', enable: enableContour"> <span data-bind="text: contourWidth"></span>px
         </div>
         <div>
-            <button type="button" data-bind="click: changeColor, enable: enableContour">Change color</button>
+            <button type="button" data-bind="click: changeColor, enable: enableContour">Change contour color</button>
         </div>
     </div>
 </div>


### PR DESCRIPTION
Fixes #6058

The button was already disabled when contour is disabled, but the styling might not be easily recognizable as disabled.

Instead, I also changed the button text from 'change color' -> 'change contour color'