### PR TITLE
Don't send key with every Bing tile request.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,6 +22,7 @@ Change Log
 * Fixed bug where 3D Tiles Point Clouds would fail in Internet Explorer. [#6220](https://github.com/AnalyticalGraphicsInc/cesium/pull/6220)
 * Fixed `Material` so it can now take a `Resource` object as an image. [#6199](https://github.com/AnalyticalGraphicsInc/cesium/issues/6199)
 * Fixed issue where `CESIUM_BASE_URL` wouldn't work without a trailing `/`. [#6225](https://github.com/AnalyticalGraphicsInc/cesium/issues/6225)
+* Fixed an issue causing the Bing Maps key to be sent unnecessarily with every tile request. [#6250](https://github.com/AnalyticalGraphicsInc/cesium/pull/6250)
 * Fixed documentation issue for the `Cesium.Math` class. [#6233](https://github.com/AnalyticalGraphicsInc/cesium/issues/6233)
 
 ##### Additions :tada:

--- a/Source/Scene/BingMapsImageryProvider.js
+++ b/Source/Scene/BingMapsImageryProvider.js
@@ -109,15 +109,9 @@ define([
         this._key = BingMapsApi.getKey(options.key);
         this._keyErrorCredit = BingMapsApi.getErrorCredit(options.key);
 
-        var urlResource = Resource.createIfNeeded(options.url, {
+        this._resource = Resource.createIfNeeded(options.url, {
             proxy: options.proxy
         });
-
-        urlResource.setQueryParameters({
-            key: this._key
-        });
-
-        this._resource = urlResource;
 
         this._tileProtocol = options.tileProtocol;
         this._mapStyle = defaultValue(options.mapStyle, BingMapsStyle.AERIAL);
@@ -157,10 +151,11 @@ define([
         this._ready = false;
         this._readyPromise = when.defer();
 
-        var metadataResource = urlResource.getDerivedResource({
+        var metadataResource = this._resource.getDerivedResource({
             url:'/REST/v1/Imagery/Metadata/' + this._mapStyle,
             queryParameters: {
-                incl: 'ImageryProviders'
+                incl: 'ImageryProviders',
+                key: this._key
             }
         });
         var that = this;


### PR DESCRIPTION
Key is only needed on the initial metadata request.

Regression from #6035.