### PR TITLE
Fix for AxisAlignedBoundingBox clone method

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@ Change Log
 ### 1.43 - 2018-03-01
 
 ##### Fixes :wrench:
-* Fixed bug where AxisAlignedBoundingBox did not copy over center value when cloning an undefined result.
+* Fixed bug where AxisAlignedBoundingBox did not copy over center value when cloning an undefined result. [#6183](https://github.com/AnalyticalGraphicsInc/cesium/pull/6183)
 
 ### 1.42.1 - 2018-02-01
 _This is an npm-only release to fix an issue with using Cesium in Node.js.__

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,11 @@
 Change Log
 ==========
 
+### 1.43 - 2018-03-01
+
+##### Fixes :wrench:
+* Fixed bug where AxisAlignedBoundingBox did not copy over center value when cloning an undefined result.
+
 ### 1.42.1 - 2018-02-01
 _This is an npm-only release to fix an issue with using Cesium in Node.js.__
 * Fixed a bug where Cesium would fail to load under Node.js. [#6177](https://github.com/AnalyticalGraphicsInc/cesium/pull/6177)

--- a/Source/Core/AxisAlignedBoundingBox.js
+++ b/Source/Core/AxisAlignedBoundingBox.js
@@ -130,7 +130,7 @@ define([
         }
 
         if (!defined(result)) {
-            result = new AxisAlignedBoundingBox();
+            return new AxisAlignedBoundingBox(box.minimum, box.maximum, box.center);
         }
 
         result.minimum = Cartesian3.clone(box.minimum, result.minimum);

--- a/Source/Core/AxisAlignedBoundingBox.js
+++ b/Source/Core/AxisAlignedBoundingBox.js
@@ -130,7 +130,7 @@ define([
         }
 
         if (!defined(result)) {
-            return new AxisAlignedBoundingBox(box.minimum, box.maximum);
+            result = new AxisAlignedBoundingBox();
         }
 
         result.minimum = Cartesian3.clone(box.minimum, result.minimum);

--- a/Specs/Core/AxisAlignedBoundingBoxSpec.js
+++ b/Specs/Core/AxisAlignedBoundingBoxSpec.js
@@ -79,6 +79,13 @@ defineSuite([
         expect(box).toEqual(result);
     });
 
+    it('clone without a result parameter with offset center', function() {
+        var box = new AxisAlignedBoundingBox(Cartesian3.UNIT_Y, Cartesian3.UNIT_X, Cartesian3.UNIT_Z);
+        var result = box.clone();
+        expect(box).not.toBe(result);
+        expect(box).toEqual(result);
+    });
+
     it('clone with a result parameter', function() {
         var box = new AxisAlignedBoundingBox(Cartesian3.UNIT_Y, Cartesian3.UNIT_X);
         var result = new AxisAlignedBoundingBox(Cartesian3.ZERO, Cartesian3.UNIT_Z);

--- a/Specs/Core/AxisAlignedBoundingBoxSpec.js
+++ b/Specs/Core/AxisAlignedBoundingBoxSpec.js
@@ -79,7 +79,7 @@ defineSuite([
         expect(box).toEqual(result);
     });
 
-    it('clone without a result parameter with offset center', function() {
+    it('clone without a result parameter with box of offset center', function() {
         var box = new AxisAlignedBoundingBox(Cartesian3.UNIT_Y, Cartesian3.UNIT_X, Cartesian3.UNIT_Z);
         var result = box.clone();
         expect(box).not.toBe(result);


### PR DESCRIPTION
before the fix - if result was not defined returned constructed AxisAlignedBoundingBox without copying over center value.

The issue with this is that if the user, for their own purposes, constructed  a center value with an offset s.t. the minimum and maximum weren't the same distance away from the center parameter, the clone method would not consider this form of construction and just solve for the default center based on max and min values.

Additionally, since the minimum and maximum values are defined in relation to the center (ie as if the center was the origin for them) the clone's box's overall position doesnt match that of the box it's cloning.