### PR TITLE
Add default Cesium ion token

### DIFF
--- a/Apps/Sandcastle/gallery/3D Tiles Adjust Height.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Adjust Height.html
@@ -57,26 +57,26 @@ var toolbar = document.getElementById('toolbar');
 Cesium.knockout.applyBindings(viewModel, toolbar);
 
 var tileset = new Cesium.Cesium3DTileset({ url: Cesium.CesiumIon.createResource(3883) });
-tileset.readyPromise
-    .then(function(tileset) {
-        viewer.scene.primitives.add(tileset);
-        viewer.zoomTo(tileset, new Cesium.HeadingPitchRange(0.0, -0.5, tileset.boundingSphere.radius * 2.0));
+tileset.readyPromise.then(function(tileset) {
+    viewer.scene.primitives.add(tileset);
+    viewer.zoomTo(tileset, new Cesium.HeadingPitchRange(0.0, -0.5, tileset.boundingSphere.radius * 2.0));
+}).otherwise(function(error) {
+    console.log(error);
+});
 
-        Cesium.knockout.getObservable(viewModel, 'height').subscribe(function(height) {
-            height = Number(height);
-            if (isNaN(height)) {
-                return;
-            }
+Cesium.knockout.getObservable(viewModel, 'height').subscribe(function(height) {
+    height = Number(height);
+    if (isNaN(height)) {
+        return;
+    }
 
-            var cartographic = Cesium.Cartographic.fromCartesian(tileset.boundingSphere.center);
-            var surface = Cesium.Cartesian3.fromRadians(cartographic.longitude, cartographic.latitude, 0.0);
-            var offset = Cesium.Cartesian3.fromRadians(cartographic.longitude, cartographic.latitude, height);
-            var translation = Cesium.Cartesian3.subtract(offset, surface, new Cesium.Cartesian3());
-            tileset.modelMatrix = Cesium.Matrix4.fromTranslation(translation);
-        });
-    }).otherwise(function(error) {
-        console.log(error);
-    });
+    var cartographic = Cesium.Cartographic.fromCartesian(tileset.boundingSphere.center);
+    var surface = Cesium.Cartesian3.fromRadians(cartographic.longitude, cartographic.latitude, 0.0);
+    var offset = Cesium.Cartesian3.fromRadians(cartographic.longitude, cartographic.latitude, height);
+    var translation = Cesium.Cartesian3.subtract(offset, surface, new Cesium.Cartesian3());
+    tileset.modelMatrix = Cesium.Matrix4.fromTranslation(translation);
+});
+
 //Sandcastle_End
 Sandcastle.finishedLoading();
 }

--- a/Apps/Sandcastle/gallery/3D Tiles Adjust Height.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Adjust Height.html
@@ -56,29 +56,27 @@ Cesium.knockout.track(viewModel);
 var toolbar = document.getElementById('toolbar');
 Cesium.knockout.applyBindings(viewModel, toolbar);
 
-Cesium.CesiumIon.create3DTileset(3883, { accessToken: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJjYjNlMTg5Zi1hMzc2LTRmZjktOGEwZC00NGEzNTM0MTAzZGUiLCJpZCI6MjU5LCJpYXQiOjE1MTgxOTE2NTV9.qaP8-_Ej6AihGnv5iB990Hm6lHr8F_rrC3_EPxdT6MQ' })
+var tileset = new Cesium.Cesium3DTileset({ url: Cesium.CesiumIon.createResource(3883) });
+tileset.readyPromise
     .then(function(tileset) {
         viewer.scene.primitives.add(tileset);
         viewer.zoomTo(tileset, new Cesium.HeadingPitchRange(0.0, -0.5, tileset.boundingSphere.radius * 2.0));
-        onLoad(tileset);
+
+        Cesium.knockout.getObservable(viewModel, 'height').subscribe(function(height) {
+            height = Number(height);
+            if (isNaN(height)) {
+                return;
+            }
+
+            var cartographic = Cesium.Cartographic.fromCartesian(tileset.boundingSphere.center);
+            var surface = Cesium.Cartesian3.fromRadians(cartographic.longitude, cartographic.latitude, 0.0);
+            var offset = Cesium.Cartesian3.fromRadians(cartographic.longitude, cartographic.latitude, height);
+            var translation = Cesium.Cartesian3.subtract(offset, surface, new Cesium.Cartesian3());
+            tileset.modelMatrix = Cesium.Matrix4.fromTranslation(translation);
+        });
     }).otherwise(function(error) {
         console.log(error);
     });
-
-function onLoad(tileset) {
-    Cesium.knockout.getObservable(viewModel, 'height').subscribe(function(height) {
-        height = Number(height);
-        if (isNaN(height)) {
-            return;
-        }
-
-        var cartographic = Cesium.Cartographic.fromCartesian(tileset.boundingSphere.center);
-        var surface = Cesium.Cartesian3.fromRadians(cartographic.longitude, cartographic.latitude, 0.0);
-        var offset = Cesium.Cartesian3.fromRadians(cartographic.longitude, cartographic.latitude, height);
-        var translation = Cesium.Cartesian3.subtract(offset, surface, new Cesium.Cartesian3());
-        tileset.modelMatrix = Cesium.Matrix4.fromTranslation(translation);
-    });
-}
 //Sandcastle_End
 Sandcastle.finishedLoading();
 }

--- a/Apps/Sandcastle/gallery/3D Tiles BIM.html
+++ b/Apps/Sandcastle/gallery/3D Tiles BIM.html
@@ -29,13 +29,14 @@ function startup(Cesium) {
 // Power Plant design model provided by Bentley Systems
 var viewer = new Cesium.Viewer('cesiumContainer');
 
-Cesium.CesiumIon.create3DTileset(1459, { accessToken: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiIzNjUyM2I5Yy01YmRhLTQ0MjktOGI0Zi02MDdmYzBjMmY0MjYiLCJpZCI6NDQsImFzc2V0cyI6WzE0NTldLCJpYXQiOjE0OTkyNjQ3ODF9.SW_rwY-ic0TwQBeiweXNqFyywoxnnUBtcVjeCmDGef4' })
-    .then(function(tileset) {
-        viewer.scene.primitives.add(tileset);
-        viewer.zoomTo(tileset, new Cesium.HeadingPitchRange(0.5, -0.2, tileset.boundingSphere.radius * 4.0));
-    }).otherwise(function(error) {
-        console.log(error);
-    });
+var tileset = new Cesium.Cesium3DTileset({ url: Cesium.CesiumIon.createResource(3837) });
+
+tileset.readyPromise.then(function(tileset) {
+    viewer.scene.primitives.add(tileset);
+    viewer.zoomTo(tileset, new Cesium.HeadingPitchRange(0.5, -0.2, tileset.boundingSphere.radius * 4.0));
+}).otherwise(function(error) {
+    console.log(error);
+});
 //Sandcastle_End
 Sandcastle.finishedLoading();
 }

--- a/Apps/Sandcastle/gallery/3D Tiles Batch Table Hierarchy.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Batch Table Hierarchy.html
@@ -84,125 +84,119 @@ function startup(Cesium) {
 var viewer = new Cesium.Viewer('cesiumContainer');
 viewer.clock.currentTime = new Cesium.JulianDate(2457522.154792);
 
-Cesium.CesiumIon.create3DTileset(3875, { accessToken: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJjYjNlMTg5Zi1hMzc2LTRmZjktOGEwZC00NGEzNTM0MTAzZGUiLCJpZCI6MjU5LCJpYXQiOjE1MTgxOTE2NTV9.qaP8-_Ej6AihGnv5iB990Hm6lHr8F_rrC3_EPxdT6MQ' })
-    .then(function(tileset) {
-        viewer.scene.primitives.add(tileset);
-        viewer.zoomTo(tileset, new Cesium.HeadingPitchRange(0.0, -0.3, 0.0));
-        onLoad(tileset);
-    }).otherwise(function(error) {
-        console.log(error);
+var tileset = new Cesium.Cesium3DTileset({ url: Cesium.CesiumIon.createResource(3875) });
+
+viewer.scene.primitives.add(tileset);
+viewer.zoomTo(tileset, new Cesium.HeadingPitchRange(0.0, -0.3, 0.0));
+
+var styles = [];
+function addStyle(name, style) {
+    styles.push({
+        name : name,
+        style : style
     });
-
-function onLoad(tileset) {
-    var styles = [];
-    function addStyle(name, style) {
-        styles.push({
-            name : name,
-            style : style
-        });
-    }
-
-    addStyle('No style', {});
-
-    addStyle('Color by building', {
-        "color" : {
-            "conditions" : [
-                ["${building_name} === 'building0'", "color('purple')"],
-                ["${building_name} === 'building1'", "color('red')"],
-                ["${building_name} === 'building2'", "color('orange')"],
-                ["true", "color('blue')"]
-            ]
-        }
-    });
-
-    addStyle('Color all doors', {
-        "color" : {
-            "conditions" : [
-                ["isExactClass('door')", "color('orange')"],
-                ["true", "color('white')"]
-            ]
-        }
-    });
-
-    addStyle('Color all features derived from door', {
-        "color" : {
-            "conditions" : [
-                ["isClass('door')", "color('orange')"],
-                ["true", "color('white')"]
-            ]
-        }
-    });
-
-    addStyle('Color features by class name', {
-        "defines" : {
-            "suffix" : "regExp('door(.*)').exec(getExactClassName())"
-        },
-        "color" : {
-            "conditions" : [
-                ["${suffix} === 'knob'", "color('yellow')"],
-                ["${suffix} === ''", "color('lime')"],
-                ["${suffix} === null", "color('gray')"],
-                ["true", "color('blue')"]
-            ]
-        }
-    });
-
-    addStyle('Style by height', {
-        "color" : {
-            "conditions" : [
-                ["${height} >= 10", "color('purple')"],
-                ["${height} >= 6", "color('red')"],
-                ["${height} >= 5", "color('orange')"],
-                ["true", "color('blue')"]
-            ]
-        }
-    });
-
-    function setStyle(style) {
-        return function() {
-            tileset.style = new Cesium.Cesium3DTileStyle(style);
-        };
-    }
-
-    var styleOptions = [];
-    for (var i = 0; i < styles.length; ++i) {
-        var style = styles[i];
-        styleOptions.push({
-            text : style.name,
-            onselect : setStyle(style.style)
-        });
-    }
-
-    Sandcastle.addToolbarMenu(styleOptions);
-
-    var handler = new Cesium.ScreenSpaceEventHandler(viewer.canvas);
-
-    // When a feature is left clicked, print its class name and properties
-    handler.setInputAction(function(movement) {
-        var feature = viewer.scene.pick(movement.position);
-        if (!Cesium.defined(feature)) {
-            return;
-        }
-        console.log('Class: ' + feature.getExactClassName());
-        console.log('Properties:');
-        var propertyNames = feature.getPropertyNames();
-        var length = propertyNames.length;
-        for (var i = 0; i < length; ++i) {
-            var name = propertyNames[i];
-            var value = feature.getProperty(name);
-            console.log('  ' + name + ': ' + value);
-        }
-    }, Cesium.ScreenSpaceEventType.LEFT_CLICK);
-
-    // When a feature is middle clicked, hide it
-    handler.setInputAction(function(movement) {
-        var feature = viewer.scene.pick(movement.position);
-        if (!Cesium.defined(feature)) {
-            return;
-        }
-        feature.show = false;
-    }, Cesium.ScreenSpaceEventType.MIDDLE_CLICK);
 }
+
+addStyle('No style', {});
+
+addStyle('Color by building', {
+    "color" : {
+        "conditions" : [
+            ["${building_name} === 'building0'", "color('purple')"],
+            ["${building_name} === 'building1'", "color('red')"],
+            ["${building_name} === 'building2'", "color('orange')"],
+            ["true", "color('blue')"]
+        ]
+    }
+});
+
+addStyle('Color all doors', {
+    "color" : {
+        "conditions" : [
+            ["isExactClass('door')", "color('orange')"],
+            ["true", "color('white')"]
+        ]
+    }
+});
+
+addStyle('Color all features derived from door', {
+    "color" : {
+        "conditions" : [
+            ["isClass('door')", "color('orange')"],
+            ["true", "color('white')"]
+        ]
+    }
+});
+
+addStyle('Color features by class name', {
+    "defines" : {
+        "suffix" : "regExp('door(.*)').exec(getExactClassName())"
+    },
+    "color" : {
+        "conditions" : [
+            ["${suffix} === 'knob'", "color('yellow')"],
+            ["${suffix} === ''", "color('lime')"],
+            ["${suffix} === null", "color('gray')"],
+            ["true", "color('blue')"]
+        ]
+    }
+});
+
+addStyle('Style by height', {
+    "color" : {
+        "conditions" : [
+            ["${height} >= 10", "color('purple')"],
+            ["${height} >= 6", "color('red')"],
+            ["${height} >= 5", "color('orange')"],
+            ["true", "color('blue')"]
+        ]
+    }
+});
+
+function setStyle(style) {
+    return function() {
+        tileset.style = new Cesium.Cesium3DTileStyle(style);
+    };
+}
+
+var styleOptions = [];
+for (var i = 0; i < styles.length; ++i) {
+    var style = styles[i];
+    styleOptions.push({
+        text : style.name,
+        onselect : setStyle(style.style)
+    });
+}
+
+Sandcastle.addToolbarMenu(styleOptions);
+
+var handler = new Cesium.ScreenSpaceEventHandler(viewer.canvas);
+
+// When a feature is left clicked, print its class name and properties
+handler.setInputAction(function(movement) {
+    var feature = viewer.scene.pick(movement.position);
+    if (!Cesium.defined(feature)) {
+        return;
+    }
+    console.log('Class: ' + feature.getExactClassName());
+    console.log('Properties:');
+    var propertyNames = feature.getPropertyNames();
+    var length = propertyNames.length;
+    for (var i = 0; i < length; ++i) {
+        var name = propertyNames[i];
+        var value = feature.getProperty(name);
+        console.log('  ' + name + ': ' + value);
+    }
+}, Cesium.ScreenSpaceEventType.LEFT_CLICK);
+
+// When a feature is middle clicked, hide it
+handler.setInputAction(function(movement) {
+    var feature = viewer.scene.pick(movement.position);
+    if (!Cesium.defined(feature)) {
+        return;
+    }
+    feature.show = false;
+}, Cesium.ScreenSpaceEventType.MIDDLE_CLICK);
 //Sandcastle_End
 Sandcastle.finishedLoading();
 }

--- a/Apps/Sandcastle/gallery/3D Tiles Clipping Planes.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Clipping Planes.html
@@ -205,14 +205,12 @@ function loadModel(url) {
 }
 
 // Power Plant design model provided by Bentley Systems
-var bimUrl = Cesium.CesiumIon.createResource(1459, { accessToken: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiIzNjUyM2I5Yy01YmRhLTQ0MjktOGI0Zi02MDdmYzBjMmY0MjYiLCJpZCI6NDQsImFzc2V0cyI6WzE0NTldLCJpYXQiOjE0OTkyNjQ3ODF9.SW_rwY-ic0TwQBeiweXNqFyywoxnnUBtcVjeCmDGef4' });
-var pointCloudUrl = Cesium.CesiumIon.createResource(1460, { accessToken: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiIyMzk2YzJiOS1jZGFmLTRlZmYtYmQ4MS00NTA3NjEwMzViZTkiLCJpZCI6NDQsImFzc2V0cyI6WzE0NjBdLCJpYXQiOjE0OTkyNjQ3NTV9.oWjvN52CRQ-dk3xtvD4e8ZnOHZhoWSpJLlw115mbQJM' });
-var instancedUrl = Cesium.CesiumIon.createResource(3876, { accessToken: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJjYjNlMTg5Zi1hMzc2LTRmZjktOGEwZC00NGEzNTM0MTAzZGUiLCJpZCI6MjU5LCJpYXQiOjE1MTgxOTE2NTV9.qaP8-_Ej6AihGnv5iB990Hm6lHr8F_rrC3_EPxdT6MQ' });
+var bimUrl = Cesium.CesiumIon.createResource(3837);
+var pointCloudUrl = Cesium.CesiumIon.createResource(3838);
+var instancedUrl = Cesium.CesiumIon.createResource(3876);
 var modelUrl = '../../SampleData/models/CesiumAir/Cesium_Air.glb';
 
-bimUrl.then(function(resource) {
-    return loadTileset(resource);
-});
+loadTileset(bimUrl);
 
 // Track and create the bindings for the view model
 var toolbar = document.getElementById('toolbar');
@@ -222,25 +220,20 @@ Cesium.knockout.applyBindings(viewModel, toolbar);
 Cesium.knockout.getObservable(viewModel, 'currentExampleType').subscribe(function(newValue) {
     reset();
 
+    var tileset;
     if (newValue === clipObjects[0]) {
-        bimUrl.then(function(resource) {
-            return loadTileset(resource);
-        });
+        return loadTileset(bimUrl);
     } else if (newValue === clipObjects[1]) {
-        pointCloudUrl.then(function(resource) {
-            return loadTileset(resource);
-        }).then(function() {
-            tileset.clippingPlanes.modelMatrix = Cesium.Transforms.eastNorthUpToFixedFrame(tileset.boundingSphere.center);
-        });
+        tileset = loadTileset(pointCloudUrl);
+        tileset.clippingPlanes.modelMatrix = Cesium.Transforms.eastNorthUpToFixedFrame(tileset.boundingSphere.center);
+        return tileset;
     } else if (newValue === clipObjects[2]) {
-        instancedUrl.then(function(resource) {
-            return loadTileset(resource);
-        }).then(function() {
-            tileset.clippingPlanes.modelMatrix = Cesium.Transforms.eastNorthUpToFixedFrame(tileset.boundingSphere.center);
-        });
-    } else {
-        loadModel(modelUrl);
+         tileset = loadTileset(instancedUrl);
+        tileset.clippingPlanes.modelMatrix = Cesium.Transforms.eastNorthUpToFixedFrame(tileset.boundingSphere.center);
+        return tileset;
     }
+
+    loadModel(modelUrl);
 });
 
 Cesium.knockout.getObservable(viewModel, 'debugBoundingVolumesEnabled').subscribe(function(value) {

--- a/Apps/Sandcastle/gallery/3D Tiles Feature Picking.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Feature Picking.html
@@ -40,10 +40,8 @@ viewer.scene.camera.setView({
 });
 
 // Load the NYC buildings tileset
-Cesium.CesiumIon.create3DTileset(1461, { accessToken: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJkYWJmM2MzNS02OWM5LTQ3OWItYjEyYS0xZmNlODM5ZDNkMTYiLCJpZCI6NDQsImFzc2V0cyI6WzE0NjFdLCJpYXQiOjE0OTkyNjQ3NDN9.vuR75SqPDKcggvUrG_vpx0Av02jdiAxnnB1fNf-9f7s' })
-    .then(function(tileset) {
-        viewer.scene.primitives.add(tileset);
-    });
+var tileset = new Cesium.Cesium3DTileset({ url: Cesium.CesiumIon.createResource(3839) });
+viewer.scene.primitives.add(tileset);
 
 // HTML overlay for showing feature name on mouseover
 var nameOverlay = document.createElement('div');

--- a/Apps/Sandcastle/gallery/3D Tiles Feature Styling.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Feature Styling.html
@@ -42,9 +42,7 @@ viewer.scene.camera.setView({
 });
 
 // Load the NYC buildings tileset.
-Cesium.CesiumIon.create3DTileset(1461, { accessToken: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJkYWJmM2MzNS02OWM5LTQ3OWItYjEyYS0xZmNlODM5ZDNkMTYiLCJpZCI6NDQsImFzc2V0cyI6WzE0NjFdLCJpYXQiOjE0OTkyNjQ3NDN9.vuR75SqPDKcggvUrG_vpx0Av02jdiAxnnB1fNf-9f7s' })
-.then(function(tileset) {
-
+var tileset = new Cesium.Cesium3DTileset({ url: Cesium.CesiumIon.createResource(3839) });
 viewer.scene.primitives.add(tileset);
 
 // Color buildings based on their height.
@@ -151,10 +149,6 @@ Sandcastle.addToolbarMenu([{
 }]);
 
 colorByHeight();
-})
-.otherwise(function(error) {
-    console.log(error);
-});
 
 //Sandcastle_End
 Sandcastle.finishedLoading();

--- a/Apps/Sandcastle/gallery/3D Tiles Formats.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Formats.html
@@ -45,43 +45,43 @@ var viewModel = {
     tilesets: [
         {
             name: 'Tileset',
-            resource: Cesium.CesiumIon.createResource(3883, { accessToken: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJjYjNlMTg5Zi1hMzc2LTRmZjktOGEwZC00NGEzNTM0MTAzZGUiLCJpZCI6MjU5LCJpYXQiOjE1MTgxOTE2NTV9.qaP8-_Ej6AihGnv5iB990Hm6lHr8F_rrC3_EPxdT6MQ' })
+            resource: Cesium.CesiumIon.createResource(3883)
         }, {
             name: 'Translucent',
-            resource: Cesium.CesiumIon.createResource(3871, { accessToken: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJjYjNlMTg5Zi1hMzc2LTRmZjktOGEwZC00NGEzNTM0MTAzZGUiLCJpZCI6MjU5LCJpYXQiOjE1MTgxOTE2NTV9.qaP8-_Ej6AihGnv5iB990Hm6lHr8F_rrC3_EPxdT6MQ' })
+            resource: Cesium.CesiumIon.createResource(3871)
         }, {
             name: 'Translucent/Opaque',
-            resource: Cesium.CesiumIon.createResource(3872, { accessToken: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJjYjNlMTg5Zi1hMzc2LTRmZjktOGEwZC00NGEzNTM0MTAzZGUiLCJpZCI6MjU5LCJpYXQiOjE1MTgxOTE2NTV9.qaP8-_Ej6AihGnv5iB990Hm6lHr8F_rrC3_EPxdT6MQ' })
+            resource: Cesium.CesiumIon.createResource(3872)
         }, {
             name: 'Multi-color',
-            resource: Cesium.CesiumIon.createResource(3870, { accessToken: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJjYjNlMTg5Zi1hMzc2LTRmZjktOGEwZC00NGEzNTM0MTAzZGUiLCJpZCI6MjU5LCJpYXQiOjE1MTgxOTE2NTV9.qaP8-_Ej6AihGnv5iB990Hm6lHr8F_rrC3_EPxdT6MQ' })
+            resource: Cesium.CesiumIon.createResource(3870)
         }, {
             name: 'Request Volume',
-            resource: Cesium.CesiumIon.createResource(3884, { accessToken: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJjYjNlMTg5Zi1hMzc2LTRmZjktOGEwZC00NGEzNTM0MTAzZGUiLCJpZCI6MjU5LCJpYXQiOjE1MTgxOTE2NTV9.qaP8-_Ej6AihGnv5iB990Hm6lHr8F_rrC3_EPxdT6MQ' })
+            resource: Cesium.CesiumIon.createResource(3884)
         }, {
             name: 'Batched',
-            resource: Cesium.CesiumIon.createResource(3873, { accessToken: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJjYjNlMTg5Zi1hMzc2LTRmZjktOGEwZC00NGEzNTM0MTAzZGUiLCJpZCI6MjU5LCJpYXQiOjE1MTgxOTE2NTV9.qaP8-_Ej6AihGnv5iB990Hm6lHr8F_rrC3_EPxdT6MQ' })
+            resource: Cesium.CesiumIon.createResource(3873)
         }, {
             name: 'Instanced',
-            resource: Cesium.CesiumIon.createResource(3877, { accessToken: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJjYjNlMTg5Zi1hMzc2LTRmZjktOGEwZC00NGEzNTM0MTAzZGUiLCJpZCI6MjU5LCJpYXQiOjE1MTgxOTE2NTV9.qaP8-_Ej6AihGnv5iB990Hm6lHr8F_rrC3_EPxdT6MQ' })
+            resource: Cesium.CesiumIon.createResource(3877)
         }, {
             name: 'Instanced/Orientation',
-            resource: Cesium.CesiumIon.createResource(3876, { accessToken: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJjYjNlMTg5Zi1hMzc2LTRmZjktOGEwZC00NGEzNTM0MTAzZGUiLCJpZCI6MjU5LCJpYXQiOjE1MTgxOTE2NTV9.qaP8-_Ej6AihGnv5iB990Hm6lHr8F_rrC3_EPxdT6MQ' })
+            resource: Cesium.CesiumIon.createResource(3876)
         }, {
             name: 'Composite',
-            resource: Cesium.CesiumIon.createResource(3874, { accessToken: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJjYjNlMTg5Zi1hMzc2LTRmZjktOGEwZC00NGEzNTM0MTAzZGUiLCJpZCI6MjU5LCJpYXQiOjE1MTgxOTE2NTV9.qaP8-_Ej6AihGnv5iB990Hm6lHr8F_rrC3_EPxdT6MQ' })
+            resource: Cesium.CesiumIon.createResource(3874)
         }, {
             name: 'PointCloud',
-            resource: Cesium.CesiumIon.createResource(3881, { accessToken: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJjYjNlMTg5Zi1hMzc2LTRmZjktOGEwZC00NGEzNTM0MTAzZGUiLCJpZCI6MjU5LCJpYXQiOjE1MTgxOTE2NTV9.qaP8-_Ej6AihGnv5iB990Hm6lHr8F_rrC3_EPxdT6MQ' })
+            resource: Cesium.CesiumIon.createResource(3881)
         }, {
             name: 'PointCloudConstantColor',
-            resource: Cesium.CesiumIon.createResource(3879, { accessToken: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJjYjNlMTg5Zi1hMzc2LTRmZjktOGEwZC00NGEzNTM0MTAzZGUiLCJpZCI6MjU5LCJpYXQiOjE1MTgxOTE2NTV9.qaP8-_Ej6AihGnv5iB990Hm6lHr8F_rrC3_EPxdT6MQ' })
+            resource: Cesium.CesiumIon.createResource(3879)
         }, {
             name: 'PointCloudNormals',
-            resource: Cesium.CesiumIon.createResource(3880, { accessToken: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJjYjNlMTg5Zi1hMzc2LTRmZjktOGEwZC00NGEzNTM0MTAzZGUiLCJpZCI6MjU5LCJpYXQiOjE1MTgxOTE2NTV9.qaP8-_Ej6AihGnv5iB990Hm6lHr8F_rrC3_EPxdT6MQ' })
+            resource: Cesium.CesiumIon.createResource(3880)
         }, {
             name: 'PointCloudBatched',
-            resource: Cesium.CesiumIon.createResource(3878, { accessToken: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJjYjNlMTg5Zi1hMzc2LTRmZjktOGEwZC00NGEzNTM0MTAzZGUiLCJpZCI6MjU5LCJpYXQiOjE1MTgxOTE2NTV9.qaP8-_Ej6AihGnv5iB990Hm6lHr8F_rrC3_EPxdT6MQ' })
+            resource: Cesium.CesiumIon.createResource(3878)
         }
     ],
     selectedTileset: undefined,
@@ -106,12 +106,11 @@ Cesium.knockout.getObservable(viewModel, 'selectedTileset').subscribe(function(o
         return;
     }
 
-    options.resource.then(function(url) {
-        tileset = viewer.scene.primitives.add(new Cesium.Cesium3DTileset({
-            url : url
-        }));
-        return tileset.readyPromise;
-    }).then(function() {
+    tileset = viewer.scene.primitives.add(new Cesium.Cesium3DTileset({
+        url : options.resource
+    }));
+
+    tileset.readyPromise.then(function() {
         inspectorViewModel.tileset = tileset;
         viewer.zoomTo(tileset, new Cesium.HeadingPitchRange(0, -2.0, Math.max(100.0 - tileset.boundingSphere.radius, 0.0)));
 

--- a/Apps/Sandcastle/gallery/3D Tiles Inspector.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Inspector.html
@@ -31,14 +31,12 @@ var viewer = new Cesium.Viewer('cesiumContainer');
 viewer.extend(Cesium.viewerCesium3DTilesInspectorMixin);
 var inspectorViewModel = viewer.cesium3DTilesInspector.viewModel;
 
-Cesium.CesiumIon.create3DTileset(1461, { accessToken: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJkYWJmM2MzNS02OWM5LTQ3OWItYjEyYS0xZmNlODM5ZDNkMTYiLCJpZCI6NDQsImFzc2V0cyI6WzE0NjFdLCJpYXQiOjE0OTkyNjQ3NDN9.vuR75SqPDKcggvUrG_vpx0Av02jdiAxnnB1fNf-9f7s' })
-    .then(function(tileset) {
-        viewer.scene.primitives.add(tileset);
-        viewer.zoomTo(tileset, new Cesium.HeadingPitchRange(0.0, -0.5, tileset.boundingSphere.radius / 4.0));
-    }).otherwise(function(error) {
-        console.log(error);
-    });
+var tileset = new Cesium.Cesium3DTileset({ url: Cesium.CesiumIon.createResource(3839) });
+viewer.scene.primitives.add(tileset);
 
+tileset.readyPromise.then(function(){
+    viewer.zoomTo(tileset, new Cesium.HeadingPitchRange(0.0, -0.5, tileset.boundingSphere.radius / 4.0));
+});
 //Sandcastle_End
 Sandcastle.finishedLoading();
 }

--- a/Apps/Sandcastle/gallery/3D Tiles Interactivity.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Interactivity.html
@@ -68,19 +68,14 @@ viewer.scene.camera.setView({
     endTransform: Cesium.Matrix4.IDENTITY
 });
 
-var tileset;
-
 // Load the NYC buildings tileset.
-Cesium.CesiumIon.create3DTileset(1461, { accessToken: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJkYWJmM2MzNS02OWM5LTQ3OWItYjEyYS0xZmNlODM5ZDNkMTYiLCJpZCI6NDQsImFzc2V0cyI6WzE0NjFdLCJpYXQiOjE0OTkyNjQ3NDN9.vuR75SqPDKcggvUrG_vpx0Av02jdiAxnnB1fNf-9f7s' })
-    .then(function(result) {
-        tileset = result;
-        scene.primitives.add(tileset);
-        tileset.style = new Cesium.Cesium3DTileStyle({
-            meta: {
-                description: "'Building id ${id} has height ${height}.'"
-            }
-        });
-    });
+var tileset = new Cesium.Cesium3DTileset({ url: Cesium.CesiumIon.createResource(3839) });
+scene.primitives.add(tileset);
+tileset.style = new Cesium.Cesium3DTileStyle({
+    meta: {
+        description: "'Building id ${id} has height ${height}.'"
+    }
+});
 
 var handler = new Cesium.ScreenSpaceEventHandler(viewer.canvas);
 

--- a/Apps/Sandcastle/gallery/3D Tiles Interior.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Interior.html
@@ -30,10 +30,10 @@ function startup(Cesium) {
 // San Miguel model created by Guillermo M. Leal Llaguno. Cleaned up and hosted by Morgan McGuire: http://graphics.cs.williams.edu/data/meshes.xml
 var viewer = new Cesium.Viewer('cesiumContainer');
 
-Cesium.CesiumIon.create3DTileset(1463, { accessToken: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiI5ZGExZTdmMS0xZjA5LTQxODAtOThmYi04MWU1YjZkMWZjNjgiLCJpZCI6NDQsImFzc2V0cyI6WzE0NjNdLCJpYXQiOjE0OTkyNzYwNzV9.eTEtaAEBUehNIZushZQnp0On9BPRtZYS7XEWFwneSRU' })
-    .then(function(tileset) {
-        viewer.scene.primitives.add(tileset);
-    });
+var tileset = new Cesium.Cesium3DTileset({
+    url: Cesium.CesiumIon.createResource(3840)
+});
+viewer.scene.primitives.add(tileset);
 
 var initialPosition = new Cesium.Cartesian3(-1111583.3721328347, -5855888.151574568, 2262561.444696748);
 var initialOrientation = new Cesium.HeadingPitchRoll.fromDegrees(100.0, -15.0, 0.0);

--- a/Apps/Sandcastle/gallery/3D Tiles Photogrammetry Classification.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Photogrammetry Classification.html
@@ -31,48 +31,35 @@ function startup(Cesium) {
 var viewer = new Cesium.Viewer('cesiumContainer');
 
 // A normal b3dm tileset of photogrammetry
-Cesium.CesiumIon.create3DTileset(1458, { accessToken: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiIxYmJiNTAxOC1lOTg5LTQzN2EtODg1OC0zMWJjM2IxNGNlYmMiLCJpZCI6NDQsImFzc2V0cyI6WzE0NThdLCJpYXQiOjE0OTkyNjM4MjB9.1WKijRa-ILkmG6utrhDWX6rDgasjD7dZv-G5ZyCmkKg' })
-    .then(function(tileset) {
-        viewer.scene.primitives.add(tileset);
-        viewer.zoomTo(tileset);
-    })
-    .otherwise(function(error) {
-        console.log(error);
-    });
+var tileset = new Cesium.Cesium3DTileset({
+    url: Cesium.CesiumIon.createResource(3836)
+});
+viewer.scene.primitives.add(tileset);
+viewer.zoomTo(tileset);
 
 // A b3dm tileset used to classify the photogrammetry tileset
-var classificationPromise = Cesium.CesiumIon.create3DTileset(3625, {
-    accessToken: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJhZDI4YzA2Ny03YTIwLTQ5ZWEtODY3My1hMzU0OTJmMjEwMWQiLCJpZCI6NDQsImFzc2V0cyI6WzM2MjVdLCJpYXQiOjE1MTU1OTMxODN9.cntiWhEEBAeUb9Lq4ECpwpUuz9yZzEqOvucYopTjA5k',
-    tilesetOptions: { classificationType: Cesium.ClassificationType.CESIUM_3D_TILE }
-}).then(function(classification) {
-    classification.style = new Cesium.Cesium3DTileStyle({
-        color: 'rgba(255, 0, 0, 0.5)'
-    });
-    return viewer.scene.primitives.add(classification);
-}).otherwise(function(error) {
-    console.log(error);
+var classificationTileset = new Cesium.Cesium3DTileset({
+    url: Cesium.CesiumIon.createResource(3843),
+    classificationType: Cesium.ClassificationType.CESIUM_3D_TILE
 });
+classificationTileset.style = new Cesium.Cesium3DTileStyle({
+    color: 'rgba(255, 0, 0, 0.5)'
+});
+viewer.scene.primitives.add(classificationTileset);
 
 // The same b3dm tileset used for classification, but rendered normally for comparison.
-var nonClassificationPromise = Cesium.CesiumIon.create3DTileset(3625, {
-    accessToken: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJhZDI4YzA2Ny03YTIwLTQ5ZWEtODY3My1hMzU0OTJmMjEwMWQiLCJpZCI6NDQsImFzc2V0cyI6WzM2MjVdLCJpYXQiOjE1MTU1OTMxODN9.cntiWhEEBAeUb9Lq4ECpwpUuz9yZzEqOvucYopTjA5k',
-    tilesetOptions: { show: false }
-}).then(function(nonClassification) {
-    nonClassification.style = new Cesium.Cesium3DTileStyle({
-        color: 'rgba(255, 0, 0, 0.5)'
-    });
-    return viewer.scene.primitives.add(nonClassification);
-}).otherwise(function(error) {
-    console.log(error);
+var nonClassificationTileset = new Cesium.Cesium3DTileset({
+    url: Cesium.CesiumIon.createResource(3843),
+    show: false
 });
+nonClassificationTileset.style = new Cesium.Cesium3DTileStyle({
+    color: 'rgba(255, 0, 0, 0.5)'
+});
+viewer.scene.primitives.add(nonClassificationTileset);
 
-Cesium.when.join(classificationPromise, nonClassificationPromise).then(function(results) {
-    var classification = results[0];
-    var nonClassification = results[1];
-    Sandcastle.addToggleButton('Show classification', true, function(checked) {
-        classification.show = checked;
-        nonClassification.show = !checked;
-    });
+Sandcastle.addToggleButton('Show classification', true, function(checked) {
+    classificationTileset.show = checked;
+    nonClassificationTileset.show = !checked;
 });
 //Sandcastle_End
 Sandcastle.finishedLoading();

--- a/Apps/Sandcastle/gallery/3D Tiles Photogrammetry.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Photogrammetry.html
@@ -28,14 +28,12 @@ function startup(Cesium) {
 //Sandcastle_Begin
 var viewer = new Cesium.Viewer('cesiumContainer');
 
-Cesium.CesiumIon.create3DTileset(1458, { accessToken: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiIxYmJiNTAxOC1lOTg5LTQzN2EtODg1OC0zMWJjM2IxNGNlYmMiLCJpZCI6NDQsImFzc2V0cyI6WzE0NThdLCJpYXQiOjE0OTkyNjM4MjB9.1WKijRa-ILkmG6utrhDWX6rDgasjD7dZv-G5ZyCmkKg' })
-    .then(function(tileset) {
-        viewer.scene.primitives.add(tileset);
-        viewer.zoomTo(tileset);
-    })
-    .otherwise(function(error) {
-        console.log(error);
-    });
+var tileset = new Cesium.Cesium3DTileset({
+    url: Cesium.CesiumIon.createResource(3836)
+});
+
+viewer.scene.primitives.add(tileset);
+viewer.zoomTo(tileset);
 
 //Sandcastle_End
 Sandcastle.finishedLoading();

--- a/Apps/Sandcastle/gallery/3D Tiles Point Cloud Classification.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Point Cloud Classification.html
@@ -30,34 +30,32 @@ function startup(Cesium) {
 var viewer = new Cesium.Viewer('cesiumContainer');
 
 //Point Cloud by Prof. Peter Allen, Columbia University Robotics Lab. Scanning by Alejandro Troccoli and Matei Ciocarlie.
-Cesium.CesiumIon.create3DTileset(1460, { accessToken: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiIyMzk2YzJiOS1jZGFmLTRlZmYtYmQ4MS00NTA3NjEwMzViZTkiLCJpZCI6NDQsImFzc2V0cyI6WzE0NjBdLCJpYXQiOjE0OTkyNjQ3NTV9.oWjvN52CRQ-dk3xtvD4e8ZnOHZhoWSpJLlw115mbQJM' })
-    .then(function(tileset) {
-        viewer.scene.primitives.add(tileset);
-    });
+var tileset = new Cesium.Cesium3DTileset({
+    url: Cesium.CesiumIon.createResource(3838)
+});
+viewer.scene.primitives.add(tileset);
 
 // Geometry Tiles are experimental and the format is subject to change in the future.
 // For more details, see:
 //    https://github.com/AnalyticalGraphicsInc/3d-tiles/tree/3d-tiles-next/TileFormats/Geometry
-Cesium.CesiumIon.create3DTileset(3624, {
-    accessToken: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJlYTdkZTFlNC1lYTZlLTQzODMtYmM5NC1iYmRkNzI1ZTg2NzkiLCJpZCI6NDQsImFzc2V0cyI6WzM2MjRdLCJpYXQiOjE1MTU1OTMxOTZ9.-YnJ5-FK5FmSsyChVZ-AwSbzD3k_rMhbuaIbqG2sKb4',
-    tilesetOptions: { classificationType: Cesium.ClassificationType.CESIUM_3D_TILE }
-})
-.then(function(classification) {
-    viewer.scene.primitives.add(classification);
+var classificationTileset = new Cesium.Cesium3DTileset({
+    url: Cesium.CesiumIon.createResource(3842),
+    classificationType: Cesium.ClassificationType.CESIUM_3D_TILE
+});
+viewer.scene.primitives.add(classificationTileset);
 
-    classification.style = new Cesium.Cesium3DTileStyle({
-        color : {
-            conditions : [
-                ["${id} === 'roof1'", "color('#004FFF', 0.5)"],
-                ["${id} === 'towerBottom1'", "color('#33BB66', 0.5)"],
-                ["${id} === 'towerTop1'", "color('#0099AA', 0.5)"],
-                ["${id} === 'roof2'", "color('#004FFF', 0.5)"],
-                ["${id} === 'tower3'", "color('#FF8833', 0.5)"],
-                ["${id} === 'tower4'", "color('#FFAA22', 0.5)"],
-                ["true", "color('#FFFF00', 0.5)"]
-            ]
-        }
-    });
+classificationTileset.style = new Cesium.Cesium3DTileStyle({
+    color : {
+        conditions : [
+            ["${id} === 'roof1'", "color('#004FFF', 0.5)"],
+            ["${id} === 'towerBottom1'", "color('#33BB66', 0.5)"],
+            ["${id} === 'towerTop1'", "color('#0099AA', 0.5)"],
+            ["${id} === 'roof2'", "color('#004FFF', 0.5)"],
+            ["${id} === 'tower3'", "color('#FF8833', 0.5)"],
+            ["${id} === 'tower4'", "color('#FFAA22', 0.5)"],
+            ["true", "color('#FFFF00', 0.5)"]
+        ]
+    }
 });
 
 viewer.scene.camera.setView({

--- a/Apps/Sandcastle/gallery/3D Tiles Point Cloud Shading.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Point Cloud Shading.html
@@ -139,44 +139,34 @@ function loadStHelens() {
     // Mt. St. Helens 3D Tileset generated from LAS provided by https://www.liblas.org/samples/
     // This tileset uses replacement refinement and has geometric error approximately equal to
     // the average interpoint distance in each tile.
-    Cesium.CesiumIon.create3DTileset(3742, { accessToken: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiIxOGZjMjlhZC03MDE1LTQ3ZTAtODEyNy05YTU3M2MwYzQ0YmEiLCJpZCI6NDQsImFzc2V0cyI6WzM3NDJdLCJpYXQiOjE1MTcyNDI3NDJ9.TJAJctFXC1UyFMpxkA3cyKVAmnh72cLtfY1yKbaQsyk' })
-        .then(function(tileset) {
-            viewer.scene.primitives.add(tileset);
+    var tileset = new Cesium.Cesium3DTileset({ url: Cesium.CesiumIon.createResource(3844) });
+    viewer.scene.primitives.add(tileset);
 
-            tileset.maximumScreenSpaceError = 8.0;
-            tileset.pointCloudShading.maximumAttenuation = undefined; // Will be based on maximumScreenSpaceError instead
-            tileset.pointCloudShading.baseResolution = undefined;
-            tileset.pointCloudShading.geometricErrorScale = 1.0;
-            tileset.pointCloudShading.attenuation = true;
-            tileset.pointCloudShading.eyeDomeLighting = true;
+    tileset.maximumScreenSpaceError = 8.0;
+    tileset.pointCloudShading.maximumAttenuation = undefined; // Will be based on maximumScreenSpaceError instead
+    tileset.pointCloudShading.baseResolution = undefined;
+    tileset.pointCloudShading.geometricErrorScale = 1.0;
+    tileset.pointCloudShading.attenuation = true;
+    tileset.pointCloudShading.eyeDomeLighting = true;
 
-            tilesetToViewModel(tileset);
-        })
-        .otherwise(function(error) {
-            console.log(error);
-        });
+    tilesetToViewModel(tileset);
 }
 
 function loadChurch() {
     // Point Cloud by Prof. Peter Allen, Columbia University Robotics Lab. Scanning by Alejandro Troccoli and Matei Ciocarlie.
     // This tileset uses additive refinement and has geometric error based on the bounding box size for each tile.
-    Cesium.CesiumIon.create3DTileset(1460, { accessToken: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiIyMzk2YzJiOS1jZGFmLTRlZmYtYmQ4MS00NTA3NjEwMzViZTkiLCJpZCI6NDQsImFzc2V0cyI6WzE0NjBdLCJpYXQiOjE0OTkyNjQ3NTV9.oWjvN52CRQ-dk3xtvD4e8ZnOHZhoWSpJLlw115mbQJM' })
-        .then(function(tileset) {
-            viewer.scene.primitives.add(tileset);
+    var tileset = new Cesium.Cesium3DTileset({ url: Cesium.CesiumIon.createResource(3838) });
+    viewer.scene.primitives.add(tileset);
 
-            tileset.maximumScreenSpaceError = 1024.0; // For better performance, due to how this tileset treats geometric error.
-            tileset.pointCloudShading.maximumAttenuation = 8.0; // Don't allow points larger than 8 pixels.
-            tileset.pointCloudShading.baseResolution = 0.05; // Assume an original capture resolution of 5 centimeters between neighboring points.
-            tileset.pointCloudShading.geometricErrorScale = 1.0; // Applies to both geometric error and the base resolution.
-            tileset.pointCloudShading.attenuation = true;
-            tileset.pointCloudShading.eyeDomeLighting = true;
+    tileset.maximumScreenSpaceError = 1024.0; // For better performance, due to how this tileset treats geometric error.
+    tileset.pointCloudShading.maximumAttenuation = 8.0; // Don't allow points larger than 8 pixels.
+    tileset.pointCloudShading.baseResolution = 0.05; // Assume an original capture resolution of 5 centimeters between neighboring points.
+    tileset.pointCloudShading.geometricErrorScale = 1.0; // Applies to both geometric error and the base resolution.
+    tileset.pointCloudShading.attenuation = true;
+    tileset.pointCloudShading.eyeDomeLighting = true;
 
-            tilesetToViewModel(tileset);
-            viewer.zoomTo(tileset);
-        })
-        .otherwise(function(error) {
-            console.log(error);
-        });
+    tilesetToViewModel(tileset);
+    viewer.zoomTo(tileset);
 }
 
 function checkZero(newValue) {

--- a/Apps/Sandcastle/gallery/3D Tiles Point Cloud Styling.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Point Cloud Styling.html
@@ -203,7 +203,6 @@ for (var i = 0; i < styles.length; ++i) {
 }
 
 Sandcastle.addToolbarMenu(styleOptions);
-tileset.style = new Cesium.Cesium3DTileStyle(styles[0].style);
 //Sandcastle_End
 Sandcastle.finishedLoading();
 }

--- a/Apps/Sandcastle/gallery/3D Tiles Point Cloud Styling.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Point Cloud Styling.html
@@ -30,189 +30,180 @@ function startup(Cesium) {
 //Sandcastle_Begin
 
 var viewer = new Cesium.Viewer('cesiumContainer');
-
 viewer.clock.currentTime = new Cesium.JulianDate(2457522.154792);
 
-Cesium.CesiumIon.create3DTileset(3882, { accessToken: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJjYjNlMTg5Zi1hMzc2LTRmZjktOGEwZC00NGEzNTM0MTAzZGUiLCJpZCI6MjU5LCJpYXQiOjE1MTgxOTE2NTV9.qaP8-_Ej6AihGnv5iB990Hm6lHr8F_rrC3_EPxdT6MQ' })
-    .then(function(tileset) {
-        viewer.scene.primitives.add(tileset);
-        viewer.zoomTo(tileset, new Cesium.HeadingPitchRange(0.0, -1.0, 50.0));
-        onLoad(tileset);
-    }).otherwise(function(error) {
-        console.log(error);
+var tileset = new Cesium.Cesium3DTileset({ url: Cesium.CesiumIon.createResource(3882) });
+viewer.scene.primitives.add(tileset);
+viewer.zoomTo(tileset, new Cesium.HeadingPitchRange(0.0, -1.0, 50.0));
+
+var styles = [];
+function addStyle(name, style) {
+    style.pointSize = Cesium.defaultValue(style.pointSize, 5.0);
+    styles.push({
+        name : name,
+        style : style
     });
-
-function onLoad(tileset) {
-    var styles = [];
-    function addStyle(name, style) {
-        style.pointSize = Cesium.defaultValue(style.pointSize, 5.0);
-        styles.push({
-            name : name,
-            style : style
-        });
-    }
-
-    addStyle('No Style', {});
-
-    addStyle('Red', {
-        color : "color('#ff0000')"
-    });
-
-    addStyle('Color Gradient', {
-        color : "color() * ${temperature}"
-    });
-
-    addStyle('Step Red/Blue', {
-        color : "${temperature} > 0.5 ? color('red') : color('blue')"
-    });
-
-    addStyle('Interpolate Red/Blue', {
-        color : "color('red') * ${temperature} + color('blue') * (1.0 - ${temperature})"
-    });
-
-    addStyle('Color Ramp', {
-        color : {
-            conditions : [
-                ["${temperature} < 0.1", "color('#000099')"],
-                ["${temperature} < 0.2", "color('#00cc99', 1.0)"],
-                ["${temperature} < 0.3", "color('#66ff33', 0.5)"],
-                ["${temperature} < 0.4", "rgba(255, 255, 0, 0.1)"],
-                ["${temperature} < 0.5", "rgb(255, 128, 0)"],
-                ["${temperature} < 0.6", "color('red')"],
-                ["${temperature} < 0.7", "color('rgb(255, 102, 102)')"],
-                ["${temperature} < 0.8", "hsl(0.875, 1.0, 0.6)"],
-                ["${temperature} < 0.9", "hsla(0.83, 1.0, 0.5, 0.1)"],
-                ["true", "color('#FFFFFF', 1.0)"]
-            ]
-        }
-    });
-
-    addStyle('Transparency', {
-        color : "rgba(0, 255, 0, ${temperature})"
-    });
-
-    addStyle('Hide Low Temperature', {
-        color : "rgb(${temperature}*255, 0, 0)",
-        show : "${temperature} > 0.3"
-    });
-
-    addStyle('Show Subsections', {
-        show : "${id} === 1 || ${id} > 250 && ${id} < 300"
-    });
-
-    addStyle('Mod', {
-        show : "${id} % 2 === 0"
-    });
-
-    addStyle('Abs', {
-        color : "color() * abs(${temperature} - 0.5)"
-    });
-
-    addStyle('Trigonometric Functions', {
-        color : "color() * radians(cos(${temperature})) + color() * sin(${temperature}) + color() * tan(${temperature})"
-
-    });
-
-    addStyle('Arc Trigonometric Functions', {
-        color : "color() * acos(degrees(${temperature})) + color() * asin(${temperature}) + color() * atan(${temperature}) + color() * atan2(${POSITION}[0],${temperature})"
-    });
-
-    addStyle('Sqrt', {
-        color : "color() * sqrt(${temperature})"
-    });
-
-    addStyle('Sign', {
-        color : "rgb(sign(${POSITION}[0]) * 255, sign(${POSITION}[1]) * 255, sign(${POSITION}[2]) * 255)"
-    });
-
-    addStyle('Rounding Functions', {
-        color : "rgb(floor(${POSITION}[0]) * 255, ceil(${POSITION}[1]) * 255, round(${POSITION}[2]) * 255)"
-    });
-
-    addStyle('Exp and Log Functions', {
-        color : "rgb(log(${POSITION}[0]) * 255, log2(${POSITION}[1]) * 255 + exp2(${POSITION}[1]) * 255, exp(${POSITION}[2]) * 255)"
-    });
-
-    addStyle('Fractional Part', {
-        color : "rgb(fract(${POSITION}[0]) * 255, fract(${POSITION}[1]) * 255, fract(${POSITION}[2]) * 255)"
-    });
-
-    addStyle('Pow', {
-        color : "color() * pow(${temperature}, 3)"
-    });
-
-    addStyle('Min and Max', {
-        color : "rgb(min(${POSITION}.x, 0.75) * 255, max(${POSITION}.z, 0.25) * 255, 255)"
-    });
-
-    addStyle('Clamp and Mix', {
-        color : "color() * clamp(${temperature}, 0.1, 0.2)"
-    });
-
-    addStyle('Secondary Color', {
-        color : {
-            conditions : [
-                ["${id} < 250", "vec4(${secondaryColor}, 1.0)"],
-                ["${id} < 500", "vec4(${secondaryColor} * ${secondaryColor}, 1.0)"],
-                ["${id} < 750", "vec4(${secondaryColor} / 5.0, 1.0)"],
-                ["${id} < 1000", "rgb(0, 0, Number(${secondaryColor}.x < 0.5) * 255)"]
-            ]
-        }
-    });
-
-    addStyle('Use point colors', {
-        color : "${COLOR} * ${temperature} + rgb(128,128,128)"
-    });
-
-    addStyle('Use point positions', {
-        show : "${POSITION}[0] > 0.5 || ${POSITION}[1] > 0.5 || ${POSITION}[2] > 0.5"
-    });
-
-    // POSITION contains 0 as its last component, so add 1.0 to make the point cloud opaque
-    addStyle('Color based on position', {
-        color : "vec4(${POSITION}, 1.0)"
-    });
-
-    addStyle('Style point size', {
-        color : "color('red')",
-        pointSize : "${temperature} * 10"
-    });
-
-    addStyle('Multiple defines', {
-        defines : {
-            length : "length(${POSITION})",
-            time : "${tiles3d_tileset_time} * 3.0"
-        },
-        color : {
-            conditions : [
-                ["${length} < 0.5", "${length} * color('red')"],
-                ["${length} < 1.0", "vec4(vec3(${temperature} * fract(${time})), 1.0)"],
-                ["true", "${COLOR}"]
-            ]
-        },
-        pointSize : "5.0 - ${length} * 2.0",
-        show : "${length} < 2.0"
-    });
-
-    function setStyle(style) {
-        return function() {
-            tileset.style = new Cesium.Cesium3DTileStyle(style);
-        };
-    }
-
-    var styleOptions = [];
-    for (var i = 0; i < styles.length; ++i) {
-        var style = styles[i];
-        styleOptions.push({
-            text : style.name,
-            onselect : setStyle(style.style)
-        });
-    }
-
-    Sandcastle.addToolbarMenu(styleOptions);
-    tileset.style = new Cesium.Cesium3DTileStyle(styles[0].style);
 }
 
+addStyle('No Style', {});
+
+addStyle('Red', {
+    color : "color('#ff0000')"
+});
+
+addStyle('Color Gradient', {
+    color : "color() * ${temperature}"
+});
+
+addStyle('Step Red/Blue', {
+    color : "${temperature} > 0.5 ? color('red') : color('blue')"
+});
+
+addStyle('Interpolate Red/Blue', {
+    color : "color('red') * ${temperature} + color('blue') * (1.0 - ${temperature})"
+});
+
+addStyle('Color Ramp', {
+    color : {
+        conditions : [
+            ["${temperature} < 0.1", "color('#000099')"],
+            ["${temperature} < 0.2", "color('#00cc99', 1.0)"],
+            ["${temperature} < 0.3", "color('#66ff33', 0.5)"],
+            ["${temperature} < 0.4", "rgba(255, 255, 0, 0.1)"],
+            ["${temperature} < 0.5", "rgb(255, 128, 0)"],
+            ["${temperature} < 0.6", "color('red')"],
+            ["${temperature} < 0.7", "color('rgb(255, 102, 102)')"],
+            ["${temperature} < 0.8", "hsl(0.875, 1.0, 0.6)"],
+            ["${temperature} < 0.9", "hsla(0.83, 1.0, 0.5, 0.1)"],
+            ["true", "color('#FFFFFF', 1.0)"]
+        ]
+    }
+});
+
+addStyle('Transparency', {
+    color : "rgba(0, 255, 0, ${temperature})"
+});
+
+addStyle('Hide Low Temperature', {
+    color : "rgb(${temperature}*255, 0, 0)",
+    show : "${temperature} > 0.3"
+});
+
+addStyle('Show Subsections', {
+    show : "${id} === 1 || ${id} > 250 && ${id} < 300"
+});
+
+addStyle('Mod', {
+    show : "${id} % 2 === 0"
+});
+
+addStyle('Abs', {
+    color : "color() * abs(${temperature} - 0.5)"
+});
+
+addStyle('Trigonometric Functions', {
+    color : "color() * radians(cos(${temperature})) + color() * sin(${temperature}) + color() * tan(${temperature})"
+
+});
+
+addStyle('Arc Trigonometric Functions', {
+    color : "color() * acos(degrees(${temperature})) + color() * asin(${temperature}) + color() * atan(${temperature}) + color() * atan2(${POSITION}[0],${temperature})"
+});
+
+addStyle('Sqrt', {
+    color : "color() * sqrt(${temperature})"
+});
+
+addStyle('Sign', {
+    color : "rgb(sign(${POSITION}[0]) * 255, sign(${POSITION}[1]) * 255, sign(${POSITION}[2]) * 255)"
+});
+
+addStyle('Rounding Functions', {
+    color : "rgb(floor(${POSITION}[0]) * 255, ceil(${POSITION}[1]) * 255, round(${POSITION}[2]) * 255)"
+});
+
+addStyle('Exp and Log Functions', {
+    color : "rgb(log(${POSITION}[0]) * 255, log2(${POSITION}[1]) * 255 + exp2(${POSITION}[1]) * 255, exp(${POSITION}[2]) * 255)"
+});
+
+addStyle('Fractional Part', {
+    color : "rgb(fract(${POSITION}[0]) * 255, fract(${POSITION}[1]) * 255, fract(${POSITION}[2]) * 255)"
+});
+
+addStyle('Pow', {
+    color : "color() * pow(${temperature}, 3)"
+});
+
+addStyle('Min and Max', {
+    color : "rgb(min(${POSITION}.x, 0.75) * 255, max(${POSITION}.z, 0.25) * 255, 255)"
+});
+
+addStyle('Clamp and Mix', {
+    color : "color() * clamp(${temperature}, 0.1, 0.2)"
+});
+
+addStyle('Secondary Color', {
+    color : {
+        conditions : [
+            ["${id} < 250", "vec4(${secondaryColor}, 1.0)"],
+            ["${id} < 500", "vec4(${secondaryColor} * ${secondaryColor}, 1.0)"],
+            ["${id} < 750", "vec4(${secondaryColor} / 5.0, 1.0)"],
+            ["${id} < 1000", "rgb(0, 0, Number(${secondaryColor}.x < 0.5) * 255)"]
+        ]
+    }
+});
+
+addStyle('Use point colors', {
+    color : "${COLOR} * ${temperature} + rgb(128,128,128)"
+});
+
+addStyle('Use point positions', {
+    show : "${POSITION}[0] > 0.5 || ${POSITION}[1] > 0.5 || ${POSITION}[2] > 0.5"
+});
+
+// POSITION contains 0 as its last component, so add 1.0 to make the point cloud opaque
+addStyle('Color based on position', {
+    color : "vec4(${POSITION}, 1.0)"
+});
+
+addStyle('Style point size', {
+    color : "color('red')",
+    pointSize : "${temperature} * 10"
+});
+
+addStyle('Multiple defines', {
+    defines : {
+        length : "length(${POSITION})",
+        time : "${tiles3d_tileset_time} * 3.0"
+    },
+    color : {
+        conditions : [
+            ["${length} < 0.5", "${length} * color('red')"],
+            ["${length} < 1.0", "vec4(vec3(${temperature} * fract(${time})), 1.0)"],
+            ["true", "${COLOR}"]
+        ]
+    },
+    pointSize : "5.0 - ${length} * 2.0",
+    show : "${length} < 2.0"
+});
+
+function setStyle(style) {
+    return function() {
+        tileset.style = new Cesium.Cesium3DTileStyle(style);
+    };
+}
+
+var styleOptions = [];
+for (var i = 0; i < styles.length; ++i) {
+    var style = styles[i];
+    styleOptions.push({
+        text : style.name,
+        onselect : setStyle(style.style)
+    });
+}
+
+Sandcastle.addToolbarMenu(styleOptions);
+tileset.style = new Cesium.Cesium3DTileStyle(styles[0].style);
 //Sandcastle_End
 Sandcastle.finishedLoading();
 }

--- a/Apps/Sandcastle/gallery/3D Tiles Point Cloud.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Point Cloud.html
@@ -29,15 +29,9 @@ function startup(Cesium) {
 //Point Cloud by Prof. Peter Allen, Columbia University Robotics Lab. Scanning by Alejandro Troccoli and Matei Ciocarlie.
 var viewer = new Cesium.Viewer('cesiumContainer');
 
-Cesium.CesiumIon.create3DTileset(1460, { accessToken: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiIyMzk2YzJiOS1jZGFmLTRlZmYtYmQ4MS00NTA3NjEwMzViZTkiLCJpZCI6NDQsImFzc2V0cyI6WzE0NjBdLCJpYXQiOjE0OTkyNjQ3NTV9.oWjvN52CRQ-dk3xtvD4e8ZnOHZhoWSpJLlw115mbQJM' })
-    .then(function(tileset) {
-        viewer.scene.primitives.add(tileset);
-        viewer.zoomTo(tileset);
-    })
-    .otherwise(function(error) {
-        console.log(error);
-    });
-
+var tileset = new Cesium.Cesium3DTileset({ url: Cesium.CesiumIon.createResource(3838) });
+viewer.scene.primitives.add(tileset);
+viewer.zoomTo(tileset);
 //Sandcastle_End
 Sandcastle.finishedLoading();
 }

--- a/Apps/Sandcastle/gallery/3D Tiles Terrain Classification.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Terrain Classification.html
@@ -42,16 +42,12 @@ geocoder.search();
 // Vector 3D Tiles are experimental and the format is subject to change in the future.
 // For more details, see:
 //    https://github.com/AnalyticalGraphicsInc/3d-tiles/tree/3d-tiles-next/TileFormats/VectorData
-Cesium.CesiumIon.create3DTileset(3623, { accessToken: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiIwODI4NTUxMC1lMzRjLTQ3OTMtODQ4NC1jM2UzYjc0MTk1NGQiLCJpZCI6NDQsImFzc2V0cyI6WzM2MjNdLCJpYXQiOjE1MTU1OTMxNjl9.PhDPnGMEPxGvxs_oIcQgfMv1OgiZhGjREJypZkwEs1g' })
-    .then(function(tileset) {
-        viewer.scene.primitives.add(tileset);
+var tileset = new Cesium.Cesium3DTileset({ url: Cesium.CesiumIon.createResource(3841) });
+viewer.scene.primitives.add(tileset);
 
-        tileset.style = new Cesium.Cesium3DTileStyle({
-            color: 'rgba(255, 255, 255, 0.5)'
-        });
-    }).otherwise(function(error) {
-        console.log(error);
-    });
+tileset.style = new Cesium.Cesium3DTileStyle({
+    color: 'rgba(255, 255, 255, 0.5)'
+});
 
 // Information about the currently highlighted feature
 var highlighted = {

--- a/Apps/Sandcastle/gallery/Classification Types.html
+++ b/Apps/Sandcastle/gallery/Classification Types.html
@@ -29,15 +29,14 @@ function startup(Cesium) {
 //Sandcastle_Begin
 var viewer = new Cesium.Viewer('cesiumContainer');
 
-Cesium.CesiumIon.create3DTileset(1458, { accessToken: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiIxYmJiNTAxOC1lOTg5LTQzN2EtODg1OC0zMWJjM2IxNGNlYmMiLCJpZCI6NDQsImFzc2V0cyI6WzE0NThdLCJpYXQiOjE0OTkyNjM4MjB9.1WKijRa-ILkmG6utrhDWX6rDgasjD7dZv-G5ZyCmkKg' })
-    .then(function(tileset) {
-        viewer.scene.primitives.add(tileset);
-        var boundingSphere = tileset.boundingSphere;
-        viewer.camera.viewBoundingSphere(boundingSphere, new Cesium.HeadingPitchRange(0.0, -0.5, boundingSphere.radius + 500.0));
-        viewer.camera.lookAtTransform(Cesium.Matrix4.IDENTITY);
-    }).otherwise(function(error) {
-        console.log(error);
-    });
+var tileset = new Cesium.Cesium3DTileset({ url: Cesium.CesiumIon.createResource(3836) });
+viewer.scene.primitives.add(tileset);
+
+tileset.readyPromise.then(function(){
+    var boundingSphere = tileset.boundingSphere;
+    viewer.camera.viewBoundingSphere(boundingSphere, new Cesium.HeadingPitchRange(0.0, -0.5, boundingSphere.radius + 500.0));
+    viewer.camera.lookAtTransform(Cesium.Matrix4.IDENTITY);
+});
 
 var cartographics = [new Cesium.Cartographic(-1.3194369277314022, 0.6988062530900625),
                      new Cesium.Cartographic(-1.3193955980204217, 0.6988091578771254),

--- a/Apps/Sandcastle/gallery/Classification.html
+++ b/Apps/Sandcastle/gallery/Classification.html
@@ -195,26 +195,22 @@ function updateAlpha(value) {
     scene.invertClassificationColor.alpha = parseFloat(value);
 }
 
-Cesium.CesiumIon.create3DTileset(1458, { accessToken: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiIxYmJiNTAxOC1lOTg5LTQzN2EtODg1OC0zMWJjM2IxNGNlYmMiLCJpZCI6NDQsImFzc2V0cyI6WzE0NThdLCJpYXQiOjE0OTkyNjM4MjB9.1WKijRa-ILkmG6utrhDWX6rDgasjD7dZv-G5ZyCmkKg' })
-    .then(function(tileset) {
-        scene.primitives.add(tileset);
+var tileset = new Cesium.Cesium3DTileset({ url: Cesium.CesiumIon.createResource(3836) });
+scene.primitives.add(tileset);
 
-        var viewModel = {
-            inverted: viewer.scene.invertClassification,
-            invertedAlpha: viewer.scene.invertClassificationColor.alpha,
-            highlightBuilding: highlightBuilding,
-            highlightTrees: highlightTrees
-        };
-        Cesium.knockout.track(viewModel);
-        var toolbar = document.getElementById('toolbar');
-        Cesium.knockout.applyBindings(viewModel, toolbar);
-        Cesium.knockout.getObservable(viewModel, 'inverted').subscribe(invertClassification);
-        Cesium.knockout.getObservable(viewModel, 'invertedAlpha').subscribe(updateAlpha);
+var viewModel = {
+    inverted: viewer.scene.invertClassification,
+    invertedAlpha: viewer.scene.invertClassificationColor.alpha,
+    highlightBuilding: highlightBuilding,
+    highlightTrees: highlightTrees
+};
+Cesium.knockout.track(viewModel);
+var toolbar = document.getElementById('toolbar');
+Cesium.knockout.applyBindings(viewModel, toolbar);
+Cesium.knockout.getObservable(viewModel, 'inverted').subscribe(invertClassification);
+Cesium.knockout.getObservable(viewModel, 'invertedAlpha').subscribe(updateAlpha);
 
-        highlightTrees();
-    }).otherwise(function(error) {
-        console.log(error);
-    });
+highlightTrees();
 
 var currentObjectId;
 var currentPrimitive;

--- a/Apps/Sandcastle/gallery/Scene Rendering Performance.html
+++ b/Apps/Sandcastle/gallery/Scene Rendering Performance.html
@@ -144,14 +144,9 @@ function resetScene() {
 function loadTilesetScenario() {
     resetScene();
 
-    Cesium.CesiumIon.create3DTileset(1458, { accessToken: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiIxYmJiNTAxOC1lOTg5LTQzN2EtODg1OC0zMWJjM2IxNGNlYmMiLCJpZCI6NDQsImFzc2V0cyI6WzE0NThdLCJpYXQiOjE0OTkyNjM4MjB9.1WKijRa-ILkmG6utrhDWX6rDgasjD7dZv-G5ZyCmkKg' })
-        .then(function(tileset) {
-            viewer.scene.primitives.add(tileset);
-            viewer.zoomTo(tileset);
-        })
-        .otherwise(function(error) {
-            console.log(error);
-        });
+    var tileset = new Cesium.Cesium3DTileset({ url: Cesium.CesiumIon.createResource(3836) });
+    viewer.scene.primitives.add(tileset);
+    viewer.zoomTo(tileset);
 }
 
 // Load an animated model and set the view.

--- a/Apps/Sandcastle/gallery/development/Shadows.html
+++ b/Apps/Sandcastle/gallery/development/Shadows.html
@@ -306,7 +306,7 @@ var uiOptions = {
         '3D Tiles' : {
             'centerLongitude' : -1.31968,
             'centerLatitude' : 0.698874,
-            'tileset' : Cesium.CesiumIon.createResource(3883, { accessToken: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJjYjNlMTg5Zi1hMzc2LTRmZjktOGEwZC00NGEzNTM0MTAzZGUiLCJpZCI6MjU5LCJpYXQiOjE1MTgxOTE2NTV9.qaP8-_Ej6AihGnv5iB990Hm6lHr8F_rrC3_EPxdT6MQ' })
+            'tileset' : Cesium.CesiumIon.createResource(3883)
         }
     }
 };

--- a/Source/Scene/CesiumIon.js
+++ b/Source/Scene/CesiumIon.js
@@ -56,7 +56,7 @@ define([
      *
      * @type {String}
      */
-    CesiumIon.defaultAccessToken = undefined;
+    CesiumIon.defaultAccessToken = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJqdGkiOiI0NDViM2NkNi0xYTE2LTRlZTUtODBlNy05M2Q4ODg4M2NmMTQiLCJpZCI6MjU5LCJpYXQiOjE1MTgxOTc4MDh9.sld5jPORDf_lWavMEsugh6vHPnjR6j3qd1aBkQTswNM';
 
     /**
      * The default Cesium ion server to use.

--- a/Specs/Scene/CesiumIonSpec.js
+++ b/Specs/Scene/CesiumIonSpec.js
@@ -100,7 +100,7 @@ defineSuite([
     it('createEndpointResource creates expected values with default parameters', function() {
         var assetId = 2348234;
         var resource = CesiumIon._createEndpointResource(assetId);
-        expect(resource.url).toBe(CesiumIon.defaultServerUrl + '/v1/assets/' + assetId + '/endpoint');
+        expect(resource.url).toBe(CesiumIon.defaultServerUrl + '/v1/assets/' + assetId + '/endpoint?access_token=' + CesiumIon.defaultAccessToken);
     });
 
     it('createEndpointResource creates expected values with overridden options', function() {


### PR DESCRIPTION
This is the first in a series of PRs to cleanup (and improve) ion support.  This one just concentrates on the default key and Sandcastle examples.

1. Add default access token for Cesium ion.
2. Update Sandcastle examples to rely on the default ion access token and also switch back to synchronous creation methods now that `Cesium3DTileset` supports it. (thanks to #6204).