### PR TITLE
update unionClippingRegions doc to be consistent

### DIFF
--- a/Source/Core/ClippingPlaneCollection.js
+++ b/Source/Core/ClippingPlaneCollection.js
@@ -119,7 +119,7 @@ define([
          *
          * @memberof ClippingPlaneCollection.prototype
          * @type {Boolean}
-         * @default true
+         * @default false
          */
         unionClippingRegions : {
             get : function() {


### PR DESCRIPTION
defaults to false, not true.  simply missed a documentation change throughout work