### PR TITLE
Fix IE 11

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@ Change Log
   * The clock does not animate by default. Set the `shouldAnimate` option to `true` when creating the Viewer to enable animation.
 * Deprecated
   * For all classes/functions that can now take a `Resource` instance, all additional parameters that are part of the `Resource` class have been deprecated and will be removed in Cesium 1.44. This generally includes `proxy`, `headers` and `query` parameters.
+* Fixed Sandcastle for IE 11. [#6169](https://github.com/AnalyticalGraphicsInc/cesium/pull/6169)
 * Major refactor of URL handling. All classes that take a url parameter, can now take a Resource or a String. This includes all imagery providers, all terrain providers, `Cesium3DTileset`, `KMLDataSource`, `CZMLDataSource`, `GeoJsonDataSource`, `Model`, `Billboard`, along with all the low level `load*()` functions.
 * Added `ClippingPlaneCollection.isSupported` function for checking if rendering with clipping planes is supported.
 * Added new `CesiumIon` utility class for working with the Cesium ion beta API.

--- a/Source/Core/getTimestamp.js
+++ b/Source/Core/getTimestamp.js
@@ -17,7 +17,7 @@ define([
      */
     var getTimestamp;
 
-    if (typeof performance !== 'undefined' && defined(performance.now)) {
+    if (typeof performance !== 'undefined' && typeof performance.now === 'function' && isFinite(performance.now())) {
         getTimestamp = function() {
             return performance.now();
         };


### PR DESCRIPTION
IE 11 seems to be returning Infinity for `performance.now()` on some systems.  This adds an extra level of validation in `getTimestamp` to make sure the value is finite.

Fixes #6146