### PR TITLE
Fixes Resource.prototype.fetch when called with no arguments

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@ Change Log
 
 ##### Fixes :wrench:
 * Fixed bug where AxisAlignedBoundingBox did not copy over center value when cloning an undefined result. [#6183](https://github.com/AnalyticalGraphicsInc/cesium/pull/6183)
+* Fixed `Resource.fetch` when called with no arguments [#6206](https://github.com/AnalyticalGraphicsInc/cesium/issues/6206)
 
 ### 1.42.1 - 2018-02-01
 _This is an npm-only release to fix an issue with using Cesium in Node.js.__

--- a/Source/Core/Resource.js
+++ b/Source/Core/Resource.js
@@ -1103,7 +1103,7 @@ define([
      * @see {@link http://wiki.commonjs.org/wiki/Promises/A|CommonJS Promises/A}
      */
     Resource.prototype.fetch = function(options) {
-        options = defaultClone(options, defaultValue.EMPTY_OBJECT);
+        options = defaultClone(options, {});
         options.method = 'GET';
 
         return makeRequest(this, options);

--- a/Specs/Core/ResourceSpec.js
+++ b/Specs/Core/ResourceSpec.js
@@ -589,4 +589,23 @@ defineSuite([
                 expect(Resource.prototype.fetch).toHaveBeenCalled();
             });
     });
+
+    it('fetch calls correct method', function() {
+        var expectedUrl = 'http://test.com/endpoint';
+        var expectedResult = {
+            status: 'success'
+        };
+
+        spyOn(Resource._Implementations, 'loadWithXhr').and.callFake(function(url, responseType, method, data, headers, deferred, overrideMimeType) {
+            expect(url).toEqual(expectedUrl);
+            expect(method).toEqual('GET');
+            deferred.resolve(expectedResult);
+        });
+
+        var resource = new Resource({url: expectedUrl});
+        return resource.fetch()
+            .then(function(result) {
+                expect(result).toEqual(expectedResult);
+            });
+    });
 });


### PR DESCRIPTION
Fixes #6206
