### PR TITLE
Add CreditDisplay.cesiumCredit

### DIFF
--- a/Source/Scene/CreditDisplay.js
+++ b/Source/Scene/CreditDisplay.js
@@ -385,15 +385,21 @@ define([
         Check.defined('credit', credit);
         //>>includeEnd('debug');
 
+        var imageCredits = this._currentFrameCredits.imageCredits;
+
         if (credit.text === 'Cesium ion') {
             // We don't want to clutter the screen with the Cesium logo and the Cesium ion
             // logo at the same time. Since the ion logo is required, we just replace the
-            // Cesium logo.  This will also add the logo if the Cesium one was removed.
-            this._currentFrameCredits.imageCredits[cesiumCredit.id] = credit;
+            // Cesium logo or add the logo if the Cesium one was removed.
+            if (defined(imageCredits[cesiumCredit.id])) {
+                imageCredits[cesiumCredit.id] = credit;
+            } else {
+                imageCredits[credit.id] = credit;
+            }
         } else if (!credit.showOnScreen) {
             this._currentFrameCredits.lightboxCredits[credit.id] = credit;
         } else if (credit.hasImage()) {
-            this._currentFrameCredits.imageCredits[credit.id] = credit;
+            imageCredits[credit.id] = credit;
         } else {
             this._currentFrameCredits.textCredits[credit.id] = credit;
         }
@@ -478,9 +484,13 @@ define([
      */
     CreditDisplay.prototype.beginFrame = function() {
         this._currentFrameCredits.imageCredits.length = 0;
-        this._currentFrameCredits.imageCredits[cesiumCredit.id] = cesiumCredit;
         this._currentFrameCredits.textCredits.length = 0;
         this._currentFrameCredits.lightboxCredits.length = 0;
+
+        var cesiumCredit = CreditDisplay.cesiumCredit;
+        if (defined(cesiumCredit)) {
+            this._currentFrameCredits.imageCredits[cesiumCredit.id] = cesiumCredit;
+        }
     };
 
     /**
@@ -537,6 +547,12 @@ define([
     CreditDisplay.prototype.isDestroyed = function() {
         return false;
     };
+
+    /**
+     * Gets or sets the Cesium logo credit.
+     * @type {Credit}
+     */
+    CreditDisplay.cesiumCredit = cesiumCredit;
 
     return CreditDisplay;
 });

--- a/Specs/Scene/CreditDisplaySpec.js
+++ b/Specs/Scene/CreditDisplaySpec.js
@@ -16,13 +16,16 @@ defineSuite([
     var imgSrc = 'imagesrc';
     var delimiter = 'cesium-credit-delimiter';
     var creditDisplay;
+    var defaultCredit;
 
     beforeEach(function() {
         container = document.createElement('div');
         container.id = 'credit-container';
+        defaultCredit = CreditDisplay.cesiumCredit;
     });
 
     afterEach(function(){
+        CreditDisplay.cesiumCredit = defaultCredit;
         if (defined(creditDisplay)) {
             creditDisplay.destroy();
             creditDisplay = undefined;
@@ -630,5 +633,47 @@ defineSuite([
         expect(creditList.childNodes.length).toEqual(0);
 
         creditDisplay.hideLightbox();
+    });
+
+    it('works if Cesium credit removed', function() {
+        creditDisplay = new CreditDisplay(container);
+        CreditDisplay.cesiumCredit = undefined;
+        creditDisplay.beginFrame();
+        expect(creditDisplay._currentFrameCredits.imageCredits.length).toEqual(0);
+        creditDisplay.endFrame();
+    });
+
+    it('works if Cesium credit replaced', function() {
+        var credit = new Credit({ text: '' });
+        CreditDisplay.cesiumCredit = credit;
+        creditDisplay = new CreditDisplay(container);
+        creditDisplay.beginFrame();
+        expect(creditDisplay._currentFrameCredits.imageCredits[credit.id]).toBe(credit);
+        creditDisplay.endFrame();
+    });
+
+    it('replaces Cesium credit if ion asset detected', function() {
+        var ionCredit = new Credit({ text: 'Cesium ion' });
+        creditDisplay = new CreditDisplay(container);
+        creditDisplay.beginFrame();
+
+        expect(creditDisplay._currentFrameCredits.imageCredits[CreditDisplay.cesiumCredit.id]).toBe(CreditDisplay.cesiumCredit);
+        creditDisplay.addCredit(ionCredit);
+        expect(creditDisplay._currentFrameCredits.imageCredits[CreditDisplay.cesiumCredit.id]).toBe(ionCredit);
+        creditDisplay.endFrame();
+    });
+
+    it('adds ion credit detected if Cesium credit replaced', function() {
+        var ionCredit = new Credit({ text: 'Cesium ion' });
+        CreditDisplay.cesiumCredit = new Credit({ text: 'not Cesium' });
+        creditDisplay = new CreditDisplay(container);
+        creditDisplay.beginFrame();
+
+        expect(creditDisplay._currentFrameCredits.imageCredits[CreditDisplay.cesiumCredit.id]).toBe(CreditDisplay.cesiumCredit);
+
+        creditDisplay.addCredit(ionCredit);
+
+        expect(creditDisplay._currentFrameCredits.imageCredits[ionCredit.id]).toBe(ionCredit);
+        creditDisplay.endFrame();
     });
 });


### PR DESCRIPTION
1. `CreditDisplay.cesiumCredit` exposes the Cesium credit showed by default in the lower left corner, it can also be set to undefined or replaced.
2. In addition to tests to cover new functionality, I also added some
ion credit-related ones that were missing from my previous PR.