### PR TITLE
Enable terrain by default in CesiumViewer

### DIFF
--- a/Apps/CesiumViewer/CesiumViewer.js
+++ b/Apps/CesiumViewer/CesiumViewer.js
@@ -1,5 +1,6 @@
 define([
         'Cesium/Core/Cartesian3',
+        'Cesium/Core/CesiumTerrainProvider',
         'Cesium/Core/defined',
         'Cesium/Core/formatError',
         'Cesium/Core/Math',
@@ -15,6 +16,7 @@ define([
         'domReady!'
     ], function(
         Cartesian3,
+        CesiumTerrainProvider,
         defined,
         formatError,
         CesiumMath,
@@ -57,6 +59,12 @@ define([
             baseLayerPicker : !defined(imageryProvider),
             scene3DOnly : endUserOptions.scene3DOnly,
             requestRenderMode : true
+        });
+
+        viewer.terrainProvider = new CesiumTerrainProvider({
+            url : 'https://assets.agi.com/stk-terrain/v1/tilesets/world/tiles',
+            requestWaterMask : true,
+            requestVertexNormals : true
         });
     } catch (exception) {
         loadingIndicator.style.display = 'none';

--- a/Apps/CesiumViewer/CesiumViewer.js
+++ b/Apps/CesiumViewer/CesiumViewer.js
@@ -54,18 +54,24 @@ define([
     var loadingIndicator = document.getElementById('loadingIndicator');
     var viewer;
     try {
+        var hasBaseLayerPicker = !defined(imageryProvider);
         viewer = new Viewer('cesiumContainer', {
             imageryProvider : imageryProvider,
-            baseLayerPicker : !defined(imageryProvider),
+            baseLayerPicker : hasBaseLayerPicker,
             scene3DOnly : endUserOptions.scene3DOnly,
             requestRenderMode : true
         });
 
-        viewer.terrainProvider = new CesiumTerrainProvider({
-            url : 'https://assets.agi.com/stk-terrain/v1/tilesets/world/tiles',
-            requestWaterMask : true,
-            requestVertexNormals : true
-        });
+        if (hasBaseLayerPicker) {
+            var viewModel = viewer.baseLayerPicker.viewModel;
+            viewModel.selectedTerrain = viewModel.terrainProviderViewModels[1];
+        } else {
+            viewer.terrainProvider = new CesiumTerrainProvider({
+                url: 'https://assets.agi.com/stk-terrain/v1/tilesets/world/tiles',
+                requestWaterMask: true,
+                requestVertexNormals: true
+            });
+        }
     } catch (exception) {
         loadingIndicator.style.display = 'none';
         var message = formatError(exception);

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,9 @@ Change Log
 ##### Fixes :wrench:
 * Fixed bug where AxisAlignedBoundingBox did not copy over center value when cloning an undefined result. [#6183](https://github.com/AnalyticalGraphicsInc/cesium/pull/6183)
 
+##### Additions :tada:
+* Enable terrain in the `CesiumViewer` demo application [#6198](https://github.com/AnalyticalGraphicsInc/cesium/pull/6198)
+
 ### 1.42.1 - 2018-02-01
 _This is an npm-only release to fix an issue with using Cesium in Node.js.__
 * Fixed a bug where Cesium would fail to load under Node.js. [#6177](https://github.com/AnalyticalGraphicsInc/cesium/pull/6177)

--- a/Source/Widgets/Viewer/viewerDragDropMixin.js
+++ b/Source/Widgets/Viewer/viewerDragDropMixin.js
@@ -272,7 +272,8 @@ define([
                         sourceUri : fileName,
                         proxy : proxy,
                         camera : scene.camera,
-                        canvas : scene.canvas
+                        canvas : scene.canvas,
+                        clampToGround: clampToGround
                     });
                 } else {
                     viewer.dropError.raiseEvent(viewer, fileName, 'Unrecognized file: ' + fileName);


### PR DESCRIPTION
Fixes #6192

@mramato is there anything else I had to do to enable clamping for the data sources?  We were already passing in `clampToGround` for `GeoJsonDataSource` and for `CzmlDataSource` it's something you enable in the CZML, right?