### PR TITLE
STK World Terrain -> Cesium World Terrain

### DIFF
--- a/Apps/CesiumViewer/CesiumViewer.js
+++ b/Apps/CesiumViewer/CesiumViewer.js
@@ -1,6 +1,6 @@
 define([
         'Cesium/Core/Cartesian3',
-        'Cesium/Core/CesiumTerrainProvider',
+        'Cesium/Core/createWorldTerrain',
         'Cesium/Core/defined',
         'Cesium/Core/formatError',
         'Cesium/Core/Math',
@@ -16,7 +16,7 @@ define([
         'domReady!'
     ], function(
         Cartesian3,
-        CesiumTerrainProvider,
+        createWorldTerrain,
         defined,
         formatError,
         CesiumMath,
@@ -66,8 +66,7 @@ define([
             var viewModel = viewer.baseLayerPicker.viewModel;
             viewModel.selectedTerrain = viewModel.terrainProviderViewModels[1];
         } else {
-            viewer.terrainProvider = new CesiumTerrainProvider({
-                url: 'https://assets.agi.com/stk-terrain/v1/tilesets/world/tiles',
+            viewer.terrainProvider = createWorldTerrain({
                 requestWaterMask: true,
                 requestVertexNormals: true
             });

--- a/Apps/Sandcastle/gallery/3D Tiles Terrain Classification.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Terrain Classification.html
@@ -27,11 +27,7 @@ function startup(Cesium) {
     'use strict';
 //Sandcastle_Begin
 var viewer = new Cesium.Viewer('cesiumContainer', {
-    terrainProvider: new Cesium.CesiumTerrainProvider({
-        url: 'https://assets.agi.com/stk-terrain/v1/tilesets/world/tiles',
-        requestWaterMask: true,
-        requestVertexNormals: true
-    })
+    terrainProvider: Cesium.createWorldTerrain()
 });
 
 var geocoder = viewer.geocoder.viewModel;

--- a/Apps/Sandcastle/gallery/Billboards.html
+++ b/Apps/Sandcastle/gallery/Billboards.html
@@ -226,11 +226,7 @@ function disableDepthTest() {
     Sandcastle.declare(disableDepthTest);
 
     terrainProvider = viewer.terrainProvider;
-    viewer.terrainProvider = new Cesium.CesiumTerrainProvider({
-        url : 'https://assets.agi.com/stk-terrain/v1/tilesets/world/tiles',
-        requestWaterMask : true,
-        requestVertexNormals : true
-    });
+    viewer.terrainProvider = Cesium.createWorldTerrain();
     viewer.scene.globe.depthTestAgainstTerrain = true;
 
     viewer.entities.add({

--- a/Apps/Sandcastle/gallery/CZML Path.html
+++ b/Apps/Sandcastle/gallery/CZML Path.html
@@ -1863,13 +1863,8 @@ var czml = [{
     }
 }];
 
-var terrainProvider = new Cesium.CesiumTerrainProvider({
-    url : 'https://assets.agi.com/stk-terrain/v1/tilesets/world/tiles',
-    requestVertexNormals : true
-});
-
 var viewer = new Cesium.Viewer('cesiumContainer', {
-    terrainProvider : terrainProvider,
+    terrainProvider : Cesium.createWorldTerrain(),
     baseLayerPicker : false,
     shouldAnimate : true
 });

--- a/Apps/Sandcastle/gallery/Cardboard.html
+++ b/Apps/Sandcastle/gallery/Cardboard.html
@@ -29,10 +29,7 @@ function startup(Cesium) {
 //Sandcastle_Begin
 var viewer = new Cesium.Viewer('cesiumContainer', {
     vrButton: true,
-    terrainProvider: new Cesium.CesiumTerrainProvider({
-        url: 'https://assets.agi.com/stk-terrain/v1/tilesets/world/tiles',
-        requestVertexNormals: true
-    })
+    terrainProvider: Cesium.createWorldTerrain()
 });
 // Click the VR button in the bottom right of the screen to switch to VR mode.
 

--- a/Apps/Sandcastle/gallery/Cesium Inspector.html
+++ b/Apps/Sandcastle/gallery/Cesium Inspector.html
@@ -32,11 +32,7 @@ function startup(Cesium) {
     'use strict';
 //Sandcastle_Begin
 var viewer = new Cesium.Viewer('cesiumContainer', {
-    terrainProvider: new Cesium.CesiumTerrainProvider({
-        url: 'https://assets.agi.com/stk-terrain/v1/tilesets/world/tiles',
-        requestWaterMask: true,
-        requestVertexNormals: true
-    })
+    terrainProvider: Cesium.createWorldTerrain()
 });
 
 var scene = viewer.scene;

--- a/Apps/Sandcastle/gallery/Globe Materials.html
+++ b/Apps/Sandcastle/gallery/Globe Materials.html
@@ -61,10 +61,8 @@ function startup(Cesium) {
     'use strict';
 //Sandcastle_Begin
 var viewer = new Cesium.Viewer('cesiumContainer', {
-    terrainProvider: new Cesium.CesiumTerrainProvider({
-        url: 'https://assets.agi.com/stk-terrain/v1/tilesets/world/tiles',
-        requestWaterMask: true,
-        requestVertexNormals: true
+    terrainProvider: Cesium.createWorldTerrain({
+        requestVertexNormals: true //Needed to visualize slope
     })
 });
 viewer.scene.globe.enableLighting = true;

--- a/Apps/Sandcastle/gallery/Ground Clamping.html
+++ b/Apps/Sandcastle/gallery/Ground Clamping.html
@@ -33,11 +33,7 @@ function startup(Cesium) {
     'use strict';
 //Sandcastle_Begin
 var viewer = new Cesium.Viewer('cesiumContainer', {
-    terrainProvider: new Cesium.CesiumTerrainProvider({
-        url: 'https://assets.agi.com/stk-terrain/v1/tilesets/world/tiles',
-        requestWaterMask: true,
-        requestVertexNormals: true
-    })
+    terrainProvider: Cesium.createWorldTerrain()
 });
 viewer.scene.globe.depthTestAgainstTerrain = true;
 

--- a/Apps/Sandcastle/gallery/Interpolation.html
+++ b/Apps/Sandcastle/gallery/Interpolation.html
@@ -33,11 +33,7 @@ var viewer = new Cesium.Viewer('cesiumContainer', {
     infoBox: false, //Disable InfoBox widget
     selectionIndicator: false, //Disable selection indicator
     shouldAnimate: true, // Enable animations
-    terrainProvider: new Cesium.CesiumTerrainProvider({
-        url: 'https://assets.agi.com/stk-terrain/v1/tilesets/world/tiles',
-        requestWaterMask: true,
-        requestVertexNormals: true
-    })
+    terrainProvider: Cesium.createWorldTerrain()
 });
 
 //Enable lighting based on sun/moon positions

--- a/Apps/Sandcastle/gallery/Physically-Based Materials.html
+++ b/Apps/Sandcastle/gallery/Physically-Based Materials.html
@@ -40,11 +40,7 @@ var clock = new Cesium.Clock({
 var viewer = new Cesium.Viewer('cesiumContainer', {
     clockViewModel : new Cesium.ClockViewModel(clock),
     selectionIndicator : false,
-    terrainProvider: new Cesium.CesiumTerrainProvider({
-        url : 'https://assets.agi.com/stk-terrain/v1/tilesets/world/tiles',
-        requestWaterMask: true,
-        requestVertexNormals: true
-    })
+    terrainProvider: Cesium.createWorldTerrain()
 });
 
 Sandcastle.addToggleButton('Shadows', viewer.shadows, function(checked) {

--- a/Apps/Sandcastle/gallery/Shadows.html
+++ b/Apps/Sandcastle/gallery/Shadows.html
@@ -34,11 +34,7 @@ var viewer = new Cesium.Viewer('cesiumContainer', {
     shadows: true,
     terrainShadows: Cesium.ShadowMode.ENABLED,
     shouldAnimate: true,
-    terrainProvider: new Cesium.CesiumTerrainProvider({
-        url: 'https://assets.agi.com/stk-terrain/v1/tilesets/world/tiles',
-        requestWaterMask: true,
-        requestVertexNormals: true
-    })
+    terrainProvider: Cesium.createWorldTerrain()
 });
 
 var shadowMap = viewer.shadowMap;

--- a/Apps/Sandcastle/gallery/Terrain Clipping Planes.html
+++ b/Apps/Sandcastle/gallery/Terrain Clipping Planes.html
@@ -45,11 +45,7 @@ function startup(Cesium) {
 var viewer = new Cesium.Viewer('cesiumContainer', {
     skyAtmosphere: false,
     shouldAnimate : true,
-    terrainProvider: new Cesium.CesiumTerrainProvider({
-        url: 'https://assets.agi.com/stk-terrain/v1/tilesets/world/tiles',
-        requestWaterMask: true,
-        requestVertexNormals: true
-    })
+    terrainProvider: Cesium.createWorldTerrain()
 });
 
 var position = Cesium.Cartesian3.fromRadians(-2.0862979473351286, 0.6586620013036164, 1400.0);

--- a/Apps/Sandcastle/gallery/Terrain Exaggeration.html
+++ b/Apps/Sandcastle/gallery/Terrain Exaggeration.html
@@ -31,11 +31,7 @@ function startup(Cesium) {
 //Sandcastle_Begin
 var viewer = new Cesium.Viewer('cesiumContainer', {
     terrainExaggeration : 2.0,
-    terrainProvider: new Cesium.CesiumTerrainProvider({
-        url : 'https://assets.agi.com/stk-terrain/v1/tilesets/world/tiles',
-        requestWaterMask: true,
-        requestVertexNormals: true
-    })
+    terrainProvider: Cesium.createWorldTerrain()
 });
 
 Sandcastle.addDefaultToolbarMenu([{

--- a/Apps/Sandcastle/gallery/Terrain.html
+++ b/Apps/Sandcastle/gallery/Terrain.html
@@ -31,10 +31,9 @@
 function startup(Cesium) {
     'use strict';
 //Sandcastle_Begin
-var worldTerrain = new Cesium.CesiumTerrainProvider({
-    url : 'https://assets.agi.com/stk-terrain/v1/tilesets/world/tiles',
-    requestWaterMask : true,
-    requestVertexNormals : true
+var worldTerrain = Cesium.createWorldTerrain({
+    requestWaterMask: true,
+    requestVertexNormals: true
 });
 
 var viewer = new Cesium.Viewer('cesiumContainer', {
@@ -53,32 +52,28 @@ var vrTheWorldProvider = new Cesium.VRTheWorldTerrainProvider({
 });
 
 Sandcastle.addToolbarMenu([{
-    text : 'CesiumTerrainProvider - STK World Terrain',
+    text : 'CesiumTerrainProvider - Cesium World Terrain',
     onselect : function() {
         viewer.terrainProvider = worldTerrain;
         viewer.scene.globe.enableLighting = true;
     }
 }, {
-    text : 'CesiumTerrainProvider - STK World Terrain - no effects',
+    text : 'CesiumTerrainProvider - Cesium World Terrain - no effects',
     onselect : function() {
-        viewer.terrainProvider = new Cesium.CesiumTerrainProvider({
-            url : 'https://assets.agi.com/stk-terrain/v1/tilesets/world/tiles'
-        });
+        viewer.terrainProvider = Cesium.createWorldTerrain();
     }
 }, {
-    text : 'CesiumTerrainProvider - STK World Terrain w/ Lighting',
+    text : 'CesiumTerrainProvider - Cesium World Terrain w/ Lighting',
     onselect : function() {
-        viewer.terrainProvider = new Cesium.CesiumTerrainProvider({
-            url : 'https://assets.agi.com/stk-terrain/v1/tilesets/world/tiles',
+        viewer.terrainProvider = Cesium.createWorldTerrain({
             requestVertexNormals : true
         });
         viewer.scene.globe.enableLighting = true;
     }
 }, {
-    text : 'CesiumTerrainProvider - STK World Terrain w/ Water',
+    text : 'CesiumTerrainProvider - Cesium World Terrain w/ Water',
     onselect : function() {
-        viewer.terrainProvider = new Cesium.CesiumTerrainProvider({
-            url : 'https://assets.agi.com/stk-terrain/v1/tilesets/world/tiles',
+        viewer.terrainProvider = Cesium.createWorldTerrain({
             requestWaterMask : true
         });
     }

--- a/Apps/Sandcastle/gallery/development/BillboardClampToGround.html
+++ b/Apps/Sandcastle/gallery/development/BillboardClampToGround.html
@@ -33,9 +33,7 @@ function startup(Cesium) {
     'use strict';
 //Sandcastle_Begin
 var viewer = new Cesium.Viewer('cesiumContainer', {
-    terrainProvider: new Cesium.CesiumTerrainProvider({
-        url: 'https://assets.agi.com/stk-terrain/v1/tilesets/world/tiles'
-    })
+    terrainProvider: Cesium.createWorldTerrain()
 });
 viewer.scene.globe.depthTestAgainstTerrain = true;
 

--- a/Apps/Sandcastle/gallery/development/Billboards Instancing.html
+++ b/Apps/Sandcastle/gallery/development/Billboards Instancing.html
@@ -33,9 +33,7 @@ function startup(Cesium) {
     'use strict';
 //Sandcastle_Begin
 var viewer = new Cesium.Viewer('cesiumContainer', {
-    terrainProvider: new Cesium.CesiumTerrainProvider({
-        url: 'https://assets.agi.com/stk-terrain/v1/tilesets/world/tiles'
-    })
+    terrainProvider: Cesium.createWorldTerrain()
 });
 
 var scene = viewer.scene;

--- a/Apps/Sandcastle/gallery/development/Fog.html
+++ b/Apps/Sandcastle/gallery/development/Fog.html
@@ -44,11 +44,7 @@ function startup(Cesium) {
     'use strict';
 //Sandcastle_Begin
 var viewer = new Cesium.Viewer('cesiumContainer', {
-    terrainProvider: new Cesium.CesiumTerrainProvider({
-        url: 'https://assets.agi.com/stk-terrain/v1/tilesets/world/tiles',
-        requestWaterMask : true,
-        requestVertexNormals : true
-    })
+    terrainProvider: Cesium.createWorldTerrain()
 });
 
 viewer.extend(Cesium.viewerCesiumInspectorMixin);

--- a/Apps/Sandcastle/gallery/development/Ground Primitive.html
+++ b/Apps/Sandcastle/gallery/development/Ground Primitive.html
@@ -28,10 +28,7 @@ function startup(Cesium) {
     'use strict';
 //Sandcastle_Begin
 var viewer = new Cesium.Viewer('cesiumContainer', {
-    terrainProvider: new Cesium.CesiumTerrainProvider({
-        url: 'https://assets.agi.com/stk-terrain/v1/tilesets/world/tiles',
-        requestVertexNormals: true
-    })
+    terrainProvider: Cesium.createWorldTerrain()
 });
 var scene = viewer.scene;
 

--- a/Apps/Sandcastle/gallery/development/Multiple Shadows.html
+++ b/Apps/Sandcastle/gallery/development/Multiple Shadows.html
@@ -42,11 +42,7 @@
             infoBox : false,
             selectionIndicator : false,
             timeline : false,
-            terrainProvider: new Cesium.CesiumTerrainProvider({
-                url: 'https://assets.agi.com/stk-terrain/v1/tilesets/world/tiles',
-                requestWaterMask: true,
-                requestVertexNormals: true
-            })
+            terrainProvider: Cesium.createWorldTerrain()
         });
 
         var scene = viewer.scene;

--- a/Apps/Sandcastle/gallery/development/Shadows.html
+++ b/Apps/Sandcastle/gallery/development/Shadows.html
@@ -486,11 +486,7 @@ function updateUI() {
 
 scene.debugShowFramesPerSecond = true;
 
-var cesiumTerrainProvider = new Cesium.CesiumTerrainProvider({
-    url : 'https://assets.agi.com/stk-terrain/v1/tilesets/world/tiles',
-    requestWaterMask : true,
-    requestVertexNormals : true
-});
+var cesiumTerrainProvider = Cesium.createWorldTerrain();
 
 var ellipsoidTerrainProvider = new Cesium.EllipsoidTerrainProvider();
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,15 +3,25 @@ Change Log
 
 ### 1.43 - 2018-03-01
 
+##### Major Announcements :loudspeaker:
+
+* Say hello to [Cesium ion](https://cesium.com/blog/2018/03/01/hello-cesium-ion/)
+* Cesium, the JavaScript library, is now officially renamed to CesiumJS (no code changes required)
+* The STK World Terrain tileset is deprecated and will be available until September 1, 2018. Check out the new high-resolution [Cesium World Terrain](https://cesium.com/blog/2018/03/01/introducing-cesium-world-terrain/)
+
 ##### Breaking Changes :mega:
 * Removed `GeometryUpdater.perInstanceColorAppearanceType` and `GeometryUpdater.materialAppearanceType`. [#6239](https://github.com/AnalyticalGraphicsInc/cesium/pull/6239)
 * `GeometryVisualizer` no longer uses a `type` parameter. [#6239](https://github.com/AnalyticalGraphicsInc/cesium/pull/6239)
 * `GeometryVisualizer` no longer displays polylines.  Use `PolylineVisualizer` instead. [#6239](https://github.com/AnalyticalGraphicsInc/cesium/pull/6239)
+* The experimental `CesiumIon` object has been completely refactored and renamed to `Ion`.
 
 ##### Deprecated :hourglass_flowing_sand:
+* The STK World Terrain, ArcticDEM, and PAMAP Terrain tilesets hosted on `assets.agi.com` are deprecated and will be available until September 1, 2018. To continue using them, access them via [Cesium ion](https://cesium.com/blog/2018/03/01/hello-cesium-ion/)
 * In the `Resource` class, `addQueryParameters` and `addTemplateValues` have been deprecated and will be removed in Cesium 1.45. Please use `setQueryParameters` and `setTemplateValues` instead.
 
 ##### Additions :tada:
+* Added new `Ion`, `IonResource`, and `IonImageryProvider` objects for loading data hosted on [Cesium ion](https://cesium.com/blog/2018/03/01/hello-cesium-ion/).
+* Added `createWorldTerrain` helper function for easily constructing the new Cesium World Terrain.
 * Added support for a promise to a resource for `CesiumTerrainProvider`, `createTileMapServiceImageryProvider` and `Cesium3DTileset` [#6204](https://github.com/AnalyticalGraphicsInc/cesium/pull/6204)
 * Added `Cesium.Math.cbrt`. [#6222](https://github.com/AnalyticalGraphicsInc/cesium/pull/6222)
 * Added `PolylineVisualizer` for displaying polyline entities [#6239](https://github.com/AnalyticalGraphicsInc/cesium/pull/6239)

--- a/Source/Core/createWorldTerrain.js
+++ b/Source/Core/createWorldTerrain.js
@@ -1,0 +1,49 @@
+define([
+        './CesiumTerrainProvider',
+        './defaultValue',
+        './IonResource'
+    ], function(
+        CesiumTerrainProvider,
+        defaultValue,
+        IonResource) {
+    'use strict';
+
+    /**
+     * Creates a {@link CesiumTerrainProvider} instance for the {@link https://cesium.com/content/cesiumworldterrain|Cesium World Terrain}.
+     *
+     * @exports createWorldTerrain
+     *
+     * @param {Boolean} [options.requestVertexNormals=false] Flag that indicates if the client should request additional lighting information from the server if available.
+     * @param {Boolean} [options.requestWaterMask=false] Flag that indicates if the client should request per tile water masks from the server if available.
+     * @returns {CesiumTerrainProvider}
+     *
+     * @see Ion
+     *
+     * @example
+     * // Create Cesium World Terrain with default settings
+     * var viewer = new Cesium.Viewer('cesiumContainer', {
+     *     terrainProvider : terrainProvider : Cesium.createWorldTerrain();
+     * });
+     *
+     * @example
+     * // Create Cesium World Terrain with water and normals.
+     * var viewer = new Cesium.Viewer('cesiumContainer', {
+     *     terrainProvider : terrainProvider : Cesium.createWorldTerrain({
+     *         requestWaterMask : true,
+     *         requestVertexNormals : true
+     *     });
+     * });
+     *
+     */
+    function createWorldTerrain(options) {
+        options = defaultValue(options, defaultValue.EMPTY_OBJECT);
+
+        return new CesiumTerrainProvider({
+            url: IonResource.fromAssetId(1),
+            requestVertexNormals: defaultValue(options.requestVertexNormals, false),
+            requestWaterMask: defaultValue(options.requestWaterMask, false)
+        });
+    }
+
+    return createWorldTerrain;
+});

--- a/Source/Core/sampleTerrain.js
+++ b/Source/Core/sampleTerrain.js
@@ -31,9 +31,7 @@ define([
      *
      * @example
      * // Query the terrain height of two Cartographic positions
-     * var terrainProvider = new Cesium.CesiumTerrainProvider({
-     *     url : 'https://assets.agi.com/stk-terrain/v1/tilesets/world/tiles'
-     * });
+     * var terrainProvider = Cesium.createWorldTerrain();
      * var positions = [
      *     Cesium.Cartographic.fromDegrees(86.925145, 27.988257),
      *     Cesium.Cartographic.fromDegrees(87.0, 28.0)

--- a/Source/Core/sampleTerrainMostDetailed.js
+++ b/Source/Core/sampleTerrainMostDetailed.js
@@ -22,9 +22,7 @@ define([
      *
      * @example
      * // Query the terrain height of two Cartographic positions
-     * var terrainProvider = new Cesium.CesiumTerrainProvider({
-     *     url : 'https://assets.agi.com/stk-terrain/v1/tilesets/world/tiles'
-     * });
+     * var terrainProvider = Cesium.createWorldTerrain();
      * var positions = [
      *     Cesium.Cartographic.fromDegrees(86.925145, 27.988257),
      *     Cesium.Cartographic.fromDegrees(87.0, 28.0)

--- a/Source/Widgets/BaseLayerPicker/createDefaultTerrainProviderViewModels.js
+++ b/Source/Widgets/BaseLayerPicker/createDefaultTerrainProviderViewModels.js
@@ -1,11 +1,11 @@
 define([
         '../../Core/buildModuleUrl',
-        '../../Core/CesiumTerrainProvider',
+        '../../Core/createWorldTerrain',
         '../../Core/EllipsoidTerrainProvider',
         '../BaseLayerPicker/ProviderViewModel'
     ], function(
         buildModuleUrl,
-        CesiumTerrainProvider,
+        createWorldTerrain,
         EllipsoidTerrainProvider,
         ProviderViewModel) {
     'use strict';
@@ -24,16 +24,14 @@ define([
             }
         }));
 
-
         providerViewModels.push(new ProviderViewModel({
-            name : 'STK World Terrain meshes',
+            name : 'Cesium World Terrain',
             iconUrl : buildModuleUrl('Widgets/Images/TerrainProviders/STK.png'),
-            tooltip : 'High-resolution, mesh-based terrain for the entire globe. Free for use on the Internet. Closed-network options are available.\nhttp://www.agi.com',
-            creationFunction : function() {
-                return new CesiumTerrainProvider({
-                    url : 'https://assets.agi.com/stk-terrain/v1/tilesets/world/tiles',
-                    requestWaterMask : true,
-                    requestVertexNormals : true
+            tooltip : 'High-resolution global terrain tileset curated from several datasources and hosted by Cesium ion',
+            creationFunction : function(){
+                return createWorldTerrain({
+                    requestWaterMask: true,
+                    requestVertexNormals: true
                 });
             }
         }));

--- a/Source/Widgets/CesiumWidget/CesiumWidget.js
+++ b/Source/Widgets/CesiumWidget/CesiumWidget.js
@@ -176,12 +176,10 @@ define([
      * //Widget with no terrain and default Bing Maps imagery provider.
      * var widget = new Cesium.CesiumWidget('cesiumContainer');
      *
-     * //Widget with OpenStreetMaps imagery provider and Cesium terrain provider hosted by AGI.
+     * //Widget with OpenStreetMaps imagery provider and Cesium World Terrain.
      * var widget = new Cesium.CesiumWidget('cesiumContainer', {
      *     imageryProvider : Cesium.createOpenStreetMapImageryProvider(),
-     *     terrainProvider : new Cesium.CesiumTerrainProvider({
-     *         url : 'https://assets.agi.com/stk-terrain/v1/tilesets/world/tiles'
-     *     }),
+     *     terrainProvider : Cesium.createWorldTerrain(),
      *     // Use high-res stars downloaded from https://github.com/AnalyticalGraphicsInc/cesium-assets
      *     skyBox : new Cesium.SkyBox({
      *         sources : {

--- a/Source/Widgets/Viewer/Viewer.js
+++ b/Source/Widgets/Viewer/Viewer.js
@@ -318,10 +318,8 @@ define([
      * var viewer = new Cesium.Viewer('cesiumContainer', {
      *     //Start in Columbus Viewer
      *     sceneMode : Cesium.SceneMode.COLUMBUS_VIEW,
-     *     //Use standard Cesium terrain
-     *     terrainProvider : new Cesium.CesiumTerrainProvider({
-     *         url : 'https://assets.agi.com/stk-terrain/v1/tilesets/world/tiles'
-     *     }),
+     *     //Use Cesium World Terrain
+     *     terrainProvider : Cesium.createWorldTerrain(),
      *     //Hide the base layer picker
      *     baseLayerPicker : false,
      *     //Use OpenStreetMaps

--- a/Specs/Core/CesiumTerrainProviderSpec.js
+++ b/Specs/Core/CesiumTerrainProviderSpec.js
@@ -314,7 +314,7 @@ defineSuite([
         return pollToPromise(function() {
             return provider.ready;
         }).then(function() {
-            expect(provider.credit.text).toBe('This is a child tileset! This amazing data is courtesy The Amazing Data Source!');
+            expect(provider._tileCredits[0].text).toBe('This is a child tileset! This amazing data is courtesy The Amazing Data Source!');
             expect(provider.requestVertexNormals).toBe(true);
             expect(provider.requestWaterMask).toBe(true);
             expect(provider.hasVertexNormals).toBe(false); // Neither tileset has them
@@ -455,7 +455,7 @@ defineSuite([
         return pollToPromise(function() {
             return provider.ready;
         }).then(function() {
-            expect(provider.credit.text).toBe('This amazing data is courtesy The Amazing Data Source!');
+            expect(provider._tileCredits[0].text).toBe('This amazing data is courtesy The Amazing Data Source!');
         });
     });
 

--- a/Specs/Core/sampleTerrainMostDetailedSpec.js
+++ b/Specs/Core/sampleTerrainMostDetailedSpec.js
@@ -1,16 +1,16 @@
 defineSuite([
         'Core/sampleTerrainMostDetailed',
         'Core/Cartographic',
-        'Core/CesiumTerrainProvider'
+        'Core/CesiumTerrainProvider',
+        'Core/createWorldTerrain'
     ], function(
         sampleTerrainMostDetailed,
         Cartographic,
-        CesiumTerrainProvider) {
+        CesiumTerrainProvider,
+        createWorldTerrain) {
     "use strict";
 
-    var terrainProvider = new CesiumTerrainProvider({
-        url : 'https://assets.agi.com/stk-terrain/v1/tilesets/world/tiles'
-    });
+    var worldTerrain = createWorldTerrain();
 
     it('queries heights', function() {
         var positions = [
@@ -18,7 +18,7 @@ defineSuite([
             Cartographic.fromDegrees(87.0, 28.0)
         ];
 
-        return sampleTerrainMostDetailed(terrainProvider, positions).then(function(passedPositions) {
+        return sampleTerrainMostDetailed(worldTerrain, positions).then(function(passedPositions) {
             expect(passedPositions).toBe(positions);
             expect(positions[0].height).toBeGreaterThan(5000);
             expect(positions[0].height).toBeLessThan(10000);
@@ -49,7 +49,7 @@ defineSuite([
             Cartographic.fromDegrees(87.0, 28.0)
         ];
 
-        return sampleTerrainMostDetailed(terrainProvider, positions).then(function() {
+        return sampleTerrainMostDetailed(worldTerrain, positions).then(function() {
             expect(positions[0].height).toBeGreaterThan(5000);
             expect(positions[0].height).toBeLessThan(10000);
             expect(positions[1].height).toBeGreaterThan(5000);
@@ -68,19 +68,15 @@ defineSuite([
         }).toThrowDeveloperError();
 
         expect(function() {
-            sampleTerrainMostDetailed(terrainProvider, undefined);
+            sampleTerrainMostDetailed(worldTerrain, undefined);
         }).toThrowDeveloperError();
 
     });
 
     it('works for a dodgy point right near the edge of a tile', function() {
-        var stkWorldTerrain = new CesiumTerrainProvider({
-            url : 'https://assets.agi.com/stk-terrain/v1/tilesets/world/tiles'
-        });
-
         var positions = [new Cartographic(0.33179290856829535, 0.7363107781851078)];
 
-        return sampleTerrainMostDetailed(stkWorldTerrain, positions).then(function() {
+        return sampleTerrainMostDetailed(worldTerrain, positions).then(function() {
             expect(positions[0].height).toBeDefined();
         });
     });

--- a/Specs/Core/sampleTerrainSpec.js
+++ b/Specs/Core/sampleTerrainSpec.js
@@ -1,16 +1,16 @@
 defineSuite([
         'Core/sampleTerrain',
         'Core/Cartographic',
-        'Core/CesiumTerrainProvider'
+        'Core/CesiumTerrainProvider',
+        'Core/createWorldTerrain'
     ], function(
         sampleTerrain,
         Cartographic,
-        CesiumTerrainProvider) {
+        CesiumTerrainProvider,
+        createWorldTerrain) {
     'use strict';
 
-    var terrainProvider = new CesiumTerrainProvider({
-        url : 'https://assets.agi.com/stk-terrain/v1/tilesets/world/tiles'
-    });
+    var worldTerrain = createWorldTerrain();
 
     it('queries heights', function() {
         var positions = [
@@ -18,7 +18,7 @@ defineSuite([
                          Cartographic.fromDegrees(87.0, 28.0)
                      ];
 
-        return sampleTerrain(terrainProvider, 11, positions).then(function(passedPositions) {
+        return sampleTerrain(worldTerrain, 11, positions).then(function(passedPositions) {
             expect(passedPositions).toBe(positions);
             expect(positions[0].height).toBeGreaterThan(5000);
             expect(positions[0].height).toBeLessThan(10000);
@@ -51,7 +51,7 @@ defineSuite([
                          Cartographic.fromDegrees(0.0, 0.0, 0.0)
                      ];
 
-        return sampleTerrain(terrainProvider, 18, positions).then(function() {
+        return sampleTerrain(worldTerrain, 18, positions).then(function() {
             expect(positions[0].height).toBeUndefined();
         });
     });
@@ -63,7 +63,7 @@ defineSuite([
                          Cartographic.fromDegrees(87.0, 28.0)
                      ];
 
-        return sampleTerrain(terrainProvider, 12, positions).then(function() {
+        return sampleTerrain(worldTerrain, 12, positions).then(function() {
             expect(positions[0].height).toBeGreaterThan(5000);
             expect(positions[0].height).toBeLessThan(10000);
             expect(positions[1].height).toBeUndefined();
@@ -84,22 +84,18 @@ defineSuite([
         }).toThrowDeveloperError();
 
         expect(function() {
-            sampleTerrain(terrainProvider, undefined, positions);
+            sampleTerrain(worldTerrain, undefined, positions);
         }).toThrowDeveloperError();
 
         expect(function() {
-            sampleTerrain(terrainProvider, 11, undefined);
+            sampleTerrain(worldTerrain, 11, undefined);
         }).toThrowDeveloperError();
     });
 
     it('works for a dodgy point right near the edge of a tile', function() {
-        var stkWorldTerrain = new CesiumTerrainProvider({
-            url : 'https://assets.agi.com/stk-terrain/v1/tilesets/world/tiles'
-        });
-
         var positions = [new Cartographic(0.33179290856829535, 0.7363107781851078)];
 
-        return sampleTerrain(stkWorldTerrain, 12, positions).then(function() {
+        return sampleTerrain(worldTerrain, 12, positions).then(function() {
             expect(positions[0].height).toBeDefined();
         });
     });

--- a/Specs/Scene/GlobeSurfaceTileProviderSpec.js
+++ b/Specs/Scene/GlobeSurfaceTileProviderSpec.js
@@ -653,7 +653,7 @@ defineSuite([
 
         var terrainCredit = new Credit({text: 'terrain credit'});
         scene.terrainProvider = new CesiumTerrainProvider({
-            url : 'https://assets.agi.com/stk-terrain/v1/tilesets/world/tiles',
+            url : 'https://s3.amazonaws.com/cesiumjs/smallTerrain',
             credit : terrainCredit
         });
 

--- a/Specs/Scene/GlobeSurfaceTileSpec.js
+++ b/Specs/Scene/GlobeSurfaceTileSpec.js
@@ -3,6 +3,7 @@ defineSuite([
         'Core/Cartesian3',
         'Core/Cartesian4',
         'Core/CesiumTerrainProvider',
+        'Core/createWorldTerrain',
         'Core/defined',
         'Core/Ellipsoid',
         'Core/GeographicTilingScheme',
@@ -25,6 +26,7 @@ defineSuite([
         Cartesian3,
         Cartesian4,
         CesiumTerrainProvider,
+        createWorldTerrain,
         defined,
         Ellipsoid,
         GeographicTilingScheme,
@@ -529,9 +531,9 @@ defineSuite([
         });
 
         it('gets correct results even when the mesh includes normals', function() {
-            var terrainProvider = new CesiumTerrainProvider({
-                url : 'https://assets.agi.com/stk-terrain/v1/tilesets/world/tiles',
-                requestVertexNormals : true
+            var terrainProvider = createWorldTerrain({
+                requestVertexNormals: true,
+                requestWaterMask: false
             });
 
             var tile = new QuadtreeTile({


### PR DESCRIPTION
1. Remove all `STK World Terrain` usage/references and replace them with `Cesium World Terrain`.
2. Add new `createWorldTerrain` helper function for creating the world terrain. Same defaults for extensions as CesiumTerrainProvider(no normals or water).
3. Replace all World Terrain examples and doc with `createWorldTerrain`. We were needlessly setting `requestWaterMask` and `requestVertexNormals` to true in most examples, so I just changed it to use the default behavior to simplify the code.
4. Add a deprecation warning and deprecation Credit when `assets.agi.com` is detected. Note that this includes ArcticDEM and PAMap, which are still being used in this PR but will be replaced in a follow-up PR after this is merged.

CC @pjcozzi 