### PR TITLE
Adjust request priority for close globe tiles

### DIFF
--- a/Source/Scene/GlobeSurfaceTile.js
+++ b/Source/Scene/GlobeSurfaceTile.js
@@ -7,6 +7,7 @@ define([
         '../Core/defineProperties',
         '../Core/IntersectionTests',
         '../Core/PixelFormat',
+        '../Core/Rectangle',
         '../Renderer/PixelDatatype',
         '../Renderer/Sampler',
         '../Renderer/Texture',
@@ -28,6 +29,7 @@ define([
         defineProperties,
         IntersectionTests,
         PixelFormat,
+        Rectangle,
         PixelDatatype,
         Sampler,
         Texture,
@@ -254,6 +256,10 @@ define([
 
     function createPriorityFunction(surfaceTile, frameState) {
         return function() {
+            if (Rectangle.contains(surfaceTile.tileBoundingRegion.rectangle, frameState.camera.positionCartographic)) {
+                // If the camera is inside this tile's bounding region treat it as highest priority
+                return 0.0;
+            }
             return surfaceTile.tileBoundingRegion.distanceToCamera(frameState);
         };
     }


### PR DESCRIPTION
For #6243 
Fixes https://github.com/AnalyticalGraphicsInc/cesium/issues/5954

If the camera is inside a globe tile's bounding rectangle, that tile will be requested with highest priority. This prevents 3D Tiles requests from possibly starving imagery/terrain requests. This is especially important for the root globe tile and other large tiles where distance is a bad metric and they should really be loaded right away.

I'm not sure if I've truly seen 3D Tiles starve imagery/terrain (https://github.com/AnalyticalGraphicsInc/cesium/issues/5954 is more of an edge case), but this would prevent that from happening.