### PR TITLE
Allow a loadedCallback per layer for a QuadtreeTile

### DIFF
--- a/Source/Scene/GlobeSurfaceTile.js
+++ b/Source/Scene/GlobeSurfaceTile.js
@@ -336,12 +336,15 @@ define([
             }
 
             if (isDoneLoading) {
-                var newCallbacks = [];
-                tile._loadedCallbacks.forEach(function(cb) {
-                    if (!cb(tile)) {
-                        newCallbacks.push(cb);
+                var callbacks = tile._loadedCallbacks;
+                var newCallbacks = {};
+                for(var layerId in callbacks) {
+                    if (callbacks.hasOwnProperty(layerId)) {
+                        if(!callbacks[layerId](tile)) {
+                            newCallbacks[layerId] = callbacks[layerId];
+                        }
                     }
-                });
+                }
                 tile._loadedCallbacks = newCallbacks;
 
                 tile.state = QuadtreeTileLoadState.DONE;

--- a/Source/Scene/GlobeSurfaceTileProvider.js
+++ b/Source/Scene/GlobeSurfaceTileProvider.js
@@ -681,7 +681,8 @@ define([
                 layer._imageryCache = {};
 
                 that._quadtree.forEachLoadedTile(function(tile) {
-                    if (tile.state !== QuadtreeTileLoadState.DONE) {
+                    // If this layer is still waiting to for the loaded callback, just return
+                    if (defined(tile._loadedCallbacks[layer._layerIndex])) {
                         return;
                     }
 
@@ -717,7 +718,7 @@ define([
                     // Create new TileImageries for all loaded tiles
                     if (layer._createTileImagerySkeletons(tile, terrainProvider, insertionPoint)) {
                         // Add callback to remove old TileImageries when the new TileImageries are ready
-                        tile._loadedCallbacks.push(getTileReadyCallback(tileImageriesToFree, layer, terrainProvider));
+                        tile._loadedCallbacks[layer._layerIndex] = getTileReadyCallback(tileImageriesToFree, layer, terrainProvider);
 
                         tile.state = QuadtreeTileLoadState.LOADING;
                     }

--- a/Source/Scene/QuadtreeTile.js
+++ b/Source/Scene/QuadtreeTile.js
@@ -71,7 +71,7 @@ define([
         this._customData = [];
         this._frameUpdated = undefined;
         this._frameRendered = undefined;
-        this._loadedCallbacks = [];
+        this._loadedCallbacks = {};
 
         /**
          * Gets or sets the current state of the tile in the tile load pipeline.


### PR DESCRIPTION
Previously, if we were refreshing a layer for a tile, refreshing another layer wouldn't happen. Now we store a callback per layer per tile.

Also added test to `GlobeSurfaceTileProviderSpec`.