### PR TITLE
Fix broken Sandcastle terrain and imagery urls

### DIFF
--- a/Apps/Sandcastle/gallery/ArcticDEM.html
+++ b/Apps/Sandcastle/gallery/ArcticDEM.html
@@ -31,7 +31,7 @@ var viewer = new Cesium.Viewer('cesiumContainer');
 
 // Load ArcticDEM terrain
 var cesiumTerrainProviderMeshes = new Cesium.CesiumTerrainProvider({
-    url : 'http://assets.agi.com/stk-terrain/v1/tilesets/ArticDEM/tiles',
+    url : 'https://assets.agi.com/stk-terrain/v1/tilesets/ArticDEM/tiles',
     requestWaterMask : true,
     requestVertexNormals : true
 });

--- a/Apps/Sandcastle/gallery/Imagery Layers Manipulation.html
+++ b/Apps/Sandcastle/gallery/Imagery Layers Manipulation.html
@@ -120,7 +120,7 @@ function setupLayers() {
     addBaseLayerOption(
             'ArcGIS World Street Maps',
             new Cesium.ArcGisMapServerImageryProvider({
-                url : 'https://server.arcgisonline.com/ArcGIS/rest/services/World_Street_Map/MapServer'
+                url : 'https://services.arcgisonline.com/ArcGIS/rest/services/World_Street_Map/MapServer'
             }));
     addBaseLayerOption(
             'OpenStreetMaps',
@@ -140,7 +140,7 @@ function setupLayers() {
     addBaseLayerOption(
             'Natural Earth II (local)',
             Cesium.createTileMapServiceImageryProvider({
-                url : require.toUrl('Assets/Textures/NaturalEarthII')
+                url : Cesium.buildModuleUrl('Assets/Textures/NaturalEarthII')
             }));
     addBaseLayerOption(
             'USGS Shaded Relief (via WMTS)',
@@ -164,8 +164,7 @@ function setupLayers() {
                 parameters : {
                     transparent : 'true',
                     format : 'image/png'
-                },
-                proxy : new Cesium.DefaultProxy('/proxy/')
+                }
             }));
     addAdditionalLayerOption(
             'United States Weather Radar',
@@ -176,8 +175,7 @@ function setupLayers() {
                 parameters : {
                     transparent : 'true',
                     format : 'image/png'
-                },
-                proxy : new Cesium.DefaultProxy('/proxy/')
+                }
             }));
     addAdditionalLayerOption(
             'TileMapService Image',

--- a/Apps/Sandcastle/gallery/Imagery Layers Split.html
+++ b/Apps/Sandcastle/gallery/Imagery Layers Split.html
@@ -51,7 +51,7 @@ function startup(Cesium) {
 //Sandcastle_Begin
 var viewer = new Cesium.Viewer('cesiumContainer', {
     imageryProvider : new Cesium.ArcGisMapServerImageryProvider({
-        url : 'https://server.arcgisonline.com/ArcGIS/rest/services/World_Street_Map/MapServer'
+        url : 'https://services.arcgisonline.com/ArcGIS/rest/services/World_Street_Map/MapServer'
     }),
     baseLayerPicker : false,
     infoBox : false

--- a/Apps/Sandcastle/gallery/Imagery Layers.html
+++ b/Apps/Sandcastle/gallery/Imagery Layers.html
@@ -29,7 +29,7 @@ function startup(Cesium) {
 //Sandcastle_Begin
 var viewer = new Cesium.Viewer('cesiumContainer', {
     imageryProvider : new Cesium.ArcGisMapServerImageryProvider({
-        url : 'https://server.arcgisonline.com/ArcGIS/rest/services/World_Street_Map/MapServer'
+        url : 'https://services.arcgisonline.com/ArcGIS/rest/services/World_Street_Map/MapServer'
     }),
     baseLayerPicker : false
 });


### PR DESCRIPTION
Fix Sandcastle demos broken because of mixed content error on cesiumjs.org, or and outdated url.