### PR TITLE
Add smokescreen test for Node support to travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,10 @@ script:
   - npm run test -- --browsers Electron --failTaskOnError --webgl-stub --release --suppressPassed
   - echo -en 'travis_fold:end:script test.release\\r'
 
+  - echo 'test node' && echo -en 'travis_fold:start:script test.node\\r'
+  - node index.js
+  - echo -en 'travis_fold:end:script test.node\\r'
+
   - echo 'cloc' && echo -en 'travis_fold:start:script.cloc\\r'
   - npm run cloc
   - echo -en 'travis_fold:end:script.cloc\\r'

--- a/Source/Scene/GroundPrimitive.js
+++ b/Source/Scene/GroundPrimitive.js
@@ -52,10 +52,6 @@ define([
         }
     };
 
-    var terrainHeightsResource = new Resource({
-        url: buildModuleUrl('Assets/approximateTerrainHeights.json')
-    });
-
     /**
      * A ground primitive represents geometry draped over the terrain in the {@link Scene}.  The geometry must be from a single {@link GeometryInstance}.
      * Batching multiple geometries is not yet supported.
@@ -667,7 +663,7 @@ define([
             return initPromise;
         }
 
-        GroundPrimitive._initPromise = terrainHeightsResource.fetchJson().then(function(json) {
+        GroundPrimitive._initPromise = Resource.fetchJson(buildModuleUrl('Assets/approximateTerrainHeights.json')).then(function(json) {
             GroundPrimitive._initialized = true;
             GroundPrimitive._terrainHeights = json;
         });


### PR DESCRIPTION
This PR should fail, showing that Cesium is broken in Node (which it is).  Once travis fails, I'll push a fix for Cesium in Node.