### PR TITLE
Fix zoom to dynamic geometry

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -40,6 +40,7 @@ Change Log
 * Fixed issue where `CESIUM_BASE_URL` wouldn't work without a trailing `/`. [#6225](https://github.com/AnalyticalGraphicsInc/cesium/issues/6225)
 * Fixed coloring for polyline entities with a dynamic color for the depth fail material [#6245](https://github.com/AnalyticalGraphicsInc/cesium/pull/6245)
 * Fixed an issue causing the Bing Maps key to be sent unnecessarily with every tile request. [#6250](https://github.com/AnalyticalGraphicsInc/cesium/pull/6250)
+* Fixed bug with zooming to dynamic geometry. [#6269](https://github.com/AnalyticalGraphicsInc/cesium/issues/6269)
 * Fixed documentation issue for the `Cesium.Math` class. [#6233](https://github.com/AnalyticalGraphicsInc/cesium/issues/6233)
 
 ##### Additions :tada:

--- a/Source/Scene/Scene.js
+++ b/Source/Scene/Scene.js
@@ -3060,13 +3060,16 @@ define([
             // Render
             this._preRender.raiseEvent(this, time);
             tryAndCatchError(this, time, render);
-            this._postRender.raiseEvent(this, time);
 
             RequestScheduler.update();
         }
 
         updateDebugShowFramesPerSecond(this, shouldRender);
         callAfterRenderFunctions(this);
+
+        if (shouldRender) {
+            this._postRender.raiseEvent(this, time);
+        }
     };
 
     /**


### PR DESCRIPTION
Fixes #6269

Moved raising the `postRender` event to after the `frameState.afterRender` functions are all called, which means the primitives are once again being marked as ready in time for the viewer to get the boundingSpheres to zoom to.

Double checked throughout the code base, and `Viewer._afterRender` was the only Cesium after render function which depended on the `frameState.afterRender` functions being called first.