### PR TITLE
Fix closed vs open geometry entities

### DIFF
--- a/Source/DataSources/CorridorGeometryUpdater.js
+++ b/Source/DataSources/CorridorGeometryUpdater.js
@@ -173,8 +173,10 @@ define([
                isColorMaterial && GroundPrimitive.isSupported(this._scene);
     };
 
-    CorridorGeometryUpdater.prototype._getIsClosed = function(entity, corridor) {
-        return defined(corridor.extrudedHeight) || this._onTerrain;
+    CorridorGeometryUpdater.prototype._getIsClosed = function(options) {
+        var height = options.height;
+        var extrudedHeight = options.extrudedHeight;
+        return height === 0 || (defined(extrudedHeight) && extrudedHeight !== height);
     };
 
     CorridorGeometryUpdater.prototype._isDynamic = function(entity, corridor) {
@@ -223,10 +225,6 @@ define([
     DynamicCorridorGeometryUpdater.prototype._isHidden = function(entity, corridor, time) {
         var options = this._options;
         return !defined(options.positions) || !defined(options.width) || DynamicGeometryUpdater.prototype._isHidden.call(this, entity, corridor, time);
-    };
-
-    DynamicCorridorGeometryUpdater.prototype._getIsClosed = function(entity, corridor, time) {
-        return defined(this._options.extrudedHeight);
     };
 
     DynamicCorridorGeometryUpdater.prototype._setOptions = function(entity, corridor, time) {

--- a/Source/DataSources/DynamicGeometryUpdater.js
+++ b/Source/DataSources/DynamicGeometryUpdater.js
@@ -56,10 +56,6 @@ define([
         return !entity.isShowing || !entity.isAvailable(time) || !Property.getValueOrDefault(geometry.show, time, true);
     };
 
-    DynamicGeometryUpdater.prototype._getIsClosed = function(entity, geometry, time) {
-        return true;
-    };
-
     DynamicGeometryUpdater.prototype._setOptions = DeveloperError.throwInstantiationError;
 
     /**
@@ -109,7 +105,7 @@ define([
                 var fillMaterialProperty = geometryUpdater.fillMaterialProperty;
                 var isColorAppearance = fillMaterialProperty instanceof ColorMaterialProperty;
                 var appearance;
-                var closed = this._getIsClosed(entity, geometry, time);
+                var closed = geometryUpdater._getIsClosed(options);
                 if (isColorAppearance) {
                     appearance = new PerInstanceColorAppearance({
                         closed: closed

--- a/Source/DataSources/EllipseGeometryUpdater.js
+++ b/Source/DataSources/EllipseGeometryUpdater.js
@@ -179,10 +179,6 @@ define([
         return this._fillEnabled && !defined(ellipse.height) && !defined(ellipse.extrudedHeight) && isColorMaterial && GroundPrimitive.isSupported(this._scene);
     };
 
-    EllipseGeometryUpdater.prototype._getIsClosed = function(entity, ellipse) {
-        return defined(ellipse.extrudedHeight) || this._onTerrain;
-    };
-
     EllipseGeometryUpdater.prototype._isDynamic = function(entity, ellipse) {
         return !entity.position.isConstant || //
                !ellipse.semiMajorAxis.isConstant || //
@@ -195,6 +191,12 @@ define([
                !Property.isConstant(ellipse.outlineWidth) || //
                !Property.isConstant(ellipse.numberOfVerticalLines) || //
                (this._onTerrain && !Property.isConstant(this._materialProperty));
+    };
+
+    EllipseGeometryUpdater.prototype._getIsClosed = function(options) {
+        var height = options.height;
+        var extrudedHeight = options.extrudedHeight;
+        return height === 0 || (defined(extrudedHeight) && extrudedHeight !== height);
     };
 
     EllipseGeometryUpdater.prototype._setStaticOptions = function(entity, ellipse) {
@@ -236,10 +238,6 @@ define([
     DynamicEllipseGeometryUpdater.prototype._isHidden = function(entity, ellipse, time) {
         var options = this._options;
         return !defined(options.center) || !defined(options.semiMajorAxis) || !defined(options.semiMinorAxis) || DynamicGeometryUpdater.prototype._isHidden.call(this, entity, ellipse, time);
-    };
-
-    DynamicEllipseGeometryUpdater.prototype._getIsClosed = function(entity, ellipse, time) {
-        return defined(this._options.extrudedHeight);
     };
 
     DynamicEllipseGeometryUpdater.prototype._setOptions = function(entity, ellipse, time) {

--- a/Source/DataSources/GeometryUpdater.js
+++ b/Source/DataSources/GeometryUpdater.js
@@ -361,11 +361,10 @@ define([
     };
 
     /**
-     * @param {Entity} entity
-     * @param {Object} geometry
+     * @param {GeometryOptions} options
      * @private
      */
-    GeometryUpdater.prototype._getIsClosed = function(entity, geometry) {
+    GeometryUpdater.prototype._getIsClosed = function(options) {
         return true;
     };
 
@@ -451,7 +450,6 @@ define([
         }
 
         this._onTerrain = onTerrain;
-        this._isClosed = this._getIsClosed(entity, geometry);
         this._outlineEnabled = outlineEnabled;
 
         if (this._isDynamic(entity, geometry)) {
@@ -461,6 +459,7 @@ define([
             }
         } else {
             this._setStaticOptions(entity, geometry);
+            this._isClosed = this._getIsClosed(this._options);
             var outlineWidth = geometry.outlineWidth;
             this._outlineWidth = defined(outlineWidth) ? outlineWidth.getValue(Iso8601.MINIMUM_VALUE) : 1.0;
             this._dynamic = false;

--- a/Source/DataSources/PlaneGeometryUpdater.js
+++ b/Source/DataSources/PlaneGeometryUpdater.js
@@ -201,7 +201,7 @@ define([
         return !defined(plane.plane) || !defined(plane.dimensions) || !defined(entity.position) || GeometryUpdater.prototype._isHidden.call(this, entity, plane);
     };
 
-    GeometryUpdater.prototype._getIsClosed = function(entity, plane) {
+    GeometryUpdater.prototype._getIsClosed = function(options) {
         return false;
     };
 
@@ -240,10 +240,6 @@ define([
         var options = this._options;
         var position = Property.getValueOrUndefined(entity.position, time, positionScratch);
         return !defined(position) || !defined(options.plane) || !defined(options.dimensions) || DynamicGeometryUpdater.prototype._isHidden.call(this, entity, plane, time);
-    };
-
-    DynamicPlaneGeometryUpdater.prototype._getIsClosed = function(entity, plane, time) {
-        return false;
     };
 
     DynamicPlaneGeometryUpdater.prototype._setOptions = function(entity, plane, time) {

--- a/Source/DataSources/PolygonGeometryUpdater.js
+++ b/Source/DataSources/PolygonGeometryUpdater.js
@@ -210,16 +210,27 @@ define([
         var closeTopValue = Property.getValueOrDefault(polygon.closeTop, Iso8601.MINIMUM_VALUE, true);
         var closeBottomValue = Property.getValueOrDefault(polygon.closeBottom, Iso8601.MINIMUM_VALUE, true);
         var extrudedHeightValue = Property.getValueOrUndefined(polygon.extrudedHeight, Iso8601.MINIMUM_VALUE);
+        var perPositionHeightValue = Property.getValueOrUndefined(polygon.perPositionHeight, Iso8601.MINIMUM_VALUE);
+
+        if (defined(extrudedHeightValue) && !defined(heightValue) && !defined(perPositionHeightValue)) {
+            heightValue = 0;
+        }
 
         options.polygonHierarchy = hierarchyValue;
         options.height = heightValue;
         options.extrudedHeight = extrudedHeightValue;
         options.granularity = Property.getValueOrUndefined(polygon.granularity, Iso8601.MINIMUM_VALUE);
         options.stRotation = Property.getValueOrUndefined(polygon.stRotation, Iso8601.MINIMUM_VALUE);
-        options.perPositionHeight = Property.getValueOrUndefined(polygon.perPositionHeight, Iso8601.MINIMUM_VALUE);
+        options.perPositionHeight = perPositionHeightValue;
         options.closeTop = closeTopValue;
         options.closeBottom = closeBottomValue;
-        this._isClosed = defined(extrudedHeightValue) && extrudedHeightValue !== heightValue && closeTopValue && closeBottomValue;
+    };
+
+    PolygonGeometryUpdater.prototype._getIsClosed = function(options) {
+        var height = options.height;
+        var extrudedHeight = options.extrudedHeight;
+        var isExtruded = defined(extrudedHeight) && extrudedHeight !== height;
+        return !options.perPositionHeight && (!isExtruded && height === 0 || (isExtruded && options.closeTop && options.closeBottom));
     };
 
     PolygonGeometryUpdater.DynamicGeometryUpdater = DyanmicPolygonGeometryUpdater;
@@ -238,11 +249,6 @@ define([
 
     DyanmicPolygonGeometryUpdater.prototype._isHidden = function(entity, polygon, time) {
         return !defined(this._options.polygonHierarchy) || DynamicGeometryUpdater.prototype._isHidden.call(this, entity, polygon, time);
-    };
-
-    DyanmicPolygonGeometryUpdater.prototype._getIsClosed = function(entity, polygon, time) {
-        var options = this._options;
-        return defined(options.extrudedHeight) && options.extrudedHeight !== options.height && options.closeTop && options.closeBottom;
     };
 
     DyanmicPolygonGeometryUpdater.prototype._setOptions = function(entity, polygon, time) {

--- a/Source/DataSources/RectangleGeometryUpdater.js
+++ b/Source/DataSources/RectangleGeometryUpdater.js
@@ -197,8 +197,6 @@ define([
         var granularity = rectangle.granularity;
         var stRotation = rectangle.stRotation;
         var rotation = rectangle.rotation;
-        var closeBottom = rectangle.closeBottom;
-        var closeTop = rectangle.closeTop;
 
         var options = this._options;
         options.vertexFormat = isColorMaterial ? PerInstanceColorAppearance.VERTEX_FORMAT : MaterialAppearance.MaterialSupport.TEXTURED.vertexFormat;
@@ -208,9 +206,14 @@ define([
         options.granularity = defined(granularity) ? granularity.getValue(Iso8601.MINIMUM_VALUE) : undefined;
         options.stRotation = defined(stRotation) ? stRotation.getValue(Iso8601.MINIMUM_VALUE) : undefined;
         options.rotation = defined(rotation) ? rotation.getValue(Iso8601.MINIMUM_VALUE) : undefined;
-        options.closeBottom = defined(closeBottom) ? closeBottom.getValue(Iso8601.MINIMUM_VALUE) : undefined;
-        options.closeTop = defined(closeTop) ? closeTop.getValue(Iso8601.MINIMUM_VALUE) : undefined;
-        this._isClosed = defined(extrudedHeight) && defined(options.closeTop) && defined(options.closeBottom) && options.closeTop && options.closeBottom;
+        options.closeBottom = Property.getValueOrDefault(rectangle.closeBottom, Iso8601.MINIMUM_VALUE, true);
+        options.closeTop =  Property.getValueOrDefault(rectangle.closeTop, Iso8601.MINIMUM_VALUE, true);
+    };
+
+    RectangleGeometryUpdater.prototype._getIsClosed = function(options) {
+        var height = options.height;
+        var extrudedHeight = options.extrudedHeight;
+        return height === 0 || defined(extrudedHeight) && extrudedHeight !== height;
     };
 
     RectangleGeometryUpdater.DynamicGeometryUpdater = DynamicRectangleGeometryUpdater;
@@ -231,11 +234,6 @@ define([
         return  !defined(this._options.rectangle) || DynamicGeometryUpdater.prototype._isHidden.call(this, entity, rectangle, time);
     };
 
-    DynamicRectangleGeometryUpdater.prototype._getIsClosed = function(entity, rectangle, time) {
-        var options = this._options;
-        return defined(options.extrudedHeight) && defined(options.closeTop) && defined(options.closeBottom) && options.closeTop && options.closeBottom;
-    };
-
     DynamicRectangleGeometryUpdater.prototype._setOptions = function(entity, rectangle, time) {
         var options = this._options;
         options.rectangle = Property.getValueOrUndefined(rectangle.coordinates, time, options.rectangle);
@@ -244,8 +242,8 @@ define([
         options.granularity = Property.getValueOrUndefined(rectangle.granularity, time);
         options.stRotation = Property.getValueOrUndefined(rectangle.stRotation, time);
         options.rotation = Property.getValueOrUndefined(rectangle.rotation, time);
-        options.closeBottom = Property.getValueOrUndefined(rectangle.closeBottom, time);
-        options.closeTop = Property.getValueOrUndefined(rectangle.closeTop, time);
+        options.closeBottom = Property.getValueOrDefault(rectangle.closeBottom, time, true);
+        options.closeTop = Property.getValueOrDefault(rectangle.closeTop, time, true);
     };
 
     return RectangleGeometryUpdater;

--- a/Source/DataSources/WallGeometryUpdater.js
+++ b/Source/DataSources/WallGeometryUpdater.js
@@ -164,7 +164,7 @@ define([
         return !defined(wall.positions) || GeometryUpdater.prototype._isHidden.call(this, entity, wall);
     };
 
-    WallGeometryUpdater.prototype._getIsClosed = function(entity, wall) {
+    WallGeometryUpdater.prototype._getIsClosed = function(options) {
         return false;
     };
 
@@ -207,10 +207,6 @@ define([
 
     DynamicWallGeometryUpdater.prototype._isHidden = function(entity, wall, time) {
         return  !defined(this._options.positions) || DynamicGeometryUpdater.prototype._isHidden.call(this, entity, wall, time);
-    };
-
-    DynamicWallGeometryUpdater.prototype._getIsClosed = function(entity, wall, time) {
-        return false;
     };
 
     DynamicWallGeometryUpdater.prototype._setOptions = function(entity, wall, time) {

--- a/Specs/DataSources/CorridorGeometryUpdaterSpec.js
+++ b/Specs/DataSources/CorridorGeometryUpdaterSpec.js
@@ -149,7 +149,7 @@ defineSuite([
         var entity = createBasicCorridor();
         var updater = new CorridorGeometryUpdater(entity, scene);
 
-        expect(updater.isClosed).toBe(false);
+        expect(updater.isClosed).toBe(true);
         expect(updater.fillEnabled).toBe(true);
         expect(updater.fillMaterialProperty).toEqual(new ColorMaterialProperty(Color.WHITE));
         expect(updater.outlineEnabled).toBe(false);

--- a/Specs/DataSources/EllipseGeometryUpdaterSpec.js
+++ b/Specs/DataSources/EllipseGeometryUpdaterSpec.js
@@ -164,7 +164,7 @@ defineSuite([
         var entity = createBasicEllipse();
         var updater = new EllipseGeometryUpdater(entity, scene);
 
-        expect(updater.isClosed).toBe(false);
+        expect(updater.isClosed).toBe(true);
         expect(updater.fillEnabled).toBe(true);
         expect(updater.fillMaterialProperty).toEqual(new ColorMaterialProperty(Color.WHITE));
         expect(updater.outlineEnabled).toBe(false);

--- a/Specs/DataSources/GeometryVisualizerSpec.js
+++ b/Specs/DataSources/GeometryVisualizerSpec.js
@@ -115,7 +115,7 @@ defineSuite([
             expect(attributes.show).toEqual(ShowGeometryInstanceAttribute.toValue(true));
             expect(attributes.color).toEqual(ColorGeometryInstanceAttribute.toValue(Color.WHITE));
             expect(primitive.appearance).toBeInstanceOf(PerInstanceColorAppearance);
-            expect(primitive.appearance.closed).toBe(false);
+            expect(primitive.appearance.closed).toBe(true);
 
             objects.remove(entity);
 

--- a/Specs/DataSources/RectangleGeometryUpdaterSpec.js
+++ b/Specs/DataSources/RectangleGeometryUpdaterSpec.js
@@ -137,7 +137,7 @@ defineSuite([
         var entity = createBasicRectangle();
         var updater = new RectangleGeometryUpdater(entity, scene);
 
-        expect(updater.isClosed).toBe(false);
+        expect(updater.isClosed).toBe(true);
         expect(updater.fillEnabled).toBe(true);
         expect(updater.fillMaterialProperty).toEqual(new ColorMaterialProperty(Color.WHITE));
         expect(updater.outlineEnabled).toBe(false);
@@ -163,12 +163,6 @@ defineSuite([
         var entity = createBasicRectangle();
         var updater = new RectangleGeometryUpdater(entity, scene);
         entity.rectangle.extrudedHeight = new ConstantProperty(1000);
-        updater._onEntityPropertyChanged(entity, 'rectangle');
-        expect(updater.isClosed).toBe(false);
-        entity.rectangle.closeBottom = new ConstantProperty(true);
-        updater._onEntityPropertyChanged(entity, 'rectangle');
-        expect(updater.isClosed).toBe(false);
-        entity.rectangle.closeTop = new ConstantProperty(true);
         updater._onEntityPropertyChanged(entity, 'rectangle');
         expect(updater.isClosed).toBe(true);
     });


### PR DESCRIPTION
- Polygon, ellipse, rectangle and corridor geometries weren't always calculating the correct value for `closed`
- Dynamic and static geometry compute `isClosed` using the same function