### PR TITLE
Support point attenuation with additive refinement

### DIFF
--- a/Source/Scene/Cesium3DTile.js
+++ b/Source/Scene/Cesium3DTile.js
@@ -330,6 +330,11 @@ define([
         this._ancestorWithLoadedContent = undefined;
         this._isClipped = true;
 
+        // Additive attenuation
+        this._leafDescendants = undefined;
+        this._accumulatedGeometricError = undefined;
+        this._descendantGeometricError = undefined;
+
         this._debugBoundingVolume = undefined;
         this._debugContentBoundingVolume = undefined;
         this._debugViewerRequestVolume = undefined;

--- a/Source/Scene/PointCloud3DTileContent.js
+++ b/Source/Scene/PointCloud3DTileContent.js
@@ -547,10 +547,14 @@ define([
                 scratch.y = content._tileset.timeSinceLoad;
 
                 if (content._attenuation) {
-                    var geometricError = content.tile.geometricError;
-                    if (geometricError === 0) {
-                        geometricError = defined(content._baseResolution) ? content._baseResolution : content._baseResolutionApproximation;
+                    var geometricError = content._tile._descendantGeometricError; // additive
+                    if (!defined(geometricError)) {
+                        geometricError = content.tile.geometricError;
+                        if (geometricError === 0) {
+                            geometricError = defined(content._baseResolution) ? content._baseResolution : content._baseResolutionApproximation;
+                        }
                     }
+
                     var frustum = frameState.camera.frustum;
                     var depthMultiplier;
                     // Attenuation is maximumAttenuation in 2D/ortho
@@ -1116,8 +1120,9 @@ define([
 
         var fs = 'varying vec4 v_color; \n';
 
+
         if (hasClippedContent) {
-            fs += 'uniform int u_clippingPlanesLength;' +
+            fs += 'uniform int u_clippingPlanesLength; \n' +
                   'uniform vec4 u_clippingPlanes[czm_maxClippingPlanes]; \n' +
                   'uniform vec4 u_clippingPlanesEdgeStyle; \n';
         }


### PR DESCRIPTION
This is a work in progress attempt to apply the new point attenuation to tilesets using additive refinement. Replacement refinement was straightforward because there is no mixing of LODs so attenuation was based on the tile's geometric error alone.

With additive refinement the points in a given area belong to many different LODs, so some points would appear larger than others. Ideally we want all points in a given area to be the same size.

The original approach I tried was for each tile to compute a `descendantGeometricError`, or the smallest geometric error of the tile's visible "leaf" descendants. This tells us the geometric error of the most detailed points in the area, so all overlapping tiles in this area will use this value and render the same point size. This works really well if all the tiles are loaded, but if tiles are still streaming in there will be visible jumps when the next highest LOD is loaded in.

The new approach is to find the average descendant geometric error instead of the smallest descendant geometric error. The jumps are still somewhat visible though so I do a final lerp with the tile's own geometric error. 

More notes:
* Instead of average, try using a median or mode of descendant geometric errors
* Points in low LOD tiles that are not near the area of focus will be rendered smaller than they should
* A foolproof solution is to compute point attenuation on a per-point basis. Check which octree node the point belongs to. This would have to been in the shader.

This isn't really ready to merge, I just wanted to get these ideas out.