### PR TITLE
Merge master into vector tiles

### DIFF
--- a/Apps/Sandcastle/gallery/3D Tiles Clipping Planes.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Clipping Planes.html
@@ -48,6 +48,7 @@ function startup(Cesium) {
 
 // Add a clipping plane, a plane geometry to show the representation of the
 // plane, and control the magnitude of the plane distance with the mouse.
+// Clipping planes are not currently supported in Internet Explorer.
 
 var viewer = new Cesium.Viewer('cesiumContainer', {
     infoBox: false,
@@ -97,7 +98,7 @@ upHandler.setInputAction(function() {
 var moveHandler = new Cesium.ScreenSpaceEventHandler(viewer.scene.canvas);
 moveHandler.setInputAction(function(movement) {
     if (Cesium.defined(selectedPlane)) {
-        var deltaY = movement.endPosition.y - movement.startPosition.y;
+        var deltaY = movement.startPosition.y - movement.endPosition.y;
         targetY += deltaY;
     }
 }, Cesium.ScreenSpaceEventType.MOUSE_MOVE);
@@ -106,10 +107,7 @@ var scratchPlane = new Cesium.Plane(Cesium.Cartesian3.UNIT_X, 0.0);
 function createPlaneUpdateFunction(plane, transform) {
     return function () {
         plane.distance = targetY;
-
-        var transformedPlane = Cesium.Plane.transform(plane, transform, scratchPlane);
-        transformedPlane.distance = -transformedPlane.distance;
-        return transformedPlane;
+        return Cesium.Plane.transform(plane, transform, scratchPlane);
     };
 }
 

--- a/Apps/Sandcastle/gallery/Globe Materials.html
+++ b/Apps/Sandcastle/gallery/Globe Materials.html
@@ -52,7 +52,7 @@
             Line Width <input style="width: 125px" type="range" min="1.0" max="10.0" step="1.0" data-bind="value: contourWidth, valueUpdate: 'input', enable: enableContour"> <span data-bind="text: contourWidth"></span>px
         </div>
         <div>
-            <button type="button" data-bind="click: changeColor, enable: enableContour">Change color</button>
+            <button type="button" data-bind="click: changeColor, enable: enableContour">Change contour color</button>
         </div>
     </div>
 </div>

--- a/Apps/Sandcastle/gallery/Terrain Clipping Planes.html
+++ b/Apps/Sandcastle/gallery/Terrain Clipping Planes.html
@@ -39,6 +39,9 @@
 function startup(Cesium) {
     'use strict';
 //Sandcastle_Begin
+// Use clipping planes to selectively hide parts of the globe surface.
+// Clipping planes are not currently supported in Internet Explorer.
+
 var viewer = new Cesium.Viewer('cesiumContainer', {
     skyAtmosphere: false
 });
@@ -75,10 +78,10 @@ globe.depthTestAgainstTerrain = true;
 globe.clippingPlanes = new Cesium.ClippingPlaneCollection({
     modelMatrix : entity.computeModelMatrix(Cesium.JulianDate.now()),
     planes : [
-        new Cesium.Plane(new Cesium.Cartesian3( 1.0,  0.0, 0.0), 700.0),
-        new Cesium.Plane(new Cesium.Cartesian3(-1.0,  0.0, 0.0), 700.0),
-        new Cesium.Plane(new Cesium.Cartesian3( 0.0,  1.0, 0.0), 700.0),
-        new Cesium.Plane(new Cesium.Cartesian3( 0.0, -1.0, 0.0), 700.0)
+        new Cesium.Plane(new Cesium.Cartesian3( 1.0,  0.0, 0.0), -700.0),
+        new Cesium.Plane(new Cesium.Cartesian3(-1.0,  0.0, 0.0), -700.0),
+        new Cesium.Plane(new Cesium.Cartesian3( 0.0,  1.0, 0.0), -700.0),
+        new Cesium.Plane(new Cesium.Cartesian3( 0.0, -1.0, 0.0), -700.0)
     ],
     edgeWidth: 1.0,
     edgeColor: Cesium.Color.WHITE

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,14 +1,20 @@
 Change Log
 ==========
 
-### 1.41 - 2017-01-02
+### 1.41 - 2018-01-02
 
+* Breaking changes
+  * Removed the `text`, `imageUrl`, and `link` parameters from `Credit`, which were deprecated in Cesium 1.40.  Use `options.text`, `options.imageUrl`, and `options.link` instead.
 * Added support for clipping planes
     * Added `clippingPlanes` property to `ModelGraphics`, `Model`, and `Cesium3DTileset`, which specifies a `ClippingPlaneCollection` to selectively disable rendering on the object. [#5913](https://github.com/AnalyticalGraphicsInc/cesium/pull/5913)
     * Added `clippingPlanes` property to `Globe` which specifies a `ClippingPlaneCollection` to selectively disable rendering of the globe surface. [#5996](https://github.com/AnalyticalGraphicsInc/cesium/pull/5996)
     * Added `Plane.transformPlane` function to apply a transformation to a plane. [#5966](https://github.com/AnalyticalGraphicsInc/cesium/pull/5966)
     * Added `PlaneGeometry`, `PlaneOutlineGeometry`, `PlaneGeometryUpdater`, and `PlaneOutlineGeometryUpdater` classes to render plane primitives. [#5996](https://github.com/AnalyticalGraphicsInc/cesium/pull/5996)
     * Added `PlaneGraphics` class and `plane` property to `Entity`. [#5996](https://github.com/AnalyticalGraphicsInc/cesium/pull/5996)
+* Fixed point cloud exception in IE. [#6051](https://github.com/AnalyticalGraphicsInc/cesium/pull/6051)
+* Fixed globe materials when `Globe.enableLighting` was `false`. [#6042](https://github.com/AnalyticalGraphicsInc/cesium/issues/6042)
+* Fixed shader compilation failure on pick when globe materials were enabled. [#6039](https://github.com/AnalyticalGraphicsInc/cesium/issues/6039)
+* Fixed exception when `invertClassification` was enabled, the invert color had an alpha less than `1.0`, and the window was resized. [#6046](https://github.com/AnalyticalGraphicsInc/cesium/issues/6046)
 * Added `AttributeCompression.zigZagDeltaDecode` which will decode delta and ZigZag encoded buffers in place.
 * Added `pack` and `unpack` functions to `OrientedBoundingBox` for packing to and unpacking from a flat buffer.
 * Added experimental support for [3D Tiles Vector Data](https://github.com/AnalyticalGraphicsInc/3d-tiles/tree/vector-tiles/TileFormats/VectorData) ([#4665](https://github.com/AnalyticalGraphicsInc/cesium/pull/4665)). The new and modified Cesium APIs are:
@@ -27,7 +33,7 @@ Change Log
 ### 1.40 - 2017-12-01
 
 * Deprecated
-  * The `text`, `imageUrl` and `link` parameters for `Credit` have been deprecated and will be removed in Cesium 1.41.  Use `options.text`, `options.imageUrl` and `options.link` instead.
+  * The `text`, `imageUrl` and `link` parameters from `Credit` have been deprecated and will be removed in Cesium 1.41.  Use `options.text`, `options.imageUrl` and `options.link` instead.
 * Added `Globe.material` to apply materials to the globe/terrain for shading such as height- or slope-based color ramps.  See the new [Sandcastle example](https://cesiumjs.org/Cesium/Apps/Sandcastle/?src=Globe%20Materials.html&label=Showcases). [#5919](https://github.com/AnalyticalGraphicsInc/cesium/pull/5919/files)
 * Added CZML support for `polyline.depthFailMaterial`, `label.scaleByDistance`, `distanceDisplayCondition`, and `disableDepthTestDistance`. [#5986](https://github.com/AnalyticalGraphicsInc/cesium/pull/5986)
 * Fixed a bug where drill picking a polygon clamped to ground would cause the browser to hang. [#5971](https://github.com/AnalyticalGraphicsInc/cesium/issues/5971)

--- a/README.md
+++ b/README.md
@@ -49,6 +49,11 @@ We appreciate attribution by including the Cesium logo and link in your app.
 ### Demos ###
 
 <p align="center">
+<a href="http://cesiumjs.org/demos/idecanarias/"><img src="http://cesiumjs.org/demos/images/idecanarias.jpg" height="150" /></a>&nbsp;
+<a href="http://cesiumjs.org/demos/pop/"><img src="http://cesiumjs.org/demos/images/pop_bubbles.jpg" height="150" /></a>&nbsp;    
+<a href="http://cesiumjs.org/demos/onesky/"><img src="http://cesiumjs.org/demos/images/onesky.jpg" height="150" /></a>&nbsp;    
+<a href="http://cesiumjs.org/demos/analyticalservices/"><img src="http://cesiumjs.org/demos/images/analyticalservices.jpg" height="150" /></a>&nbsp;    
+<a href="http://cesiumjs.org/demos/uch_enmek/"><img src="http://cesiumjs.org/demos/images/uch_enmek.png" height="150" /></a>&nbsp;
 <a href="http://cesiumjs.org/demos/fishing/"><img src="http://cesiumjs.org/demos/images/fishing.jpg" height="150" /></a>&nbsp;
 <a href="http://cesiumjs.org/demos/moontrek/"><img src="http://cesiumjs.org/demos/images/moontrek.jpg" height="150" /></a>&nbsp;
 <a href="http://cesiumjs.org/demos/maven/"><img src="http://cesiumjs.org/demos/images/maven.jpg" height="150" /></a>&nbsp;

--- a/Source/Core/Credit.js
+++ b/Source/Core/Credit.js
@@ -2,13 +2,11 @@ define([
     './defaultValue',
     './defined',
     './defineProperties',
-    './deprecationWarning',
     './DeveloperError'
 ], function(
     defaultValue,
     defined,
     defineProperties,
-    deprecationWarning,
     DeveloperError) {
     'use strict';
 
@@ -26,23 +24,23 @@ define([
      * @alias Credit
      * @constructor
      *
+     * @exception {DeveloperError} options.text, options.imageUrl, or options.link is required.
+     *
      * @example
      * //Create a credit with a tooltip, image and link
-     * var credit = new Cesium.Credit('Cesium', '/images/cesium_logo.png', 'http://cesiumjs.org/');
+     * var credit = new Cesium.Credit({
+     *     text : 'Cesium',
+     *     imageUrl : '/images/cesium_logo.png',
+     *     link : 'http://cesiumjs.org/'
+     * });
      */
-    function Credit(options, imageUrl, link) {
-        var text;
-        var showOnScreen;
-        if (typeof options !== 'object') {
-            deprecationWarning('Credit parameters', 'The Credit text, imageUrl and link parameters have been replaced by a single options object parameter with text, imageUrl and link properties. Use of the old parameters will be removed in Cesium 1.41');
-            text = options;
-            showOnScreen = false;
-        } else {
-            text = options.text;
-            imageUrl = options.imageUrl;
-            link = options.link;
-            showOnScreen = defaultValue(options.showOnScreen, false);
-        }
+    function Credit(options) {
+        options = defaultValue(options, defaultValue.EMPTY_OBJECT);
+
+        var text = options.text;
+        var imageUrl = options.imageUrl;
+        var link = options.link;
+        var showOnScreen = defaultValue(options.showOnScreen, false);
 
         var hasLink = (defined(link));
         var hasImage = (defined(imageUrl));
@@ -50,7 +48,7 @@ define([
 
         //>>includeStart('debug', pragmas.debug);
         if (!hasText && !hasImage && !hasLink) {
-            throw new DeveloperError('text, imageUrl or link is required');
+            throw new DeveloperError('options.text, options.imageUrl, or options.link is required.');
         }
         //>>includeEnd('debug');
 

--- a/Source/Core/Plane.js
+++ b/Source/Core/Plane.js
@@ -174,7 +174,7 @@ define([
         Matrix4.multiplyByPointAsVector(transform, plane.normal, scratchNormal);
         Cartesian3.normalize(scratchNormal, scratchNormal);
 
-        Cartesian3.multiplyByScalar(plane.normal, plane.distance, scratchPosition);
+        Cartesian3.multiplyByScalar(plane.normal, -plane.distance, scratchPosition);
         Matrix4.multiplyByPoint(transform, scratchPosition, scratchPosition);
 
         return Plane.fromPointNormal(scratchPosition, scratchNormal, result);

--- a/Source/DataSources/PlaneGeometryUpdater.js
+++ b/Source/DataSources/PlaneGeometryUpdater.js
@@ -686,7 +686,7 @@ define([
             dimensions = new Cartesian2(1.0, 1.0);
         }
 
-        var translation = Cartesian3.multiplyByScalar(normal, distance, scratchTranslation);
+        var translation = Cartesian3.multiplyByScalar(normal, -distance, scratchTranslation);
         translation = Matrix4.multiplyByPoint(modelMatrix, translation, translation);
 
         var transformedNormal = Matrix4.multiplyByPointAsVector(modelMatrix, normal, scratchNormal);

--- a/Source/Scene/BingMapsImageryProvider.js
+++ b/Source/Scene/BingMapsImageryProvider.js
@@ -150,6 +150,10 @@ define([
         var metadataError;
 
         function metadataSuccess(data) {
+            if (data.resourceSets.length !== 1) {
+                metadataFailure();
+                return;
+            }
             var resource = data.resourceSets[0].resources[0];
 
             that._tileWidth = resource.imageWidth;

--- a/Source/Scene/Cesium3DTileBatchTable.js
+++ b/Source/Scene/Cesium3DTileBatchTable.js
@@ -864,9 +864,12 @@ define([
 
             if (ContextLimits.maximumVertexTextureImageUnits > 0) {
                 // When VTF is supported, perform per-feature show/hide in the vertex shader
-                newMain =
+                newMain = '';
+                if (handleTranslucent) {
+                    newMain += 'uniform bool tile_translucentCommand; \n';
+                }
+                newMain +=
                     'uniform sampler2D tile_batchTexture; \n' +
-                    'uniform bool tile_translucentCommand; \n' +
                     'varying vec4 tile_featureColor; \n' +
                     'void main() \n' +
                     '{ \n' +
@@ -1011,9 +1014,11 @@ define([
                     '    tile_color(tile_featureColor); \n' +
                     '}';
             } else {
+                if (handleTranslucent) {
+                    source += 'uniform bool tile_translucentCommand; \n';
+                }
                 source +=
                     'uniform sampler2D tile_batchTexture; \n' +
-                    'uniform bool tile_translucentCommand; \n' +
                     'varying vec2 tile_featureSt; \n' +
                     'void main() \n' +
                     '{ \n' +

--- a/Source/Scene/Cesium3DTileset.js
+++ b/Source/Scene/Cesium3DTileset.js
@@ -105,7 +105,7 @@ define([
      * @param {Number} [options.skipLevels=1] When <code>skipLevelOfDetail</code> is <code>true</code>, a constant defining the minimum number of levels to skip when loading tiles. When it is 0, no levels are skipped. Used in conjunction with <code>skipScreenSpaceErrorFactor</code> to determine which tiles to load.
      * @param {Boolean} [options.immediatelyLoadDesiredLevelOfDetail=false] When <code>skipLevelOfDetail</code> is <code>true</code>, only tiles that meet the maximum screen space error will ever be downloaded. Skipping factors are ignored and just the desired tiles are loaded.
      * @param {Boolean} [options.loadSiblings=false] When <code>skipLevelOfDetail</code> is <code>true</code>, determines whether siblings of visible tiles are always downloaded during traversal.
-     * @param {ClippingPlaneCollection} [options.clippingPlanes] The {@link ClippingPlaneCollection} used to selectively disable rendering the tileset.
+     * @param {ClippingPlaneCollection} [options.clippingPlanes] The {@link ClippingPlaneCollection} used to selectively disable rendering the tileset. Clipping planes are not currently supported in Internet Explorer.
      * @param {ClassificationType} [options.classificationType] Determines whether terrain, 3D Tiles or both will be classified by this tileset. See {@link Cesium3DTileset#classificationType} for details about restrictions and limitations.
      * @param {Ellipsoid} [options.ellipsoid=Ellipsoid.WGS84] The ellipsoid determining the size and shape of the globe.
      * @param {Boolean} [options.debugFreezeFrame=false] For debugging only. Determines if only the tiles from last frame should be used for rendering.
@@ -530,7 +530,7 @@ define([
         this.loadSiblings = defaultValue(options.loadSiblings, false);
 
         /**
-         * The {@link ClippingPlaneCollection} used to selectively disable rendering the tileset.
+         * The {@link ClippingPlaneCollection} used to selectively disable rendering the tileset. Clipping planes are not currently supported in Internet Explorer.
          *
          * @type {ClippingPlaneCollection}
          */

--- a/Source/Scene/Globe.js
+++ b/Source/Scene/Globe.js
@@ -232,7 +232,7 @@ define([
             }
         },
         /**
-         * A property specifying a {@link ClippingPlaneCollection} used to selectively disable rendering on the outside of each plane.
+         * A property specifying a {@link ClippingPlaneCollection} used to selectively disable rendering on the outside of each plane. Clipping planes are not currently supported in Internet Explorer.
          *
          * @memberof Globe.prototype
          * @type {ClippingPlaneCollection}
@@ -261,6 +261,9 @@ define([
                 if (value !== this._terrainProvider) {
                     this._terrainProvider = value;
                     this._terrainProviderChanged.raiseEvent(value);
+                    if (defined(this._material)) {
+                        makeShadersDirty(this);
+                    }
                 }
             }
         },
@@ -311,8 +314,10 @@ define([
     function makeShadersDirty(globe) {
         var defines = [];
 
+        var requireNormals = defined(globe._material) && (globe._material.shaderSource.match(/slope/) || globe._material.shaderSource.match('normalEC'));
+
         var fragmentSources = [];
-        if (defined(globe._material)) {
+        if (defined(globe._material) && (!requireNormals || globe._terrainProvider.requestVertexNormals)) {
             fragmentSources.push(globe._material.shaderSource);
             defines.push('APPLY_MATERIAL');
             globe._surface._tileProvider.uniformMap = globe._material._uniforms;

--- a/Source/Scene/GlobeSurfaceTileProvider.js
+++ b/Source/Scene/GlobeSurfaceTileProvider.js
@@ -13,6 +13,7 @@ define([
         '../Core/destroyObject',
         '../Core/DeveloperError',
         '../Core/Event',
+        '../Core/FeatureDetection',
         '../Core/GeometryInstance',
         '../Core/GeometryPipeline',
         '../Core/IndexDatatype',
@@ -59,6 +60,7 @@ define([
         destroyObject,
         DeveloperError,
         Event,
+        FeatureDetection,
         GeometryInstance,
         GeometryPipeline,
         IndexDatatype,
@@ -1320,7 +1322,7 @@ define([
                 uniformMapProperties.clippingPlanesEdgeWidth = clippingPlanes.edgeWidth;
             }
 
-            var clippingPlanesEnabled = defined(clippingPlanes) && clippingPlanes.enabled && (uniformMapProperties.clippingPlanes.length > 0);
+            var clippingPlanesEnabled = defined(clippingPlanes) && clippingPlanes.enabled && (uniformMapProperties.clippingPlanes.length > 0) && !FeatureDetection.isInternetExplorer();
             var unionClippingRegions = clippingPlanesEnabled ? clippingPlanes.unionClippingRegions : false;
 
             if (defined(tileProvider.uniformMap)) {

--- a/Source/Scene/InvertClassification.js
+++ b/Source/Scene/InvertClassification.js
@@ -220,7 +220,7 @@ define([
                 })
             });
 
-            if (previousFramebufferChanged && !defined(this._previousFramebuffer)) {
+            if (!defined(this._previousFramebuffer)) {
                 this._classifiedTexture = new Texture({
                     context : context,
                     width : width,

--- a/Source/Scene/Model.js
+++ b/Source/Scene/Model.js
@@ -271,7 +271,7 @@ define([
      * @param {Number} [options.colorBlendAmount=0.5] Value used to determine the color strength when the <code>colorBlendMode</code> is <code>MIX</code>. A value of 0.0 results in the model's rendered color while a value of 1.0 results in a solid color, with any value in-between resulting in a mix of the two.
      * @param {Color} [options.silhouetteColor=Color.RED] The silhouette color. If more than 256 models have silhouettes enabled, there is a small chance that overlapping models will have minor artifacts.
      * @param {Number} [options.silhouetteSize=0.0] The size of the silhouette in pixels.
-     * @param {ClippingPlaneCollection} [options.clippingPlanes] The {@link ClippingPlaneCollection} used to selectively disable rendering the model.
+     * @param {ClippingPlaneCollection} [options.clippingPlanes] The {@link ClippingPlaneCollection} used to selectively disable rendering the model. Clipping planes are not currently supported in Internet Explorer.
      *
      * @exception {DeveloperError} bgltf is not a valid Binary glTF file.
      * @exception {DeveloperError} Only glTF Binary version 1 is supported.
@@ -517,7 +517,7 @@ define([
         this.colorBlendAmount = defaultValue(options.colorBlendAmount, 0.5);
 
         /**
-         * The {@link ClippingPlaneCollection} used to selectively disable rendering the model.
+         * The {@link ClippingPlaneCollection} used to selectively disable rendering the model. Clipping planes are not currently supported in Internet Explorer.
          *
          * @type {ClippingPlaneCollection}
          */
@@ -1876,7 +1876,9 @@ define([
 
         var premultipliedAlpha = hasPremultipliedAlpha(model);
         var finalFS = modifyShaderForColor(fs, premultipliedAlpha);
-        finalFS = modifyShaderForClippingPlanes(finalFS);
+        if (!FeatureDetection.isInternetExplorer()) {
+            finalFS = modifyShaderForClippingPlanes(finalFS);
+        }
 
         var drawVS = modifyShader(vs, id, model._vertexShaderLoaded);
         var drawFS = modifyShader(finalFS, id, model._fragmentShaderLoaded);

--- a/Source/Scene/PointCloud3DTileContent.js
+++ b/Source/Scene/PointCloud3DTileContent.js
@@ -844,7 +844,7 @@ define([
         var hasColorStyle = defined(colorStyleFunction);
         var hasShowStyle = defined(showStyleFunction);
         var hasPointSizeStyle = defined(pointSizeStyleFunction);
-        var hasClippedContent = defined(clippingPlanes) && clippingPlanes.enabled && content._tile._isClipped;
+        var hasClippedContent = defined(clippingPlanes) && clippingPlanes.enabled && content._tile._isClipped && !FeatureDetection.isInternetExplorer();
 
         // Get the properties in use by the style
         var styleableProperties = [];

--- a/Source/Scene/Scene.js
+++ b/Source/Scene/Scene.js
@@ -2686,7 +2686,7 @@ define([
             clear.execute(context, passState);
         }
 
-        var useInvertClassification = environmentState.useInvertClassification = defined(passState.framebuffer) && scene.invertClassification;
+        var useInvertClassification = environmentState.useInvertClassification = !picking && defined(passState.framebuffer) && scene.invertClassification;
         if (useInvertClassification) {
             var depthFramebuffer;
             if (scene.frameState.invertClassificationColor.alpha === 1.0) {

--- a/Source/Scene/WebMapTileServiceImageryProvider.js
+++ b/Source/Scene/WebMapTileServiceImageryProvider.js
@@ -78,7 +78,7 @@ define([
      *     tileMatrixSetID : 'default028mm',
      *     // tileMatrixLabels : ['default028mm:0', 'default028mm:1', 'default028mm:2' ...],
      *     maximumLevel: 19,
-     *     credit : new Cesium.Credit('U. S. Geological Survey')
+     *     credit : new Cesium.Credit({ text : 'U. S. Geological Survey' })
      * });
      * viewer.imageryLayers.addImageryProvider(shadedRelief1);
      *
@@ -91,7 +91,7 @@ define([
      *     format : 'image/jpeg',
      *     tileMatrixSetID : 'default028mm',
      *     maximumLevel: 19,
-     *     credit : new Cesium.Credit('U. S. Geological Survey')
+     *     credit : new Cesium.Credit({ text : 'U. S. Geological Survey' })
      * });
      * viewer.imageryLayers.addImageryProvider(shadedRelief2);
      *
@@ -114,7 +114,7 @@ define([
      *     format : 'image/png',
      *     clock: clock,
      *     times: times,
-     *     credit : new Cesium.Credit('NASA Global Imagery Browse Services for EOSDIS')
+     *     credit : new Cesium.Credit({ text : 'NASA Global Imagery Browse Services for EOSDIS' })
      * });
      * viewer.imageryLayers.addImageryProvider(weather);
      *

--- a/Source/Shaders/GlobeVS.glsl
+++ b/Source/Shaders/GlobeVS.glsl
@@ -135,10 +135,10 @@ void main()
     float height = position3DAndHeight.w;
     vec2 textureCoordinates = textureCoordAndEncodedNormals.xy;
 
-#if (defined(ENABLE_VERTEX_LIGHTING) || defined(GENERATE_POSITION_AND_NORMAL)) && defined(INCLUDE_WEB_MERCATOR_Y)
+#if (defined(ENABLE_VERTEX_LIGHTING) || defined(GENERATE_POSITION_AND_NORMAL) || defined(APPLY_MATERIAL)) && defined(INCLUDE_WEB_MERCATOR_Y)
     float webMercatorT = textureCoordAndEncodedNormals.z;
     float encodedNormal = textureCoordAndEncodedNormals.w;
-#elif defined(ENABLE_VERTEX_LIGHTING) || defined(GENERATE_POSITION_AND_NORMAL)
+#elif defined(ENABLE_VERTEX_LIGHTING) || defined(GENERATE_POSITION_AND_NORMAL) || defined(APPLY_MATERIAL)
     float webMercatorT = textureCoordinates.y;
     float encodedNormal = textureCoordAndEncodedNormals.z;
 #elif defined(INCLUDE_WEB_MERCATOR_Y)
@@ -156,7 +156,7 @@ void main()
 
     v_textureCoordinates = vec3(textureCoordinates, webMercatorT);
 
-#if defined(ENABLE_VERTEX_LIGHTING) || defined(GENERATE_POSITION_AND_NORMAL)
+#if defined(ENABLE_VERTEX_LIGHTING) || defined(GENERATE_POSITION_AND_NORMAL) || defined(APPLY_MATERIAL)
     v_positionEC = (u_modifiedModelView * vec4(position, 1.0)).xyz;
     v_positionMC = position3DWC;                                 // position in model coordinates
     vec3 normalMC = czm_octDecode(encodedNormal);

--- a/Specs/Core/ClippingPlaneCollectionSpec.js
+++ b/Specs/Core/ClippingPlaneCollectionSpec.js
@@ -24,7 +24,7 @@ defineSuite([
         new Plane(Cartesian3.UNIT_Y, 2.0)
     ];
 
-    var transform = new Matrix4.fromTranslation(new Cartesian3(1.0, 2.0, 3.0));
+    var transform = new Matrix4.fromTranslation(new Cartesian3(1.0, 3.0, 2.0));
     var boundingVolume  = new BoundingSphere(Cartesian3.ZERO, 1.0);
 
     it('default constructor', function() {
@@ -125,8 +125,8 @@ defineSuite([
 
         var result = clippingPlanes.transformAndPackPlanes(transform);
         expect(result.length).toEqual(2);
-        expect(result[0]).toEqual(new Cartesian4(1.0, 0.0, 0.0, -2.0));
-        expect(result[1]).toEqual(new Cartesian4(0.0, 1.0, 0.0, -4.0));
+        expect(result[0]).toEqual(new Cartesian4(1.0, 0.0, 0.0, 0.0));
+        expect(result[1]).toEqual(new Cartesian4(0.0, 1.0, 0.0, -1.0));
     });
 
     it('transforms and packs planes with no result parameter creates new array', function() {
@@ -203,7 +203,7 @@ defineSuite([
         var intersect = clippingPlanes.computeIntersectionWithBoundingVolume(boundingVolume);
         expect(intersect).toEqual(Intersect.INSIDE);
 
-        clippingPlanes.add(new Plane(Cartesian3.UNIT_X, 2.0));
+        clippingPlanes.add(new Plane(Cartesian3.UNIT_X, -2.0));
         intersect = clippingPlanes.computeIntersectionWithBoundingVolume(boundingVolume);
         expect(intersect).toEqual(Intersect.OUTSIDE);
 
@@ -211,7 +211,7 @@ defineSuite([
         intersect = clippingPlanes.computeIntersectionWithBoundingVolume(boundingVolume);
         expect(intersect).toEqual(Intersect.INTERSECTING);
 
-        clippingPlanes.add(new Plane(Cartesian3.UNIT_Z, -1.0));
+        clippingPlanes.add(new Plane(Cartesian3.UNIT_Z, 1.0));
         intersect = clippingPlanes.computeIntersectionWithBoundingVolume(boundingVolume);
         expect(intersect).toEqual(Intersect.INSIDE);
 
@@ -228,11 +228,11 @@ defineSuite([
         var intersect = clippingPlanes.computeIntersectionWithBoundingVolume(boundingVolume);
         expect(intersect).toEqual(Intersect.INSIDE);
 
-        clippingPlanes.add(new Plane(Cartesian3.UNIT_Z, -1.0));
+        clippingPlanes.add(new Plane(Cartesian3.UNIT_Z, 1.0));
         intersect = clippingPlanes.computeIntersectionWithBoundingVolume(boundingVolume);
         expect(intersect).toEqual(Intersect.INSIDE);
 
-        var temp = new Plane(Cartesian3.UNIT_Y, 2.0);
+        var temp = new Plane(Cartesian3.UNIT_Y, -2.0);
         clippingPlanes.add(temp);
         intersect = clippingPlanes.computeIntersectionWithBoundingVolume(boundingVolume);
         expect(intersect).toEqual(Intersect.OUTSIDE);

--- a/Specs/Core/PlaneSpec.js
+++ b/Specs/Core/PlaneSpec.js
@@ -201,7 +201,7 @@ defineSuite([
         transform = Matrix4.multiplyByMatrix3(transform, Matrix3.fromRotationY(Math.PI), transform);
 
         var transformedPlane = Plane.transform(plane, transform);
-        expect(transformedPlane.distance).toEqual(-plane.distance * 2.0);
+        expect(transformedPlane.distance).toEqual(plane.distance * 2.0);
         expect(transformedPlane.normal.x).toEqualEpsilon(-plane.normal.x, CesiumMath.EPSILON10);
         expect(transformedPlane.normal.y).toEqual(plane.normal.y);
         expect(transformedPlane.normal.z).toEqual(-plane.normal.z);

--- a/Specs/Scene/Cesium3DTilesetSpec.js
+++ b/Specs/Scene/Cesium3DTilesetSpec.js
@@ -2815,7 +2815,7 @@ defineSuite([
 
             expect(visibility).not.toBe(CullingVolume.MASK_OUTSIDE);
 
-            var plane = new Plane(Cartesian3.UNIT_Z, 100000000.0);
+            var plane = new Plane(Cartesian3.UNIT_Z, -100000000.0);
             tileset.clippingPlanes = new ClippingPlaneCollection({
                 planes : [
                     plane
@@ -2839,7 +2839,7 @@ defineSuite([
 
             expect(visibility).not.toBe(Intersect.OUTSIDE);
 
-            var plane = new Plane(Cartesian3.UNIT_Z, 100000000.0);
+            var plane = new Plane(Cartesian3.UNIT_Z, -100000000.0);
             tileset.clippingPlanes = new ClippingPlaneCollection({
                 planes : [
                     plane
@@ -2881,7 +2881,7 @@ defineSuite([
             expect(statistics.numberOfCommands).toEqual(5);
             expect(root._isClipped).toBe(false);
 
-            plane.distance = 4081630.311150717; // center
+            plane.distance = -4081630.311150717; // center
 
             tileset.update(scene.frameState);
             scene.renderForSpecs();
@@ -2889,7 +2889,7 @@ defineSuite([
             expect(statistics.numberOfCommands).toEqual(3);
             expect(root._isClipped).toBe(true);
 
-            plane.distance = 4081630.31115071 + 287.0736139905632; // center + radius
+            plane.distance = -4081630.31115071 - 287.0736139905632; // center + radius
 
             tileset.update(scene.frameState);
             scene.renderForSpecs();
@@ -2923,7 +2923,7 @@ defineSuite([
             expect(statistics.numberOfCommands).toEqual(6);
             expect(root._isClipped).toBe(false);
 
-            plane.distance = 4081608.4377916814; // center
+            plane.distance = -4081608.4377916814; // center
 
             tileset.update(scene.frameState);
             scene.renderForSpecs();
@@ -2931,7 +2931,7 @@ defineSuite([
             expect(statistics.numberOfCommands).toEqual(6);
             expect(root._isClipped).toBe(true);
 
-            plane.distance = 4081608.4377916814 + 142.19001637409772; // center + radius
+            plane.distance = -4081608.4377916814 - 142.19001637409772; // center + radius
 
             tileset.update(scene.frameState);
             scene.renderForSpecs();

--- a/Specs/Scene/Composite3DTileContentSpec.js
+++ b/Specs/Scene/Composite3DTileContentSpec.js
@@ -4,7 +4,7 @@ defineSuite([
         'Core/HeadingPitchRange',
         'Specs/Cesium3DTilesTester',
         'Specs/createScene'
-    ], function(
+    ], 'Scene/Composite3DTileContent', function(
         Cartesian3,
         Color,
         HeadingPitchRange,

--- a/Specs/Scene/GlobeSurfaceTileProviderSpec.js
+++ b/Specs/Scene/GlobeSurfaceTileProviderSpec.js
@@ -714,7 +714,7 @@ defineSuite([
                 expect(rgba).not.toEqual([0, 0, 0, 255]);
             });
 
-            var clipPlane = new Plane(Cartesian3.UNIT_Z, 10000.0);
+            var clipPlane = new Plane(Cartesian3.UNIT_Z, -10000.0);
             scene.globe.clippingPlanes = new ClippingPlaneCollection ({
                 planes : [
                     clipPlane
@@ -745,7 +745,7 @@ defineSuite([
                 expect(rgba).not.toEqual([0, 0, 0, 255]);
             });
 
-            var clipPlane = new Plane(Cartesian3.UNIT_Z, 1000.0);
+            var clipPlane = new Plane(Cartesian3.UNIT_Z, -1000.0);
             scene.globe.clippingPlanes = new ClippingPlaneCollection ({
                 planes : [
                     clipPlane
@@ -780,8 +780,8 @@ defineSuite([
 
             scene.globe.clippingPlanes = new ClippingPlaneCollection ({
                 planes : [
-                    new Plane(Cartesian3.UNIT_Z, 10000.0),
-                    new Plane(Cartesian3.UNIT_X, 1000.0)
+                    new Plane(Cartesian3.UNIT_Z, -10000.0),
+                    new Plane(Cartesian3.UNIT_X, -1000.0)
                 ],
                 unionClippingRegions: true
             });
@@ -809,7 +809,7 @@ defineSuite([
         var globe = scene.globe;
         globe.clippingPlanes = new ClippingPlaneCollection ({
             planes : [
-                new Plane(Cartesian3.UNIT_Z, 1000000.0)
+                new Plane(Cartesian3.UNIT_Z, -1000000.0)
             ]
         });
 
@@ -845,7 +845,7 @@ defineSuite([
         var globe = scene.globe;
         globe.clippingPlanes = new ClippingPlaneCollection ({
             planes : [
-                new Plane(Cartesian3.UNIT_Z, -10000000.0)
+                new Plane(Cartesian3.UNIT_Z, 10000000.0)
             ]
         });
 

--- a/Specs/Scene/Instanced3DModel3DTileContentSpec.js
+++ b/Specs/Scene/Instanced3DModel3DTileContentSpec.js
@@ -9,7 +9,7 @@ defineSuite([
         'Scene/TileBoundingSphere',
         'Specs/Cesium3DTilesTester',
         'Specs/createScene'
-    ], function(
+    ], 'Scene/Instanced3DModel3DTileContent', function(
         Cartesian3,
         ClippingPlaneCollection,
         Color,

--- a/Specs/Scene/ModelSpec.js
+++ b/Specs/Scene/ModelSpec.js
@@ -2588,7 +2588,7 @@ defineSuite([
                 expect(rgba).not.toEqual(modelColor);
             });
 
-            plane.distance = -10.0;
+            plane.distance = 10.0;
             model.update(scene.frameState);
             expect(scene).toRenderAndCall(function(rgba) {
                 expect(rgba).toEqual(modelColor);
@@ -2623,7 +2623,7 @@ defineSuite([
                 expect(rgba).not.toEqual(modelColor);
             });
 
-            plane.distance = -5.0;
+            plane.distance = 5.0;
             model.update(scene.frameState);
             expect(scene).toRenderAndCall(function(rgba) {
                 expect(rgba).toEqual([0, 0, 255, 255]);
@@ -2646,7 +2646,7 @@ defineSuite([
 
             model.clippingPlanes = new ClippingPlaneCollection({
                 planes : [
-                    new Plane(Cartesian3.UNIT_Z, -5.0),
+                    new Plane(Cartesian3.UNIT_Z, 5.0),
                     new Plane(Cartesian3.UNIT_X, 0.0)
                 ],
                 unionClippingRegions: true

--- a/Specs/Scene/PointCloud3DTileContentSpec.js
+++ b/Specs/Scene/PointCloud3DTileContentSpec.js
@@ -16,7 +16,7 @@ defineSuite([
         'Specs/Cesium3DTilesTester',
         'Specs/createScene',
         'ThirdParty/when'
-    ], function(
+    ], 'Scene/PointCloud3DTileContent', function(
         Cartesian3,
         ClippingPlaneCollection,
         Color,
@@ -740,7 +740,7 @@ defineSuite([
                 color = rgba;
             });
 
-            var clipPlane = new Plane(Cartesian3.UNIT_Z, 10.0);
+            var clipPlane = new Plane(Cartesian3.UNIT_Z, -10.0);
             tileset.clippingPlanes = new ClippingPlaneCollection({
                 planes : [
                     clipPlane
@@ -763,7 +763,7 @@ defineSuite([
                 color = rgba;
             });
 
-            var clipPlane = new Plane(Cartesian3.UNIT_Z, 10.0);
+            var clipPlane = new Plane(Cartesian3.UNIT_Z, -10.0);
             tileset.clippingPlanes = new ClippingPlaneCollection ({
                 planes : [
                     clipPlane
@@ -786,7 +786,7 @@ defineSuite([
 
             tileset.clippingPlanes = new ClippingPlaneCollection ({
                 planes : [
-                    new Plane(Cartesian3.UNIT_Z, 10.0),
+                    new Plane(Cartesian3.UNIT_Z, -10.0),
                     new Plane(Cartesian3.UNIT_X, 0.0)
                 ],
                 modelMatrix : Transforms.eastNorthUpToFixedFrame(tileset.boundingSphere.center),

--- a/Specs/Scene/Tileset3DTileContentSpec.js
+++ b/Specs/Scene/Tileset3DTileContentSpec.js
@@ -3,7 +3,7 @@ defineSuite([
         'Core/HeadingPitchRange',
         'Specs/Cesium3DTilesTester',
         'Specs/createScene'
-    ], function(
+    ], 'Scene/Tileset3DTileContent', function(
         Cartesian3,
         HeadingPitchRange,
         Cesium3DTilesTester,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cesium",
-  "version": "1.40.0",
+  "version": "1.41.0",
   "description": "Cesium is a JavaScript library for creating 3D globes and 2D maps in a web browser without a plugin.",
   "homepage": "http://cesiumjs.org",
   "license": "Apache-2.0",


### PR DESCRIPTION
Merge the newly released v1.41 into vector tiles.
This merge allows people relying on the vector-tiles branch to publish their own packages.
This is similar to #5960, #5875 and #5810.

Merge conflicts related to the cliping planes in two files were fixed:
- CHANGES.md (used the version from the vector-tiles branch which was more detailed);
- Source/Scene/Cesium3DTileset.js (the note about Internet Explorer compatibility was added).