### PR TITLE
Added workaround for broken tilesets.

### DIFF
--- a/Source/Core/Resource.js
+++ b/Source/Core/Resource.js
@@ -318,6 +318,10 @@ define([
      * @param {Boolean{ [proxy=false] If true, the url is processed the proxy object if defined.
      */
     Resource.prototype.getUrlComponent = function(query, proxy) {
+        if(this.isDataUri) {
+            return this._url;
+        }
+
         var uri = new Uri(this._url);
 
         if (query) {

--- a/Source/Scene/Cesium3DTile.js
+++ b/Source/Scene/Cesium3DTile.js
@@ -189,10 +189,15 @@ define([
         baseResource = Resource.createIfNeeded(baseResource);
 
         if (defined(contentHeader)) {
+            var contentHeaderUrl = contentHeader.url;
+            if (tileset._brokenUrlWorkaround && contentHeaderUrl.length > 0 && (contentHeaderUrl[0] === '/')) {
+                contentHeaderUrl = contentHeader.url = contentHeaderUrl.substring(1);
+            }
+
             hasEmptyContent = false;
             contentState = Cesium3DTileContentState.UNLOADED;
             contentResource = baseResource.getDerivedResource({
-                url : contentHeader.url
+                url : contentHeaderUrl
             });
             serverKey = RequestScheduler.getServerKey(contentResource.getUrlComponent());
         } else {


### PR DESCRIPTION
A bunch of tilesets were generated that have a leading / in front of all URLs in the tileset.json. If the tiles aren't at the root of the domain they will not load anymore. If we find a b3dm file with a leading slash, we test load a tile. If it succeeds we continue on. If it fails, we set this to true so we know to strip the slash when loading tiles.