### PR TITLE
Let Viewer to take imageryProvider or terrainProvider with BaseLayerPicker

### DIFF
--- a/Apps/Sandcastle/gallery/3D Tiles Terrain Classification.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Terrain Classification.html
@@ -26,12 +26,12 @@
 function startup(Cesium) {
     'use strict';
 //Sandcastle_Begin
-var viewer = new Cesium.Viewer('cesiumContainer');
-
-viewer.terrainProvider = new Cesium.CesiumTerrainProvider({
-    url : 'https://assets.agi.com/stk-terrain/v1/tilesets/world/tiles',
-    requestWaterMask : true,
-    requestVertexNormals : true
+var viewer = new Cesium.Viewer('cesiumContainer', {
+    terrainProvider: new Cesium.CesiumTerrainProvider({
+        url: 'https://assets.agi.com/stk-terrain/v1/tilesets/world/tiles',
+        requestWaterMask: true,
+        requestVertexNormals: true
+    })
 });
 
 var geocoder = viewer.geocoder.viewModel;

--- a/Apps/Sandcastle/gallery/ArcticDEM.html
+++ b/Apps/Sandcastle/gallery/ArcticDEM.html
@@ -27,15 +27,14 @@
 function startup(Cesium) {
     'use strict';
 //Sandcastle_Begin
-var viewer = new Cesium.Viewer('cesiumContainer');
-
-// Load ArcticDEM terrain
-var cesiumTerrainProviderMeshes = new Cesium.CesiumTerrainProvider({
-    url : 'https://assets.agi.com/stk-terrain/v1/tilesets/ArticDEM/tiles',
-    requestWaterMask : true,
-    requestVertexNormals : true
+var viewer = new Cesium.Viewer('cesiumContainer', {
+    // Load ArcticDEM terrain
+    terrainProvider: new Cesium.CesiumTerrainProvider({
+        url: 'https://assets.agi.com/stk-terrain/v1/tilesets/ArticDEM/tiles',
+        requestWaterMask: true,
+        requestVertexNormals: true
+    })
 });
-viewer.terrainProvider = cesiumTerrainProviderMeshes;
 
 // Add Alaskan locations
 Sandcastle.addDefaultToolbarMenu([{

--- a/Apps/Sandcastle/gallery/Cardboard.html
+++ b/Apps/Sandcastle/gallery/Cardboard.html
@@ -28,17 +28,15 @@ function startup(Cesium) {
     'use strict';
 //Sandcastle_Begin
 var viewer = new Cesium.Viewer('cesiumContainer', {
-    vrButton : true
+    vrButton: true,
+    terrainProvider: new Cesium.CesiumTerrainProvider({
+        url: 'https://assets.agi.com/stk-terrain/v1/tilesets/world/tiles',
+        requestVertexNormals: true
+    })
 });
 // Click the VR button in the bottom right of the screen to switch to VR mode.
 
 viewer.scene.globe.enableLighting = true;
-
-viewer.terrainProvider = new Cesium.CesiumTerrainProvider({
-    url : 'https://assets.agi.com/stk-terrain/v1/tilesets/world/tiles',
-    requestVertexNormals : true
-});
-
 viewer.scene.globe.depthTestAgainstTerrain = true;
 
 // Follow the path of a plane. See the interpolation Sandcastle example.

--- a/Apps/Sandcastle/gallery/Cesium Inspector.html
+++ b/Apps/Sandcastle/gallery/Cesium Inspector.html
@@ -31,18 +31,16 @@
 function startup(Cesium) {
     'use strict';
 //Sandcastle_Begin
-var viewer = new Cesium.Viewer('cesiumContainer');
-var scene = viewer.scene;
-var globe = scene.globe;
-globe.depthTestAgainstTerrain = true;
-
-var cesiumTerrainProviderHeightmaps = new Cesium.CesiumTerrainProvider({
-    url : 'https://assets.agi.com/stk-terrain/v1/tilesets/world/tiles',
-    requestWaterMask: true,
-    requestVertexNormals: true
+var viewer = new Cesium.Viewer('cesiumContainer', {
+    terrainProvider: new Cesium.CesiumTerrainProvider({
+        url: 'https://assets.agi.com/stk-terrain/v1/tilesets/world/tiles',
+        requestWaterMask: true,
+        requestVertexNormals: true
+    })
 });
 
-viewer.terrainProvider = cesiumTerrainProviderHeightmaps;
+var scene = viewer.scene;
+scene.globe.depthTestAgainstTerrain = true;
 
 //Add Cesium Inspector
 viewer.extend(Cesium.viewerCesiumInspectorMixin);

--- a/Apps/Sandcastle/gallery/Globe Materials.html
+++ b/Apps/Sandcastle/gallery/Globe Materials.html
@@ -60,11 +60,12 @@
 function startup(Cesium) {
     'use strict';
 //Sandcastle_Begin
-var viewer = new Cesium.Viewer('cesiumContainer');
-viewer.terrainProvider = new Cesium.CesiumTerrainProvider({
-    url : 'https://assets.agi.com/stk-terrain/v1/tilesets/world/tiles',
-    requestWaterMask : true,
-    requestVertexNormals : true
+var viewer = new Cesium.Viewer('cesiumContainer', {
+    terrainProvider: new Cesium.CesiumTerrainProvider({
+        url: 'https://assets.agi.com/stk-terrain/v1/tilesets/world/tiles',
+        requestWaterMask: true,
+        requestVertexNormals: true
+    })
 });
 viewer.scene.globe.enableLighting = true;
 

--- a/Apps/Sandcastle/gallery/Ground Clamping.html
+++ b/Apps/Sandcastle/gallery/Ground Clamping.html
@@ -32,14 +32,15 @@
 function startup(Cesium) {
     'use strict';
 //Sandcastle_Begin
-var viewer = new Cesium.Viewer('cesiumContainer');
-var cesiumTerrainProviderMeshes = new Cesium.CesiumTerrainProvider({
-    url : 'https://assets.agi.com/stk-terrain/v1/tilesets/world/tiles',
-    requestWaterMask : true,
-    requestVertexNormals : true
+var viewer = new Cesium.Viewer('cesiumContainer', {
+    terrainProvider: new Cesium.CesiumTerrainProvider({
+        url: 'https://assets.agi.com/stk-terrain/v1/tilesets/world/tiles',
+        requestWaterMask: true,
+        requestVertexNormals: true
+    })
 });
-viewer.terrainProvider = cesiumTerrainProviderMeshes;
 viewer.scene.globe.depthTestAgainstTerrain = true;
+
 Sandcastle.addDefaultToolbarMenu([{
     //
     // To clamp points or billboards set the heightReference to CLAMP_TO_GROUND or RELATIVE_TO_GROUND

--- a/Apps/Sandcastle/gallery/Interpolation.html
+++ b/Apps/Sandcastle/gallery/Interpolation.html
@@ -30,21 +30,18 @@ function startup(Cesium) {
     'use strict';
 //Sandcastle_Begin
 var viewer = new Cesium.Viewer('cesiumContainer', {
-    terrainProviderViewModels : [], //Disable terrain changing
-    infoBox : false, //Disable InfoBox widget
-    selectionIndicator : false, //Disable selection indicator
-    shouldAnimate : true // Enable animations
+    infoBox: false, //Disable InfoBox widget
+    selectionIndicator: false, //Disable selection indicator
+    shouldAnimate: true, // Enable animations
+    terrainProvider: new Cesium.CesiumTerrainProvider({
+        url: 'https://assets.agi.com/stk-terrain/v1/tilesets/world/tiles',
+        requestWaterMask: true,
+        requestVertexNormals: true
+    })
 });
 
 //Enable lighting based on sun/moon positions
 viewer.scene.globe.enableLighting = true;
-
-//Use STK World Terrain
-viewer.terrainProvider = new Cesium.CesiumTerrainProvider({
-    url : 'https://assets.agi.com/stk-terrain/v1/tilesets/world/tiles',
-    requestWaterMask : true,
-    requestVertexNormals : true
-});
 
 //Enable depth testing so things behind the terrain disappear.
 viewer.scene.globe.depthTestAgainstTerrain = true;

--- a/Apps/Sandcastle/gallery/PATerrain.html
+++ b/Apps/Sandcastle/gallery/PATerrain.html
@@ -27,15 +27,14 @@
 function startup(Cesium) {
     'use strict';
 //Sandcastle_Begin
-var viewer = new Cesium.Viewer('cesiumContainer');
-
-// Load PA terrain
-var cesiumTerrainProviderMeshes = new Cesium.CesiumTerrainProvider({
-    url : 'https://assets.agi.com/stk-terrain/v1/tilesets/PAMAP/tiles',
-    requestWaterMask : true,
-    requestVertexNormals : true
+var viewer = new Cesium.Viewer('cesiumContainer', {
+    // Load PA terrain
+    terrainProvider: new Cesium.CesiumTerrainProvider({
+        url: 'https://assets.agi.com/stk-terrain/v1/tilesets/PAMAP/tiles',
+        requestWaterMask: true,
+        requestVertexNormals: true
+    })
 });
-viewer.terrainProvider = cesiumTerrainProviderMeshes;
 
 // Add PA locations
 Sandcastle.addDefaultToolbarMenu([{

--- a/Apps/Sandcastle/gallery/Physically-Based Materials.html
+++ b/Apps/Sandcastle/gallery/Physically-Based Materials.html
@@ -39,7 +39,12 @@ var clock = new Cesium.Clock({
 
 var viewer = new Cesium.Viewer('cesiumContainer', {
     clockViewModel : new Cesium.ClockViewModel(clock),
-    selectionIndicator : false
+    selectionIndicator : false,
+    terrainProvider: new Cesium.CesiumTerrainProvider({
+        url : 'https://assets.agi.com/stk-terrain/v1/tilesets/world/tiles',
+        requestWaterMask: true,
+        requestVertexNormals: true
+    })
 });
 
 Sandcastle.addToggleButton('Shadows', viewer.shadows, function(checked) {
@@ -48,13 +53,6 @@ Sandcastle.addToggleButton('Shadows', viewer.shadows, function(checked) {
 
 viewer.scene.globe.enableLighting = true;
 viewer.scene.globe.depthTestAgainstTerrain = true;
-
-var cesiumTerrainProviderMeshes = new Cesium.CesiumTerrainProvider({
-    url : 'https://assets.agi.com/stk-terrain/v1/tilesets/world/tiles',
-    requestWaterMask : true,
-    requestVertexNormals : true
-});
-viewer.terrainProvider = cesiumTerrainProviderMeshes;
 
 var position = new Cesium.Cartesian3(-1371108.6511167218, -5508684.080096612, 2901825.449865087);
 var heading = Cesium.Math.toRadians(180);
@@ -116,39 +114,37 @@ var upwardsView = {
     maximumHeight : 100
 };
 
-cesiumTerrainProviderMeshes.readyPromise.then(function() {
-    viewer.scene.camera.flyTo({
-        destination : frontView.destination,
-        orientation :  frontView.orientation,
-        duration : 5.0,
-        pitchAdjustHeight : 20
-    });
-    Sandcastle.addToolbarMenu([{
-        text : 'Front reflection',
-        onselect : function() {
-            viewer.scene.camera.flyTo(frontView);
-            viewer.clockViewModel.clock.currentTime = Cesium.JulianDate.fromIso8601("2017-07-11T20:00:00Z");
-        }
-    }, {
-        text : 'Three quarters sunrise',
-        onselect : function() {
-            viewer.scene.camera.flyTo(threeQuartersView);
-            viewer.clockViewModel.clock.currentTime = Cesium.JulianDate.fromIso8601("2017-07-11T11:00:00Z");
-        }
-    }, {
-        text : 'Top reflection',
-        onselect : function() {
-            viewer.scene.camera.flyTo(topView);
-            viewer.clockViewModel.clock.currentTime = Cesium.JulianDate.fromIso8601("2017-07-11T12:00:00Z");
-        }
-    }, {
-        text : 'Upward angle side reflection',
-        onselect : function() {
-            viewer.scene.camera.flyTo(upwardsView);
-            viewer.clockViewModel.clock.currentTime = Cesium.JulianDate.fromIso8601("2017-07-11T23:00:00Z");
-        }
-    }], 'toolbar');
+viewer.scene.camera.flyTo({
+    destination : frontView.destination,
+    orientation :  frontView.orientation,
+    duration : 5.0,
+    pitchAdjustHeight : 20
 });
+Sandcastle.addToolbarMenu([{
+    text : 'Front reflection',
+    onselect : function() {
+        viewer.scene.camera.flyTo(frontView);
+        viewer.clockViewModel.clock.currentTime = Cesium.JulianDate.fromIso8601("2017-07-11T20:00:00Z");
+    }
+}, {
+    text : 'Three quarters sunrise',
+    onselect : function() {
+        viewer.scene.camera.flyTo(threeQuartersView);
+        viewer.clockViewModel.clock.currentTime = Cesium.JulianDate.fromIso8601("2017-07-11T11:00:00Z");
+    }
+}, {
+    text : 'Top reflection',
+    onselect : function() {
+        viewer.scene.camera.flyTo(topView);
+        viewer.clockViewModel.clock.currentTime = Cesium.JulianDate.fromIso8601("2017-07-11T12:00:00Z");
+    }
+}, {
+    text : 'Upward angle side reflection',
+    onselect : function() {
+        viewer.scene.camera.flyTo(upwardsView);
+        viewer.clockViewModel.clock.currentTime = Cesium.JulianDate.fromIso8601("2017-07-11T23:00:00Z");
+    }
+}], 'toolbar');
 //Sandcastle_End
 Sandcastle.finishedLoading();
 }

--- a/Apps/Sandcastle/gallery/Shadows.html
+++ b/Apps/Sandcastle/gallery/Shadows.html
@@ -28,19 +28,17 @@
 function startup(Cesium) {
     'use strict';
 //Sandcastle_Begin
-
 var viewer = new Cesium.Viewer('cesiumContainer', {
-    infoBox : false,
-    selectionIndicator : false,
-    shadows : true,
-    terrainShadows : Cesium.ShadowMode.ENABLED,
-    shouldAnimate : true
-});
-
-viewer.terrainProvider = new Cesium.CesiumTerrainProvider({
-    url : 'https://assets.agi.com/stk-terrain/v1/tilesets/world/tiles',
-    requestWaterMask : true,
-    requestVertexNormals : true
+    infoBox: false,
+    selectionIndicator: false,
+    shadows: true,
+    terrainShadows: Cesium.ShadowMode.ENABLED,
+    shouldAnimate: true,
+    terrainProvider: new Cesium.CesiumTerrainProvider({
+        url: 'https://assets.agi.com/stk-terrain/v1/tilesets/world/tiles',
+        requestWaterMask: true,
+        requestVertexNormals: true
+    })
 });
 
 var shadowMap = viewer.shadowMap;

--- a/Apps/Sandcastle/gallery/Terrain Clipping Planes.html
+++ b/Apps/Sandcastle/gallery/Terrain Clipping Planes.html
@@ -44,13 +44,12 @@ function startup(Cesium) {
 
 var viewer = new Cesium.Viewer('cesiumContainer', {
     skyAtmosphere: false,
-    shouldAnimate : true
-});
-
-viewer.terrainProvider = new Cesium.CesiumTerrainProvider({
-    url : 'https://assets.agi.com/stk-terrain/v1/tilesets/world/tiles',
-    requestWaterMask : true,
-    requestVertexNormals : true
+    shouldAnimate : true,
+    terrainProvider: new Cesium.CesiumTerrainProvider({
+        url: 'https://assets.agi.com/stk-terrain/v1/tilesets/world/tiles',
+        requestWaterMask: true,
+        requestVertexNormals: true
+    })
 });
 
 var position = Cesium.Cartesian3.fromRadians(-2.0862979473351286, 0.6586620013036164, 1400.0);

--- a/Apps/Sandcastle/gallery/Terrain Exaggeration.html
+++ b/Apps/Sandcastle/gallery/Terrain Exaggeration.html
@@ -30,16 +30,13 @@ function startup(Cesium) {
     'use strict';
 //Sandcastle_Begin
 var viewer = new Cesium.Viewer('cesiumContainer', {
-    terrainExaggeration : 2.0
+    terrainExaggeration : 2.0,
+    terrainProvider: new Cesium.CesiumTerrainProvider({
+        url : 'https://assets.agi.com/stk-terrain/v1/tilesets/world/tiles',
+        requestWaterMask: true,
+        requestVertexNormals: true
+    })
 });
-
-var cesiumTerrainProviderMeshes = new Cesium.CesiumTerrainProvider({
-    url : 'https://assets.agi.com/stk-terrain/v1/tilesets/world/tiles',
-    requestWaterMask : true,
-    requestVertexNormals : true
-});
-viewer.terrainProvider = cesiumTerrainProviderMeshes;
-
 
 Sandcastle.addDefaultToolbarMenu([{
     text : 'Mount Everest',

--- a/Apps/Sandcastle/gallery/Terrain.html
+++ b/Apps/Sandcastle/gallery/Terrain.html
@@ -31,17 +31,18 @@
 function startup(Cesium) {
     'use strict';
 //Sandcastle_Begin
-var viewer = new Cesium.Viewer('cesiumContainer');
-
-// set lighting to true
-viewer.scene.globe.enableLighting = true;
-
-var cesiumTerrainProviderMeshes = new Cesium.CesiumTerrainProvider({
+var worldTerrain = new Cesium.CesiumTerrainProvider({
     url : 'https://assets.agi.com/stk-terrain/v1/tilesets/world/tiles',
     requestWaterMask : true,
     requestVertexNormals : true
 });
-viewer.terrainProvider = cesiumTerrainProviderMeshes;
+
+var viewer = new Cesium.Viewer('cesiumContainer', {
+    terrainProvider: worldTerrain
+});
+
+// set lighting to true
+viewer.scene.globe.enableLighting = true;
 
 // setup alternative terrain providers
 var ellipsoidProvider = new Cesium.EllipsoidTerrainProvider();
@@ -54,7 +55,7 @@ var vrTheWorldProvider = new Cesium.VRTheWorldTerrainProvider({
 Sandcastle.addToolbarMenu([{
     text : 'CesiumTerrainProvider - STK World Terrain',
     onselect : function() {
-        viewer.terrainProvider = cesiumTerrainProviderMeshes;
+        viewer.terrainProvider = worldTerrain;
         viewer.scene.globe.enableLighting = true;
     }
 }, {

--- a/Apps/Sandcastle/gallery/development/BillboardClampToGround.html
+++ b/Apps/Sandcastle/gallery/development/BillboardClampToGround.html
@@ -32,12 +32,11 @@
 function startup(Cesium) {
     'use strict';
 //Sandcastle_Begin
-var viewer = new Cesium.Viewer('cesiumContainer');
-
-var cesiumTerrainProviderMeshes = new Cesium.CesiumTerrainProvider({
-    url : 'https://assets.agi.com/stk-terrain/v1/tilesets/world/tiles'
+var viewer = new Cesium.Viewer('cesiumContainer', {
+    terrainProvider: new Cesium.CesiumTerrainProvider({
+        url: 'https://assets.agi.com/stk-terrain/v1/tilesets/world/tiles'
+    })
 });
-viewer.terrainProvider = cesiumTerrainProviderMeshes;
 viewer.scene.globe.depthTestAgainstTerrain = true;
 
 var ellipsoid = viewer.scene.globe.ellipsoid;

--- a/Apps/Sandcastle/gallery/development/Billboards Instancing.html
+++ b/Apps/Sandcastle/gallery/development/Billboards Instancing.html
@@ -32,15 +32,15 @@
 function startup(Cesium) {
     'use strict';
 //Sandcastle_Begin
-var viewer = new Cesium.Viewer('cesiumContainer');
+var viewer = new Cesium.Viewer('cesiumContainer', {
+    terrainProvider: new Cesium.CesiumTerrainProvider({
+        url: 'https://assets.agi.com/stk-terrain/v1/tilesets/world/tiles'
+    })
+});
+
 var scene = viewer.scene;
 var context = scene.context;
 
-var cesiumTerrainProviderMeshes = new Cesium.CesiumTerrainProvider({
-    url : 'https://assets.agi.com/stk-terrain/v1/tilesets/world/tiles'
-});
-
-viewer.terrainProvider = cesiumTerrainProviderMeshes;
 scene.debugShowFramesPerSecond = true;
 
 var ellipsoid = scene.globe.ellipsoid;

--- a/Apps/Sandcastle/gallery/development/Fog.html
+++ b/Apps/Sandcastle/gallery/development/Fog.html
@@ -43,11 +43,12 @@
 function startup(Cesium) {
     'use strict';
 //Sandcastle_Begin
-var viewer = new Cesium.Viewer('cesiumContainer');
-viewer.terrainProvider = new Cesium.CesiumTerrainProvider({
-    url : 'https://assets.agi.com/stk-terrain/v1/tilesets/world/tiles',
-    requestWaterMask : true,
-    requestVertexNormals : true
+var viewer = new Cesium.Viewer('cesiumContainer', {
+    terrainProvider: new Cesium.CesiumTerrainProvider({
+        url: 'https://assets.agi.com/stk-terrain/v1/tilesets/world/tiles',
+        requestWaterMask : true,
+        requestVertexNormals : true
+    })
 });
 
 viewer.extend(Cesium.viewerCesiumInspectorMixin);

--- a/Apps/Sandcastle/gallery/development/Ground Primitive.html
+++ b/Apps/Sandcastle/gallery/development/Ground Primitive.html
@@ -27,14 +27,13 @@
 function startup(Cesium) {
     'use strict';
 //Sandcastle_Begin
-
-//Create the viewer.
-var viewer = new Cesium.Viewer('cesiumContainer');
-var scene = viewer.scene;
-scene.terrainProvider = new Cesium.CesiumTerrainProvider({
-    url : 'https://assets.agi.com/stk-terrain/v1/tilesets/world/tiles',
-    requestVertexNormals : true
+var viewer = new Cesium.Viewer('cesiumContainer', {
+    terrainProvider: new Cesium.CesiumTerrainProvider({
+        url: 'https://assets.agi.com/stk-terrain/v1/tilesets/world/tiles',
+        requestVertexNormals: true
+    })
 });
+var scene = viewer.scene;
 
 function offsetPositions(positions, degreeOffset) {
     positions = scene.globe.ellipsoid.cartesianArrayToCartographicArray(positions);

--- a/Apps/Sandcastle/gallery/development/Multiple Shadows.html
+++ b/Apps/Sandcastle/gallery/development/Multiple Shadows.html
@@ -41,12 +41,12 @@
             scene3DOnly : true,
             infoBox : false,
             selectionIndicator : false,
-            timeline : false
-        });
-        viewer.terrainProvider = new Cesium.CesiumTerrainProvider({
-            url : 'https://assets.agi.com/stk-terrain/v1/tilesets/world/tiles',
-            requestWaterMask : true,
-            requestVertexNormals : true
+            timeline : false,
+            terrainProvider: new Cesium.CesiumTerrainProvider({
+                url: 'https://assets.agi.com/stk-terrain/v1/tilesets/world/tiles',
+                requestWaterMask: true,
+                requestVertexNormals: true
+            })
         });
 
         var scene = viewer.scene;

--- a/Source/Widgets/BaseLayerPicker/BaseLayerPicker.js
+++ b/Source/Widgets/BaseLayerPicker/BaseLayerPicker.js
@@ -127,7 +127,7 @@ click: toggleDropDown');
         imgElement.setAttribute('draggable', 'false');
         imgElement.className = 'cesium-baseLayerPicker-selected';
         imgElement.setAttribute('data-bind', '\
-attr: { src: buttonImageUrl }');
+attr: { src: buttonImageUrl }, visible: !!buttonImageUrl');
         element.appendChild(imgElement);
 
         var dropPanel = document.createElement('div');

--- a/Source/Widgets/BaseLayerPicker/BaseLayerPickerViewModel.js
+++ b/Source/Widgets/BaseLayerPicker/BaseLayerPickerViewModel.js
@@ -97,13 +97,10 @@ define([
          */
         this.buttonImageUrl = undefined;
         knockout.defineProperty(this, 'buttonImageUrl', function() {
-            var viewModel = this.selectedImagery;
-            if (defined(viewModel)) {
-                return viewModel.iconUrl;
+            var selectedImagery = this.selectedImagery;
+            if (defined(selectedImagery)) {
+                return selectedImagery.iconUrl;
             }
-
-            viewModel = this.selectedTerrain;
-            return defined(viewModel) ? viewModel.iconUrl : undefined;
         });
 
         /**
@@ -129,12 +126,14 @@ define([
                 var currentImageryProviders = this._currentImageryProviders;
                 var currentImageryProvidersLength = currentImageryProviders.length;
                 var imageryLayers = this._globe.imageryLayers;
+                var hadExistingBaseLayer = false;
                 for (i = 0; i < currentImageryProvidersLength; i++) {
                     var layersLength = imageryLayers.length;
                     for ( var x = 0; x < layersLength; x++) {
                         var layer = imageryLayers.get(x);
                         if (layer.imageryProvider === currentImageryProviders[i]) {
                             imageryLayers.remove(layer);
+                            hadExistingBaseLayer = true;
                             break;
                         }
                     }
@@ -150,7 +149,15 @@ define([
                         this._currentImageryProviders = newProviders.slice(0);
                     } else {
                         this._currentImageryProviders = [newProviders];
-                        imageryLayers.addImageryProvider(newProviders, 0);
+                        if (hadExistingBaseLayer) {
+                            imageryLayers.addImageryProvider(newProviders, 0);
+                        } else {
+                            var baseLayer = imageryLayers.get(0);
+                            if (defined(baseLayer)) {
+                                imageryLayers.remove(baseLayer);
+                            }
+                            imageryLayers.addImageryProvider(newProviders, 0);
+                        }
                     }
                 }
                 selectedImageryViewModel(value);

--- a/Source/Widgets/BaseLayerPicker/BaseLayerPickerViewModel.js
+++ b/Source/Widgets/BaseLayerPicker/BaseLayerPickerViewModel.js
@@ -98,6 +98,11 @@ define([
         this.buttonImageUrl = undefined;
         knockout.defineProperty(this, 'buttonImageUrl', function() {
             var viewModel = this.selectedImagery;
+            if (defined(viewModel)) {
+                return viewModel.iconUrl;
+            }
+
+            viewModel = this.selectedTerrain;
             return defined(viewModel) ? viewModel.iconUrl : undefined;
         });
 

--- a/Source/Widgets/Viewer/Viewer.js
+++ b/Source/Widgets/Viewer/Viewer.js
@@ -299,8 +299,6 @@ define([
      * @param {Number} [options.maximumRenderTimeChange=0.0] If requestRenderMode is true, this value defines the maximum change in simulation time allowed before a render is requested. See {@link https://cesium.com/blog/2018/01/24/cesium-scene-rendering-performance/|Improving Performance with Explicit Rendering}.
      *
      * @exception {DeveloperError} Element with id "container" does not exist in the document.
-     * @exception {DeveloperError} options.imageryProvider is not available when using the BaseLayerPicker widget, specify options.selectedImageryProviderViewModel instead.
-     * @exception {DeveloperError} options.terrainProvider is not available when using the BaseLayerPicker widget, specify options.selectedTerrainProviderViewModel instead.
      * @exception {DeveloperError} options.selectedImageryProviderViewModel is not available when not using the BaseLayerPicker widget, specify options.imageryProvider instead.
      * @exception {DeveloperError} options.selectedTerrainProviderViewModel is not available when not using the BaseLayerPicker widget, specify options.terrainProvider instead.
      *
@@ -368,22 +366,10 @@ define([
                                     (!defined(options.baseLayerPicker) || options.baseLayerPicker !== false);
 
         //>>includeStart('debug', pragmas.debug);
-        // If using BaseLayerPicker, imageryProvider is an invalid option
-        if (createBaseLayerPicker && defined(options.imageryProvider)) {
-            throw new DeveloperError('options.imageryProvider is not available when using the BaseLayerPicker widget. \
-Either specify options.selectedImageryProviderViewModel instead or set options.baseLayerPicker to false.');
-        }
-
         // If not using BaseLayerPicker, selectedImageryProviderViewModel is an invalid option
         if (!createBaseLayerPicker && defined(options.selectedImageryProviderViewModel)) {
             throw new DeveloperError('options.selectedImageryProviderViewModel is not available when not using the BaseLayerPicker widget. \
 Either specify options.imageryProvider instead or set options.baseLayerPicker to true.');
-        }
-
-        // If using BaseLayerPicker, terrainProvider is an invalid option
-        if (createBaseLayerPicker && defined(options.terrainProvider)) {
-            throw new DeveloperError('options.terrainProvider is not available when using the BaseLayerPicker widget. \
-Either specify options.selectedTerrainProviderViewModel instead or set options.baseLayerPicker to false.');
         }
 
         // If not using BaseLayerPicker, selectedTerrainProviderViewModel is an invalid option
@@ -430,8 +416,6 @@ Either specify options.terrainProvider instead or set options.baseLayerPicker to
 
         // Cesium widget
         var cesiumWidget = new CesiumWidget(cesiumWidgetContainer, {
-            terrainProvider : options.terrainProvider,
-            imageryProvider : createBaseLayerPicker ? false : options.imageryProvider,
             clock : clock,
             skyBox : options.skyBox,
             skyAtmosphere : options.skyAtmosphere,
@@ -461,15 +445,17 @@ Either specify options.terrainProvider instead or set options.baseLayerPicker to
             destroyDataSourceCollection = true;
         }
 
+        var scene = cesiumWidget.scene;
+
         var dataSourceDisplay = new DataSourceDisplay({
-            scene : cesiumWidget.scene,
+            scene : scene,
             dataSourceCollection : dataSourceCollection
         });
 
         var eventHelper = new EventHelper();
 
         eventHelper.add(clock.onTick, Viewer.prototype._onTick, this);
-        eventHelper.add(cesiumWidget.scene.morphStart, Viewer.prototype._clearTrackedObject, this);
+        eventHelper.add(scene.morphStart, Viewer.prototype._clearTrackedObject, this);
 
         // Selection Indicator
         var selectionIndicator;
@@ -477,7 +463,7 @@ Either specify options.terrainProvider instead or set options.baseLayerPicker to
             var selectionIndicatorContainer = document.createElement('div');
             selectionIndicatorContainer.className = 'cesium-viewer-selectionIndicatorContainer';
             viewerContainer.appendChild(selectionIndicatorContainer);
-            selectionIndicator = new SelectionIndicator(selectionIndicatorContainer, cesiumWidget.scene);
+            selectionIndicator = new SelectionIndicator(selectionIndicatorContainer, scene);
         }
 
         // Info Box
@@ -507,7 +493,7 @@ Either specify options.terrainProvider instead or set options.baseLayerPicker to
             geocoder = new Geocoder({
                 container : geocoderContainer,
                 geocoderServices : defined(options.geocoder) ? (isArray(options.geocoder) ? options.geocoder : [options.geocoder]) : undefined,
-                scene : cesiumWidget.scene
+                scene : scene
             });
             // Subscribe to search so that we can clear the trackedEntity when it is clicked.
             eventHelper.add(geocoder.viewModel.search.beforeExecute, Viewer.prototype._clearObjects, this);
@@ -516,7 +502,7 @@ Either specify options.terrainProvider instead or set options.baseLayerPicker to
         // HomeButton
         var homeButton;
         if (!defined(options.homeButton) || options.homeButton !== false) {
-            homeButton = new HomeButton(toolbar, cesiumWidget.scene);
+            homeButton = new HomeButton(toolbar, scene);
             if (defined(geocoder)) {
                 eventHelper.add(homeButton.viewModel.command.afterExecute, function() {
                     var viewModel = geocoder.viewModel;
@@ -541,12 +527,12 @@ Either specify options.terrainProvider instead or set options.baseLayerPicker to
 
         var sceneModePicker;
         if (!scene3DOnly && (!defined(options.sceneModePicker) || options.sceneModePicker !== false)) {
-            sceneModePicker = new SceneModePicker(toolbar, cesiumWidget.scene);
+            sceneModePicker = new SceneModePicker(toolbar, scene);
         }
 
         var projectionPicker;
         if (options.projectionPicker) {
-            projectionPicker = new ProjectionPicker(toolbar, cesiumWidget.scene);
+            projectionPicker = new ProjectionPicker(toolbar, scene);
         }
 
         // BaseLayerPicker
@@ -557,7 +543,7 @@ Either specify options.terrainProvider instead or set options.baseLayerPicker to
             var terrainProviderViewModels = defaultValue(options.terrainProviderViewModels, createDefaultTerrainProviderViewModels());
 
             baseLayerPicker = new BaseLayerPicker(toolbar, {
-                globe : cesiumWidget.scene.globe,
+                globe : scene.globe,
                 imageryProviderViewModels : imageryProviderViewModels,
                 selectedImageryProviderViewModel : options.selectedImageryProviderViewModel,
                 terrainProviderViewModels : terrainProviderViewModels,
@@ -567,6 +553,15 @@ Either specify options.terrainProvider instead or set options.baseLayerPicker to
             //Grab the dropdown for resize code.
             var elements = toolbar.getElementsByClassName('cesium-baseLayerPicker-dropDown');
             baseLayerPickerDropDown = elements[0];
+        }
+
+        // These need to be set after the BaseLayerPicker is created in order to take effect
+        if (defined(options.imageryProvider)) {
+            scene.imageryLayers.removeAll();
+            scene.imageryLayers.addImageryProvider(options.imageryProvider);
+        }
+        if (defined(options.terrainProvider)) {
+            scene.terrainProvider = options.terrainProvider;
         }
 
         // Navigation Help Button
@@ -642,7 +637,7 @@ Either specify options.terrainProvider instead or set options.baseLayerPicker to
             var vrContainer = document.createElement('div');
             vrContainer.className = 'cesium-viewer-vrContainer';
             viewerContainer.appendChild(vrContainer);
-            vrButton = new VRButton(vrContainer, cesiumWidget.scene, options.fullScreenElement);
+            vrButton = new VRButton(vrContainer, scene, options.fullScreenElement);
 
             vrSubscription = subscribeAndEvaluate(vrButton.viewModel, 'isVREnabled', function(isVREnabled) {
                 vrContainer.style.display = isVREnabled ? 'block' : 'none';
@@ -716,8 +711,8 @@ Either specify options.terrainProvider instead or set options.baseLayerPicker to
         eventHelper.add(dataSourceCollection.dataSourceRemoved, Viewer.prototype._onDataSourceRemoved, this);
 
         // Prior to each render, check if anything needs to be resized.
-        eventHelper.add(cesiumWidget.scene.postUpdate, Viewer.prototype.resize, this);
-        eventHelper.add(cesiumWidget.scene.postRender, Viewer.prototype._postRender, this);
+        eventHelper.add(scene.postUpdate, Viewer.prototype.resize, this);
+        eventHelper.add(scene.postRender, Viewer.prototype._postRender, this);
 
         // We need to subscribe to the data sources and collections so that we can clear the
         // tracked object when it is removed from the scene.

--- a/Source/Widgets/Viewer/Viewer.js
+++ b/Source/Widgets/Viewer/Viewer.js
@@ -558,10 +558,16 @@ Either specify options.terrainProvider instead or set options.baseLayerPicker to
 
         // These need to be set after the BaseLayerPicker is created in order to take effect
         if (defined(options.imageryProvider)) {
+            if (createBaseLayerPicker) {
+                baseLayerPicker.viewModel.selectedImagery = undefined;
+            }
             scene.imageryLayers.removeAll();
             scene.imageryLayers.addImageryProvider(options.imageryProvider);
         }
         if (defined(options.terrainProvider)) {
+            if (createBaseLayerPicker) {
+                baseLayerPicker.viewModel.selectedTerrain = undefined;
+            }
             scene.terrainProvider = options.terrainProvider;
         }
 

--- a/Source/Widgets/Viewer/Viewer.js
+++ b/Source/Widgets/Viewer/Viewer.js
@@ -416,6 +416,7 @@ Either specify options.terrainProvider instead or set options.baseLayerPicker to
 
         // Cesium widget
         var cesiumWidget = new CesiumWidget(cesiumWidgetContainer, {
+            imageryProvider: createBaseLayerPicker || defined(options.imageryProvider) ? false : undefined,
             clock : clock,
             skyBox : options.skyBox,
             skyAtmosphere : options.skyAtmosphere,

--- a/Specs/Widgets/Viewer/ViewerSpec.js
+++ b/Specs/Widgets/Viewer/ViewerSpec.js
@@ -621,14 +621,6 @@ defineSuite([
         }).toThrowDeveloperError();
     });
 
-    it('constructor throws if using imageryProvider with BaseLayerPicker enabled', function() {
-        expect(function() {
-            return createViewer(container, {
-                imageryProvider : testProvider
-            });
-        }).toThrowDeveloperError();
-    });
-
     it('extend throws with undefined mixin', function() {
         viewer = createViewer(container);
         expect(function() {


### PR DESCRIPTION
We've had a check in Viewer forever to see if the base layer picker was being used when a terrainProvider or imageryProvider was specified and throw if so.  This lead to a ton of code where we work around that error by creating the viewer and then specifying viewer.terrainProvider anyway:

```js
var viewer = new Cesium.Viewer('cesiumContainer');
viewer.terrainProvider = new Cesium.CesiumTerrainProvider({
    url: 'https://assets.agi.com/stk-terrain/v1/tilesets/world/tiles'
})
```

Basically, this check was pointless and just made the code more verbose.  The check also prevented devs from specifying a terrainProvider but still using BaseLayerPicker for imagery (and vice versa). Now we just let the user do what they want, which was probably the right call from the beginning:

```js
var viewer = new Cesium.Viewer('cesiumContainer', {
    terrainProvider: new Cesium.CesiumTerrainProvider({
        url: 'https://assets.agi.com/stk-terrain/v1/tilesets/world/tiles'
    })
});
```

This is a really small change in `Viewer.js` and then a bunch of cleanup in Sandcastle examples to match.  This will also allow us to clean up some website examples which are using CesiumWidget instead of Viewer for the above reason.