### PR TITLE
Add ability to load Sandcastle demos encoded into a url

### DIFF
--- a/Apps/Sandcastle/CesiumSandcastle.js
+++ b/Apps/Sandcastle/CesiumSandcastle.js
@@ -776,13 +776,13 @@ require({
 
                 jsEditor.setValue(code);
                 htmlEditor.setValue(html);
-                demoCode = code;
-                demoHtml = html;
+                demoCode = code.replace(/\s/g, '');
+                demoHtml = html.replace(/\s/g, '');
                 gistCode = code;
                 gistHtml = html;
                 previousCode = code;
                 previousHtml = html;
-                sandcastleUrl = getBaseUri(window.location.href) + '?src=Hello%20World.html&label=Showcases&code=' + queryObject.code;
+                sandcastleUrl = getBaseUri(window.location.href) + '?src=Hello%20World.html&label=Showcases&code=' + code;
                 CodeMirror.commands.runCesium(jsEditor);
                 clearRun();
             } else {
@@ -1227,6 +1227,7 @@ require({
                 window.open('gallery/' + demo.name + '.html');
             } else {
                 delete queryObject.gistId;
+                delete queryObject.code;
                 var htmlText = (htmlEditor.getValue()).replace(/\s/g, '');
                 var jsText = (jsEditor.getValue()).replace(/\s/g, '');
                 var confirmChange = true;

--- a/Apps/Sandcastle/CesiumSandcastle.js
+++ b/Apps/Sandcastle/CesiumSandcastle.js
@@ -768,6 +768,23 @@ require({
                         appendConsole('consoleError', 'Unable to GET from GitHub API. This could be due to too many request, try again in an hour or copy and paste the code from the gist: https://gist.github.com/' + gistId , true);
                         console.log(error);
                 });
+            } else if (defined(queryObject.code)) {
+                //The code query parameter is a Base64 encoded JSON string with `code` and `html` properties.
+                var json = JSON.parse(window.atob(queryObject.code));
+                var code = json.code;
+                var html = json.html;
+
+                jsEditor.setValue(code);
+                htmlEditor.setValue(html);
+                demoCode = code;
+                demoHtml = html;
+                gistCode = code;
+                gistHtml = html;
+                previousCode = code;
+                previousHtml = html;
+                sandcastleUrl = getBaseUri(window.location.href) + '?src=Hello%20World.html&label=Showcases&code=' + queryObject.code;
+                CodeMirror.commands.runCesium(jsEditor);
+                clearRun();
             } else {
                 jsEditor.setValue(scriptCode);
             }


### PR DESCRIPTION
I wanted to be able to share Sandcastle demos without going through GitHub gists (basically, I'm working on an app that generates Sandcastle examples on the fly).

Turns out it was really simple to just encode an entire demo into a URL query parameter.  I just stringify and base64 encode a JSON object with `code` and `html` properties:

```Javascript
var example = {
    code: '//I was a query param!!\nvar viewer = new Cesium.Viewer(\'cesiumContainer\');',
    html: '<style>\n@import url(../templates/bucket.css);\n</style>\n<div id="cesiumContainer" class="fullSize"></div>\n<div id="loadingOverlay"><h1>Loading...</h1></div>\n<div id="toolbar"></div>\n'
}
var codeParam = btoa(JSON.stringify(example));
console.log(codeParam);
```

The end result is definitely verbose, but works great for my purposes (because it's not meant for human consumption).  Plus a URL shortener could be used if needed.

http://localhost:8080/Apps/Sandcastle/index.html?src=Hello%20World.html&label=Showcases&code=eyJjb2RlIjoiLy9JIHdhcyBhIHF1ZXJ5IHBhcmFtISFcbnZhciB2aWV3ZXIgPSBuZXcgQ2VzaXVtLlZpZXdlcignY2VzaXVtQ29udGFpbmVyJyk7IiwiaHRtbCI6IjxzdHlsZT5cbkBpbXBvcnQgdXJsKC4uL3RlbXBsYXRlcy9idWNrZXQuY3NzKTtcbjwvc3R5bGU+XG48ZGl2IGlkPVwiY2VzaXVtQ29udGFpbmVyXCIgY2xhc3M9XCJmdWxsU2l6ZVwiPjwvZGl2PlxuPGRpdiBpZD1cImxvYWRpbmdPdmVybGF5XCI+PGgxPkxvYWRpbmcuLi48L2gxPjwvZGl2PlxuPGRpdiBpZD1cInRvb2xiYXJcIj48L2Rpdj5cbiJ9

CC @emackey 