### PR TITLE
Fix Cesium ion external asset handling

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -2,6 +2,7 @@ Apps/HelloWorld.html
 Apps/Sandcastle/ThirdParty/**
 Build/**
 Documentation/**
+Instrumented/**
 Source/Shaders/**
 Source/ThirdParty/**
 Source/Workers/cesiumWorkerBootstrapper.js

--- a/Source/Scene/CesiumIon.js
+++ b/Source/Scene/CesiumIon.js
@@ -91,7 +91,7 @@ define([
      *   });
      */
     CesiumIon.createResource = function(assetId, options) {
-        var endpointResource = CesiumIon.createEndpointResource(assetId, options);
+        var endpointResource = CesiumIon._createEndpointResource(assetId, options);
 
         return CesiumIon._loadJson(endpointResource)
             .then(function (endpoint) {
@@ -108,14 +108,14 @@ define([
                 }
 
                 //External imagery assets have additional configuration that can't be represented as a Resource
-                throw new RuntimeError('CesiumIon.createResource does not support external imagery assets.');
+                throw new RuntimeError('CesiumIon.createResource does not support external imagery assets; use CesiumIon.createImageryProvider instead.');
             });
     };
 
     /**
      * @private
      */
-    CesiumIon.createEndpointResource = function (assetId, options) {
+    CesiumIon._createEndpointResource = function (assetId, options) {
         //>>includeStart('debug', pragmas.debug);
         Check.defined('assetId', assetId);
         //>>includeEnd('debug');
@@ -173,7 +173,7 @@ define([
      *   });
      */
     CesiumIon.createImageryProvider = function(assetId, options) {
-        var endpointResource = CesiumIon.createEndpointResource(assetId, options);
+        var endpointResource = CesiumIon._createEndpointResource(assetId, options);
 
         return CesiumIon._loadJson(endpointResource)
             .then(function(endpoint) {

--- a/Source/Scene/CesiumIon.js
+++ b/Source/Scene/CesiumIon.js
@@ -1,37 +1,39 @@
 define([
-        './ArcGisMapServerImageryProvider',
-        './BingMapsImageryProvider',
-        './createTileMapServiceImageryProvider',
-        './GoogleEarthEnterpriseMapsProvider',
-        './MapboxImageryProvider',
-        './SingleTileImageryProvider',
-        './UrlTemplateImageryProvider',
-        './WebMapServiceImageryProvider',
-        './WebMapTileServiceImageryProvider',
         '../Core/Check',
         '../Core/defaultValue',
         '../Core/defined',
         '../Core/loadJson',
         '../Core/Resource',
         '../Core/RuntimeError',
-        '../ThirdParty/when'
+        '../ThirdParty/when',
+        './ArcGisMapServerImageryProvider',
+        './BingMapsImageryProvider',
+        './CesiumIonResource',
+        './createTileMapServiceImageryProvider',
+        './GoogleEarthEnterpriseMapsProvider',
+        './MapboxImageryProvider',
+        './SingleTileImageryProvider',
+        './UrlTemplateImageryProvider',
+        './WebMapServiceImageryProvider',
+        './WebMapTileServiceImageryProvider'
     ], function(
-        ArcGisMapServerImageryProvider,
-        BingMapsImageryProvider,
-        createTileMapServiceImageryProvider,
-        GoogleEarthEnterpriseMapsProvider,
-        MapboxImageryProvider,
-        SingleTileImageryProvider,
-        UrlTemplateImageryProvider,
-        WebMapServiceImageryProvider,
-        WebMapTileServiceImageryProvider,
         Check,
         defaultValue,
         defined,
         loadJson,
         Resource,
         RuntimeError,
-        when) {
+        when,
+        ArcGisMapServerImageryProvider,
+        BingMapsImageryProvider,
+        CesiumIonResource,
+        createTileMapServiceImageryProvider,
+        GoogleEarthEnterpriseMapsProvider,
+        MapboxImageryProvider,
+        SingleTileImageryProvider,
+        UrlTemplateImageryProvider,
+        WebMapServiceImageryProvider,
+        WebMapTileServiceImageryProvider) {
     'use strict';
 
     /**
@@ -199,108 +201,8 @@ define([
             });
     };
 
-    /**
-     * A {@link Resource} instance that encapsulates Cesium ion asset
-     * creation and automatic refresh token handling. This object
-     * should not be created directly, use CesiumIonResource.create.
-     *
-     * @private
-     */
-    function CesiumIonResource(options, endpoint, endpointResource) {
-        Resource.call(this, options);
-
-        // The asset endpoint data returned from ion.
-        this.ionEndpoint = endpoint;
-
-        // The endpoint resource to fetch when a new token is needed
-        this.ionEndpointResource = endpointResource;
-
-        // The primary CesiumIonResource from which an instance is derived
-        this.ionRoot = undefined;
-    }
-
-    CesiumIonResource.create = function (endpoint, endpointResource) {
-        var options = {
-            url: endpoint.url,
-            retryAttempts: 1,
-            queryParameters: { access_token: endpoint.accessToken },
-            retryCallback: createRetryCallback(endpoint, endpointResource)
-        };
-
-        return new CesiumIonResource(options, endpoint, endpointResource);
-    };
-
-    if (defined(Object.create)) {
-        CesiumIonResource.prototype = Object.create(Resource.prototype);
-        CesiumIonResource.prototype.constructor = CesiumIonResource;
-    }
-
-    CesiumIonResource.prototype.clone = function(result) {
-        // We always want to use the root's information because it's the most up-to-date
-        var ionRoot = defaultValue(this.ionRoot, this);
-
-        if (!defined(result)) {
-            result = new CesiumIonResource({ url: this._url }, ionRoot.ionEndpoint, ionRoot.ionEndpointResource);
-        }
-
-        result = Resource.prototype.clone.call(this, result);
-        result.ionRoot = ionRoot;
-        result.queryParameters.access_token = ionRoot.queryParameters.access_token;
-        return result;
-    };
-
-    function createRetryCallback(endpoint, endpointResource) {
-        // We use a shared pending promise for all derived assets, since they share
-        // a common access_token.  If we're already requesting a new token for this
-        // asset, we wait on the same promise.
-        var pendingPromise;
-
-        var retryCallback = function(that, error) {
-            // We only want to retry in the case of invalid credentials (401) or image
-            // requests(since Image failures can not provide a status code)
-            if (!defined(error) || (error.statusCode !== 401 && !(error.target instanceof Image))) {
-                return when.resolve(false);
-            }
-
-            if (!defined(pendingPromise)) {
-                pendingPromise = CesiumIon._loadJson(endpointResource)
-                    .then(function(newEndpoint) {
-                        //Set the token for root resource so derived resources automatically pick it up
-                        var ionRoot = that.ionRoot;
-                        if (defined(ionRoot)) {
-                            ionRoot.ionEndpoint = newEndpoint;
-                            ionRoot.queryParameters.access_token = newEndpoint.accessToken;
-                        }
-                        return newEndpoint;
-                    })
-                    .always(function(newEndpoint) {
-                        // Pass or fail, we're done with this promise, the next failure should use a new one.
-                        pendingPromise = undefined;
-
-                        // We need this return because our old busted version of when
-                        // doesn't conform to spec of returning the result of the above `then`.
-                        return newEndpoint;
-                    });
-            }
-
-            return pendingPromise.then(function(newEndpoint) {
-                // Set the new token and endpoint for this resource
-                that.ionEndpoint = newEndpoint;
-                that.queryParameters.access_token = newEndpoint.accessToken;
-                return true;
-            });
-        };
-
-        //Exposed for testing
-        retryCallback._pendingPromise = pendingPromise;
-
-        return retryCallback;
-    }
-
     //Exposed for testing
-    CesiumIon._CesiumIonResource = CesiumIonResource;
     CesiumIon._loadJson = loadJson;
-    CesiumIon._createRetryCallback = createRetryCallback;
 
     return CesiumIon;
 });

--- a/Source/Scene/CesiumIonResource.js
+++ b/Source/Scene/CesiumIonResource.js
@@ -1,0 +1,140 @@
+define([
+        '../Core/Check',
+        '../Core/defaultValue',
+        '../Core/defined',
+        '../Core/loadJson',
+        '../Core/Resource',
+        '../Core/RuntimeError',
+        '../ThirdParty/when',
+        './ArcGisMapServerImageryProvider',
+        './BingMapsImageryProvider',
+        './createTileMapServiceImageryProvider',
+        './GoogleEarthEnterpriseMapsProvider',
+        './MapboxImageryProvider',
+        './SingleTileImageryProvider',
+        './UrlTemplateImageryProvider',
+        './WebMapServiceImageryProvider',
+        './WebMapTileServiceImageryProvider'
+    ], function(
+        Check,
+        defaultValue,
+        defined,
+        loadJson,
+        Resource,
+        RuntimeError,
+        when,
+        ArcGisMapServerImageryProvider,
+        BingMapsImageryProvider,
+        createTileMapServiceImageryProvider,
+        GoogleEarthEnterpriseMapsProvider,
+        MapboxImageryProvider,
+        SingleTileImageryProvider,
+        UrlTemplateImageryProvider,
+        WebMapServiceImageryProvider,
+        WebMapTileServiceImageryProvider) {
+'use strict';
+
+    /**
+     * A {@link Resource} instance that encapsulates Cesium ion asset
+     * creation and automatic refresh token handling. This object
+     * should not be created directly, use CesiumIonResource.create.
+     *
+     * @private
+     */
+    function CesiumIonResource(options, endpoint, endpointResource) {
+        Resource.call(this, options);
+
+        // The asset endpoint data returned from ion.
+        this.ionEndpoint = endpoint;
+
+        // The endpoint resource to fetch when a new token is needed
+        this.ionEndpointResource = endpointResource;
+
+        // The primary CesiumIonResource from which an instance is derived
+        this.ionRoot = undefined;
+    }
+
+    CesiumIonResource.create = function (endpoint, endpointResource) {
+        var options = {
+            url: endpoint.url,
+            retryAttempts: 1,
+            queryParameters: { access_token: endpoint.accessToken },
+            retryCallback: createRetryCallback(endpoint, endpointResource)
+        };
+
+        return new CesiumIonResource(options, endpoint, endpointResource);
+    };
+
+    if (defined(Object.create)) {
+        CesiumIonResource.prototype = Object.create(Resource.prototype);
+        CesiumIonResource.prototype.constructor = CesiumIonResource;
+    }
+
+    CesiumIonResource.prototype.clone = function(result) {
+        // We always want to use the root's information because it's the most up-to-date
+        var ionRoot = defaultValue(this.ionRoot, this);
+
+        if (!defined(result)) {
+            result = new CesiumIonResource({ url: this._url }, ionRoot.ionEndpoint, ionRoot.ionEndpointResource);
+        }
+
+        result = Resource.prototype.clone.call(this, result);
+        result.ionRoot = ionRoot;
+        result.queryParameters.access_token = ionRoot.queryParameters.access_token;
+        return result;
+    };
+
+    function createRetryCallback(endpoint, endpointResource) {
+        // We use a shared pending promise for all derived assets, since they share
+        // a common access_token.  If we're already requesting a new token for this
+        // asset, we wait on the same promise.
+        var pendingPromise;
+
+        var retryCallback = function(that, error) {
+            // We only want to retry in the case of invalid credentials (401) or image
+            // requests(since Image failures can not provide a status code)
+            if (!defined(error) || (error.statusCode !== 401 && !(error.target instanceof Image))) {
+                return when.resolve(false);
+            }
+
+            if (!defined(pendingPromise)) {
+                pendingPromise = CesiumIonResource._loadJson(endpointResource)
+                    .then(function(newEndpoint) {
+                        //Set the token for root resource so derived resources automatically pick it up
+                        var ionRoot = that.ionRoot;
+                        if (defined(ionRoot)) {
+                            ionRoot.ionEndpoint = newEndpoint;
+                            ionRoot.queryParameters.access_token = newEndpoint.accessToken;
+                        }
+                        return newEndpoint;
+                    })
+                    .always(function(newEndpoint) {
+                        // Pass or fail, we're done with this promise, the next failure should use a new one.
+                        pendingPromise = undefined;
+
+                        // We need this return because our old busted version of when
+                        // doesn't conform to spec of returning the result of the above `then`.
+                        return newEndpoint;
+                    });
+            }
+
+            return pendingPromise.then(function(newEndpoint) {
+                // Set the new token and endpoint for this resource
+                that.ionEndpoint = newEndpoint;
+                that.queryParameters.access_token = newEndpoint.accessToken;
+                return true;
+            });
+        };
+
+        //Exposed for testing
+        retryCallback._pendingPromise = pendingPromise;
+
+        return retryCallback;
+    }
+
+    CesiumIonResource._CesiumIonResource = CesiumIonResource;
+    CesiumIonResource._createRetryCallback = createRetryCallback;
+    CesiumIonResource._loadJson = loadJson;
+
+    return CesiumIonResource;
+});

--- a/Specs/Scene/CesiumIonResourceSpec.js
+++ b/Specs/Scene/CesiumIonResourceSpec.js
@@ -1,0 +1,136 @@
+defineSuite([
+    'Scene/CesiumIonResource',
+    'Core/RequestErrorEvent',
+    'Core/Resource',
+    'Scene/CesiumIon',
+    'ThirdParty/when'
+], function(
+    CesiumIonResource,
+    RequestErrorEvent,
+    Resource,
+    CesiumIon,
+    when) {
+'use strict';
+
+    var assetId = 123890213;
+    var endpoint = {
+        type: '3DTILES',
+        url: 'https://assets.cesium.com/' + assetId + '/tileset.json',
+        accessToken: 'not_really_a_refresh_token'
+    };
+
+    it('constructs with expected values', function() {
+        spyOn(Resource, 'call').and.callThrough();
+
+        var endpointResource = CesiumIon._createEndpointResource(assetId);
+        var resource = CesiumIonResource.create(endpoint, endpointResource);
+        expect(resource).toBeInstanceOf(Resource);
+        expect(resource.ionEndpoint).toEqual(endpoint);
+        expect(Resource.call).toHaveBeenCalledWith(resource, {
+            url: endpoint.url,
+            retryCallback: resource.retryCallback,
+            retryAttempts: 1,
+            queryParameters: { access_token: endpoint.accessToken }
+        });
+    });
+
+    it('clone works', function() {
+        var endpointResource = CesiumIon._createEndpointResource(assetId);
+        var resource = CesiumIonResource.create(endpoint, endpointResource);
+        var cloned = resource.clone();
+        expect(cloned).not.toBe(resource);
+        expect(cloned.ionRoot).toBe(resource);
+        cloned.ionRoot = undefined;
+        expect(cloned).toEqual(resource);
+    });
+
+    it('create creates the expected resource', function() {
+        var endpointResource = CesiumIon._createEndpointResource(assetId);
+        var resource = CesiumIonResource.create(endpoint, endpointResource);
+        expect(resource.getUrlComponent()).toEqual(endpoint.url);
+        expect(resource.queryParameters).toEqual({ access_token: 'not_really_a_refresh_token' });
+        expect(resource.ionEndpoint).toBe(endpoint);
+        expect(resource.ionEndpointResource).toEqual(endpointResource);
+        expect(resource.retryCallback).toBeDefined();
+        expect(resource.retryAttempts).toBe(1);
+    });
+
+    describe('retryCallback', function() {
+        var endpointResource;
+        var resource;
+        var retryCallback;
+
+        beforeEach(function() {
+            endpointResource = new Resource({ url: 'https://api.test.invalid', access_token: 'not_the_token' });
+            resource = CesiumIonResource.create(endpoint, endpointResource);
+            retryCallback = CesiumIonResource._createRetryCallback(endpoint, endpointResource, resource);
+        });
+
+        it('returns false when error is undefined', function() {
+            return retryCallback(resource, undefined).then(function(result) {
+                expect(result).toBe(false);
+            });
+        });
+
+        it('returns false when error is non-401', function() {
+            var error = new RequestErrorEvent(404);
+            return retryCallback(resource, error).then(function(result) {
+                expect(result).toBe(false);
+            });
+        });
+
+        it('returns false when error is event with non-Image target', function() {
+            var event = { target: {} };
+            return retryCallback(resource, event).then(function(result) {
+                expect(result).toBe(false);
+            });
+        });
+
+        function testCallback(resource, event) {
+            var deferred = when.defer();
+            spyOn(CesiumIonResource, '_loadJson').and.returnValue(deferred.promise);
+
+            var newEndpoint = {
+                type: '3DTILES',
+                url: 'https://assets.cesium.com/' + assetId,
+                accessToken: 'not_not_really_a_refresh_token'
+            };
+
+            var promise = retryCallback(resource, event);
+            var resultPromise = promise.then(function(result) {
+                expect(resource.queryParameters.access_token).toEqual(newEndpoint.accessToken);
+                expect(result).toBe(true);
+            });
+
+            expect(CesiumIonResource._loadJson).toHaveBeenCalledWith(endpointResource);
+
+            //A second retry should re-use the same pending promise
+            var promise2 = retryCallback(resource, event);
+            expect(promise._pendingPromise).toBe(promise2._pendingPromise);
+
+            deferred.resolve(newEndpoint);
+
+            return resultPromise;
+        }
+
+        it('works when error is a 401', function() {
+            var error = new RequestErrorEvent(401);
+            return testCallback(resource, error);
+        });
+
+        it('works when error is event with Image target', function() {
+            var event = { target: new Image() };
+            return testCallback(resource, event);
+        });
+
+        it('works with derived resource and sets root access_token', function() {
+            var derived = resource.getDerivedResource('1');
+            var error = new RequestErrorEvent(401);
+            return testCallback(derived, error)
+            .then(function(){
+                expect(derived.ionEndpoint).toBe(resource.ionEndpoint);
+                expect(derived.queryParameters.access_token).toEqual(resource.queryParameters.access_token);
+            });
+        });
+    });
+});

--- a/Specs/Scene/CesiumIonSpec.js
+++ b/Specs/Scene/CesiumIonSpec.js
@@ -37,7 +37,7 @@ defineSuite([
         };
 
         var options = {};
-        var resourceEndpoint = CesiumIon.createEndpointResource(tilesAssetId, options);
+        var resourceEndpoint = CesiumIon._createEndpointResource(tilesAssetId, options);
         var expectedResource = CesiumIon._CesiumIonResource.create(tilesEndpoint, resourceEndpoint);
 
         spyOn(CesiumIon, '_loadJson').and.returnValue(when.resolve(tilesEndpoint));
@@ -47,7 +47,7 @@ defineSuite([
         return CesiumIon.createResource(tilesAssetId, options)
             .then(function(resource) {
                 expect(resource).toBe(expectedResource);
-                expect(CesiumIon.createEndpointResource).toHaveBeenCalledWith(tilesAssetId, options);
+                expect(CesiumIon._createEndpointResource).toHaveBeenCalledWith(tilesAssetId, options);
                 expect(CesiumIon._loadJson(resourceEndpoint));
                 expect(CesiumIon._CesiumIonResource.create).toHaveBeenCalledWith(tilesEndpoint, resourceEndpoint);
             });
@@ -95,7 +95,7 @@ defineSuite([
 
     it('createEndpointResource creates expected values with default parameters', function() {
         var assetId = 2348234;
-        var resource = CesiumIon.createEndpointResource(assetId);
+        var resource = CesiumIon._createEndpointResource(assetId);
         expect(resource.url).toBe(CesiumIon.defaultServerUrl + '/v1/assets/' + assetId + '/endpoint');
     });
 
@@ -104,7 +104,7 @@ defineSuite([
         var accessToken = 'not_a_token';
 
         var assetId = 2348234;
-        var resource = CesiumIon.createEndpointResource(assetId, { serverUrl: serverUrl, accessToken: accessToken });
+        var resource = CesiumIon._createEndpointResource(assetId, { serverUrl: serverUrl, accessToken: accessToken });
         expect(resource.url).toBe(serverUrl + '/v1/assets/' + assetId + '/endpoint?access_token=' + accessToken);
     });
 
@@ -116,7 +116,7 @@ defineSuite([
         CesiumIon.defaultAccessToken = 'not_a_token';
 
         var assetId = 2348234;
-        var resource = CesiumIon.createEndpointResource(assetId);
+        var resource = CesiumIon._createEndpointResource(assetId);
         expect(resource.url).toBe(CesiumIon.defaultServerUrl + '/v1/assets/' + assetId + '/endpoint?access_token=' + CesiumIon.defaultAccessToken);
 
         CesiumIon.defaultServerUrl = defaultServerUrl;
@@ -232,7 +232,7 @@ defineSuite([
         it('constructs with expected values', function() {
             spyOn(Resource, 'call').and.callThrough();
 
-            var endpointResource = CesiumIon.createEndpointResource(assetId);
+            var endpointResource = CesiumIon._createEndpointResource(assetId);
             var resource = CesiumIon._CesiumIonResource.create(endpoint, endpointResource);
             expect(resource).toBeInstanceOf(Resource);
             expect(resource.ionEndpoint).toEqual(endpoint);
@@ -245,7 +245,7 @@ defineSuite([
         });
 
         it('clone works', function() {
-            var endpointResource = CesiumIon.createEndpointResource(assetId);
+            var endpointResource = CesiumIon._createEndpointResource(assetId);
             var resource = CesiumIon._CesiumIonResource.create(endpoint, endpointResource);
             var cloned = resource.clone();
             expect(cloned).not.toBe(resource);
@@ -255,7 +255,7 @@ defineSuite([
         });
 
         it('create creates the expected resource', function() {
-            var endpointResource = CesiumIon.createEndpointResource(assetId);
+            var endpointResource = CesiumIon._createEndpointResource(assetId);
             var resource = CesiumIon._CesiumIonResource.create(endpoint, endpointResource);
             expect(resource.getUrlComponent()).toEqual(endpoint.url);
             expect(resource.queryParameters).toEqual({ access_token: 'not_really_a_refresh_token' });

--- a/Specs/Scene/CesiumIonSpec.js
+++ b/Specs/Scene/CesiumIonSpec.js
@@ -41,7 +41,7 @@ defineSuite([
         var expectedResource = CesiumIon._CesiumIonResource.create(tilesEndpoint, resourceEndpoint);
 
         spyOn(CesiumIon, '_loadJson').and.returnValue(when.resolve(tilesEndpoint));
-        spyOn(CesiumIon, 'createEndpointResource').and.returnValue(resourceEndpoint);
+        spyOn(CesiumIon, '_createEndpointResource').and.returnValue(resourceEndpoint);
         spyOn(CesiumIon._CesiumIonResource, 'create').and.returnValue(expectedResource);
 
         return CesiumIon.createResource(tilesAssetId, options)

--- a/Specs/Scene/CesiumIonSpec.js
+++ b/Specs/Scene/CesiumIonSpec.js
@@ -1,5 +1,6 @@
 defineSuite([
         'Scene/CesiumIon',
+        'Core/RuntimeError',
         'Core/RequestErrorEvent',
         'Core/Resource',
         'Scene/ArcGisMapServerImageryProvider',
@@ -13,6 +14,7 @@ defineSuite([
         'ThirdParty/when'
     ], function(
         CesiumIon,
+        RuntimeError,
         RequestErrorEvent,
         Resource,
         ArcGisMapServerImageryProvider,
@@ -26,70 +28,211 @@ defineSuite([
         when) {
     'use strict';
 
-    var assetId;
-    var endpoint;
-
-    beforeEach(function() {
-        assetId = 123890213;
-        endpoint = {
+    it('createResource calls CesiumIonResource.create for non-external endpoint with expected parameters', function() {
+        var tilesAssetId = 123890213;
+        var tilesEndpoint = {
             type: '3DTILES',
-            url: 'https://assets.cesium.com/' + assetId,
+            url: 'https://assets.cesium.com/' + tilesAssetId + '/tileset.json',
             accessToken: 'not_really_a_refresh_token'
         };
-    });
-
-    it('createResource calls CesiumIonResource.create with expected default parameters', function() {
-        var mockResource = {};
-        var loadJson = spyOn(CesiumIon, '_loadJson').and.returnValue(when.resolve(endpoint));
-        var create = spyOn(CesiumIon._CesiumIonResource, 'create').and.returnValue(mockResource);
-
-        return CesiumIon.createResource(assetId).then(function(resource) {
-            var loadArgs = loadJson.calls.argsFor(0);
-            var endpointResource = loadArgs[0];
-            expect(endpointResource).toBeInstanceOf(Resource);
-            expect(endpointResource.getUrlComponent()).toEqual(CesiumIon.defaultServerUrl + '/v1/assets/' + assetId + '/endpoint');
-            expect(create).toHaveBeenCalledWith(endpoint, endpointResource);
-            expect(resource).toBe(mockResource);
-        });
-    });
-
-    it('createResource calls CesiumIonResource.create with expected parameters', function() {
-        var mockResource = {};
-        var options = { accessToken: 'not_a_token', serverUrl: 'https://test.invalid' };
-        var loadJson = spyOn(CesiumIon, '_loadJson').and.returnValue(when.resolve(endpoint));
-        var create = spyOn(CesiumIon._CesiumIonResource, 'create').and.returnValue(mockResource);
-
-        return CesiumIon.createResource(assetId, options).then(function(resource) {
-            var loadArgs = loadJson.calls.argsFor(0);
-            var endpointResource = loadArgs[0];
-            expect(endpointResource).toBeInstanceOf(Resource);
-            expect(endpointResource.getUrlComponent()).toEqual(options.serverUrl + '/v1/assets/' + assetId + '/endpoint');
-            expect(endpointResource.queryParameters).toEqual({ access_token: options.accessToken });
-            expect(create).toHaveBeenCalledWith(endpoint, endpointResource);
-            expect(resource).toBe(mockResource);
-        });
-    });
-
-    it('createImageryProvider calls createResource and returns createImageryProvider result', function() {
-        var mockImageryProvider = {};
-        var mockResource = { createImageryProvider: jasmine.createSpy('createImageryProvider').and.returnValue(mockImageryProvider) };
-
-        spyOn(CesiumIon, 'createResource').and.returnValue(when.resolve(mockResource));
 
         var options = {};
-        return CesiumIon.createImageryProvider(assetId, options)
+        var resourceEndpoint = CesiumIon.createEndpointResource(tilesAssetId, options);
+        var expectedResource = CesiumIon._CesiumIonResource.create(tilesEndpoint, resourceEndpoint);
+
+        spyOn(CesiumIon, '_loadJson').and.returnValue(when.resolve(tilesEndpoint));
+        spyOn(CesiumIon, 'createEndpointResource').and.returnValue(resourceEndpoint);
+        spyOn(CesiumIon._CesiumIonResource, 'create').and.returnValue(expectedResource);
+
+        return CesiumIon.createResource(tilesAssetId, options)
+            .then(function(resource) {
+                expect(resource).toBe(expectedResource);
+                expect(CesiumIon.createEndpointResource).toHaveBeenCalledWith(tilesAssetId, options);
+                expect(CesiumIon._loadJson(resourceEndpoint));
+                expect(CesiumIon._CesiumIonResource.create).toHaveBeenCalledWith(tilesEndpoint, resourceEndpoint);
+            });
+    });
+
+    function testNonImageryExternalResource(externalEndpoint) {
+        spyOn(CesiumIon, '_loadJson').and.returnValue(when.resolve(externalEndpoint));
+        spyOn(CesiumIon._CesiumIonResource, 'create');
+
+        return CesiumIon.createResource(123890213)
+            .then(function(resource) {
+                expect(resource).toBeInstanceOf(Resource);
+                expect(resource).not.toBeInstanceOf(CesiumIon._CesiumIonResource);
+                expect(resource.url).toEqual(externalEndpoint.options.url);
+            });
+    }
+
+    it('createResource returns basic Resource for external 3D tilesets', function() {
+        return testNonImageryExternalResource({
+            type: '3DTILES',
+            externalType: '3DTILES',
+            options: { url: 'https://test.invalid/tileset.json' }
+        });
+    });
+
+    it('createResource returns basic Resource for external 3D tilesets', function() {
+        return testNonImageryExternalResource({
+            type: 'TERRAIN',
+            externalType: 'STK_TERRAIN_SERVER',
+            options: { url: 'https://test.invalid/world' }
+        });
+    });
+
+    it('createResource rejects for external imagery', function() {
+        return testNonImageryExternalResource({
+            type: 'IMAGERY',
+            externalType: 'URL_TEMPLATE',
+            url: 'https://test.invalid/world'
+        })
+        .then(fail)
+        .otherwise(function(e) {
+            expect(e).toBeInstanceOf(RuntimeError);
+        });
+    });
+
+    it('createEndpointResource creates expected values with default parameters', function() {
+        var assetId = 2348234;
+        var resource = CesiumIon.createEndpointResource(assetId);
+        expect(resource.url).toBe(CesiumIon.defaultServerUrl + '/v1/assets/' + assetId + '/endpoint');
+    });
+
+    it('createEndpointResource creates expected values with overridden options', function() {
+        var serverUrl = 'https://api.cesium.test';
+        var accessToken = 'not_a_token';
+
+        var assetId = 2348234;
+        var resource = CesiumIon.createEndpointResource(assetId, { serverUrl: serverUrl, accessToken: accessToken });
+        expect(resource.url).toBe(serverUrl + '/v1/assets/' + assetId + '/endpoint?access_token=' + accessToken);
+    });
+
+    it('createEndpointResource creates expected values with overridden defaults', function() {
+        var defaultServerUrl = CesiumIon.defaultServerUrl;
+        var defaultAccessToken = CesiumIon.defaultAccessToken;
+
+        CesiumIon.defaultServerUrl = 'https://api.cesium.test';
+        CesiumIon.defaultAccessToken = 'not_a_token';
+
+        var assetId = 2348234;
+        var resource = CesiumIon.createEndpointResource(assetId);
+        expect(resource.url).toBe(CesiumIon.defaultServerUrl + '/v1/assets/' + assetId + '/endpoint?access_token=' + CesiumIon.defaultAccessToken);
+
+        CesiumIon.defaultServerUrl = defaultServerUrl;
+        CesiumIon.defaultAccessToken = defaultAccessToken;
+    });
+
+    it('createImageryProvider works with non-external imagery', function() {
+        var endpoint = {
+            type: 'IMAGERY',
+            url: 'https://assets.cesium.com/' + 123890213 + '/',
+            accessToken: 'not_really_a_refresh_token'
+        };
+
+        spyOn(CesiumIon, '_loadJson').and.returnValue(when.resolve(endpoint));
+
+        return CesiumIon.createImageryProvider(123890213)
             .then(function(imageryProvider) {
-                expect(CesiumIon.createResource).toHaveBeenCalledWith(assetId, options);
-                expect(mockResource.createImageryProvider).toHaveBeenCalledWith();
-                expect(imageryProvider).toBe(mockImageryProvider);
+                expect(imageryProvider).toBeInstanceOf(UrlTemplateImageryProvider);
+            });
+    });
+
+    function testExternalImagery(type, options, ImageryClass) {
+        var endpoint = {
+            type: 'IMAGERY',
+            externalType: type,
+            options: options
+        };
+
+        spyOn(CesiumIon, '_loadJson').and.returnValue(when.resolve(endpoint));
+
+        return CesiumIon.createImageryProvider(123890213)
+            .then(function(imageryProvider) {
+                expect(imageryProvider).toBeInstanceOf(ImageryClass);
+            });
+    }
+
+    it('createImageryProvider works with ARCGIS_MAPSERVER', function() {
+        return testExternalImagery('ARCGIS_MAPSERVER', { url: 'https://test.invalid' }, ArcGisMapServerImageryProvider);
+    });
+
+    it('createImageryProvider works with BING', function() {
+        return testExternalImagery('BING', { url: 'https://test.invalid' }, BingMapsImageryProvider);
+    });
+
+    it('createImageryProvider works with GOOGLE_EARTH', function() {
+        return testExternalImagery('GOOGLE_EARTH', { url: 'https://test.invalid', channel: 1 }, GoogleEarthEnterpriseMapsProvider);
+    });
+
+    it('createImageryProvider works with MAPBOX', function() {
+        return testExternalImagery('MAPBOX', { url: 'https://test.invalid', mapId: 1 }, MapboxImageryProvider);
+    });
+
+    it('createImageryProvider works with SINGLE_TILE', function() {
+        return testExternalImagery('SINGLE_TILE', { url: 'https://test.invalid' }, SingleTileImageryProvider);
+    });
+
+    it('createImageryProvider works with TMS', function() {
+        return testExternalImagery('TMS', { url: 'https://test.invalid' }, UrlTemplateImageryProvider);
+    });
+
+    it('createImageryProvider works with URL_TEMPLATE', function() {
+        return testExternalImagery('URL_TEMPLATE', { url: 'https://test.invalid' }, UrlTemplateImageryProvider);
+    });
+
+    it('createImageryProvider works with WMS', function() {
+        return testExternalImagery('WMS', { url: 'https://test.invalid', layers: [] }, WebMapServiceImageryProvider);
+    });
+
+    it('createImageryProvider works with WMTS', function() {
+        return testExternalImagery('WMTS', { url: 'https://test.invalid', layer: '', style: '', tileMatrixSetID: 1 }, WebMapTileServiceImageryProvider);
+    });
+
+    it('createImageryProvider rejects with non-imagery', function() {
+        var endpoint = {
+            type: '3DTILES',
+            url: 'https://assets.cesium.com/' + 123890213 + '/tileset.json',
+            accessToken: 'not_really_a_refresh_token'
+        };
+
+        spyOn(CesiumIon, '_loadJson').and.returnValue(when.resolve(endpoint));
+
+        return CesiumIon.createImageryProvider(123890213)
+            .then(fail)
+            .otherwise(function(error){
+                expect(error).toBeInstanceOf(RuntimeError);
+            });
+    });
+
+    it('createImageryProvider rejects unknown external imagery type', function() {
+        var endpoint = {
+            type: 'IMAGERY',
+            externalType: 'TUBALCAIN',
+            options: {}
+        };
+
+        spyOn(CesiumIon, '_loadJson').and.returnValue(when.resolve(endpoint));
+
+        return CesiumIon.createImageryProvider(123890213)
+            .then(fail)
+            .otherwise(function(error){
+                expect(error).toBeInstanceOf(RuntimeError);
             });
     });
 
     describe('CesiumIonResource', function() {
+        var assetId = 123890213;
+        var endpoint = {
+            type: '3DTILES',
+            url: 'https://assets.cesium.com/' + assetId + '/tileset.json',
+            accessToken: 'not_really_a_refresh_token'
+        };
+
         it('constructs with expected values', function() {
             spyOn(Resource, 'call').and.callThrough();
 
-            var endpointResource = new Resource({ url: 'https://api.test.invalid' });
+            var endpointResource = CesiumIon.createEndpointResource(assetId);
             var resource = CesiumIon._CesiumIonResource.create(endpoint, endpointResource);
             expect(resource).toBeInstanceOf(Resource);
             expect(resource.ionEndpoint).toEqual(endpoint);
@@ -102,7 +245,7 @@ defineSuite([
         });
 
         it('clone works', function() {
-            var endpointResource = new Resource({ url: 'https://api.test.invalid' });
+            var endpointResource = CesiumIon.createEndpointResource(assetId);
             var resource = CesiumIon._CesiumIonResource.create(endpoint, endpointResource);
             var cloned = resource.clone();
             expect(cloned).not.toBe(resource);
@@ -112,9 +255,9 @@ defineSuite([
         });
 
         it('create creates the expected resource', function() {
-            var endpointResource = new Resource({ url: 'https://api.test.invalid', access_token: 'not_the_token' });
+            var endpointResource = CesiumIon.createEndpointResource(assetId);
             var resource = CesiumIon._CesiumIonResource.create(endpoint, endpointResource);
-            expect(resource.getUrlComponent()).toEqual('https://assets.cesium.com/123890213');
+            expect(resource.getUrlComponent()).toEqual(endpoint.url);
             expect(resource.queryParameters).toEqual({ access_token: 'not_really_a_refresh_token' });
             expect(resource.ionEndpoint).toBe(endpoint);
             expect(resource.ionEndpointResource).toEqual(endpointResource);
@@ -122,101 +265,83 @@ defineSuite([
             expect(resource.retryAttempts).toBe(1);
         });
 
-        function testImageryAsset(endpoint, ImageryClass) {
-            var endpointResource = new Resource({ url: 'https://api.test.invalid' });
-            var resource = CesiumIon._CesiumIonResource.create(endpoint, endpointResource);
-            var imageryProvider = resource.createImageryProvider();
-            expect(imageryProvider).toBeInstanceOf(ImageryClass);
-        }
+        describe('retryCallback', function() {
+            var endpointResource;
+            var resource;
+            var retryCallback;
 
-        it('createImageryProvider works', function() {
-            var url = 'https://test.invalid';
-            testImageryAsset({ type: 'IMAGERY', url: url }, UrlTemplateImageryProvider);
-            testImageryAsset({ type: 'ARCGIS_MAPSERVER', url: url }, ArcGisMapServerImageryProvider);
-            testImageryAsset({ type: 'BING', url: url }, BingMapsImageryProvider);
-            testImageryAsset({ type: 'GOOGLE_EARTH', url: url, channel: 1 }, GoogleEarthEnterpriseMapsProvider);
-            testImageryAsset({ type: 'MAPBOX', url: url, mapId: 1 }, MapboxImageryProvider);
-            testImageryAsset({ type: 'SINGLE_TILE', url: url }, SingleTileImageryProvider);
-            testImageryAsset({ type: 'TMS', url: url }, UrlTemplateImageryProvider);
-            testImageryAsset({ type: 'URL_TEMPLATE', url: url }, UrlTemplateImageryProvider);
-            testImageryAsset({ type: 'WMS', url: url, layers: [] }, WebMapServiceImageryProvider);
-            testImageryAsset({ type: 'WMTS', url: url, layer: '', style: '', tileMatrixSetID: 1 }, WebMapTileServiceImageryProvider);
-        });
-
-        it('createImageryProvider throws with unknown asset type', function() {
-            endpoint.type = 'ADSASDS';
-            var endpointResource = new Resource({ url: 'https://api.test.invalid' });
-            var resource = CesiumIon._CesiumIonResource.create(endpoint, endpointResource);
-            expect(function() { resource.createImageryProvider(); }).toThrowRuntimeError();
-        });
-    });
-
-    describe('retryCallback', function() {
-        var endpointResource;
-        var resource;
-        var retryCallback;
-
-        beforeEach(function() {
-            endpointResource = new Resource({ url: 'https://api.test.invalid', access_token: 'not_the_token' });
-            resource = CesiumIon._CesiumIonResource.create(endpoint, endpointResource);
-            retryCallback = CesiumIon._createRetryCallback(endpoint, endpointResource, resource);
-        });
-
-        it('returns false when error is undefined', function() {
-            return retryCallback(resource, undefined).then(function(result) {
-                expect(result).toBe(false);
-            });
-        });
-
-        it('returns false when error is non-401', function() {
-            var error = new RequestErrorEvent(404);
-            return retryCallback(resource, error).then(function(result) {
-                expect(result).toBe(false);
-            });
-        });
-
-        it('returns false when error is event with non-Image target', function() {
-            var event = { target: {} };
-            return retryCallback(resource, event).then(function(result) {
-                expect(result).toBe(false);
-            });
-        });
-
-        function testCallback(resource, event) {
-            var deferred = when.defer();
-            spyOn(CesiumIon, '_loadJson').and.returnValue(deferred.promise);
-
-            var newEndpoint = {
-                type: '3DTILES',
-                url: 'https://assets.cesium.com/' + assetId,
-                accessToken: 'not_not_really_a_refresh_token'
-            };
-
-            var promise = retryCallback(resource, event);
-            var resultPromise = promise.then(function(result) {
-                expect(resource.queryParameters.access_token).toEqual(newEndpoint.accessToken);
-                expect(result).toBe(true);
+            beforeEach(function() {
+                endpointResource = new Resource({ url: 'https://api.test.invalid', access_token: 'not_the_token' });
+                resource = CesiumIon._CesiumIonResource.create(endpoint, endpointResource);
+                retryCallback = CesiumIon._createRetryCallback(endpoint, endpointResource, resource);
             });
 
-            expect(CesiumIon._loadJson).toHaveBeenCalledWith(endpointResource);
+            it('returns false when error is undefined', function() {
+                return retryCallback(resource, undefined).then(function(result) {
+                    expect(result).toBe(false);
+                });
+            });
 
-            //A second retry should re-use the same pending promise
-            var promise2 = retryCallback(resource, event);
-            expect(promise._pendingPromise).toBe(promise2._pendingPromise);
+            it('returns false when error is non-401', function() {
+                var error = new RequestErrorEvent(404);
+                return retryCallback(resource, error).then(function(result) {
+                    expect(result).toBe(false);
+                });
+            });
 
-            deferred.resolve(newEndpoint);
+            it('returns false when error is event with non-Image target', function() {
+                var event = { target: {} };
+                return retryCallback(resource, event).then(function(result) {
+                    expect(result).toBe(false);
+                });
+            });
 
-            return resultPromise;
-        }
+            function testCallback(resource, event) {
+                var deferred = when.defer();
+                spyOn(CesiumIon, '_loadJson').and.returnValue(deferred.promise);
 
-        it('works when error is a 401', function() {
-            var error = new RequestErrorEvent(401);
-            return testCallback(resource, error);
-        });
+                var newEndpoint = {
+                    type: '3DTILES',
+                    url: 'https://assets.cesium.com/' + assetId,
+                    accessToken: 'not_not_really_a_refresh_token'
+                };
 
-        it('works when error is event with Image target', function() {
-            var event = { target: new Image() };
-            return testCallback(resource, event);
+                var promise = retryCallback(resource, event);
+                var resultPromise = promise.then(function(result) {
+                    expect(resource.queryParameters.access_token).toEqual(newEndpoint.accessToken);
+                    expect(result).toBe(true);
+                });
+
+                expect(CesiumIon._loadJson).toHaveBeenCalledWith(endpointResource);
+
+                //A second retry should re-use the same pending promise
+                var promise2 = retryCallback(resource, event);
+                expect(promise._pendingPromise).toBe(promise2._pendingPromise);
+
+                deferred.resolve(newEndpoint);
+
+                return resultPromise;
+            }
+
+            it('works when error is a 401', function() {
+                var error = new RequestErrorEvent(401);
+                return testCallback(resource, error);
+            });
+
+            it('works when error is event with Image target', function() {
+                var event = { target: new Image() };
+                return testCallback(resource, event);
+            });
+
+            it('works with derived resource and sets root access_token', function() {
+                var derived = resource.getDerivedResource('1');
+                var error = new RequestErrorEvent(401);
+                return testCallback(derived, error)
+                .then(function(){
+                    expect(derived.ionEndpoint).toBe(resource.ionEndpoint);
+                    expect(derived.queryParameters.access_token).toEqual(resource.queryParameters.access_token);
+                });
+            });
         });
     });
 });

--- a/Specs/Scene/CesiumIonSpec.js
+++ b/Specs/Scene/CesiumIonSpec.js
@@ -5,6 +5,7 @@ defineSuite([
         'Core/Resource',
         'Scene/ArcGisMapServerImageryProvider',
         'Scene/BingMapsImageryProvider',
+        'Scene/CesiumIonResource',
         'Scene/GoogleEarthEnterpriseMapsProvider',
         'Scene/MapboxImageryProvider',
         'Scene/SingleTileImageryProvider',
@@ -19,6 +20,7 @@ defineSuite([
         Resource,
         ArcGisMapServerImageryProvider,
         BingMapsImageryProvider,
+        CesiumIonResource,
         GoogleEarthEnterpriseMapsProvider,
         MapboxImageryProvider,
         SingleTileImageryProvider,
@@ -38,29 +40,29 @@ defineSuite([
 
         var options = {};
         var resourceEndpoint = CesiumIon._createEndpointResource(tilesAssetId, options);
-        var expectedResource = CesiumIon._CesiumIonResource.create(tilesEndpoint, resourceEndpoint);
+        var expectedResource = CesiumIonResource.create(tilesEndpoint, resourceEndpoint);
 
         spyOn(CesiumIon, '_loadJson').and.returnValue(when.resolve(tilesEndpoint));
         spyOn(CesiumIon, '_createEndpointResource').and.returnValue(resourceEndpoint);
-        spyOn(CesiumIon._CesiumIonResource, 'create').and.returnValue(expectedResource);
+        spyOn(CesiumIonResource, 'create').and.returnValue(expectedResource);
 
         return CesiumIon.createResource(tilesAssetId, options)
             .then(function(resource) {
                 expect(resource).toBe(expectedResource);
                 expect(CesiumIon._createEndpointResource).toHaveBeenCalledWith(tilesAssetId, options);
                 expect(CesiumIon._loadJson(resourceEndpoint));
-                expect(CesiumIon._CesiumIonResource.create).toHaveBeenCalledWith(tilesEndpoint, resourceEndpoint);
+                expect(CesiumIonResource.create).toHaveBeenCalledWith(tilesEndpoint, resourceEndpoint);
             });
     });
 
     function testNonImageryExternalResource(externalEndpoint) {
         spyOn(CesiumIon, '_loadJson').and.returnValue(when.resolve(externalEndpoint));
-        spyOn(CesiumIon._CesiumIonResource, 'create');
+        spyOn(CesiumIonResource, 'create');
 
         return CesiumIon.createResource(123890213)
             .then(function(resource) {
                 expect(resource).toBeInstanceOf(Resource);
-                expect(resource).not.toBeInstanceOf(CesiumIon._CesiumIonResource);
+                expect(resource).not.toBeInstanceOf(CesiumIonResource);
                 expect(resource.url).toEqual(externalEndpoint.options.url);
             });
     }
@@ -219,129 +221,5 @@ defineSuite([
             .otherwise(function(error){
                 expect(error).toBeInstanceOf(RuntimeError);
             });
-    });
-
-    describe('CesiumIonResource', function() {
-        var assetId = 123890213;
-        var endpoint = {
-            type: '3DTILES',
-            url: 'https://assets.cesium.com/' + assetId + '/tileset.json',
-            accessToken: 'not_really_a_refresh_token'
-        };
-
-        it('constructs with expected values', function() {
-            spyOn(Resource, 'call').and.callThrough();
-
-            var endpointResource = CesiumIon._createEndpointResource(assetId);
-            var resource = CesiumIon._CesiumIonResource.create(endpoint, endpointResource);
-            expect(resource).toBeInstanceOf(Resource);
-            expect(resource.ionEndpoint).toEqual(endpoint);
-            expect(Resource.call).toHaveBeenCalledWith(resource, {
-                url: endpoint.url,
-                retryCallback: resource.retryCallback,
-                retryAttempts: 1,
-                queryParameters: { access_token: endpoint.accessToken }
-            });
-        });
-
-        it('clone works', function() {
-            var endpointResource = CesiumIon._createEndpointResource(assetId);
-            var resource = CesiumIon._CesiumIonResource.create(endpoint, endpointResource);
-            var cloned = resource.clone();
-            expect(cloned).not.toBe(resource);
-            expect(cloned.ionRoot).toBe(resource);
-            cloned.ionRoot = undefined;
-            expect(cloned).toEqual(resource);
-        });
-
-        it('create creates the expected resource', function() {
-            var endpointResource = CesiumIon._createEndpointResource(assetId);
-            var resource = CesiumIon._CesiumIonResource.create(endpoint, endpointResource);
-            expect(resource.getUrlComponent()).toEqual(endpoint.url);
-            expect(resource.queryParameters).toEqual({ access_token: 'not_really_a_refresh_token' });
-            expect(resource.ionEndpoint).toBe(endpoint);
-            expect(resource.ionEndpointResource).toEqual(endpointResource);
-            expect(resource.retryCallback).toBeDefined();
-            expect(resource.retryAttempts).toBe(1);
-        });
-
-        describe('retryCallback', function() {
-            var endpointResource;
-            var resource;
-            var retryCallback;
-
-            beforeEach(function() {
-                endpointResource = new Resource({ url: 'https://api.test.invalid', access_token: 'not_the_token' });
-                resource = CesiumIon._CesiumIonResource.create(endpoint, endpointResource);
-                retryCallback = CesiumIon._createRetryCallback(endpoint, endpointResource, resource);
-            });
-
-            it('returns false when error is undefined', function() {
-                return retryCallback(resource, undefined).then(function(result) {
-                    expect(result).toBe(false);
-                });
-            });
-
-            it('returns false when error is non-401', function() {
-                var error = new RequestErrorEvent(404);
-                return retryCallback(resource, error).then(function(result) {
-                    expect(result).toBe(false);
-                });
-            });
-
-            it('returns false when error is event with non-Image target', function() {
-                var event = { target: {} };
-                return retryCallback(resource, event).then(function(result) {
-                    expect(result).toBe(false);
-                });
-            });
-
-            function testCallback(resource, event) {
-                var deferred = when.defer();
-                spyOn(CesiumIon, '_loadJson').and.returnValue(deferred.promise);
-
-                var newEndpoint = {
-                    type: '3DTILES',
-                    url: 'https://assets.cesium.com/' + assetId,
-                    accessToken: 'not_not_really_a_refresh_token'
-                };
-
-                var promise = retryCallback(resource, event);
-                var resultPromise = promise.then(function(result) {
-                    expect(resource.queryParameters.access_token).toEqual(newEndpoint.accessToken);
-                    expect(result).toBe(true);
-                });
-
-                expect(CesiumIon._loadJson).toHaveBeenCalledWith(endpointResource);
-
-                //A second retry should re-use the same pending promise
-                var promise2 = retryCallback(resource, event);
-                expect(promise._pendingPromise).toBe(promise2._pendingPromise);
-
-                deferred.resolve(newEndpoint);
-
-                return resultPromise;
-            }
-
-            it('works when error is a 401', function() {
-                var error = new RequestErrorEvent(401);
-                return testCallback(resource, error);
-            });
-
-            it('works when error is event with Image target', function() {
-                var event = { target: new Image() };
-                return testCallback(resource, event);
-            });
-
-            it('works with derived resource and sets root access_token', function() {
-                var derived = resource.getDerivedResource('1');
-                var error = new RequestErrorEvent(401);
-                return testCallback(derived, error)
-                .then(function(){
-                    expect(derived.ionEndpoint).toBe(resource.ionEndpoint);
-                    expect(derived.queryParameters.access_token).toEqual(resource.queryParameters.access_token);
-                });
-            });
-        });
     });
 });


### PR DESCRIPTION
I was so excited about #6136 that I totally glossed over some important details of external assets and for the most part, they didn't work.  `CesiumIonResource` should only be used for ion hosted assets, so create a standard Resource instance for external 3D Tiles and Terrain.  This also means that `CesiumIonResource.createImageryProvider` can't exist and needs to just be on `CesiumIon` directly instead.

It's probably easier to review this as a whole file again rather than looking at the diff.

I also add `Instrumented` directory to .eslintignore becuase it was linting the results of `instrumentForCoverage`

CC @hpinkos @tfili 