### PR TITLE
Fixed build module url

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,7 @@ Change Log
 * Fixed `Resource.clone` to clone the `Request` object, so resource can be used in parallel. [#6208](https://github.com/AnalyticalGraphicsInc/cesium/issues/6208)
 * Fixed bug where 3D Tiles Point Clouds would fail in Internet Explorer. [#6220](https://github.com/AnalyticalGraphicsInc/cesium/pull/6220)
 * Fixed `Material` so it can now take a `Resource` object as an image. [#6199](https://github.com/AnalyticalGraphicsInc/cesium/issues/6199)
+* Fixed issue where `CESIUM_BASE_URL` wouldn't work without a trailing `/`. [#6225](https://github.com/AnalyticalGraphicsInc/cesium/issues/6225)
 
 ##### Additions :tada:
 * Enable terrain in the `CesiumViewer` demo application [#6198](https://github.com/AnalyticalGraphicsInc/cesium/pull/6198)

--- a/Source/Core/buildModuleUrl.js
+++ b/Source/Core/buildModuleUrl.js
@@ -48,6 +48,7 @@ define([
         baseResource = new Resource({
             url: baseUrlString
         });
+        baseResource.appendForwardSlash();
 
         return baseResource;
     }
@@ -98,6 +99,10 @@ define([
 
     // exposed for testing
     buildModuleUrl._cesiumScriptRegex = cesiumScriptRegex;
+    buildModuleUrl._buildModuleUrlFromBaseUrl = buildModuleUrlFromBaseUrl;
+    buildModuleUrl._clearBaseResource = function() {
+        baseResource = undefined;
+    };
 
     /**
      * Sets the base URL for resolving modules.

--- a/Specs/Core/buildModuleUrlSpec.js
+++ b/Specs/Core/buildModuleUrlSpec.js
@@ -28,4 +28,34 @@ defineSuite([
 
         expect(r.exec('assets/foo/bar.cesium.js')).toBeNull();
     });
+
+    it('CESIUM_BASE_URL works with trailing slash', function() {
+        // Set new variables
+        var oldCESIUM_BASE_URL = window.CESIUM_BASE_URL;
+        window.CESIUM_BASE_URL = 'http://test.com/source/';
+        buildModuleUrl._clearBaseResource();
+
+        // Verify we use CESIUM_BASE_URL
+        var url = buildModuleUrl._buildModuleUrlFromBaseUrl('Core/Cartesian3.js');
+        expect(url).toEqual('http://test.com/source/Core/Cartesian3.js');
+
+        // Reset old values
+        window.CESIUM_BASE_URL = oldCESIUM_BASE_URL;
+        buildModuleUrl._clearBaseResource();
+    });
+
+    it('CESIUM_BASE_URL works without trailing slash', function() {
+        // Set new variables
+        var oldCESIUM_BASE_URL = window.CESIUM_BASE_URL;
+        window.CESIUM_BASE_URL = 'http://test.com/source';
+        buildModuleUrl._clearBaseResource();
+
+        // Verify we use CESIUM_BASE_URL
+        var url = buildModuleUrl._buildModuleUrlFromBaseUrl('Core/Cartesian3.js');
+        expect(url).toEqual('http://test.com/source/Core/Cartesian3.js');
+
+        // Reset old values
+        window.CESIUM_BASE_URL = oldCESIUM_BASE_URL;
+        buildModuleUrl._clearBaseResource();
+    });
 });


### PR DESCRIPTION
Fixes #6225 

With the introduction of the `Resource` class we accidentally required a trailing slash to CESIUM_BASE_URL.