### PR TITLE
Disable clip plane shader code in IE, update docs

### DIFF
--- a/Apps/Sandcastle/gallery/3D Tiles Clipping Planes.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Clipping Planes.html
@@ -48,6 +48,7 @@ function startup(Cesium) {
 
 // Add a clipping plane, a plane geometry to show the representation of the
 // plane, and control the magnitude of the plane distance with the mouse.
+// Clipping planes are not currently supported in Internet Explorer.
 
 var viewer = new Cesium.Viewer('cesiumContainer', {
     infoBox: false,

--- a/Apps/Sandcastle/gallery/Terrain Clipping Planes.html
+++ b/Apps/Sandcastle/gallery/Terrain Clipping Planes.html
@@ -39,6 +39,9 @@
 function startup(Cesium) {
     'use strict';
 //Sandcastle_Begin
+// Use clipping planes to selectively hide parts of the globe surface.
+// Clipping planes are not currently supported in Internet Explorer.
+
 var viewer = new Cesium.Viewer('cesiumContainer', {
     skyAtmosphere: false
 });

--- a/Source/Scene/Cesium3DTileset.js
+++ b/Source/Scene/Cesium3DTileset.js
@@ -101,7 +101,7 @@ define([
      * @param {Number} [options.skipLevels=1] When <code>skipLevelOfDetail</code> is <code>true</code>, a constant defining the minimum number of levels to skip when loading tiles. When it is 0, no levels are skipped. Used in conjunction with <code>skipScreenSpaceErrorFactor</code> to determine which tiles to load.
      * @param {Boolean} [options.immediatelyLoadDesiredLevelOfDetail=false] When <code>skipLevelOfDetail</code> is <code>true</code>, only tiles that meet the maximum screen space error will ever be downloaded. Skipping factors are ignored and just the desired tiles are loaded.
      * @param {Boolean} [options.loadSiblings=false] When <code>skipLevelOfDetail</code> is <code>true</code>, determines whether siblings of visible tiles are always downloaded during traversal.
-     * @param {ClippingPlaneCollection} [options.clippingPlanes] The {@link ClippingPlaneCollection} used to selectively disable rendering the tileset.
+     * @param {ClippingPlaneCollection} [options.clippingPlanes] The {@link ClippingPlaneCollection} used to selectively disable rendering the tileset. Clipping planes are not currently supported in Internet Explorer.
      * @param {Boolean} [options.debugFreezeFrame=false] For debugging only. Determines if only the tiles from last frame should be used for rendering.
      * @param {Boolean} [options.debugColorizeTiles=false] For debugging only. When true, assigns a random color to each tile.
      * @param {Boolean} [options.debugWireframe=false] For debugging only. When true, render's each tile's content as a wireframe.
@@ -520,7 +520,7 @@ define([
         this.loadSiblings = defaultValue(options.loadSiblings, false);
 
         /**
-         * The {@link ClippingPlaneCollection} used to selectively disable rendering the tileset.
+         * The {@link ClippingPlaneCollection} used to selectively disable rendering the tileset. Clipping planes are not currently supported in Internet Explorer.
          *
          * @type {ClippingPlaneCollection}
          */

--- a/Source/Scene/Globe.js
+++ b/Source/Scene/Globe.js
@@ -232,7 +232,7 @@ define([
             }
         },
         /**
-         * A property specifying a {@link ClippingPlaneCollection} used to selectively disable rendering on the outside of each plane.
+         * A property specifying a {@link ClippingPlaneCollection} used to selectively disable rendering on the outside of each plane. Clipping planes are not currently supported in Internet Explorer.
          *
          * @memberof Globe.prototype
          * @type {ClippingPlaneCollection}

--- a/Source/Scene/GlobeSurfaceTileProvider.js
+++ b/Source/Scene/GlobeSurfaceTileProvider.js
@@ -13,6 +13,7 @@ define([
         '../Core/destroyObject',
         '../Core/DeveloperError',
         '../Core/Event',
+        '../Core/FeatureDetection',
         '../Core/GeometryInstance',
         '../Core/GeometryPipeline',
         '../Core/IndexDatatype',
@@ -59,6 +60,7 @@ define([
         destroyObject,
         DeveloperError,
         Event,
+        FeatureDetection,
         GeometryInstance,
         GeometryPipeline,
         IndexDatatype,
@@ -1320,7 +1322,7 @@ define([
                 uniformMapProperties.clippingPlanesEdgeWidth = clippingPlanes.edgeWidth;
             }
 
-            var clippingPlanesEnabled = defined(clippingPlanes) && clippingPlanes.enabled && (uniformMapProperties.clippingPlanes.length > 0);
+            var clippingPlanesEnabled = defined(clippingPlanes) && clippingPlanes.enabled && (uniformMapProperties.clippingPlanes.length > 0) && !FeatureDetection.isInternetExplorer();
             var unionClippingRegions = clippingPlanesEnabled ? clippingPlanes.unionClippingRegions : false;
 
             if (defined(tileProvider.uniformMap)) {

--- a/Source/Scene/Model.js
+++ b/Source/Scene/Model.js
@@ -340,7 +340,7 @@ define([
      * @param {Number} [options.colorBlendAmount=0.5] Value used to determine the color strength when the <code>colorBlendMode</code> is <code>MIX</code>. A value of 0.0 results in the model's rendered color while a value of 1.0 results in a solid color, with any value in-between resulting in a mix of the two.
      * @param {Color} [options.silhouetteColor=Color.RED] The silhouette color. If more than 256 models have silhouettes enabled, there is a small chance that overlapping models will have minor artifacts.
      * @param {Number} [options.silhouetteSize=0.0] The size of the silhouette in pixels.
-     * @param {ClippingPlaneCollection} [options.clippingPlanes] The {@link ClippingPlaneCollection} used to selectively disable rendering the model.
+     * @param {ClippingPlaneCollection} [options.clippingPlanes] The {@link ClippingPlaneCollection} used to selectively disable rendering the model. Clipping planes are not currently supported in Internet Explorer.
      *
      * @exception {DeveloperError} bgltf is not a valid Binary glTF file.
      * @exception {DeveloperError} Only glTF Binary version 1 is supported.
@@ -586,7 +586,7 @@ define([
         this.colorBlendAmount = defaultValue(options.colorBlendAmount, 0.5);
 
         /**
-         * The {@link ClippingPlaneCollection} used to selectively disable rendering the model.
+         * The {@link ClippingPlaneCollection} used to selectively disable rendering the model. Clipping planes are not currently supported in Internet Explorer.
          *
          * @type {ClippingPlaneCollection}
          */
@@ -2116,7 +2116,9 @@ define([
 
         var premultipliedAlpha = hasPremultipliedAlpha(model);
         var finalFS = modifyShaderForColor(fs, premultipliedAlpha);
-        finalFS = modifyShaderForClippingPlanes(finalFS);
+        if (!FeatureDetection.isInternetExplorer()) {
+            finalFS = modifyShaderForClippingPlanes(finalFS);
+        }
 
         var drawVS = modifyShader(vs, id, model._vertexShaderLoaded);
         var drawFS = modifyShader(finalFS, id, model._fragmentShaderLoaded);

--- a/Source/Scene/PointCloud3DTileContent.js
+++ b/Source/Scene/PointCloud3DTileContent.js
@@ -844,7 +844,7 @@ define([
         var hasColorStyle = defined(colorStyleFunction);
         var hasShowStyle = defined(showStyleFunction);
         var hasPointSizeStyle = defined(pointSizeStyleFunction);
-        var hasClippedContent = defined(clippingPlanes) && clippingPlanes.enabled && content._tile._isClipped;
+        var hasClippedContent = defined(clippingPlanes) && clippingPlanes.enabled && content._tile._isClipped && !FeatureDetection.isInternetExplorer();
 
         // Get the properties in use by the style
         var styleableProperties = [];


### PR DESCRIPTION
CC #6077

Disable clip plane shader code from generating in IE, updated docs and Sandcastle examples to reflect this.

Should I add tests to check that the code is not generated in IE, or is that not necessary?