### PR TITLE
Fix IE tests broken by `slice`

### DIFF
--- a/Source/Scene/Vector3DTilePoints.js
+++ b/Source/Scene/Vector3DTilePoints.js
@@ -1,4 +1,5 @@
 define([
+        '../Core/arraySlice',
         '../Core/Cartesian2',
         '../Core/Cartesian3',
         '../Core/Color',
@@ -19,6 +20,7 @@ define([
         './PolylineCollection',
         './VerticalOrigin'
     ], function(
+        arraySlice,
         Cartesian2,
         Cartesian3,
         Color,
@@ -158,8 +160,8 @@ define([
 
             if (!defined(packedBuffer)) {
                 // Copy because they may be the views on the same buffer.
-                positions = points._positions = positions.slice();
-                points._batchIds = points._batchIds.slice();
+                positions = points._positions = arraySlice(positions);
+                points._batchIds = arraySlice(points._batchIds);
 
                 packedBuffer = points._packedBuffer = packBuffer(points, ellipsoid);
             }

--- a/Source/Scene/Vector3DTilePolygons.js
+++ b/Source/Scene/Vector3DTilePolygons.js
@@ -1,4 +1,5 @@
 define([
+        '../Core/arraySlice',
         '../Core/Cartesian3',
         '../Core/Color',
         '../Core/defaultValue',
@@ -16,6 +17,7 @@ define([
         './Vector3DTileBatch',
         './Vector3DTilePrimitive'
     ], function(
+        arraySlice,
         Cartesian3,
         Color,
         defaultValue,
@@ -251,10 +253,10 @@ define([
 
             if (!defined(batchTableColors)) {
                 // Copy because they may be the views on the same buffer.
-                positions = polygons._positions = polygons._positions.slice();
-                counts = polygons._counts = polygons._counts.slice();
-                indexCounts = polygons._indexCounts= polygons._indexCounts.slice();
-                indices = polygons._indices = polygons._indices.slice();
+                positions = polygons._positions = arraySlice(polygons._positions);
+                counts = polygons._counts = arraySlice(polygons._counts);
+                indexCounts = polygons._indexCounts= arraySlice(polygons._indexCounts);
+                indices = polygons._indices = arraySlice(polygons._indices);
 
                 polygons._center = polygons._ellipsoid.cartographicToCartesian(Rectangle.center(polygons._rectangle));
 

--- a/Source/Scene/Vector3DTilePolylines.js
+++ b/Source/Scene/Vector3DTilePolylines.js
@@ -1,4 +1,5 @@
 define([
+        '../Core/arraySlice',
         '../Core/Cartesian3',
         '../Core/Color',
         '../Core/ComponentDatatype',
@@ -25,6 +26,7 @@ define([
         './BlendingState',
         './Cesium3DTileFeature'
     ], function(
+        arraySlice,
         Cartesian3,
         Color,
         ComponentDatatype,
@@ -211,11 +213,11 @@ define([
 
             if (!defined(packedBuffer)) {
                 // Copy because they may be the views on the same buffer.
-                positions = polylines._positions = positions.slice();
-                widths = polylines._widths = widths.slice();
-                counts = polylines._counts = counts.slice();
+                positions = polylines._positions = arraySlice(positions);
+                widths = polylines._widths = arraySlice(widths);
+                counts = polylines._counts = arraySlice(counts);
 
-                batchIds = polylines._transferrableBatchIds = polylines._batchIds.slice();
+                batchIds = polylines._transferrableBatchIds = arraySlice(polylines._batchIds);
 
                 packedBuffer = polylines._packedBuffer = packBuffer(polylines);
             }


### PR DESCRIPTION
Replaces array.slice to arraySlice for typed arrays. Fixes #6124.