### PR TITLE
Resource fixes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,10 +6,16 @@ Change Log
 ##### Deprecated :hourglass_flowing_sand:
 * In the `Resource` class, `addQueryParameters` and `addTemplateValues` have been deprecated and will be removed in Cesium 1.45. Please use `setQueryParameters` and `setTemplateValues` instead.
 
+##### Additions :tada:
+* `Resource` class [#6205](https://github.com/AnalyticalGraphicsInc/cesium/issues/6205)
+  * Added `put`, `patch`, `delete`, `options` and `head` methods, so it can be used for all XHR requests.
+  * Added `preserveQueryParameters` parameter to `getDerivedResource`, to allow us to append query parameters instead of always replacing them.
+  * Added `setQueryParameters` and `appendQueryParameters` to allow for better handling of query strings.
+
 ##### Fixes :wrench:
 * Fixed bug where AxisAlignedBoundingBox did not copy over center value when cloning an undefined result. [#6183](https://github.com/AnalyticalGraphicsInc/cesium/pull/6183)
 * Fixed `Resource.fetch` when called with no arguments [#6206](https://github.com/AnalyticalGraphicsInc/cesium/issues/6206)
-* Added `put`, `patch`, `delete`, `options` and `head` methods to the `Resource` class, so it can be used for all XHR requests.
+* Fixed `Resource.clone` to clone the `Request` object, so resource can be used in parallel. [#6208](https://github.com/AnalyticalGraphicsInc/cesium/issues/6208)
 
 ### 1.42.1 - 2018-02-01
 _This is an npm-only release to fix an issue with using Cesium in Node.js.__

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,9 +3,13 @@ Change Log
 
 ### 1.43 - 2018-03-01
 
+##### Deprecated :hourglass_flowing_sand:
+* In the `Resource` class, `addQueryParameters` and `addTemplateValues` have been deprecated and will be removed in Cesium 1.45. Please use `setQueryParameters` and `setTemplateValues` instead.
+
 ##### Fixes :wrench:
 * Fixed bug where AxisAlignedBoundingBox did not copy over center value when cloning an undefined result. [#6183](https://github.com/AnalyticalGraphicsInc/cesium/pull/6183)
 * Fixed `Resource.fetch` when called with no arguments [#6206](https://github.com/AnalyticalGraphicsInc/cesium/issues/6206)
+* Added `put`, `patch`, `delete`, `options` and `head` methods to the `Resource` class, so it can be used for all XHR requests.
 
 ### 1.42.1 - 2018-02-01
 _This is an npm-only release to fix an issue with using Cesium in Node.js.__

--- a/Source/Core/Resource.js
+++ b/Source/Core/Resource.js
@@ -239,7 +239,10 @@ define([
      */
     Resource.createIfNeeded = function(resource, options) {
         if (resource instanceof Resource) {
-            return resource.clone();
+            // Keep existing request
+            return  resource.getDerivedResource({
+                request: resource.request
+            });
         }
 
         if (typeof resource !== 'string') {
@@ -492,9 +495,6 @@ define([
         }
         if (defined(options.request)) {
             resource.request = options.request;
-        } else {
-            // Clone the request so we keep all the throttle settings
-            resource.request = this.request.clone();
         }
         if (defined(options.retryCallback)) {
             resource.retryCallback = options.retryCallback;
@@ -552,10 +552,7 @@ define([
         result.retryCallback = this.retryCallback;
         result.retryAttempts = this.retryAttempts;
         result._retryCount = 0;
-
-        // In practice, we don't want this cloned. It usually not set, unless we purposely set it internally and not
-        //  using the request will break the request scheduler.
-        result.request = this.request;
+        result.request = this.request.clone();
 
         return result;
     };

--- a/Source/Core/Resource.js
+++ b/Source/Core/Resource.js
@@ -512,6 +512,8 @@ define([
      * @param {Error} [error] The error that was encountered.
      *
      * @returns {Promise<Boolean>} A promise to a boolean, that if true will cause the resource request to be retried.
+     *
+     * @private
      */
     Resource.prototype.retryOnError = function(error) {
         var retryCallback = this.retryCallback;
@@ -1078,38 +1080,9 @@ define([
     };
 
     /**
-     * Asynchronously loads the given resource.  Returns a promise that will resolve to
-     * the result once loaded, or reject if the resource failed to load.  The data is loaded
-     * using XMLHttpRequest, which means that in order to make requests to another origin,
-     * the server must have Cross-Origin Resource Sharing (CORS) headers enabled.
-     *
-     * @param {Object} [options] Object with the following properties:
-     * @param {String} [options.responseType] The type of response.  This controls the type of item returned.
-     * @param {Object} [options.headers] Additional HTTP headers to send with the request, if any.
-     * @param {String} [options.overrideMimeType] Overrides the MIME type returned by the server.
-     * @returns {Promise.<Object>|undefined} a promise that will resolve to the requested data when loaded. Returns undefined if <code>request.throttle</code> is true and the request does not have high enough priority.
-     *
-     *
-     * @example
-     * // Load a single resource asynchronously. In real code, you should use loadBlob instead.
-     * resource.fetch()
-     *   .then(function(blob) {
-     *       // use the data
-     *   }).otherwise(function(error) {
-     *       // an error occurred
-     *   });
-     *
-     * @see {@link http://www.w3.org/TR/cors/|Cross-Origin Resource Sharing}
-     * @see {@link http://wiki.commonjs.org/wiki/Promises/A|CommonJS Promises/A}
+     * @private
      */
-    Resource.prototype.fetch = function(options) {
-        options = defaultClone(options, {});
-        options.method = 'GET';
-
-        return makeRequest(this, options);
-    };
-
-    function makeRequest(resource, options) {
+    Resource._makeRequest = function(resource, options) {
         checkAndResetRequest(resource.request);
 
         var request = resource.request;
@@ -1158,7 +1131,7 @@ define([
                         return when.reject(e);
                     });
             });
-    }
+    };
 
     var dataUriRegex = /^data:(.*?)(;base64)?,(.*)$/;
 
@@ -1210,6 +1183,38 @@ define([
     }
 
     /**
+     * Asynchronously loads the given resource.  Returns a promise that will resolve to
+     * the result once loaded, or reject if the resource failed to load.  The data is loaded
+     * using XMLHttpRequest, which means that in order to make requests to another origin,
+     * the server must have Cross-Origin Resource Sharing (CORS) headers enabled.
+     *
+     * @param {Object} [options] Object with the following properties:
+     * @param {String} [options.responseType] The type of response.  This controls the type of item returned.
+     * @param {Object} [options.headers] Additional HTTP headers to send with the request, if any.
+     * @param {String} [options.overrideMimeType] Overrides the MIME type returned by the server.
+     * @returns {Promise.<Object>|undefined} a promise that will resolve to the requested data when loaded. Returns undefined if <code>request.throttle</code> is true and the request does not have high enough priority.
+     *
+     *
+     * @example
+     * // Load a single resource asynchronously. In real code, you should use loadBlob instead.
+     * resource.fetch()
+     *   .then(function(blob) {
+     *       // use the data
+     *   }).otherwise(function(error) {
+     *       // an error occurred
+     *   });
+     *
+     * @see {@link http://www.w3.org/TR/cors/|Cross-Origin Resource Sharing}
+     * @see {@link http://wiki.commonjs.org/wiki/Promises/A|CommonJS Promises/A}
+     */
+    Resource.prototype.fetch = function(options) {
+        options = defaultClone(options, {});
+        options.method = 'GET';
+
+        return Resource._makeRequest(this, options);
+    };
+
+    /**
      * Creates a Resource from a URL and calls fetch() on it.
      *
      * @param {String|Object} options A url or an object with the following properties
@@ -1235,7 +1240,64 @@ define([
     };
 
     /**
-     * Asynchronously posts data the given resource.  Returns a promise that will resolve to
+     * Asynchronously loads the given resource.  Returns a promise that will resolve to
+     * the result once loaded, or reject if the resource failed to load.  The data is loaded
+     * using XMLHttpRequest, which means that in order to make requests to another origin,
+     * the server must have Cross-Origin Resource Sharing (CORS) headers enabled.
+     *
+     * @param {Object} [options] Object with the following properties:
+     * @param {String} [options.responseType] The type of response.  This controls the type of item returned.
+     * @param {Object} [options.headers] Additional HTTP headers to send with the request, if any.
+     * @param {String} [options.overrideMimeType] Overrides the MIME type returned by the server.
+     * @returns {Promise.<Object>|undefined} a promise that will resolve to the requested data when loaded. Returns undefined if <code>request.throttle</code> is true and the request does not have high enough priority.
+     *
+     *
+     * @example
+     * // Load a single resource asynchronously. In real code, you should use loadBlob instead.
+     * resource.delete()
+     *   .then(function(blob) {
+     *       // use the data
+     *   }).otherwise(function(error) {
+     *       // an error occurred
+     *   });
+     *
+     * @see {@link http://www.w3.org/TR/cors/|Cross-Origin Resource Sharing}
+     * @see {@link http://wiki.commonjs.org/wiki/Promises/A|CommonJS Promises/A}
+     */
+    Resource.prototype.delete = function(options) {
+        options = defaultClone(options, {});
+        options.method = 'DELETE';
+
+        return Resource._makeRequest(this, options);
+    };
+
+    /**
+     * Creates a Resource from a URL and calls fetch() on it.
+     *
+     * @param {String|Object} options A url or an object with the following properties
+     * @param {String} options.url The url of the resource.
+     * @param {Object} [options.queryParameters] An object containing query parameters that will be sent when retrieving the resource.
+     * @param {Object} [options.templateValues] Key/Value pairs that are used to replace template values (eg. {x}).
+     * @param {Object} [options.headers={}] Additional HTTP headers that will be sent.
+     * @param {DefaultProxy} [options.proxy] A proxy to be used when loading the resource.
+     * @param {Resource~RetryCallback} [options.retryCallback] The Function to call when a request for this resource fails. If it returns true, the request will be retried.
+     * @param {Number} [options.retryAttempts=0] The number of times the retryCallback should be called before giving up.
+     * @param {Request} [options.request] A Request object that will be used. Intended for internal use only.
+     * @param {String} [options.responseType] The type of response.  This controls the type of item returned.
+     * @param {String} [options.overrideMimeType] Overrides the MIME type returned by the server.
+     * @returns {Promise.<Object>|undefined} a promise that will resolve to the requested data when loaded. Returns undefined if <code>request.throttle</code> is true and the request does not have high enough priority.
+     */
+    Resource.delete = function (options) {
+        var resource = new Resource(options);
+        return resource.delete({
+            // Make copy of just the needed fields because headers can be passed to both the constructor and to fetch
+            responseType: options.responseType,
+            overrideMimeType: options.overrideMimeType
+        });
+    };
+
+    /**
+     * Asynchronously posts data to the given resource.  Returns a promise that will resolve to
      * the result once loaded, or reject if the resource failed to load.  The data is loaded
      * using XMLHttpRequest, which means that in order to make requests to another origin,
      * the server must have Cross-Origin Resource Sharing (CORS) headers enabled.
@@ -1267,13 +1329,13 @@ define([
         options.method = 'POST';
         options.data = data;
 
-        return makeRequest(this, options);
+        return Resource._makeRequest(this, options);
     };
 
     /**
-     * Creates a Resource from a URL and calls fetch() on it.
+     * Creates a Resource from a URL and calls post() on it.
      *
-     * @param {String|Object} options A url or an object with the following properties
+     * @param {Object} options A url or an object with the following properties
      * @param {String} options.url The url of the resource.
      * @param {Object} options.data Data that is posted with the resource.
      * @param {Object} [options.queryParameters] An object containing query parameters that will be sent when retrieving the resource.
@@ -1290,6 +1352,130 @@ define([
     Resource.post = function (options) {
         var resource = new Resource(options);
         return resource.post(options.data, {
+            // Make copy of just the needed fields because headers can be passed to both the constructor and to post
+            responseType: options.responseType,
+            overrideMimeType: options.overrideMimeType
+        });
+    };
+
+    /**
+     * Asynchronously puts data to the given resource.  Returns a promise that will resolve to
+     * the result once loaded, or reject if the resource failed to load.  The data is loaded
+     * using XMLHttpRequest, which means that in order to make requests to another origin,
+     * the server must have Cross-Origin Resource Sharing (CORS) headers enabled.
+     *
+     * @param {Object} data Data that is posted with the resource.
+     * @param {Object} [options] Object with the following properties:
+     * @param {String} [options.responseType] The type of response.  This controls the type of item returned.
+     * @param {Object} [options.headers] Additional HTTP headers to send with the request, if any.
+     * @param {String} [options.overrideMimeType] Overrides the MIME type returned by the server.
+     * @returns {Promise.<Object>|undefined} a promise that will resolve to the requested data when loaded. Returns undefined if <code>request.throttle</code> is true and the request does not have high enough priority.
+     *
+     *
+     * @example
+     * // Load a single resource asynchronously. In real code, you should use loadBlob instead.
+     * resource.put(data)
+     *   .then(function(result) {
+     *       // use the result
+     *   }).otherwise(function(error) {
+     *       // an error occurred
+     *   });
+     *
+     * @see {@link http://www.w3.org/TR/cors/|Cross-Origin Resource Sharing}
+     * @see {@link http://wiki.commonjs.org/wiki/Promises/A|CommonJS Promises/A}
+     */
+    Resource.prototype.put = function(data, options) {
+        Check.defined('data', data);
+
+        options = defaultClone(options, {});
+        options.method = 'PUT';
+        options.data = data;
+
+        return Resource._makeRequest(this, options);
+    };
+
+    /**
+     * Creates a Resource from a URL and calls put() on it.
+     *
+     * @param {Object} options A url or an object with the following properties
+     * @param {String} options.url The url of the resource.
+     * @param {Object} options.data Data that is posted with the resource.
+     * @param {Object} [options.queryParameters] An object containing query parameters that will be sent when retrieving the resource.
+     * @param {Object} [options.templateValues] Key/Value pairs that are used to replace template values (eg. {x}).
+     * @param {Object} [options.headers={}] Additional HTTP headers that will be sent.
+     * @param {DefaultProxy} [options.proxy] A proxy to be used when loading the resource.
+     * @param {Resource~RetryCallback} [options.retryCallback] The Function to call when a request for this resource fails. If it returns true, the request will be retried.
+     * @param {Number} [options.retryAttempts=0] The number of times the retryCallback should be called before giving up.
+     * @param {Request} [options.request] A Request object that will be used. Intended for internal use only.
+     * @param {String} [options.responseType] The type of response.  This controls the type of item returned.
+     * @param {String} [options.overrideMimeType] Overrides the MIME type returned by the server.
+     * @returns {Promise.<Object>|undefined} a promise that will resolve to the requested data when loaded. Returns undefined if <code>request.throttle</code> is true and the request does not have high enough priority.
+     */
+    Resource.put = function (options) {
+        var resource = new Resource(options);
+        return resource.put(options.data, {
+            // Make copy of just the needed fields because headers can be passed to both the constructor and to post
+            responseType: options.responseType,
+            overrideMimeType: options.overrideMimeType
+        });
+    };
+
+    /**
+     * Asynchronously patches data to the given resource.  Returns a promise that will resolve to
+     * the result once loaded, or reject if the resource failed to load.  The data is loaded
+     * using XMLHttpRequest, which means that in order to make requests to another origin,
+     * the server must have Cross-Origin Resource Sharing (CORS) headers enabled.
+     *
+     * @param {Object} data Data that is posted with the resource.
+     * @param {Object} [options] Object with the following properties:
+     * @param {String} [options.responseType] The type of response.  This controls the type of item returned.
+     * @param {Object} [options.headers] Additional HTTP headers to send with the request, if any.
+     * @param {String} [options.overrideMimeType] Overrides the MIME type returned by the server.
+     * @returns {Promise.<Object>|undefined} a promise that will resolve to the requested data when loaded. Returns undefined if <code>request.throttle</code> is true and the request does not have high enough priority.
+     *
+     *
+     * @example
+     * // Load a single resource asynchronously. In real code, you should use loadBlob instead.
+     * resource.patch(data)
+     *   .then(function(result) {
+     *       // use the result
+     *   }).otherwise(function(error) {
+     *       // an error occurred
+     *   });
+     *
+     * @see {@link http://www.w3.org/TR/cors/|Cross-Origin Resource Sharing}
+     * @see {@link http://wiki.commonjs.org/wiki/Promises/A|CommonJS Promises/A}
+     */
+    Resource.prototype.patch = function(data, options) {
+        Check.defined('data', data);
+
+        options = defaultClone(options, {});
+        options.method = 'PATCH';
+        options.data = data;
+
+        return Resource._makeRequest(this, options);
+    };
+
+    /**
+     * Creates a Resource from a URL and calls patch() on it.
+     *
+     * @param {Object} options A url or an object with the following properties
+     * @param {String} options.url The url of the resource.
+     * @param {Object} options.data Data that is posted with the resource.
+     * @param {Object} [options.queryParameters] An object containing query parameters that will be sent when retrieving the resource.
+     * @param {Object} [options.templateValues] Key/Value pairs that are used to replace template values (eg. {x}).
+     * @param {Object} [options.headers={}] Additional HTTP headers that will be sent.
+     * @param {DefaultProxy} [options.proxy] A proxy to be used when loading the resource.
+     * @param {Resource~RetryCallback} [options.retryCallback] The Function to call when a request for this resource fails. If it returns true, the request will be retried.
+     * @param {Number} [options.retryAttempts=0] The number of times the retryCallback should be called before giving up.
+     * @param {Request} [options.request] A Request object that will be used. Intended for internal use only.
+     * @param {String} [options.responseType] The type of response.  This controls the type of item returned.
+     * @param {String} [options.overrideMimeType] Overrides the MIME type returned by the server.
+     * @returns {Promise.<Object>|undefined} a promise that will resolve to the requested data when loaded. Returns undefined if <code>request.throttle</code> is true and the request does not have high enough priority.
+     */
+    Resource.patch = function (options) {
+        var resource = new Resource(options);
+        return resource.patch(options.data, {
             // Make copy of just the needed fields because headers can be passed to both the constructor and to post
             responseType: options.responseType,
             overrideMimeType: options.overrideMimeType

--- a/Source/Core/Resource.js
+++ b/Source/Core/Resource.js
@@ -1237,7 +1237,7 @@ define([
     };
 
     /**
-     * Asynchronously loads the given resource.  Returns a promise that will resolve to
+     * Asynchronously deletes the given resource.  Returns a promise that will resolve to
      * the result once loaded, or reject if the resource failed to load.  The data is loaded
      * using XMLHttpRequest, which means that in order to make requests to another origin,
      * the server must have Cross-Origin Resource Sharing (CORS) headers enabled.
@@ -1269,7 +1269,7 @@ define([
     };
 
     /**
-     * Creates a Resource from a URL and calls fetch() on it.
+     * Creates a Resource from a URL and calls delete() on it.
      *
      * @param {String|Object} options A url or an object with the following properties
      * @param {String} options.url The url of the resource.
@@ -1287,6 +1287,120 @@ define([
     Resource.delete = function (options) {
         var resource = new Resource(options);
         return resource.delete({
+            // Make copy of just the needed fields because headers can be passed to both the constructor and to fetch
+            responseType: options.responseType,
+            overrideMimeType: options.overrideMimeType
+        });
+    };
+
+    /**
+     * Asynchronously gets headers the given resource.  Returns a promise that will resolve to
+     * the result once loaded, or reject if the resource failed to load.  The data is loaded
+     * using XMLHttpRequest, which means that in order to make requests to another origin,
+     * the server must have Cross-Origin Resource Sharing (CORS) headers enabled.
+     *
+     * @param {Object} [options] Object with the following properties:
+     * @param {String} [options.responseType] The type of response.  This controls the type of item returned.
+     * @param {Object} [options.headers] Additional HTTP headers to send with the request, if any.
+     * @param {String} [options.overrideMimeType] Overrides the MIME type returned by the server.
+     * @returns {Promise.<Object>|undefined} a promise that will resolve to the requested data when loaded. Returns undefined if <code>request.throttle</code> is true and the request does not have high enough priority.
+     *
+     *
+     * @example
+     * // Load a single resource asynchronously. In real code, you should use loadBlob instead.
+     * resource.head()
+     *   .then(function(headers) {
+     *       // use the data
+     *   }).otherwise(function(error) {
+     *       // an error occurred
+     *   });
+     *
+     * @see {@link http://www.w3.org/TR/cors/|Cross-Origin Resource Sharing}
+     * @see {@link http://wiki.commonjs.org/wiki/Promises/A|CommonJS Promises/A}
+     */
+    Resource.prototype.head = function(options) {
+        options = defaultClone(options, {});
+        options.method = 'HEAD';
+
+        return Resource._makeRequest(this, options);
+    };
+
+    /**
+     * Creates a Resource from a URL and calls head() on it.
+     *
+     * @param {String|Object} options A url or an object with the following properties
+     * @param {String} options.url The url of the resource.
+     * @param {Object} [options.queryParameters] An object containing query parameters that will be sent when retrieving the resource.
+     * @param {Object} [options.templateValues] Key/Value pairs that are used to replace template values (eg. {x}).
+     * @param {Object} [options.headers={}] Additional HTTP headers that will be sent.
+     * @param {DefaultProxy} [options.proxy] A proxy to be used when loading the resource.
+     * @param {Resource~RetryCallback} [options.retryCallback] The Function to call when a request for this resource fails. If it returns true, the request will be retried.
+     * @param {Number} [options.retryAttempts=0] The number of times the retryCallback should be called before giving up.
+     * @param {Request} [options.request] A Request object that will be used. Intended for internal use only.
+     * @param {String} [options.responseType] The type of response.  This controls the type of item returned.
+     * @param {String} [options.overrideMimeType] Overrides the MIME type returned by the server.
+     * @returns {Promise.<Object>|undefined} a promise that will resolve to the requested data when loaded. Returns undefined if <code>request.throttle</code> is true and the request does not have high enough priority.
+     */
+    Resource.head = function (options) {
+        var resource = new Resource(options);
+        return resource.head({
+            // Make copy of just the needed fields because headers can be passed to both the constructor and to fetch
+            responseType: options.responseType,
+            overrideMimeType: options.overrideMimeType
+        });
+    };
+
+    /**
+     * Asynchronously gets options the given resource.  Returns a promise that will resolve to
+     * the result once loaded, or reject if the resource failed to load.  The data is loaded
+     * using XMLHttpRequest, which means that in order to make requests to another origin,
+     * the server must have Cross-Origin Resource Sharing (CORS) headers enabled.
+     *
+     * @param {Object} [options] Object with the following properties:
+     * @param {String} [options.responseType] The type of response.  This controls the type of item returned.
+     * @param {Object} [options.headers] Additional HTTP headers to send with the request, if any.
+     * @param {String} [options.overrideMimeType] Overrides the MIME type returned by the server.
+     * @returns {Promise.<Object>|undefined} a promise that will resolve to the requested data when loaded. Returns undefined if <code>request.throttle</code> is true and the request does not have high enough priority.
+     *
+     *
+     * @example
+     * // Load a single resource asynchronously. In real code, you should use loadBlob instead.
+     * resource.head()
+     *   .then(function(headers) {
+     *       // use the data
+     *   }).otherwise(function(error) {
+     *       // an error occurred
+     *   });
+     *
+     * @see {@link http://www.w3.org/TR/cors/|Cross-Origin Resource Sharing}
+     * @see {@link http://wiki.commonjs.org/wiki/Promises/A|CommonJS Promises/A}
+     */
+    Resource.prototype.options = function(options) {
+        options = defaultClone(options, {});
+        options.method = 'OPTIONS';
+
+        return Resource._makeRequest(this, options);
+    };
+
+    /**
+     * Creates a Resource from a URL and calls options() on it.
+     *
+     * @param {String|Object} options A url or an object with the following properties
+     * @param {String} options.url The url of the resource.
+     * @param {Object} [options.queryParameters] An object containing query parameters that will be sent when retrieving the resource.
+     * @param {Object} [options.templateValues] Key/Value pairs that are used to replace template values (eg. {x}).
+     * @param {Object} [options.headers={}] Additional HTTP headers that will be sent.
+     * @param {DefaultProxy} [options.proxy] A proxy to be used when loading the resource.
+     * @param {Resource~RetryCallback} [options.retryCallback] The Function to call when a request for this resource fails. If it returns true, the request will be retried.
+     * @param {Number} [options.retryAttempts=0] The number of times the retryCallback should be called before giving up.
+     * @param {Request} [options.request] A Request object that will be used. Intended for internal use only.
+     * @param {String} [options.responseType] The type of response.  This controls the type of item returned.
+     * @param {String} [options.overrideMimeType] Overrides the MIME type returned by the server.
+     * @returns {Promise.<Object>|undefined} a promise that will resolve to the requested data when loaded. Returns undefined if <code>request.throttle</code> is true and the request does not have high enough priority.
+     */
+    Resource.options = function (options) {
+        var resource = new Resource(options);
+        return resource.options({
             // Make copy of just the needed fields because headers can be passed to both the constructor and to fetch
             responseType: options.responseType,
             overrideMimeType: options.overrideMimeType
@@ -1553,6 +1667,21 @@ define([
 
             var response = xhr.response;
             var browserResponseType = xhr.responseType;
+
+            if (method === 'HEAD' || method === 'OPTIONS') {
+                var responseHeaderString = xhr.getAllResponseHeaders();
+                var splitHeaders = responseHeaderString.trim().split(/[\r\n]+/);
+
+                var responseHeaders = {};
+                splitHeaders.forEach(function (line) {
+                    var parts = line.split(': ');
+                    var header = parts.shift();
+                    responseHeaders[header] = parts.join(': ');
+                });
+
+                deferred.resolve(responseHeaders);
+                return;
+            }
 
             //All modern browsers will go into either the first or second if block or last else block.
             //Other code paths support older browsers that either do not support the supplied responseType

--- a/Source/Core/loadWithXhr.js
+++ b/Source/Core/loadWithXhr.js
@@ -66,7 +66,8 @@ define([
         return Resource._makeRequest(resource, {
             responseType: options.responseType,
             overrideMimeType: options.overrideMimeType,
-            method: defaultValue(options.method, 'GET')
+            method: defaultValue(options.method, 'GET'),
+            data: options.data
         });
     }
 

--- a/Source/Core/loadWithXhr.js
+++ b/Source/Core/loadWithXhr.js
@@ -1,12 +1,14 @@
 define([
         '../ThirdParty/when',
         './Check',
+        './defaultValue',
         './defineProperties',
         './deprecationWarning',
         './Resource'
     ], function(
         when,
         Check,
+        defaultValue,
         defineProperties,
         deprecationWarning,
         Resource) {
@@ -61,9 +63,10 @@ define([
         // Take advantage that most parameters are the same
         var resource = new Resource(options);
 
-        return resource.fetch({
+        return Resource._makeRequest(resource, {
             responseType: options.responseType,
-            overrideMimeType: options.overrideMimeType
+            overrideMimeType: options.overrideMimeType,
+            method: defaultValue(options.method, 'GET')
         });
     }
 

--- a/Source/DataSources/KmlDataSource.js
+++ b/Source/DataSources/KmlDataSource.js
@@ -728,10 +728,10 @@ define([
             var viewFormat = defaultValue(queryStringValue(iconNode, 'viewFormat', namespaces.kml), defaultViewFormat);
             var httpQuery = queryStringValue(iconNode, 'httpQuery', namespaces.kml);
             if (defined(viewFormat)) {
-                hrefResource.addQueryParameters(queryToObject(cleanupString(viewFormat)));
+                hrefResource.setQueryParameters(queryToObject(cleanupString(viewFormat)));
             }
             if (defined(httpQuery)) {
-                hrefResource.addQueryParameters(queryToObject(cleanupString(httpQuery)));
+                hrefResource.setQueryParameters(queryToObject(cleanupString(httpQuery)));
             }
 
             processNetworkLinkQueryString(hrefResource, dataSource._camera, dataSource._canvas, viewBoundScale, dataSource._lastCameraView.bbox);
@@ -2108,7 +2108,7 @@ define([
         queryString = queryString.replace('[clientName]', 'Cesium');
         queryString = queryString.replace('[language]', 'English');
 
-        resource.addQueryParameters(queryToObject(queryString));
+        resource.setQueryParameters(queryToObject(queryString));
     }
 
     function processNetworkLink(dataSource, parent, node, entityCollection, styleCollection, sourceResource, uriResolver, promises, context) {
@@ -2145,10 +2145,10 @@ define([
                     var viewFormat = defaultValue(queryStringValue(link, 'viewFormat', namespaces.kml), defaultViewFormat);
                     var httpQuery = queryStringValue(link, 'httpQuery', namespaces.kml);
                     if (defined(viewFormat)) {
-                        href.addQueryParameters(queryToObject(cleanupString(viewFormat)));
+                        href.setQueryParameters(queryToObject(cleanupString(viewFormat)));
                     }
                     if (defined(httpQuery)) {
-                        href.addQueryParameters(queryToObject(cleanupString(httpQuery)));
+                        href.setQueryParameters(queryToObject(cleanupString(httpQuery)));
                     }
 
                     processNetworkLinkQueryString(href, dataSource._camera, dataSource._canvas, viewBoundScale, dataSource._lastCameraView.bbox);
@@ -2391,7 +2391,7 @@ define([
         }
 
         if (defined(query)) {
-            sourceUri.addQueryParameters(query);
+            sourceUri.setQueryParameters(query);
         }
 
         return when(promise)
@@ -2976,7 +2976,7 @@ define([
                     networkLink.updating = true;
                     var newEntityCollection = new EntityCollection();
                     var href = networkLink.href.clone();
-                    href.addQueryParameters(networkLink.cookie);
+                    href.setQueryParameters(networkLink.cookie);
                     processNetworkLinkQueryString(href, that._camera, that._canvas, networkLink.viewBoundScale, lastCameraView.bbox);
                     load(that, newEntityCollection, href, {context : entity.id})
                         .then(getNetworkLinkUpdateCallback(that, networkLink, newEntityCollection, newNetworkLinks, href))

--- a/Source/DataSources/KmlDataSource.js
+++ b/Source/DataSources/KmlDataSource.js
@@ -2525,7 +2525,7 @@ define([
     /**
      * Creates a Promise to a new instance loaded with the provided KML data.
      *
-     * @param {String|Document|Blob} data A url, parsed KML document, or Blob containing binary KMZ data or a parsed KML document.
+     * @param {Resource|String|Document|Blob} data A url, parsed KML document, or Blob containing binary KMZ data or a parsed KML document.
      * @param {Object} options An object with the following properties:
      * @param {Camera} options.camera The camera that is used for viewRefreshModes and sending camera properties to network links.
      * @param {Canvas} options.canvas The canvas that is used for sending viewer properties to network links.
@@ -2681,9 +2681,9 @@ define([
      * @param {Resource|String|Document|Blob} data A url, parsed KML document, or Blob containing binary KMZ data or a parsed KML document.
      * @param {Object} [options] An object with the following properties:
      * @param {Resource|String} [options.sourceUri] Overrides the url to use for resolving relative links and other KML network features.
-     * @returns {Promise.<KmlDataSource>} A promise that will resolve to this instances once the KML is loaded.
      * @param {Boolean} [options.clampToGround=false] true if we want the geometry features (Polygons, LineStrings and LinearRings) clamped to the ground. If true, lines will use corridors so use Entity.corridor instead of Entity.polyline.
-     * @param {Object} [options.query] Key-value pairs which are appended to all URIs in the CZML.
+     *
+     * @returns {Promise.<KmlDataSource>} A promise that will resolve to this instances once the KML is loaded.
      */
     KmlDataSource.prototype.load = function(data, options) {
         //>>includeStart('debug', pragmas.debug);

--- a/Source/Scene/ArcGisMapServerImageryProvider.js
+++ b/Source/Scene/ArcGisMapServerImageryProvider.js
@@ -125,7 +125,7 @@ define([
         resource.appendForwardSlash();
 
         if (defined(options.token)) {
-            resource.addQueryParameters({
+            resource.setQueryParameters({
                 token: options.token
             });
         }

--- a/Source/Scene/BingMapsImageryProvider.js
+++ b/Source/Scene/BingMapsImageryProvider.js
@@ -113,7 +113,7 @@ define([
             proxy: options.proxy
         });
 
-        urlResource.addQueryParameters({
+        urlResource.setQueryParameters({
             key: this._key
         });
 

--- a/Source/Scene/Cesium3DTile.js
+++ b/Source/Scene/Cesium3DTile.js
@@ -619,7 +619,7 @@ define([
         var expired = this.contentExpired;
         if (expired) {
             // Append a query parameter of the tile expiration date to prevent caching
-            resource.addQueryParameters({
+            resource.setQueryParameters({
                 expired: this.expireDate.toString()
             });
         }

--- a/Source/Scene/Cesium3DTileset.js
+++ b/Source/Scene/Cesium3DTileset.js
@@ -1254,7 +1254,7 @@ define([
                 v: defaultValue(asset.tilesetVersion, '0.0')
             };
             this._basePath += '?v=' + versionQuery.v;
-            tilesetResource.addQueryParameters(versionQuery);
+            tilesetResource.setQueryParameters(versionQuery);
         }
 
         // A tileset.json referenced from a tile may exist in a different directory than the root tileset.

--- a/Source/Scene/GoogleEarthEnterpriseMapsProvider.js
+++ b/Source/Scene/GoogleEarthEnterpriseMapsProvider.js
@@ -118,9 +118,14 @@ define([
 
         var url = options.url;
         var path = defaultValue(options.path, '/default_map');
-        var resource = Resource.createIfNeeded(url + path, {
-            proxy: options.proxy
+
+        var resource = Resource.createIfNeeded(url, {
+            proxy : options.proxy
+        }).getDerivedResource({
+            // We used to just append path to url, so now that we do proper URI resolution, removed the /
+            url : (path[0] === '/') ? path.substring(1) : path
         });
+
         resource.appendForwardSlash();
 
         this._resource = resource;

--- a/Source/Scene/MapboxImageryProvider.js
+++ b/Source/Scene/MapboxImageryProvider.js
@@ -100,7 +100,7 @@ define([
         templateUrl += mapId + '/{z}/{x}/{y}' + this._format;
         resource.url = templateUrl;
 
-        resource.addQueryParameters({
+        resource.setQueryParameters({
             access_token: accessToken
         });
 

--- a/Source/Scene/WebMapServiceImageryProvider.js
+++ b/Source/Scene/WebMapServiceImageryProvider.js
@@ -111,15 +111,15 @@ define([
 
         var pickFeatureResource = resource.clone();
 
-        resource.addQueryParameters(WebMapServiceImageryProvider.DefaultParameters, true);
-        pickFeatureResource.addQueryParameters(WebMapServiceImageryProvider.GetFeatureInfoDefaultParameters, true);
+        resource.setQueryParameters(WebMapServiceImageryProvider.DefaultParameters, true);
+        pickFeatureResource.setQueryParameters(WebMapServiceImageryProvider.GetFeatureInfoDefaultParameters, true);
 
         if (defined(options.parameters)) {
-            resource.addQueryParameters(objectToLowercase(options.parameters));
+            resource.setQueryParameters(objectToLowercase(options.parameters));
         }
 
         if (defined(options.getFeatureInfoParameters)) {
-            pickFeatureResource.addQueryParameters(objectToLowercase(options.getFeatureInfoParameters));
+            pickFeatureResource.setQueryParameters(objectToLowercase(options.getFeatureInfoParameters));
         }
 
         var parameters = {};
@@ -139,8 +139,8 @@ define([
             parameters.srs = options.tilingScheme instanceof WebMercatorTilingScheme ? 'EPSG:3857' : 'EPSG:4326';
         }
 
-        resource.addQueryParameters(parameters, true);
-        pickFeatureResource.addQueryParameters(parameters, true);
+        resource.setQueryParameters(parameters, true);
+        pickFeatureResource.setQueryParameters(parameters, true);
 
         var pickFeatureParams = {
             query_layers: options.layers,
@@ -148,7 +148,7 @@ define([
             y: '{j}',
             info_format: '{format}'
         };
-        pickFeatureResource.addQueryParameters(pickFeatureParams, true);
+        pickFeatureResource.setQueryParameters(pickFeatureParams, true);
 
         this._resource = resource;
         this._pickFeaturesResource = pickFeatureResource;

--- a/Source/Scene/WebMapTileServiceImageryProvider.js
+++ b/Source/Scene/WebMapTileServiceImageryProvider.js
@@ -175,10 +175,10 @@ define([
                 TileMatrixSet : tileMatrixSetID
             };
 
-            resource.addTemplateValues(templateValues);
+            resource.setTemplateValues(templateValues);
             this._useKvp = false;
         } else {
-            resource.addQueryParameters(defaultParameters);
+            resource.setQueryParameters(defaultParameters);
             this._useKvp = true;
         }
 
@@ -265,14 +265,14 @@ define([
             resource = imageryProvider._resource.getDerivedResource({
                 request: request
             });
-            resource.addTemplateValues(templateValues);
+            resource.setTemplateValues(templateValues);
 
             if (defined(staticDimensions)) {
-                resource.addTemplateValues(staticDimensions);
+                resource.setTemplateValues(staticDimensions);
             }
 
             if (defined(dynamicIntervalData)) {
-                resource.addTemplateValues(dynamicIntervalData);
+                resource.setTemplateValues(dynamicIntervalData);
             }
         } else {
             // build KVP request

--- a/Specs/Core/ResourceSpec.js
+++ b/Specs/Core/ResourceSpec.js
@@ -790,4 +790,74 @@ defineSuite([
                 expect(result).toEqual(expectedResult);
             });
     });
+
+    it('static head calls correct method', function() {
+        var resource = Resource.DEFAULT.getDerivedResource({
+            url: './Data/Images/Blue.png'
+        });
+        spyOn(Resource.prototype, 'head').and.callThrough();
+        return Resource.head(resource)
+            .then(function() {
+                expect(Resource.prototype.head).toHaveBeenCalled();
+            });
+    });
+
+    it('head calls correct method', function() {
+        var resource = Resource.DEFAULT.getDerivedResource({
+            url: 'Data/Images/Blue.png'
+        });
+        spyOn(Resource._Implementations, 'loadWithXhr').and.callFake(function(url, responseType, method, data, headers, deferred, overrideMimeType) {
+            expect(url).toEqual(resource.url);
+            expect(method).toEqual('HEAD');
+            Resource._DefaultImplementations.loadWithXhr(url, responseType, method, data, headers, deferred, overrideMimeType);
+        });
+
+        return resource.head()
+            .then(function(result) {
+                expect(result.date).toBeDefined();
+                expect(result['last-modified']).toBeDefined();
+                expect(result['x-powered-by']).toBeDefined();
+                expect(result.etag).toBeDefined();
+                expect(result['content-type']).toBe('image/png');
+                expect(result['access-control-allow-origin']).toBe('*');
+                expect(result['cache-control']).toBe('public, max-age=0');
+                expect(result['accept-ranges']).toBe('bytes');
+                expect(result['access-control-allow-headers']).toBe('Origin, X-Requested-With, Content-Type, Accept');
+                expect(result['content-length']).toBeDefined();
+            });
+    });
+
+    it('static options calls correct method', function() {
+        var resource = Resource.DEFAULT.getDerivedResource({
+            url: './Data/Images/Blue.png'
+        });
+        spyOn(Resource.prototype, 'options').and.callThrough();
+        return Resource.options(resource)
+            .then(function() {
+                expect(Resource.prototype.options).toHaveBeenCalled();
+            });
+    });
+
+    it('options calls correct method', function() {
+        var resource = Resource.DEFAULT.getDerivedResource({
+            url: './Data/Images/Blue.png'
+        });
+        spyOn(Resource._Implementations, 'loadWithXhr').and.callFake(function(url, responseType, method, data, headers, deferred, overrideMimeType) {
+            expect(url).toEqual(resource.url);
+            expect(method).toEqual('OPTIONS');
+            Resource._DefaultImplementations.loadWithXhr(url, responseType, method, data, headers, deferred, overrideMimeType);
+        });
+
+        return resource.options(resource)
+            .then(function(result) {
+                expect(result.date).toBeDefined();
+                expect(result['x-powered-by']).toBeDefined();
+                expect(result.etag).toBeDefined();
+                expect(result['content-type']).toBeDefined();
+                expect(result['access-control-allow-origin']).toBe('*');
+                expect(result['access-control-allow-methods']).toBe('GET, PUT, POST, DELETE, OPTIONS');
+                expect(result['access-control-allow-headers']).toBe('Origin, X-Requested-With, Content-Type, Accept');
+                expect(result['content-length']).toBeDefined();
+            });
+    });
 });

--- a/Specs/Core/ResourceSpec.js
+++ b/Specs/Core/ResourceSpec.js
@@ -518,6 +518,160 @@ defineSuite([
             });
     });
 
+    it('put calls with correct method', function() {
+        var expectedUrl = 'http://test.com/endpoint';
+        var expectedResponseType = 'json';
+        var expectedData = {
+            stuff: 'myStuff'
+        };
+        var expectedHeaders = {
+            'X-My-Header': 'My-Value'
+        };
+        var expectedResult = {
+            status: 'success'
+        };
+        var expectedMimeType = 'application/test-data';
+        var resource = new Resource({
+            url: expectedUrl,
+            headers: expectedHeaders
+        });
+
+        spyOn(Resource._Implementations, 'loadWithXhr').and.callFake(function(url, responseType, method, data, headers, deferred, overrideMimeType) {
+            expect(url).toEqual(expectedUrl);
+            expect(responseType).toEqual(expectedResponseType);
+            expect(method).toEqual('PUT');
+            expect(data).toEqual(expectedData);
+            expect(headers['X-My-Header']).toEqual('My-Value');
+            expect(headers['X-My-Other-Header']).toEqual('My-Other-Value');
+            expect(overrideMimeType).toBe(expectedMimeType);
+            deferred.resolve(expectedResult);
+        });
+
+        return resource.put(expectedData, {
+            responseType: expectedResponseType,
+            headers: {
+                'X-My-Other-Header': 'My-Other-Value'
+            },
+            overrideMimeType: expectedMimeType
+        })
+            .then(function(result) {
+                expect(result).toEqual(expectedResult);
+            });
+    });
+
+    it('static put calls with correct method', function() {
+        var expectedUrl = 'http://test.com/endpoint';
+        var expectedResponseType = 'json';
+        var expectedData = {
+            stuff: 'myStuff'
+        };
+        var expectedHeaders = {
+            'X-My-Header': 'My-Value'
+        };
+        var expectedResult = {
+            status: 'success'
+        };
+        var expectedMimeType = 'application/test-data';
+
+        spyOn(Resource._Implementations, 'loadWithXhr').and.callFake(function(url, responseType, method, data, headers, deferred, overrideMimeType) {
+            expect(url).toEqual(expectedUrl);
+            expect(responseType).toEqual(expectedResponseType);
+            expect(method).toEqual('PUT');
+            expect(data).toEqual(expectedData);
+            expect(headers).toEqual(expectedHeaders);
+            expect(overrideMimeType).toBe(expectedMimeType);
+            deferred.resolve(expectedResult);
+        });
+
+        return Resource.put({
+            url: expectedUrl,
+            data: expectedData,
+            responseType: expectedResponseType,
+            headers: expectedHeaders,
+            overrideMimeType: expectedMimeType
+        })
+            .then(function(result) {
+                expect(result).toEqual(expectedResult);
+            });
+    });
+
+    it('patch calls with correct method', function() {
+        var expectedUrl = 'http://test.com/endpoint';
+        var expectedResponseType = 'json';
+        var expectedData = {
+            stuff: 'myStuff'
+        };
+        var expectedHeaders = {
+            'X-My-Header': 'My-Value'
+        };
+        var expectedResult = {
+            status: 'success'
+        };
+        var expectedMimeType = 'application/test-data';
+        var resource = new Resource({
+            url: expectedUrl,
+            headers: expectedHeaders
+        });
+
+        spyOn(Resource._Implementations, 'loadWithXhr').and.callFake(function(url, responseType, method, data, headers, deferred, overrideMimeType) {
+            expect(url).toEqual(expectedUrl);
+            expect(responseType).toEqual(expectedResponseType);
+            expect(method).toEqual('PATCH');
+            expect(data).toEqual(expectedData);
+            expect(headers['X-My-Header']).toEqual('My-Value');
+            expect(headers['X-My-Other-Header']).toEqual('My-Other-Value');
+            expect(overrideMimeType).toBe(expectedMimeType);
+            deferred.resolve(expectedResult);
+        });
+
+        return resource.patch(expectedData, {
+            responseType: expectedResponseType,
+            headers: {
+                'X-My-Other-Header': 'My-Other-Value'
+            },
+            overrideMimeType: expectedMimeType
+        })
+            .then(function(result) {
+                expect(result).toEqual(expectedResult);
+            });
+    });
+
+    it('static patch calls with correct method', function() {
+        var expectedUrl = 'http://test.com/endpoint';
+        var expectedResponseType = 'json';
+        var expectedData = {
+            stuff: 'myStuff'
+        };
+        var expectedHeaders = {
+            'X-My-Header': 'My-Value'
+        };
+        var expectedResult = {
+            status: 'success'
+        };
+        var expectedMimeType = 'application/test-data';
+
+        spyOn(Resource._Implementations, 'loadWithXhr').and.callFake(function(url, responseType, method, data, headers, deferred, overrideMimeType) {
+            expect(url).toEqual(expectedUrl);
+            expect(responseType).toEqual(expectedResponseType);
+            expect(method).toEqual('PATCH');
+            expect(data).toEqual(expectedData);
+            expect(headers).toEqual(expectedHeaders);
+            expect(overrideMimeType).toBe(expectedMimeType);
+            deferred.resolve(expectedResult);
+        });
+
+        return Resource.patch({
+            url: expectedUrl,
+            data: expectedData,
+            responseType: expectedResponseType,
+            headers: expectedHeaders,
+            overrideMimeType: expectedMimeType
+        })
+            .then(function(result) {
+                expect(result).toEqual(expectedResult);
+            });
+    });
+
     it('static fetchArrayBuffer calls correct method', function() {
         var url = 'http://test.com/data';
         spyOn(Resource.prototype, 'fetchArrayBuffer').and.returnValue(when.resolve());
@@ -604,6 +758,34 @@ defineSuite([
 
         var resource = new Resource({url: expectedUrl});
         return resource.fetch()
+            .then(function(result) {
+                expect(result).toEqual(expectedResult);
+            });
+    });
+
+    it('static delete calls correct method', function() {
+        var url = 'http://test.com/data';
+        spyOn(Resource.prototype, 'delete').and.returnValue(when.resolve());
+        return Resource.delete(url)
+            .then(function() {
+                expect(Resource.prototype.delete).toHaveBeenCalled();
+            });
+    });
+
+    it('delete calls correct method', function() {
+        var expectedUrl = 'http://test.com/endpoint';
+        var expectedResult = {
+            status: 'success'
+        };
+
+        spyOn(Resource._Implementations, 'loadWithXhr').and.callFake(function(url, responseType, method, data, headers, deferred, overrideMimeType) {
+            expect(url).toEqual(expectedUrl);
+            expect(method).toEqual('DELETE');
+            deferred.resolve(expectedResult);
+        });
+
+        var resource = new Resource({url: expectedUrl});
+        return resource.delete()
             .then(function(result) {
                 expect(result).toEqual(expectedResult);
             });

--- a/Specs/Core/ResourceSpec.js
+++ b/Specs/Core/ResourceSpec.js
@@ -892,72 +892,127 @@ defineSuite([
     });
 
     it('static head calls correct method', function() {
-        var resource = Resource.DEFAULT.getDerivedResource({
-            url: './Data/Images/Blue.png'
-        });
-        spyOn(Resource.prototype, 'head').and.callThrough();
-        return Resource.head(resource)
+        var url = 'http://test.com/data';
+        spyOn(Resource.prototype, 'head').and.returnValue(when.resolve({}));
+        return Resource.head(url)
             .then(function() {
                 expect(Resource.prototype.head).toHaveBeenCalled();
             });
     });
 
     it('head calls correct method', function() {
-        var resource = Resource.DEFAULT.getDerivedResource({
-            url: 'Data/Images/Blue.png'
-        });
+        var expectedUrl = 'http://test.com/endpoint';
+        var expectedResult = {
+            'accept-ranges': 'bytes',
+            'access-control-allow-headers' : 'Origin, X-Requested-With, Content-Type, Accept',
+            'access-control-allow-origin' : '*',
+            'cache-control': 'public, max-age=0',
+            'connection' : 'keep-alive',
+            'content-length' : '883',
+            'content-type' : 'image/png',
+            'date' : 'Tue, 13 Feb 2018 03:38:55 GMT',
+            'etag' : 'W/"373-15e34d146a1"',
+            'vary' : 'Accept-Encoding',
+            'x-powered-vy' : 'Express'
+        };
+        var headerString = '';
+        for (var key in expectedResult) {
+            if (expectedResult.hasOwnProperty(key)) {
+                headerString += key + ': ' + expectedResult[key] + '\r\n';
+            }
+        }
+        var fakeXHR = {
+            status: 200,
+            send : function() {
+                this.onload();
+            },
+            open : function() {},
+            getAllResponseHeaders : function() {
+                return headerString;
+            }
+        };
+        spyOn(window, 'XMLHttpRequest').and.returnValue(fakeXHR);
+
         spyOn(Resource._Implementations, 'loadWithXhr').and.callFake(function(url, responseType, method, data, headers, deferred, overrideMimeType) {
-            expect(url).toEqual(resource.url);
+            expect(url).toEqual(expectedUrl);
             expect(method).toEqual('HEAD');
             Resource._DefaultImplementations.loadWithXhr(url, responseType, method, data, headers, deferred, overrideMimeType);
         });
 
+        var resource = new Resource({url: expectedUrl});
         return resource.head()
             .then(function(result) {
-                expect(result.date).toBeDefined();
-                expect(result['last-modified']).toBeDefined();
-                expect(result['x-powered-by']).toBeDefined();
-                expect(result.etag).toBeDefined();
-                expect(result['content-type']).toBe('image/png');
-                expect(result['access-control-allow-origin']).toBe('*');
-                expect(result['cache-control']).toBe('public, max-age=0');
-                expect(result['accept-ranges']).toBe('bytes');
-                expect(result['access-control-allow-headers']).toBe('Origin, X-Requested-With, Content-Type, Accept');
-                expect(result['content-length']).toBeDefined();
+                expect(result.date).toEqual(expectedResult.date);
+                expect(result['last-modified']).toEqual(expectedResult['last-modified']);
+                expect(result['x-powered-by']).toEqual(expectedResult['x-powered-by']);
+                expect(result.etag).toEqual(expectedResult.etag);
+                expect(result['content-type']).toEqual(expectedResult['content-type']);
+                expect(result['access-control-allow-origin']).toEqual(expectedResult['access-control-allow-origin']);
+                expect(result['cache-control']).toEqual(expectedResult['cache-control']);
+                expect(result['accept-ranges']).toEqual(expectedResult['accept-ranges']);
+                expect(result['access-control-allow-headers']).toEqual(expectedResult['access-control-allow-headers']);
+                expect(result['content-length']).toEqual(expectedResult['content-length']);
             });
     });
 
     it('static options calls correct method', function() {
-        var resource = Resource.DEFAULT.getDerivedResource({
-            url: './Data/Images/Blue.png'
-        });
-        spyOn(Resource.prototype, 'options').and.callThrough();
-        return Resource.options(resource)
+        var url = 'http://test.com/data';
+        spyOn(Resource.prototype, 'options').and.returnValue(when.resolve({}));
+        return Resource.options(url)
             .then(function() {
                 expect(Resource.prototype.options).toHaveBeenCalled();
             });
     });
 
     it('options calls correct method', function() {
-        var resource = Resource.DEFAULT.getDerivedResource({
-            url: './Data/Images/Blue.png'
-        });
+        var expectedUrl = 'http://test.com/endpoint';
+        var expectedResult = {
+            'access-control-allow-headers' : 'Origin, X-Requested-With, Content-Type, Accept',
+            'access-control-allow-methods' : 'GET, PUT, POST, DELETE, OPTIONS',
+            'access-control-allow-origin' : '*',
+            'connection' : 'keep-alive',
+            'content-length' : '2',
+            'content-type' : 'text/plain; charset=utf-8',
+            'date' : 'Tue, 13 Feb 2018 03:38:55 GMT',
+            'etag' : 'W/"2-nOO9QiTIwXgNtWtBJezz8kv3SLc"',
+            'vary' : 'Accept-Encoding',
+            'x-powered-vy' : 'Express'
+        };
+        var headerString = '';
+        for (var key in expectedResult) {
+            if (expectedResult.hasOwnProperty(key)) {
+                headerString += key + ': ' + expectedResult[key] + '\r\n';
+            }
+        }
+        var fakeXHR = {
+            status: 200,
+            send : function() {
+                this.onload();
+            },
+            open : function() {},
+            getAllResponseHeaders : function() {
+                return headerString;
+            }
+        };
+        spyOn(window, 'XMLHttpRequest').and.returnValue(fakeXHR);
+
         spyOn(Resource._Implementations, 'loadWithXhr').and.callFake(function(url, responseType, method, data, headers, deferred, overrideMimeType) {
-            expect(url).toEqual(resource.url);
+            expect(url).toEqual(expectedUrl);
             expect(method).toEqual('OPTIONS');
             Resource._DefaultImplementations.loadWithXhr(url, responseType, method, data, headers, deferred, overrideMimeType);
         });
 
-        return resource.options(resource)
+        var resource = new Resource({url: expectedUrl});
+        return resource.options()
             .then(function(result) {
-                expect(result.date).toBeDefined();
-                expect(result['x-powered-by']).toBeDefined();
-                expect(result.etag).toBeDefined();
-                expect(result['content-type']).toBeDefined();
-                expect(result['access-control-allow-origin']).toBe('*');
-                expect(result['access-control-allow-methods']).toBe('GET, PUT, POST, DELETE, OPTIONS');
-                expect(result['access-control-allow-headers']).toBe('Origin, X-Requested-With, Content-Type, Accept');
-                expect(result['content-length']).toBeDefined();
+                expect(result.date).toEqual(expectedResult.date);
+                expect(result['x-powered-by']).toEqual(expectedResult['x-powered-by']);
+                expect(result.etag).toEqual(expectedResult.etag);
+                expect(result['content-type']).toEqual(expectedResult['content-type']);
+                expect(result['access-control-allow-origin']).toEqual(expectedResult['access-control-allow-origin']);
+                expect(result['access-control-allow-methods']).toEqual(expectedResult['access-control-allow-methods']);
+                expect(result['access-control-allow-headers']).toEqual(expectedResult['access-control-allow-headers']);
+                expect(result['content-length']).toEqual(expectedResult['content-length']);
             });
     });
 });

--- a/Specs/Scene/GoogleEarthEnterpriseMapsProviderSpec.js
+++ b/Specs/Scene/GoogleEarthEnterpriseMapsProviderSpec.js
@@ -106,7 +106,7 @@ defineSuite([
     });
 
     it('rejects readyPromise on error', function() {
-        var url = 'invalid.localhost';
+        var url = 'http://invalid.localhost';
         var provider = new GoogleEarthEnterpriseMapsProvider({
             url : url,
             channel : 1234
@@ -296,7 +296,7 @@ defineSuite([
     });
 
     it('raises error on invalid url', function() {
-        var url = 'invalid.localhost';
+        var url = 'http://invalid.localhost';
         var provider = new GoogleEarthEnterpriseMapsProvider({
             url : url,
             channel : 1234

--- a/server.js
+++ b/server.js
@@ -55,14 +55,7 @@
     app.use(function(req, res, next) {
         res.header('Access-Control-Allow-Origin', '*');
         res.header('Access-Control-Allow-Headers', 'Origin, X-Requested-With, Content-Type, Accept');
-        //intercepts OPTIONS method
-        if ('OPTIONS' === req.method) {
-            res.header('Access-Control-Allow-Methods', 'GET, PUT, POST, DELETE, OPTIONS');
-            //respond with 200
-            res.sendStatus(200);
-        } else {
-            next();
-        }
+        next();
     });
 
     function checkGzipAndNext(req, res, next) {

--- a/server.js
+++ b/server.js
@@ -55,7 +55,14 @@
     app.use(function(req, res, next) {
         res.header('Access-Control-Allow-Origin', '*');
         res.header('Access-Control-Allow-Headers', 'Origin, X-Requested-With, Content-Type, Accept');
-        next();
+        //intercepts OPTIONS method
+        if ('OPTIONS' === req.method) {
+            res.header('Access-Control-Allow-Methods', 'GET, PUT, POST, DELETE, OPTIONS');
+            //respond with 200
+            res.sendStatus(200);
+        } else {
+            next();
+        }
     });
 
     function checkGzipAndNext(req, res, next) {


### PR DESCRIPTION
- We now handle multiple parameters with the same name.
  - `addQueryParameters` has been replaced with `setQueryParameters` and `appendQueryParameters`.
  - `addTemplateValues` has been replaced with `setTemplateValues` for consistency.
- We added static and prototype methods for the other methods
  - PUT, PATCH, DELETE
  - OPTIONS and HEAD have methods that return a dictionary object of the headers
- `loadWithXhr` has been fixed to actually pass through the method. Even though it is deprecated, this was broken in the last release and can lead to weird bugs if a user was doing anything but a GET.
- `Resource.clone` now functions as expected. Internal logic was moved into the private method `Resource.createIfNeeded`.
- ~~`server.js` was modified to handle `OPTIONS` requests, so it can be tested.~~
- Various doc fixes