### PR TITLE
Use CesiumIon for ion hosted examples

### DIFF
--- a/Apps/Sandcastle/gallery/3D Tiles BIM.html
+++ b/Apps/Sandcastle/gallery/3D Tiles BIM.html
@@ -29,15 +29,13 @@ function startup(Cesium) {
 // Power Plant design model provided by Bentley Systems
 var viewer = new Cesium.Viewer('cesiumContainer');
 
-var tileset = viewer.scene.primitives.add(new Cesium.Cesium3DTileset({
-    url : 'https://beta.cesium.com/api/assets/1459?access_token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiIzNjUyM2I5Yy01YmRhLTQ0MjktOGI0Zi02MDdmYzBjMmY0MjYiLCJpZCI6NDQsImFzc2V0cyI6WzE0NTldLCJpYXQiOjE0OTkyNjQ3ODF9.SW_rwY-ic0TwQBeiweXNqFyywoxnnUBtcVjeCmDGef4'
-}));
-
-tileset.readyPromise.then(function() {
-    viewer.zoomTo(tileset, new Cesium.HeadingPitchRange(0.5, -0.2, tileset.boundingSphere.radius * 4.0));
-}).otherwise(function(error) {
-    throw(error);
-});
+Cesium.CesiumIon.create3DTileset(1459, { accessToken: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiIzNjUyM2I5Yy01YmRhLTQ0MjktOGI0Zi02MDdmYzBjMmY0MjYiLCJpZCI6NDQsImFzc2V0cyI6WzE0NTldLCJpYXQiOjE0OTkyNjQ3ODF9.SW_rwY-ic0TwQBeiweXNqFyywoxnnUBtcVjeCmDGef4' })
+    .then(function(tileset) {
+        viewer.scene.primitives.add(tileset);
+        viewer.zoomTo(tileset, new Cesium.HeadingPitchRange(0.5, -0.2, tileset.boundingSphere.radius * 4.0));
+    }).otherwise(function(error) {
+        console.log(error);
+    });
 //Sandcastle_End
 Sandcastle.finishedLoading();
 }

--- a/Apps/Sandcastle/gallery/3D Tiles Clipping Planes.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Clipping Planes.html
@@ -125,7 +125,8 @@ function loadTileset(url) {
         })
     }));
 
-    tileset.readyPromise.then(function() {
+    tileset.debugShowBoundingVolume = viewModel.debugBoundingVolumesEnabled;
+    return tileset.readyPromise.then(function() {
         var boundingSphere = tileset.boundingSphere;
         var radius = boundingSphere.radius;
 
@@ -147,10 +148,8 @@ function loadTileset(url) {
             planeEntities.push(planeEntity);
         }
     }).otherwise(function(error) {
-        throw(error);
+        console.log(error);
     });
-
-    tileset.debugShowBoundingVolume = viewModel.debugBoundingVolumesEnabled;
 }
 
 var modelEntityClippingPlanes;
@@ -206,12 +205,14 @@ function loadModel(url) {
 }
 
 // Power Plant design model provided by Bentley Systems
-var bimUrl = 'https://beta.cesium.com/api/assets/1459?access_token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiIzNjUyM2I5Yy01YmRhLTQ0MjktOGI0Zi02MDdmYzBjMmY0MjYiLCJpZCI6NDQsImFzc2V0cyI6WzE0NTldLCJpYXQiOjE0OTkyNjQ3ODF9.SW_rwY-ic0TwQBeiweXNqFyywoxnnUBtcVjeCmDGef4';
-var pointCloudUrl = 'https://beta.cesium.com/api/assets/1460?access_token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiIyMzk2YzJiOS1jZGFmLTRlZmYtYmQ4MS00NTA3NjEwMzViZTkiLCJpZCI6NDQsImFzc2V0cyI6WzE0NjBdLCJpYXQiOjE0OTkyNjQ3NTV9.oWjvN52CRQ-dk3xtvD4e8ZnOHZhoWSpJLlw115mbQJM';
+var bimUrl = Cesium.CesiumIon.createResource(1459, { accessToken: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiIzNjUyM2I5Yy01YmRhLTQ0MjktOGI0Zi02MDdmYzBjMmY0MjYiLCJpZCI6NDQsImFzc2V0cyI6WzE0NTldLCJpYXQiOjE0OTkyNjQ3ODF9.SW_rwY-ic0TwQBeiweXNqFyywoxnnUBtcVjeCmDGef4' });
+var pointCloudUrl = Cesium.CesiumIon.createResource(1460, { accessToken: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiIyMzk2YzJiOS1jZGFmLTRlZmYtYmQ4MS00NTA3NjEwMzViZTkiLCJpZCI6NDQsImFzc2V0cyI6WzE0NjBdLCJpYXQiOjE0OTkyNjQ3NTV9.oWjvN52CRQ-dk3xtvD4e8ZnOHZhoWSpJLlw115mbQJM' });
 var instancedUrl = '../../../Specs/Data/Cesium3DTiles/Instanced/InstancedOrientation/';
 var modelUrl = '../../SampleData/models/CesiumAir/Cesium_Air.glb';
 
-loadTileset(bimUrl);
+bimUrl.then(function(resource) {
+    return loadTileset(resource);
+});
 
 // Track and create the bindings for the view model
 var toolbar = document.getElementById('toolbar');
@@ -222,15 +223,17 @@ Cesium.knockout.getObservable(viewModel, 'currentExampleType').subscribe(functio
     reset();
 
     if (newValue === clipObjects[0]) {
-        loadTileset(bimUrl);
+        bimUrl.then(function(resource) {
+            return loadTileset(resource);
+        });
     } else if (newValue === clipObjects[1]) {
-        loadTileset(pointCloudUrl);
-        tileset.readyPromise.then(function () {
+        pointCloudUrl.then(function(resource) {
+            return loadTileset(resource);
+        }).then(function() {
             tileset.clippingPlanes.modelMatrix = Cesium.Transforms.eastNorthUpToFixedFrame(tileset.boundingSphere.center);
         });
     } else if (newValue === clipObjects[2]) {
-        loadTileset(instancedUrl);
-        tileset.readyPromise.then(function () {
+        loadTileset(instancedUrl).then(function() {
             tileset.clippingPlanes.modelMatrix = Cesium.Transforms.eastNorthUpToFixedFrame(tileset.boundingSphere.center);
         });
     } else {

--- a/Apps/Sandcastle/gallery/3D Tiles Feature Picking.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Feature Picking.html
@@ -40,9 +40,10 @@ viewer.scene.camera.setView({
 });
 
 // Load the NYC buildings tileset
-var tileset = viewer.scene.primitives.add(new Cesium.Cesium3DTileset({
-    url: 'https://beta.cesium.com/api/assets/1461?access_token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJkYWJmM2MzNS02OWM5LTQ3OWItYjEyYS0xZmNlODM5ZDNkMTYiLCJpZCI6NDQsImFzc2V0cyI6WzE0NjFdLCJpYXQiOjE0OTkyNjQ3NDN9.vuR75SqPDKcggvUrG_vpx0Av02jdiAxnnB1fNf-9f7s'
-}));
+Cesium.CesiumIon.createCesium3DTileset(1461, { accessToken: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJkYWJmM2MzNS02OWM5LTQ3OWItYjEyYS0xZmNlODM5ZDNkMTYiLCJpZCI6NDQsImFzc2V0cyI6WzE0NjFdLCJpYXQiOjE0OTkyNjQ3NDN9.vuR75SqPDKcggvUrG_vpx0Av02jdiAxnnB1fNf-9f7s' })
+    .then(function(tileset) {
+        viewer.scene.primitives.add(tileset);
+    });
 
 // HTML overlay for showing feature name on mouseover
 var nameOverlay = document.createElement('div');

--- a/Apps/Sandcastle/gallery/3D Tiles Feature Picking.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Feature Picking.html
@@ -40,7 +40,7 @@ viewer.scene.camera.setView({
 });
 
 // Load the NYC buildings tileset
-Cesium.CesiumIon.createCesium3DTileset(1461, { accessToken: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJkYWJmM2MzNS02OWM5LTQ3OWItYjEyYS0xZmNlODM5ZDNkMTYiLCJpZCI6NDQsImFzc2V0cyI6WzE0NjFdLCJpYXQiOjE0OTkyNjQ3NDN9.vuR75SqPDKcggvUrG_vpx0Av02jdiAxnnB1fNf-9f7s' })
+Cesium.CesiumIon.create3DTileset(1461, { accessToken: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJkYWJmM2MzNS02OWM5LTQ3OWItYjEyYS0xZmNlODM5ZDNkMTYiLCJpZCI6NDQsImFzc2V0cyI6WzE0NjFdLCJpYXQiOjE0OTkyNjQ3NDN9.vuR75SqPDKcggvUrG_vpx0Av02jdiAxnnB1fNf-9f7s' })
     .then(function(tileset) {
         viewer.scene.primitives.add(tileset);
     });

--- a/Apps/Sandcastle/gallery/3D Tiles Feature Styling.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Feature Styling.html
@@ -42,9 +42,10 @@ viewer.scene.camera.setView({
 });
 
 // Load the NYC buildings tileset.
-var tileset = viewer.scene.primitives.add(new Cesium.Cesium3DTileset({
-    url: 'https://beta.cesium.com/api/assets/1461?access_token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJkYWJmM2MzNS02OWM5LTQ3OWItYjEyYS0xZmNlODM5ZDNkMTYiLCJpZCI6NDQsImFzc2V0cyI6WzE0NjFdLCJpYXQiOjE0OTkyNjQ3NDN9.vuR75SqPDKcggvUrG_vpx0Av02jdiAxnnB1fNf-9f7s'
-}));
+Cesium.CesiumIon.create3DTileset(1461, { accessToken: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJkYWJmM2MzNS02OWM5LTQ3OWItYjEyYS0xZmNlODM5ZDNkMTYiLCJpZCI6NDQsImFzc2V0cyI6WzE0NjFdLCJpYXQiOjE0OTkyNjQ3NDN9.vuR75SqPDKcggvUrG_vpx0Av02jdiAxnnB1fNf-9f7s' })
+.then(function(tileset) {
+
+viewer.scene.primitives.add(tileset);
 
 // Color buildings based on their height.
 function colorByHeight() {
@@ -148,6 +149,12 @@ Sandcastle.addToolbarMenu([{
         hideByHeight();
     }
 }]);
+
+colorByHeight();
+})
+.otherwise(function(error) {
+    console.log(error);
+});
 
 //Sandcastle_End
 Sandcastle.finishedLoading();

--- a/Apps/Sandcastle/gallery/3D Tiles Inspector.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Inspector.html
@@ -31,15 +31,14 @@ var viewer = new Cesium.Viewer('cesiumContainer');
 viewer.extend(Cesium.viewerCesium3DTilesInspectorMixin);
 var inspectorViewModel = viewer.cesium3DTilesInspector.viewModel;
 
-var tileset = viewer.scene.primitives.add(new Cesium.Cesium3DTileset({
-    url: 'https://beta.cesium.com/api/assets/1461?access_token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJkYWJmM2MzNS02OWM5LTQ3OWItYjEyYS0xZmNlODM5ZDNkMTYiLCJpZCI6NDQsImFzc2V0cyI6WzE0NjFdLCJpYXQiOjE0OTkyNjQ3NDN9.vuR75SqPDKcggvUrG_vpx0Av02jdiAxnnB1fNf-9f7s'
-}));
+Cesium.CesiumIon.create3DTileset(1461, { accessToken: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJkYWJmM2MzNS02OWM5LTQ3OWItYjEyYS0xZmNlODM5ZDNkMTYiLCJpZCI6NDQsImFzc2V0cyI6WzE0NjFdLCJpYXQiOjE0OTkyNjQ3NDN9.vuR75SqPDKcggvUrG_vpx0Av02jdiAxnnB1fNf-9f7s' })
+    .then(function(tileset) {
+        viewer.scene.primitives.add(tileset);
+        viewer.zoomTo(tileset, new Cesium.HeadingPitchRange(0.0, -0.5, tileset.boundingSphere.radius / 4.0));
+    }).otherwise(function(error) {
+        console.log(error);
+    });
 
-tileset.readyPromise.then(function() {
-    viewer.zoomTo(tileset, new Cesium.HeadingPitchRange(0.0, -0.5, tileset.boundingSphere.radius / 4.0));
-}).otherwise(function(error) {
-    throw(error);
-});
 //Sandcastle_End
 Sandcastle.finishedLoading();
 }

--- a/Apps/Sandcastle/gallery/3D Tiles Interactivity.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Interactivity.html
@@ -68,16 +68,19 @@ viewer.scene.camera.setView({
     endTransform: Cesium.Matrix4.IDENTITY
 });
 
-// Load the NYC buildings tileset.
-var tileset = scene.primitives.add(new Cesium.Cesium3DTileset({
-    url: 'https://beta.cesium.com/api/assets/1461?access_token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJkYWJmM2MzNS02OWM5LTQ3OWItYjEyYS0xZmNlODM5ZDNkMTYiLCJpZCI6NDQsImFzc2V0cyI6WzE0NjFdLCJpYXQiOjE0OTkyNjQ3NDN9.vuR75SqPDKcggvUrG_vpx0Av02jdiAxnnB1fNf-9f7s'
-}));
+var tileset;
 
-tileset.style = new Cesium.Cesium3DTileStyle({
-    meta: {
-        description: "'Building id ${id} has height ${height}.'"
-    }
-});
+// Load the NYC buildings tileset.
+Cesium.CesiumIon.create3DTileset(1461, { accessToken: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJkYWJmM2MzNS02OWM5LTQ3OWItYjEyYS0xZmNlODM5ZDNkMTYiLCJpZCI6NDQsImFzc2V0cyI6WzE0NjFdLCJpYXQiOjE0OTkyNjQ3NDN9.vuR75SqPDKcggvUrG_vpx0Av02jdiAxnnB1fNf-9f7s' })
+    .then(function(result) {
+        tileset = result;
+        scene.primitives.add(tileset);
+        tileset.style = new Cesium.Cesium3DTileStyle({
+            meta: {
+                description: "'Building id ${id} has height ${height}.'"
+            }
+        });
+    });
 
 var handler = new Cesium.ScreenSpaceEventHandler(viewer.canvas);
 

--- a/Apps/Sandcastle/gallery/3D Tiles Interior.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Interior.html
@@ -30,9 +30,10 @@ function startup(Cesium) {
 // San Miguel model created by Guillermo M. Leal Llaguno. Cleaned up and hosted by Morgan McGuire: http://graphics.cs.williams.edu/data/meshes.xml
 var viewer = new Cesium.Viewer('cesiumContainer');
 
-viewer.scene.primitives.add(new Cesium.Cesium3DTileset({
-    url : 'https://beta.cesium.com/api/assets/1463?access_token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiI5ZGExZTdmMS0xZjA5LTQxODAtOThmYi04MWU1YjZkMWZjNjgiLCJpZCI6NDQsImFzc2V0cyI6WzE0NjNdLCJpYXQiOjE0OTkyNzYwNzV9.eTEtaAEBUehNIZushZQnp0On9BPRtZYS7XEWFwneSRU'
-}));
+Cesium.CesiumIon.create3DTileset(1463, { accessToken: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiI5ZGExZTdmMS0xZjA5LTQxODAtOThmYi04MWU1YjZkMWZjNjgiLCJpZCI6NDQsImFzc2V0cyI6WzE0NjNdLCJpYXQiOjE0OTkyNzYwNzV9.eTEtaAEBUehNIZushZQnp0On9BPRtZYS7XEWFwneSRU' })
+    .then(function(tileset) {
+        viewer.scene.primitives.add(tileset);
+    });
 
 var initialPosition = new Cesium.Cartesian3(-1111583.3721328347, -5855888.151574568, 2262561.444696748);
 var initialOrientation = new Cesium.HeadingPitchRoll.fromDegrees(100.0, -15.0, 0.0);

--- a/Apps/Sandcastle/gallery/3D Tiles Photogrammetry Classification.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Photogrammetry Classification.html
@@ -31,43 +31,44 @@ function startup(Cesium) {
 var viewer = new Cesium.Viewer('cesiumContainer');
 
 // A normal b3dm tileset of photogrammetry
-var tileset = viewer.scene.primitives.add(new Cesium.Cesium3DTileset({
-    url : 'https://beta.cesium.com/api/assets/1458?access_token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiIxYmJiNTAxOC1lOTg5LTQzN2EtODg1OC0zMWJjM2IxNGNlYmMiLCJpZCI6NDQsImFzc2V0cyI6WzE0NThdLCJpYXQiOjE0OTkyNjM4MjB9.1WKijRa-ILkmG6utrhDWX6rDgasjD7dZv-G5ZyCmkKg'
-}));
-
-// Move the camera to view the tileset on load.
-viewer.zoomTo(tileset).otherwise(function(error) {
-    throw(error);
-});
+Cesium.CesiumIon.create3DTileset(1458, { accessToken: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiIxYmJiNTAxOC1lOTg5LTQzN2EtODg1OC0zMWJjM2IxNGNlYmMiLCJpZCI6NDQsImFzc2V0cyI6WzE0NThdLCJpYXQiOjE0OTkyNjM4MjB9.1WKijRa-ILkmG6utrhDWX6rDgasjD7dZv-G5ZyCmkKg' })
+    .then(function(tileset) {
+        viewer.scene.primitives.add(tileset);
+        viewer.zoomTo(tileset);
+    })
+    .otherwise(function(error) {
+        console.log(error);
+    });
 
 // A b3dm tileset used to classify the photogrammetry tileset
-var classification = viewer.scene.primitives.add(new Cesium.Cesium3DTileset({
-    url: 'https://beta.cesium.com/api/assets/3625?access_token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJhZDI4YzA2Ny03YTIwLTQ5ZWEtODY3My1hMzU0OTJmMjEwMWQiLCJpZCI6NDQsImFzc2V0cyI6WzM2MjVdLCJpYXQiOjE1MTU1OTMxODN9.cntiWhEEBAeUb9Lq4ECpwpUuz9yZzEqOvucYopTjA5k',
-    classificationType : Cesium.ClassificationType.CESIUM_3D_TILE
-}));
-
-classification.readyPromise.then(function() {
+var classificationPromise = Cesium.CesiumIon.create3DTileset(3625, {
+    accessToken: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJhZDI4YzA2Ny03YTIwLTQ5ZWEtODY3My1hMzU0OTJmMjEwMWQiLCJpZCI6NDQsImFzc2V0cyI6WzM2MjVdLCJpYXQiOjE1MTU1OTMxODN9.cntiWhEEBAeUb9Lq4ECpwpUuz9yZzEqOvucYopTjA5k',
+    tilesetOptions: { classificationType: Cesium.ClassificationType.CESIUM_3D_TILE }
+}).then(function(classification) {
     classification.style = new Cesium.Cesium3DTileStyle({
-        color : 'rgba(255, 0, 0, 0.5)'
+        color: 'rgba(255, 0, 0, 0.5)'
     });
+    return viewer.scene.primitives.add(classification);
 }).otherwise(function(error) {
-    throw(error);
+    console.log(error);
 });
 
 // The same b3dm tileset used for classification, but rendered normally for comparison.
-var nonClassification = viewer.scene.primitives.add(new Cesium.Cesium3DTileset({
-    url: 'https://beta.cesium.com/api/assets/3625?access_token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJhZDI4YzA2Ny03YTIwLTQ5ZWEtODY3My1hMzU0OTJmMjEwMWQiLCJpZCI6NDQsImFzc2V0cyI6WzM2MjVdLCJpYXQiOjE1MTU1OTMxODN9.cntiWhEEBAeUb9Lq4ECpwpUuz9yZzEqOvucYopTjA5k',
-    show : false
-}));
-nonClassification.readyPromise.then(function() {
+var nonClassificationPromise = Cesium.CesiumIon.create3DTileset(3625, {
+    accessToken: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJhZDI4YzA2Ny03YTIwLTQ5ZWEtODY3My1hMzU0OTJmMjEwMWQiLCJpZCI6NDQsImFzc2V0cyI6WzM2MjVdLCJpYXQiOjE1MTU1OTMxODN9.cntiWhEEBAeUb9Lq4ECpwpUuz9yZzEqOvucYopTjA5k',
+    tilesetOptions: { show: false }
+}).then(function(nonClassification) {
     nonClassification.style = new Cesium.Cesium3DTileStyle({
-        color : 'rgba(255, 0, 0, 0.5)'
+        color: 'rgba(255, 0, 0, 0.5)'
     });
+    return viewer.scene.primitives.add(nonClassification);
 }).otherwise(function(error) {
-    throw(error);
+    console.log(error);
 });
 
-Cesium.when.join(classification.readyPromise, nonClassification.readyPromise).then(function() {
+Cesium.when.join(classificationPromise, nonClassificationPromise).then(function(results) {
+    var classification = results[0];
+    var nonClassification = results[1];
     Sandcastle.addToggleButton('Show classification', true, function(checked) {
         classification.show = checked;
         nonClassification.show = !checked;

--- a/Apps/Sandcastle/gallery/3D Tiles Photogrammetry.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Photogrammetry.html
@@ -28,13 +28,15 @@ function startup(Cesium) {
 //Sandcastle_Begin
 var viewer = new Cesium.Viewer('cesiumContainer');
 
-var tileset = viewer.scene.primitives.add(new Cesium.Cesium3DTileset({
-    url : 'https://beta.cesium.com/api/assets/1458?access_token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiIxYmJiNTAxOC1lOTg5LTQzN2EtODg1OC0zMWJjM2IxNGNlYmMiLCJpZCI6NDQsImFzc2V0cyI6WzE0NThdLCJpYXQiOjE0OTkyNjM4MjB9.1WKijRa-ILkmG6utrhDWX6rDgasjD7dZv-G5ZyCmkKg'
-}));
+Cesium.CesiumIon.create3DTileset(1458, { accessToken: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiIxYmJiNTAxOC1lOTg5LTQzN2EtODg1OC0zMWJjM2IxNGNlYmMiLCJpZCI6NDQsImFzc2V0cyI6WzE0NThdLCJpYXQiOjE0OTkyNjM4MjB9.1WKijRa-ILkmG6utrhDWX6rDgasjD7dZv-G5ZyCmkKg' })
+    .then(function(tileset) {
+        viewer.scene.primitives.add(tileset);
+        viewer.zoomTo(tileset);
+    })
+    .otherwise(function(error) {
+        console.log(error);
+    });
 
-viewer.zoomTo(tileset).otherwise(function(error) {
-    throw(error);
-});
 //Sandcastle_End
 Sandcastle.finishedLoading();
 }

--- a/Apps/Sandcastle/gallery/3D Tiles Point Cloud Classification.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Point Cloud Classification.html
@@ -30,18 +30,21 @@ function startup(Cesium) {
 var viewer = new Cesium.Viewer('cesiumContainer');
 
 //Point Cloud by Prof. Peter Allen, Columbia University Robotics Lab. Scanning by Alejandro Troccoli and Matei Ciocarlie.
-viewer.scene.primitives.add(new Cesium.Cesium3DTileset({
-    url : 'https://beta.cesium.com/api/assets/1460?access_token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiIyMzk2YzJiOS1jZGFmLTRlZmYtYmQ4MS00NTA3NjEwMzViZTkiLCJpZCI6NDQsImFzc2V0cyI6WzE0NjBdLCJpYXQiOjE0OTkyNjQ3NTV9.oWjvN52CRQ-dk3xtvD4e8ZnOHZhoWSpJLlw115mbQJM'
-}));
+Cesium.CesiumIon.create3DTileset(1460, { accessToken: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiIyMzk2YzJiOS1jZGFmLTRlZmYtYmQ4MS00NTA3NjEwMzViZTkiLCJpZCI6NDQsImFzc2V0cyI6WzE0NjBdLCJpYXQiOjE0OTkyNjQ3NTV9.oWjvN52CRQ-dk3xtvD4e8ZnOHZhoWSpJLlw115mbQJM' })
+    .then(function(tileset) {
+        viewer.scene.primitives.add(tileset);
+    });
 
 // Geometry Tiles are experimental and the format is subject to change in the future.
 // For more details, see:
 //    https://github.com/AnalyticalGraphicsInc/3d-tiles/tree/3d-tiles-next/TileFormats/Geometry
-var classification = viewer.scene.primitives.add(new Cesium.Cesium3DTileset({
-    url: 'https://beta.cesium.com/api/assets/3624?access_token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJlYTdkZTFlNC1lYTZlLTQzODMtYmM5NC1iYmRkNzI1ZTg2NzkiLCJpZCI6NDQsImFzc2V0cyI6WzM2MjRdLCJpYXQiOjE1MTU1OTMxOTZ9.-YnJ5-FK5FmSsyChVZ-AwSbzD3k_rMhbuaIbqG2sKb4',
-    classificationType : Cesium.ClassificationType.CESIUM_3D_TILE
-}));
-classification.readyPromise.then(function() {
+Cesium.CesiumIon.create3DTileset(3624, {
+    accessToken: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJlYTdkZTFlNC1lYTZlLTQzODMtYmM5NC1iYmRkNzI1ZTg2NzkiLCJpZCI6NDQsImFzc2V0cyI6WzM2MjRdLCJpYXQiOjE1MTU1OTMxOTZ9.-YnJ5-FK5FmSsyChVZ-AwSbzD3k_rMhbuaIbqG2sKb4',
+    tilesetOptions: { classificationType: Cesium.ClassificationType.CESIUM_3D_TILE }
+})
+.then(function(classification) {
+    viewer.scene.primitives.add(classification);
+
     classification.style = new Cesium.Cesium3DTileStyle({
         color : {
             conditions : [

--- a/Apps/Sandcastle/gallery/3D Tiles Point Cloud.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Point Cloud.html
@@ -29,13 +29,15 @@ function startup(Cesium) {
 //Point Cloud by Prof. Peter Allen, Columbia University Robotics Lab. Scanning by Alejandro Troccoli and Matei Ciocarlie.
 var viewer = new Cesium.Viewer('cesiumContainer');
 
-var tileset = viewer.scene.primitives.add(new Cesium.Cesium3DTileset({
-    url : 'https://beta.cesium.com/api/assets/1460?access_token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiIyMzk2YzJiOS1jZGFmLTRlZmYtYmQ4MS00NTA3NjEwMzViZTkiLCJpZCI6NDQsImFzc2V0cyI6WzE0NjBdLCJpYXQiOjE0OTkyNjQ3NTV9.oWjvN52CRQ-dk3xtvD4e8ZnOHZhoWSpJLlw115mbQJM'
-}));
+Cesium.CesiumIon.create3DTileset(1460, { accessToken: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiIyMzk2YzJiOS1jZGFmLTRlZmYtYmQ4MS00NTA3NjEwMzViZTkiLCJpZCI6NDQsImFzc2V0cyI6WzE0NjBdLCJpYXQiOjE0OTkyNjQ3NTV9.oWjvN52CRQ-dk3xtvD4e8ZnOHZhoWSpJLlw115mbQJM' })
+    .then(function(tileset) {
+        viewer.scene.primitives.add(tileset);
+        viewer.zoomTo(tileset);
+    })
+    .otherwise(function(error) {
+        console.log(error);
+    });
 
-viewer.zoomTo(tileset).otherwise(function(error) {
-    throw(error);
-});
 //Sandcastle_End
 Sandcastle.finishedLoading();
 }

--- a/Apps/Sandcastle/gallery/3D Tiles Terrain Classification.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Terrain Classification.html
@@ -39,22 +39,19 @@ geocoder.searchText = 'Vienna';
 geocoder.flightDuration = 0.0;
 geocoder.search();
 
-
 // Vector 3D Tiles are experimental and the format is subject to change in the future.
 // For more details, see:
 //    https://github.com/AnalyticalGraphicsInc/3d-tiles/tree/3d-tiles-next/TileFormats/VectorData
-var tileset = viewer.scene.primitives.add(new Cesium.Cesium3DTileset({
-    url: 'https://beta.cesium.com/api/assets/3623?access_token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiIwODI4NTUxMC1lMzRjLTQ3OTMtODQ4NC1jM2UzYjc0MTk1NGQiLCJpZCI6NDQsImFzc2V0cyI6WzM2MjNdLCJpYXQiOjE1MTU1OTMxNjl9.PhDPnGMEPxGvxs_oIcQgfMv1OgiZhGjREJypZkwEs1g',
-    classificationType : Cesium.ClassificationType.TERRAIN
-}));
+Cesium.CesiumIon.create3DTileset(3623, { accessToken: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiIwODI4NTUxMC1lMzRjLTQ3OTMtODQ4NC1jM2UzYjc0MTk1NGQiLCJpZCI6NDQsImFzc2V0cyI6WzM2MjNdLCJpYXQiOjE1MTU1OTMxNjl9.PhDPnGMEPxGvxs_oIcQgfMv1OgiZhGjREJypZkwEs1g' })
+    .then(function(tileset) {
+        viewer.scene.primitives.add(tileset);
 
-tileset.readyPromise.then(function() {
-    tileset.style = new Cesium.Cesium3DTileStyle({
-        color : 'rgba(255, 255, 255, 0.5)'
+        tileset.style = new Cesium.Cesium3DTileStyle({
+            color: 'rgba(255, 255, 255, 0.5)'
+        });
+    }).otherwise(function(error) {
+        console.log(error);
     });
-}).otherwise(function(error) {
-    throw(error);
-});
 
 // Information about the currently highlighted feature
 var highlighted = {

--- a/Apps/Sandcastle/gallery/Classification Types.html
+++ b/Apps/Sandcastle/gallery/Classification Types.html
@@ -29,17 +29,15 @@ function startup(Cesium) {
 //Sandcastle_Begin
 var viewer = new Cesium.Viewer('cesiumContainer');
 
-var tileset = viewer.scene.primitives.add(new Cesium.Cesium3DTileset({
-    url : 'https://beta.cesium.com/api/assets/1458?access_token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiIxYmJiNTAxOC1lOTg5LTQzN2EtODg1OC0zMWJjM2IxNGNlYmMiLCJpZCI6NDQsImFzc2V0cyI6WzE0NThdLCJpYXQiOjE0OTkyNjM4MjB9.1WKijRa-ILkmG6utrhDWX6rDgasjD7dZv-G5ZyCmkKg'
-}));
-
-tileset.readyPromise.then(function() {
-    var boundingSphere = tileset.boundingSphere;
-    viewer.camera.viewBoundingSphere(boundingSphere, new Cesium.HeadingPitchRange(0.0, -0.5, boundingSphere.radius + 500.0));
-    viewer.camera.lookAtTransform(Cesium.Matrix4.IDENTITY);
-}).otherwise(function(error) {
-    throw(error);
-});
+Cesium.CesiumIon.create3DTileset(1458, { accessToken: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiIxYmJiNTAxOC1lOTg5LTQzN2EtODg1OC0zMWJjM2IxNGNlYmMiLCJpZCI6NDQsImFzc2V0cyI6WzE0NThdLCJpYXQiOjE0OTkyNjM4MjB9.1WKijRa-ILkmG6utrhDWX6rDgasjD7dZv-G5ZyCmkKg' })
+    .then(function(tileset) {
+        viewer.scene.primitives.add(tileset);
+        var boundingSphere = tileset.boundingSphere;
+        viewer.camera.viewBoundingSphere(boundingSphere, new Cesium.HeadingPitchRange(0.0, -0.5, boundingSphere.radius + 500.0));
+        viewer.camera.lookAtTransform(Cesium.Matrix4.IDENTITY);
+    }).otherwise(function(error) {
+        console.log(error);
+    });
 
 var cartographics = [new Cesium.Cartographic(-1.3194369277314022, 0.6988062530900625),
                      new Cesium.Cartographic(-1.3193955980204217, 0.6988091578771254),

--- a/Apps/Sandcastle/gallery/Classification.html
+++ b/Apps/Sandcastle/gallery/Classification.html
@@ -195,27 +195,26 @@ function updateAlpha(value) {
     scene.invertClassificationColor.alpha = parseFloat(value);
 }
 
-var tileset = scene.primitives.add(new Cesium.Cesium3DTileset({
-    url : 'https://beta.cesium.com/api/assets/1458?access_token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiIxYmJiNTAxOC1lOTg5LTQzN2EtODg1OC0zMWJjM2IxNGNlYmMiLCJpZCI6NDQsImFzc2V0cyI6WzE0NThdLCJpYXQiOjE0OTkyNjM4MjB9.1WKijRa-ILkmG6utrhDWX6rDgasjD7dZv-G5ZyCmkKg'
-}));
+Cesium.CesiumIon.create3DTileset(1458, { accessToken: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiIxYmJiNTAxOC1lOTg5LTQzN2EtODg1OC0zMWJjM2IxNGNlYmMiLCJpZCI6NDQsImFzc2V0cyI6WzE0NThdLCJpYXQiOjE0OTkyNjM4MjB9.1WKijRa-ILkmG6utrhDWX6rDgasjD7dZv-G5ZyCmkKg' })
+    .then(function(tileset) {
+        scene.primitives.add(tileset);
 
-tileset.readyPromise.then(function() {
-    var viewModel = {
-        inverted : viewer.scene.invertClassification,
-        invertedAlpha : viewer.scene.invertClassificationColor.alpha,
-        highlightBuilding : highlightBuilding,
-        highlightTrees : highlightTrees
-    };
-    Cesium.knockout.track(viewModel);
-    var toolbar = document.getElementById('toolbar');
-    Cesium.knockout.applyBindings(viewModel, toolbar);
-    Cesium.knockout.getObservable(viewModel, 'inverted').subscribe(invertClassification);
-    Cesium.knockout.getObservable(viewModel, 'invertedAlpha').subscribe(updateAlpha);
+        var viewModel = {
+            inverted: viewer.scene.invertClassification,
+            invertedAlpha: viewer.scene.invertClassificationColor.alpha,
+            highlightBuilding: highlightBuilding,
+            highlightTrees: highlightTrees
+        };
+        Cesium.knockout.track(viewModel);
+        var toolbar = document.getElementById('toolbar');
+        Cesium.knockout.applyBindings(viewModel, toolbar);
+        Cesium.knockout.getObservable(viewModel, 'inverted').subscribe(invertClassification);
+        Cesium.knockout.getObservable(viewModel, 'invertedAlpha').subscribe(updateAlpha);
 
-    highlightTrees();
-}).otherwise(function(error) {
-    throw(error);
-});
+        highlightTrees();
+    }).otherwise(function(error) {
+        console.log(error);
+    });
 
 var currentObjectId;
 var currentPrimitive;

--- a/Specs/Scene/CesiumIonSpec.js
+++ b/Specs/Scene/CesiumIonSpec.js
@@ -1,10 +1,14 @@
 defineSuite([
         'Scene/CesiumIon',
+        'Core/loadImage',
+        'Core/loadJsonp',
+        'Core/loadWithXhr',
         'Core/RuntimeError',
         'Core/RequestErrorEvent',
         'Core/Resource',
         'Scene/ArcGisMapServerImageryProvider',
         'Scene/BingMapsImageryProvider',
+        'Scene/Cesium3DTileset',
         'Scene/CesiumIonResource',
         'Scene/GoogleEarthEnterpriseMapsProvider',
         'Scene/MapboxImageryProvider',
@@ -15,11 +19,15 @@ defineSuite([
         'ThirdParty/when'
     ], function(
         CesiumIon,
+        loadImage,
+        loadJsonp,
+        loadWithXhr,
         RuntimeError,
         RequestErrorEvent,
         Resource,
         ArcGisMapServerImageryProvider,
         BingMapsImageryProvider,
+        Cesium3DTileset,
         CesiumIonResource,
         GoogleEarthEnterpriseMapsProvider,
         MapboxImageryProvider,
@@ -156,15 +164,25 @@ defineSuite([
     }
 
     it('createImageryProvider works with ARCGIS_MAPSERVER', function() {
+        spyOn(loadJsonp, 'loadAndExecuteScript').and.callFake(function(url, name, deffered) {
+            deffered.resolve({ resourceSets: [{ resources: [{ imageUrl: '', imageUrlSubdomains: [], zoomMax: 0 }] }] });
+        });
         return testExternalImagery('ARCGIS_MAPSERVER', { url: 'https://test.invalid' }, ArcGisMapServerImageryProvider);
     });
 
     it('createImageryProvider works with BING', function() {
+        spyOn(loadJsonp, 'loadAndExecuteScript').and.callFake(function(url, name, deffered) {
+            deffered.resolve({ resourceSets: [{ resources: [{ imageUrl: '', imageUrlSubdomains: [], zoomMax: 0 }] }] });
+        });
         return testExternalImagery('BING', { url: 'https://test.invalid' }, BingMapsImageryProvider);
     });
 
     it('createImageryProvider works with GOOGLE_EARTH', function() {
-        return testExternalImagery('GOOGLE_EARTH', { url: 'https://test.invalid', channel: 1 }, GoogleEarthEnterpriseMapsProvider);
+        spyOn(loadWithXhr, 'load').and.callFake(function(url, responseType, method, data, headers, deferred, overrideMimeType) {
+            deferred.resolve(JSON.stringify({ layers: [{ id: 0, version: '' }] }));
+        });
+
+        return testExternalImagery('GOOGLE_EARTH', { url: 'https://test.invalid', channel: 0 }, GoogleEarthEnterpriseMapsProvider);
     });
 
     it('createImageryProvider works with MAPBOX', function() {
@@ -172,6 +190,10 @@ defineSuite([
     });
 
     it('createImageryProvider works with SINGLE_TILE', function() {
+        spyOn(loadImage, 'createImage').and.callFake(function(url, crossOrigin, deferred) {
+            deferred.resolve({});
+        });
+
         return testExternalImagery('SINGLE_TILE', { url: 'https://test.invalid' }, SingleTileImageryProvider);
     });
 
@@ -217,6 +239,86 @@ defineSuite([
         spyOn(CesiumIon, '_loadJson').and.returnValue(when.resolve(endpoint));
 
         return CesiumIon.createImageryProvider(123890213)
+            .then(fail)
+            .otherwise(function(error){
+                expect(error).toBeInstanceOf(RuntimeError);
+            });
+    });
+
+    function load3DTileset(endpoint, options) {
+        spyOn(CesiumIon, '_loadJson').and.returnValue(when.resolve(endpoint));
+        spyOn(Cesium3DTileset, 'loadJson').and.returnValue(when.resolve({ asset: { version: '0.0' }, root: { content: {} } }));
+        spyOn(Cesium3DTileset.prototype, 'loadTileset').and.returnValue(when.resolve({ content: {} }));
+
+        return CesiumIon.create3DTileset(123890213, options);
+    }
+
+    it('create3DTileset works with non-external tileset', function() {
+        var endpoint = {
+            type: '3DTILES',
+            url: 'https://test.invalid/',
+            accessToken: 'not_really_a_refresh_token'
+        };
+
+        return load3DTileset(endpoint)
+            .then(function(tileset) {
+                expect(tileset.show).toBe(true);
+                expect(tileset.url).toBe(endpoint.url + '?access_token=' + endpoint.accessToken);
+            });
+    });
+
+    it('create3DTileset works with external tileset', function() {
+        var endpoint = {
+            type: '3DTILES',
+            externalType: '3DTILES',
+            options: { url: 'https://test.invalid/' }
+        };
+
+        return load3DTileset(endpoint, { tilesetOptions: { show: false } })
+            .then(function(tileset) {
+                expect(tileset.url).toBe(endpoint.options.url);
+            });
+    });
+
+    it('create3DTileset passes options tileset', function() {
+        var endpoint = {
+            type: '3DTILES',
+            url: 'https://test.invalid/',
+            accessToken: 'not_really_a_refresh_token'
+        };
+
+        return load3DTileset(endpoint, { tilesetOptions: { show: false } })
+            .then(function(tileset) {
+                expect(tileset.show).toBe(false);
+            });
+    });
+
+    it('create3DTileset rejects with non 3DTiles asset', function() {
+        var endpoint = {
+            type: 'IMAGERY',
+            url: 'https://assets.cesium.com/' + 123890213 + '/',
+            accessToken: 'not_really_a_refresh_token'
+        };
+
+        spyOn(CesiumIon, '_loadJson').and.returnValue(when.resolve(endpoint));
+
+        return CesiumIon.create3DTileset(123890213)
+            .then(fail)
+            .otherwise(function(error){
+                expect(error).toBeInstanceOf(RuntimeError);
+            });
+    });
+
+    it('create3DTileset rejects unknown external type', function() {
+        var endpoint = {
+            type: '3DTILES',
+            externalType: 'TUBALCAIN',
+            options: {}
+        };
+
+        spyOn(CesiumIon, '_loadJson').and.returnValue(when.resolve(endpoint));
+
+        return CesiumIon.create3DTileset(123890213)
             .then(fail)
             .otherwise(function(error){
                 expect(error).toBeInstanceOf(RuntimeError);


### PR DESCRIPTION
Added `CesiumIon.create3DTileset` helper function because updating the examples showed it to be a useful shortcut. Also make `create3DTileset`and `createImageryProvider` wait for the `readyPromise` because they are already async and almost everything creating a tileset was already waiting on the promise.

I haven't added tests for `create3DTileset` because I wanted feedback on the API, specifically how we handle 3D Tileset options, right now I added a `tilesetOptions` property onto the `options` object, which is the safest choice but I'm open to ideas.

Finally, I cleaned up some weird `throw` calls in example error handling which just hid the error from the end-user.  Replaced them with console logs.

I tested all of the examples, but someone who's more familiar with them may want to check them out.  Just search CesionIon in Sandcastle and it will filter them.