### PR TITLE
Don't try to clone FormData

### DIFF
--- a/Source/Core/Resource.js
+++ b/Source/Core/Resource.js
@@ -139,6 +139,11 @@ define([
         Check.typeOf.string('options.url', options.url);
         //>>includeEnd('debug');
 
+        var data = options.data;
+        if (!(options.data instanceof FormData)) {
+            data = defaultClone(options.data);
+        }
+
         this._url = undefined;
         this._templateValues = defaultClone(options.templateValues, {});
         this._queryParameters = defaultClone(options.queryParameters, {});
@@ -176,7 +181,7 @@ define([
          *
          * @type {Object}
          */
-        this.data = defaultClone(options.data);
+        this.data = data;
 
         /**
          * Overrides the MIME type returned by the server.

--- a/Source/Core/Resource.js
+++ b/Source/Core/Resource.js
@@ -139,11 +139,6 @@ define([
         Check.typeOf.string('options.url', options.url);
         //>>includeEnd('debug');
 
-        var data = options.data;
-        if (!(options.data instanceof FormData)) {
-            data = defaultClone(options.data);
-        }
-
         this._url = undefined;
         this._templateValues = defaultClone(options.templateValues, {});
         this._queryParameters = defaultClone(options.queryParameters, {});
@@ -181,7 +176,7 @@ define([
          *
          * @type {Object}
          */
-        this.data = data;
+        this.data = options.data;
 
         /**
          * Overrides the MIME type returned by the server.


### PR DESCRIPTION
For a `Resource`, `data` can be a `FormData` for something like uploading a file.  We shouldn't try to clone it into a generic object in this case.