### PR TITLE
Sun lighting option for Models and 3D Tilesets

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -40,7 +40,7 @@ Change Log
 * Fixed sandcastle Particle System example for better visual [#6132](https://github.com/AnalyticalGraphicsInc/cesium/pull/6132)
 * Fixed camera movement and look functions for 2D mode [#5884](https://github.com/AnalyticalGraphicsInc/cesium/issues/5884)
 * Fixed discrepancy between default value used and commented value for default value for halfAxes of OrientedBoundingBox. [#6147](https://github.com/AnalyticalGraphicsInc/cesium/pull/6147)
-* Added `enableLighting` option to `Cesium3DTileset` and `Model` to control whether the tileset or model is shaded based on the sun direction. This option is ignored if the model has built-in shaders. [#6160](https://github.com/AnalyticalGraphicsInc/cesium/pull/6160)
+* Added `sunLighting` option to `Cesium3DTileset` and `Model` to control whether the tileset or model is shaded based on the sun direction. This option is ignored if the model has built-in shaders. [#6160](https://github.com/AnalyticalGraphicsInc/cesium/pull/6160)
 
 ### 1.41 - 2018-01-02
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -30,7 +30,7 @@ Change Log
    * Only one mesh per node is supported.
    * Only one primitive per mesh is supported.
 * Updated documentation links to reflect new locations on cesiumjs.org and cesium.com.
-* Updated 'Viewer.zoomTo' and 'Viewer.flyTo' to take in Cesium3DTilesets as a target and updated sandcastle 3DTileset examples to reflect this change
+* Updated `Viewer.zoomTo` and `Viewer.flyTo` to take in Cesium3DTilesets as a target and updated sandcastle 3DTileset examples to reflect this change
 * Fixed a glTF animation bug that caused certain animations to jitter. [#5740](https://github.com/AnalyticalGraphicsInc/cesium/pull/5740)
 * Fixed a bug when creating billboard and model entities without a globe. [#6109](https://github.com/AnalyticalGraphicsInc/cesium/pull/6109)
 * Added support for vertex shader uniforms when `tileset.colorBlendMode` is  `MIX` or `REPLACE`. [#5874](https://github.com/AnalyticalGraphicsInc/cesium/pull/5874)
@@ -40,6 +40,7 @@ Change Log
 * Fixed sandcastle Particle System example for better visual [#6132](https://github.com/AnalyticalGraphicsInc/cesium/pull/6132)
 * Fixed camera movement and look functions for 2D mode [#5884](https://github.com/AnalyticalGraphicsInc/cesium/issues/5884)
 * Fixed discrepancy between default value used and commented value for default value for halfAxes of OrientedBoundingBox. [#6147](https://github.com/AnalyticalGraphicsInc/cesium/pull/6147)
+* Added `enableLighting` option to `Cesium3DTileset` and `Model` to control whether the tileset or model is shaded based on the sun direction. This option is ignored if the model has built-in shaders. [#6160](https://github.com/AnalyticalGraphicsInc/cesium/pull/6160)
 
 ### 1.41 - 2018-01-02
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -40,7 +40,7 @@ Change Log
 * Fixed sandcastle Particle System example for better visual [#6132](https://github.com/AnalyticalGraphicsInc/cesium/pull/6132)
 * Fixed camera movement and look functions for 2D mode [#5884](https://github.com/AnalyticalGraphicsInc/cesium/issues/5884)
 * Fixed discrepancy between default value used and commented value for default value for halfAxes of OrientedBoundingBox. [#6147](https://github.com/AnalyticalGraphicsInc/cesium/pull/6147)
-* Added `sunLighting` option to `Cesium3DTileset` and `Model` to control whether the tileset or model is shaded based on the sun direction. This option is ignored if the model has built-in shaders. [#6160](https://github.com/AnalyticalGraphicsInc/cesium/pull/6160)
+* Added `sunLighting` option to `Cesium3DTileset`, `Model`, and `Model.fromGltf` to control whether the tileset or model is shaded based on the sun direction. This option is ignored if the model has built-in shaders. [#6160](https://github.com/AnalyticalGraphicsInc/cesium/pull/6160)
 
 ### 1.41 - 2018-01-02
 

--- a/Source/DataSources/ModelGraphics.js
+++ b/Source/DataSources/ModelGraphics.js
@@ -48,6 +48,7 @@ define([
      * @param {Property} [options.clampAnimations=true] A boolean Property specifying if glTF animations should hold the last pose for time durations with no keyframes.
      * @param {Property} [options.nodeTransformations] An object, where keys are names of nodes, and values are {@link TranslationRotationScale} Properties describing the transformation to apply to that node.
      * @param {Property} [options.shadows=ShadowMode.ENABLED] An enum Property specifying whether the model casts or receives shadows from each light source.
+     * @param {Property} [options.sunLighting=true] An boolean Property specifying whether to enable lighting the model with the sun as a light source. This value is ignored if the model has built-in shaders.
      * @param {Property} [options.heightReference=HeightReference.NONE] A Property specifying what the height is relative to.
      * @param {Property} [options.distanceDisplayCondition] A Property specifying at what distance from the camera that this model will be displayed.
      * @param {Property} [options.silhouetteColor=Color.RED] A Property specifying the {@link Color} of the silhouette.
@@ -73,6 +74,8 @@ define([
         this._incrementallyLoadTexturesSubscription = undefined;
         this._shadows = undefined;
         this._shadowsSubscription = undefined;
+        this._sunLighting = undefined;
+        this._sunLightingSubsciption = undefined;
         this._uri = undefined;
         this._uriSubscription = undefined;
         this._runAnimations = undefined;
@@ -168,6 +171,16 @@ define([
          * @default ShadowMode.ENABLED
          */
         shadows : createPropertyDescriptor('shadows'),
+
+        /**
+         * Get or sets the boolean Property specifying whether to
+         * enable lighting the model with the sun as a light source.
+         * This value is ignored if the model has built-in shaders.
+         * @memberof ModelGraphics.prototype
+         * @type {Property}
+         * @default true
+         */
+        sunLighting : createPropertyDescriptor('sunLighting'),
 
         /**
          * Gets or sets the string Property specifying the URI of the glTF asset.
@@ -281,6 +294,7 @@ define([
         result.maximumScale = this.maximumScale;
         result.incrementallyLoadTextures = this.incrementallyLoadTextures;
         result.shadows = this.shadows;
+        result.sunLighting = this.sunLighting;
         result.uri = this.uri;
         result.runAnimations = this.runAnimations;
         result.clampAnimations = this.clampAnimations;
@@ -316,6 +330,7 @@ define([
         this.maximumScale = defaultValue(this.maximumScale, source.maximumScale);
         this.incrementallyLoadTextures = defaultValue(this.incrementallyLoadTextures, source.incrementallyLoadTextures);
         this.shadows = defaultValue(this.shadows, source.shadows);
+        this.sunLighting = defaultValue(this.sunLighting, source.sunLighting);
         this.uri = defaultValue(this.uri, source.uri);
         this.runAnimations = defaultValue(this.runAnimations, source.runAnimations);
         this.clampAnimations = defaultValue(this.clampAnimations, source.clampAnimations);

--- a/Source/DataSources/ModelVisualizer.js
+++ b/Source/DataSources/ModelVisualizer.js
@@ -37,6 +37,7 @@ define([
     var defaultIncrementallyLoadTextures = true;
     var defaultClampAnimations = true;
     var defaultShadows = ShadowMode.ENABLED;
+    var defaultSunLighting = true;
     var defaultHeightReference = HeightReference.NONE;
     var defaultSilhouetteColor = Color.RED;
     var defaultSilhouetteSize = 0.0;
@@ -121,9 +122,11 @@ define([
                     primitives.removeAndDestroy(model);
                     delete modelHash[entity.id];
                 }
+
                 model = Model.fromGltf({
                     url : resource,
                     incrementallyLoadTextures : Property.getValueOrDefault(modelGraphics._incrementallyLoadTextures, time, defaultIncrementallyLoadTextures),
+                    sunLighting : Property.getValueOrDefault(modelGraphics._sunLighting, time, defaultSunLighting),
                     scene : this._scene
                 });
 
@@ -148,6 +151,7 @@ define([
             model.maximumScale = Property.getValueOrUndefined(modelGraphics._maximumScale, time);
             model.modelMatrix = Matrix4.clone(modelMatrix, model.modelMatrix);
             model.shadows = Property.getValueOrDefault(modelGraphics._shadows, time, defaultShadows);
+            model.sunLighting = Property.getValueOrDefault(modelGraphics._sunLighting, time, defaultSunLighting);
             model.heightReference = Property.getValueOrDefault(modelGraphics._heightReference, time, defaultHeightReference);
             model.distanceDisplayCondition = Property.getValueOrUndefined(modelGraphics._distanceDisplayCondition, time);
             model.silhouetteColor = Property.getValueOrDefault(modelGraphics._silhouetteColor, time, defaultSilhouetteColor, model._silhouetteColor);

--- a/Source/DataSources/ModelVisualizer.js
+++ b/Source/DataSources/ModelVisualizer.js
@@ -122,7 +122,6 @@ define([
                     primitives.removeAndDestroy(model);
                     delete modelHash[entity.id];
                 }
-
                 model = Model.fromGltf({
                     url : resource,
                     incrementallyLoadTextures : Property.getValueOrDefault(modelGraphics._incrementallyLoadTextures, time, defaultIncrementallyLoadTextures),

--- a/Source/Scene/Batched3DModel3DTileContent.js
+++ b/Source/Scene/Batched3DModel3DTileContent.js
@@ -402,7 +402,7 @@ define([
                 shadows: tileset.shadows,
                 debugWireframe: tileset.debugWireframe,
                 incrementallyLoadTextures : false,
-                enableLighting : tileset._enableLighting,
+                sunLighting : tileset._sunLighting,
                 vertexShaderLoaded : getVertexShaderCallback(content),
                 fragmentShaderLoaded : getFragmentShaderCallback(content),
                 uniformMapLoaded : batchTable.getUniformMapCallback(),

--- a/Source/Scene/Batched3DModel3DTileContent.js
+++ b/Source/Scene/Batched3DModel3DTileContent.js
@@ -402,6 +402,7 @@ define([
                 shadows: tileset.shadows,
                 debugWireframe: tileset.debugWireframe,
                 incrementallyLoadTextures : false,
+                enableLighting : tileset._enableLighting,
                 vertexShaderLoaded : getVertexShaderCallback(content),
                 fragmentShaderLoaded : getFragmentShaderCallback(content),
                 uniformMapLoaded : batchTable.getUniformMapCallback(),

--- a/Source/Scene/Cesium3DTileset.js
+++ b/Source/Scene/Cesium3DTileset.js
@@ -98,6 +98,7 @@ define([
      * @param {Boolean} [options.show=true] Determines if the tileset will be shown.
      * @param {Matrix4} [options.modelMatrix=Matrix4.IDENTITY] A 4x4 transformation matrix that transforms the tileset's root tile.
      * @param {ShadowMode} [options.shadows=ShadowMode.ENABLED] Determines whether the tileset casts or receives shadows from each light source.
+     * @param {Boolean} [options.enableLighting=true] Enable lighting the tileset with the sun as a light source.
      * @param {Number} [options.maximumScreenSpaceError=16] The maximum screen space error used to drive level of detail refinement.
      * @param {Number} [options.maximumMemoryUsage=512] The maximum amount of memory in MB that can be used by the tileset.
      * @param {Boolean} [options.cullWithChildrenBounds=true] Optimization option. Whether to cull tiles using the union of their children bounding volumes.
@@ -222,6 +223,8 @@ define([
         this._styleEngine = new Cesium3DTileStyleEngine();
 
         this._modelMatrix = defined(options.modelMatrix) ? Matrix4.clone(options.modelMatrix) : Matrix4.clone(Matrix4.IDENTITY);
+
+        this._enableLighting = defaultValue(options.enableLighting, true);
 
         this._statistics = new Cesium3DTilesetStatistics();
         this._statisticsLastColor = new Cesium3DTilesetStatistics();

--- a/Source/Scene/Cesium3DTileset.js
+++ b/Source/Scene/Cesium3DTileset.js
@@ -98,7 +98,7 @@ define([
      * @param {Boolean} [options.show=true] Determines if the tileset will be shown.
      * @param {Matrix4} [options.modelMatrix=Matrix4.IDENTITY] A 4x4 transformation matrix that transforms the tileset's root tile.
      * @param {ShadowMode} [options.shadows=ShadowMode.ENABLED] Determines whether the tileset casts or receives shadows from each light source.
-     * @param {Boolean} [options.enableLighting=true] Enable lighting the tileset with the sun as a light source.
+     * @param {Boolean} [options.sunLighting=true] Enable lighting the tileset with the sun as a light source.
      * @param {Number} [options.maximumScreenSpaceError=16] The maximum screen space error used to drive level of detail refinement.
      * @param {Number} [options.maximumMemoryUsage=512] The maximum amount of memory in MB that can be used by the tileset.
      * @param {Boolean} [options.cullWithChildrenBounds=true] Optimization option. Whether to cull tiles using the union of their children bounding volumes.
@@ -224,7 +224,7 @@ define([
 
         this._modelMatrix = defined(options.modelMatrix) ? Matrix4.clone(options.modelMatrix) : Matrix4.clone(Matrix4.IDENTITY);
 
-        this._enableLighting = defaultValue(options.enableLighting, true);
+        this._sunLighting = defaultValue(options.sunLighting, true);
 
         this._statistics = new Cesium3DTilesetStatistics();
         this._statisticsLastColor = new Cesium3DTilesetStatistics();

--- a/Source/Scene/Instanced3DModel3DTileContent.js
+++ b/Source/Scene/Instanced3DModel3DTileContent.js
@@ -313,7 +313,7 @@ define([
             url : undefined,
             requestType : RequestType.TILES3D,
             gltf : undefined,
-            enableLighting : content._tileset._enableLighting,
+            sunLighting : content._tileset._sunLighting,
             basePath : undefined,
             incrementallyLoadTextures : false,
             upAxis : content._tileset._gltfUpAxis,

--- a/Source/Scene/Instanced3DModel3DTileContent.js
+++ b/Source/Scene/Instanced3DModel3DTileContent.js
@@ -313,6 +313,7 @@ define([
             url : undefined,
             requestType : RequestType.TILES3D,
             gltf : undefined,
+            enableLighting : content._tileset._enableLighting,
             basePath : undefined,
             incrementallyLoadTextures : false,
             upAxis : content._tileset._gltfUpAxis,

--- a/Source/Scene/Model.js
+++ b/Source/Scene/Model.js
@@ -263,6 +263,7 @@ define([
      * @param {Boolean} [options.asynchronous=true] Determines if model WebGL resource creation will be spread out over several frames or block until completion once all glTF files are loaded.
      * @param {Boolean} [options.clampAnimations=true] Determines if the model's animations should hold a pose over frames where no keyframes are specified.
      * @param {ShadowMode} [options.shadows=ShadowMode.ENABLED] Determines whether the model casts or receives shadows from each light source.
+     * @param {Boolean} [options.enableLighting=true] Enable lighting the model with the sun as a light source. This value is ignored if the glTF has built-in shaders.
      * @param {Boolean} [options.debugShowBoundingVolume=false] For debugging only. Draws the bounding sphere for each draw command in the model.
      * @param {Boolean} [options.debugWireframe=false] For debugging only. Draws the model in wireframe.
      * @param {HeightReference} [options.heightReference] Determines how the model is drawn relative to terrain.
@@ -474,6 +475,7 @@ define([
 
         this._defaultTexture = undefined;
         this._incrementallyLoadTextures = defaultValue(options.incrementallyLoadTextures, true);
+        this._enableLighting = defaultValue(options.enableLighting, true);
         this._asynchronous = defaultValue(options.asynchronous, true);
 
         /**
@@ -1056,6 +1058,7 @@ define([
      * @param {Boolean} [options.asynchronous=true] Determines if model WebGL resource creation will be spread out over several frames or block until completion once all glTF files are loaded.
      * @param {Boolean} [options.clampAnimations=true] Determines if the model's animations should hold a pose over frames where no keyframes are specified.
      * @param {ShadowMode} [options.shadows=ShadowMode.ENABLED] Determines whether the model casts or receives shadows from each light source.
+     * @param {Boolean} [options.enableLighting=true] Enable lighting the model with the sun as a light source. This value is ignored if the glTF has built-in shaders.
      * @param {Boolean} [options.debugShowBoundingVolume=false] For debugging only. Draws the bounding sphere for each {@link DrawCommand} in the model.
      * @param {Boolean} [options.debugWireframe=false] For debugging only. Draws the model in wireframe.
      * @param {HeightReference} [options.heightReference] Determines how the model is drawn relative to terrain.
@@ -4102,6 +4105,7 @@ define([
                 if (!this._updatedGltfVersion) {
                     var options = {
                         optimizeForCesium: true,
+                        enableLighting: this._enableLighting,
                         addBatchIdToGeneratedShaders : this._addBatchIdToGeneratedShaders
                     };
                     frameState.brdfLutGenerator.update(frameState);

--- a/Source/Scene/Model.js
+++ b/Source/Scene/Model.js
@@ -263,7 +263,7 @@ define([
      * @param {Boolean} [options.asynchronous=true] Determines if model WebGL resource creation will be spread out over several frames or block until completion once all glTF files are loaded.
      * @param {Boolean} [options.clampAnimations=true] Determines if the model's animations should hold a pose over frames where no keyframes are specified.
      * @param {ShadowMode} [options.shadows=ShadowMode.ENABLED] Determines whether the model casts or receives shadows from each light source.
-     * @param {Boolean} [options.sunLighting=true] Enable lighting the model with the sun as a light source. This value is ignored if the glTF has built-in shaders.
+     * @param {Boolean} [options.sunLighting=true] Enable lighting the model with the sun as a light source. This value is ignored if the model has built-in shaders.
      * @param {Boolean} [options.debugShowBoundingVolume=false] For debugging only. Draws the bounding sphere for each draw command in the model.
      * @param {Boolean} [options.debugWireframe=false] For debugging only. Draws the model in wireframe.
      * @param {HeightReference} [options.heightReference] Determines how the model is drawn relative to terrain.
@@ -1058,7 +1058,7 @@ define([
      * @param {Boolean} [options.asynchronous=true] Determines if model WebGL resource creation will be spread out over several frames or block until completion once all glTF files are loaded.
      * @param {Boolean} [options.clampAnimations=true] Determines if the model's animations should hold a pose over frames where no keyframes are specified.
      * @param {ShadowMode} [options.shadows=ShadowMode.ENABLED] Determines whether the model casts or receives shadows from each light source.
-     * @param {Boolean} [options.sunLighting=true] Enable lighting the model with the sun as a light source. This value is ignored if the glTF has built-in shaders.
+     * @param {Boolean} [options.sunLighting=true] Enable lighting the model with the sun as a light source. This value is ignored if the model has built-in shaders.
      * @param {Boolean} [options.debugShowBoundingVolume=false] For debugging only. Draws the bounding sphere for each {@link DrawCommand} in the model.
      * @param {Boolean} [options.debugWireframe=false] For debugging only. Draws the model in wireframe.
      * @param {HeightReference} [options.heightReference] Determines how the model is drawn relative to terrain.

--- a/Source/Scene/Model.js
+++ b/Source/Scene/Model.js
@@ -263,7 +263,7 @@ define([
      * @param {Boolean} [options.asynchronous=true] Determines if model WebGL resource creation will be spread out over several frames or block until completion once all glTF files are loaded.
      * @param {Boolean} [options.clampAnimations=true] Determines if the model's animations should hold a pose over frames where no keyframes are specified.
      * @param {ShadowMode} [options.shadows=ShadowMode.ENABLED] Determines whether the model casts or receives shadows from each light source.
-     * @param {Boolean} [options.enableLighting=true] Enable lighting the model with the sun as a light source. This value is ignored if the glTF has built-in shaders.
+     * @param {Boolean} [options.sunLighting=true] Enable lighting the model with the sun as a light source. This value is ignored if the glTF has built-in shaders.
      * @param {Boolean} [options.debugShowBoundingVolume=false] For debugging only. Draws the bounding sphere for each draw command in the model.
      * @param {Boolean} [options.debugWireframe=false] For debugging only. Draws the model in wireframe.
      * @param {HeightReference} [options.heightReference] Determines how the model is drawn relative to terrain.
@@ -475,7 +475,7 @@ define([
 
         this._defaultTexture = undefined;
         this._incrementallyLoadTextures = defaultValue(options.incrementallyLoadTextures, true);
-        this._enableLighting = defaultValue(options.enableLighting, true);
+        this._sunLighting = defaultValue(options.sunLighting, true);
         this._asynchronous = defaultValue(options.asynchronous, true);
 
         /**
@@ -1058,7 +1058,7 @@ define([
      * @param {Boolean} [options.asynchronous=true] Determines if model WebGL resource creation will be spread out over several frames or block until completion once all glTF files are loaded.
      * @param {Boolean} [options.clampAnimations=true] Determines if the model's animations should hold a pose over frames where no keyframes are specified.
      * @param {ShadowMode} [options.shadows=ShadowMode.ENABLED] Determines whether the model casts or receives shadows from each light source.
-     * @param {Boolean} [options.enableLighting=true] Enable lighting the model with the sun as a light source. This value is ignored if the glTF has built-in shaders.
+     * @param {Boolean} [options.sunLighting=true] Enable lighting the model with the sun as a light source. This value is ignored if the glTF has built-in shaders.
      * @param {Boolean} [options.debugShowBoundingVolume=false] For debugging only. Draws the bounding sphere for each {@link DrawCommand} in the model.
      * @param {Boolean} [options.debugWireframe=false] For debugging only. Draws the model in wireframe.
      * @param {HeightReference} [options.heightReference] Determines how the model is drawn relative to terrain.
@@ -4105,7 +4105,7 @@ define([
                 if (!this._updatedGltfVersion) {
                     var options = {
                         optimizeForCesium: true,
-                        enableLighting: this._enableLighting,
+                        sunLighting: this._sunLighting,
                         addBatchIdToGeneratedShaders : this._addBatchIdToGeneratedShaders
                     };
                     frameState.brdfLutGenerator.update(frameState);

--- a/Source/Scene/ModelInstanceCollection.js
+++ b/Source/Scene/ModelInstanceCollection.js
@@ -86,7 +86,7 @@ define([
      * @param {Boolean} [options.asynchronous=true] Determines if model WebGL resource creation will be spread out over several frames or block until completion once all glTF files are loaded.
      * @param {Boolean} [options.incrementallyLoadTextures=true] Determine if textures may continue to stream in after the model is loaded.
      * @param {ShadowMode} [options.shadows=ShadowMode.ENABLED] Determines whether the collection casts or receives shadows from each light source.
-     * @param {Boolean} [options.enableLighting=true] Enable lighting the instances with the sun as a light source.
+     * @param {Boolean} [options.sunLighting=true] Enable lighting the instances with the sun as a light source.
      * @param {Boolean} [options.debugShowBoundingVolume=false] For debugging only. Draws the bounding sphere for the collection.
      * @param {Boolean} [options.debugWireframe=false] For debugging only. Draws the instances in wireframe.
      *
@@ -156,7 +156,7 @@ define([
         this._asynchronous = options.asynchronous;
         this._incrementallyLoadTextures = options.incrementallyLoadTextures;
         this._upAxis = options.upAxis; // Undocumented option
-        this._enableLighting = defaultValue(options.enableLighting, true);
+        this._sunLighting = defaultValue(options.sunLighting, true);
 
         this.shadows = defaultValue(options.shadows, ShadowMode.ENABLED);
         this._shadows = this.shadows;
@@ -607,7 +607,7 @@ define([
             asynchronous : collection._asynchronous,
             allowPicking : allowPicking,
             incrementallyLoadTextures : collection._incrementallyLoadTextures,
-            enableLighting : collection._enableLighting,
+            sunLighting : collection._sunLighting,
             upAxis : collection._upAxis,
             precreatedAttributes : undefined,
             vertexShaderLoaded : undefined,

--- a/Source/Scene/ModelInstanceCollection.js
+++ b/Source/Scene/ModelInstanceCollection.js
@@ -86,6 +86,7 @@ define([
      * @param {Boolean} [options.asynchronous=true] Determines if model WebGL resource creation will be spread out over several frames or block until completion once all glTF files are loaded.
      * @param {Boolean} [options.incrementallyLoadTextures=true] Determine if textures may continue to stream in after the model is loaded.
      * @param {ShadowMode} [options.shadows=ShadowMode.ENABLED] Determines whether the collection casts or receives shadows from each light source.
+     * @param {Boolean} [options.enableLighting=true] Enable lighting the instances with the sun as a light source.
      * @param {Boolean} [options.debugShowBoundingVolume=false] For debugging only. Draws the bounding sphere for the collection.
      * @param {Boolean} [options.debugWireframe=false] For debugging only. Draws the instances in wireframe.
      *
@@ -155,6 +156,7 @@ define([
         this._asynchronous = options.asynchronous;
         this._incrementallyLoadTextures = options.incrementallyLoadTextures;
         this._upAxis = options.upAxis; // Undocumented option
+        this._enableLighting = defaultValue(options.enableLighting, true);
 
         this.shadows = defaultValue(options.shadows, ShadowMode.ENABLED);
         this._shadows = this.shadows;
@@ -605,6 +607,7 @@ define([
             asynchronous : collection._asynchronous,
             allowPicking : allowPicking,
             incrementallyLoadTextures : collection._incrementallyLoadTextures,
+            enableLighting : collection._enableLighting,
             upAxis : collection._upAxis,
             precreatedAttributes : undefined,
             vertexShaderLoaded : undefined,

--- a/Source/Scene/PointCloud3DTileContent.js
+++ b/Source/Scene/PointCloud3DTileContent.js
@@ -818,6 +818,7 @@ define([
         var backFaceCulling = content._backFaceCulling;
         var vertexArray = content._drawCommand.vertexArray;
         var clippingPlanes = content._tileset.clippingPlanes;
+        var enableLighting = content._tileset._enableLighting;
 
         var colorStyleFunction;
         var showStyleFunction;
@@ -1039,8 +1040,13 @@ define([
         vs += '    color = color * u_highlightColor; \n';
 
         if (hasNormals) {
-            vs += '    normal = czm_normal * normal; \n' +
-                  '    float diffuseStrength = czm_getLambertDiffuse(czm_sunDirectionEC, normal); \n' +
+            vs += '    normal = czm_normal * normal; \n';
+            if (enableLighting) {
+                vs += '  vec3 lightDirection = normalize(czm_sunDirectionEC);\n';
+            } else {
+                vs += '  vec3 lightDirection = vec3(0.0, 0.0, 1.0);\n';
+            }
+            vs += '    float diffuseStrength = czm_getLambertDiffuse(lightDirection, normal); \n' +
                   '    diffuseStrength = max(diffuseStrength, 0.4); \n' + // Apply some ambient lighting
                   '    color *= diffuseStrength; \n';
         }

--- a/Source/Scene/PointCloud3DTileContent.js
+++ b/Source/Scene/PointCloud3DTileContent.js
@@ -818,7 +818,7 @@ define([
         var backFaceCulling = content._backFaceCulling;
         var vertexArray = content._drawCommand.vertexArray;
         var clippingPlanes = content._tileset.clippingPlanes;
-        var enableLighting = content._tileset._enableLighting;
+        var sunLighting = content._tileset._sunLighting;
 
         var colorStyleFunction;
         var showStyleFunction;
@@ -1041,7 +1041,7 @@ define([
 
         if (hasNormals) {
             vs += '    normal = czm_normal * normal; \n';
-            if (enableLighting) {
+            if (sunLighting) {
                 vs += '  vec3 lightDirection = normalize(czm_sunDirectionEC);\n';
             } else {
                 vs += '  vec3 lightDirection = vec3(0.0, 0.0, 1.0);\n';

--- a/Source/ThirdParty/GltfPipeline/processModelMaterialsCommon.js
+++ b/Source/ThirdParty/GltfPipeline/processModelMaterialsCommon.js
@@ -228,7 +228,7 @@ define([
 
     function generateTechnique(gltf, khrMaterialsCommon, lightParameters, options) {
         var optimizeForCesium = defaultValue(options.optimizeForCesium, false);
-        var enableLighting = defaultValue(options.enableLighting, true);
+        var sunLighting = defaultValue(options.sunLighting, true);
         var hasCesiumRTCExtension = defined(gltf.extensions) && defined(gltf.extensions.CESIUM_RTC);
         var addBatchIdToGeneratedShaders = defaultValue(options.addBatchIdToGeneratedShaders, false);
 
@@ -548,7 +548,7 @@ define([
         }
 
         if (!hasNonAmbientLights && (lightingModel !== 'CONSTANT')) {
-            if (optimizeForCesium && enableLighting) {
+            if (optimizeForCesium && sunLighting) {
                 fragmentLightingBlock += '  vec3 l = normalize(czm_sunDirectionEC);\n';
             } else {
                 fragmentLightingBlock += '  vec3 l = vec3(0.0, 0.0, 1.0);\n';
@@ -794,7 +794,7 @@ define([
             techniqueKey += skinningInfo.type + ';';
         }
         techniqueKey += primitiveInfo.hasVertexColors + ';';
-        techniqueKey += options.enableLighting;
+        techniqueKey += options.sunLighting;
 
         return techniqueKey;
     }

--- a/Source/ThirdParty/GltfPipeline/processModelMaterialsCommon.js
+++ b/Source/ThirdParty/GltfPipeline/processModelMaterialsCommon.js
@@ -70,7 +70,7 @@ define([
             ForEach.material(gltf, function(material) {
                 if (defined(material.extensions) && defined(material.extensions.KHR_materials_common)) {
                     var khrMaterialsCommon = material.extensions.KHR_materials_common;
-                    var techniqueKey = getTechniqueKey(khrMaterialsCommon);
+                    var techniqueKey = getTechniqueKey(khrMaterialsCommon, options);
                     var technique = techniques[techniqueKey];
                     if (!defined(technique)) {
                         technique = generateTechnique(gltf, khrMaterialsCommon, lightParameters, options);
@@ -228,6 +228,7 @@ define([
 
     function generateTechnique(gltf, khrMaterialsCommon, lightParameters, options) {
         var optimizeForCesium = defaultValue(options.optimizeForCesium, false);
+        var enableLighting = defaultValue(options.enableLighting, true);
         var hasCesiumRTCExtension = defined(gltf.extensions) && defined(gltf.extensions.CESIUM_RTC);
         var addBatchIdToGeneratedShaders = defaultValue(options.addBatchIdToGeneratedShaders, false);
 
@@ -547,7 +548,7 @@ define([
         }
 
         if (!hasNonAmbientLights && (lightingModel !== 'CONSTANT')) {
-            if (optimizeForCesium) {
+            if (optimizeForCesium && enableLighting) {
                 fragmentLightingBlock += '  vec3 l = normalize(czm_sunDirectionEC);\n';
             } else {
                 fragmentLightingBlock += '  vec3 l = vec3(0.0, 0.0, 1.0);\n';
@@ -766,7 +767,7 @@ define([
         }
     }
 
-    function getTechniqueKey(khrMaterialsCommon) {
+    function getTechniqueKey(khrMaterialsCommon, options) {
         var techniqueKey = '';
         techniqueKey += 'technique:' + khrMaterialsCommon.technique + ';';
 
@@ -792,7 +793,8 @@ define([
         if (jointCount > 0) {
             techniqueKey += skinningInfo.type + ';';
         }
-        techniqueKey += primitiveInfo.hasVertexColors;
+        techniqueKey += primitiveInfo.hasVertexColors + ';';
+        techniqueKey += options.enableLighting;
 
         return techniqueKey;
     }

--- a/Source/ThirdParty/GltfPipeline/processPbrMetallicRoughness.js
+++ b/Source/ThirdParty/GltfPipeline/processPbrMetallicRoughness.js
@@ -70,6 +70,7 @@ define([
 
     function generateTechnique(gltf, material, options) {
         var optimizeForCesium = defaultValue(options.optimizeForCesium, false);
+        var enableLighting = defaultValue(options.enableLighting, true);
         var hasCesiumRTCExtension = defined(gltf.extensions) && defined(gltf.extensions.CESIUM_RTC);
         var addBatchIdToGeneratedShaders = defaultValue(options.addBatchIdToGeneratedShaders, false);
 
@@ -504,7 +505,7 @@ define([
 
         // Generate fragment shader's lighting block
         fragmentShader += '    vec3 lightColor = vec3(1.0, 1.0, 1.0);\n';
-        if (optimizeForCesium) {
+        if (optimizeForCesium && enableLighting) {
             fragmentShader += '    vec3 l = normalize(czm_sunDirectionEC);\n';
         } else {
             fragmentShader += '    vec3 l = vec3(0.0, 0.0, 1.0);\n';

--- a/Source/ThirdParty/GltfPipeline/processPbrMetallicRoughness.js
+++ b/Source/ThirdParty/GltfPipeline/processPbrMetallicRoughness.js
@@ -70,7 +70,7 @@ define([
 
     function generateTechnique(gltf, material, options) {
         var optimizeForCesium = defaultValue(options.optimizeForCesium, false);
-        var enableLighting = defaultValue(options.enableLighting, true);
+        var sunLighting = defaultValue(options.sunLighting, true);
         var hasCesiumRTCExtension = defined(gltf.extensions) && defined(gltf.extensions.CESIUM_RTC);
         var addBatchIdToGeneratedShaders = defaultValue(options.addBatchIdToGeneratedShaders, false);
 
@@ -505,7 +505,7 @@ define([
 
         // Generate fragment shader's lighting block
         fragmentShader += '    vec3 lightColor = vec3(1.0, 1.0, 1.0);\n';
-        if (optimizeForCesium && enableLighting) {
+        if (optimizeForCesium && sunLighting) {
             fragmentShader += '    vec3 l = normalize(czm_sunDirectionEC);\n';
         } else {
             fragmentShader += '    vec3 l = vec3(0.0, 0.0, 1.0);\n';

--- a/Specs/DataSources/ModelGraphicsSpec.js
+++ b/Specs/DataSources/ModelGraphicsSpec.js
@@ -39,6 +39,7 @@ defineSuite([
             runAnimations : false,
             clampAnimations : false,
             shadows : ShadowMode.DISABLED,
+            sunLighting : false,
             heightReference : HeightReference.CLAMP_TO_GROUND,
             distanceDisplayCondition : new DistanceDisplayCondition(),
             silhouetteColor : new Color(1.0, 0.0, 0.0, 1.0),
@@ -64,6 +65,7 @@ defineSuite([
         expect(model.maximumScale).toBeInstanceOf(ConstantProperty);
         expect(model.incrementallyLoadTextures).toBeInstanceOf(ConstantProperty);
         expect(model.shadows).toBeInstanceOf(ConstantProperty);
+        expect(model.sunLighting).toBeInstanceOf(ConstantProperty);
         expect(model.heightReference).toBeInstanceOf(ConstantProperty);
         expect(model.distanceDisplayCondition).toBeInstanceOf(ConstantProperty);
         expect(model.silhouetteColor).toBeInstanceOf(ConstantProperty);
@@ -84,6 +86,7 @@ defineSuite([
         expect(model.maximumScale.getValue()).toEqual(options.maximumScale);
         expect(model.incrementallyLoadTextures.getValue()).toEqual(options.incrementallyLoadTextures);
         expect(model.shadows.getValue()).toEqual(options.shadows);
+        expect(model.sunLighting.getValue()).toEqual(options.sunLighting);
         expect(model.heightReference.getValue()).toEqual(options.heightReference);
         expect(model.distanceDisplayCondition.getValue()).toEqual(options.distanceDisplayCondition);
         expect(model.silhouetteColor.getValue()).toEqual(options.silhouetteColor);
@@ -113,6 +116,7 @@ defineSuite([
         source.maximumScale = new ConstantProperty(200.0);
         source.incrementallyLoadTextures = new ConstantProperty(true);
         source.shadows = new ConstantProperty(ShadowMode.ENABLED);
+        source.sunLighting = new ConstantProperty(true);
         source.heightReference = new ConstantProperty(HeightReference.CLAMP_TO_GROUND);
         source.distanceDisplayCondition = new ConstantProperty(new DistanceDisplayCondition());
         source.silhouetteColor = new ConstantProperty(new Color(1.0, 0.0, 0.0, 1.0));
@@ -144,6 +148,7 @@ defineSuite([
         expect(target.maximumScale).toBe(source.maximumScale);
         expect(target.incrementallyLoadTextures).toBe(source.incrementallyLoadTextures);
         expect(target.shadows).toBe(source.shadows);
+        expect(target.sunLighting).toBe(source.sunLighting);
         expect(target.heightReference).toBe(source.heightReference);
         expect(target.distanceDisplayCondition).toBe(source.distanceDisplayCondition);
         expect(target.silhouetteColor).toEqual(source.silhouetteColor);
@@ -166,6 +171,7 @@ defineSuite([
         source.maximumScale = new ConstantProperty(200.0);
         source.incrementallyLoadTextures = new ConstantProperty(true);
         source.shadows = new ConstantProperty(ShadowMode.ENABLED);
+        source.sunLighting = new ConstantProperty(true);
         source.heightReference = new ConstantProperty(HeightReference.CLAMP_TO_GROUND);
         source.distanceDisplayCondition = new ConstantProperty(new DistanceDisplayCondition());
         source.silhouetteColor = new ConstantProperty(new Color());
@@ -187,6 +193,7 @@ defineSuite([
         var maximumScale = new ConstantProperty(200.0);
         var incrementallyLoadTextures = new ConstantProperty(true);
         var shadows = new ConstantProperty(ShadowMode.ENABLED);
+        var sunLighting = new ConstantProperty(true);
         var heightReference = new ConstantProperty(HeightReference.CLAMP_TO_GROUND);
         var distanceDisplayCondition = new ConstantProperty(new DistanceDisplayCondition());
         var silhouetteColor = new ConstantProperty(new Color());
@@ -209,6 +216,7 @@ defineSuite([
         target.maximumScale = maximumScale;
         target.incrementallyLoadTextures = incrementallyLoadTextures;
         target.shadows = shadows;
+        target.sunLighting = sunLighting;
         target.heightReference = heightReference;
         target.distanceDisplayCondition = distanceDisplayCondition;
         target.silhouetteColor = silhouetteColor;
@@ -230,6 +238,7 @@ defineSuite([
         expect(target.maximumScale).toBe(maximumScale);
         expect(target.incrementallyLoadTextures).toBe(incrementallyLoadTextures);
         expect(target.shadows).toBe(shadows);
+        expect(target.sunLighting).toBe(sunLighting);
         expect(target.heightReference).toBe(heightReference);
         expect(target.distanceDisplayCondition).toBe(distanceDisplayCondition);
         expect(target.silhouetteColor).toBe(silhouetteColor);
@@ -252,6 +261,7 @@ defineSuite([
         source.maximumScale = new ConstantProperty(200.0);
         source.incrementallyLoadTextures = new ConstantProperty(true);
         source.shadows = new ConstantProperty(ShadowMode.ENABLED);
+        source.sunLighting = new ConstantProperty(true);
         source.heightReference = new ConstantProperty(HeightReference.CLAMP_TO_GROUND);
         source.distanceDisplayCondition = new ConstantProperty(new DistanceDisplayCondition());
         source.silhouetteColor = new ConstantProperty(new Color());
@@ -275,6 +285,7 @@ defineSuite([
         expect(result.maximumScale).toBe(source.maximumScale);
         expect(result.incrementallyLoadTextures).toBe(source.incrementallyLoadTextures);
         expect(result.shadows).toBe(source.shadows);
+        expect(result.sunLighting).toBe(source.sunLighting);
         expect(result.heightReference).toBe(source.heightReference);
         expect(result.distanceDisplayCondition).toBe(source.distanceDisplayCondition);
         expect(result.silhouetteColor).toEqual(source.silhouetteColor);

--- a/Specs/Scene/Batched3DModel3DTileContentSpec.js
+++ b/Specs/Scene/Batched3DModel3DTileContentSpec.js
@@ -8,7 +8,8 @@ defineSuite([
         'Core/Plane',
         'Core/Transforms',
         'Specs/Cesium3DTilesTester',
-        'Specs/createScene'
+        'Specs/createScene',
+        'ThirdParty/when'
     ], function(
         Batched3DModel3DTileContent,
         Cartesian3,
@@ -19,7 +20,8 @@ defineSuite([
         Plane,
         Transforms,
         Cesium3DTilesTester,
-        createScene) {
+        createScene,
+        when) {
     'use strict';
 
     var scene;
@@ -320,6 +322,16 @@ defineSuite([
 
             expect(model.clippingPlanes).toBeDefined();
             expect(model.clippingPlanes.enabled).toBe(false);
+        });
+    });
+
+    it('sets enableLighting', function() {
+        return when.all([
+            Cesium3DTilesTester.loadTileset(scene, withKHRMaterialsCommonUrl, {enableLighting : true}),
+            Cesium3DTilesTester.loadTileset(scene, withKHRMaterialsCommonUrl, {enableLighting : false})
+        ]).then(function(tilesets) {
+            expect(tilesets[0]._root.content._model._enableLighting).toBe(true);
+            expect(tilesets[1]._root.content._model._enableLighting).toBe(false);
         });
     });
 

--- a/Specs/Scene/Batched3DModel3DTileContentSpec.js
+++ b/Specs/Scene/Batched3DModel3DTileContentSpec.js
@@ -325,13 +325,13 @@ defineSuite([
         });
     });
 
-    it('sets enableLighting', function() {
+    it('sets sunLighting', function() {
         return when.all([
-            Cesium3DTilesTester.loadTileset(scene, withKHRMaterialsCommonUrl, {enableLighting : true}),
-            Cesium3DTilesTester.loadTileset(scene, withKHRMaterialsCommonUrl, {enableLighting : false})
+            Cesium3DTilesTester.loadTileset(scene, withKHRMaterialsCommonUrl, {sunLighting : true}),
+            Cesium3DTilesTester.loadTileset(scene, withKHRMaterialsCommonUrl, {sunLighting : false})
         ]).then(function(tilesets) {
-            expect(tilesets[0]._root.content._model._enableLighting).toBe(true);
-            expect(tilesets[1]._root.content._model._enableLighting).toBe(false);
+            expect(tilesets[0]._root.content._model._sunLighting).toBe(true);
+            expect(tilesets[1]._root.content._model._sunLighting).toBe(false);
         });
     });
 

--- a/Specs/Scene/Instanced3DModel3DTileContentSpec.js
+++ b/Specs/Scene/Instanced3DModel3DTileContentSpec.js
@@ -338,13 +338,13 @@ defineSuite([
         });
     });
 
-    it('sets enableLighting', function() {
+    it('sets sunLighting', function() {
         return when.all([
-            Cesium3DTilesTester.loadTileset(scene, withBatchTableUrl, {enableLighting : true}),
-            Cesium3DTilesTester.loadTileset(scene, withBatchTableUrl, {enableLighting : false})
+            Cesium3DTilesTester.loadTileset(scene, withBatchTableUrl, {sunLighting : true}),
+            Cesium3DTilesTester.loadTileset(scene, withBatchTableUrl, {sunLighting : false})
         ]).then(function(tilesets) {
-            expect(tilesets[0]._root.content._modelInstanceCollection._model._enableLighting).toBe(true);
-            expect(tilesets[1]._root.content._modelInstanceCollection._model._enableLighting).toBe(false);
+            expect(tilesets[0]._root.content._modelInstanceCollection._model._sunLighting).toBe(true);
+            expect(tilesets[1]._root.content._modelInstanceCollection._model._sunLighting).toBe(false);
         });
     });
 

--- a/Specs/Scene/Instanced3DModel3DTileContentSpec.js
+++ b/Specs/Scene/Instanced3DModel3DTileContentSpec.js
@@ -8,7 +8,8 @@ defineSuite([
         'Core/Transforms',
         'Scene/TileBoundingSphere',
         'Specs/Cesium3DTilesTester',
-        'Specs/createScene'
+        'Specs/createScene',
+        'ThirdParty/when'
     ], 'Scene/Instanced3DModel3DTileContent', function(
         Cartesian3,
         ClippingPlaneCollection,
@@ -19,7 +20,8 @@ defineSuite([
         Transforms,
         TileBoundingSphere,
         Cesium3DTilesTester,
-        createScene) {
+        createScene,
+        when) {
     'use strict';
 
     var scene;
@@ -333,6 +335,16 @@ defineSuite([
 
             expect(model.clippingPlanes).toBeDefined();
             expect(model.clippingPlanes.enabled).toBe(false);
+        });
+    });
+
+    it('sets enableLighting', function() {
+        return when.all([
+            Cesium3DTilesTester.loadTileset(scene, withBatchTableUrl, {enableLighting : true}),
+            Cesium3DTilesTester.loadTileset(scene, withBatchTableUrl, {enableLighting : false})
+        ]).then(function(tilesets) {
+            expect(tilesets[0]._root.content._modelInstanceCollection._model._enableLighting).toBe(true);
+            expect(tilesets[1]._root.content._modelInstanceCollection._model._enableLighting).toBe(false);
         });
     });
 

--- a/Specs/Scene/ModelInstanceCollectionSpec.js
+++ b/Specs/Scene/ModelInstanceCollectionSpec.js
@@ -555,6 +555,24 @@ defineSuite([
         });
     });
 
+    it('enableLighting', function() {
+        return when.all([
+            loadCollection({
+                gltf : boxGltf,
+                instances : createInstances(4),
+                enableLighting : true
+            }),
+            loadCollection({
+                gltf : boxGltf,
+                instances : createInstances(4),
+                enableLighting : false
+            })
+        ]).then(function(collections) {
+            expect(collections[0]._model._enableLighting).toBe(true);
+            expect(collections[1]._model._enableLighting).toBe(false);
+        });
+    });
+
     it('picks', function() {
         return loadCollection({
             gltf : boxGltf,

--- a/Specs/Scene/ModelInstanceCollectionSpec.js
+++ b/Specs/Scene/ModelInstanceCollectionSpec.js
@@ -555,21 +555,21 @@ defineSuite([
         });
     });
 
-    it('enableLighting', function() {
+    it('sunLighting', function() {
         return when.all([
             loadCollection({
                 gltf : boxGltf,
                 instances : createInstances(4),
-                enableLighting : true
+                sunLighting : true
             }),
             loadCollection({
                 gltf : boxGltf,
                 instances : createInstances(4),
-                enableLighting : false
+                sunLighting : false
             })
         ]).then(function(collections) {
-            expect(collections[0]._model._enableLighting).toBe(true);
-            expect(collections[1]._model._enableLighting).toBe(false);
+            expect(collections[0]._model._sunLighting).toBe(true);
+            expect(collections[1]._model._sunLighting).toBe(false);
         });
     });
 

--- a/Specs/Scene/ModelSpec.js
+++ b/Specs/Scene/ModelSpec.js
@@ -277,10 +277,10 @@ defineSuite([
         });
     }
 
-    function verifyEnableLighting(modelUrl) {
+    function verifySunLighting(modelUrl) {
         return when.all([
-            loadModel(boxLambertUrl, {enableLighting : true, cacheKey : modelUrl + '-enableLighting-true'}),
-            loadModel(boxLambertUrl, {enableLighting : false, cacheKey : modelUrl + '-enableLighting-false'})
+            loadModel(boxLambertUrl, {sunLighting : true, cacheKey : modelUrl + '-sunLighting-true'}),
+            loadModel(boxLambertUrl, {sunLighting : false, cacheKey : modelUrl + '-sunLighting-false'})
         ]).then(function(models) {
             var time = JulianDate.fromDate(new Date('January 1, 2014 23:30:00 UTC'));
             var renderOptions = {
@@ -2012,8 +2012,8 @@ defineSuite([
         });
     });
 
-    it('loads a glTF with KHR_material_common with enableLighting true and false', function() {
-        return verifyEnableLighting(boxLambertUrl);
+    it('loads a glTF with KHR_material_common with sunLighting true and false', function() {
+        return verifySunLighting(boxLambertUrl);
     });
 
     it('loads a glTF with WEB3D_quantized_attributes POSITION and NORMAL', function() {
@@ -2191,8 +2191,8 @@ defineSuite([
         });
     });
 
-    it('loads a glTF 2.0 with enableLighting true and false', function() {
-        return verifyEnableLighting(boxPbrUrl);
+    it('loads a glTF 2.0 with sunLighting true and false', function() {
+        return verifySunLighting(boxPbrUrl);
     });
 
     function testBoxSideColors(m) {

--- a/Specs/Scene/PointCloud3DTileContentSpec.js
+++ b/Specs/Scene/PointCloud3DTileContentSpec.js
@@ -6,6 +6,7 @@ defineSuite([
         'Core/defined',
         'Core/HeadingPitchRange',
         'Core/HeadingPitchRoll',
+        'Core/JulianDate',
         'Core/Math',
         'Core/Matrix4',
         'Core/PerspectiveFrustum',
@@ -25,6 +26,7 @@ defineSuite([
         defined,
         HeadingPitchRange,
         HeadingPitchRoll,
+        JulianDate,
         CesiumMath,
         Matrix4,
         PerspectiveFrustum,
@@ -823,6 +825,32 @@ defineSuite([
             tileset.clippingPlanes.unionClippingRegions = false;
 
             expect(scene).toRender(color);
+        });
+    });
+
+    it('sets enableLighting', function() {
+        return when.all([
+            Cesium3DTilesTester.loadTileset(scene, pointCloudNormalsUrl, {enableLighting : true}),
+            Cesium3DTilesTester.loadTileset(scene, pointCloudNormalsUrl, {enableLighting : false})
+        ]).then(function(tilesets) {
+            var time = JulianDate.fromDate(new Date('January 1, 2014 12:30:00 UTC'));
+            var renderOptions = {
+                scene : scene,
+                time : time
+            };
+            tilesets[0].show = true;
+            tilesets[1].show = false;
+            var rgbaLighting;
+            expect(renderOptions).toRenderAndCall(function(rgba) {
+                rgbaLighting = rgba;
+            });
+            tilesets[0].show = false;
+            tilesets[1].show = true;
+            expect(renderOptions).toRenderAndCall(function(rgbaNoLighting) {
+                expect(rgbaLighting).not.toEqual([0, 0, 0, 255]);
+                expect(rgbaNoLighting).not.toEqual([0, 0, 0, 255]);
+                expect(rgbaLighting).not.toEqual(rgbaNoLighting);
+            });
         });
     });
 

--- a/Specs/Scene/PointCloud3DTileContentSpec.js
+++ b/Specs/Scene/PointCloud3DTileContentSpec.js
@@ -828,10 +828,10 @@ defineSuite([
         });
     });
 
-    it('sets enableLighting', function() {
+    it('sets sunLighting', function() {
         return when.all([
-            Cesium3DTilesTester.loadTileset(scene, pointCloudNormalsUrl, {enableLighting : true}),
-            Cesium3DTilesTester.loadTileset(scene, pointCloudNormalsUrl, {enableLighting : false})
+            Cesium3DTilesTester.loadTileset(scene, pointCloudNormalsUrl, {sunLighting : true}),
+            Cesium3DTilesTester.loadTileset(scene, pointCloudNormalsUrl, {sunLighting : false})
         ]).then(function(tilesets) {
             var time = JulianDate.fromDate(new Date('January 1, 2014 12:30:00 UTC'));
             var renderOptions = {


### PR DESCRIPTION
If a model uses the `KHR_materials_common` extension or is a 2.0 PBR model, the shaders we generate use the Cesium sun as the light source.

This PR adds an `enableLighting` option to `Cesium3DTileset`, `Model`, and `ModelInstanceCollection` that controls whether models are shaded based on the sun direction (the default) or based on the camera direction. The latter is better when the sun is on the opposite side of the globe and the model just appears black.

This options also controls lighting for point clouds that contain normals.

The reason `enableLighting` can't be changed dynamically is we still don't have a good way of recompiling shaders for models. Until then this will need to stay as a constructor parameter.

TODO
* [x] Add to entity API

gltf-pipeline PR: https://github.com/AnalyticalGraphicsInc/gltf-pipeline/pull/346

For https://groups.google.com/forum/#!topic/cesium-dev/vIMLLYxYx4g