### PR TITLE
Handle unexpected json response from bing api

### DIFF
--- a/Source/Scene/BingMapsImageryProvider.js
+++ b/Source/Scene/BingMapsImageryProvider.js
@@ -150,6 +150,10 @@ define([
         var metadataError;
 
         function metadataSuccess(data) {
+            if (data.resourceSets.length !== 1) {
+                metadataFailure();
+                return;
+            }
             var resource = data.resourceSets[0].resources[0];
 
             that._tileWidth = resource.imageWidth;


### PR DESCRIPTION
`data.resourceSets` may be an empty array if something happens unexpectedly (for example, hitting a rate limit)