### PR TITLE
Remove unused rectangle closeTop and closeBottom options

### DIFF
--- a/Source/Core/RectangleGeometry.js
+++ b/Source/Core/RectangleGeometry.js
@@ -609,8 +609,6 @@ define([
      * @param {Number} [options.rotation=0.0] The rotation of the rectangle, in radians. A positive rotation is counter-clockwise.
      * @param {Number} [options.stRotation=0.0] The rotation of the texture coordinates, in radians. A positive rotation is counter-clockwise.
      * @param {Number} [options.extrudedHeight] The distance in meters between the rectangle's extruded face and the ellipsoid surface.
-     * @param {Boolean} [options.closeTop=true] Specifies whether the rectangle has a top cover when extruded.
-     * @param {Boolean} [options.closeBottom=true] Specifies whether the rectangle has a bottom cover when extruded.
      *
      * @exception {DeveloperError} <code>options.rectangle.north</code> must be in the interval [<code>-Pi/2</code>, <code>Pi/2</code>].
      * @exception {DeveloperError} <code>options.rectangle.south</code> must be in the interval [<code>-Pi/2</code>, <code>Pi/2</code>].
@@ -636,8 +634,7 @@ define([
      *   ellipsoid : Cesium.Ellipsoid.WGS84,
      *   rectangle : Cesium.Rectangle.fromDegrees(-80.0, 39.0, -74.0, 42.0),
      *   height : 10000.0,
-     *   extrudedHeight: 300000,
-     *   closeTop: false
+     *   extrudedHeight: 300000
      * });
      * var geometry = Cesium.RectangleGeometry.createGeometry(rectangle);
      */
@@ -664,8 +661,6 @@ define([
         this._vertexFormat = VertexFormat.clone(defaultValue(options.vertexFormat, VertexFormat.DEFAULT));
         this._extrudedHeight = defaultValue(options.extrudedHeight, 0.0);
         this._extrude = defined(options.extrudedHeight);
-        this._closeTop = defaultValue(options.closeTop, true);
-        this._closeBottom = defaultValue(options.closeBottom, true);
         this._shadowVolume = defaultValue(options.shadowVolume, false);
         this._workerName = 'createRectangleGeometry';
         this._rotatedRectangle = computeRectangle(this._rectangle, this._ellipsoid, rotation);
@@ -675,7 +670,7 @@ define([
      * The number of elements used to pack the object into an array.
      * @type {Number}
      */
-    RectangleGeometry.packedLength = Rectangle.packedLength + Ellipsoid.packedLength + VertexFormat.packedLength + Rectangle.packedLength + 9;
+    RectangleGeometry.packedLength = Rectangle.packedLength + Ellipsoid.packedLength + VertexFormat.packedLength + Rectangle.packedLength + 7;
 
     /**
      * Stores the provided instance into the provided array.
@@ -712,8 +707,6 @@ define([
         array[startingIndex++] = value._stRotation;
         array[startingIndex++] = value._extrudedHeight;
         array[startingIndex++] = value._extrude ? 1.0 : 0.0;
-        array[startingIndex++] = value._closeTop ? 1.0 : 0.0;
-        array[startingIndex++] = value._closeBottom ? 1.0 : 0.0;
         array[startingIndex] = value._shadowVolume ? 1.0 : 0.0;
 
         return array;
@@ -731,8 +724,6 @@ define([
         rotation : undefined,
         stRotation : undefined,
         extrudedHeight : undefined,
-        closeTop : undefined,
-        closeBottom : undefined,
         shadowVolume : undefined
     };
 
@@ -769,8 +760,6 @@ define([
         var stRotation = array[startingIndex++];
         var extrudedHeight = array[startingIndex++];
         var extrude = array[startingIndex++] === 1.0;
-        var closeTop = array[startingIndex++] === 1.0;
-        var closeBottom = array[startingIndex++] === 1.0;
         var shadowVolume = array[startingIndex] === 1.0;
 
         if (!defined(result)) {
@@ -779,8 +768,6 @@ define([
             scratchOptions.rotation = rotation;
             scratchOptions.stRotation = stRotation;
             scratchOptions.extrudedHeight = extrude ? extrudedHeight : undefined;
-            scratchOptions.closeTop = closeTop;
-            scratchOptions.closeBottom = closeBottom;
             scratchOptions.shadowVolume = shadowVolume;
             return new RectangleGeometry(scratchOptions);
         }
@@ -794,8 +781,6 @@ define([
         result._stRotation = stRotation;
         result._extrudedHeight = extrude ? extrudedHeight : undefined;
         result._extrude = extrude;
-        result._closeTop = closeTop;
-        result._closeBottom = closeBottom;
         result._rotatedRectangle = rotatedRectangle;
         result._shadowVolume = shadowVolume;
 
@@ -896,8 +881,6 @@ define([
             granularity : granularity,
             extrudedHeight : maxHeight,
             height : minHeight,
-            closeTop : true,
-            closeBottom : true,
             vertexFormat : VertexFormat.POSITION_ONLY,
             shadowVolume : true
         });

--- a/Source/DataSources/CzmlDataSource.js
+++ b/Source/DataSources/CzmlDataSource.js
@@ -1828,8 +1828,6 @@ define([
         processPacketData(Boolean, rectangle, 'outline', rectangleData.outline, interval, sourceUri, entityCollection);
         processPacketData(Color, rectangle, 'outlineColor', rectangleData.outlineColor, interval, sourceUri, entityCollection);
         processPacketData(Number, rectangle, 'outlineWidth', rectangleData.outlineWidth, interval, sourceUri, entityCollection);
-        processPacketData(Boolean, rectangle, 'closeTop', rectangleData.closeTop, interval, sourceUri, entityCollection);
-        processPacketData(Boolean, rectangle, 'closeBottom', rectangleData.closeBottom, interval, sourceUri, entityCollection);
         processPacketData(ShadowMode, rectangle, 'shadows', rectangleData.shadows, interval, sourceUri, entityCollection);
         processPacketData(DistanceDisplayCondition, rectangle, 'distanceDisplayCondition', rectangleData.distanceDisplayCondition, interval, sourceUri, entityCollection);
     }

--- a/Source/DataSources/RectangleGeometryUpdater.js
+++ b/Source/DataSources/RectangleGeometryUpdater.js
@@ -49,8 +49,6 @@ define([
         this.id = entity;
         this.vertexFormat = undefined;
         this.rectangle = undefined;
-        this.closeBottom = undefined;
-        this.closeTop = undefined;
         this.height = undefined;
         this.extrudedHeight = undefined;
         this.granularity = undefined;
@@ -184,8 +182,6 @@ define([
                !Property.isConstant(rectangle.stRotation) || //
                !Property.isConstant(rectangle.rotation) || //
                !Property.isConstant(rectangle.outlineWidth) || //
-               !Property.isConstant(rectangle.closeBottom) || //
-               !Property.isConstant(rectangle.closeTop) || //
                (this._onTerrain && !Property.isConstant(this._materialProperty));
     };
 
@@ -197,8 +193,6 @@ define([
         var granularity = rectangle.granularity;
         var stRotation = rectangle.stRotation;
         var rotation = rectangle.rotation;
-        var closeBottom = rectangle.closeBottom;
-        var closeTop = rectangle.closeTop;
 
         var options = this._options;
         options.vertexFormat = isColorMaterial ? PerInstanceColorAppearance.VERTEX_FORMAT : MaterialAppearance.MaterialSupport.TEXTURED.vertexFormat;
@@ -208,9 +202,7 @@ define([
         options.granularity = defined(granularity) ? granularity.getValue(Iso8601.MINIMUM_VALUE) : undefined;
         options.stRotation = defined(stRotation) ? stRotation.getValue(Iso8601.MINIMUM_VALUE) : undefined;
         options.rotation = defined(rotation) ? rotation.getValue(Iso8601.MINIMUM_VALUE) : undefined;
-        options.closeBottom = defined(closeBottom) ? closeBottom.getValue(Iso8601.MINIMUM_VALUE) : undefined;
-        options.closeTop = defined(closeTop) ? closeTop.getValue(Iso8601.MINIMUM_VALUE) : undefined;
-        this._isClosed = defined(extrudedHeight) && defined(options.closeTop) && defined(options.closeBottom) && options.closeTop && options.closeBottom;
+        this._isClosed = defined(extrudedHeight);
     };
 
     RectangleGeometryUpdater.DynamicGeometryUpdater = DynamicRectangleGeometryUpdater;
@@ -233,7 +225,7 @@ define([
 
     DynamicRectangleGeometryUpdater.prototype._getIsClosed = function(entity, rectangle, time) {
         var options = this._options;
-        return defined(options.extrudedHeight) && defined(options.closeTop) && defined(options.closeBottom) && options.closeTop && options.closeBottom;
+        return defined(options.extrudedHeight);
     };
 
     DynamicRectangleGeometryUpdater.prototype._setOptions = function(entity, rectangle, time) {
@@ -244,8 +236,6 @@ define([
         options.granularity = Property.getValueOrUndefined(rectangle.granularity, time);
         options.stRotation = Property.getValueOrUndefined(rectangle.stRotation, time);
         options.rotation = Property.getValueOrUndefined(rectangle.rotation, time);
-        options.closeBottom = Property.getValueOrUndefined(rectangle.closeBottom, time);
-        options.closeTop = Property.getValueOrUndefined(rectangle.closeTop, time);
     };
 
     return RectangleGeometryUpdater;

--- a/Source/DataSources/RectangleGraphics.js
+++ b/Source/DataSources/RectangleGraphics.js
@@ -28,8 +28,6 @@ define([
      * @param {Property} [options.coordinates] The Property specifying the {@link Rectangle}.
      * @param {Property} [options.height=0] A numeric Property specifying the altitude of the rectangle relative to the ellipsoid surface.
      * @param {Property} [options.extrudedHeight] A numeric Property specifying the altitude of the rectangle's extruded face relative to the ellipsoid surface.
-     * @param {Property} [options.closeTop=true] A boolean Property specifying whether the rectangle has a top cover when extruded
-     * @param {Property} [options.closeBottom=true] A boolean Property specifying whether the rectangle has a bottom cover when extruded.
      * @param {Property} [options.show=true] A boolean Property specifying the visibility of the rectangle.
      * @param {Property} [options.fill=true] A boolean Property specifying whether the rectangle is filled with the provided material.
      * @param {MaterialProperty} [options.material=Color.WHITE] A Property specifying the material used to fill the rectangle.
@@ -62,10 +60,6 @@ define([
         this._stRotationSubscription = undefined;
         this._rotation = undefined;
         this._rotationSubscription = undefined;
-        this._closeTop = undefined;
-        this._closeTopSubscription = undefined;
-        this._closeBottom = undefined;
-        this._closeBottomSubscription = undefined;
         this._fill = undefined;
         this._fillSubscription = undefined;
         this._outline = undefined;
@@ -193,22 +187,6 @@ define([
         outlineWidth : createPropertyDescriptor('outlineWidth'),
 
         /**
-         * Gets or sets the boolean Property specifying whether the rectangle has a top cover when extruded.
-         * @memberof RectangleGraphics.prototype
-         * @type {Property}
-         * @default true
-         */
-        closeTop : createPropertyDescriptor('closeTop'),
-
-        /**
-         * Gets or sets the boolean Property specifying whether the rectangle has a bottom cover when extruded.
-         * @memberof RectangleGraphics.prototype
-         * @type {Property}
-         * @default true
-         */
-        closeBottom : createPropertyDescriptor('closeBottom'),
-
-        /**
          * Get or sets the enum Property specifying whether the rectangle
          * casts or receives shadows from each light source.
          * @memberof RectangleGraphics.prototype
@@ -247,8 +225,6 @@ define([
         result.outline = this.outline;
         result.outlineColor = this.outlineColor;
         result.outlineWidth = this.outlineWidth;
-        result.closeTop = this.closeTop;
-        result.closeBottom = this.closeBottom;
         result.shadows = this.shadows;
         result.distanceDisplayCondition = this.distanceDisplayCondition;
         return result;
@@ -279,8 +255,6 @@ define([
         this.outline = defaultValue(this.outline, source.outline);
         this.outlineColor = defaultValue(this.outlineColor, source.outlineColor);
         this.outlineWidth = defaultValue(this.outlineWidth, source.outlineWidth);
-        this.closeTop = defaultValue(this.closeTop, source.closeTop);
-        this.closeBottom = defaultValue(this.closeBottom, source.closeBottom);
         this.shadows = defaultValue(this.shadows, source.shadows);
         this.distanceDisplayCondition = defaultValue(this.distanceDisplayCondition, source.distanceDisplayCondition);
     };

--- a/Specs/Core/RectangleGeometrySpec.js
+++ b/Specs/Core/RectangleGeometrySpec.js
@@ -348,6 +348,6 @@ defineSuite([
         granularity : 1.0,
         ellipsoid : Ellipsoid.UNIT_SPHERE
     });
-    var packedInstance = [-2.0, -1.0, 0.0, 1.0, 1.0, 1.0, 1.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, -2.0, -1.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 0.0];
+    var packedInstance = [-2.0, -1.0, 0.0, 1.0, 1.0, 1.0, 1.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, -2.0, -1.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0];
     createPackableSpecs(RectangleGeometry, rectangle, packedInstance);
 });

--- a/Specs/Data/CZML/ValidationDocument.czml
+++ b/Specs/Data/CZML/ValidationDocument.czml
@@ -520,8 +520,6 @@
         ]
       },
       "outlineWidth":59794,
-      "closeTop":true,
-      "closeBottom":true,
       "shadows":"CAST_ONLY",
       "distanceDisplayCondition":{
         "distanceDisplayCondition":[
@@ -6369,12 +6367,6 @@
       },
       "outlineWidth":{
         "reference":"Constant#rectangle.outlineWidth"
-      },
-      "closeTop":{
-        "reference":"Constant#rectangle.closeTop"
-      },
-      "closeBottom":{
-        "reference":"Constant#rectangle.closeBottom"
       },
       "shadows":{
         "reference":"Constant#rectangle.shadows"

--- a/Specs/DataSources/CzmlDataSourceSpec.js
+++ b/Specs/DataSources/CzmlDataSourceSpec.js
@@ -2931,8 +2931,6 @@ defineSuite([
                 granularity : 3,
                 rotation : 4,
                 stRotation : 5,
-                closeBottom : true,
-                closeTop : false,
                 show : true,
                 outline : true,
                 outlineColor : {
@@ -2958,8 +2956,6 @@ defineSuite([
             expect(entity.rectangle.granularity.getValue(Iso8601.MINIMUM_VALUE)).toEqual(czmlRectangle.granularity);
             expect(entity.rectangle.rotation.getValue(Iso8601.MINIMUM_VALUE)).toEqual(czmlRectangle.rotation);
             expect(entity.rectangle.stRotation.getValue(Iso8601.MINIMUM_VALUE)).toEqual(czmlRectangle.stRotation);
-            expect(entity.rectangle.closeBottom.getValue(Iso8601.MINIMUM_VALUE)).toEqual(czmlRectangle.closeBottom);
-            expect(entity.rectangle.closeTop.getValue(Iso8601.MINIMUM_VALUE)).toEqual(czmlRectangle.closeTop);
             expect(entity.rectangle.outline.getValue(Iso8601.MINIMUM_VALUE)).toEqual(true);
             expect(entity.rectangle.outlineColor.getValue(Iso8601.MINIMUM_VALUE)).toEqual(new Color(0.2, 0.2, 0.2, 0.2));
             expect(entity.rectangle.outlineWidth.getValue(Iso8601.MINIMUM_VALUE)).toEqual(6);
@@ -3800,8 +3796,6 @@ defineSuite([
             expect(e.rectangle.outline.getValue(date)).toEqual(true);
             expect(e.rectangle.outlineColor.getValue(date)).toEqual(Color.fromBytes(196, 59, 142, 36));
             expect(e.rectangle.outlineWidth.getValue(date)).toEqual(59794.0);
-            expect(e.rectangle.closeTop.getValue(date)).toEqual(true);
-            expect(e.rectangle.closeBottom.getValue(date)).toEqual(true);
             expect(e.rectangle.shadows.getValue(date)).toEqual(ShadowMode.CAST_ONLY);
             expect(e.rectangle.distanceDisplayCondition.getValue(date)).toEqual(new DistanceDisplayCondition(21388, 23379));
             expect(e.wall.show.getValue(date)).toEqual(true);
@@ -4611,8 +4605,6 @@ defineSuite([
             expect(e.rectangle.outline.getValue(date)).toEqual(constant.rectangle.outline.getValue(date));
             expect(e.rectangle.outlineColor.getValue(date)).toEqual(constant.rectangle.outlineColor.getValue(date));
             expect(e.rectangle.outlineWidth.getValue(date)).toEqual(constant.rectangle.outlineWidth.getValue(date));
-            expect(e.rectangle.closeTop.getValue(date)).toEqual(constant.rectangle.closeTop.getValue(date));
-            expect(e.rectangle.closeBottom.getValue(date)).toEqual(constant.rectangle.closeBottom.getValue(date));
             expect(e.rectangle.shadows.getValue(date)).toEqual(constant.rectangle.shadows.getValue(date));
             expect(e.rectangle.distanceDisplayCondition.getValue(date)).toEqual(constant.rectangle.distanceDisplayCondition.getValue(date));
             expect(e.wall.show.getValue(date)).toEqual(constant.wall.show.getValue(date));

--- a/Specs/DataSources/RectangleGeometryUpdaterSpec.js
+++ b/Specs/DataSources/RectangleGeometryUpdaterSpec.js
@@ -164,12 +164,6 @@ defineSuite([
         var updater = new RectangleGeometryUpdater(entity, scene);
         entity.rectangle.extrudedHeight = new ConstantProperty(1000);
         updater._onEntityPropertyChanged(entity, 'rectangle');
-        expect(updater.isClosed).toBe(false);
-        entity.rectangle.closeBottom = new ConstantProperty(true);
-        updater._onEntityPropertyChanged(entity, 'rectangle');
-        expect(updater.isClosed).toBe(false);
-        entity.rectangle.closeTop = new ConstantProperty(true);
-        updater._onEntityPropertyChanged(entity, 'rectangle');
         expect(updater.isClosed).toBe(true);
     });
 
@@ -233,34 +227,6 @@ defineSuite([
         expect(updater.isDynamic).toBe(true);
     });
 
-    it('A time-varying closeTop causes geometry to be dynamic', function() {
-        var entity = createBasicRectangle();
-        var updater = new RectangleGeometryUpdater(entity, scene);
-        entity.rectangle.closeTop = new TimeIntervalCollectionProperty();
-        entity.rectangle.closeTop.intervals.addInterval(new TimeInterval({
-            start : time,
-            stop : time2,
-            data : false
-        }));
-        updater._onEntityPropertyChanged(entity, 'rectangle');
-
-        expect(updater.isDynamic).toBe(true);
-    });
-
-    it('A time-varying closeBottom causes geometry to be dynamic', function() {
-        var entity = createBasicRectangle();
-        var updater = new RectangleGeometryUpdater(entity, scene);
-        entity.rectangle.closeBottom = new TimeIntervalCollectionProperty();
-        entity.rectangle.closeBottom.intervals.addInterval(new TimeInterval({
-            start : time,
-            stop : time2,
-            data : false
-        }));
-        updater._onEntityPropertyChanged(entity, 'rectangle');
-
-        expect(updater.isDynamic).toBe(true);
-    });
-
     it('A time-varying color causes ground geometry to be dynamic', function() {
         var entity = createBasicRectangleWithoutHeight();
         var updater = new RectangleGeometryUpdater(entity, scene);
@@ -286,8 +252,6 @@ defineSuite([
         rectangle.height = new ConstantProperty(options.height);
         rectangle.extrudedHeight = new ConstantProperty(options.extrudedHeight);
         rectangle.granularity = new ConstantProperty(options.granularity);
-        rectangle.closeTop = new ConstantProperty(options.closeTop);
-        rectangle.closeBottom = new ConstantProperty(options.closeBottom);
         rectangle.distanceDisplayCondition = options.distanceDisplayCondition;
 
         var updater = new RectangleGeometryUpdater(entity, scene);
@@ -303,8 +267,6 @@ defineSuite([
             expect(geometry._surfaceHeight).toEqual(options.height);
             expect(geometry._granularity).toEqual(options.granularity);
             expect(geometry._extrudedHeight).toEqual(options.extrudedHeight);
-            expect(geometry._closeTop).toEqual(options.closeTop);
-            expect(geometry._closeBottom).toEqual(options.closeBottom);
 
             attributes = instance.attributes;
             if (options.material instanceof ColorMaterialProperty) {
@@ -345,9 +307,7 @@ defineSuite([
             stRotation : 12,
             fill : true,
             outline : true,
-            outlineColor : Color.BLUE,
-            closeTop : false,
-            closeBottom : true
+            outlineColor : Color.BLUE
         });
     });
 
@@ -362,9 +322,7 @@ defineSuite([
             stRotation : 12,
             fill : true,
             outline : true,
-            outlineColor : Color.BLUE,
-            closeTop : false,
-            closeBottom : true
+            outlineColor : Color.BLUE
         });
     });
 
@@ -380,8 +338,6 @@ defineSuite([
             fill : true,
             outline : true,
             outlineColor : Color.BLUE,
-            closeTop : false,
-            closeBottom : true,
             distanceDisplayCondition : new DistanceDisplayCondition(10.0, 100.0)
         });
     });

--- a/Specs/DataSources/RectangleGraphicsSpec.js
+++ b/Specs/DataSources/RectangleGraphicsSpec.js
@@ -34,8 +34,6 @@ defineSuite([
             outline : false,
             outlineColor : Color.RED,
             outlineWidth : 10,
-            closeTop : false,
-            closeBottom : false,
             shadows : ShadowMode.DISABLED,
             distanceDisplayCondition : new DistanceDisplayCondition()
         };
@@ -53,8 +51,6 @@ defineSuite([
         expect(rectangle.outline).toBeInstanceOf(ConstantProperty);
         expect(rectangle.outlineColor).toBeInstanceOf(ConstantProperty);
         expect(rectangle.outlineWidth).toBeInstanceOf(ConstantProperty);
-        expect(rectangle.closeTop).toBeInstanceOf(ConstantProperty);
-        expect(rectangle.closeBottom).toBeInstanceOf(ConstantProperty);
         expect(rectangle.shadows).toBeInstanceOf(ConstantProperty);
         expect(rectangle.distanceDisplayCondition).toBeInstanceOf(ConstantProperty);
 
@@ -70,8 +66,6 @@ defineSuite([
         expect(rectangle.outline.getValue()).toEqual(options.outline);
         expect(rectangle.outlineColor.getValue()).toEqual(options.outlineColor);
         expect(rectangle.outlineWidth.getValue()).toEqual(options.outlineWidth);
-        expect(rectangle.closeTop.getValue()).toEqual(options.closeTop);
-        expect(rectangle.closeBottom.getValue()).toEqual(options.closeBottom);
         expect(rectangle.shadows.getValue()).toEqual(options.shadows);
         expect(rectangle.distanceDisplayCondition.getValue()).toEqual(options.distanceDisplayCondition);
     });
@@ -90,8 +84,6 @@ defineSuite([
         source.outline = new ConstantProperty();
         source.outlineColor = new ConstantProperty();
         source.outlineWidth = new ConstantProperty();
-        source.closeTop = new ConstantProperty();
-        source.closeBottom = new ConstantProperty();
         source.shadows = new ConstantProperty(ShadowMode.ENABLED);
         source.distanceDisplayCondition = new ConstantProperty();
 
@@ -110,8 +102,6 @@ defineSuite([
         expect(target.outline).toBe(source.outline);
         expect(target.outlineColor).toBe(source.outlineColor);
         expect(target.outlineWidth).toBe(source.outlineWidth);
-        expect(target.closeTop).toBe(source.closeTop);
-        expect(target.closeBottom).toBe(source.closeBottom);
         expect(target.shadows).toBe(source.shadows);
         expect(target.distanceDisplayCondition).toBe(source.distanceDisplayCondition);
     });
@@ -131,8 +121,6 @@ defineSuite([
         var outline = new ConstantProperty();
         var outlineColor = new ConstantProperty();
         var outlineWidth = new ConstantProperty();
-        var closeTop = new ConstantProperty();
-        var closeBottom = new ConstantProperty();
         var shadows = new ConstantProperty();
         var distanceDisplayCondition = new ConstantProperty();
 
@@ -149,8 +137,6 @@ defineSuite([
         target.outline = outline;
         target.outlineColor = outlineColor;
         target.outlineWidth = outlineWidth;
-        target.closeTop = closeTop;
-        target.closeBottom = closeBottom;
         target.shadows = shadows;
         target.distanceDisplayCondition = distanceDisplayCondition;
 
@@ -168,8 +154,6 @@ defineSuite([
         expect(target.outline).toBe(outline);
         expect(target.outlineColor).toBe(outlineColor);
         expect(target.outlineWidth).toBe(outlineWidth);
-        expect(target.closeTop).toBe(closeTop);
-        expect(target.closeBottom).toBe(closeBottom);
         expect(target.shadows).toBe(shadows);
         expect(target.distanceDisplayCondition).toBe(distanceDisplayCondition);
     });
@@ -188,8 +172,6 @@ defineSuite([
         source.outline = new ConstantProperty();
         source.outlineColor = new ConstantProperty();
         source.outlineWidth = new ConstantProperty();
-        source.closeTop = new ConstantProperty();
-        source.closeBottom = new ConstantProperty();
         source.shadows = new ConstantProperty();
         source.distanceDisplayCondition = new ConstantProperty();
 
@@ -206,8 +188,6 @@ defineSuite([
         expect(result.outline).toBe(source.outline);
         expect(result.outlineColor).toBe(source.outlineColor);
         expect(result.outlineWidth).toBe(source.outlineWidth);
-        expect(result.closeTop).toBe(source.closeTop);
-        expect(result.closeBottom).toBe(source.closeBottom);
         expect(result.shadows).toBe(source.shadows);
         expect(result.distanceDisplayCondition).toBe(source.distanceDisplayCondition);
     });
@@ -233,8 +213,6 @@ defineSuite([
         testDefinitionChanged(property, 'outline', true, false);
         testDefinitionChanged(property, 'outlineColor', Color.RED, Color.BLUE);
         testDefinitionChanged(property, 'outlineWidth', 2, 3);
-        testDefinitionChanged(property, 'closeTop', false, true);
-        testDefinitionChanged(property, 'closeBottom', false, true);
         testDefinitionChanged(property, 'shadows', ShadowMode.ENABLED, ShadowMode.DISABLED);
         testDefinitionChanged(property, 'distanceDisplayCondition', new DistanceDisplayCondition(), new DistanceDisplayCondition(10.0, 100.0));
     });


### PR DESCRIPTION
According to `CHANGES.md`, we removed `closeTop` and `closeBottom` support from `RectangleGeometry` for the `1.0` release.
However, through some sequence of bad merges and miscommunication, these options were still made available at the data source level and piped through to the `RectangleGeometry` even through they were never used to construct the geometry.

And I guess no one tried to use these options because no one reported it as a bug in 40+ releases.

So I've removed these options from the doc and code because they never worked anyway.