### PR TITLE
Fix deprecation warnings for load functions

### DIFF
--- a/Specs/Core/BingMapsGeocoderServiceSpec.js
+++ b/Specs/Core/BingMapsGeocoderServiceSpec.js
@@ -1,12 +1,12 @@
 defineSuite([
         'Core/BingMapsGeocoderService',
-        'Core/loadJsonp',
         'Core/Rectangle',
+        'Core/Resource',
         'Specs/createScene'
     ], function(
         BingMapsGeocoderService,
-        loadJsonp,
         Rectangle,
+        Resource,
         createScene) {
     'use strict';
 
@@ -22,7 +22,7 @@ defineSuite([
     });
 
     afterAll(function() {
-        loadJsonp.loadAndExecuteScript = loadJsonp.defaultLoadAndExecuteScript;
+        Resource._Implementations.loadAndExecuteScript = Resource._DefaultImplementations.loadAndExecuteScript;
     });
 
     it('constructor throws without scene', function() {
@@ -41,7 +41,7 @@ defineSuite([
                 }]
             }]
         };
-        loadJsonp.loadAndExecuteScript = function(url, functionName, deferred) {
+        Resource._Implementations.loadAndExecuteScript = function(url, functionName, deferred) {
             deferred.resolve(data);
         };
         service.geocode(query).then(function(results) {
@@ -57,7 +57,7 @@ defineSuite([
         var data = {
             resourceSets: []
         };
-        loadJsonp.loadAndExecuteScript = function(url, functionName, deferred) {
+        Resource._Implementations.loadAndExecuteScript = function(url, functionName, deferred) {
             deferred.resolve(data);
         };
         service.geocode(query).then(function(results) {
@@ -73,7 +73,7 @@ defineSuite([
                 resources: []
             }]
         };
-        loadJsonp.loadAndExecuteScript = function(url, functionName, deferred) {
+        Resource._Implementations.loadAndExecuteScript = function(url, functionName, deferred) {
             deferred.resolve(data);
         };
         service.geocode(query).then(function(results) {

--- a/Specs/Core/CesiumTerrainProviderSpec.js
+++ b/Specs/Core/CesiumTerrainProviderSpec.js
@@ -5,7 +5,6 @@ defineSuite([
         'Core/GeographicTilingScheme',
         'Core/getAbsoluteUri',
         'Core/HeightmapTerrainData',
-        'Core/loadWithXhr',
         'Core/Math',
         'Core/QuantizedMeshTerrainData',
         'Core/Request',
@@ -21,7 +20,6 @@ defineSuite([
         GeographicTilingScheme,
         getAbsoluteUri,
         HeightmapTerrainData,
-        loadWithXhr,
         CesiumMath,
         QuantizedMeshTerrainData,
         Request,
@@ -37,14 +35,14 @@ defineSuite([
     });
 
     afterEach(function() {
-        loadWithXhr.load = loadWithXhr.defaultLoad;
+        Resource._Implementations.loadWithXhr = Resource._DefaultImplementations.loadWithXhr;
     });
 
     function returnTileJson(path) {
-        var oldLoad = loadWithXhr.load;
-        loadWithXhr.load = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
+        var oldLoad = Resource._Implementations.loadWithXhr;
+        Resource._Implementations.loadWithXhr = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
             if (url.indexOf('layer.json') >= 0) {
-                loadWithXhr.defaultLoad(path, responseType, method, data, headers, deferred);
+                Resource._DefaultImplementations.loadWithXhr(path, responseType, method, data, headers, deferred);
             } else {
                 return oldLoad(url, responseType, method, data, headers, deferred, overrideMimeType);
             }
@@ -79,10 +77,10 @@ defineSuite([
         var paths = ['Data/CesiumTerrainTileJson/ParentUrl.tile.json',
                      'Data/CesiumTerrainTileJson/Parent.tile.json'];
         var i = 0;
-        var oldLoad = loadWithXhr.load;
-        loadWithXhr.load = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
+        var oldLoad = Resource._Implementations.loadWithXhr;
+        Resource._Implementations.loadWithXhr = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
             if (url.indexOf('layer.json') >= 0) {
-                loadWithXhr.defaultLoad(paths[i++], responseType, method, data, headers, deferred);
+                Resource._DefaultImplementations.loadWithXhr(paths[i++], responseType, method, data, headers, deferred);
             } else {
                 return oldLoad(url, responseType, method, data, headers, deferred, overrideMimeType);
             }
@@ -447,15 +445,15 @@ defineSuite([
             return pollToPromise(function() {
                 return provider.ready;
             }).then(function() {
-                spyOn(loadWithXhr, 'load');
+                spyOn(Resource._Implementations, 'loadWithXhr');
                 provider.requestTileGeometry(0, 0, 0);
-                expect(loadWithXhr.load.calls.mostRecent().args[0]).toContain('foo0.com');
+                expect(Resource._Implementations.loadWithXhr.calls.mostRecent().args[0]).toContain('foo0.com');
                 provider.requestTileGeometry(1, 0, 0);
-                expect(loadWithXhr.load.calls.mostRecent().args[0]).toContain('foo1.com');
+                expect(Resource._Implementations.loadWithXhr.calls.mostRecent().args[0]).toContain('foo1.com');
                 provider.requestTileGeometry(1, -1, 0);
-                expect(loadWithXhr.load.calls.mostRecent().args[0]).toContain('foo2.com');
+                expect(Resource._Implementations.loadWithXhr.calls.mostRecent().args[0]).toContain('foo2.com');
                 provider.requestTileGeometry(1, 0, 1);
-                expect(loadWithXhr.load.calls.mostRecent().args[0]).toContain('foo3.com');
+                expect(Resource._Implementations.loadWithXhr.calls.mostRecent().args[0]).toContain('foo3.com');
             });
         });
 
@@ -471,26 +469,26 @@ defineSuite([
             return pollToPromise(function() {
                 return provider.ready;
             }).then(function() {
-                spyOn(loadWithXhr, 'load');
+                spyOn(Resource._Implementations, 'loadWithXhr');
                 provider.requestTileGeometry(0, 0, 0);
-                expect(loadWithXhr.load.calls.mostRecent().args[0]).toContain('foo0.com');
+                expect(Resource._Implementations.loadWithXhr.calls.mostRecent().args[0]).toContain('foo0.com');
                 provider.requestTileGeometry(1, 0, 0);
-                expect(loadWithXhr.load.calls.mostRecent().args[0]).toContain('foo1.com');
+                expect(Resource._Implementations.loadWithXhr.calls.mostRecent().args[0]).toContain('foo1.com');
                 provider.requestTileGeometry(1, -1, 0);
-                expect(loadWithXhr.load.calls.mostRecent().args[0]).toContain('foo2.com');
+                expect(Resource._Implementations.loadWithXhr.calls.mostRecent().args[0]).toContain('foo2.com');
                 provider.requestTileGeometry(1, 0, 1);
-                expect(loadWithXhr.load.calls.mostRecent().args[0]).toContain('foo3.com');
+                expect(Resource._Implementations.loadWithXhr.calls.mostRecent().args[0]).toContain('foo3.com');
             });
         });
 
         it('uses the proxy if one is supplied', function() {
             var baseUrl = 'made/up/url';
 
-            loadWithXhr.load = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
+            Resource._Implementations.loadWithXhr = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
                 expect(url.indexOf('/proxy/?')).toBe(0);
 
                 // Just return any old file, as long as its big enough
-                loadWithXhr.defaultLoad('Data/EarthOrientationParameters/IcrfToFixedStkComponentsRotationData.json', responseType, method, data, headers, deferred);
+                Resource._DefaultImplementations.loadWithXhr('Data/EarthOrientationParameters/IcrfToFixedStkComponentsRotationData.json', responseType, method, data, headers, deferred);
             };
 
             returnHeightmapTileJson();
@@ -508,9 +506,9 @@ defineSuite([
         });
 
         it('provides HeightmapTerrainData', function() {
-            loadWithXhr.load = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
+            Resource._Implementations.loadWithXhr = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
                 // Just return any old file, as long as its big enough
-                loadWithXhr.defaultLoad('Data/EarthOrientationParameters/IcrfToFixedStkComponentsRotationData.json', responseType, method, data, headers, deferred);
+                Resource._DefaultImplementations.loadWithXhr('Data/EarthOrientationParameters/IcrfToFixedStkComponentsRotationData.json', responseType, method, data, headers, deferred);
             };
 
             returnHeightmapTileJson();
@@ -521,8 +519,8 @@ defineSuite([
         });
 
         it('provides QuantizedMeshTerrainData', function() {
-            loadWithXhr.load = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
-                loadWithXhr.defaultLoad('Data/CesiumTerrainTileJson/tile.terrain', responseType, method, data, headers, deferred);
+            Resource._Implementations.loadWithXhr = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
+                Resource._DefaultImplementations.loadWithXhr('Data/CesiumTerrainTileJson/tile.terrain', responseType, method, data, headers, deferred);
             };
 
             returnQuantizedMeshTileJson();
@@ -533,8 +531,8 @@ defineSuite([
         });
 
         it('provides QuantizedMeshTerrainData with 32bit indices', function() {
-            loadWithXhr.load = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
-                loadWithXhr.defaultLoad('Data/CesiumTerrainTileJson/tile.32bitIndices.terrain', responseType, method, data, headers, deferred);
+            Resource._Implementations.loadWithXhr = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
+                Resource._DefaultImplementations.loadWithXhr('Data/CesiumTerrainTileJson/tile.32bitIndices.terrain', responseType, method, data, headers, deferred);
             };
 
             returnQuantizedMeshTileJson();
@@ -546,8 +544,8 @@ defineSuite([
         });
 
         it('provides QuantizedMeshTerrainData with VertexNormals', function() {
-            loadWithXhr.load = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
-                loadWithXhr.defaultLoad('Data/CesiumTerrainTileJson/tile.vertexnormals.terrain', responseType, method, data, headers, deferred);
+            Resource._Implementations.loadWithXhr = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
+                Resource._DefaultImplementations.loadWithXhr('Data/CesiumTerrainTileJson/tile.vertexnormals.terrain', responseType, method, data, headers, deferred);
             };
 
             returnVertexNormalTileJson();
@@ -559,8 +557,8 @@ defineSuite([
         });
 
         it('provides QuantizedMeshTerrainData with WaterMask', function() {
-            loadWithXhr.load = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
-                loadWithXhr.defaultLoad('Data/CesiumTerrainTileJson/tile.watermask.terrain', responseType, method, data, headers, deferred);
+            Resource._Implementations.loadWithXhr = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
+                Resource._DefaultImplementations.loadWithXhr('Data/CesiumTerrainTileJson/tile.watermask.terrain', responseType, method, data, headers, deferred);
             };
 
             returnWaterMaskTileJson();
@@ -572,8 +570,8 @@ defineSuite([
         });
 
         it('provides QuantizedMeshTerrainData with VertexNormals and WaterMask', function() {
-            loadWithXhr.load = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
-                loadWithXhr.defaultLoad('Data/CesiumTerrainTileJson/tile.octvertexnormals.watermask.terrain', responseType, method, data, headers, deferred);
+            Resource._Implementations.loadWithXhr = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
+                Resource._DefaultImplementations.loadWithXhr('Data/CesiumTerrainTileJson/tile.octvertexnormals.watermask.terrain', responseType, method, data, headers, deferred);
             };
 
             returnWaterMaskTileJson();
@@ -586,8 +584,8 @@ defineSuite([
         });
 
         it('provides QuantizedMeshTerrainData with OctVertexNormals', function() {
-            loadWithXhr.load = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
-                loadWithXhr.defaultLoad('Data/CesiumTerrainTileJson/tile.octvertexnormals.terrain', responseType, method, data, headers, deferred);
+            Resource._Implementations.loadWithXhr = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
+                Resource._DefaultImplementations.loadWithXhr('Data/CesiumTerrainTileJson/tile.octvertexnormals.terrain', responseType, method, data, headers, deferred);
             };
 
             returnOctVertexNormalTileJson();
@@ -599,8 +597,8 @@ defineSuite([
         });
 
         it('provides QuantizedMeshTerrainData with VertexNormals and unknown extensions', function() {
-            loadWithXhr.load = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
-                loadWithXhr.defaultLoad('Data/CesiumTerrainTileJson/tile.vertexnormals.unknownext.terrain', responseType, method, data, headers, deferred);
+            Resource._Implementations.loadWithXhr = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
+                Resource._DefaultImplementations.loadWithXhr('Data/CesiumTerrainTileJson/tile.vertexnormals.unknownext.terrain', responseType, method, data, headers, deferred);
             };
 
             returnVertexNormalTileJson();
@@ -612,8 +610,8 @@ defineSuite([
         });
 
         it('provides QuantizedMeshTerrainData with OctVertexNormals and unknown extensions', function() {
-            loadWithXhr.load = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
-                loadWithXhr.defaultLoad('Data/CesiumTerrainTileJson/tile.octvertexnormals.unknownext.terrain', responseType, method, data, headers, deferred);
+            Resource._Implementations.loadWithXhr = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
+                Resource._DefaultImplementations.loadWithXhr('Data/CesiumTerrainTileJson/tile.octvertexnormals.unknownext.terrain', responseType, method, data, headers, deferred);
             };
 
             returnOctVertexNormalTileJson();
@@ -625,8 +623,8 @@ defineSuite([
         });
 
         it('provides QuantizedMeshTerrainData with unknown extension', function() {
-            loadWithXhr.load = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
-                loadWithXhr.defaultLoad('Data/CesiumTerrainTileJson/tile.unknownext.terrain', responseType, method, data, headers, deferred);
+            Resource._Implementations.loadWithXhr = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
+                Resource._DefaultImplementations.loadWithXhr('Data/CesiumTerrainTileJson/tile.unknownext.terrain', responseType, method, data, headers, deferred);
             };
 
             returnOctVertexNormalTileJson();
@@ -641,7 +639,7 @@ defineSuite([
 
             var deferreds = [];
 
-            loadWithXhr.load = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
+            Resource._Implementations.loadWithXhr = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
                 // Do nothing, so requests never complete
                 deferreds.push(deferred);
             };
@@ -675,8 +673,8 @@ defineSuite([
         it('supports getTileDataAvailable()', function() {
             var baseUrl = 'made/up/url';
 
-            loadWithXhr.load = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
-                loadWithXhr.defaultLoad('Data/CesiumTerrainTileJson/tile.terrain', responseType, method, data, headers, deferred);
+            Resource._Implementations.loadWithXhr = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
+                Resource._DefaultImplementations.loadWithXhr('Data/CesiumTerrainTileJson/tile.terrain', responseType, method, data, headers, deferred);
             };
 
             returnQuantizedMeshTileJson();
@@ -711,9 +709,9 @@ defineSuite([
         });
 
         it('supports a query string in the base URL', function() {
-            loadWithXhr.load = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
+            Resource._Implementations.loadWithXhr = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
                 // Just return any old file, as long as its big enough
-                loadWithXhr.defaultLoad('Data/EarthOrientationParameters/IcrfToFixedStkComponentsRotationData.json', responseType, method, data, headers, deferred);
+                Resource._DefaultImplementations.loadWithXhr('Data/EarthOrientationParameters/IcrfToFixedStkComponentsRotationData.json', responseType, method, data, headers, deferred);
             };
 
             returnHeightmapTileJson();

--- a/Specs/Core/GoogleEarthEnterpriseMetadataSpec.js
+++ b/Specs/Core/GoogleEarthEnterpriseMetadataSpec.js
@@ -4,7 +4,6 @@ defineSuite([
         'Core/DefaultProxy',
         'Core/defaultValue',
         'Core/GoogleEarthEnterpriseTileInformation',
-        'Core/loadWithXhr',
         'Core/Math',
         'Core/Request',
         'Core/Resource',
@@ -15,7 +14,6 @@ defineSuite([
         DefaultProxy,
         defaultValue,
         GoogleEarthEnterpriseTileInformation,
-        loadWithXhr,
         CesiumMath,
         Request,
         Resource,
@@ -155,14 +153,14 @@ defineSuite([
         var baseurl = 'http://fake.fake.invalid/';
 
         var req = 0;
-        spyOn(loadWithXhr, 'load').and.callFake(function(url, responseType, method, data, headers, deferred, overrideMimeType) {
+        spyOn(Resource._Implementations, 'loadWithXhr').and.callFake(function(url, responseType, method, data, headers, deferred, overrideMimeType) {
             expect(responseType).toEqual('arraybuffer');
             if (req === 0) {
                 expect(url).toEqual(baseurl + 'dbRoot.v5?output=proto');
                 deferred.reject(); // Reject dbRoot request and use defaults
             } else {
                 expect(url).toEqual(baseurl + 'flatfile?q2-0-q.1');
-                loadWithXhr.defaultLoad('Data/GoogleEarthEnterprise/gee.metadata', responseType, method, data, headers, deferred);
+                Resource._DefaultImplementations.loadWithXhr('Data/GoogleEarthEnterprise/gee.metadata', responseType, method, data, headers, deferred);
             }
             ++req;
         });
@@ -199,14 +197,14 @@ defineSuite([
         });
 
         var req = 0;
-        spyOn(loadWithXhr, 'load').and.callFake(function(url, responseType, method, data, headers, deferred, overrideMimeType) {
+        spyOn(Resource._Implementations, 'loadWithXhr').and.callFake(function(url, responseType, method, data, headers, deferred, overrideMimeType) {
             expect(responseType).toEqual('arraybuffer');
             if (req === 0) {
                 expect(url).toEqual(baseurl + 'dbRoot.v5?output=proto');
                 deferred.reject(); // Reject dbRoot request and use defaults
             } else {
                 expect(url).toEqual(baseurl + 'flatfile?q2-0-q.1');
-                loadWithXhr.defaultLoad('Data/GoogleEarthEnterprise/gee.metadata', responseType, method, data, headers, deferred);
+                Resource._DefaultImplementations.loadWithXhr('Data/GoogleEarthEnterprise/gee.metadata', responseType, method, data, headers, deferred);
             }
             ++req;
         });
@@ -252,14 +250,14 @@ defineSuite([
         var baseurl = 'http://fake.fake.invalid/';
 
         var req = 0;
-        spyOn(loadWithXhr, 'load').and.callFake(function(url, responseType, method, data, headers, deferred, overrideMimeType) {
+        spyOn(Resource._Implementations, 'loadWithXhr').and.callFake(function(url, responseType, method, data, headers, deferred, overrideMimeType) {
             expect(responseType).toEqual('arraybuffer');
             if (req === 0) {
                 expect(url).toEqual(proxy.getURL(baseurl + 'dbRoot.v5?output=proto'));
                 deferred.reject(); // Reject dbRoot request and use defaults
             } else {
                 expect(url).toEqual(proxy.getURL(baseurl + 'flatfile?q2-0-q.1'));
-                loadWithXhr.defaultLoad('Data/GoogleEarthEnterprise/gee.metadata', responseType, method, data, headers, deferred);
+                Resource._DefaultImplementations.loadWithXhr('Data/GoogleEarthEnterprise/gee.metadata', responseType, method, data, headers, deferred);
             }
             ++req;
         });

--- a/Specs/Core/GoogleEarthEnterpriseTerrainProviderSpec.js
+++ b/Specs/Core/GoogleEarthEnterpriseTerrainProviderSpec.js
@@ -7,7 +7,6 @@ defineSuite([
         'Core/GoogleEarthEnterpriseMetadata',
         'Core/GoogleEarthEnterpriseTerrainData',
         'Core/GoogleEarthEnterpriseTileInformation',
-        'Core/loadWithXhr',
         'Core/Math',
         'Core/Request',
         'Core/RequestScheduler',
@@ -24,7 +23,6 @@ defineSuite([
         GoogleEarthEnterpriseMetadata,
         GoogleEarthEnterpriseTerrainData,
         GoogleEarthEnterpriseTileInformation,
-        loadWithXhr,
         CesiumMath,
         Request,
         RequestScheduler,
@@ -86,7 +84,7 @@ defineSuite([
     });
 
     afterEach(function() {
-        loadWithXhr.load = loadWithXhr.defaultLoad;
+        Resource._Implementations.loadWithXhr = Resource._DefaultImplementations.loadWithXhr;
     });
 
     it('conforms to TerrainProvider interface', function() {
@@ -266,10 +264,10 @@ defineSuite([
             installMockGetQuadTreePacket();
             var baseUrl = 'made/up/url';
 
-            loadWithXhr.load = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
+            Resource._Implementations.loadWithXhr = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
                 expect(url.indexOf('/proxy/?')).toBe(0);
 
-                loadWithXhr.defaultLoad('Data/GoogleEarthEnterprise/gee.terrain', responseType, method, data, headers, deferred);
+                Resource._DefaultImplementations.loadWithXhr('Data/GoogleEarthEnterprise/gee.terrain', responseType, method, data, headers, deferred);
             };
 
             terrainProvider = new GoogleEarthEnterpriseTerrainProvider({
@@ -286,8 +284,8 @@ defineSuite([
 
         it('provides GoogleEarthEnterpriseTerrainData', function() {
             installMockGetQuadTreePacket();
-            loadWithXhr.load = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
-                loadWithXhr.defaultLoad('Data/GoogleEarthEnterprise/gee.terrain', responseType, method, data, headers, deferred);
+            Resource._Implementations.loadWithXhr = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
+                Resource._DefaultImplementations.loadWithXhr('Data/GoogleEarthEnterprise/gee.terrain', responseType, method, data, headers, deferred);
             };
 
             return waitForTile(0, 0, 0, function(loadedData) {
@@ -301,14 +299,14 @@ defineSuite([
 
             var deferreds = [];
             var loadRealTile = true;
-            loadWithXhr.load = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
+            Resource._Implementations.loadWithXhr = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
                 if (url.indexOf('dbRoot.v5') !== -1) {
                     return deferred.reject(); // Just reject dbRoot file and use defaults.
                 }
 
                 if (loadRealTile) {
                     loadRealTile = false;
-                    return loadWithXhr.defaultLoad('Data/GoogleEarthEnterprise/gee.terrain', responseType, method, data, headers, deferred);
+                    return Resource._DefaultImplementations.loadWithXhr('Data/GoogleEarthEnterprise/gee.terrain', responseType, method, data, headers, deferred);
                 }
                 // Do nothing, so requests never complete
                 deferreds.push(deferred);
@@ -364,8 +362,8 @@ defineSuite([
             installMockGetQuadTreePacket();
             var baseUrl = 'made/up/url';
 
-            loadWithXhr.load = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
-                loadWithXhr.defaultLoad('Data/CesiumTerrainTileJson/tile.terrain', responseType, method, data, headers, deferred);
+            Resource._Implementations.loadWithXhr = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
+                Resource._DefaultImplementations.loadWithXhr('Data/CesiumTerrainTileJson/tile.terrain', responseType, method, data, headers, deferred);
             };
 
             terrainProvider = new GoogleEarthEnterpriseTerrainProvider({

--- a/Specs/Core/TransformsSpec.js
+++ b/Specs/Core/TransformsSpec.js
@@ -9,11 +9,11 @@ defineSuite([
         'Core/HeadingPitchRoll',
         'Core/Iau2006XysData',
         'Core/JulianDate',
-        'Core/loadJson',
         'Core/Math',
         'Core/Matrix3',
         'Core/Matrix4',
         'Core/Quaternion',
+        'Core/Resource',
         'Core/TimeInterval'
     ], function(
         Transforms,
@@ -26,11 +26,11 @@ defineSuite([
         HeadingPitchRoll,
         Iau2006XysData,
         JulianDate,
-        loadJson,
         CesiumMath,
         Matrix3,
         Matrix4,
         Quaternion,
+        Resource,
         TimeInterval) {
     'use strict';
 
@@ -695,7 +695,7 @@ defineSuite([
             // The rotation data from Components span before and after the EOP data so as to test
             // what happens when we try evaluating at times when we don't have EOP as well as at
             // times where we do.  The samples are not at exact EOP times, in order to test interpolation.
-            return loadJson('Data/EarthOrientationParameters/IcrfToFixedStkComponentsRotationData.json').then(function(componentsData) {
+            return Resource.fetchJson('Data/EarthOrientationParameters/IcrfToFixedStkComponentsRotationData.json').then(function(componentsData) {
                 var start = JulianDate.fromIso8601(componentsData[0].date);
                 var stop = JulianDate.fromIso8601(componentsData[componentsData.length - 1].date);
 

--- a/Specs/Core/VRTheWorldTerrainProviderSpec.js
+++ b/Specs/Core/VRTheWorldTerrainProviderSpec.js
@@ -3,8 +3,6 @@ defineSuite([
         'Core/DefaultProxy',
         'Core/GeographicTilingScheme',
         'Core/HeightmapTerrainData',
-        'Core/loadImage',
-        'Core/loadWithXhr',
         'Core/Math',
         'Core/Request',
         'Core/RequestScheduler',
@@ -17,8 +15,6 @@ defineSuite([
         DefaultProxy,
         GeographicTilingScheme,
         HeightmapTerrainData,
-        loadImage,
-        loadWithXhr,
         CesiumMath,
         Request,
         RequestScheduler,
@@ -30,7 +26,7 @@ defineSuite([
 
     beforeEach(function() {
         RequestScheduler.clearForSpecs();
-        loadWithXhr.load = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
+        Resource._Implementations.loadWithXhr = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
             setTimeout(function() {
                 var parser = new DOMParser();
                 var xmlString =
@@ -60,8 +56,8 @@ defineSuite([
     });
 
     afterEach(function() {
-        loadImage.createImage = loadImage.defaultCreateImage;
-        loadWithXhr.load = loadWithXhr.defaultLoad;
+        Resource._Implementations.createImage = Resource._DefaultImplementations.createImage;
+        Resource._Implementations.loadWithXhr = Resource._DefaultImplementations.loadWithXhr;
     });
 
     function createRequest() {
@@ -183,7 +179,7 @@ defineSuite([
     });
 
     it('raises an error if the SRS is not supported', function() {
-        loadWithXhr.load = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
+        Resource._Implementations.loadWithXhr = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
             setTimeout(function() {
                 var parser = new DOMParser();
                 var xmlString =
@@ -239,12 +235,12 @@ defineSuite([
         it('uses the proxy if one is supplied', function() {
             var baseUrl = 'made/up/url';
 
-            loadImage.createImage = function(url, crossOrigin, deferred) {
+            Resource._Implementations.createImage = function(url, crossOrigin, deferred) {
                 expect(url.indexOf('/proxy/?')).toBe(0);
                 expect(url.indexOf(encodeURIComponent('.tif?cesium=true'))).toBeGreaterThanOrEqualTo(0);
 
                 // Just return any old image.
-                loadImage.defaultCreateImage('Data/Images/Red16x16.png', crossOrigin, deferred);
+                Resource._DefaultImplementations.createImage('Data/Images/Red16x16.png', crossOrigin, deferred);
             };
 
             var terrainProvider = new VRTheWorldTerrainProvider({
@@ -262,11 +258,11 @@ defineSuite([
         it('provides HeightmapTerrainData', function() {
             var baseUrl = 'made/up/url';
 
-            loadImage.createImage = function(url, crossOrigin, deferred) {
+            Resource._Implementations.createImage = function(url, crossOrigin, deferred) {
                 expect(url.indexOf('.tif?cesium=true')).toBeGreaterThanOrEqualTo(0);
 
                 // Just return any old image.
-                loadImage.defaultCreateImage('Data/Images/Red16x16.png', crossOrigin, deferred);
+                Resource._DefaultImplementations.createImage('Data/Images/Red16x16.png', crossOrigin, deferred);
             };
 
             var terrainProvider = new VRTheWorldTerrainProvider({
@@ -288,7 +284,7 @@ defineSuite([
 
             var deferreds = [];
 
-            loadImage.createImage = function(url, crossOrigin, deferred) {
+            Resource._Implementations.createImage = function(url, crossOrigin, deferred) {
                 // Do nothing, so requests never complete
                 deferreds.push(deferred);
             };

--- a/Specs/Core/buildModuleUrlSpec.js
+++ b/Specs/Core/buildModuleUrlSpec.js
@@ -1,10 +1,10 @@
 defineSuite([
         'Core/buildModuleUrl',
-        'Core/loadText',
+        'Core/Resource',
         'ThirdParty/Uri'
     ], function(
         buildModuleUrl,
-        loadText,
+        Resource,
         Uri) {
     'use strict';
 
@@ -15,7 +15,7 @@ defineSuite([
         expect(new Uri(url).isAbsolute()).toBe(true);
 
         // make sure it actually exists at that URL
-        return loadText(url);
+        return Resource.fetchText(url);
     });
 
     it('matches the expected forms of URLs to Cesium.js', function() {

--- a/Specs/Core/loadImageFromTypedArraySpec.js
+++ b/Specs/Core/loadImageFromTypedArraySpec.js
@@ -1,13 +1,13 @@
 defineSuite([
         'Core/loadImageFromTypedArray',
-        'Core/loadArrayBuffer'
+        'Core/Resource'
     ], function(
         loadImageFromTypedArray,
-        loadArrayBuffer) {
+        Resource) {
     'use strict';
 
     it('can load an image', function() {
-        return loadArrayBuffer('./Data/Images/Blue10x10.png').then(function(arrayBuffer) {
+        return Resource.fetchArrayBuffer('./Data/Images/Blue10x10.png').then(function(arrayBuffer) {
             var arr = new Uint8Array(arrayBuffer);
             return loadImageFromTypedArray(arr, 'image/png').then(function(image) {
                 expect(image.width).toEqual(10);

--- a/Specs/Core/loadImageSpec.js
+++ b/Specs/Core/loadImageSpec.js
@@ -1,13 +1,11 @@
 defineSuite([
         'Core/loadImage',
-        'Core/loadWithXhr',
         'Core/Request',
         'Core/RequestScheduler',
         'Core/Resource',
         'ThirdParty/when'
     ], function(
         loadImage,
-        loadWithXhr,
         Request,
         RequestScheduler,
         Resource,
@@ -142,7 +140,7 @@ defineSuite([
         var expectedHeaders = {
             'X-my-header': 'my-value'
         };
-        spyOn(loadWithXhr, 'load').and.callFake(function(url, responseType, method, data, headers, deferred, overrideMimeType) {
+        spyOn(Resource._Implementations, 'loadWithXhr').and.callFake(function(url, responseType, method, data, headers, deferred, overrideMimeType) {
             expect(url).toEqual(expectedUrl);
             expect(headers).toEqual(expectedHeaders);
             expect(responseType).toEqual('blob');
@@ -170,7 +168,7 @@ defineSuite([
     });
 
     it('Doesn\'t call loadWithXhr with blob response type if headers is set but is a data URI', function() {
-        spyOn(loadWithXhr, 'load').and.callFake(function(url, responseType, method, data, headers, deferred, overrideMimeType) {
+        spyOn(Resource._Implementations, 'loadWithXhr').and.callFake(function(url, responseType, method, data, headers, deferred, overrideMimeType) {
             deferred.reject('this shouldn\'t happen');
         });
 

--- a/Specs/Core/loadWithXhrSpec.js
+++ b/Specs/Core/loadWithXhrSpec.js
@@ -1,13 +1,11 @@
 defineSuite([
         'Core/loadWithXhr',
-        'Core/loadImage',
         'Core/Request',
         'Core/RequestErrorEvent',
         'Core/RequestScheduler',
         'Core/Resource'
     ], function(
         loadWithXhr,
-        loadImage,
         Request,
         RequestErrorEvent,
         RequestScheduler,
@@ -157,7 +155,7 @@ defineSuite([
                 /*global URL*/
                 var blobUrl = URL.createObjectURL(result);
 
-                return loadImage(blobUrl).then(function(image) {
+                return Resource.fetchImage(blobUrl).then(function(image) {
                     expect(image.width).toEqual(24);
                     expect(image.height).toEqual(24);
                 });

--- a/Specs/DataSources/CzmlDataSourceSpec.js
+++ b/Specs/DataSources/CzmlDataSourceSpec.js
@@ -14,8 +14,6 @@ defineSuite([
         'Core/ExtrapolationType',
         'Core/Iso8601',
         'Core/JulianDate',
-        'Core/loadJson',
-        'Core/loadWithXhr',
         'Core/Math',
         'Core/NearFarScalar',
         'Core/Quaternion',
@@ -54,8 +52,6 @@ defineSuite([
         ExtrapolationType,
         Iso8601,
         JulianDate,
-        loadJson,
-        loadWithXhr,
         CesiumMath,
         NearFarScalar,
         Quaternion,
@@ -164,10 +160,10 @@ defineSuite([
 
     beforeAll(function() {
         return when.join(
-            loadJson(simpleUrl).then(function(result) {
+            Resource.fetchJson(simpleUrl).then(function(result) {
                 simple = result;
             }),
-            loadJson(vehicleUrl).then(function(result) {
+            Resource.fetchJson(vehicleUrl).then(function(result) {
                 vehicle = result;
             }));
     });
@@ -662,7 +658,7 @@ defineSuite([
         var dataSource = new CzmlDataSource();
         var requestNetworkLink = when.defer();
 
-        spyOn(loadWithXhr, 'load').and.callFake(function(url, responseType, method, data, headers, deferred, overrideMimeType) {
+        spyOn(Resource._Implementations, 'loadWithXhr').and.callFake(function(url, responseType, method, data, headers, deferred, overrideMimeType) {
             requestNetworkLink.resolve(url);
             deferred.reject();
         });

--- a/Specs/DataSources/KmlDataSourceSpec.js
+++ b/Specs/DataSources/KmlDataSourceSpec.js
@@ -16,8 +16,6 @@ defineSuite([
         'Core/Event',
         'Core/Iso8601',
         'Core/JulianDate',
-        'Core/loadBlob',
-        'Core/loadWithXhr',
         'Core/Math',
         'Core/NearFarScalar',
         'Core/Rectangle',
@@ -55,8 +53,6 @@ defineSuite([
         Event,
         Iso8601,
         JulianDate,
-        loadBlob,
-        loadWithXhr,
         CesiumMath,
         NearFarScalar,
         Rectangle,
@@ -207,7 +203,7 @@ defineSuite([
 
     it('load works with a KMZ file', function() {
         var dataSource = new KmlDataSource(options);
-        return loadBlob('Data/KML/simple.kmz').then(function(blob) {
+        return Resource.fetchBlob('Data/KML/simple.kmz').then(function(blob) {
             return dataSource.load(blob);
         }).then(function(source) {
             expect(source).toBe(dataSource);
@@ -220,7 +216,7 @@ defineSuite([
         var spy = jasmine.createSpy('errorEvent');
         dataSource.errorEvent.addEventListener(spy);
 
-        return loadBlob('Data/Images/Blue.png').then(function(blob) {
+        return Resource.fetchBlob('Data/Images/Blue.png').then(function(blob) {
             return dataSource.load(blob);
         }).otherwise(function(e) {
             expect(e).toBeInstanceOf(RuntimeError);
@@ -229,7 +225,7 @@ defineSuite([
     });
 
     it('load rejects KMZ file with no KML contained', function() {
-        return loadBlob('Data/KML/empty.kmz').then(function(blob) {
+        return Resource.fetchBlob('Data/KML/empty.kmz').then(function(blob) {
             return KmlDataSource.load(blob, options);
         }).otherwise(function(e) {
             expect(e).toBeInstanceOf(RuntimeError);
@@ -328,7 +324,7 @@ defineSuite([
 
     it('if load contains <icon> tag with no image included, no image is added', function() {
         var dataSource = new KmlDataSource(options);
-        return loadBlob('Data/KML/simpleNoIcon.kml').then(function(blob) {
+        return Resource.fetchBlob('Data/KML/simpleNoIcon.kml').then(function(blob) {
             return dataSource.load(blob);
         }).then(function(source) {
             expect(source.entities);
@@ -340,7 +336,7 @@ defineSuite([
 
     it('if load does not contain icon <style> tag for placemark, default yellow pin does show', function() {
         var dataSource = new KmlDataSource(options);
-        return loadBlob('Data/KML/simpleNoStyle.kml').then(function(blob) {
+        return Resource.fetchBlob('Data/KML/simpleNoStyle.kml').then(function(blob) {
             return dataSource.load(blob);
         }).then(function(source) {
             expect(source.entities);
@@ -352,7 +348,7 @@ defineSuite([
 
     it('if load contains empty <IconStyle> tag for placemark, default yellow pin does show', function() {
         var dataSource = new KmlDataSource(options);
-        return loadBlob('Data/KML/simpleEmptyIconStyle.kml').then(function(blob) {
+        return Resource.fetchBlob('Data/KML/simpleEmptyIconStyle.kml').then(function(blob) {
             return dataSource.load(blob);
         }).then(function(source) {
             expect(source.entities);
@@ -3364,7 +3360,7 @@ defineSuite([
 
     it('NetworkLink: Appends query tokens to source URL', function() {
         var requestNetworkLink = when.defer();
-        spyOn(loadWithXhr, 'load').and.callFake(function(url, responseType, method, data, headers, deferred, overrideMimeType) {
+        spyOn(Resource._Implementations, 'loadWithXhr').and.callFake(function(url, responseType, method, data, headers, deferred, overrideMimeType) {
             requestNetworkLink.resolve(url);
             deferred.reject();
         });
@@ -3393,7 +3389,7 @@ defineSuite([
           </NetworkLink>';
 
         var requestNetworkLink = when.defer();
-        spyOn(loadWithXhr, 'load').and.callFake(function(url, responseType, method, data, headers, deferred, overrideMimeType) {
+        spyOn(Resource._Implementations, 'loadWithXhr').and.callFake(function(url, responseType, method, data, headers, deferred, overrideMimeType) {
             requestNetworkLink.resolve(url);
             deferred.reject();
         });
@@ -3551,7 +3547,7 @@ defineSuite([
           </NetworkLink>';
 
         var requestNetworkLink = when.defer();
-        spyOn(loadWithXhr, 'load').and.callFake(function(url, responseType, method, data, headers, deferred, overrideMimeType) {
+        spyOn(Resource._Implementations, 'loadWithXhr').and.callFake(function(url, responseType, method, data, headers, deferred, overrideMimeType) {
             requestNetworkLink.resolve(url);
             deferred.reject();
         });
@@ -3572,7 +3568,7 @@ defineSuite([
           </NetworkLink>';
 
         var requestNetworkLink = when.defer();
-        spyOn(loadWithXhr, 'load').and.callFake(function(url, responseType, method, data, headers, deferred, overrideMimeType) {
+        spyOn(Resource._Implementations, 'loadWithXhr').and.callFake(function(url, responseType, method, data, headers, deferred, overrideMimeType) {
             requestNetworkLink.resolve(url);
             deferred.reject();
         });
@@ -3594,7 +3590,7 @@ defineSuite([
           </NetworkLink>';
 
         var requestNetworkLink = when.defer();
-        spyOn(loadWithXhr, 'load').and.callFake(function(url, responseType, method, data, headers, deferred, overrideMimeType) {
+        spyOn(Resource._Implementations, 'loadWithXhr').and.callFake(function(url, responseType, method, data, headers, deferred, overrideMimeType) {
             requestNetworkLink.resolve(url);
             deferred.reject();
         });
@@ -3617,7 +3613,7 @@ defineSuite([
           </NetworkLink>';
 
         var requestNetworkLink = when.defer();
-        spyOn(loadWithXhr, 'load').and.callFake(function(url, responseType, method, data, headers, deferred, overrideMimeType) {
+        spyOn(Resource._Implementations, 'loadWithXhr').and.callFake(function(url, responseType, method, data, headers, deferred, overrideMimeType) {
             requestNetworkLink.resolve(url);
             deferred.reject();
         });
@@ -3640,7 +3636,7 @@ defineSuite([
           </NetworkLink>';
 
         var requestNetworkLink = when.defer();
-        spyOn(loadWithXhr, 'load').and.callFake(function(url, responseType, method, data, headers, deferred, overrideMimeType) {
+        spyOn(Resource._Implementations, 'loadWithXhr').and.callFake(function(url, responseType, method, data, headers, deferred, overrideMimeType) {
             requestNetworkLink.resolve(url);
             deferred.reject();
         });
@@ -3663,7 +3659,7 @@ defineSuite([
           </NetworkLink>';
 
         var requestNetworkLink = when.defer();
-        spyOn(loadWithXhr, 'load').and.callFake(function(url, responseType, method, data, headers, deferred, overrideMimeType) {
+        spyOn(Resource._Implementations, 'loadWithXhr').and.callFake(function(url, responseType, method, data, headers, deferred, overrideMimeType) {
             requestNetworkLink.resolve(url);
             deferred.reject();
         });
@@ -3693,7 +3689,7 @@ defineSuite([
           </NetworkLink>';
 
         var requestNetworkLink = when.defer();
-        spyOn(loadWithXhr, 'load').and.callFake(function(url, responseType, method, data, headers, deferred, overrideMimeType) {
+        spyOn(Resource._Implementations, 'loadWithXhr').and.callFake(function(url, responseType, method, data, headers, deferred, overrideMimeType) {
             requestNetworkLink.resolve(url);
             deferred.reject();
         });
@@ -3724,7 +3720,7 @@ defineSuite([
           </NetworkLink>';
 
         var requestNetworkLink = when.defer();
-        spyOn(loadWithXhr, 'load').and.callFake(function(url, responseType, method, data, headers, deferred, overrideMimeType) {
+        spyOn(Resource._Implementations, 'loadWithXhr').and.callFake(function(url, responseType, method, data, headers, deferred, overrideMimeType) {
             requestNetworkLink.resolve(url);
             deferred.reject();
         });
@@ -3749,7 +3745,7 @@ defineSuite([
           </NetworkLink>';
 
         var requestNetworkLink = when.defer();
-        spyOn(loadWithXhr, 'load').and.callFake(function(url, responseType, method, data, headers, deferred, overrideMimeType) {
+        spyOn(Resource._Implementations, 'loadWithXhr').and.callFake(function(url, responseType, method, data, headers, deferred, overrideMimeType) {
             requestNetworkLink.resolve(url);
             deferred.reject();
         });
@@ -3774,7 +3770,7 @@ defineSuite([
           </NetworkLink>';
 
         var requestNetworkLink = when.defer();
-        spyOn(loadWithXhr, 'load').and.callFake(function(url, responseType, method, data, headers, deferred, overrideMimeType) {
+        spyOn(Resource._Implementations, 'loadWithXhr').and.callFake(function(url, responseType, method, data, headers, deferred, overrideMimeType) {
             requestNetworkLink.resolve(url);
             deferred.reject();
         });
@@ -3805,7 +3801,7 @@ defineSuite([
           </NetworkLink>';
 
         var requestNetworkLink = when.defer();
-        spyOn(loadWithXhr, 'load').and.callFake(function(url, responseType, method, data, headers, deferred, overrideMimeType) {
+        spyOn(Resource._Implementations, 'loadWithXhr').and.callFake(function(url, responseType, method, data, headers, deferred, overrideMimeType) {
             requestNetworkLink.resolve(url);
             deferred.reject();
         });
@@ -3835,7 +3831,7 @@ defineSuite([
           </NetworkLink>';
 
         var requestNetworkLink = when.defer();
-        spyOn(loadWithXhr, 'load').and.callFake(function(url, responseType, method, data, headers, deferred, overrideMimeType) {
+        spyOn(Resource._Implementations, 'loadWithXhr').and.callFake(function(url, responseType, method, data, headers, deferred, overrideMimeType) {
             requestNetworkLink.resolve(url);
             deferred.reject();
         });
@@ -3859,7 +3855,7 @@ defineSuite([
           </NetworkLink>';
 
         var requestNetworkLink = when.defer();
-        spyOn(loadWithXhr, 'load').and.callFake(function(url, responseType, method, data, headers, deferred, overrideMimeType) {
+        spyOn(Resource._Implementations, 'loadWithXhr').and.callFake(function(url, responseType, method, data, headers, deferred, overrideMimeType) {
             requestNetworkLink.resolve(url);
             deferred.reject();
         });

--- a/Specs/Renderer/CubeMapSpec.js
+++ b/Specs/Renderer/CubeMapSpec.js
@@ -2,8 +2,8 @@ defineSuite([
         'Renderer/CubeMap',
         'Core/Cartesian3',
         'Core/Color',
-        'Core/loadImage',
         'Core/PixelFormat',
+        'Core/Resource',
         'Renderer/ClearCommand',
         'Renderer/ContextLimits',
         'Renderer/PixelDatatype',
@@ -18,8 +18,8 @@ defineSuite([
         CubeMap,
         Cartesian3,
         Color,
-        loadImage,
         PixelFormat,
+        Resource,
         ClearCommand,
         ContextLimits,
         PixelDatatype,
@@ -85,19 +85,19 @@ defineSuite([
         context = createContext();
 
         var promises = [];
-        promises.push(loadImage('./Data/Images/Green.png').then(function(result) {
+        promises.push(Resource.fetchImage('./Data/Images/Green.png').then(function(result) {
             greenImage = result;
         }));
-        promises.push(loadImage('./Data/Images/Blue.png').then(function(result) {
+        promises.push(Resource.fetchImage('./Data/Images/Blue.png').then(function(result) {
             blueImage = result;
         }));
-        promises.push(loadImage('./Data/Images/BlueAlpha.png').then(function(result) {
+        promises.push(Resource.fetchImage('./Data/Images/BlueAlpha.png').then(function(result) {
             blueAlphaImage = result;
         }));
-        promises.push(loadImage('./Data/Images/BlueOverRed.png').then(function(result) {
+        promises.push(Resource.fetchImage('./Data/Images/BlueOverRed.png').then(function(result) {
             blueOverRedImage = result;
         }));
-        promises.push(loadImage('./Data/Images/Red16x16.png').then(function(result) {
+        promises.push(Resource.fetchImage('./Data/Images/Red16x16.png').then(function(result) {
             red16x16Image = result;
         }));
 

--- a/Specs/Renderer/TextureSpec.js
+++ b/Specs/Renderer/TextureSpec.js
@@ -2,9 +2,9 @@ defineSuite([
         'Renderer/Texture',
         'Core/Cartesian2',
         'Core/Color',
-        'Core/loadImage',
         'Core/loadKTX',
         'Core/PixelFormat',
+        'Core/Resource',
         'Renderer/ClearCommand',
         'Renderer/ContextLimits',
         'Renderer/PixelDatatype',
@@ -18,9 +18,9 @@ defineSuite([
         Texture,
         Cartesian2,
         Color,
-        loadImage,
         loadKTX,
         PixelFormat,
+        Resource,
         ClearCommand,
         ContextLimits,
         PixelDatatype,
@@ -57,19 +57,19 @@ defineSuite([
         context = createContext();
 
         var promises = [];
-        promises.push(loadImage('./Data/Images/Green.png').then(function(image) {
+        promises.push(Resource.fetchImage('./Data/Images/Green.png').then(function(image) {
             greenImage = image;
         }));
-        promises.push(loadImage('./Data/Images/Blue.png').then(function(image) {
+        promises.push(Resource.fetchImage('./Data/Images/Blue.png').then(function(image) {
             blueImage = image;
         }));
-        promises.push(loadImage('./Data/Images/BlueAlpha.png').then(function(image) {
+        promises.push(Resource.fetchImage('./Data/Images/BlueAlpha.png').then(function(image) {
             blueAlphaImage = image;
         }));
-        promises.push(loadImage('./Data/Images/BlueOverRed.png').then(function(image) {
+        promises.push(Resource.fetchImage('./Data/Images/BlueOverRed.png').then(function(image) {
             blueOverRedImage = image;
         }));
-        promises.push(loadImage('./Data/Images/Red16x16.png').then(function(image) {
+        promises.push(Resource.fetchImage('./Data/Images/Red16x16.png').then(function(image) {
             red16x16Image = image;
         }));
         promises.push(loadKTX('./Data/Images/Green4x4DXT1.ktx').then(function(image) {

--- a/Specs/Scene/ArcGisMapServerImageryProviderSpec.js
+++ b/Specs/Scene/ArcGisMapServerImageryProviderSpec.js
@@ -8,9 +8,6 @@ defineSuite([
         'Core/defined',
         'Core/GeographicTilingScheme',
         'Core/getAbsoluteUri',
-        'Core/loadImage',
-        'Core/loadJsonp',
-        'Core/loadWithXhr',
         'Core/objectToQuery',
         'Core/queryToObject',
         'Core/Rectangle',
@@ -36,9 +33,6 @@ defineSuite([
         defined,
         GeographicTilingScheme,
         getAbsoluteUri,
-        loadImage,
-        loadJsonp,
-        loadWithXhr,
         objectToQuery,
         queryToObject,
         Rectangle,
@@ -61,9 +55,9 @@ defineSuite([
     });
 
     afterEach(function() {
-        loadJsonp.loadAndExecuteScript = loadJsonp.defaultLoadAndExecuteScript;
-        loadImage.createImage = loadImage.defaultCreateImage;
-        loadWithXhr.load = loadWithXhr.defaultLoad;
+        Resource._Implementations.loadAndExecuteScript = Resource._DefaultImplementations.loadAndExecuteScript;
+        Resource._Implementations.createImage = Resource._DefaultImplementations.createImage;
+        Resource._Implementations.loadWithXhr = Resource._DefaultImplementations.loadWithXhr;
     });
 
     function expectCorrectUrl(expectedBaseUrl, actualUrl, functionName, withProxy, token) {
@@ -91,7 +85,7 @@ defineSuite([
     }
 
     function stubJSONPCall(baseUrl, result, withProxy, token) {
-        loadJsonp.loadAndExecuteScript = function(url, functionName) {
+        Resource._Implementations.loadAndExecuteScript = function(url, functionName) {
             expectCorrectUrl(baseUrl, url, functionName, withProxy, token);
             setTimeout(function() {
                 window[functionName](result);
@@ -211,23 +205,23 @@ defineSuite([
             expect(provider.usingPrecachedTiles).toEqual(true);
             expect(provider.hasAlphaChannel).toBeDefined();
 
-            loadImage.createImage = function(url, crossOrigin, deferred) {
+            Resource._Implementations.createImage = function(url, crossOrigin, deferred) {
                 if (/^blob:/.test(url)) {
                     // load blob url normally
-                    loadImage.defaultCreateImage(url, crossOrigin, deferred);
+                    Resource._DefaultImplementations.createImage(url, crossOrigin, deferred);
                 } else {
                     expect(url).toEqual(getAbsoluteUri(baseUrl + 'tile/0/0/0'));
 
                     // Just return any old image.
-                    loadImage.defaultCreateImage('Data/Images/Red16x16.png', crossOrigin, deferred);
+                    Resource._DefaultImplementations.createImage('Data/Images/Red16x16.png', crossOrigin, deferred);
                 }
             };
 
-            loadWithXhr.load = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
+            Resource._Implementations.loadWithXhr = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
                 expect(url).toEqual(getAbsoluteUri(baseUrl + 'tile/0/0/0'));
 
                 // Just return any old image.
-                loadWithXhr.defaultLoad('Data/Images/Red16x16.png', responseType, method, data, headers, deferred);
+                Resource._DefaultImplementations.loadWithXhr('Data/Images/Red16x16.png', responseType, method, data, headers, deferred);
             };
 
             return provider.requestImage(0, 0, 0).then(function(image) {
@@ -288,23 +282,23 @@ defineSuite([
             expect(provider.rectangle).toEqual(new GeographicTilingScheme().rectangle);
             expect(provider.usingPrecachedTiles).toEqual(true);
 
-            loadImage.createImage = function(url, crossOrigin, deferred) {
+            Resource._Implementations.createImage = function(url, crossOrigin, deferred) {
                 if (/^blob:/.test(url)) {
                     // load blob url normally
-                    loadImage.defaultCreateImage(url, crossOrigin, deferred);
+                    Resource._DefaultImplementations.createImage(url, crossOrigin, deferred);
                 } else {
                     expect(url).toEqual(getAbsoluteUri(baseUrl + 'tile/0/0/0'));
 
                     // Just return any old image.
-                    loadImage.defaultCreateImage('Data/Images/Red16x16.png', crossOrigin, deferred);
+                    Resource._DefaultImplementations.createImage('Data/Images/Red16x16.png', crossOrigin, deferred);
                 }
             };
 
-            loadWithXhr.load = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
+            Resource._Implementations.loadWithXhr = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
                 expect(url).toEqual(getAbsoluteUri(baseUrl + 'tile/0/0/0'));
 
                 // Just return any old image.
-                loadWithXhr.defaultLoad('Data/Images/Red16x16.png', responseType, method, data, headers, deferred);
+                Resource._DefaultImplementations.loadWithXhr('Data/Images/Red16x16.png', responseType, method, data, headers, deferred);
             };
 
             return provider.requestImage(0, 0, 0).then(function(image) {
@@ -340,7 +334,7 @@ defineSuite([
             expect(provider.usingPrecachedTiles).toEqual(false);
             expect(provider.enablePickFeatures).toBe(true);
 
-            loadImage.createImage = function(url, crossOrigin, deferred) {
+            Resource._Implementations.createImage = function(url, crossOrigin, deferred) {
                 var uri = new Uri(url);
                 var params = queryToObject(uri.query);
 
@@ -357,7 +351,7 @@ defineSuite([
                 expect(params.size).toEqual('256,256');
 
                 // Just return any old image.
-                loadImage.defaultCreateImage('Data/Images/Red16x16.png', crossOrigin, deferred);
+                Resource._DefaultImplementations.createImage('Data/Images/Red16x16.png', crossOrigin, deferred);
             };
 
             return provider.requestImage(0, 0, 0).then(function(image) {
@@ -402,7 +396,7 @@ defineSuite([
             expect(provider.enablePickFeatures).toBe(false);
             expect(provider.layers).toEqual('foo,bar');
 
-            loadImage.createImage = function(url, crossOrigin, deferred) {
+            Resource._Implementations.createImage = function(url, crossOrigin, deferred) {
                 var uri = new Uri(url);
                 var params = queryToObject(uri.query);
 
@@ -421,7 +415,7 @@ defineSuite([
                 expect(params.token).toEqual(token);
 
                 // Just return any old image.
-                loadImage.defaultCreateImage('Data/Images/Red16x16.png', crossOrigin, deferred);
+                Resource._DefaultImplementations.createImage('Data/Images/Red16x16.png', crossOrigin, deferred);
             };
 
             return provider.requestImage(0, 0, 0).then(function(image) {
@@ -461,23 +455,23 @@ defineSuite([
             expect(provider.usingPrecachedTiles).toEqual(true);
             expect(provider.hasAlphaChannel).toBeDefined();
 
-            loadImage.createImage = function(url, crossOrigin, deferred) {
+            Resource._Implementations.createImage = function(url, crossOrigin, deferred) {
                 if (/^blob:/.test(url)) {
                     // load blob url normally
-                    loadImage.defaultCreateImage(url, crossOrigin, deferred);
+                    Resource._DefaultImplementations.createImage(url, crossOrigin, deferred);
                 } else {
                     expect(url).toEqual(expectedTileUrl);
 
                     // Just return any old image.
-                    loadImage.defaultCreateImage('Data/Images/Red16x16.png', crossOrigin, deferred);
+                    Resource._DefaultImplementations.createImage('Data/Images/Red16x16.png', crossOrigin, deferred);
                 }
             };
 
-            loadWithXhr.load = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
+            Resource._Implementations.loadWithXhr = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
                 expect(url).toEqual(expectedTileUrl);
 
                 // Just return any old image.
-                loadWithXhr.defaultLoad('Data/Images/Red16x16.png', responseType, method, data, headers, deferred);
+                Resource._DefaultImplementations.loadWithXhr('Data/Images/Red16x16.png', responseType, method, data, headers, deferred);
             };
 
             return provider.requestImage(0, 0, 0).then(function(image) {
@@ -512,23 +506,23 @@ defineSuite([
             expect(provider.proxy).toEqual(proxy);
             expect(provider.usingPrecachedTiles).toEqual(true);
 
-            loadImage.createImage = function(url, crossOrigin, deferred) {
+            Resource._Implementations.createImage = function(url, crossOrigin, deferred) {
                 if (/^blob:/.test(url)) {
                     // load blob url normally
-                    loadImage.defaultCreateImage(url, crossOrigin, deferred);
+                    Resource._DefaultImplementations.createImage(url, crossOrigin, deferred);
                 } else {
                     expect(url).toEqual(getAbsoluteUri(baseUrl + 'tile/0/0/0'));
 
                     // Just return any old image.
-                    loadImage.defaultCreateImage('Data/Images/Red16x16.png', crossOrigin, deferred);
+                    Resource._DefaultImplementations.createImage('Data/Images/Red16x16.png', crossOrigin, deferred);
                 }
             };
 
-            loadWithXhr.load = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
+            Resource._Implementations.loadWithXhr = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
                 expect(url).toEqual(proxy.getURL(getAbsoluteUri(baseUrl + 'tile/0/0/0')));
 
                 // Just return any old image.
-                loadWithXhr.defaultLoad('Data/Images/Red16x16.png', responseType, method, data, headers, deferred);
+                Resource._DefaultImplementations.loadWithXhr('Data/Images/Red16x16.png', responseType, method, data, headers, deferred);
             };
 
             return provider.requestImage(0, 0, 0).then(function(image) {
@@ -643,10 +637,10 @@ defineSuite([
             }, 1);
         });
 
-        loadImage.createImage = function(url, crossOrigin, deferred) {
+        Resource._Implementations.createImage = function(url, crossOrigin, deferred) {
             if (tries === 2) {
                 // Succeed after 2 tries
-                loadImage.defaultCreateImage('Data/Images/Red16x16.png', crossOrigin, deferred);
+                Resource._DefaultImplementations.createImage('Data/Images/Red16x16.png', crossOrigin, deferred);
             } else {
                 // fail
                 setTimeout(function() {
@@ -921,9 +915,9 @@ defineSuite([
                 usePreCachedTilesIfAvailable : false
             });
 
-            loadWithXhr.load = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
+            Resource._Implementations.loadWithXhr = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
                 expect(url).toContain('identify');
-                loadWithXhr.defaultLoad('Data/ArcGIS/identify-WebMercator.json', responseType, method, data, headers, deferred, overrideMimeType);
+                Resource._DefaultImplementations.loadWithXhr('Data/ArcGIS/identify-WebMercator.json', responseType, method, data, headers, deferred, overrideMimeType);
             };
 
             return pollToPromise(function() {
@@ -946,9 +940,9 @@ defineSuite([
                 usePreCachedTilesIfAvailable : false
             });
 
-            loadWithXhr.load = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
+            Resource._Implementations.loadWithXhr = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
                 expect(url).toContain('identify');
-                loadWithXhr.defaultLoad('Data/ArcGIS/identify-Geographic.json', responseType, method, data, headers, deferred, overrideMimeType);
+                Resource._DefaultImplementations.loadWithXhr('Data/ArcGIS/identify-Geographic.json', responseType, method, data, headers, deferred, overrideMimeType);
             };
 
             return pollToPromise(function() {
@@ -1018,12 +1012,12 @@ defineSuite([
                 layers : 'someLayer,anotherLayerYay'
             });
 
-            loadWithXhr.load = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
+            Resource._Implementations.loadWithXhr = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
                 var uri = new Uri(url);
                 var query = queryToObject(uri.getQuery());
 
                 expect(query.layers).toContain('visible:someLayer,anotherLayerYay');
-                loadWithXhr.defaultLoad('Data/ArcGIS/identify-WebMercator.json', responseType, method, data, headers, deferred, overrideMimeType);
+                Resource._DefaultImplementations.loadWithXhr('Data/ArcGIS/identify-WebMercator.json', responseType, method, data, headers, deferred, overrideMimeType);
             };
 
             return pollToPromise(function() {
@@ -1047,14 +1041,14 @@ defineSuite([
                 proxy : proxy
             });
 
-            loadWithXhr.load = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
+            Resource._Implementations.loadWithXhr = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
                 var proxiedUri = new Uri(url);
                 var originalUriQuery = new Uri(decodeURIComponent(proxiedUri.query)).query;
 
                 // DefaultProxy simply puts the original request as the query string; duplicate it here expect match
                 expect(proxiedUri.toString()).toEqual(proxy.getURL(baseUrl + 'identify?' + originalUriQuery));
 
-                loadWithXhr.defaultLoad('Data/ArcGIS/identify-WebMercator.json', responseType, method, data, headers, deferred, overrideMimeType);
+                Resource._DefaultImplementations.loadWithXhr('Data/ArcGIS/identify-WebMercator.json', responseType, method, data, headers, deferred, overrideMimeType);
             };
 
             return pollToPromise(function() {

--- a/Specs/Scene/BillboardCollectionSpec.js
+++ b/Specs/Scene/BillboardCollectionSpec.js
@@ -7,12 +7,12 @@ defineSuite([
         'Core/CesiumTerrainProvider',
         'Core/Color',
         'Core/DistanceDisplayCondition',
-        'Core/loadImage',
         'Core/Math',
         'Core/NearFarScalar',
         'Core/OrthographicOffCenterFrustum',
         'Core/PerspectiveFrustum',
         'Core/Rectangle',
+        'Core/Resource',
         'Scene/Billboard',
         'Scene/BlendOption',
         'Scene/HeightReference',
@@ -32,12 +32,12 @@ defineSuite([
         CesiumTerrainProvider,
         Color,
         DistanceDisplayCondition,
-        loadImage,
         CesiumMath,
         NearFarScalar,
         OrthographicOffCenterFrustum,
         PerspectiveFrustum,
         Rectangle,
+        Resource,
         Billboard,
         BlendOption,
         HeightReference,
@@ -66,16 +66,16 @@ defineSuite([
         camera = scene.camera;
 
         return when.join(
-            loadImage('./Data/Images/Green2x2.png').then(function(result) {
+            Resource.fetchImage('./Data/Images/Green2x2.png').then(function(result) {
                 greenImage = result;
             }),
-            loadImage('./Data/Images/Blue2x2.png').then(function(result) {
+            Resource.fetchImage('./Data/Images/Blue2x2.png').then(function(result) {
                 blueImage = result;
             }),
-            loadImage('./Data/Images/White2x2.png').then(function(result) {
+            Resource.fetchImage('./Data/Images/White2x2.png').then(function(result) {
                 whiteImage = result;
             }),
-            loadImage('./Data/Images/Blue10x10.png').then(function(result) {
+            Resource.fetchImage('./Data/Images/Blue10x10.png').then(function(result) {
                 largeBlueImage = result;
             }));
     });

--- a/Specs/Scene/BingMapsImageryProviderSpec.js
+++ b/Specs/Scene/BingMapsImageryProviderSpec.js
@@ -2,9 +2,6 @@ defineSuite([
         'Scene/BingMapsImageryProvider',
         'Core/DefaultProxy',
         'Core/defined',
-        'Core/loadImage',
-        'Core/loadJsonp',
-        'Core/loadWithXhr',
         'Core/queryToObject',
         'Core/RequestScheduler',
         'Core/Resource',
@@ -21,9 +18,6 @@ defineSuite([
         BingMapsImageryProvider,
         DefaultProxy,
         defined,
-        loadImage,
-        loadJsonp,
-        loadWithXhr,
         queryToObject,
         RequestScheduler,
         Resource,
@@ -43,9 +37,9 @@ defineSuite([
     });
 
     afterEach(function() {
-        loadJsonp.loadAndExecuteScript = loadJsonp.defaultLoadAndExecuteScript;
-        loadImage.createImage = loadImage.defaultCreateImage;
-        loadWithXhr.load = loadWithXhr.defaultLoad;
+        Resource._Implementations.loadAndExecuteScript = Resource._DefaultImplementations.loadAndExecuteScript;
+        Resource._Implementations.loadAndExecuteScript = Resource._DefaultImplementations.loadAndExecuteScript;
+        Resource._Implementations.loadWithXhr = Resource._DefaultImplementations.loadWithXhr;
     });
 
     it('tileXYToQuadKey works for examples in Bing Maps documentation', function() {
@@ -155,7 +149,7 @@ defineSuite([
     function installFakeMetadataRequest(url, mapStyle, proxy) {
         var expectedUrl = url + '/REST/v1/Imagery/Metadata/' + mapStyle;
 
-        loadJsonp.loadAndExecuteScript = function(url, functionName) {
+        Resource._Implementations.loadAndExecuteScript = function(url, functionName) {
             var uri = new Uri(url);
             if (proxy) {
                 uri = new Uri(decodeURIComponent(uri.query));
@@ -176,10 +170,10 @@ defineSuite([
     }
 
     function installFakeImageRequest(expectedUrl, expectedParams, proxy) {
-        loadImage.createImage = function(url, crossOrigin, deferred) {
+        Resource._Implementations.createImage = function(url, crossOrigin, deferred) {
             if (/^blob:/.test(url)) {
                 // load blob url normally
-                loadImage.defaultCreateImage(url, crossOrigin, deferred);
+                Resource._DefaultImplementations.createImage(url, crossOrigin, deferred);
             } else {
                 if (defined(expectedUrl)) {
                     var uri = new Uri(url);
@@ -197,11 +191,11 @@ defineSuite([
                     }
                 }
                 // Just return any old image.
-                loadImage.defaultCreateImage('Data/Images/Red16x16.png', crossOrigin, deferred);
+                Resource._DefaultImplementations.createImage('Data/Images/Red16x16.png', crossOrigin, deferred);
             }
         };
 
-        loadWithXhr.load = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
+        Resource._Implementations.loadWithXhr = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
             if (defined(expectedUrl)) {
                 var uri = new Uri(url);
                 if (proxy) {
@@ -219,7 +213,7 @@ defineSuite([
             }
 
             // Just return any old image.
-            loadWithXhr.defaultLoad('Data/Images/Red16x16.png', responseType, method, data, headers, deferred);
+            Resource._DefaultImplementations.loadWithXhr('Data/Images/Red16x16.png', responseType, method, data, headers, deferred);
         };
     }
 
@@ -443,13 +437,13 @@ defineSuite([
             }, 1);
         });
 
-        loadImage.createImage = function(url, crossOrigin, deferred) {
+        Resource._Implementations.createImage = function(url, crossOrigin, deferred) {
             if (/^blob:/.test(url)) {
                 // load blob url normally
-                loadImage.defaultCreateImage(url, crossOrigin, deferred);
+                Resource._DefaultImplementations.createImage(url, crossOrigin, deferred);
             } else if (tries === 2) {
                 // Succeed after 2 tries
-                loadImage.defaultCreateImage('Data/Images/Red16x16.png', crossOrigin, deferred);
+                Resource._DefaultImplementations.createImage('Data/Images/Red16x16.png', crossOrigin, deferred);
             } else {
                 // fail
                 setTimeout(function() {
@@ -458,10 +452,10 @@ defineSuite([
             }
         };
 
-        loadWithXhr.load = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
+        Resource._Implementations.loadWithXhr = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
             if (tries === 2) {
                 // Succeed after 2 tries
-                loadWithXhr.defaultLoad('Data/Images/Red16x16.png', responseType, method, data, headers, deferred);
+                Resource._DefaultImplementations.loadWithXhr('Data/Images/Red16x16.png', responseType, method, data, headers, deferred);
             } else {
                 // fail
                 setTimeout(function() {

--- a/Specs/Scene/CesiumIonSpec.js
+++ b/Specs/Scene/CesiumIonSpec.js
@@ -1,8 +1,5 @@
 defineSuite([
         'Scene/CesiumIon',
-        'Core/loadImage',
-        'Core/loadJsonp',
-        'Core/loadWithXhr',
         'Core/RuntimeError',
         'Core/RequestErrorEvent',
         'Core/Resource',
@@ -19,9 +16,6 @@ defineSuite([
         'ThirdParty/when'
     ], function(
         CesiumIon,
-        loadImage,
-        loadJsonp,
-        loadWithXhr,
         RuntimeError,
         RequestErrorEvent,
         Resource,
@@ -164,21 +158,21 @@ defineSuite([
     }
 
     it('createImageryProvider works with ARCGIS_MAPSERVER', function() {
-        spyOn(loadJsonp, 'loadAndExecuteScript').and.callFake(function(url, name, deffered) {
+        spyOn(Resource._Implementations, 'loadAndExecuteScript').and.callFake(function(url, name, deffered) {
             deffered.resolve({ resourceSets: [{ resources: [{ imageUrl: '', imageUrlSubdomains: [], zoomMax: 0 }] }] });
         });
         return testExternalImagery('ARCGIS_MAPSERVER', { url: 'https://test.invalid' }, ArcGisMapServerImageryProvider);
     });
 
     it('createImageryProvider works with BING', function() {
-        spyOn(loadJsonp, 'loadAndExecuteScript').and.callFake(function(url, name, deffered) {
+        spyOn(Resource._Implementations, 'loadAndExecuteScript').and.callFake(function(url, name, deffered) {
             deffered.resolve({ resourceSets: [{ resources: [{ imageUrl: '', imageUrlSubdomains: [], zoomMax: 0 }] }] });
         });
         return testExternalImagery('BING', { url: 'https://test.invalid' }, BingMapsImageryProvider);
     });
 
     it('createImageryProvider works with GOOGLE_EARTH', function() {
-        spyOn(loadWithXhr, 'load').and.callFake(function(url, responseType, method, data, headers, deferred, overrideMimeType) {
+        spyOn(Resource._Implementations, 'loadWithXhr').and.callFake(function(url, responseType, method, data, headers, deferred, overrideMimeType) {
             deferred.resolve(JSON.stringify({ layers: [{ id: 0, version: '' }] }));
         });
 
@@ -190,7 +184,7 @@ defineSuite([
     });
 
     it('createImageryProvider works with SINGLE_TILE', function() {
-        spyOn(loadImage, 'createImage').and.callFake(function(url, crossOrigin, deferred) {
+        spyOn(Resource._Implementations, 'createImage').and.callFake(function(url, crossOrigin, deferred) {
             deferred.resolve({});
         });
 

--- a/Specs/Scene/ClassificationModelSpec.js
+++ b/Specs/Scene/ClassificationModelSpec.js
@@ -8,11 +8,11 @@ defineSuite([
         'Core/Ellipsoid',
         'Core/GeometryInstance',
         'Core/HeadingPitchRange',
-        'Core/loadArrayBuffer',
         'Core/Math',
         'Core/Matrix4',
         'Core/Rectangle',
         'Core/RectangleGeometry',
+        'Core/Resource',
         'Core/Transforms',
         'Renderer/Pass',
         'Scene/ClassificationType',
@@ -31,11 +31,11 @@ defineSuite([
         Ellipsoid,
         GeometryInstance,
         HeadingPitchRange,
-        loadArrayBuffer,
         CesiumMath,
         Matrix4,
         Rectangle,
         RectangleGeometry,
+        Resource,
         Transforms,
         Pass,
         ClassificationType,
@@ -129,7 +129,7 @@ defineSuite([
         var translation = Ellipsoid.WGS84.geodeticSurfaceNormalCartographic(new Cartographic(centerLongitude, centerLatitude));
         Cartesian3.multiplyByScalar(translation, -5.0, translation);
 
-        return loadArrayBuffer(batchedModel).then(function(arrayBuffer) {
+        return Resource.fetchArrayBuffer(batchedModel).then(function(arrayBuffer) {
             var model = scene.primitives.add(new ClassificationModel({
                 gltf : arrayBuffer,
                 classificationType : ClassificationType.CESIUM_3D_TILE,
@@ -159,7 +159,7 @@ defineSuite([
         var translation = Ellipsoid.WGS84.geodeticSurfaceNormalCartographic(new Cartographic(centerLongitude, centerLatitude));
         Cartesian3.multiplyByScalar(translation, -5.0, translation);
 
-        return loadArrayBuffer(quantizedModel).then(function(arrayBuffer) {
+        return Resource.fetchArrayBuffer(quantizedModel).then(function(arrayBuffer) {
             var model = scene.primitives.add(new ClassificationModel({
                 gltf : arrayBuffer,
                 classificationType : ClassificationType.CESIUM_3D_TILE,
@@ -186,7 +186,7 @@ defineSuite([
     });
 
     it('throws with invalid number of nodes', function() {
-        return loadArrayBuffer(batchedModel).then(function(arrayBuffer) {
+        return Resource.fetchArrayBuffer(batchedModel).then(function(arrayBuffer) {
             var gltf = new Uint8Array(arrayBuffer);
             gltf = parseBinaryGltf(gltf);
             gltf.nodes.push({});
@@ -199,7 +199,7 @@ defineSuite([
     });
 
     it('throws with invalid number of meshes', function() {
-        return loadArrayBuffer(batchedModel).then(function(arrayBuffer) {
+        return Resource.fetchArrayBuffer(batchedModel).then(function(arrayBuffer) {
             var gltf = new Uint8Array(arrayBuffer);
             gltf = parseBinaryGltf(gltf);
             gltf.meshes.push({});
@@ -212,7 +212,7 @@ defineSuite([
     });
 
     it('throws with invalid number of primitives', function() {
-        return loadArrayBuffer(batchedModel).then(function(arrayBuffer) {
+        return Resource.fetchArrayBuffer(batchedModel).then(function(arrayBuffer) {
             var gltf = new Uint8Array(arrayBuffer);
             gltf = parseBinaryGltf(gltf);
             gltf.meshes[0].primitives.push({});
@@ -225,7 +225,7 @@ defineSuite([
     });
 
     it('throws with position semantic', function() {
-        return loadArrayBuffer(batchedModel).then(function(arrayBuffer) {
+        return Resource.fetchArrayBuffer(batchedModel).then(function(arrayBuffer) {
             var gltf = new Uint8Array(arrayBuffer);
             gltf = parseBinaryGltf(gltf);
             gltf.meshes[0].primitives[0].attributes.POSITION = undefined;
@@ -238,7 +238,7 @@ defineSuite([
     });
 
     it('throws with batch id semantic', function() {
-        return loadArrayBuffer(batchedModel).then(function(arrayBuffer) {
+        return Resource.fetchArrayBuffer(batchedModel).then(function(arrayBuffer) {
             var gltf = new Uint8Array(arrayBuffer);
             gltf = parseBinaryGltf(gltf);
             gltf.meshes[0].primitives[0].attributes._BATCHID = undefined;

--- a/Specs/Scene/GlobeSpec.js
+++ b/Specs/Scene/GlobeSpec.js
@@ -1,16 +1,16 @@
 defineSuite([
         'Scene/Globe',
         'Core/CesiumTerrainProvider',
-        'Core/loadWithXhr',
         'Core/Rectangle',
+        'Core/Resource',
         'Scene/SingleTileImageryProvider',
         'Specs/createScene',
         'Specs/pollToPromise'
     ], function(
         Globe,
         CesiumTerrainProvider,
-        loadWithXhr,
         Rectangle,
+        Resource,
         SingleTileImageryProvider,
         createScene,
         pollToPromise) {
@@ -34,14 +34,14 @@ defineSuite([
 
     afterEach(function() {
         scene.globe = undefined;
-        loadWithXhr.load = loadWithXhr.defaultLoad;
+        Resource._Implementations.loadWithXhr = Resource._DefaultImplementations.loadWithXhr;
     });
 
     function returnTileJson(path) {
-        var oldLoad = loadWithXhr.load;
-        loadWithXhr.load = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
+        var oldLoad = Resource._Implementations.loadWithXhr;
+        Resource._Implementations.loadWithXhr = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
             if (url.indexOf('layer.json') >= 0) {
-                loadWithXhr.defaultLoad(path, responseType, method, data, headers, deferred);
+                Resource._DefaultImplementations.loadWithXhr(path, responseType, method, data, headers, deferred);
             } else {
                 return oldLoad(url, responseType, method, data, headers, deferred, overrideMimeType);
             }
@@ -155,8 +155,8 @@ defineSuite([
         layerCollection.removeAll();
         layerCollection.addImageryProvider(new SingleTileImageryProvider({url : 'Data/Images/Red16x16.png'}));
 
-        loadWithXhr.load = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
-            loadWithXhr.defaultLoad('Data/CesiumTerrainTileJson/tile.vertexnormals.terrain', responseType, method, data, headers, deferred);
+        Resource._Implementations.loadWithXhr = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
+            Resource._DefaultImplementations.loadWithXhr('Data/CesiumTerrainTileJson/tile.vertexnormals.terrain', responseType, method, data, headers, deferred);
         };
 
         returnVertexNormalTileJson();

--- a/Specs/Scene/GoogleEarthEnterpriseImageryProviderSpec.js
+++ b/Specs/Scene/GoogleEarthEnterpriseImageryProviderSpec.js
@@ -7,8 +7,6 @@ defineSuite([
         'Core/GeographicTilingScheme',
         'Core/GoogleEarthEnterpriseMetadata',
         'Core/GoogleEarthEnterpriseTileInformation',
-        'Core/loadImage',
-        'Core/loadWithXhr',
         'Core/Rectangle',
         'Core/RequestScheduler',
         'Core/Resource',
@@ -29,8 +27,6 @@ defineSuite([
         GeographicTilingScheme,
         GoogleEarthEnterpriseMetadata,
         GoogleEarthEnterpriseTileInformation,
-        loadImage,
-        loadWithXhr,
         Rectangle,
         RequestScheduler,
         Resource,
@@ -58,8 +54,8 @@ defineSuite([
 
     var imageryProvider;
     afterEach(function() {
-        loadImage.createImage = loadImage.defaultCreateImage;
-        loadWithXhr.load = loadWithXhr.defaultLoad;
+        Resource._Implementations.createImage = Resource._DefaultImplementations.createImage;
+        Resource._Implementations.loadWithXhr = Resource._DefaultImplementations.loadWithXhr;
     });
 
     it('conforms to ImageryProvider interface', function() {
@@ -87,10 +83,10 @@ defineSuite([
     }
 
     function installFakeImageRequest(expectedUrl, proxy) {
-        loadImage.createImage = function(url, crossOrigin, deferred) {
+        Resource._Implementations.createImage = function(url, crossOrigin, deferred) {
             if (/^blob:/.test(url)) {
                 // load blob url normally
-                loadImage.defaultCreateImage(url, crossOrigin, deferred);
+                Resource._DefaultImplementations.createImage(url, crossOrigin, deferred);
             } else {
                 if (proxy) {
                     var uri = new Uri(url);
@@ -100,11 +96,11 @@ defineSuite([
                     expect(url).toEqual(expectedUrl);
                 }
                 // Just return any old image.
-                loadImage.defaultCreateImage('Data/Images/Red16x16.png', crossOrigin, deferred);
+                Resource._DefaultImplementations.createImage('Data/Images/Red16x16.png', crossOrigin, deferred);
             }
         };
 
-        loadWithXhr.load = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
+        Resource._Implementations.loadWithXhr = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
             if (defined(expectedUrl)) {
                 if (proxy) {
                     var uri = new Uri(url);
@@ -115,7 +111,7 @@ defineSuite([
             }
 
             // Just return any old image.
-            loadWithXhr.defaultLoad('Data/Images/Red16x16.png', responseType, method, data, headers, deferred);
+            Resource._DefaultImplementations.loadWithXhr('Data/Images/Red16x16.png', responseType, method, data, headers, deferred);
         };
     }
 
@@ -300,10 +296,10 @@ defineSuite([
             }, 1);
         });
 
-        loadWithXhr.load = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
+        Resource._Implementations.loadWithXhr = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
             if (tries === 2) {
                 // Succeed after 2 tries
-                loadWithXhr.defaultLoad('Data/Images/Red16x16.png', responseType, method, data, headers, deferred);
+                Resource._DefaultImplementations.loadWithXhr('Data/Images/Red16x16.png', responseType, method, data, headers, deferred);
             } else {
                 // fail
                 setTimeout(function() {

--- a/Specs/Scene/GoogleEarthEnterpriseMapsProviderSpec.js
+++ b/Specs/Scene/GoogleEarthEnterpriseMapsProviderSpec.js
@@ -2,8 +2,6 @@ defineSuite([
         'Scene/GoogleEarthEnterpriseMapsProvider',
         'Core/DefaultProxy',
         'Core/GeographicTilingScheme',
-        'Core/loadImage',
-        'Core/loadWithXhr',
         'Core/Rectangle',
         'Core/RequestScheduler',
         'Core/Resource',
@@ -17,8 +15,6 @@ defineSuite([
         GoogleEarthEnterpriseMapsProvider,
         DefaultProxy,
         GeographicTilingScheme,
-        loadImage,
-        loadWithXhr,
         Rectangle,
         RequestScheduler,
         Resource,
@@ -31,8 +27,8 @@ defineSuite([
     'use strict';
 
     afterEach(function() {
-        loadImage.createImage = loadImage.defaultCreateImage;
-        loadWithXhr.load = loadWithXhr.defaultLoad;
+        Resource._Implementations.createImage = Resource._DefaultImplementations.createImage;
+        Resource._Implementations.loadWithXhr = Resource._DefaultImplementations.loadWithXhr;
     });
 
     it('conforms to ImageryProvider interface', function() {
@@ -64,8 +60,8 @@ defineSuite([
         var url = 'http://example.invalid';
         var channel = 1234;
 
-        loadWithXhr.load = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
-            loadWithXhr.defaultLoad('Data/GoogleEarthEnterpriseMapsProvider/good.json', responseType, method, data, headers, deferred);
+        Resource._Implementations.loadWithXhr = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
+            Resource._DefaultImplementations.loadWithXhr('Data/GoogleEarthEnterpriseMapsProvider/good.json', responseType, method, data, headers, deferred);
         };
 
         var provider = new GoogleEarthEnterpriseMapsProvider({
@@ -85,8 +81,8 @@ defineSuite([
         var url = 'http://example.invalid';
         var channel = 1234;
 
-        loadWithXhr.load = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
-            loadWithXhr.defaultLoad('Data/GoogleEarthEnterpriseMapsProvider/good.json', responseType, method, data, headers, deferred);
+        Resource._Implementations.loadWithXhr = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
+            Resource._DefaultImplementations.loadWithXhr('Data/GoogleEarthEnterpriseMapsProvider/good.json', responseType, method, data, headers, deferred);
         };
 
         var resource = new Resource({
@@ -125,8 +121,8 @@ defineSuite([
         var url = 'http://example.invalid';
         var channel = 1234;
 
-        loadWithXhr.load = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
-            loadWithXhr.defaultLoad('Data/GoogleEarthEnterpriseMapsProvider/good.json', responseType, method, data, headers, deferred);
+        Resource._Implementations.loadWithXhr = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
+            Resource._DefaultImplementations.loadWithXhr('Data/GoogleEarthEnterpriseMapsProvider/good.json', responseType, method, data, headers, deferred);
         };
 
         var provider = new GoogleEarthEnterpriseMapsProvider({
@@ -148,8 +144,8 @@ defineSuite([
         var channel = 1234;
         var version = 1;
 
-        loadWithXhr.load = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
-            loadWithXhr.defaultLoad('Data/GoogleEarthEnterpriseMapsProvider/good.json', responseType, method, data, headers, deferred);
+        Resource._Implementations.loadWithXhr = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
+            Resource._DefaultImplementations.loadWithXhr('Data/GoogleEarthEnterpriseMapsProvider/good.json', responseType, method, data, headers, deferred);
         };
 
         var provider = new GoogleEarthEnterpriseMapsProvider({
@@ -175,23 +171,23 @@ defineSuite([
             expect(provider.rectangle).toEqual(new WebMercatorTilingScheme().rectangle);
             expect(provider.credit).toBeInstanceOf(Object);
 
-            loadImage.createImage = function(url, crossOrigin, deferred) {
+            Resource._Implementations.createImage = function(url, crossOrigin, deferred) {
                 if (/^blob:/.test(url)) {
                     // load blob url normally
-                    loadImage.defaultCreateImage(url, crossOrigin, deferred);
+                    Resource._DefaultImplementations.createImage(url, crossOrigin, deferred);
                 } else {
                     expect(url).toEqual('http://example.invalid/query?request=ImageryMaps&channel=1234&version=1&x=0&y=0&z=1');
 
                     // Just return any old image.
-                    loadImage.defaultCreateImage('Data/Images/Red16x16.png', crossOrigin, deferred);
+                    Resource._DefaultImplementations.createImage('Data/Images/Red16x16.png', crossOrigin, deferred);
                 }
             };
 
-            loadWithXhr.load = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
+            Resource._Implementations.loadWithXhr = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
                 expect(url).toEqual('http://example.invalid/query?request=ImageryMaps&channel=1234&version=1&x=0&y=0&z=1');
 
                 // Just return any old image.
-                loadWithXhr.defaultLoad('Data/Images/Red16x16.png', responseType, method, data, headers, deferred);
+                Resource._DefaultImplementations.loadWithXhr('Data/Images/Red16x16.png', responseType, method, data, headers, deferred);
             };
 
             return provider.requestImage(0, 0, 0).then(function(image) {
@@ -206,7 +202,7 @@ defineSuite([
         var version = 1;
         var channel = 1234;
 
-        loadWithXhr.load = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
+        Resource._Implementations.loadWithXhr = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
             return deferred.resolve('{\n' +
                                     'isAuthenticated: true,\n' +
                                     'layers: [\n' +
@@ -253,8 +249,8 @@ defineSuite([
         var url = 'http://example.invalid';
         var proxy = new DefaultProxy('/proxy/');
 
-        loadWithXhr.load = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
-            loadWithXhr.defaultLoad('Data/GoogleEarthEnterpriseMapsProvider/good.json', responseType, method, data, headers, deferred);
+        Resource._Implementations.loadWithXhr = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
+            Resource._DefaultImplementations.loadWithXhr('Data/GoogleEarthEnterpriseMapsProvider/good.json', responseType, method, data, headers, deferred);
         };
 
         var provider = new GoogleEarthEnterpriseMapsProvider({
@@ -270,23 +266,23 @@ defineSuite([
         return pollToPromise(function() {
             return provider.ready;
         }).then(function() {
-            loadImage.createImage = function(url, crossOrigin, deferred) {
+            Resource._Implementations.createImage = function(url, crossOrigin, deferred) {
                 if (/^blob:/.test(url)) {
                     // load blob url normally
-                    loadImage.defaultCreateImage(url, crossOrigin, deferred);
+                    Resource._DefaultImplementations.createImage(url, crossOrigin, deferred);
                 } else {
                     expect(url).toEqual(proxy.getURL('http://example.invalid/default_map/query?request=ImageryMaps&channel=1234&version=1&x=0&y=0&z=1'));
 
                     // Just return any old image.
-                    loadImage.defaultCreateImage('Data/Images/Red16x16.png', crossOrigin, deferred);
+                    Resource._DefaultImplementations.createImage('Data/Images/Red16x16.png', crossOrigin, deferred);
                 }
             };
 
-            loadWithXhr.load = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
+            Resource._Implementations.loadWithXhr = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
                 expect(url).toEqual(proxy.getURL('http://example.invalid/default_map/query?request=ImageryMaps&channel=1234&version=1&x=0&y=0&z=1'));
 
                 // Just return any old image.
-                loadWithXhr.defaultLoad('Data/Images/Red16x16.png', responseType, method, data, headers, deferred);
+                Resource._DefaultImplementations.loadWithXhr('Data/Images/Red16x16.png', responseType, method, data, headers, deferred);
             };
 
             return provider.requestImage(0, 0, 0).then(function(image) {
@@ -317,8 +313,8 @@ defineSuite([
     });
 
     it('raises error event when image cannot be loaded', function() {
-        loadWithXhr.load = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
-            loadWithXhr.defaultLoad('Data/GoogleEarthEnterpriseMapsProvider/good.json', responseType, method, data, headers, deferred);
+        Resource._Implementations.loadWithXhr = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
+            Resource._DefaultImplementations.loadWithXhr('Data/GoogleEarthEnterpriseMapsProvider/good.json', responseType, method, data, headers, deferred);
         };
 
         var provider = new GoogleEarthEnterpriseMapsProvider({
@@ -340,13 +336,13 @@ defineSuite([
             }, 1);
         });
 
-        loadImage.createImage = function(url, crossOrigin, deferred) {
+        Resource._Implementations.createImage = function(url, crossOrigin, deferred) {
             if (/^blob:/.test(url)) {
                 // load blob url normally
-                loadImage.defaultCreateImage(url, crossOrigin, deferred);
+                Resource._DefaultImplementations.createImage(url, crossOrigin, deferred);
             } else if (tries === 2) {
                 // Succeed after 2 tries
-                loadImage.defaultCreateImage('Data/Images/Red16x16.png', crossOrigin, deferred);
+                Resource._DefaultImplementations.createImage('Data/Images/Red16x16.png', crossOrigin, deferred);
             } else {
                 // fail
                 setTimeout(function() {
@@ -355,10 +351,10 @@ defineSuite([
             }
         };
 
-        loadWithXhr.load = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
+        Resource._Implementations.loadWithXhr = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
             if (tries === 2) {
                 // Succeed after 2 tries
-                loadWithXhr.defaultLoad('Data/Images/Red16x16.png', responseType, method, data, headers, deferred);
+                Resource._DefaultImplementations.loadWithXhr('Data/Images/Red16x16.png', responseType, method, data, headers, deferred);
             } else {
                 // fail
                 setTimeout(function() {
@@ -386,7 +382,7 @@ defineSuite([
     });
 
     it('defaults to WebMercatorTilingScheme when no projection specified', function() {
-        loadWithXhr.load = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
+        Resource._Implementations.loadWithXhr = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
             return deferred.resolve(JSON.stringify({
                 "isAuthenticated" : true,
                 "layers" : [{
@@ -416,7 +412,7 @@ defineSuite([
     });
 
     it('Projection is WebMercatorTilingScheme when server projection is mercator', function() {
-        loadWithXhr.load = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
+        Resource._Implementations.loadWithXhr = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
             return deferred.resolve(JSON.stringify({
                 "isAuthenticated" : true,
                 "layers" : [{
@@ -447,7 +443,7 @@ defineSuite([
     });
 
     it('Projection is GeographicTilingScheme when server projection is flat', function() {
-        loadWithXhr.load = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
+        Resource._Implementations.loadWithXhr = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
             return deferred.resolve(JSON.stringify({
                 "isAuthenticated" : true,
                 "layers" : [{
@@ -478,8 +474,8 @@ defineSuite([
     });
 
     it('raises error when channel cannot be found', function() {
-        loadWithXhr.load = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
-            loadWithXhr.defaultLoad('Data/GoogleEarthEnterpriseMapsProvider/bad_channel.json', responseType, method, data, headers, deferred);
+        Resource._Implementations.loadWithXhr = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
+            Resource._DefaultImplementations.loadWithXhr('Data/GoogleEarthEnterpriseMapsProvider/bad_channel.json', responseType, method, data, headers, deferred);
         };
 
         var provider = new GoogleEarthEnterpriseMapsProvider({
@@ -502,8 +498,8 @@ defineSuite([
     });
 
     it('raises error when channel version cannot be found', function() {
-        loadWithXhr.load = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
-            loadWithXhr.defaultLoad('Data/GoogleEarthEnterpriseMapsProvider/bad_version.json', responseType, method, data, headers, deferred);
+        Resource._Implementations.loadWithXhr = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
+            Resource._DefaultImplementations.loadWithXhr('Data/GoogleEarthEnterpriseMapsProvider/bad_version.json', responseType, method, data, headers, deferred);
         };
 
         var provider = new GoogleEarthEnterpriseMapsProvider({
@@ -526,8 +522,8 @@ defineSuite([
     });
 
     it('raises error when unsupported projection is specified', function() {
-        loadWithXhr.load = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
-            loadWithXhr.defaultLoad('Data/GoogleEarthEnterpriseMapsProvider/bad_projection.json', responseType, method, data, headers, deferred);
+        Resource._Implementations.loadWithXhr = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
+            Resource._DefaultImplementations.loadWithXhr('Data/GoogleEarthEnterpriseMapsProvider/bad_projection.json', responseType, method, data, headers, deferred);
         };
 
         var provider = new GoogleEarthEnterpriseMapsProvider({

--- a/Specs/Scene/ImageryLayerSpec.js
+++ b/Specs/Scene/ImageryLayerSpec.js
@@ -1,11 +1,9 @@
 defineSuite([
         'Scene/ImageryLayer',
         'Core/EllipsoidTerrainProvider',
-        'Core/loadImage',
-        'Core/loadJsonp',
-        'Core/loadWithXhr',
         'Core/Rectangle',
         'Core/RequestScheduler',
+        'Core/Resource',
         'Renderer/ComputeEngine',
         'Renderer/TextureMagnificationFilter',
         'Renderer/TextureMinificationFilter',
@@ -26,11 +24,9 @@ defineSuite([
     ], function(
         ImageryLayer,
         EllipsoidTerrainProvider,
-        loadImage,
-        loadJsonp,
-        loadWithXhr,
         Rectangle,
         RequestScheduler,
+        Resource,
         ComputeEngine,
         TextureMagnificationFilter,
         TextureMinificationFilter,
@@ -64,9 +60,9 @@ defineSuite([
     });
 
     afterEach(function() {
-        loadJsonp.loadAndExecuteScript = loadJsonp.defaultLoadAndExecuteScript;
-        loadImage.createImage = loadImage.defaultCreateImage;
-        loadWithXhr.load = loadWithXhr.defaultLoad;
+        Resource._Implementations.loadAndExecuteScript = Resource._DefaultImplementations.loadAndExecuteScript;
+        Resource._Implementations.createImage = Resource._DefaultImplementations.createImage;
+        Resource._Implementations.loadWithXhr = Resource._DefaultImplementations.loadWithXhr;
 
         scene.frameState.commandList.length = 0;
     });
@@ -84,12 +80,12 @@ defineSuite([
     };
 
     it('discards tiles when the ImageryProviders discard policy says to do so', function() {
-        loadImage.createImage = function(url, crossOrigin, deferred) {
-            loadImage.defaultCreateImage('Data/Images/Red16x16.png', crossOrigin, deferred);
+        Resource._Implementations.createImage = function(url, crossOrigin, deferred) {
+            Resource._DefaultImplementations.createImage('Data/Images/Red16x16.png', crossOrigin, deferred);
         };
 
-        loadWithXhr.load = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
-            loadWithXhr.defaultLoad('Data/Images/Red16x16.png', responseType, method, data, headers, deferred);
+        Resource._Implementations.loadWithXhr = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
+            Resource._DefaultImplementations.loadWithXhr('Data/Images/Red16x16.png', responseType, method, data, headers, deferred);
         };
 
         var discardPolicy = new CustomDiscardPolicy();
@@ -122,7 +118,7 @@ defineSuite([
     });
 
     function createWebMercatorProvider() {
-        loadJsonp.loadAndExecuteScript = function(url, functionName) {
+        Resource._Implementations.loadAndExecuteScript = function(url, functionName) {
             window[functionName]({
                 "authenticationResultCode" : "ValidCredentials",
                 "brandLogoUri" : "http:\/\/dev.virtualearth.net\/Branding\/logo_powered_by.png",
@@ -148,12 +144,12 @@ defineSuite([
             });
         };
 
-        loadImage.createImage = function(url, crossOrigin, deferred) {
-            loadImage.defaultCreateImage('Data/Images/Red16x16.png', crossOrigin, deferred);
+        Resource._Implementations.createImage = function(url, crossOrigin, deferred) {
+            Resource._DefaultImplementations.createImage('Data/Images/Red16x16.png', crossOrigin, deferred);
         };
 
-        loadWithXhr.load = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
-            loadWithXhr.defaultLoad('Data/Images/Red16x16.png', responseType, method, data, headers, deferred);
+        Resource._Implementations.loadWithXhr = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
+            Resource._DefaultImplementations.loadWithXhr('Data/Images/Red16x16.png', responseType, method, data, headers, deferred);
         };
 
         return new BingMapsImageryProvider({
@@ -289,8 +285,8 @@ defineSuite([
     });
 
     it('assigns texture property when reprojection is skipped because the tile is very small', function() {
-        loadImage.createImage = function(url, crossOrigin, deferred) {
-            loadImage.defaultCreateImage('Data/Images/Red256x256.png', crossOrigin, deferred);
+        Resource._Implementations.createImage = function(url, crossOrigin, deferred) {
+            Resource._DefaultImplementations.createImage('Data/Images/Red256x256.png', crossOrigin, deferred);
         };
 
         var provider = new UrlTemplateImageryProvider({

--- a/Specs/Scene/MapboxImageryProviderSpec.js
+++ b/Specs/Scene/MapboxImageryProviderSpec.js
@@ -1,7 +1,6 @@
 defineSuite([
         'Scene/MapboxImageryProvider',
         'Core/DefaultProxy',
-        'Core/loadImage',
         'Core/Math',
         'Core/Rectangle',
         'Core/RequestScheduler',
@@ -15,7 +14,6 @@ defineSuite([
     ], function(
         MapboxImageryProvider,
         DefaultProxy,
-        loadImage,
         CesiumMath,
         Rectangle,
         RequestScheduler,
@@ -33,7 +31,7 @@ defineSuite([
     });
 
     afterEach(function() {
-        loadImage.createImage = loadImage.defaultCreateImage;
+        Resource._Implementations.createImage = Resource._DefaultImplementations.createImage;
     });
 
     it('conforms to ImageryProvider interface', function() {
@@ -96,15 +94,15 @@ defineSuite([
         return pollToPromise(function() {
             return provider.ready;
         }).then(function() {
-            spyOn(loadImage, 'createImage').and.callFake(function(url, crossOrigin, deferred) {
+            spyOn(Resource._Implementations, 'createImage').and.callFake(function(url, crossOrigin, deferred) {
                 expect(url).not.toContain('//');
 
                 // Just return any old image.
-                loadImage.defaultCreateImage('Data/Images/Red16x16.png', crossOrigin, deferred);
+                Resource._DefaultImplementations.createImage('Data/Images/Red16x16.png', crossOrigin, deferred);
             });
 
             return provider.requestImage(0, 0, 0).then(function(image) {
-                expect(loadImage.createImage).toHaveBeenCalled();
+                expect(Resource._Implementations.createImage).toHaveBeenCalled();
                 expect(image).toBeInstanceOf(Image);
             });
         });
@@ -119,15 +117,15 @@ defineSuite([
         return pollToPromise(function() {
             return provider.ready;
         }).then(function() {
-            spyOn(loadImage, 'createImage').and.callFake(function(url, crossOrigin, deferred) {
+            spyOn(Resource._Implementations, 'createImage').and.callFake(function(url, crossOrigin, deferred) {
                 expect(url).toContain('made/up/mapbox/server/');
 
                 // Just return any old image.
-                loadImage.defaultCreateImage('Data/Images/Red16x16.png', crossOrigin, deferred);
+                Resource._DefaultImplementations.createImage('Data/Images/Red16x16.png', crossOrigin, deferred);
             });
 
             return provider.requestImage(0, 0, 0).then(function(image) {
-                expect(loadImage.createImage).toHaveBeenCalled();
+                expect(Resource._Implementations.createImage).toHaveBeenCalled();
                 expect(image).toBeInstanceOf(Image);
             });
         });
@@ -150,13 +148,13 @@ defineSuite([
             expect(provider.tilingScheme).toBeInstanceOf(WebMercatorTilingScheme);
             expect(provider.rectangle).toEqual(new WebMercatorTilingScheme().rectangle);
 
-            spyOn(loadImage, 'createImage').and.callFake(function(url, crossOrigin, deferred) {
+            spyOn(Resource._Implementations, 'createImage').and.callFake(function(url, crossOrigin, deferred) {
                 // Just return any old image.
-                loadImage.defaultCreateImage('Data/Images/Red16x16.png', crossOrigin, deferred);
+                Resource._DefaultImplementations.createImage('Data/Images/Red16x16.png', crossOrigin, deferred);
             });
 
             return provider.requestImage(0, 0, 0).then(function(image) {
-                expect(loadImage.createImage).toHaveBeenCalled();
+                expect(Resource._Implementations.createImage).toHaveBeenCalled();
                 expect(image).toBeInstanceOf(Image);
             });
         });
@@ -175,15 +173,15 @@ defineSuite([
         }).then(function() {
             expect(provider.proxy).toEqual(proxy);
 
-            spyOn(loadImage, 'createImage').and.callFake(function(url, crossOrigin, deferred) {
+            spyOn(Resource._Implementations, 'createImage').and.callFake(function(url, crossOrigin, deferred) {
                 expect(url.indexOf(proxy.getURL('made/up/mapbox/server'))).toEqual(0);
 
                 // Just return any old image.
-                loadImage.defaultCreateImage('Data/Images/Red16x16.png', crossOrigin, deferred);
+                Resource._DefaultImplementations.createImage('Data/Images/Red16x16.png', crossOrigin, deferred);
             });
 
             return provider.requestImage(0, 0, 0).then(function(image) {
-                expect(loadImage.createImage).toHaveBeenCalled();
+                expect(Resource._Implementations.createImage).toHaveBeenCalled();
                 expect(image).toBeInstanceOf(Image);
             });
         });
@@ -207,15 +205,15 @@ defineSuite([
             expect(provider.rectangle).toEqualEpsilon(rectangle, CesiumMath.EPSILON14);
             expect(provider.tileDiscardPolicy).toBeUndefined();
 
-            spyOn(loadImage, 'createImage').and.callFake(function(url, crossOrigin, deferred) {
+            spyOn(Resource._Implementations, 'createImage').and.callFake(function(url, crossOrigin, deferred) {
                 expect(url).toContain('/0/0/0');
 
                 // Just return any old image.
-                loadImage.defaultCreateImage('Data/Images/Red16x16.png', crossOrigin, deferred);
+                Resource._DefaultImplementations.createImage('Data/Images/Red16x16.png', crossOrigin, deferred);
             });
 
             return provider.requestImage(0, 0, 0).then(function(image) {
-                expect(loadImage.createImage).toHaveBeenCalled();
+                expect(Resource._Implementations.createImage).toHaveBeenCalled();
                 expect(image).toBeInstanceOf(Image);
             });
         });
@@ -278,10 +276,10 @@ defineSuite([
             }, 1);
         });
 
-        loadImage.createImage = function(url, crossOrigin, deferred) {
+        Resource._Implementations.createImage = function(url, crossOrigin, deferred) {
             if (tries === 2) {
                 // Succeed after 2 tries
-                loadImage.defaultCreateImage('Data/Images/Red16x16.png', crossOrigin, deferred);
+                Resource._DefaultImplementations.createImage('Data/Images/Red16x16.png', crossOrigin, deferred);
             } else {
                 // fail
                 setTimeout(function() {
@@ -318,15 +316,15 @@ defineSuite([
         return pollToPromise(function() {
             return provider.ready;
         }).then(function() {
-            spyOn(loadImage, 'createImage').and.callFake(function(url, crossOrigin, deferred) {
+            spyOn(Resource._Implementations, 'createImage').and.callFake(function(url, crossOrigin, deferred) {
                 expect(/made\/up\/mapbox\/server\/test-id\/0\/0\/0@2x\.png\?access_token=/.test(url)).toBe(true);
 
                 // Just return any old image.
-                loadImage.defaultCreateImage('Data/Images/Red16x16.png', crossOrigin, deferred);
+                Resource._DefaultImplementations.createImage('Data/Images/Red16x16.png', crossOrigin, deferred);
             });
 
             return provider.requestImage(0, 0, 0).then(function(image) {
-                expect(loadImage.createImage).toHaveBeenCalled();
+                expect(Resource._Implementations.createImage).toHaveBeenCalled();
             });
         });
     });
@@ -341,15 +339,15 @@ defineSuite([
         return pollToPromise(function() {
             return provider.ready;
         }).then(function() {
-            spyOn(loadImage, 'createImage').and.callFake(function(url, crossOrigin, deferred) {
+            spyOn(Resource._Implementations, 'createImage').and.callFake(function(url, crossOrigin, deferred) {
                 expect(/made\/up\/mapbox\/server\/test-id\/0\/0\/0\.png\?access_token=/.test(url)).toBe(true);
 
                 // Just return any old image.
-                loadImage.defaultCreateImage('Data/Images/Red16x16.png', crossOrigin, deferred);
+                Resource._DefaultImplementations.createImage('Data/Images/Red16x16.png', crossOrigin, deferred);
             });
 
             return provider.requestImage(0, 0, 0).then(function(image) {
-                expect(loadImage.createImage).toHaveBeenCalled();
+                expect(Resource._Implementations.createImage).toHaveBeenCalled();
             });
         });
     });

--- a/Specs/Scene/ModelSpec.js
+++ b/Specs/Scene/ModelSpec.js
@@ -15,9 +15,6 @@ defineSuite([
         'Core/FeatureDetection',
         'Core/HeadingPitchRange',
         'Core/JulianDate',
-        'Core/loadArrayBuffer',
-        'Core/loadJson',
-        'Core/loadWithXhr',
         'Core/Math',
         'Core/Matrix3',
         'Core/Matrix4',
@@ -54,9 +51,6 @@ defineSuite([
         FeatureDetection,
         HeadingPitchRange,
         JulianDate,
-        loadArrayBuffer,
-        loadJson,
-        loadWithXhr,
         CesiumMath,
         Matrix3,
         Matrix4,
@@ -296,7 +290,7 @@ defineSuite([
     });
 
     it('fromGltf takes Resource as url and basePath parameters', function() {
-        spyOn(loadWithXhr, 'load').and.callThrough();
+        spyOn(Resource._Implementations, 'loadWithXhr').and.callThrough();
 
         var url = new Resource({
             url: texturedBoxUrl
@@ -309,7 +303,7 @@ defineSuite([
             basePath: basePath
         });
         expect(model._resource).toEqual(basePath);
-        expect(loadWithXhr.load.calls.argsFor(0)[0]).toEqual(url.url);
+        expect(Resource._Implementations.loadWithXhr.calls.argsFor(0)[0]).toEqual(url.url);
     });
 
     it('renders', function() {
@@ -396,7 +390,7 @@ defineSuite([
     });
 
     it('Renders x-up model', function() {
-        return loadJson(boxEcefUrl).then(function(gltf) {
+        return Resource.fetchJson(boxEcefUrl).then(function(gltf) {
             // Model data is z-up. Edit the transform to be z-up to x-up.
             gltf.nodes.node_transform.matrix = Matrix4.pack(Axis.Z_UP_TO_X_UP, new Array(16));
 
@@ -412,7 +406,7 @@ defineSuite([
     });
 
     it('Renders y-up model', function() {
-        return loadJson(boxEcefUrl).then(function(gltf) {
+        return Resource.fetchJson(boxEcefUrl).then(function(gltf) {
             // Model data is z-up. Edit the transform to be z-up to y-up.
             gltf.nodes.node_transform.matrix = Matrix4.pack(Axis.Z_UP_TO_Y_UP, new Array(16));
 
@@ -428,7 +422,7 @@ defineSuite([
     });
 
     it('Renders z-up model', function() {
-        return loadJson(boxEcefUrl).then(function(gltf) {
+        return Resource.fetchJson(boxEcefUrl).then(function(gltf) {
             // Model data is z-up. Edit the transform to be the identity.
             gltf.nodes.node_transform.matrix = Matrix4.pack(Matrix4.IDENTITY, new Array(16));
 
@@ -450,7 +444,7 @@ defineSuite([
     });
 
     it('rejects readyPromise on error', function() {
-        return loadJson(boomBoxUrl).then(function(gltf) {
+        return Resource.fetchJson(boomBoxUrl).then(function(gltf) {
             gltf.images[0].uri = 'invalid.png';
             var model = primitives.add(new Model({
                 gltf : gltf
@@ -772,7 +766,7 @@ defineSuite([
     ///////////////////////////////////////////////////////////////////////////
 
     it('Throws because of invalid extension', function() {
-        return loadJson(boxUrl).then(function(gltf) {
+        return Resource.fetchJson(boxUrl).then(function(gltf) {
             gltf.extensionsRequired = ['NOT_supported_extension'];
             var model = primitives.add(new Model({
                 gltf : gltf
@@ -786,7 +780,7 @@ defineSuite([
     });
 
     it('Throws because of invalid extension', function() {
-        return loadJson(boxUrl).then(function(gltf) {
+        return Resource.fetchJson(boxUrl).then(function(gltf) {
             gltf.extensionsRequired = ['CESIUM_binary_glTF'];
             var model = primitives.add(new Model({
                 gltf : gltf
@@ -845,7 +839,7 @@ defineSuite([
     });
 
     it('loads a model with the KHR_binary_glTF extension as an ArrayBuffer using new Model', function() {
-        return loadArrayBuffer(texturedBoxKhrBinaryUrl).then(function(arrayBuffer) {
+        return Resource.fetchArrayBuffer(texturedBoxKhrBinaryUrl).then(function(arrayBuffer) {
             return loadModelJson(arrayBuffer).then(function(model) {
                 verifyRender(model);
                 primitives.remove(model);
@@ -854,7 +848,7 @@ defineSuite([
     });
 
     it('loads a model with the KHR_binary_glTF extension as an Uint8Array using new Model', function() {
-        return loadArrayBuffer(texturedBoxKhrBinaryUrl).then(function(arrayBuffer) {
+        return Resource.fetchArrayBuffer(texturedBoxKhrBinaryUrl).then(function(arrayBuffer) {
             return loadModelJson(new Uint8Array(arrayBuffer)).then(function(model) {
                 verifyRender(model);
                 primitives.remove(model);
@@ -2049,7 +2043,7 @@ defineSuite([
     });
 
     it('loads a glTF 2.0 with alphaMode set to OPAQUE', function() {
-        return loadJson(boxPbrUrl).then(function(gltf) {
+        return Resource.fetchJson(boxPbrUrl).then(function(gltf) {
             gltf.materials[0].alphaMode = 'OPAQUE';
 
             return loadModelJson(gltf).then(function(m) {
@@ -2060,7 +2054,7 @@ defineSuite([
     });
 
     it('loads a glTF 2.0 with alphaMode set to MASK', function() {
-        return loadJson(boxPbrUrl).then(function(gltf) {
+        return Resource.fetchJson(boxPbrUrl).then(function(gltf) {
             gltf.materials[0].alphaMode = 'MASK';
             gltf.materials[0].alphaCutoff = 0.5;
 
@@ -2072,7 +2066,7 @@ defineSuite([
     });
 
     it('loads a glTF 2.0 with alphaMode set to BLEND', function() {
-        return loadJson(boxPbrUrl).then(function(gltf) {
+        return Resource.fetchJson(boxPbrUrl).then(function(gltf) {
             gltf.materials[0].alphaMode = 'BLEND';
 
             return loadModelJson(gltf).then(function(m) {
@@ -2131,7 +2125,7 @@ defineSuite([
     }
 
     it('loads a glTF 2.0 with doubleSided set to false', function() {
-        return loadJson(twoSidedPlaneUrl).then(function(gltf) {
+        return Resource.fetchJson(twoSidedPlaneUrl).then(function(gltf) {
             gltf.materials[0].doubleSided = false;
             return loadModelJson(gltf).then(function(m) {
                 m.show = true;

--- a/Specs/Scene/MultifrustumSpec.js
+++ b/Specs/Scene/MultifrustumSpec.js
@@ -8,9 +8,9 @@ defineSuite([
         'Core/defined',
         'Core/destroyObject',
         'Core/GeometryPipeline',
-        'Core/loadImage',
         'Core/Math',
         'Core/Matrix4',
+        'Core/Resource',
         'Renderer/BufferUsage',
         'Renderer/DrawCommand',
         'Renderer/Pass',
@@ -35,9 +35,9 @@ defineSuite([
         defined,
         destroyObject,
         GeometryPipeline,
-        loadImage,
         CesiumMath,
         Matrix4,
+        Resource,
         BufferUsage,
         DrawCommand,
         Pass,
@@ -65,13 +65,13 @@ defineSuite([
 
     beforeAll(function() {
         return when.join(
-            loadImage('./Data/Images/Green.png').then(function(image) {
+            Resource.fetchImage('./Data/Images/Green.png').then(function(image) {
                 greenImage = image;
             }),
-            loadImage('./Data/Images/Blue.png').then(function(image) {
+            Resource.fetchImage('./Data/Images/Blue.png').then(function(image) {
                 blueImage = image;
             }),
-            loadImage('./Data/Images/White.png').then(function(image) {
+            Resource.fetchImage('./Data/Images/White.png').then(function(image) {
                 whiteImage = image;
             }));
     });

--- a/Specs/Scene/ParticleSystemSpec.js
+++ b/Specs/Scene/ParticleSystemSpec.js
@@ -2,8 +2,8 @@ defineSuite([
         'Scene/ParticleSystem',
         'Core/Cartesian3',
         'Core/Color',
-        'Core/loadImage',
         'Core/Matrix4',
+        'Core/Resource',
         'Scene/CircleEmitter',
         'Scene/ParticleBurst',
         'Specs/createScene'
@@ -11,8 +11,8 @@ defineSuite([
         ParticleSystem,
         Cartesian3,
         Color,
-        loadImage,
         Matrix4,
+        Resource,
         CircleEmitter,
         ParticleBurst,
         createScene) {
@@ -23,7 +23,7 @@ defineSuite([
 
     beforeAll(function() {
         scene = createScene();
-        return loadImage('./Data/Images/Green2x2.png').then(function(result) {
+        return Resource.fetchImage('./Data/Images/Green2x2.png').then(function(result) {
             greenImage = result;
         });
     });

--- a/Specs/Scene/PrimitiveCullingSpec.js
+++ b/Specs/Scene/PrimitiveCullingSpec.js
@@ -4,11 +4,11 @@ defineSuite([
         'Core/ColorGeometryInstanceAttribute',
         'Core/defaultValue',
         'Core/GeometryInstance',
-        'Core/loadImage',
         'Core/Math',
         'Core/PerspectiveFrustum',
         'Core/Rectangle',
         'Core/RectangleGeometry',
+        'Core/Resource',
         'Core/Transforms',
         'Scene/BillboardCollection',
         'Scene/Globe',
@@ -27,11 +27,11 @@ defineSuite([
         ColorGeometryInstanceAttribute,
         defaultValue,
         GeometryInstance,
-        loadImage,
         CesiumMath,
         PerspectiveFrustum,
         Rectangle,
         RectangleGeometry,
+        Resource,
         Transforms,
         BillboardCollection,
         Globe,
@@ -55,7 +55,7 @@ defineSuite([
         scene = createScene();
         scene.primitives.destroyPrimitives = false;
 
-        return loadImage('./Data/Images/Green.png').then(function(image) {
+        return Resource.fetchImage('./Data/Images/Green.png').then(function(image) {
             greenImage = image;
         });
     });

--- a/Specs/Scene/SingleTileImageryProviderSpec.js
+++ b/Specs/Scene/SingleTileImageryProviderSpec.js
@@ -3,7 +3,6 @@ defineSuite([
         'Core/DefaultProxy',
         'Core/Ellipsoid',
         'Core/GeographicTilingScheme',
-        'Core/loadImage',
         'Core/Rectangle',
         'Core/Resource',
         'Scene/Imagery',
@@ -17,7 +16,6 @@ defineSuite([
         DefaultProxy,
         Ellipsoid,
         GeographicTilingScheme,
-        loadImage,
         Rectangle,
         Resource,
         Imagery,
@@ -29,7 +27,7 @@ defineSuite([
     'use strict';
 
     afterEach(function() {
-        loadImage.createImage = loadImage.defaultCreateImage;
+        Resource._Implementations.createImage = Resource._DefaultImplementations.createImage;
     });
 
     it('conforms to ImageryProvider interface', function() {
@@ -138,16 +136,16 @@ defineSuite([
     it('requests the single image immediately upon construction', function() {
         var imageUrl = 'Data/Images/Red16x16.png';
 
-        spyOn(loadImage, 'createImage').and.callFake(function(url, crossOrigin, deferred) {
+        spyOn(Resource._Implementations, 'createImage').and.callFake(function(url, crossOrigin, deferred) {
             expect(url).toEqual(imageUrl);
-            loadImage.defaultCreateImage(url, crossOrigin, deferred);
+            Resource._DefaultImplementations.createImage(url, crossOrigin, deferred);
         });
 
         var provider = new SingleTileImageryProvider({
             url : imageUrl
         });
 
-        expect(loadImage.createImage).toHaveBeenCalled();
+        expect(Resource._Implementations.createImage).toHaveBeenCalled();
 
         return pollToPromise(function() {
             return provider.ready;
@@ -185,9 +183,9 @@ defineSuite([
         var imageUrl = 'Data/Images/Red16x16.png';
         var proxy = new DefaultProxy('/proxy/');
 
-        spyOn(loadImage, 'createImage').and.callFake(function(url, crossOrigin, deferred) {
+        spyOn(Resource._Implementations, 'createImage').and.callFake(function(url, crossOrigin, deferred) {
             expect(url.indexOf(proxy.getURL('Data/Images/Red16x16.png'))).toEqual(0);
-            loadImage.defaultCreateImage(url, crossOrigin, deferred);
+            Resource._DefaultImplementations.createImage(url, crossOrigin, deferred);
         });
 
         var provider = new SingleTileImageryProvider({
@@ -195,7 +193,7 @@ defineSuite([
             proxy : proxy
         });
 
-        expect(loadImage.createImage).toHaveBeenCalled();
+        expect(Resource._Implementations.createImage).toHaveBeenCalled();
 
         expect(provider).toBeDefined();
         expect(provider.proxy).toEqual(proxy);
@@ -217,10 +215,10 @@ defineSuite([
             }
         });
 
-        loadImage.createImage = function(url, crossOrigin, deferred) {
+        Resource._Implementations.createImage = function(url, crossOrigin, deferred) {
             if (tries === 2) {
                 // Succeed after 2 tries
-                loadImage.defaultCreateImage('Data/Images/Red16x16.png', crossOrigin, deferred);
+                Resource._DefaultImplementations.createImage('Data/Images/Red16x16.png', crossOrigin, deferred);
             } else {
                 // fail
                 setTimeout(function() {

--- a/Specs/Scene/SkyBoxSpec.js
+++ b/Specs/Scene/SkyBoxSpec.js
@@ -1,11 +1,11 @@
 defineSuite([
         'Scene/SkyBox',
-        'Core/loadImage',
+        'Core/Resource',
         'Scene/SceneMode',
         'Specs/createScene'
     ], function(
         SkyBox,
-        loadImage,
+        Resource,
         SceneMode,
         createScene) {
     'use strict';
@@ -17,7 +17,7 @@ defineSuite([
     beforeAll(function() {
         scene = createScene();
 
-        return loadImage('./Data/Images/Blue.png').then(function(image) {
+        return Resource.fetchImage('./Data/Images/Blue.png').then(function(image) {
             loadedImage = image;
         });
     });

--- a/Specs/Scene/TextureAtlasSpec.js
+++ b/Specs/Scene/TextureAtlasSpec.js
@@ -2,18 +2,18 @@ defineSuite([
         'Scene/TextureAtlas',
         'Core/BoundingRectangle',
         'Core/Cartesian2',
-        'Core/loadImage',
         'Core/Math',
         'Core/PixelFormat',
+        'Core/Resource',
         'Specs/createScene',
         'ThirdParty/when'
     ], function(
         TextureAtlas,
         BoundingRectangle,
         Cartesian2,
-        loadImage,
         CesiumMath,
         PixelFormat,
+        Resource,
         createScene,
         when) {
     'use strict';
@@ -31,22 +31,22 @@ defineSuite([
         scene = createScene();
 
         return when.join(
-            loadImage('./Data/Images/Green.png').then(function(image) {
+            Resource.fetchImage('./Data/Images/Green.png').then(function(image) {
                 greenImage = image;
             }),
-            loadImage('./Data/Images/Green1x4.png').then(function(image) {
+            Resource.fetchImage('./Data/Images/Green1x4.png').then(function(image) {
                 tallGreenImage = image;
             }),
-            loadImage('./Data/Images/Blue.png').then(function(image) {
+            Resource.fetchImage('./Data/Images/Blue.png').then(function(image) {
                 blueImage = image;
             }),
-            loadImage('./Data/Images/Red16x16.png').then(function(image) {
+            Resource.fetchImage('./Data/Images/Red16x16.png').then(function(image) {
                 bigRedImage = image;
             }),
-            loadImage('./Data/Images/Blue10x10.png').then(function(image) {
+            Resource.fetchImage('./Data/Images/Blue10x10.png').then(function(image) {
                 bigBlueImage = image;
             }),
-            loadImage('./Data/Images/Green4x4.png').then(function(image) {
+            Resource.fetchImage('./Data/Images/Green4x4.png').then(function(image) {
                 bigGreenImage = image;
             }));
     });

--- a/Specs/Scene/UrlTemplateImageryProviderSpec.js
+++ b/Specs/Scene/UrlTemplateImageryProviderSpec.js
@@ -3,7 +3,6 @@ defineSuite([
         'Core/DefaultProxy',
         'Core/Ellipsoid',
         'Core/GeographicTilingScheme',
-        'Core/loadImage',
         'Core/Math',
         'Core/Rectangle',
         'Core/RequestScheduler',
@@ -22,7 +21,6 @@ defineSuite([
         DefaultProxy,
         Ellipsoid,
         GeographicTilingScheme,
-        loadImage,
         CesiumMath,
         Rectangle,
         RequestScheduler,
@@ -43,7 +41,7 @@ defineSuite([
     });
 
     afterEach(function() {
-        loadImage.createImage = loadImage.defaultCreateImage;
+        Resource._Implementations.createImage = Resource._DefaultImplementations.createImage;
     });
 
     it('conforms to ImageryProvider interface', function() {
@@ -113,13 +111,13 @@ defineSuite([
             expect(provider.tilingScheme).toBeInstanceOf(WebMercatorTilingScheme);
             expect(provider.rectangle).toEqual(new WebMercatorTilingScheme().rectangle);
 
-            spyOn(loadImage, 'createImage').and.callFake(function(url, crossOrigin, deferred) {
+            spyOn(Resource._Implementations, 'createImage').and.callFake(function(url, crossOrigin, deferred) {
                 // Just return any old image.
-                loadImage.defaultCreateImage('Data/Images/Red16x16.png', crossOrigin, deferred);
+                Resource._DefaultImplementations.createImage('Data/Images/Red16x16.png', crossOrigin, deferred);
             });
 
             return provider.requestImage(0, 0, 0).then(function(image) {
-                expect(loadImage.createImage).toHaveBeenCalled();
+                expect(Resource._Implementations.createImage).toHaveBeenCalled();
                 expect(image).toBeInstanceOf(Image);
             });
         });
@@ -152,15 +150,15 @@ defineSuite([
         }).then(function() {
             expect(provider.proxy).toEqual(proxy);
 
-            spyOn(loadImage, 'createImage').and.callFake(function(url, crossOrigin, deferred) {
+            spyOn(Resource._Implementations, 'createImage').and.callFake(function(url, crossOrigin, deferred) {
                 expect(url.indexOf(proxy.getURL('made/up/tms/server'))).toEqual(0);
 
                 // Just return any old image.
-                loadImage.defaultCreateImage('Data/Images/Red16x16.png', crossOrigin, deferred);
+                Resource._DefaultImplementations.createImage('Data/Images/Red16x16.png', crossOrigin, deferred);
             });
 
             return provider.requestImage(0, 0, 0).then(function(image) {
-                expect(loadImage.createImage).toHaveBeenCalled();
+                expect(Resource._Implementations.createImage).toHaveBeenCalled();
                 expect(image).toBeInstanceOf(Image);
             });
         });
@@ -184,15 +182,15 @@ defineSuite([
             expect(provider.rectangle).toEqualEpsilon(rectangle, CesiumMath.EPSILON14);
             expect(provider.tileDiscardPolicy).toBeUndefined();
 
-            spyOn(loadImage, 'createImage').and.callFake(function(url, crossOrigin, deferred) {
+            spyOn(Resource._Implementations, 'createImage').and.callFake(function(url, crossOrigin, deferred) {
                 expect(url).toContain('/0/0/0');
 
                 // Just return any old image.
-                loadImage.defaultCreateImage('Data/Images/Red16x16.png', crossOrigin, deferred);
+                Resource._DefaultImplementations.createImage('Data/Images/Red16x16.png', crossOrigin, deferred);
             });
 
             return provider.requestImage(0, 0, 0).then(function(image) {
-                expect(loadImage.createImage).toHaveBeenCalled();
+                expect(Resource._Implementations.createImage).toHaveBeenCalled();
                 expect(image).toBeInstanceOf(Image);
             });
         });
@@ -232,10 +230,10 @@ defineSuite([
             }, 1);
         });
 
-        loadImage.createImage = function(url, crossOrigin, deferred) {
+        Resource._Implementations.createImage = function(url, crossOrigin, deferred) {
             if (tries === 2) {
                 // Succeed after 2 tries
-                loadImage.defaultCreateImage('Data/Images/Red16x16.png', crossOrigin, deferred);
+                Resource._DefaultImplementations.createImage('Data/Images/Red16x16.png', crossOrigin, deferred);
             } else {
                 // fail
                 setTimeout(function() {
@@ -272,15 +270,15 @@ defineSuite([
         return pollToPromise(function() {
             return provider.ready;
         }).then(function() {
-            spyOn(loadImage, 'createImage').and.callFake(function(url, crossOrigin, deferred) {
+            spyOn(Resource._Implementations, 'createImage').and.callFake(function(url, crossOrigin, deferred) {
                 expect(url).toEqual('made/up/tms/server/2/3/2/1/4/3.PNG');
 
                 // Just return any old image.
-                loadImage.defaultCreateImage('Data/Images/Red16x16.png', crossOrigin, deferred);
+                Resource._DefaultImplementations.createImage('Data/Images/Red16x16.png', crossOrigin, deferred);
             });
 
             return provider.requestImage(3, 1, 2).then(function(image) {
-                expect(loadImage.createImage).toHaveBeenCalled();
+                expect(Resource._Implementations.createImage).toHaveBeenCalled();
                 expect(image).toBeInstanceOf(Image);
             });
         });
@@ -301,15 +299,15 @@ defineSuite([
         return pollToPromise(function() {
             return provider.ready;
         }).then(function() {
-            spyOn(loadImage, 'createImage').and.callFake(function(url, crossOrigin, deferred) {
+            spyOn(Resource._Implementations, 'createImage').and.callFake(function(url, crossOrigin, deferred) {
                 expect(url).toEqual('made/up/tms/server/0002/3/2/0001/4/0003.PNG');
 
                 // Just return any old image.
-                loadImage.defaultCreateImage('Data/Images/Red16x16.png', crossOrigin, deferred);
+                Resource._DefaultImplementations.createImage('Data/Images/Red16x16.png', crossOrigin, deferred);
             });
 
             return provider.requestImage(3, 1, 2).then(function(image) {
-                expect(loadImage.createImage).toHaveBeenCalled();
+                expect(Resource._Implementations.createImage).toHaveBeenCalled();
                 expect(image).toBeInstanceOf(Image);
             });
         });
@@ -330,15 +328,15 @@ defineSuite([
         return pollToPromise(function() {
             return provider.ready;
         }).then(function() {
-            spyOn(loadImage, 'createImage').and.callFake(function(url, crossOrigin, deferred) {
+            spyOn(Resource._Implementations, 'createImage').and.callFake(function(url, crossOrigin, deferred) {
                 expect(url).toEqual('made/up/tms/server/2/0003/0002/1/0004/3.PNG');
 
                 // Just return any old image.
-                loadImage.defaultCreateImage('Data/Images/Red16x16.png', crossOrigin, deferred);
+                Resource._DefaultImplementations.createImage('Data/Images/Red16x16.png', crossOrigin, deferred);
             });
 
             return provider.requestImage(3, 1, 2).then(function(image) {
-                expect(loadImage.createImage).toHaveBeenCalled();
+                expect(Resource._Implementations.createImage).toHaveBeenCalled();
                 expect(image).toBeInstanceOf(Image);
             });
         });
@@ -359,15 +357,15 @@ defineSuite([
         return pollToPromise(function() {
             return provider.ready;
         }).then(function() {
-            spyOn(loadImage, 'createImage').and.callFake(function(url, crossOrigin, deferred) {
+            spyOn(Resource._Implementations, 'createImage').and.callFake(function(url, crossOrigin, deferred) {
                 expect(url).toEqual('made/up/tms/server/0005/0/21/0010/51/0012.PNG');
 
                 // Just return any old image.
-                loadImage.defaultCreateImage('Data/Images/Red16x16.png', crossOrigin, deferred);
+                Resource._DefaultImplementations.createImage('Data/Images/Red16x16.png', crossOrigin, deferred);
             });
 
             return provider.requestImage(12, 10, 5).then(function(image) {
-                expect(loadImage.createImage).toHaveBeenCalled();
+                expect(Resource._Implementations.createImage).toHaveBeenCalled();
                 expect(image).toBeInstanceOf(Image);
             });
         });
@@ -382,15 +380,15 @@ defineSuite([
         return pollToPromise(function() {
             return provider.ready;
         }).then(function() {
-            spyOn(loadImage, 'createImage').and.callFake(function(url, crossOrigin, deferred) {
+            spyOn(Resource._Implementations, 'createImage').and.callFake(function(url, crossOrigin, deferred) {
                 expect(url).toEqualEpsilon(45.0, CesiumMath.EPSILON11);
 
                 // Just return any old image.
-                loadImage.defaultCreateImage('Data/Images/Red16x16.png', crossOrigin, deferred);
+                Resource._DefaultImplementations.createImage('Data/Images/Red16x16.png', crossOrigin, deferred);
             });
 
             return provider.requestImage(3, 1, 2).then(function(image) {
-                expect(loadImage.createImage).toHaveBeenCalled();
+                expect(Resource._Implementations.createImage).toHaveBeenCalled();
                 expect(image).toBeInstanceOf(Image);
             });
         });
@@ -405,15 +403,15 @@ defineSuite([
         return pollToPromise(function() {
             return provider.ready;
         }).then(function() {
-            spyOn(loadImage, 'createImage').and.callFake(function(url, crossOrigin, deferred) {
+            spyOn(Resource._Implementations, 'createImage').and.callFake(function(url, crossOrigin, deferred) {
                 expect(url).toEqualEpsilon(0.0, CesiumMath.EPSILON11);
 
                 // Just return any old image.
-                loadImage.defaultCreateImage('Data/Images/Red16x16.png', crossOrigin, deferred);
+                Resource._DefaultImplementations.createImage('Data/Images/Red16x16.png', crossOrigin, deferred);
             });
 
             return provider.requestImage(3, 1, 2).then(function(image) {
-                expect(loadImage.createImage).toHaveBeenCalled();
+                expect(Resource._Implementations.createImage).toHaveBeenCalled();
                 expect(image).toBeInstanceOf(Image);
             });
         });
@@ -428,15 +426,15 @@ defineSuite([
         return pollToPromise(function() {
             return provider.ready;
         }).then(function() {
-            spyOn(loadImage, 'createImage').and.callFake(function(url, crossOrigin, deferred) {
+            spyOn(Resource._Implementations, 'createImage').and.callFake(function(url, crossOrigin, deferred) {
                 expect(url).toEqualEpsilon(0.0, CesiumMath.EPSILON11);
 
                 // Just return any old image.
-                loadImage.defaultCreateImage('Data/Images/Red16x16.png', crossOrigin, deferred);
+                Resource._DefaultImplementations.createImage('Data/Images/Red16x16.png', crossOrigin, deferred);
             });
 
             return provider.requestImage(3, 1, 2).then(function(image) {
-                expect(loadImage.createImage).toHaveBeenCalled();
+                expect(Resource._Implementations.createImage).toHaveBeenCalled();
                 expect(image).toBeInstanceOf(Image);
             });
         });
@@ -451,15 +449,15 @@ defineSuite([
         return pollToPromise(function() {
             return provider.ready;
         }).then(function() {
-            spyOn(loadImage, 'createImage').and.callFake(function(url, crossOrigin, deferred) {
+            spyOn(Resource._Implementations, 'createImage').and.callFake(function(url, crossOrigin, deferred) {
                 expect(url).toEqualEpsilon(-45.0, CesiumMath.EPSILON11);
 
                 // Just return any old image.
-                loadImage.defaultCreateImage('Data/Images/Red16x16.png', crossOrigin, deferred);
+                Resource._DefaultImplementations.createImage('Data/Images/Red16x16.png', crossOrigin, deferred);
             });
 
             return provider.requestImage(3, 1, 2).then(function(image) {
-                expect(loadImage.createImage).toHaveBeenCalled();
+                expect(Resource._Implementations.createImage).toHaveBeenCalled();
                 expect(image).toBeInstanceOf(Image);
             });
         });
@@ -474,15 +472,15 @@ defineSuite([
         return pollToPromise(function() {
             return provider.ready;
         }).then(function() {
-            spyOn(loadImage, 'createImage').and.callFake(function(url, crossOrigin, deferred) {
+            spyOn(Resource._Implementations, 'createImage').and.callFake(function(url, crossOrigin, deferred) {
                 expect(url).toEqualEpsilon(Math.PI * Ellipsoid.WGS84.maximumRadius / 2.0, CesiumMath.EPSILON11);
 
                 // Just return any old image.
-                loadImage.defaultCreateImage('Data/Images/Red16x16.png', crossOrigin, deferred);
+                Resource._DefaultImplementations.createImage('Data/Images/Red16x16.png', crossOrigin, deferred);
             });
 
             return provider.requestImage(3, 1, 2).then(function(image) {
-                expect(loadImage.createImage).toHaveBeenCalled();
+                expect(Resource._Implementations.createImage).toHaveBeenCalled();
                 expect(image).toBeInstanceOf(Image);
             });
         });
@@ -496,15 +494,15 @@ defineSuite([
         return pollToPromise(function() {
             return provider.ready;
         }).then(function() {
-            spyOn(loadImage, 'createImage').and.callFake(function(url, crossOrigin, deferred) {
+            spyOn(Resource._Implementations, 'createImage').and.callFake(function(url, crossOrigin, deferred) {
                 expect(url).toEqualEpsilon(Math.PI * Ellipsoid.WGS84.maximumRadius / 2.0, CesiumMath.EPSILON11);
 
                 // Just return any old image.
-                loadImage.defaultCreateImage('Data/Images/Red16x16.png', crossOrigin, deferred);
+                Resource._DefaultImplementations.createImage('Data/Images/Red16x16.png', crossOrigin, deferred);
             });
 
             return provider.requestImage(3, 0, 2).then(function(image) {
-                expect(loadImage.createImage).toHaveBeenCalled();
+                expect(Resource._Implementations.createImage).toHaveBeenCalled();
                 expect(image).toBeInstanceOf(Image);
             });
         });
@@ -518,15 +516,15 @@ defineSuite([
         return pollToPromise(function() {
             return provider.ready;
         }).then(function() {
-            spyOn(loadImage, 'createImage').and.callFake(function(url, crossOrigin, deferred) {
+            spyOn(Resource._Implementations, 'createImage').and.callFake(function(url, crossOrigin, deferred) {
                 expect(url).toEqualEpsilon(-Math.PI * Ellipsoid.WGS84.maximumRadius / 2.0, CesiumMath.EPSILON11);
 
                 // Just return any old image.
-                loadImage.defaultCreateImage('Data/Images/Red16x16.png', crossOrigin, deferred);
+                Resource._DefaultImplementations.createImage('Data/Images/Red16x16.png', crossOrigin, deferred);
             });
 
             return provider.requestImage(0, 1, 2).then(function(image) {
-                expect(loadImage.createImage).toHaveBeenCalled();
+                expect(Resource._Implementations.createImage).toHaveBeenCalled();
                 expect(image).toBeInstanceOf(Image);
             });
         });
@@ -540,15 +538,15 @@ defineSuite([
         return pollToPromise(function() {
             return provider.ready;
         }).then(function() {
-            spyOn(loadImage, 'createImage').and.callFake(function(url, crossOrigin, deferred) {
+            spyOn(Resource._Implementations, 'createImage').and.callFake(function(url, crossOrigin, deferred) {
                 expect(url).toEqualEpsilon(-Math.PI * Ellipsoid.WGS84.maximumRadius / 2.0, CesiumMath.EPSILON11);
 
                 // Just return any old image.
-                loadImage.defaultCreateImage('Data/Images/Red16x16.png', crossOrigin, deferred);
+                Resource._DefaultImplementations.createImage('Data/Images/Red16x16.png', crossOrigin, deferred);
             });
 
             return provider.requestImage(1, 1, 2).then(function(image) {
-                expect(loadImage.createImage).toHaveBeenCalled();
+                expect(Resource._Implementations.createImage).toHaveBeenCalled();
                 expect(image).toBeInstanceOf(Image);
             });
         });
@@ -562,7 +560,7 @@ defineSuite([
         return pollToPromise(function() {
             return provider.ready;
         }).then(function() {
-            spyOn(loadImage, 'createImage').and.callFake(function(url, crossOrigin, deferred) {
+            spyOn(Resource._Implementations, 'createImage').and.callFake(function(url, crossOrigin, deferred) {
                 expect(url).toEqual(
                     '-90 ' +
                     (-Math.PI * Ellipsoid.WGS84.maximumRadius / 2.0) + ' ' +
@@ -574,11 +572,11 @@ defineSuite([
                     (Math.PI * Ellipsoid.WGS84.maximumRadius / 2.0));
 
                 // Just return any old image.
-                loadImage.defaultCreateImage('Data/Images/Red16x16.png', crossOrigin, deferred);
+                Resource._DefaultImplementations.createImage('Data/Images/Red16x16.png', crossOrigin, deferred);
             });
 
             return provider.requestImage(1, 1, 2).then(function(image) {
-                expect(loadImage.createImage).toHaveBeenCalled();
+                expect(Resource._Implementations.createImage).toHaveBeenCalled();
                 expect(image).toBeInstanceOf(Image);
             });
         });
@@ -592,15 +590,15 @@ defineSuite([
         return pollToPromise(function() {
             return provider.ready;
         }).then(function() {
-            spyOn(loadImage, 'createImage').and.callFake(function(url, crossOrigin, deferred) {
+            spyOn(Resource._Implementations, 'createImage').and.callFake(function(url, crossOrigin, deferred) {
                 expect(['a', 'b', 'c'].indexOf(url)).toBeGreaterThanOrEqualTo(0);
 
                 // Just return any old image.
-                loadImage.defaultCreateImage('Data/Images/Red16x16.png', crossOrigin, deferred);
+                Resource._DefaultImplementations.createImage('Data/Images/Red16x16.png', crossOrigin, deferred);
             });
 
             return provider.requestImage(3, 1, 2).then(function(image) {
-                expect(loadImage.createImage).toHaveBeenCalled();
+                expect(Resource._Implementations.createImage).toHaveBeenCalled();
                 expect(image).toBeInstanceOf(Image);
             });
         });
@@ -615,15 +613,15 @@ defineSuite([
         return pollToPromise(function() {
             return provider.ready;
         }).then(function() {
-            spyOn(loadImage, 'createImage').and.callFake(function(url, crossOrigin, deferred) {
+            spyOn(Resource._Implementations, 'createImage').and.callFake(function(url, crossOrigin, deferred) {
                 expect(['1', '2', '3'].indexOf(url)).toBeGreaterThanOrEqualTo(0);
 
                 // Just return any old image.
-                loadImage.defaultCreateImage('Data/Images/Red16x16.png', crossOrigin, deferred);
+                Resource._DefaultImplementations.createImage('Data/Images/Red16x16.png', crossOrigin, deferred);
             });
 
             return provider.requestImage(3, 1, 2).then(function(image) {
-                expect(loadImage.createImage).toHaveBeenCalled();
+                expect(Resource._Implementations.createImage).toHaveBeenCalled();
                 expect(image).toBeInstanceOf(Image);
             });
         });
@@ -638,15 +636,15 @@ defineSuite([
         return pollToPromise(function() {
             return provider.ready;
         }).then(function() {
-            spyOn(loadImage, 'createImage').and.callFake(function(url, crossOrigin, deferred) {
+            spyOn(Resource._Implementations, 'createImage').and.callFake(function(url, crossOrigin, deferred) {
                 expect(['foo', 'bar'].indexOf(url)).toBeGreaterThanOrEqualTo(0);
 
                 // Just return any old image.
-                loadImage.defaultCreateImage('Data/Images/Red16x16.png', crossOrigin, deferred);
+                Resource._DefaultImplementations.createImage('Data/Images/Red16x16.png', crossOrigin, deferred);
             });
 
             return provider.requestImage(3, 1, 2).then(function(image) {
-                expect(loadImage.createImage).toHaveBeenCalled();
+                expect(Resource._Implementations.createImage).toHaveBeenCalled();
                 expect(image).toBeInstanceOf(Image);
             });
         });
@@ -666,15 +664,15 @@ defineSuite([
         return pollToPromise(function() {
             return provider.ready;
         }).then(function() {
-            spyOn(loadImage, 'createImage').and.callFake(function(url, crossOrigin, deferred) {
+            spyOn(Resource._Implementations, 'createImage').and.callFake(function(url, crossOrigin, deferred) {
                 expect(url).toEqual('made/up/tms/server/foo/bar/2/1/3.PNG');
 
                 // Just return any old image.
-                loadImage.defaultCreateImage('Data/Images/Red16x16.png', crossOrigin, deferred);
+                Resource._DefaultImplementations.createImage('Data/Images/Red16x16.png', crossOrigin, deferred);
             });
 
             return provider.requestImage(3, 1, 2).then(function(image) {
-                expect(loadImage.createImage).toHaveBeenCalled();
+                expect(Resource._Implementations.createImage).toHaveBeenCalled();
                 expect(image).toBeInstanceOf(Image);
             });
         });

--- a/Specs/Scene/ViewportQuadSpec.js
+++ b/Specs/Scene/ViewportQuadSpec.js
@@ -2,7 +2,7 @@ defineSuite([
         'Scene/ViewportQuad',
         'Core/BoundingRectangle',
         'Core/Color',
-        'Core/loadImage',
+        'Core/Resource',
         'Renderer/Texture',
         'Scene/Material',
         'Specs/createScene',
@@ -11,7 +11,7 @@ defineSuite([
         ViewportQuad,
         BoundingRectangle,
         Color,
-        loadImage,
+        Resource,
         Texture,
         Material,
         createScene,
@@ -24,7 +24,7 @@ defineSuite([
 
     beforeAll(function() {
         scene = createScene();
-        return loadImage('./Data/Images/Red16x16.png').then(function(image) {
+        return Resource.fetchImage('./Data/Images/Red16x16.png').then(function(image) {
             testImage = image;
         });
     });

--- a/Specs/Scene/WebMapServiceImageryProviderSpec.js
+++ b/Specs/Scene/WebMapServiceImageryProviderSpec.js
@@ -4,8 +4,6 @@ defineSuite([
         'Core/DefaultProxy',
         'Core/Ellipsoid',
         'Core/GeographicTilingScheme',
-        'Core/loadImage',
-        'Core/loadWithXhr',
         'Core/Math',
         'Core/queryToObject',
         'Core/Rectangle',
@@ -26,8 +24,6 @@ defineSuite([
         DefaultProxy,
         Ellipsoid,
         GeographicTilingScheme,
-        loadImage,
-        loadWithXhr,
         CesiumMath,
         queryToObject,
         Rectangle,
@@ -49,8 +45,8 @@ defineSuite([
     });
 
     afterEach(function() {
-        loadImage.createImage = loadImage.defaultCreateImage;
-        loadWithXhr.load = loadWithXhr.defaultLoad;
+        Resource._Implementations.createImage = Resource._DefaultImplementations.createImage;
+        Resource._Implementations.loadWithXhr = Resource._DefaultImplementations.loadWithXhr;
     });
 
     it('conforms to ImageryProvider interface', function() {
@@ -145,7 +141,7 @@ defineSuite([
         return pollToPromise(function() {
             return provider.ready;
         }).then(function() {
-            spyOn(loadImage, 'createImage').and.callFake(function(url, crossOrigin, deferred) {
+            spyOn(Resource._Implementations, 'createImage').and.callFake(function(url, crossOrigin, deferred) {
                 var uri = new Uri(url);
                 var params = queryToObject(uri.query);
                 expect(params.something).toEqual('foo');
@@ -157,7 +153,7 @@ defineSuite([
             });
 
             return provider.requestImage(0, 0, 0).then(function(image) {
-                expect(loadImage.createImage).toHaveBeenCalled();
+                expect(Resource._Implementations.createImage).toHaveBeenCalled();
             });
 
         });
@@ -198,7 +194,7 @@ defineSuite([
         return pollToPromise(function() {
             return provider.ready;
         }).then(function() {
-            spyOn(loadImage, 'createImage').and.callFake(function(url, crossOrigin, deferred) {
+            spyOn(Resource._Implementations, 'createImage').and.callFake(function(url, crossOrigin, deferred) {
                 var questionMarkCount = url.match(/\?/g).length;
                 expect(questionMarkCount).toEqual(1);
 
@@ -207,7 +203,7 @@ defineSuite([
             });
 
             return provider.requestImage(0, 0, 0).then(function(image) {
-                expect(loadImage.createImage).toHaveBeenCalled();
+                expect(Resource._Implementations.createImage).toHaveBeenCalled();
             });
         });
     });
@@ -221,7 +217,7 @@ defineSuite([
         return pollToPromise(function() {
             return provider.ready;
         }).then(function() {
-            spyOn(loadImage, 'createImage').and.callFake(function(url, crossOrigin, deferred) {
+            spyOn(Resource._Implementations, 'createImage').and.callFake(function(url, crossOrigin, deferred) {
                 var questionMarkCount = url.match(/\?/g).length;
                 expect(questionMarkCount).toEqual(1);
                 expect(url).not.toContain('&&');
@@ -231,7 +227,7 @@ defineSuite([
             });
 
             return provider.requestImage(0, 0, 0).then(function(image) {
-                expect(loadImage.createImage).toHaveBeenCalled();
+                expect(Resource._Implementations.createImage).toHaveBeenCalled();
             });
         });
     });
@@ -245,7 +241,7 @@ defineSuite([
         return pollToPromise(function() {
             return provider.ready;
         }).then(function() {
-            spyOn(loadImage, 'createImage').and.callFake(function(url, crossOrigin, deferred) {
+            spyOn(Resource._Implementations, 'createImage').and.callFake(function(url, crossOrigin, deferred) {
                 var questionMarkCount = url.match(/\?/g).length;
                 expect(questionMarkCount).toEqual(1);
 
@@ -259,7 +255,7 @@ defineSuite([
 
             provider.requestImage(0, 0, 0);
 
-            expect(loadImage.createImage).toHaveBeenCalled();
+            expect(Resource._Implementations.createImage).toHaveBeenCalled();
         });
     });
 
@@ -273,7 +269,7 @@ defineSuite([
         return pollToPromise(function() {
             return provider.ready;
         }).then(function() {
-            spyOn(loadImage, 'createImage').and.callFake(function(url, crossOrigin, deferred) {
+            spyOn(Resource._Implementations, 'createImage').and.callFake(function(url, crossOrigin, deferred) {
 
                 var uri = new Uri(url);
                 var params = queryToObject(uri.query);
@@ -285,7 +281,7 @@ defineSuite([
 
             provider.requestImage(0, 0, 0);
 
-            expect(loadImage.createImage).toHaveBeenCalled();
+            expect(Resource._Implementations.createImage).toHaveBeenCalled();
         });
     });
 
@@ -307,13 +303,13 @@ defineSuite([
             expect(provider.tilingScheme).toBeInstanceOf(GeographicTilingScheme);
             expect(provider.rectangle).toEqual(new GeographicTilingScheme().rectangle);
 
-            spyOn(loadImage, 'createImage').and.callFake(function(url, crossOrigin, deferred) {
+            spyOn(Resource._Implementations, 'createImage').and.callFake(function(url, crossOrigin, deferred) {
                 // Just return any old image.
-                loadImage.defaultCreateImage('Data/Images/Red16x16.png', crossOrigin, deferred);
+                Resource._DefaultImplementations.createImage('Data/Images/Red16x16.png', crossOrigin, deferred);
             });
 
             return provider.requestImage(0, 0, 0).then(function(image) {
-                expect(loadImage.createImage).toHaveBeenCalled();
+                expect(Resource._Implementations.createImage).toHaveBeenCalled();
                 expect(image).toBeInstanceOf(Image);
             });
         });
@@ -339,7 +335,7 @@ defineSuite([
             expect(provider.tilingScheme).toBeInstanceOf(WebMercatorTilingScheme);
             expect(provider.rectangle).toEqual(new WebMercatorTilingScheme().rectangle);
 
-            spyOn(loadImage, 'createImage').and.callFake(function(url, crossOrigin, deferred) {
+            spyOn(Resource._Implementations, 'createImage').and.callFake(function(url, crossOrigin, deferred) {
                 var uri = new Uri(url);
                 var params = queryToObject(uri.query);
 
@@ -349,11 +345,11 @@ defineSuite([
                 var rect = tilingScheme.tileXYToNativeRectangle(0, 0, 0);
                 expect(params.bbox).toEqual(rect.west + ',' + rect.south + ',' + rect.east + ',' + rect.north);
 
-                loadImage.defaultCreateImage('Data/Images/Red16x16.png', crossOrigin, deferred);
+                Resource._DefaultImplementations.createImage('Data/Images/Red16x16.png', crossOrigin, deferred);
             });
 
             return provider.requestImage(0, 0, 0).then(function(image) {
-                expect(loadImage.createImage).toHaveBeenCalled();
+                expect(Resource._Implementations.createImage).toHaveBeenCalled();
                 expect(image).toBeInstanceOf(Image);
             });
         });
@@ -382,7 +378,7 @@ defineSuite([
             expect(provider.tilingScheme).toBeInstanceOf(WebMercatorTilingScheme);
             expect(provider.rectangle).toEqual(new WebMercatorTilingScheme().rectangle);
 
-            spyOn(loadImage, 'createImage').and.callFake(function(url, crossOrigin, deferred) {
+            spyOn(Resource._Implementations, 'createImage').and.callFake(function(url, crossOrigin, deferred) {
                 var uri = new Uri(url);
                 var params = queryToObject(uri.query);
 
@@ -392,11 +388,11 @@ defineSuite([
                 var rect = tilingScheme.tileXYToNativeRectangle(0, 0, 0);
                 expect(params.bbox).toEqual(rect.west + ',' + rect.south + ',' + rect.east + ',' + rect.north);
 
-                loadImage.defaultCreateImage('Data/Images/Red16x16.png', crossOrigin, deferred);
+                Resource._DefaultImplementations.createImage('Data/Images/Red16x16.png', crossOrigin, deferred);
             });
 
             return provider.requestImage(0, 0, 0).then(function(image) {
-                expect(loadImage.createImage).toHaveBeenCalled();
+                expect(Resource._Implementations.createImage).toHaveBeenCalled();
                 expect(image).toBeInstanceOf(Image);
             });
         });
@@ -422,7 +418,7 @@ defineSuite([
             expect(provider.tilingScheme).toBeInstanceOf(GeographicTilingScheme);
             expect(provider.rectangle).toEqual(new GeographicTilingScheme().rectangle);
 
-            spyOn(loadImage, 'createImage').and.callFake(function(url, crossOrigin, deferred) {
+            spyOn(Resource._Implementations, 'createImage').and.callFake(function(url, crossOrigin, deferred) {
                 var uri = new Uri(url);
                 var params = queryToObject(uri.query);
 
@@ -432,11 +428,11 @@ defineSuite([
                 var rect = tilingScheme.tileXYToNativeRectangle(0, 0, 0);
                 expect(params.bbox).toEqual(rect.west + ',' + rect.south + ',' + rect.east + ',' + rect.north);
 
-                loadImage.defaultCreateImage('Data/Images/Red16x16.png', crossOrigin, deferred);
+                Resource._DefaultImplementations.createImage('Data/Images/Red16x16.png', crossOrigin, deferred);
             });
 
             return provider.requestImage(0, 0, 0).then(function(image) {
-                expect(loadImage.createImage).toHaveBeenCalled();
+                expect(Resource._Implementations.createImage).toHaveBeenCalled();
                 expect(image).toBeInstanceOf(Image);
             });
         });
@@ -465,7 +461,7 @@ defineSuite([
             expect(provider.tilingScheme).toBeInstanceOf(GeographicTilingScheme);
             expect(provider.rectangle).toEqual(new GeographicTilingScheme().rectangle);
 
-            spyOn(loadImage, 'createImage').and.callFake(function(url, crossOrigin, deferred) {
+            spyOn(Resource._Implementations, 'createImage').and.callFake(function(url, crossOrigin, deferred) {
                 var uri = new Uri(url);
                 var params = queryToObject(uri.query);
 
@@ -475,11 +471,11 @@ defineSuite([
                 var rect = tilingScheme.tileXYToNativeRectangle(0, 0, 0);
                 expect(params.bbox).toEqual(rect.west + ',' + rect.south + ',' + rect.east + ',' + rect.north);
 
-                loadImage.defaultCreateImage('Data/Images/Red16x16.png', crossOrigin, deferred);
+                Resource._DefaultImplementations.createImage('Data/Images/Red16x16.png', crossOrigin, deferred);
             });
 
             return provider.requestImage(0, 0, 0).then(function(image) {
-                expect(loadImage.createImage).toHaveBeenCalled();
+                expect(Resource._Implementations.createImage).toHaveBeenCalled();
                 expect(image).toBeInstanceOf(Image);
             });
         });
@@ -508,7 +504,7 @@ defineSuite([
             expect(provider.tilingScheme).toBeInstanceOf(GeographicTilingScheme);
             expect(provider.rectangle).toEqual(new GeographicTilingScheme().rectangle);
 
-            spyOn(loadImage, 'createImage').and.callFake(function(url, crossOrigin, deferred) {
+            spyOn(Resource._Implementations, 'createImage').and.callFake(function(url, crossOrigin, deferred) {
                 var uri = new Uri(url);
                 var params = queryToObject(uri.query);
 
@@ -518,11 +514,11 @@ defineSuite([
                 var rect = tilingScheme.tileXYToNativeRectangle(0, 0, 0);
                 expect(params.bbox).toEqual(rect.west + ',' + rect.south + ',' + rect.east + ',' + rect.north);
 
-                loadImage.defaultCreateImage('Data/Images/Red16x16.png', crossOrigin, deferred);
+                Resource._DefaultImplementations.createImage('Data/Images/Red16x16.png', crossOrigin, deferred);
             });
 
             return provider.requestImage(0, 0, 0).then(function(image) {
-                expect(loadImage.createImage).toHaveBeenCalled();
+                expect(Resource._Implementations.createImage).toHaveBeenCalled();
                 expect(image).toBeInstanceOf(Image);
             });
         });
@@ -551,7 +547,7 @@ defineSuite([
             expect(provider.tilingScheme).toBeInstanceOf(GeographicTilingScheme);
             expect(provider.rectangle).toEqual(new GeographicTilingScheme().rectangle);
 
-            spyOn(loadImage, 'createImage').and.callFake(function(url, crossOrigin, deferred) {
+            spyOn(Resource._Implementations, 'createImage').and.callFake(function(url, crossOrigin, deferred) {
                 var uri = new Uri(url);
                 var params = queryToObject(uri.query);
 
@@ -561,11 +557,11 @@ defineSuite([
                 var rect = tilingScheme.tileXYToNativeRectangle(0, 0, 0);
                 expect(params.bbox).toEqual(rect.west + ',' + rect.south + ',' + rect.east + ',' + rect.north);
 
-                loadImage.defaultCreateImage('Data/Images/Red16x16.png', crossOrigin, deferred);
+                Resource._DefaultImplementations.createImage('Data/Images/Red16x16.png', crossOrigin, deferred);
             });
 
             return provider.requestImage(0, 0, 0).then(function(image) {
-                expect(loadImage.createImage).toHaveBeenCalled();
+                expect(Resource._Implementations.createImage).toHaveBeenCalled();
                 expect(image).toBeInstanceOf(Image);
             });
         });
@@ -583,7 +579,7 @@ defineSuite([
         return pollToPromise(function() {
             return provider.ready;
         }).then(function() {
-            spyOn(loadImage, 'createImage').and.callFake(function(url, crossOrigin, deferred) {
+            spyOn(Resource._Implementations, 'createImage').and.callFake(function(url, crossOrigin, deferred) {
                 var uri = new Uri(url);
                 var params = queryToObject(uri.query);
 
@@ -591,11 +587,11 @@ defineSuite([
                 expect(params.format).not.toEqual('image/jpeg');
 
                 // Just return any old image.
-                loadImage.defaultCreateImage('Data/Images/Red16x16.png', crossOrigin, deferred);
+                Resource._DefaultImplementations.createImage('Data/Images/Red16x16.png', crossOrigin, deferred);
             });
 
             return provider.requestImage(0, 0, 0).then(function(image) {
-                expect(loadImage.createImage).toHaveBeenCalled();
+                expect(Resource._Implementations.createImage).toHaveBeenCalled();
             });
         });
     });
@@ -628,15 +624,15 @@ defineSuite([
         }).then(function() {
             expect(provider.proxy).toEqual(proxy);
 
-            spyOn(loadImage, 'createImage').and.callFake(function(url, crossOrigin, deferred) {
+            spyOn(Resource._Implementations, 'createImage').and.callFake(function(url, crossOrigin, deferred) {
                 expect(url.indexOf(proxy.getURL('made/up/wms/server'))).toEqual(0);
 
                 // Just return any old image.
-                loadImage.defaultCreateImage('Data/Images/Red16x16.png', crossOrigin, deferred);
+                Resource._DefaultImplementations.createImage('Data/Images/Red16x16.png', crossOrigin, deferred);
             });
 
             return provider.requestImage(0, 0, 0).then(function(image) {
-                expect(loadImage.createImage).toHaveBeenCalled();
+                expect(Resource._Implementations.createImage).toHaveBeenCalled();
                 expect(image).toBeInstanceOf(Image);
             });
         });
@@ -731,10 +727,10 @@ defineSuite([
                 }, 1);
             });
 
-            loadImage.createImage = function(url, crossOrigin, deferred) {
+            Resource._Implementations.createImage = function(url, crossOrigin, deferred) {
                 if (tries === 2) {
                     // Succeed after 2 tries
-                    loadImage.defaultCreateImage('Data/Images/Red16x16.png', crossOrigin, deferred);
+                    Resource._DefaultImplementations.createImage('Data/Images/Red16x16.png', crossOrigin, deferred);
                 } else {
                     // fail
                     setTimeout(function() {
@@ -765,9 +761,9 @@ defineSuite([
                 layers : 'someLayer'
             });
 
-            loadWithXhr.load = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
+            Resource._Implementations.loadWithXhr = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
                 expect(url).toContain('GetFeatureInfo');
-                loadWithXhr.defaultLoad('Data/WMS/GetFeatureInfo-GeoJSON.json', responseType, method, data, headers, deferred, overrideMimeType);
+                Resource._DefaultImplementations.loadWithXhr('Data/WMS/GetFeatureInfo-GeoJSON.json', responseType, method, data, headers, deferred, overrideMimeType);
             };
 
             return pollToPromise(function() {
@@ -791,9 +787,9 @@ defineSuite([
                 layers : 'someLayer'
             });
 
-            loadWithXhr.load = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
+            Resource._Implementations.loadWithXhr = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
                 expect(url).toContain('GetFeatureInfo');
-                loadWithXhr.defaultLoad('Data/WMS/GetFeatureInfo-MapInfoMXP.xml', responseType, method, data, headers, deferred, overrideMimeType);
+                Resource._DefaultImplementations.loadWithXhr('Data/WMS/GetFeatureInfo-MapInfoMXP.xml', responseType, method, data, headers, deferred, overrideMimeType);
             };
 
             return pollToPromise(function() {
@@ -816,9 +812,9 @@ defineSuite([
                 layers : 'someLayer'
             });
 
-            loadWithXhr.load = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
+            Resource._Implementations.loadWithXhr = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
                 expect(url).toContain('GetFeatureInfo');
-                loadWithXhr.defaultLoad('Data/WMS/GetFeatureInfo-Esri.xml', responseType, method, data, headers, deferred, overrideMimeType);
+                Resource._DefaultImplementations.loadWithXhr('Data/WMS/GetFeatureInfo-Esri.xml', responseType, method, data, headers, deferred, overrideMimeType);
             };
 
             return pollToPromise(function() {
@@ -841,9 +837,9 @@ defineSuite([
                 layers : 'someLayer'
             });
 
-            loadWithXhr.load = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
+            Resource._Implementations.loadWithXhr = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
                 expect(url).toContain('GetFeatureInfo');
-                loadWithXhr.defaultLoad('Data/WMS/GetFeatureInfo-THREDDS.xml', responseType, method, data, headers, deferred, overrideMimeType);
+                Resource._DefaultImplementations.loadWithXhr('Data/WMS/GetFeatureInfo-THREDDS.xml', responseType, method, data, headers, deferred, overrideMimeType);
             };
 
             return pollToPromise(function() {
@@ -866,9 +862,9 @@ defineSuite([
                 layers : 'someLayer'
             });
 
-            loadWithXhr.load = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
+            Resource._Implementations.loadWithXhr = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
                 expect(url).toContain('GetFeatureInfo');
-                loadWithXhr.defaultLoad('Data/WMS/GetFeatureInfo-msGMLOutput.xml', responseType, method, data, headers, deferred, overrideMimeType);
+                Resource._DefaultImplementations.loadWithXhr('Data/WMS/GetFeatureInfo-msGMLOutput.xml', responseType, method, data, headers, deferred, overrideMimeType);
             };
 
             return pollToPromise(function() {
@@ -892,9 +888,9 @@ defineSuite([
                 layers : 'someLayer'
             });
 
-            loadWithXhr.load = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
+            Resource._Implementations.loadWithXhr = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
                 expect(url).toContain('GetFeatureInfo');
-                loadWithXhr.defaultLoad('Data/WMS/GetFeatureInfo-Unknown.xml', responseType, method, data, headers, deferred, overrideMimeType);
+                Resource._DefaultImplementations.loadWithXhr('Data/WMS/GetFeatureInfo-Unknown.xml', responseType, method, data, headers, deferred, overrideMimeType);
             };
 
             return pollToPromise(function() {
@@ -917,9 +913,9 @@ defineSuite([
                 layers : 'someLayer'
             });
 
-            loadWithXhr.load = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
+            Resource._Implementations.loadWithXhr = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
                 expect(url).toContain('GetFeatureInfo');
-                loadWithXhr.defaultLoad('Data/WMS/GetFeatureInfo-ServiceException.xml', responseType, method, data, headers, deferred, overrideMimeType);
+                Resource._DefaultImplementations.loadWithXhr('Data/WMS/GetFeatureInfo-ServiceException.xml', responseType, method, data, headers, deferred, overrideMimeType);
             };
 
             return pollToPromise(function() {
@@ -1004,10 +1000,10 @@ defineSuite([
                 ]
             });
 
-            loadWithXhr.load = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
+            Resource._Implementations.loadWithXhr = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
                 expect(url).toContain('GetFeatureInfo');
                 expect(url).not.toContain('json');
-                loadWithXhr.defaultLoad('Data/WMS/GetFeatureInfo-MapInfoMXP.xml', responseType, method, data, headers, deferred, overrideMimeType);
+                Resource._DefaultImplementations.loadWithXhr('Data/WMS/GetFeatureInfo-MapInfoMXP.xml', responseType, method, data, headers, deferred, overrideMimeType);
             };
 
             return pollToPromise(function() {
@@ -1036,14 +1032,14 @@ defineSuite([
             return pollToPromise(function() {
                 return provider.ready;
             }).then(function() {
-                loadWithXhr.load = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
+                Resource._Implementations.loadWithXhr = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
                     expect(url).toContain('GetFeatureInfo');
 
                     if (url.indexOf('json') >= 0) {
                         deferred.reject();
                     } else {
                         // this should not happen
-                        loadWithXhr.defaultLoad('Data/WMS/GetFeatureInfo-MapInfoMXP.xml', responseType, method, data, headers, deferred, overrideMimeType);
+                        Resource._DefaultImplementations.loadWithXhr('Data/WMS/GetFeatureInfo-MapInfoMXP.xml', responseType, method, data, headers, deferred, overrideMimeType);
                     }
                 };
 
@@ -1074,14 +1070,14 @@ defineSuite([
             return pollToPromise(function() {
                 return provider.ready;
             }).then(function() {
-                loadWithXhr.load = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
+                Resource._Implementations.loadWithXhr = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
                     expect(url).toContain('GetFeatureInfo');
 
                     if (url.indexOf(encodeURIComponent('application/foo')) < 0) {
                         deferred.reject();
                     }
 
-                    return loadWithXhr.defaultLoad('Data/WMS/GetFeatureInfo-Custom.json', responseType, method, data, headers, deferred, overrideMimeType);
+                    return Resource._DefaultImplementations.loadWithXhr('Data/WMS/GetFeatureInfo-Custom.json', responseType, method, data, headers, deferred, overrideMimeType);
                 };
 
                 return provider.pickFeatures(0, 0, 0, 0.5, 0.5).then(function(features) {
@@ -1097,12 +1093,12 @@ defineSuite([
                 layers : 'someLayer'
             });
 
-            loadWithXhr.load = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
+            Resource._Implementations.loadWithXhr = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
                 expect(url).toContain('GetFeatureInfo');
                 if (url.indexOf(encodeURIComponent('text/html')) < 0) {
                     deferred.reject();
                 }
-                loadWithXhr.defaultLoad('Data/WMS/GetFeatureInfo.html', responseType, method, data, headers, deferred, overrideMimeType);
+                Resource._DefaultImplementations.loadWithXhr('Data/WMS/GetFeatureInfo.html', responseType, method, data, headers, deferred, overrideMimeType);
             };
 
             return pollToPromise(function() {

--- a/Specs/Scene/WebMapTileServiceImageryProviderSpec.js
+++ b/Specs/Scene/WebMapTileServiceImageryProviderSpec.js
@@ -6,7 +6,6 @@ defineSuite([
         'Core/DefaultProxy',
         'Core/GeographicTilingScheme',
         'Core/JulianDate',
-        'Core/loadImage',
         'Core/objectToQuery',
         'Core/queryToObject',
         'Core/Request',
@@ -29,7 +28,6 @@ defineSuite([
         DefaultProxy,
         GeographicTilingScheme,
         JulianDate,
-        loadImage,
         objectToQuery,
         queryToObject,
         Request,
@@ -51,7 +49,7 @@ defineSuite([
     });
 
     afterEach(function() {
-        loadImage.createImage = loadImage.defaultCreateImage;
+        Resource._Implementations.createImage = Resource._DefaultImplementations.createImage;
     });
 
     it('conforms to ImageryProvider interface', function() {
@@ -335,16 +333,16 @@ defineSuite([
         return pollToPromise(function() {
             return provider1.ready && provider2.ready;
         }).then(function() {
-            spyOn(loadImage, 'createImage').and.callFake(function(url, crossOrigin, deferred) {
+            spyOn(Resource._Implementations, 'createImage').and.callFake(function(url, crossOrigin, deferred) {
                 // Just return any old image.
-                loadImage.defaultCreateImage('Data/Images/Red16x16.png', crossOrigin, deferred);
+                Resource._DefaultImplementations.createImage('Data/Images/Red16x16.png', crossOrigin, deferred);
             });
 
             return provider1.requestImage(0, 0, 0).then(function(image) {
                 return provider2.requestImage(0, 0, 0).then(function(image) {
-                    expect(loadImage.createImage.calls.count()).toEqual(2);
+                    expect(Resource._Implementations.createImage.calls.count()).toEqual(2);
                     //expect the two image URLs to be the same between the two providers
-                    var allCalls = loadImage.createImage.calls.all();
+                    var allCalls = Resource._Implementations.createImage.calls.all();
                     expect(allCalls[1].args[0]).toEqual(allCalls[0].args[0]);
                 });
             });
@@ -362,13 +360,13 @@ defineSuite([
         return pollToPromise(function() {
             return provider.ready;
         }).then(function() {
-            spyOn(loadImage, 'createImage').and.callFake(function(url, crossOrigin, deferred) {
+            spyOn(Resource._Implementations, 'createImage').and.callFake(function(url, crossOrigin, deferred) {
                 // Just return any old image.
-                loadImage.defaultCreateImage('Data/Images/Red16x16.png', crossOrigin, deferred);
+                Resource._DefaultImplementations.createImage('Data/Images/Red16x16.png', crossOrigin, deferred);
             });
 
             return provider.requestImage(0, 0, 0).then(function(image) {
-                expect(loadImage.createImage).toHaveBeenCalled();
+                expect(Resource._Implementations.createImage).toHaveBeenCalled();
                 expect(image).toBeInstanceOf(Image);
             });
         });
@@ -387,15 +385,15 @@ defineSuite([
         return pollToPromise(function() {
             return provider.ready;
         }).then(function() {
-            spyOn(loadImage, 'createImage').and.callFake(function(url, crossOrigin, deferred) {
+            spyOn(Resource._Implementations, 'createImage').and.callFake(function(url, crossOrigin, deferred) {
                 expect(url.indexOf(proxy.getURL('http://wmts.invalid'))).toEqual(0);
 
                 // Just return any old image.
-                loadImage.defaultCreateImage('Data/Images/Red16x16.png', crossOrigin, deferred);
+                Resource._DefaultImplementations.createImage('Data/Images/Red16x16.png', crossOrigin, deferred);
             });
 
             return provider.requestImage(0, 0, 0).then(function(image) {
-                expect(loadImage.createImage).toHaveBeenCalled();
+                expect(Resource._Implementations.createImage).toHaveBeenCalled();
                 expect(image).toBeInstanceOf(Image);
             });
         });
@@ -423,10 +421,10 @@ defineSuite([
             }, 1);
         });
 
-        loadImage.createImage = function(url, crossOrigin, deferred) {
+        Resource._Implementations.createImage = function(url, crossOrigin, deferred) {
             if (tries === 2) {
                 // Succeed after 2 tries
-                loadImage.defaultCreateImage('Data/Images/Red16x16.png', crossOrigin, deferred);
+                Resource._DefaultImplementations.createImage('Data/Images/Red16x16.png', crossOrigin, deferred);
             } else {
                 // fail
                 setTimeout(function() {
@@ -476,8 +474,8 @@ defineSuite([
             times : times
         });
 
-        loadImage.createImage = function(url, crossOrigin, deferred) {
-            loadImage.defaultCreateImage('Data/Images/Red16x16.png', crossOrigin, deferred);
+        Resource._Implementations.createImage = function(url, crossOrigin, deferred) {
+            Resource._DefaultImplementations.createImage('Data/Images/Red16x16.png', crossOrigin, deferred);
         };
 
         var entry;
@@ -528,8 +526,8 @@ defineSuite([
             times : times
         });
 
-        loadImage.createImage = function(url, crossOrigin, deferred) {
-            loadImage.defaultCreateImage('Data/Images/Red16x16.png', crossOrigin, deferred);
+        Resource._Implementations.createImage = function(url, crossOrigin, deferred) {
+            Resource._DefaultImplementations.createImage('Data/Images/Red16x16.png', crossOrigin, deferred);
         };
 
         var entry;
@@ -577,8 +575,8 @@ defineSuite([
             shouldAnimate : true
         });
 
-        loadImage.createImage = function(url, crossOrigin, deferred) {
-            loadImage.defaultCreateImage('Data/Images/Red16x16.png', crossOrigin, deferred);
+        Resource._Implementations.createImage = function(url, crossOrigin, deferred) {
+            Resource._DefaultImplementations.createImage('Data/Images/Red16x16.png', crossOrigin, deferred);
         };
 
         var provider = new WebMapTileServiceImageryProvider({
@@ -618,9 +616,9 @@ defineSuite([
 
     it('dimensions work with RESTful requests', function() {
         var lastUrl;
-        loadImage.createImage = function(url, crossOrigin, deferred) {
+        Resource._Implementations.createImage = function(url, crossOrigin, deferred) {
             lastUrl = url;
-            loadImage.defaultCreateImage('Data/Images/Red16x16.png', crossOrigin, deferred);
+            Resource._DefaultImplementations.createImage('Data/Images/Red16x16.png', crossOrigin, deferred);
         };
 
         var provider = new WebMapTileServiceImageryProvider({
@@ -657,9 +655,9 @@ defineSuite([
 
     it('dimensions work with KVP requests', function() {
         var lastUrl;
-        loadImage.createImage = function(url, crossOrigin, deferred) {
+        Resource._Implementations.createImage = function(url, crossOrigin, deferred) {
             lastUrl = url;
-            loadImage.defaultCreateImage('Data/Images/Red16x16.png', crossOrigin, deferred);
+            Resource._DefaultImplementations.createImage('Data/Images/Red16x16.png', crossOrigin, deferred);
         };
 
         var uri = new Uri('http://wmts.invalid/kvp');

--- a/Specs/Scene/createOpenStreetMapImageryProviderSpec.js
+++ b/Specs/Scene/createOpenStreetMapImageryProviderSpec.js
@@ -1,7 +1,6 @@
 defineSuite([
         'Scene/createOpenStreetMapImageryProvider',
         'Core/DefaultProxy',
-        'Core/loadImage',
         'Core/Math',
         'Core/Rectangle',
         'Core/RequestScheduler',
@@ -15,7 +14,6 @@ defineSuite([
     ], function(
         createOpenStreetMapImageryProvider,
         DefaultProxy,
-        loadImage,
         CesiumMath,
         Rectangle,
         RequestScheduler,
@@ -33,7 +31,7 @@ defineSuite([
     });
 
     afterEach(function() {
-        loadImage.createImage = loadImage.defaultCreateImage;
+        Resource._Implementations.createImage = Resource._DefaultImplementations.createImage;
     });
 
     it('return a UrlTemplateImageryProvider', function() {
@@ -65,15 +63,15 @@ defineSuite([
         return pollToPromise(function() {
             return provider.ready;
         }).then(function() {
-            spyOn(loadImage, 'createImage').and.callFake(function(url, crossOrigin, deferred) {
+            spyOn(Resource._Implementations, 'createImage').and.callFake(function(url, crossOrigin, deferred) {
                 expect(url).not.toContain('//');
 
                 // Just return any old image.
-                loadImage.defaultCreateImage('Data/Images/Red16x16.png', crossOrigin, deferred);
+                Resource._DefaultImplementations.createImage('Data/Images/Red16x16.png', crossOrigin, deferred);
             });
 
             return provider.requestImage(0, 0, 0).then(function(image) {
-                expect(loadImage.createImage).toHaveBeenCalled();
+                expect(Resource._Implementations.createImage).toHaveBeenCalled();
                 expect(image).toBeInstanceOf(Image);
             });
         });
@@ -87,15 +85,15 @@ defineSuite([
         return pollToPromise(function() {
             return provider.ready;
         }).then(function() {
-            spyOn(loadImage, 'createImage').and.callFake(function(url, crossOrigin, deferred) {
+            spyOn(Resource._Implementations, 'createImage').and.callFake(function(url, crossOrigin, deferred) {
                 expect(url).not.toContain('//');
 
                 // Just return any old image.
-                loadImage.defaultCreateImage('Data/Images/Red16x16.png', crossOrigin, deferred);
+                Resource._DefaultImplementations.createImage('Data/Images/Red16x16.png', crossOrigin, deferred);
             });
 
             return provider.requestImage(0, 0, 0).then(function(image) {
-                expect(loadImage.createImage).toHaveBeenCalled();
+                expect(Resource._Implementations.createImage).toHaveBeenCalled();
                 expect(image).toBeInstanceOf(Image);
             });
         });
@@ -109,15 +107,15 @@ defineSuite([
         return pollToPromise(function() {
             return provider.ready;
         }).then(function() {
-            spyOn(loadImage, 'createImage').and.callFake(function(url, crossOrigin, deferred) {
+            spyOn(Resource._Implementations, 'createImage').and.callFake(function(url, crossOrigin, deferred) {
                 expect(url).toContain('made/up/osm/server/');
 
                 // Just return any old image.
-                loadImage.defaultCreateImage('Data/Images/Red16x16.png', crossOrigin, deferred);
+                Resource._DefaultImplementations.createImage('Data/Images/Red16x16.png', crossOrigin, deferred);
             });
 
             return provider.requestImage(0, 0, 0).then(function(image) {
-                expect(loadImage.createImage).toHaveBeenCalled();
+                expect(Resource._Implementations.createImage).toHaveBeenCalled();
                 expect(image).toBeInstanceOf(Image);
             });
         });
@@ -139,13 +137,13 @@ defineSuite([
             expect(provider.tilingScheme).toBeInstanceOf(WebMercatorTilingScheme);
             expect(provider.rectangle).toEqual(new WebMercatorTilingScheme().rectangle);
 
-            spyOn(loadImage, 'createImage').and.callFake(function(url, crossOrigin, deferred) {
+            spyOn(Resource._Implementations, 'createImage').and.callFake(function(url, crossOrigin, deferred) {
                 // Just return any old image.
-                loadImage.defaultCreateImage('Data/Images/Red16x16.png', crossOrigin, deferred);
+                Resource._DefaultImplementations.createImage('Data/Images/Red16x16.png', crossOrigin, deferred);
             });
 
             return provider.requestImage(0, 0, 0).then(function(image) {
-                expect(loadImage.createImage).toHaveBeenCalled();
+                expect(Resource._Implementations.createImage).toHaveBeenCalled();
                 expect(image).toBeInstanceOf(Image);
             });
         });
@@ -178,15 +176,15 @@ defineSuite([
         }).then(function() {
             expect(provider.proxy).toEqual(proxy);
 
-            spyOn(loadImage, 'createImage').and.callFake(function(url, crossOrigin, deferred) {
+            spyOn(Resource._Implementations, 'createImage').and.callFake(function(url, crossOrigin, deferred) {
                 expect(url.indexOf(proxy.getURL('made/up/osm/server'))).toEqual(0);
 
                 // Just return any old image.
-                loadImage.defaultCreateImage('Data/Images/Red16x16.png', crossOrigin, deferred);
+                Resource._DefaultImplementations.createImage('Data/Images/Red16x16.png', crossOrigin, deferred);
             });
 
             return provider.requestImage(0, 0, 0).then(function(image) {
-                expect(loadImage.createImage).toHaveBeenCalled();
+                expect(Resource._Implementations.createImage).toHaveBeenCalled();
                 expect(image).toBeInstanceOf(Image);
             });
         });
@@ -212,15 +210,15 @@ defineSuite([
             expect(provider.rectangle.north).toBeCloseTo(rectangle.north, CesiumMath.EPSILON10);
             expect(provider.tileDiscardPolicy).toBeUndefined();
 
-            spyOn(loadImage, 'createImage').and.callFake(function(url, crossOrigin, deferred) {
+            spyOn(Resource._Implementations, 'createImage').and.callFake(function(url, crossOrigin, deferred) {
                 expect(url).toContain('/0/0/0');
 
                 // Just return any old image.
-                loadImage.defaultCreateImage('Data/Images/Red16x16.png', crossOrigin, deferred);
+                Resource._DefaultImplementations.createImage('Data/Images/Red16x16.png', crossOrigin, deferred);
             });
 
             return provider.requestImage(0, 0, 0).then(function(image) {
-                expect(loadImage.createImage).toHaveBeenCalled();
+                expect(Resource._Implementations.createImage).toHaveBeenCalled();
                 expect(image).toBeInstanceOf(Image);
             });
         });
@@ -261,10 +259,10 @@ defineSuite([
             }, 1);
         });
 
-        loadImage.createImage = function(url, crossOrigin, deferred) {
+        Resource._Implementations.createImage = function(url, crossOrigin, deferred) {
             if (tries === 2) {
                 // Succeed after 2 tries
-                loadImage.defaultCreateImage('Data/Images/Red16x16.png', crossOrigin, deferred);
+                Resource._DefaultImplementations.createImage('Data/Images/Red16x16.png', crossOrigin, deferred);
             } else {
                 // fail
                 setTimeout(function() {

--- a/Specs/Scene/createTileMapServiceImageryProviderSpec.js
+++ b/Specs/Scene/createTileMapServiceImageryProviderSpec.js
@@ -6,8 +6,6 @@ defineSuite([
         'Core/GeographicProjection',
         'Core/GeographicTilingScheme',
         'Core/getAbsoluteUri',
-        'Core/loadImage',
-        'Core/loadWithXhr',
         'Core/Math',
         'Core/Rectangle',
         'Core/RequestScheduler',
@@ -28,8 +26,6 @@ defineSuite([
         GeographicProjection,
         GeographicTilingScheme,
         getAbsoluteUri,
-        loadImage,
-        loadWithXhr,
         CesiumMath,
         Rectangle,
         RequestScheduler,
@@ -49,8 +45,8 @@ defineSuite([
     });
 
     afterEach(function() {
-        loadImage.createImage = loadImage.defaultCreateImage;
-        loadWithXhr.load = loadWithXhr.defaultLoad;
+        Resource._Implementations.createImage = Resource._DefaultImplementations.createImage;
+        Resource._Implementations.loadWithXhr = Resource._DefaultImplementations.loadWithXhr;
     });
 
     it('return a UrlTemplateImageryProvider', function() {
@@ -87,7 +83,7 @@ defineSuite([
     });
 
     it('rejects readyPromise on error', function() {
-        loadWithXhr.load = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
+        Resource._Implementations.loadWithXhr = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
             // We can't resolve the promise immediately, because then the error would be raised
             // before we could subscribe to it.  This a problem particular to tests.
             setTimeout(function() {
@@ -123,7 +119,7 @@ defineSuite([
     });
 
     it('rejects readyPromise on invalid xml', function() {
-        loadWithXhr.load = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
+        Resource._Implementations.loadWithXhr = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
             // We can't resolve the promise immediately, because then the error would be raised
             // before we could subscribe to it.  This a problem particular to tests.
             setTimeout(function() {
@@ -185,15 +181,15 @@ defineSuite([
         return pollToPromise(function() {
             return provider.ready;
         }).then(function() {
-            spyOn(loadImage, 'createImage').and.callFake(function(url, crossOrigin, deferred) {
+            spyOn(Resource._Implementations, 'createImage').and.callFake(function(url, crossOrigin, deferred) {
                 expect(url).toStartWith(getAbsoluteUri(baseUrl));
 
                 // Just return any old image.
-                loadImage.defaultCreateImage('Data/Images/Red16x16.png', crossOrigin, deferred);
+                Resource._DefaultImplementations.createImage('Data/Images/Red16x16.png', crossOrigin, deferred);
             });
 
             return provider.requestImage(0, 0, 0).then(function(image) {
-                expect(loadImage.createImage).toHaveBeenCalled();
+                expect(Resource._Implementations.createImage).toHaveBeenCalled();
                 expect(image).toBeInstanceOf(Image);
             });
         });
@@ -207,15 +203,15 @@ defineSuite([
         return pollToPromise(function() {
             return provider.ready;
         }).then(function() {
-            spyOn(loadImage, 'createImage').and.callFake(function(url, crossOrigin, deferred) {
+            spyOn(Resource._Implementations, 'createImage').and.callFake(function(url, crossOrigin, deferred) {
                 expect(url).toContain('made/up/tms/server/');
 
                 // Just return any old image.
-                loadImage.defaultCreateImage('Data/Images/Red16x16.png', crossOrigin, deferred);
+                Resource._DefaultImplementations.createImage('Data/Images/Red16x16.png', crossOrigin, deferred);
             });
 
             return provider.requestImage(0, 0, 0).then(function(image) {
-                expect(loadImage.createImage).toHaveBeenCalled();
+                expect(Resource._Implementations.createImage).toHaveBeenCalled();
                 expect(image).toBeInstanceOf(Image);
             });
         });
@@ -230,15 +226,15 @@ defineSuite([
         return pollToPromise(function() {
             return provider.ready;
         }).then(function() {
-            spyOn(loadImage, 'createImage').and.callFake(function(url, crossOrigin, deferred) {
+            spyOn(Resource._Implementations, 'createImage').and.callFake(function(url, crossOrigin, deferred) {
                 expect(url).toStartWith(getAbsoluteUri(baseUrl));
                 expect(url).toContain('?a=some&b=query');
                 // Just return any old image.
-                loadImage.defaultCreateImage('Data/Images/Red16x16.png', crossOrigin, deferred);
+                Resource._DefaultImplementations.createImage('Data/Images/Red16x16.png', crossOrigin, deferred);
             });
 
             return provider.requestImage(0, 0, 0).then(function(image) {
-                expect(loadImage.createImage).toHaveBeenCalled();
+                expect(Resource._Implementations.createImage).toHaveBeenCalled();
                 expect(image).toBeInstanceOf(Image);
             });
         });
@@ -259,13 +255,13 @@ defineSuite([
             expect(provider.tilingScheme).toBeInstanceOf(WebMercatorTilingScheme);
             expect(provider.rectangle).toEqual(new WebMercatorTilingScheme().rectangle);
 
-            spyOn(loadImage, 'createImage').and.callFake(function(url, crossOrigin, deferred) {
+            spyOn(Resource._Implementations, 'createImage').and.callFake(function(url, crossOrigin, deferred) {
                 // Just return any old image.
-                loadImage.defaultCreateImage('Data/Images/Red16x16.png', crossOrigin, deferred);
+                Resource._DefaultImplementations.createImage('Data/Images/Red16x16.png', crossOrigin, deferred);
             });
 
             return provider.requestImage(0, 0, 0).then(function(image) {
-                expect(loadImage.createImage).toHaveBeenCalled();
+                expect(Resource._Implementations.createImage).toHaveBeenCalled();
                 expect(image).toBeInstanceOf(Image);
             });
         });
@@ -298,7 +294,7 @@ defineSuite([
         /*eslint-disable no-unused-vars*/
         var proxy = new DefaultProxy('/proxy/');
         var requestMetadata = when.defer();
-        spyOn(loadWithXhr, 'load').and.callFake(function(url, responseType, method, data, headers, deferred, overrideMimeType) {
+        spyOn(Resource._Implementations, 'loadWithXhr').and.callFake(function(url, responseType, method, data, headers, deferred, overrideMimeType) {
             requestMetadata.resolve(url);
             deferred.reject(); //since the TMS server doesn't exist (and doesn't need too) we can just reject here.
         });
@@ -317,7 +313,7 @@ defineSuite([
     it('resource request takes a query string', function() {
         /*eslint-disable no-unused-vars*/
         var requestMetadata = when.defer();
-        spyOn(loadWithXhr, 'load').and.callFake(function(url, responseType, method, data, headers, deferred, overrideMimeType) {
+        spyOn(Resource._Implementations, 'loadWithXhr').and.callFake(function(url, responseType, method, data, headers, deferred, overrideMimeType) {
             requestMetadata.resolve(url);
             deferred.reject(); //since the TMS server doesn't exist (and doesn't need too) we can just reject here.
         });
@@ -344,15 +340,15 @@ defineSuite([
         }).then(function() {
             expect(provider.proxy).toEqual(proxy);
 
-            spyOn(loadImage, 'createImage').and.callFake(function(url, crossOrigin, deferred) {
+            spyOn(Resource._Implementations, 'createImage').and.callFake(function(url, crossOrigin, deferred) {
                 expect(url.indexOf(proxy.getURL(getAbsoluteUri('made/up/tms/server')))).toEqual(0);
 
                 // Just return any old image.
-                loadImage.defaultCreateImage('Data/Images/Red16x16.png', crossOrigin, deferred);
+                Resource._DefaultImplementations.createImage('Data/Images/Red16x16.png', crossOrigin, deferred);
             });
 
             return provider.requestImage(0, 0, 0).then(function(image) {
-                expect(loadImage.createImage).toHaveBeenCalled();
+                expect(Resource._Implementations.createImage).toHaveBeenCalled();
                 expect(image).toBeInstanceOf(Image);
             });
         });
@@ -378,15 +374,15 @@ defineSuite([
             expect(provider.rectangle.south).toEqualEpsilon(rectangle.south, CesiumMath.EPSILON14);
             expect(provider.tileDiscardPolicy).toBeUndefined();
 
-            spyOn(loadImage, 'createImage').and.callFake(function(url, crossOrigin, deferred) {
+            spyOn(Resource._Implementations, 'createImage').and.callFake(function(url, crossOrigin, deferred) {
                 expect(url).toContain('/0/0/0');
 
                 // Just return any old image.
-                loadImage.defaultCreateImage('Data/Images/Red16x16.png', crossOrigin, deferred);
+                Resource._DefaultImplementations.createImage('Data/Images/Red16x16.png', crossOrigin, deferred);
             });
 
             return provider.requestImage(0, 0, 0).then(function(image) {
-                expect(loadImage.createImage).toHaveBeenCalled();
+                expect(Resource._Implementations.createImage).toHaveBeenCalled();
                 expect(image).toBeInstanceOf(Image);
             });
         });
@@ -424,10 +420,10 @@ defineSuite([
             }, 1);
         });
 
-        loadImage.createImage = function(url, crossOrigin, deferred) {
+        Resource._Implementations.createImage = function(url, crossOrigin, deferred) {
             if (tries === 2) {
                 // Succeed after 2 tries
-                loadImage.defaultCreateImage('Data/Images/Red16x16.png', crossOrigin, deferred);
+                Resource._DefaultImplementations.createImage('Data/Images/Red16x16.png', crossOrigin, deferred);
             } else {
                 // fail
                 setTimeout(function() {
@@ -455,7 +451,7 @@ defineSuite([
     });
 
     it('keeps the rectangle within the bounds allowed by the tiling scheme no matter what the tilemapresource.xml says.', function() {
-        loadWithXhr.load = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
+        Resource._Implementations.loadWithXhr = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
             var parser = new DOMParser();
             var xmlString =
                 "<TileMap version='1.0.0' tilemapservice='http://tms.osgeo.org/1.0.0'>" +
@@ -492,7 +488,7 @@ defineSuite([
     });
 
     it('uses a minimum level if the tilemapresource.xml specifies one and it is reasonable', function() {
-        loadWithXhr.load = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
+        Resource._Implementations.loadWithXhr = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
             var parser = new DOMParser();
             var xmlString =
                 "<TileMap version='1.0.0' tilemapservice='http://tms.osgeo.org/1.0.0'>" +
@@ -524,7 +520,7 @@ defineSuite([
     });
 
     it('ignores the minimum level in the tilemapresource.xml if it is unreasonable', function() {
-        loadWithXhr.load = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
+        Resource._Implementations.loadWithXhr = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
             var parser = new DOMParser();
             var xmlString =
                 "<TileMap version='1.0.0' tilemapservice='http://tms.osgeo.org/1.0.0'>" +
@@ -556,7 +552,7 @@ defineSuite([
     });
 
     it('handles XML with casing differences', function() {
-        loadWithXhr.load = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
+        Resource._Implementations.loadWithXhr = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
             var parser = new DOMParser();
             var xmlString =
                 "<Tilemap version='1.0.0' tilemapservice='http://tms.osgeo.org/1.0.0'>" +
@@ -588,7 +584,7 @@ defineSuite([
     });
 
     it('supports the global-mercator profile with a non-flipped, mercator bounding box', function() {
-        loadWithXhr.load = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
+        Resource._Implementations.loadWithXhr = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
             var parser = new DOMParser();
             var xmlString =
                 '<TileMap version="1.0.0" tilemapservice="http://tms.osgeo.org/1.0.0">' +
@@ -629,7 +625,7 @@ defineSuite([
     });
 
     it('supports the global-geodetic profile with a non-flipped, geographic bounding box', function() {
-        loadWithXhr.load = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
+        Resource._Implementations.loadWithXhr = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
             var parser = new DOMParser();
             var xmlString =
                 '<TileMap version="1.0.0" tilemapservice="http://tms.osgeo.org/1.0.0">' +
@@ -669,7 +665,7 @@ defineSuite([
     });
 
     it('supports the old mercator profile with a flipped, geographic bounding box', function() {
-        loadWithXhr.load = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
+        Resource._Implementations.loadWithXhr = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
             var parser = new DOMParser();
             var xmlString =
                 '<TileMap version="1.0.0" tilemapservice="http://tms.osgeo.org/1.0.0">' +
@@ -710,7 +706,7 @@ defineSuite([
     });
 
     it('supports the old geodetic profile with a flipped, geographic bounding box', function() {
-        loadWithXhr.load = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
+        Resource._Implementations.loadWithXhr = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
             var parser = new DOMParser();
             var xmlString =
                 '<TileMap version="1.0.0" tilemapservice="http://tms.osgeo.org/1.0.0">' +
@@ -751,7 +747,7 @@ defineSuite([
     });
 
     it('raises an error if tilemapresource.xml specifies an unsupported profile', function() {
-        loadWithXhr.load = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
+        Resource._Implementations.loadWithXhr = function(url, responseType, method, data, headers, deferred, overrideMimeType) {
             // We can't resolve the promise immediately, because then the error would be raised
             // before we could subscribe to it.  This a problem particular to tests.
             setTimeout(function() {


### PR DESCRIPTION
Fixes #6202 

Only removes the use of the deprecated functions for tests outside the load tests. The load tests will be removed in 1.44.