### PR TITLE
Fix for default scale of oriented bounding box

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -37,6 +37,7 @@ Change Log
 * Added separate file for the Cesium [Code of Conduct](https://github.com/AnalyticalGraphicsInc/cesium/blob/master/CODE_OF_CONDUCT.md). [#6129](https://github.com/AnalyticalGraphicsInc/cesium/pull/6129)
 * Fixed applying a translucent style to a point cloud tileset. [#6113](https://github.com/AnalyticalGraphicsInc/cesium/pull/6113)
 * Fixed Sandcastle Particle System example for better visual [#6132](https://github.com/AnalyticalGraphicsInc/cesium/pull/6132)
+* Fixed discrepancy between default value used and commented value for default value for halfAxes of OrientedBoundingBox.
 
 ### 1.41 - 2018-01-02
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -36,7 +36,6 @@ Change Log
 * Added support for vertex shader uniforms when `tileset.colorBlendMode` is  `MIX` or `REPLACE`. [#5874](https://github.com/AnalyticalGraphicsInc/cesium/pull/5874)
 * Added separate file for the Cesium [Code of Conduct](https://github.com/AnalyticalGraphicsInc/cesium/blob/master/CODE_OF_CONDUCT.md). [#6129](https://github.com/AnalyticalGraphicsInc/cesium/pull/6129)
 * Fixed applying a translucent style to a point cloud tileset. [#6113](https://github.com/AnalyticalGraphicsInc/cesium/pull/6113)
-* Fixed Sandcastle Particle System example for better visual [#6132](https://github.com/AnalyticalGraphicsInc/cesium/pull/6132)
 * Fixed sandcastle Particle System example for better visual [#6132](https://github.com/AnalyticalGraphicsInc/cesium/pull/6132)
 * Fixed camera movement and look functions for 2D mode [#5884](https://github.com/AnalyticalGraphicsInc/cesium/issues/5884)
 * Fixed discrepancy between default value used and commented value for default value for halfAxes of OrientedBoundingBox.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -38,7 +38,7 @@ Change Log
 * Fixed applying a translucent style to a point cloud tileset. [#6113](https://github.com/AnalyticalGraphicsInc/cesium/pull/6113)
 * Fixed sandcastle Particle System example for better visual [#6132](https://github.com/AnalyticalGraphicsInc/cesium/pull/6132)
 * Fixed camera movement and look functions for 2D mode [#5884](https://github.com/AnalyticalGraphicsInc/cesium/issues/5884)
-* Fixed discrepancy between default value used and commented value for default value for halfAxes of OrientedBoundingBox.
+* Fixed discrepancy between default value used and commented value for default value for halfAxes of OrientedBoundingBox. [#6147](https://github.com/AnalyticalGraphicsInc/cesium/pull/6147)
 
 ### 1.41 - 2018-01-02
 

--- a/Source/Core/OrientedBoundingBox.js
+++ b/Source/Core/OrientedBoundingBox.js
@@ -42,7 +42,7 @@ define([
      *
      * @param {Cartesian3} [center=Cartesian3.ZERO] The center of the box.
      * @param {Matrix3} [halfAxes=Matrix3.ZERO] The three orthogonal half-axes of the bounding box.
-     *                                          Equivalently, the transformation matrix, to rotate and scale a 2x2x2
+     *                                          Equivalently, the transformation matrix, to rotate and scale a 1x1x1
      *                                          cube centered at the origin.
      *
      *
@@ -68,7 +68,7 @@ define([
          * @type {Matrix3}
          * @default {@link Matrix3.IDENTITY}
          */
-        this.halfAxes = Matrix3.clone(defaultValue(halfAxes, Matrix3.ZERO));
+        this.halfAxes = Matrix3.clone(defaultValue(halfAxes, Matrix3.IDENTITY));
     }
 
     /**

--- a/Source/Core/OrientedBoundingBox.js
+++ b/Source/Core/OrientedBoundingBox.js
@@ -42,7 +42,7 @@ define([
      *
      * @param {Cartesian3} [center=Cartesian3.ZERO] The center of the box.
      * @param {Matrix3} [halfAxes=Matrix3.ZERO] The three orthogonal half-axes of the bounding box.
-     *                                          Equivalently, the transformation matrix, to rotate and scale a 1x1x1
+     *                                          Equivalently, the transformation matrix, to rotate and scale a 0x0x0
      *                                          cube centered at the origin.
      *
      *
@@ -66,9 +66,9 @@ define([
         /**
          * The transformation matrix, to rotate the box to the right position.
          * @type {Matrix3}
-         * @default {@link Matrix3.IDENTITY}
+         * @default {@link Matrix3.ZERO}
          */
-        this.halfAxes = Matrix3.clone(defaultValue(halfAxes, Matrix3.IDENTITY));
+        this.halfAxes = Matrix3.clone(defaultValue(halfAxes, Matrix3.ZERO));
     }
 
     /**


### PR DESCRIPTION
constructor comment said scale was 2x2x2, comment above variable definition in constructor said Matrix3.IDENTITY, and variable was defaulted with Matrix3.ZERO. --> for orientedBoundingBox halfAxes variable.

updated to all be Matrix3.ZERO to match other types of default construction used in the rest of the class.