### PR TITLE
Globe imagery and terrain loading trigger renders in requestRenderMode

### DIFF
--- a/Apps/Sandcastle/gallery/Scene Rendering Performance.html
+++ b/Apps/Sandcastle/gallery/Scene Rendering Performance.html
@@ -125,6 +125,18 @@ scene.postRender.addEventListener(function() {
     Cesium.knockout.getObservable(viewModel, 'lastRenderTime')(value);
 });
 
+Sandcastle.addToolbarButton('Load a tileset', function() {
+    scene.primitives.add(new Cesium.Cesium3DTileset({
+        url : 'https://beta.cesium.com/api/assets/1459?access_token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiIzNjUyM2I5Yy01YmRhLTQ0MjktOGI0Zi02MDdmYzBjMmY0MjYiLCJpZCI6NDQsImFzc2V0cyI6WzE0NTldLCJpYXQiOjE0OTkyNjQ3ODF9.SW_rwY-ic0TwQBeiweXNqFyywoxnnUBtcVjeCmDGef4'
+    })).readyPromise.then(function(tileset) {
+        var boundingSphere = tileset.boundingSphere;
+        viewer.camera.viewBoundingSphere(boundingSphere, new Cesium.HeadingPitchRange(0.5, -0.2, boundingSphere.radius * 4.0));
+        viewer.camera.lookAtTransform(Cesium.Matrix4.IDENTITY);
+    }).otherwise(function(error) {
+        throw(error);
+    });
+});
+
 //Sandcastle_End
     Sandcastle.finishedLoading();
 }

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,7 +8,7 @@ Change Log
     * `Scene.requestRender` will explicitly request a new render frame when in request render mode.
     * Added `Scene.preUpdate` and `Scene.postUpdate` events that are raised before and after the scene updates respectively. The scene is always updated before executing a potential render. Continue to listen to `Scene.preRender and `Scene.postRender` events for when the scene renders a frame.
     * Added `CreditDisplay.update`, which updates the credit display before a new frame is rendered.
-    * Added `Globe.imageryLayersUpdatedEvent`, which is raised when imagery layer is added, shown, hidden, moved, or removed on the globe.
+    * Added `Globe.imageryLayersUpdatedEvent`, which is raised when an imagery layer is added, shown, hidden, moved, or removed on the globe.
 
 ### 1.41 - 2017-01-02
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,10 +3,12 @@ Change Log
 
 ### 1.42 - 2017-02-01
 
-* Added optional scene request render mode to reduce CPU usage. [#6065](https://github.com/AnalyticalGraphicsInc/cesium/pull/6065)
+* Added optional scene request render mode to reduce CPU usage. [#6065](https://github.com/AnalyticalGraphicsInc/cesium/pull/6065) and [#6107](https://github.com/AnalyticalGraphicsInc/cesium/pull/6107)
     * `Scene.requestRenderMode` enables a mode which will only request new render frames on changes to the scene, or when the simulation time change exceeds `scene.maximumRenderTimeChange`. 
     * `Scene.requestRender` will explicitly request a new render frame when in request render mode.
     * Added `Scene.preUpdate` and `Scene.postUpdate` events that are raised before and after the scene updates respectively. The scene is always updated before executing a potential render. Continue to listen to `Scene.preRender and `Scene.postRender` events for when the scene renders a frame.
+    * Added `CreditDisplay.update`, which updates the credit display before a new frame is rendered.
+    * Added `Globe.imageryLayersUpdatedEvent`, which is raised when imagery layer is added, shown, hidden, moved, or removed on the globe.
 
 ### 1.41 - 2017-01-02
 

--- a/Source/Scene/CreditDisplay.js
+++ b/Source/Scene/CreditDisplay.js
@@ -182,6 +182,11 @@ define([
                 removeCreditDomElement(credit);
             }
         }
+    }
+
+    function removeUnusedLightboxCredits(creditDisplay) {
+        var i;
+        var credit;
         var displayedLightboxCredits = creditDisplay._displayedCredits.lightboxCredits;
         for (i = 0; i < displayedLightboxCredits.length; i++) {
             credit = displayedLightboxCredits[i];
@@ -486,6 +491,23 @@ define([
     };
 
     /**
+     * Updates the credit display before a new frame is rendered.
+     */
+    CreditDisplay.prototype.update = function() {
+        var displayedLightboxCredits = [];
+
+        if (this._expanded && defined(this._creditsToUpdate)) {
+            styleLightboxContainer(this);
+            displayLightboxCredits(this, this._creditsToUpdate);
+            displayedLightboxCredits = this._creditsToUpdate.slice();
+        }
+
+        removeUnusedLightboxCredits(this);
+
+        this._displayedCredits.lightboxCredits = displayedLightboxCredits;
+    };
+
+    /**
      * Resets the credit display to a beginning of frame state, clearing out current credits.
      */
     CreditDisplay.prototype.beginFrame = function() {
@@ -495,7 +517,7 @@ define([
     };
 
     /**
-     * Sets the credit display to the end of frame state, displaying current credits in the credit container
+     * Sets the credit display to the end of frame state, displaying credits from the last frame in the credit container.
      */
     CreditDisplay.prototype.endFrame = function() {
         displayImageCredits(this, this._defaultImageCredits);
@@ -506,22 +528,16 @@ define([
 
         var displayedTextCredits = this._defaultTextCredits.concat(this._currentFrameCredits.textCredits);
         var displayedImageCredits = this._defaultImageCredits.concat(this._currentFrameCredits.imageCredits);
-        var displayedLightboxCredits = [];
 
         var showLightboxLink = this._currentFrameCredits.lightboxCredits.length > 0;
         this._expandLink.style.display = showLightboxLink ? 'inline' : 'none';
-        if (this._expanded) {
-            styleLightboxContainer(this);
-            displayLightboxCredits(this, this._currentFrameCredits.lightboxCredits);
-
-            displayedLightboxCredits = this._currentFrameCredits.lightboxCredits.slice();
-        }
 
         removeUnusedCredits(this);
 
         this._displayedCredits.textCredits = displayedTextCredits;
         this._displayedCredits.imageCredits = displayedImageCredits;
-        this._displayedCredits.lightboxCredits = displayedLightboxCredits;
+
+        this._creditsToUpdate = this._currentFrameCredits.lightboxCredits.slice();
     };
 
     /**

--- a/Source/Scene/Globe.js
+++ b/Source/Scene/Globe.js
@@ -219,6 +219,18 @@ define([
             }
         },
         /**
+         * Gets an event that's raised when an imagery layer is added, shown, hidden, moved, or removed.
+         *
+         * @memberof Globe.prototype
+         * @type {Event}
+         * @readonly
+         */
+        imageryLayersUpdatedEvent : {
+            get : function() {
+                return this._surface.tileProvider.imageryLayersUpdatedEvent;
+            }
+        },
+        /**
          * Gets or sets the color of the globe when no imagery is available.
          * @memberof Globe.prototype
          * @type {Color}
@@ -515,7 +527,7 @@ define([
     /**
      * @private
      */
-    Globe.prototype.beginFrame = function(frameState) {
+    Globe.prototype.update = function(frameState) {
         if (!this.show) {
             return;
         }
@@ -549,6 +561,26 @@ define([
             }
         }
 
+        surface.maximumScreenSpaceError = this.maximumScreenSpaceError;
+        surface.tileCacheSize = this.tileCacheSize;
+
+        tileProvider.terrainProvider = terrainProvider;
+        tileProvider.lightingFadeOutDistance = this.lightingFadeOutDistance;
+        tileProvider.lightingFadeInDistance = this.lightingFadeInDistance;
+        tileProvider.zoomedOutOceanSpecularIntensity = this._zoomedOutOceanSpecularIntensity;
+        tileProvider.hasWaterMask = hasWaterMask;
+        tileProvider.oceanNormalMap = this._oceanNormalMap;
+        tileProvider.enableLighting = this.enableLighting;
+        tileProvider.shadows = this.shadows;
+
+        surface.update(frameState);
+    };
+
+    /**
+     * @private
+     */
+    Globe.prototype.beginFrame = function(frameState) {
+        var surface = this._surface;
         var mode = frameState.mode;
         var pass = frameState.passes;
 
@@ -560,18 +592,6 @@ define([
                 this._zoomedOutOceanSpecularIntensity = 0.0;
             }
 
-            surface.maximumScreenSpaceError = this.maximumScreenSpaceError;
-            surface.tileCacheSize = this.tileCacheSize;
-
-            tileProvider.terrainProvider = this.terrainProvider;
-            tileProvider.lightingFadeOutDistance = this.lightingFadeOutDistance;
-            tileProvider.lightingFadeInDistance = this.lightingFadeInDistance;
-            tileProvider.zoomedOutOceanSpecularIntensity = this._zoomedOutOceanSpecularIntensity;
-            tileProvider.hasWaterMask = hasWaterMask;
-            tileProvider.oceanNormalMap = this._oceanNormalMap;
-            tileProvider.enableLighting = this.enableLighting;
-            tileProvider.shadows = this.shadows;
-
             surface.beginFrame(frameState);
         }
     };
@@ -579,7 +599,7 @@ define([
     /**
      * @private
      */
-    Globe.prototype.update = function(frameState) {
+    Globe.prototype.render = function(frameState) {
         if (!this.show) {
             return;
         }
@@ -592,11 +612,11 @@ define([
         var pass = frameState.passes;
 
         if (pass.render) {
-            surface.update(frameState);
+            surface.render(frameState);
         }
 
         if (pass.pick) {
-            surface.update(frameState);
+            surface.render(frameState);
         }
     };
 

--- a/Source/Scene/QuadtreePrimitive.js
+++ b/Source/Scene/QuadtreePrimitive.js
@@ -173,6 +173,8 @@ define([
         replacementQueue.tail = undefined;
         replacementQueue.count = 0;
 
+        clearTileLoadQueue(this);
+
         // Free and recreate the level zero tiles.
         var levelZeroTiles = this._levelZeroTiles;
         if (defined(levelZeroTiles)) {
@@ -260,76 +262,26 @@ define([
         return object.removeFunc;
     };
 
-    /**
-     * @private
-     */
-    QuadtreePrimitive.prototype.beginFrame = function(frameState) {
-        var passes = frameState.passes;
-        if (!passes.render) {
-            return;
-        }
-
-        // Gets commands for any texture re-projections and updates the credit display
-        this._tileProvider.initialize(frameState);
-
-        var debug = this._debug;
-        if (debug.suspendLodUpdate) {
-            return;
-        }
-
-        debug.maxDepth = 0;
-        debug.tilesVisited = 0;
-        debug.tilesCulled = 0;
-        debug.tilesRendered = 0;
-        debug.tilesWaitingForChildren = 0;
-
-        this._tileLoadQueueHigh.length = 0;
-        this._tileLoadQueueMedium.length = 0;
-        this._tileLoadQueueLow.length = 0;
-        this._tileReplacementQueue.markStartOfRenderFrame();
-    };
+    function createTileLoadProgressEventFunction(primitive, loadQueueLength) {
+        return function () {
+            primitive._tileLoadProgressEvent.raiseEvent(loadQueueLength);
+        };
+    }
 
     /**
-     * @private
+     * Checks if the load queue length has changed since the last time we raised a queue change event - if so, raises
+     * a new change event at the end of the render cycle.
      */
-    QuadtreePrimitive.prototype.update = function(frameState) {
-        var passes = frameState.passes;
+    function updateTileLoadProgress(primitive, frameState) {
+        var currentLoadQueueLength = primitive._tileLoadQueueHigh.length + primitive._tileLoadQueueMedium.length + primitive._tileLoadQueueLow.length;
 
-        if (passes.render) {
-            this._tileProvider.beginUpdate(frameState);
-
-            selectTilesForRendering(this, frameState);
-            createRenderCommandsForSelectedTiles(this, frameState);
-
-            this._tileProvider.endUpdate(frameState);
+        if (currentLoadQueueLength !== primitive._lastTileLoadQueueLength) {
+            frameState.afterRender.push(createTileLoadProgressEventFunction(primitive, currentLoadQueueLength));
+            primitive._lastTileLoadQueueLength = currentLoadQueueLength;
         }
 
-        if (passes.pick && this._tilesToRender.length > 0) {
-            this._tileProvider.updateForPick(frameState);
-        }
-    };
-
-    /**
-     * @private
-     */
-    QuadtreePrimitive.prototype.endFrame = function(frameState) {
-        var passes = frameState.passes;
-        if (!passes.render || frameState.mode === SceneMode.MORPHING) {
-            // Only process the load queue for a single pass.
-            // Don't process the load queue or update heights during the morph flights.
-            return;
-        }
-
-        // Load/create resources for terrain and imagery. Prepare texture re-projections for the next frame.
-        processTileLoadQueue(this, frameState);
-        updateHeights(this, frameState);
-
-        var debug = this._debug;
-        if (debug.suspendLodUpdate) {
-            return;
-        }
-
-        if (debug.enableDebugOutput) {
+        var debug = primitive._debug;
+        if (debug.enableDebugOutput  && !debug.suspendLodUpdate) {
             if (debug.tilesVisited !== debug.lastTilesVisited ||
                 debug.tilesRendered !== debug.lastTilesRendered ||
                 debug.tilesCulled !== debug.lastTilesCulled ||
@@ -345,6 +297,90 @@ define([
                 debug.lastTilesWaitingForChildren = debug.tilesWaitingForChildren;
             }
         }
+    }
+
+    /**
+     * Updates the tile provider imagery and continues to process the tile load queue.
+     * @private
+     */
+    QuadtreePrimitive.prototype.update = function(frameState) {
+        this._tileProvider.updateImagery();
+
+        // Don't process the load queue or update heights during the morph flights.
+        if (frameState.mode !== SceneMode.MORPHING) {
+            // Load/create resources for terrain and imagery. Prepare texture re-projections for the next frame.
+            processTileLoadQueue(this, frameState);
+            updateTileLoadProgress(this, frameState);
+        }
+    };
+
+    function clearTileLoadQueue(primitive) {
+        var debug = primitive._debug;
+        debug.maxDepth = 0;
+        debug.tilesVisited = 0;
+        debug.tilesCulled = 0;
+        debug.tilesRendered = 0;
+        debug.tilesWaitingForChildren = 0;
+
+        primitive._tileLoadQueueHigh.length = 0;
+        primitive._tileLoadQueueMedium.length = 0;
+        primitive._tileLoadQueueLow.length = 0;
+    }
+
+    /**
+     * Initializes values for a new render frame and prepare the tile load queue.
+     * @private
+     */
+    QuadtreePrimitive.prototype.beginFrame = function(frameState) {
+        var passes = frameState.passes;
+        if (!passes.render) {
+            return;
+        }
+
+        // Gets commands for any texture re-projections
+        this._tileProvider.initialize(frameState);
+
+        if (this._debug.suspendLodUpdate) {
+            return;
+        }
+
+        clearTileLoadQueue(this);
+        this._tileReplacementQueue.markStartOfRenderFrame();
+    };
+
+    /**
+     * Selects new tiles to load based on the frame state and creates render commands.
+     * @private
+     */
+    QuadtreePrimitive.prototype.render = function(frameState) {
+        var passes = frameState.passes;
+        var tileProvider = this._tileProvider;
+
+        if (passes.render) {
+            tileProvider.beginUpdate(frameState);
+
+            selectTilesForRendering(this, frameState);
+            createRenderCommandsForSelectedTiles(this, frameState);
+
+            tileProvider.endUpdate(frameState);
+        }
+
+        if (passes.pick && this._tilesToRender.length > 0) {
+            tileProvider.updateForPick(frameState);
+        }
+    };
+
+    /**
+     * Updates terrain heights.
+     * @private
+     */
+    QuadtreePrimitive.prototype.endFrame = function(frameState) {
+        var passes = frameState.passes;
+        if (!passes.render) {
+            return;
+        }
+
+        updateHeights(this, frameState);
     };
 
     /**
@@ -407,17 +443,15 @@ define([
             return;
         }
 
-        var i;
-        var len;
-
         // Clear the render list.
         var tilesToRender = primitive._tilesToRender;
         tilesToRender.length = 0;
 
         // We can't render anything before the level zero tiles exist.
+        var tileProvider = primitive._tileProvider;
         if (!defined(primitive._levelZeroTiles)) {
-            if (primitive._tileProvider.ready) {
-                var tilingScheme = primitive._tileProvider.tilingScheme;
+            if (tileProvider.ready) {
+                var tilingScheme = tileProvider.tilingScheme;
                 primitive._levelZeroTiles = QuadtreeTile.createLevelZeroTiles(tilingScheme);
             } else {
                 // Nothing to do until the provider is ready.
@@ -429,8 +463,6 @@ define([
 
         var tile;
         var levelZeroTiles = primitive._levelZeroTiles;
-
-        var tileProvider = primitive._tileProvider;
         var occluders = levelZeroTiles.length > 1 ? primitive._occluders : undefined;
 
         // Sort the level zero tiles by the distance from the center to the camera.
@@ -443,6 +475,8 @@ define([
         var customDataRemoved = primitive._removeHeightCallbacks;
         var frameNumber = frameState.frameNumber;
 
+        var i;
+        var len;
         if (customDataAdded.length > 0 || customDataRemoved.length > 0) {
             for (i = 0, len = levelZeroTiles.length; i < len; ++i) {
                 tile = levelZeroTiles[i];
@@ -493,14 +527,6 @@ define([
                 ++debug.tilesCulled;
             }
         }
-
-        frameState.afterRender.push(createTileProgressFunction(primitive));
-    }
-
-    function createTileProgressFunction(primitive) {
-        return function() {
-            raiseTileLoadProgressEvent(primitive);
-        };
     }
 
     function visitTile(primitive, frameState, tile) {
@@ -655,18 +681,6 @@ define([
             primitive._tileReplacementQueue.markTileRendered(tile);
         }
     }
-    /**
-     * Checks if the load queue length has changed since the last time we raised a queue change event - if so, raises
-     * a new one.
-     */
-    function raiseTileLoadProgressEvent(primitive) {
-        var currentLoadQueueLength = primitive._tileLoadQueueHigh.length + primitive._tileLoadQueueMedium.length + primitive._tileLoadQueueLow.length;
-
-        if (currentLoadQueueLength !== primitive._lastTileLoadQueueLength) {
-            primitive._tileLoadProgressEvent.raiseEvent(currentLoadQueueLength);
-            primitive._lastTileLoadQueueLength = currentLoadQueueLength;
-        }
-    }
 
     function screenSpaceError(primitive, frameState, tile) {
         if (frameState.mode === SceneMode.SCENE2D || frameState.camera.frustum instanceof OrthographicFrustum) {
@@ -719,7 +733,6 @@ define([
         var tileLoadQueueHigh = primitive._tileLoadQueueHigh;
         var tileLoadQueueMedium = primitive._tileLoadQueueMedium;
         var tileLoadQueueLow = primitive._tileLoadQueueLow;
-        var tileProvider = primitive._tileProvider;
 
         if (tileLoadQueueHigh.length === 0 && tileLoadQueueMedium.length === 0 && tileLoadQueueLow.length === 0) {
             return;
@@ -730,6 +743,7 @@ define([
         primitive._tileReplacementQueue.trimTiles(primitive.tileCacheSize);
 
         var endTime = getTimestamp() + primitive._loadQueueTimeSlice;
+        var tileProvider = primitive._tileProvider;
 
         processSinglePriorityLoadQueue(primitive, frameState, tileProvider, endTime, tileLoadQueueHigh);
         processSinglePriorityLoadQueue(primitive, frameState, tileProvider, endTime, tileLoadQueueMedium);

--- a/Source/Scene/QuadtreePrimitive.js
+++ b/Source/Scene/QuadtreePrimitive.js
@@ -304,7 +304,9 @@ define([
      * @private
      */
     QuadtreePrimitive.prototype.update = function(frameState) {
-        this._tileProvider.updateImagery();
+        if (defined(this._tileProvider.updateImagery)) {
+            this._tileProvider.updateImagery();
+        }
 
         // Don't process the load queue or update heights during the morph flights.
         if (frameState.mode !== SceneMode.MORPHING) {

--- a/Source/Scene/Scene.js
+++ b/Source/Scene/Scene.js
@@ -2936,7 +2936,7 @@ define([
         }
     }
 
-    function update(scene, time) {
+    function update(scene) {
         var frameState = scene._frameState;
 
         if (defined(scene.globe)) {

--- a/Source/Scene/Scene.js
+++ b/Source/Scene/Scene.js
@@ -755,6 +755,8 @@ define([
 
         this._removeRequestListenerCallback = RequestScheduler.requestLoadedEvent.addEventListener(requestRenderListener(this));
         this._removeTaskProcessorListenerCallback = TaskProcessor.taskCompletedEvent.addEventListener(requestRenderListener(this));
+        this._removeGlobeTileLoadCallback = undefined;
+        this._removeGlobeImageryUpdateCallback = undefined;
 
         // initial guess at frustums.
         var near = camera.frustum.near;
@@ -768,6 +770,28 @@ define([
     }
 
     var OPAQUE_FRUSTUM_NEAR_OFFSET = 0.9999;
+
+    function updateGlobeListeners(scene, globe) {
+        if (defined(scene._removeGlobeTileLoadCallback)) {
+            scene._removeGlobeTileLoadCallback();
+        }
+        if (defined(scene._removeGlobeImageryUpdateCallback)) {
+            scene._removeGlobeImageryUpdateCallback();
+        }
+
+        var removeGlobeTileLoadCallback;
+        var removeGlobeImageryUpdateCallback;
+        if (defined(globe)) {
+            if (defined(globe.tileLoadProgressEvent)) {
+                removeGlobeTileLoadCallback = globe.tileLoadProgressEvent.addEventListener(requestRenderListener(scene));
+            }
+            if (defined(globe.imageryLayersUpdatedEvent)) {
+                removeGlobeImageryUpdateCallback = globe.imageryLayersUpdatedEvent.addEventListener(requestRenderListener(scene));
+            }
+        }
+        scene._removeGlobeTileLoadCallback = removeGlobeTileLoadCallback;
+        scene._removeGlobeImageryUpdateCallback = removeGlobeImageryUpdateCallback;
+    }
 
     defineProperties(Scene.prototype, {
         /**
@@ -870,6 +894,8 @@ define([
             set: function(globe) {
                 this._globe = this._globe && this._globe.destroy();
                 this._globe = globe;
+
+                updateGlobeListeners(this, globe);
             }
         },
 
@@ -2381,7 +2407,7 @@ define([
             updateAndClearFramebuffers(scene, passState, backgroundColor);
 
             if (!depthOnly) {
-                updatePrimitives(scene);
+                updateAndRenderPrimitives(scene);
             }
 
             createPotentiallyVisibleSet(scene);
@@ -2561,7 +2587,7 @@ define([
         }
 
         if (!depthOnly) {
-            updatePrimitives(scene);
+            updateAndRenderPrimitives(scene);
         }
 
         createPotentiallyVisibleSet(scene);
@@ -2696,7 +2722,7 @@ define([
         }
     }
 
-    function updatePrimitives(scene) {
+    function updateAndRenderPrimitives(scene) {
         var frameState = scene._frameState;
 
         scene._groundPrimitives.update(frameState);
@@ -2706,7 +2732,7 @@ define([
         updateShadowMaps(scene);
 
         if (scene._globe) {
-            scene._globe.update(frameState);
+            scene._globe.render(frameState);
         }
     }
 
@@ -2836,13 +2862,15 @@ define([
         }
     }
 
-    function callAfterRenderFunctions(frameState) {
+    function callAfterRenderFunctions(scene) {
         // Functions are queued up during primitive update and executed here in case
         // the function modifies scene state that should remain constant over the frame.
-        var functions = frameState.afterRender;
+        var functions = scene._frameState.afterRender;
         for (var i = 0, length = functions.length; i < length; ++i) {
             functions[i]();
+            scene.requestRender();
         }
+
         functions.length = 0;
     }
 
@@ -2909,7 +2937,13 @@ define([
     }
 
     function update(scene, time) {
-        // TODO: Update primitives, including globe
+        var frameState = scene._frameState;
+
+        if (defined(scene.globe)) {
+            scene.globe.update(frameState);
+        }
+
+        frameState.creditDisplay.update();
     }
 
     function render(scene, time) {
@@ -3010,7 +3044,7 @@ define([
 
         updateDebugShowFramesPerSecond(this, shouldRender);
         RequestScheduler.update();
-        callAfterRenderFunctions(this._frameState);
+        callAfterRenderFunctions(this);
     };
 
     /**
@@ -3191,7 +3225,7 @@ define([
 
         var object = this._pickFramebuffer.end(scratchRectangle);
         context.endFrame();
-        callAfterRenderFunctions(frameState);
+        callAfterRenderFunctions(this);
         return object;
     };
 
@@ -3716,6 +3750,12 @@ define([
 
         this._removeRequestListenerCallback();
         this._removeTaskProcessorListenerCallback();
+        if (defined(this._removeGlobeTileLoadCallback)) {
+            this._removeGlobeTileLoadCallback();
+        }
+        if (defined(this._removeGlobeImageryUpdateCallback)) {
+            this._removeGlobeImageryUpdateCallback();
+        }
 
         return destroyObject(this);
     };

--- a/Source/Scene/Scene.js
+++ b/Source/Scene/Scene.js
@@ -782,9 +782,8 @@ define([
         var removeGlobeTileLoadCallback;
         var removeGlobeImageryUpdateCallback;
         if (defined(globe)) {
-            if (defined(globe.tileLoadProgressEvent)) {
-                removeGlobeTileLoadCallback = globe.tileLoadProgressEvent.addEventListener(requestRenderListener(scene));
-            }
+            removeGlobeTileLoadCallback = globe.tileLoadProgressEvent.addEventListener(requestRenderListener(scene));
+
             if (defined(globe.imageryLayersUpdatedEvent)) {
                 removeGlobeImageryUpdateCallback = globe.imageryLayersUpdatedEvent.addEventListener(requestRenderListener(scene));
             }

--- a/Specs/DataSources/EntityClusterSpec.js
+++ b/Specs/DataSources/EntityClusterSpec.js
@@ -48,6 +48,7 @@ defineSuite([
                     tilesWaitingForChildren : 0
                 }
             },
+            tileLoadProgressEvent : new Event(),
             beginFrame : function() {},
             update : function() {},
             render : function() {},

--- a/Specs/DataSources/EntityClusterSpec.js
+++ b/Specs/DataSources/EntityClusterSpec.js
@@ -50,6 +50,7 @@ defineSuite([
             },
             beginFrame : function() {},
             update : function() {},
+            render : function() {},
             endFrame : function() {}
 
         };

--- a/Specs/DataSources/PointVisualizerSpec.js
+++ b/Specs/DataSources/PointVisualizerSpec.js
@@ -50,7 +50,8 @@ defineSuite([
         scene = createScene();
         scene.globe = {
             ellipsoid : Ellipsoid.WGS84,
-            _surface : {}
+            _surface : {},
+            tileLoadProgressEvent : new Event()
         };
 
         scene.globe.getHeight = function() {

--- a/Specs/Scene/CreditDisplaySpec.js
+++ b/Specs/Scene/CreditDisplaySpec.js
@@ -529,6 +529,7 @@ defineSuite([
         creditDisplay.beginFrame();
         creditDisplay.addCredit(credit1);
         creditDisplay.endFrame();
+        creditDisplay.update();
 
         var innerHTML = creditList.innerHTML;
         expect(creditList.childNodes.length).toEqual(1);
@@ -537,6 +538,8 @@ defineSuite([
         creditDisplay.beginFrame();
         creditDisplay.addCredit(credit2);
         creditDisplay.endFrame();
+        creditDisplay.update();
+
         expect(creditList.innerHTML).not.toEqual(innerHTML);
         innerHTML = creditList.innerHTML;
         expect(creditList.childNodes.length).toEqual(1);
@@ -546,12 +549,16 @@ defineSuite([
         creditDisplay.addCredit(credit1);
         creditDisplay.addCredit(credit2);
         creditDisplay.endFrame();
+        creditDisplay.update();
+
         expect(creditList.innerHTML).not.toEqual(innerHTML);
         innerHTML = creditList.innerHTML;
         expect(creditList.childNodes.length).toEqual(2);
 
         creditDisplay.beginFrame();
         creditDisplay.endFrame();
+        creditDisplay.update();
+
         expect(creditList.innerHTML).not.toEqual(innerHTML);
         expect(creditList.childNodes.length).toEqual(0);
 
@@ -569,6 +576,8 @@ defineSuite([
         creditDisplay.addCredit(credit1);
         creditDisplay.addCredit(credit2);
         creditDisplay.endFrame();
+        creditDisplay.update();
+
         expect(creditList.childNodes.length).toEqual(0);
 
         creditDisplay.showLightbox();
@@ -577,7 +586,41 @@ defineSuite([
         creditDisplay.addCredit(credit1);
         creditDisplay.addCredit(credit2);
         creditDisplay.endFrame();
+        creditDisplay.update();
+
         expect(creditList.childNodes.length).toEqual(2);
+
+        creditDisplay.hideLightbox();
+    });
+
+    it('updates lightbox when a new frames are not rendered', function() {
+        var credit1 = new Credit({text: 'credit1'});
+        var credit2 = new Credit({imageUrl: imgSrc});
+
+        creditDisplay = new CreditDisplay(container);
+        var creditList = creditDisplay._creditList;
+
+        creditDisplay.update();
+
+        expect(creditList.childNodes.length).toEqual(0);
+
+        creditDisplay.beginFrame();
+        creditDisplay.addCredit(credit1);
+        creditDisplay.addCredit(credit2);
+        creditDisplay.endFrame();
+        creditDisplay.update();
+
+        expect(creditList.childNodes.length).toEqual(0);
+
+        creditDisplay.showLightbox();
+        creditDisplay.update();
+
+        expect(creditList.childNodes.length).toEqual(2);
+
+        creditDisplay.hideLightbox();
+        creditDisplay.update();
+
+        expect(creditList.childNodes.length).toEqual(0);
 
         creditDisplay.hideLightbox();
     });

--- a/Specs/Scene/GlobeSpec.js
+++ b/Specs/Scene/GlobeSpec.js
@@ -99,6 +99,41 @@ defineSuite([
         });
     });
 
+    it('ImageryLayersUpdated event fires when layer is added, hidden, shown, moved, or removed', function() {
+        var timesEventRaised = 0;
+        globe.imageryLayersUpdatedEvent.addEventListener(function () {
+            ++timesEventRaised;
+        });
+
+        var layerCollection = globe.imageryLayers;
+        layerCollection.removeAll();
+        var layer = layerCollection.addImageryProvider(new SingleTileImageryProvider({url : 'Data/Images/Red16x16.png'}));
+        layerCollection.addImageryProvider(new SingleTileImageryProvider({url : 'Data/Images/Red16x16.png'}));
+        return updateUntilDone(globe).then(function() {
+            expect(timesEventRaised).toEqual(2);
+
+            layer.show = false;
+            return updateUntilDone(globe);
+        }).then(function () {
+            expect(timesEventRaised).toEqual(3);
+
+            layer.show = true;
+            return updateUntilDone(globe);
+        }).then(function () {
+            expect(timesEventRaised).toEqual(4);
+
+            layerCollection.raise(layer);
+            return updateUntilDone(globe);
+        }).then(function () {
+            expect(timesEventRaised).toEqual(5);
+
+            layerCollection.remove(layer);
+            return updateUntilDone(globe);
+        }).then(function () {
+            expect(timesEventRaised).toEqual(6);
+        });
+    });
+
     it('terrainProviderChanged event fires', function() {
         var terrainProvider = new CesiumTerrainProvider({
             url : 'made/up/url',

--- a/Specs/Scene/ModelSpec.js
+++ b/Specs/Scene/ModelSpec.js
@@ -2704,6 +2704,7 @@ defineSuite([
                 removedCallback : false,
                 ellipsoid : Ellipsoid.WGS84,
                 update : function() {},
+                render : function() {},
                 getHeight : function() {
                     return 0.0;
                 },

--- a/Specs/Scene/ModelSpec.js
+++ b/Specs/Scene/ModelSpec.js
@@ -2719,6 +2719,7 @@ defineSuite([
                         tilesWaitingForChildren : 0
                     }
                 },
+                tileLoadProgressEvent : new Event(),
                 destroy : function() {}
             };
 

--- a/Specs/createGlobe.js
+++ b/Specs/createGlobe.js
@@ -25,6 +25,7 @@ define([
                 return 0.0;
             },
             _surface : {},
+            tileLoadProgressEvent : new Event(),
             destroy : function() {}
         };
 

--- a/Specs/createGlobe.js
+++ b/Specs/createGlobe.js
@@ -20,6 +20,7 @@ define([
             beginFrame: function() {},
             endFrame: function() {},
             update : function() {},
+            render : function() {},
             getHeight : function() {
                 return 0.0;
             },


### PR DESCRIPTION
Following #6065 
Part of #1865

Refactored some of the update/render logic in `Globe`, `QuadtreePrimitive`, and `GlobeSurfaceTileProvider` in order to perform loading and rendering separately. The globe surface should always be processing the tile load queue, so I move the tile loading from the end of 

Scene now watch for `globe.tileLoadEvent` to watch for changes to the load queue happening during the update, as well as a new `globe.ImageryLayersUpdated` event that watches for changes in the imagery layer collection. These will both trigger new renders. When the scene has `requestRenderMode` enabled and there is a large or undefined `maximumRenderTimeChange`, the globe will still load in completely, and changing terrain providers or imagery will automatically trigger a render.

Also `Scene` now also checks for the number of `afterRender` functions in `frameState`. If a function was called after the last render frame, we assume there is new content to be rendered (like a model is now ready to be shown). This covers loading in a tileset much better, as individual LODs being ready to be shown will now automatically trigger renders as well.