### PR TITLE
Clean up loadWithXhr

### DIFF
--- a/Source/Core/loadWithXhr.js
+++ b/Source/Core/loadWithXhr.js
@@ -79,7 +79,9 @@ define([
             resource = new Resource(optionsOrResource);
         }
 
-        resource.request = defaultValue(resource.request, new Request());
+		if (!defined(resource.request)) {
+			resource.request = new Request();
+		}
 
         return makeRequest(resource);
     }


### PR DESCRIPTION
Don't create a new `Request` object each time this gets called