### PR TITLE
Use equalEpsilon for time comparisons in requestRender tests

### DIFF
--- a/Specs/Scene/SceneSpec.js
+++ b/Specs/Scene/SceneSpec.js
@@ -1326,7 +1326,7 @@ defineSuite([
         scene.requestRenderMode = true;
         scene.maximumRenderTimeChange = undefined;
         scene.renderForSpecs();
-        expect(scene.lastRenderTime).toEqual(lastRenderTime);
+        expect(scene.lastRenderTime).toEqualEpsilon(lastRenderTime, CesiumMath.EPSILON6);
 
         scene.destroyForSpecs();
     });
@@ -1522,7 +1522,7 @@ defineSuite([
         lastRenderTime = JulianDate.clone(scene.lastRenderTime, scratchTime);
 
         scene.renderForSpecs();
-        expect(scene.lastRenderTime).toEqual(lastRenderTime);
+        expect(scene.lastRenderTime).toEqualEpsilon(lastRenderTime, CesiumMath.EPSILON6);
         lastRenderTime = JulianDate.clone(scene.lastRenderTime, scratchTime);
 
         scene.morphToColumbusView(1.0);
@@ -1534,7 +1534,7 @@ defineSuite([
         lastRenderTime = JulianDate.clone(scene.lastRenderTime, scratchTime);
 
         scene.renderForSpecs();
-        expect(scene.lastRenderTime).toEqual(lastRenderTime);
+        expect(scene.lastRenderTime).toEqualEpsilon(lastRenderTime, CesiumMath.EPSILON6);
         lastRenderTime = JulianDate.clone(scene.lastRenderTime, scratchTime);
 
         scene.morphTo3D(1.0);
@@ -1546,7 +1546,7 @@ defineSuite([
         lastRenderTime = JulianDate.clone(scene.lastRenderTime, scratchTime);
 
         scene.renderForSpecs();
-        expect(scene.lastRenderTime).toEqual(lastRenderTime);
+        expect(scene.lastRenderTime).toEqualEpsilon(lastRenderTime, CesiumMath.EPSILON6);
 
         scene.destroyForSpecs();
     });
@@ -1567,10 +1567,10 @@ defineSuite([
 
         scene.maximumRenderTimeChange = 100.0;
 
-        scene.renderForSpecs(JulianDate.addSeconds(lastRenderTime, 100.0, new JulianDate()));
-        expect(scene.lastRenderTime).toEqual(lastRenderTime);
+        scene.renderForSpecs(JulianDate.addSeconds(lastRenderTime, 50.0, new JulianDate()));
+        expect(scene.lastRenderTime).toEqualEpsilon(lastRenderTime, CesiumMath.EPSILON6);
 
-        scene.renderForSpecs(JulianDate.addSeconds(lastRenderTime, 100.1, new JulianDate()));
+        scene.renderForSpecs(JulianDate.addSeconds(lastRenderTime, 150.0, new JulianDate()));
         expect(scene.lastRenderTime).not.toEqual(lastRenderTime);
 
         scene.destroyForSpecs();

--- a/Specs/Scene/SceneSpec.js
+++ b/Specs/Scene/SceneSpec.js
@@ -1326,7 +1326,7 @@ defineSuite([
         scene.requestRenderMode = true;
         scene.maximumRenderTimeChange = undefined;
         scene.renderForSpecs();
-        expect(scene.lastRenderTime).toEqualEpsilon(lastRenderTime, CesiumMath.EPSILON6);
+        expect(scene.lastRenderTime).toEqualEpsilon(lastRenderTime, CesiumMath.EPSILON15);
 
         scene.destroyForSpecs();
     });
@@ -1522,7 +1522,7 @@ defineSuite([
         lastRenderTime = JulianDate.clone(scene.lastRenderTime, scratchTime);
 
         scene.renderForSpecs();
-        expect(scene.lastRenderTime).toEqualEpsilon(lastRenderTime, CesiumMath.EPSILON6);
+        expect(scene.lastRenderTime).toEqualEpsilon(lastRenderTime, CesiumMath.EPSILON15);
         lastRenderTime = JulianDate.clone(scene.lastRenderTime, scratchTime);
 
         scene.morphToColumbusView(1.0);
@@ -1534,7 +1534,7 @@ defineSuite([
         lastRenderTime = JulianDate.clone(scene.lastRenderTime, scratchTime);
 
         scene.renderForSpecs();
-        expect(scene.lastRenderTime).toEqualEpsilon(lastRenderTime, CesiumMath.EPSILON6);
+        expect(scene.lastRenderTime).toEqualEpsilon(lastRenderTime, CesiumMath.EPSILON15);
         lastRenderTime = JulianDate.clone(scene.lastRenderTime, scratchTime);
 
         scene.morphTo3D(1.0);
@@ -1546,7 +1546,7 @@ defineSuite([
         lastRenderTime = JulianDate.clone(scene.lastRenderTime, scratchTime);
 
         scene.renderForSpecs();
-        expect(scene.lastRenderTime).toEqualEpsilon(lastRenderTime, CesiumMath.EPSILON6);
+        expect(scene.lastRenderTime).toEqualEpsilon(lastRenderTime, CesiumMath.EPSILON15);
 
         scene.destroyForSpecs();
     });
@@ -1568,7 +1568,7 @@ defineSuite([
         scene.maximumRenderTimeChange = 100.0;
 
         scene.renderForSpecs(JulianDate.addSeconds(lastRenderTime, 50.0, new JulianDate()));
-        expect(scene.lastRenderTime).toEqualEpsilon(lastRenderTime, CesiumMath.EPSILON6);
+        expect(scene.lastRenderTime).toEqualEpsilon(lastRenderTime, CesiumMath.EPSILON15);
 
         scene.renderForSpecs(JulianDate.addSeconds(lastRenderTime, 150.0, new JulianDate()));
         expect(scene.lastRenderTime).not.toEqual(lastRenderTime);


### PR DESCRIPTION
Fixes #6178

Use `equalEpsilon` for time comparisons in the unit tests for `requestRenderMode`. I've run these several times locally and they are consistently passing.