### PR TITLE
Project point onto plane

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@ Change Log
   *
 * Added `ClippingPlaneCollection.isSupported` function for checking if rendering with clipping planes is supported.
 * Improved CZML Custom Properties sandcastle example [#6086](https://github.com/AnalyticalGraphicsInc/cesium/pull/6086)
+* Added `Plane.projectPointOntoPlane` for projecting a `Cartesian3` position onto a `Plane` [#6092](https://github.com/AnalyticalGraphicsInc/cesium/pull/6092) 
 
 ### 1.41 - 2018-01-02
 

--- a/Source/Core/Plane.js
+++ b/Source/Core/Plane.js
@@ -1,19 +1,19 @@
 define([
-        './Cartesian3',
-        './Check',
-        './defined',
-        './DeveloperError',
-        './freezeObject',
-        './Math',
-        './Matrix4'
-    ], function(
-        Cartesian3,
-        Check,
-        defined,
-        DeveloperError,
-        freezeObject,
-        CesiumMath,
-        Matrix4) {
+    './Cartesian3',
+    './Check',
+    './defined',
+    './DeveloperError',
+    './freezeObject',
+    './Math',
+    './Matrix4'
+], function(
+    Cartesian3,
+    Check,
+    defined,
+    DeveloperError,
+    freezeObject,
+    CesiumMath,
+    Matrix4) {
     'use strict';
 
     /**
@@ -154,6 +154,30 @@ define([
         //>>includeEnd('debug');
 
         return Cartesian3.dot(plane.normal, point) + plane.distance;
+    };
+
+    var scratchCartesian = new Cartesian3();
+    /**
+     * Projects a point onto the plane.
+     * @param {Plane} plane The plane to project the point onto
+     * @param {Cartesian3} point The point to project onto the plane
+     * @param {Cartesian3} [result] The result point.  If undefined, a new Cartesian3 will be created.
+     */
+    Plane.projectPointOntoPlane = function(plane, point, result) {
+        //>>includeStart('debug', pragmas.debug);
+        Check.typeOf.object('plane', plane);
+        Check.typeOf.object('point', point);
+        //>>includeEnd('debug');
+
+        if (!defined(result)) {
+            result = new Cartesian3();
+        }
+
+        // projectedPoint = point - (normal.point + scale) * normal
+        var pointDistance = Plane.getPointDistance(plane, point);
+        var scaledNormal = Cartesian3.multiplyByScalar(plane.normal, pointDistance, scratchCartesian);
+
+        return Cartesian3.subtract(point, scaledNormal, result);
     };
 
     var scratchPosition = new Cartesian3();

--- a/Source/Core/Plane.js
+++ b/Source/Core/Plane.js
@@ -1,19 +1,19 @@
 define([
-    './Cartesian3',
-    './Check',
-    './defined',
-    './DeveloperError',
-    './freezeObject',
-    './Math',
-    './Matrix4'
-], function(
-    Cartesian3,
-    Check,
-    defined,
-    DeveloperError,
-    freezeObject,
-    CesiumMath,
-    Matrix4) {
+        './Cartesian3',
+        './Check',
+        './defined',
+        './DeveloperError',
+        './freezeObject',
+        './Math',
+        './Matrix4'
+    ], function(
+        Cartesian3,
+        Check,
+        defined,
+        DeveloperError,
+        freezeObject,
+        CesiumMath,
+        Matrix4) {
     'use strict';
 
     /**

--- a/Specs/Core/PlaneSpec.js
+++ b/Specs/Core/PlaneSpec.js
@@ -129,6 +129,26 @@ defineSuite([
         }).toThrowDeveloperError();
     });
 
+    it('projects a point onto the plane', function() {
+        var plane = new Plane(Cartesian3.UNIT_X, 0.0);
+        var point = new Cartesian3(1.0, 1.0, 0.0);
+        var result = Plane.projectPointOntoPlane(plane, point);
+        expect(result).toEqual(new Cartesian3(0.0, 1.0, 0.0));
+
+        plane = new Plane(Cartesian3.UNIT_Y, 0.0);
+        result = Plane.projectPointOntoPlane(plane, point);
+        expect(result).toEqual(new Cartesian3(1.0, 0.0, 0.0));
+    });
+
+    it('projectPointOntoPlane uses result parameter', function() {
+        var plane = new Plane(Cartesian3.UNIT_X, 0.0);
+        var point = new Cartesian3(1.0, 1.0, 0.0);
+        var result = new Cartesian3();
+        var returnedResult = Plane.projectPointOntoPlane(plane, point, result);
+        expect(result).toBe(returnedResult);
+        expect(result).toEqual(new Cartesian3(0.0, 1.0, 0.0));
+    });
+
     it('clone throws without a plane', function() {
         expect(function() {
             Plane.clone(undefined);

--- a/Specs/Core/PlaneSpec.js
+++ b/Specs/Core/PlaneSpec.js
@@ -149,6 +149,16 @@ defineSuite([
         expect(result).toEqual(new Cartesian3(0.0, 1.0, 0.0));
     });
 
+    it('projectPointOntoPlane requires the plane and point parameters', function() {
+        expect(function() {
+            return Plane.projectPointOntoPlane(new Plane(Cartesian3.UNIT_X, 0), undefined);
+        }).toThrowDeveloperError();
+
+        expect(function() {
+            return Plane.projectPointOntoPlane(undefined, new Cartesian3());
+        }).toThrowDeveloperError();
+    });
+
     it('clone throws without a plane', function() {
         expect(function() {
             Plane.clone(undefined);


### PR DESCRIPTION
Adds a function for projecting a `Cartesian3` point onto a plane.  
I've been using this function a lot lately, so I thought it would be helpful to have in core Cesium.