### PR TITLE
Fix CI makeZipFile failure?

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ script:
 
   - echo 'makeZipFile' && echo -en 'travis_fold:start:script.makeZipFile\\r'
   - npm run clean
-  - npm run makeZipFile -- --concurrency 2
+  - npm run makeZipFile -- --concurrency 1
   - npm pack
   - echo -en 'travis_fold:end:script.makeZipFile\\r'
 


### PR DESCRIPTION
For #6230

Reducing the concurrency to 1 to see if that prevents intermittent CI failures when running `makeZipFile`