### PR TITLE
Attempt to fix spec failure

### DIFF
--- a/Specs/Scene/Cesium3DTilesetSpec.js
+++ b/Specs/Scene/Cesium3DTilesetSpec.js
@@ -183,6 +183,12 @@ defineSuite([
         scene.camera.moveDown(200.0);
     }
 
+    function viewBottomRight() {
+        viewAllTiles();
+        scene.camera.moveRight(200.0);
+        scene.camera.moveDown(200.0);
+    }
+
     function viewInstances() {
         setZoom(30.0);
     }
@@ -2654,7 +2660,7 @@ defineSuite([
     });
 
     it('immediatelyLoadDesiredLevelOfDetail', function() {
-        viewBottomLeft();
+        viewBottomRight();
         var tileset = scene.primitives.add(new Cesium3DTileset({
             url : tilesetOfTilesetsUrl,
             immediatelyLoadDesiredLevelOfDetail : true


### PR DESCRIPTION
Maybe fixes #6221 

I didn't really have time to deep dive into this but the lower left tile is owned by an external tileset while the bottom right isn't, possibly leading to some edge case in the tile load order. It passed Travis this time at least.