### PR TITLE
Entity classification type

### DIFF
--- a/Apps/Sandcastle/gallery/Classification Types.html
+++ b/Apps/Sandcastle/gallery/Classification Types.html
@@ -38,43 +38,28 @@ tileset.readyPromise.then(function(){
     viewer.camera.lookAtTransform(Cesium.Matrix4.IDENTITY);
 });
 
-var cartographics = [new Cesium.Cartographic(-1.3194369277314022, 0.6988062530900625),
-                     new Cesium.Cartographic(-1.3193955980204217, 0.6988091578771254),
-                     new Cesium.Cartographic(-1.3193931220959367, 0.698743632490865),
-                     new Cesium.Cartographic(-1.3194358224045408, 0.6987471965556998)];
-var rectangle = Cesium.Rectangle.fromCartographicArray(cartographics);
-var rectanglePrimitive = viewer.scene.primitives.add(new Cesium.GroundPrimitive({
-    geometryInstances : new Cesium.GeometryInstance({
-        geometry : new Cesium.RectangleGeometry({
-            rectangle : rectangle
-        }),
-        attributes: {
-            color: Cesium.ColorGeometryInstanceAttribute.fromColor(new Cesium.Color(1.0, 0.0, 0.0, 0.5))
-        }
-    }),
-    classificationType : Cesium.ClassificationType.BOTH
-}));
+var entity = viewer.entities.add({
+    polygon : {
+        hierarchy : new Cesium.PolygonHierarchy(Cesium.Cartesian3.fromRadiansArray([-1.3194369277314022, 0.6988062530900625, -1.3193955980204217, 0.6988091578771254, -1.3193931220959367, 0.698743632490865, -1.3194358224045408, 0.6987471965556998])),
+        material : Cesium.Color.RED.withAlpha(0.5),
+        classificationType : Cesium.ClassificationType.BOTH
+    }
+});
 
 var options = [{
     text : 'Classify Both',
     onselect : function() {
-        if (Cesium.defined(rectanglePrimitive)) {
-            rectanglePrimitive.classificationType = Cesium.ClassificationType.BOTH;
-        }
+        entity.polygon.classificationType = Cesium.ClassificationType.BOTH;
     }
 }, {
     text : 'Classify Terrain',
     onselect : function() {
-        if (Cesium.defined(rectanglePrimitive)) {
-            rectanglePrimitive.classificationType = Cesium.ClassificationType.TERRAIN;
-        }
+        entity.polygon.classificationType = Cesium.ClassificationType.TERRAIN;
     }
 }, {
     text : 'Classify 3D Tiles',
     onselect : function() {
-        if (Cesium.defined(rectanglePrimitive)) {
-            rectanglePrimitive.classificationType = Cesium.ClassificationType.CESIUM_3D_TILE;
-        }
+        entity.polygon.classificationType = Cesium.ClassificationType.CESIUM_3D_TILE;
     }
 }];
 Sandcastle.addToolbarMenu(options);

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -31,6 +31,7 @@ Change Log
   * Added `setQueryParameters` and `appendQueryParameters` to allow for better handling of query strings.
 * Enable terrain in the `CesiumViewer` demo application [#6198](https://github.com/AnalyticalGraphicsInc/cesium/pull/6198)
 * Added `Globe.tilesLoaded` getter property to determine if all terrain and imagery is loaded. [#6194](https://github.com/AnalyticalGraphicsInc/cesium/pull/6194)
+* Added `classificationType` property to entities which specifies whether an entity on the ground, like a polygon or rectangle, should be clamped to terrain, 3D Tiles, or both. [#6195](https://github.com/AnalyticalGraphicsInc/cesium/issues/6195)
 
 ##### Fixes :wrench:
 * Fixed bug where `AxisAlignedBoundingBox` did not copy over center value when cloning an undefined result. [#6183](https://github.com/AnalyticalGraphicsInc/cesium/pull/6183)

--- a/Source/DataSources/CorridorGraphics.js
+++ b/Source/DataSources/CorridorGraphics.js
@@ -72,6 +72,8 @@ define([
         this._shadowsSubscription = undefined;
         this._distanceDisplayCondition = undefined;
         this._distanceDisplayConditionSubscription = undefined;
+        this._classificationType = undefined;
+        this._classificationTypeSubscription = undefined;
         this._definitionChanged = new Event();
 
         this.merge(defaultValue(options, defaultValue.EMPTY_OBJECT));
@@ -199,7 +201,15 @@ define([
          * @memberof CorridorGraphics.prototype
          * @type {Property}
          */
-        distanceDisplayCondition : createPropertyDescriptor('distanceDisplayCondition')
+        distanceDisplayCondition : createPropertyDescriptor('distanceDisplayCondition'),
+
+        /**
+         * Gets or sets the {@link ClassificationType} Property specifying whether this corridor will classify terrain, 3D Tiles, or both when on the ground.
+         * @memberof CorridorGraphics.prototype
+         * @type {Property}
+         * @default ClassificationType.BOTH
+         */
+        classificationType : createPropertyDescriptor('classificationType')
     });
 
     /**
@@ -226,6 +236,7 @@ define([
         result.cornerType = this.cornerType;
         result.shadows = this.shadows;
         result.distanceDisplayCondition = this.distanceDisplayCondition;
+        result.classificationType = this.classificationType;
         return result;
     };
 
@@ -256,6 +267,7 @@ define([
         this.cornerType = defaultValue(this.cornerType, source.cornerType);
         this.shadows = defaultValue(this.shadows, source.shadows);
         this.distanceDisplayCondition = defaultValue(this.distanceDisplayCondition, source.distanceDisplayCondition);
+        this.classificationType = defaultValue(this.classificationType, source.classificationType);
     };
 
     return CorridorGraphics;

--- a/Source/DataSources/EllipseGraphics.js
+++ b/Source/DataSources/EllipseGraphics.js
@@ -78,6 +78,8 @@ define([
         this._shadowsSubscription = undefined;
         this._distanceDisplayCondition = undefined;
         this._distanceDisplayConditionSubscription = undefined;
+        this._classificationType = undefined;
+        this._classificationTypeSubscription = undefined;
         this._definitionChanged = new Event();
 
         this.merge(defaultValue(options, defaultValue.EMPTY_OBJECT));
@@ -221,7 +223,15 @@ define([
          * @memberof EllipseGraphics.prototype
          * @type {Property}
          */
-        distanceDisplayCondition : createPropertyDescriptor('distanceDisplayCondition')
+        distanceDisplayCondition : createPropertyDescriptor('distanceDisplayCondition'),
+
+        /**
+         * Gets or sets the {@link ClassificationType} Property specifying whether this ellipse will classify terrain, 3D Tiles, or both when on the ground.
+         * @memberof EllipseGraphics.prototype
+         * @type {Property}
+         * @default ClassificationType.BOTH
+         */
+        classificationType : createPropertyDescriptor('classificationType')
     });
 
     /**
@@ -250,6 +260,7 @@ define([
         result.numberOfVerticalLines = this.numberOfVerticalLines;
         result.shadows = this.shadows;
         result.distanceDisplayCondition = this.distanceDisplayCondition;
+        result.classificationType = this.classificationType;
         return result;
     };
 
@@ -282,6 +293,7 @@ define([
         this.numberOfVerticalLines = defaultValue(this.numberOfVerticalLines, source.numberOfVerticalLines);
         this.shadows = defaultValue(this.shadows, source.shadows);
         this.distanceDisplayCondition = defaultValue(this.distanceDisplayCondition, source.distanceDisplayCondition);
+        this.classificationType = defaultValue(this.classificationType, source.classificationType);
     };
 
     return EllipseGraphics;

--- a/Source/DataSources/GeometryUpdater.js
+++ b/Source/DataSources/GeometryUpdater.js
@@ -10,6 +10,7 @@ define([
     '../Core/Event',
     '../Core/Iso8601',
     '../Core/oneTimeWarning',
+    '../Scene/ClassificationType',
     '../Scene/ShadowMode',
     './ColorMaterialProperty',
     './ConstantProperty',
@@ -26,6 +27,7 @@ define([
     Event,
     Iso8601,
     oneTimeWarning,
+    ClassificationType,
     ShadowMode,
     ColorMaterialProperty,
     ConstantProperty,
@@ -39,6 +41,7 @@ define([
     var defaultOutlineColor = new ConstantProperty(Color.BLACK);
     var defaultShadows = new ConstantProperty(ShadowMode.DISABLED);
     var defaultDistanceDisplayCondition = new ConstantProperty(new DistanceDisplayCondition());
+    var defaultClassificationType = new ConstantProperty(ClassificationType.BOTH);
 
     /**
      * A {@link GeometryUpdater} for boxes.
@@ -80,6 +83,7 @@ define([
         this._outlineWidth = 1.0;
         this._shadowsProperty = undefined;
         this._distanceDisplayConditionProperty = undefined;
+        this._classificationTypeProperty = undefined;
         this._options = options.geometryOptions;
         this._geometryPropertyName = geometryPropertyName;
         this._id = geometryPropertyName + '-' + entity.id;
@@ -226,6 +230,18 @@ define([
         distanceDisplayConditionProperty : {
             get : function() {
                 return this._distanceDisplayConditionProperty;
+            }
+        },
+        /**
+         * Gets or sets the {@link ClassificationType} Property specifying if this geometry will classify terrain, 3D Tiles, or both when on the ground.
+         * @memberof GeometryUpdater.prototype
+         *
+         * @type {Property}
+         * @readonly
+         */
+        classificationTypeProperty : {
+            get : function() {
+                return this._classificationTypeProperty;
             }
         },
         /**
@@ -440,6 +456,7 @@ define([
         this._outlineColorProperty = outlineEnabled ? defaultValue(geometry.outlineColor, defaultOutlineColor) : undefined;
         this._shadowsProperty = defaultValue(geometry.shadows, defaultShadows);
         this._distanceDisplayConditionProperty = defaultValue(geometry.distanceDisplayCondition, defaultDistanceDisplayCondition);
+        this._classificationTypeProperty = defaultValue(geometry.classificationType, defaultClassificationType);
 
         this._fillEnabled = fillEnabled;
 

--- a/Source/DataSources/GeometryVisualizer.js
+++ b/Source/DataSources/GeometryVisualizer.js
@@ -7,6 +7,7 @@ define([
         '../Core/DeveloperError',
         '../Core/Event',
         '../Core/EventHelper',
+        '../Scene/ClassificationType',
         '../Scene/MaterialAppearance',
         '../Scene/PerInstanceColorAppearance',
         '../Scene/ShadowMode',
@@ -36,6 +37,7 @@ define([
         DeveloperError,
         Event,
         EventHelper,
+        ClassificationType,
         MaterialAppearance,
         PerInstanceColorAppearance,
         ShadowMode,
@@ -139,7 +141,8 @@ define([
         this._openColorBatches = new Array(numberOfShadowModes);
         this._openMaterialBatches = new Array(numberOfShadowModes);
 
-        for (var i = 0; i < numberOfShadowModes; ++i) {
+        var i;
+        for (i = 0; i < numberOfShadowModes; ++i) {
             this._outlineBatches[i] = new StaticOutlineGeometryBatch(primitives, scene, i);
 
             this._closedColorBatches[i] = new StaticGeometryColorBatch(primitives, PerInstanceColorAppearance, undefined, true, i);
@@ -148,10 +151,16 @@ define([
             this._openMaterialBatches[i] = new StaticGeometryPerMaterialBatch(primitives, MaterialAppearance, undefined, false, i);
         }
 
-        this._groundColorBatch = new StaticGroundGeometryColorBatch(groundPrimitives);
+        var numberOfClassificationTypes = ClassificationType.NUMBER_OF_CLASSIFICATION_TYPES;
+        this._groundColorBatches = new Array(numberOfClassificationTypes);
+
+        for (i = 0; i < numberOfClassificationTypes; ++i) {
+            this._groundColorBatches[i] = new StaticGroundGeometryColorBatch(groundPrimitives, i);
+        }
+
         this._dynamicBatch = new DynamicGeometryBatch(primitives, groundPrimitives);
 
-        this._batches = this._outlineBatches.concat(this._closedColorBatches, this._closedMaterialBatches, this._openColorBatches, this._openMaterialBatches, this._groundColorBatch, this._dynamicBatch);
+        this._batches = this._outlineBatches.concat(this._closedColorBatches, this._closedMaterialBatches, this._openColorBatches, this._openMaterialBatches, this._groundColorBatches, this._dynamicBatch);
 
         this._subscriptions = new AssociativeArray();
         this._updaterSets = new AssociativeArray();
@@ -362,7 +371,8 @@ define([
 
         if (updater.fillEnabled) {
             if (updater.onTerrain) {
-                this._groundColorBatch.add(time, updater);
+                var classificationType = updater.classificationTypeProperty.getValue(time);
+                this._groundColorBatches[classificationType].add(time, updater);
             } else if (updater.isClosed) {
                 if (updater.fillMaterialProperty instanceof ColorMaterialProperty) {
                     this._closedColorBatches[shadows].add(time, updater);

--- a/Source/DataSources/PolygonGraphics.js
+++ b/Source/DataSources/PolygonGraphics.js
@@ -70,7 +70,6 @@ define([
         this._outlineWidthSubscription = undefined;
         this._fill = undefined;
         this._fillSubscription = undefined;
-        this._definitionChanged = new Event();
         this._closeTop = undefined;
         this._closeTopSubscription = undefined;
         this._closeBottom = undefined;
@@ -79,6 +78,9 @@ define([
         this._shadowsSubscription = undefined;
         this._distanceDisplayCondition = undefined;
         this._distanceDisplayConditionSubscription = undefined;
+        this._classificationType = undefined;
+        this._classificationTypeSubscription = undefined;
+        this._definitionChanged = new Event();
 
         this.merge(defaultValue(options, defaultValue.EMPTY_OBJECT));
     }
@@ -222,7 +224,15 @@ define([
          * @memberof PolygonGraphics.prototype
          * @type {Property}
          */
-        distanceDisplayCondition : createPropertyDescriptor('distanceDisplayCondition')
+        distanceDisplayCondition : createPropertyDescriptor('distanceDisplayCondition'),
+
+        /**
+         * Gets or sets the {@link ClassificationType} Property specifying whether this polygon will classify terrain, 3D Tiles, or both when on the ground.
+         * @memberof PolygonGraphics.prototype
+         * @type {Property}
+         * @default ClassificationType.BOTH
+         */
+        classificationType : createPropertyDescriptor('classificationType')
     });
 
     /**
@@ -251,6 +261,7 @@ define([
         result.closeBottom = this.closeBottom;
         result.shadows = this.shadows;
         result.distanceDisplayCondition = this.distanceDisplayCondition;
+        result.classificationType = this.classificationType;
         return result;
     };
 
@@ -283,6 +294,7 @@ define([
         this.closeBottom = defaultValue(this.closeBottom, source.closeBottom);
         this.shadows = defaultValue(this.shadows, source.shadows);
         this.distanceDisplayCondition = defaultValue(this.distanceDisplayCondition, source.distanceDisplayCondition);
+        this.classificationType = defaultValue(this.classificationType, source.classificationType);
     };
 
     return PolygonGraphics;

--- a/Source/DataSources/RectangleGraphics.js
+++ b/Source/DataSources/RectangleGraphics.js
@@ -72,6 +72,8 @@ define([
         this._shadowsSubscription = undefined;
         this._distanceDisplayCondition = undefined;
         this._distancedisplayConditionSubscription = undefined;
+        this._classificationType = undefined;
+        this._classificationTypeSubscription = undefined;
         this._definitionChanged = new Event();
 
         this.merge(defaultValue(options, defaultValue.EMPTY_OBJECT));
@@ -200,7 +202,15 @@ define([
          * @memberof RectangleGraphics.prototype
          * @type {Property}
          */
-        distanceDisplayCondition : createPropertyDescriptor('distanceDisplayCondition')
+        distanceDisplayCondition : createPropertyDescriptor('distanceDisplayCondition'),
+
+        /**
+         * Gets or sets the {@link ClassificationType} Property specifying whether this rectangle will classify terrain, 3D Tiles, or both when on the ground.
+         * @memberof RectangleGraphics.prototype
+         * @type {Property}
+         * @default ClassificationType.BOTH
+         */
+        classificationType : createPropertyDescriptor('classificationType')
     });
 
     /**
@@ -227,6 +237,7 @@ define([
         result.outlineWidth = this.outlineWidth;
         result.shadows = this.shadows;
         result.distanceDisplayCondition = this.distanceDisplayCondition;
+        result.classificationType = this.classificationType;
         return result;
     };
 
@@ -257,6 +268,7 @@ define([
         this.outlineWidth = defaultValue(this.outlineWidth, source.outlineWidth);
         this.shadows = defaultValue(this.shadows, source.shadows);
         this.distanceDisplayCondition = defaultValue(this.distanceDisplayCondition, source.distanceDisplayCondition);
+        this.classificationType = defaultValue(this.classificationType, source.classificationType);
     };
 
     return RectangleGraphics;

--- a/Source/DataSources/StaticGroundGeometryColorBatch.js
+++ b/Source/DataSources/StaticGroundGeometryColorBatch.js
@@ -23,8 +23,9 @@ define([
     var colorScratch = new Color();
     var distanceDisplayConditionScratch = new DistanceDisplayCondition();
 
-    function Batch(primitives, color, key) {
+    function Batch(primitives, classificationType, color, key) {
         this.primitives = primitives;
+        this.classificationType = classificationType;
         this.color = color;
         this.key = key;
         this.createPrimitive = false;
@@ -110,7 +111,8 @@ define([
 
                 primitive = new GroundPrimitive({
                     asynchronous : true,
-                    geometryInstances : geometries
+                    geometryInstances : geometries,
+                    classificationType : this.classificationType
                 });
                 primitives.add(primitive);
                 isUpdated = false;
@@ -250,9 +252,10 @@ define([
     /**
      * @private
      */
-    function StaticGroundGeometryColorBatch(primitives) {
+    function StaticGroundGeometryColorBatch(primitives, classificationType) {
         this._batches = new AssociativeArray();
         this._primitives = primitives;
+        this._classificationType = classificationType;
     }
 
     StaticGroundGeometryColorBatch.prototype.add = function(time, updater) {
@@ -264,7 +267,7 @@ define([
         if (batches.contains(batchKey)) {
             batch = batches.get(batchKey);
         } else {
-            batch = new Batch(this._primitives, instance.attributes.color.value, batchKey);
+            batch = new Batch(this._primitives, this._classificationType, instance.attributes.color.value, batchKey);
             batches.set(batchKey, batch);
         }
         batch.add(updater, instance);

--- a/Source/Scene/ClassificationType.js
+++ b/Source/Scene/ClassificationType.js
@@ -30,7 +30,11 @@ define([
          * @type {Number}
          * @constant
          */
-        BOTH : 2
+        BOTH : 2,
+        /**
+         * @private
+         */
+        NUMBER_OF_CLASSIFICATION_TYPES : 3
     };
 
     return freezeObject(ClassificationType);

--- a/Specs/DataSources/CorridorGraphicsSpec.js
+++ b/Specs/DataSources/CorridorGraphicsSpec.js
@@ -5,6 +5,7 @@ defineSuite([
         'Core/DistanceDisplayCondition',
         'DataSources/ColorMaterialProperty',
         'DataSources/ConstantProperty',
+        'Scene/ClassificationType',
         'Scene/ShadowMode',
         'Specs/testDefinitionChanged',
         'Specs/testMaterialDefinitionChanged'
@@ -15,6 +16,7 @@ defineSuite([
         DistanceDisplayCondition,
         ColorMaterialProperty,
         ConstantProperty,
+        ClassificationType,
         ShadowMode,
         testDefinitionChanged,
         testMaterialDefinitionChanged) {
@@ -35,7 +37,8 @@ defineSuite([
             outlineWidth : 5,
             cornerType : CornerType.BEVELED,
             shadows : ShadowMode.DISABLED,
-            distanceDisplayCondition : new DistanceDisplayCondition(10.0, 100.0)
+            distanceDisplayCondition : new DistanceDisplayCondition(10.0, 100.0),
+            classificationType : ClassificationType.TERRAIN
         };
 
         var corridor = new CorridorGraphics(options);
@@ -53,6 +56,7 @@ defineSuite([
         expect(corridor.cornerType).toBeInstanceOf(ConstantProperty);
         expect(corridor.shadows).toBeInstanceOf(ConstantProperty);
         expect(corridor.distanceDisplayCondition).toBeInstanceOf(ConstantProperty);
+        expect(corridor.classificationType).toBeInstanceOf(ConstantProperty);
 
         expect(corridor.material.color.getValue()).toEqual(options.material);
         expect(corridor.positions.getValue()).toEqual(options.positions);
@@ -68,6 +72,7 @@ defineSuite([
         expect(corridor.cornerType.getValue()).toEqual(options.cornerType);
         expect(corridor.shadows.getValue()).toEqual(options.shadows);
         expect(corridor.distanceDisplayCondition.getValue()).toEqual(options.distanceDisplayCondition);
+        expect(corridor.classificationType.getValue()).toEqual(options.classificationType);
     });
 
     it('merge assigns unassigned properties', function() {
@@ -86,6 +91,7 @@ defineSuite([
         source.cornerType = new ConstantProperty();
         source.shadows = new ConstantProperty(ShadowMode.ENABLED);
         source.distanceDisplayCondition = new ConstantProperty(new DistanceDisplayCondition(10.0, 100.0));
+        source.classificationType = new ConstantProperty(ClassificationType.TERRAIN);
 
         var target = new CorridorGraphics();
         target.merge(source);
@@ -104,6 +110,7 @@ defineSuite([
         expect(target.cornerType).toBe(source.cornerType);
         expect(target.shadows).toBe(source.shadows);
         expect(target.distanceDisplayCondition).toBe(source.distanceDisplayCondition);
+        expect(target.classificationType).toBe(source.classificationType);
     });
 
     it('merge does not assign assigned properties', function() {
@@ -123,6 +130,7 @@ defineSuite([
         var cornerType = new ConstantProperty();
         var shadows = new ConstantProperty();
         var distanceDisplayCondition = new ConstantProperty();
+        var classificationType = new ConstantProperty();
 
         var target = new CorridorGraphics();
         target.material = material;
@@ -139,6 +147,7 @@ defineSuite([
         target.cornerType = cornerType;
         target.shadows = shadows;
         target.distanceDisplayCondition = distanceDisplayCondition;
+        target.classificationType = classificationType;
 
         target.merge(source);
 
@@ -156,6 +165,7 @@ defineSuite([
         expect(target.cornerType).toBe(cornerType);
         expect(target.shadows).toBe(shadows);
         expect(target.distanceDisplayCondition).toBe(distanceDisplayCondition);
+        expect(target.classificationType).toBe(classificationType);
     });
 
     it('clone works', function() {
@@ -174,6 +184,7 @@ defineSuite([
         source.cornerType = new ConstantProperty();
         source.shadows = new ConstantProperty();
         source.distanceDisplayCondition = new ConstantProperty();
+        source.classificationType = new ConstantProperty();
 
         var result = source.clone();
         expect(result.material).toBe(source.material);
@@ -190,6 +201,7 @@ defineSuite([
         expect(result.cornerType).toBe(source.cornerType);
         expect(result.shadows).toBe(source.shadows);
         expect(result.distanceDisplayCondition).toBe(source.distanceDisplayCondition);
+        expect(result.classificationType).toBe(source.classificationType);
     });
 
     it('merge throws if source undefined', function() {
@@ -215,5 +227,6 @@ defineSuite([
         testDefinitionChanged(property, 'cornerType', CornerType.BEVELED, CornerType.MITERED);
         testDefinitionChanged(property, 'shadows', ShadowMode.ENABLED, ShadowMode.DISABLED);
         testDefinitionChanged(property, 'distanceDisplayCondition', new DistanceDisplayCondition(), new DistanceDisplayCondition(10.0, 100.0));
+        testDefinitionChanged(property, 'classificationType', ClassificationType.TERRAIN, ClassificationType.BOTH);
     });
 });

--- a/Specs/DataSources/EllipseGraphicsSpec.js
+++ b/Specs/DataSources/EllipseGraphicsSpec.js
@@ -4,6 +4,7 @@ defineSuite([
         'Core/DistanceDisplayCondition',
         'DataSources/ColorMaterialProperty',
         'DataSources/ConstantProperty',
+        'Scene/ClassificationType',
         'Scene/ShadowMode',
         'Specs/testDefinitionChanged',
         'Specs/testMaterialDefinitionChanged'
@@ -13,6 +14,7 @@ defineSuite([
         DistanceDisplayCondition,
         ColorMaterialProperty,
         ConstantProperty,
+        ClassificationType,
         ShadowMode,
         testDefinitionChanged,
         testMaterialDefinitionChanged) {
@@ -35,7 +37,8 @@ defineSuite([
             outlineColor : Color.RED,
             outlineWidth : 9,
             shadows : ShadowMode.DISABLED,
-            distanceDisplayCondition : new DistanceDisplayCondition()
+            distanceDisplayCondition : new DistanceDisplayCondition(),
+            classificationType : ClassificationType.TERRAIN
         };
 
         var ellipse = new EllipseGraphics(options);
@@ -55,6 +58,7 @@ defineSuite([
         expect(ellipse.outlineWidth).toBeInstanceOf(ConstantProperty);
         expect(ellipse.shadows).toBeInstanceOf(ConstantProperty);
         expect(ellipse.distanceDisplayCondition).toBeInstanceOf(ConstantProperty);
+        expect(ellipse.classificationType).toBeInstanceOf(ConstantProperty);
 
         expect(ellipse.material.color.getValue()).toEqual(options.material);
         expect(ellipse.show.getValue()).toEqual(options.show);
@@ -72,6 +76,7 @@ defineSuite([
         expect(ellipse.outlineWidth.getValue()).toEqual(options.outlineWidth);
         expect(ellipse.shadows.getValue()).toEqual(options.shadows);
         expect(ellipse.distanceDisplayCondition.getValue()).toEqual(options.distanceDisplayCondition);
+        expect(ellipse.classificationType.getValue()).toEqual(options.classificationType);
     });
 
     it('merge assigns unassigned properties', function() {
@@ -92,6 +97,7 @@ defineSuite([
         source.numberOfVerticalLines = new ConstantProperty();
         source.shadows = new ConstantProperty(ShadowMode.ENABLED);
         source.distanceDisplayCondition = new ConstantProperty(new DistanceDisplayCondition(10.0, 100.0));
+        source.classificationType = new ConstantProperty(ClassificationType.TERRAIN);
 
         var target = new EllipseGraphics();
         target.merge(source);
@@ -112,6 +118,7 @@ defineSuite([
         expect(target.numberOfVerticalLines).toBe(source.numberOfVerticalLines);
         expect(target.shadows).toBe(source.shadows);
         expect(target.distanceDisplayCondition).toBe(source.distanceDisplayCondition);
+        expect(target.classificationType).toBe(source.classificationType);
     });
 
     it('merge does not assign assigned properties', function() {
@@ -133,6 +140,7 @@ defineSuite([
         var numberOfVerticalLines = new ConstantProperty();
         var shadows = new ConstantProperty();
         var distanceDisplayCondition = new ConstantProperty();
+        var classificationType = new ConstantProperty();
 
         var target = new EllipseGraphics();
         target.material = material;
@@ -151,6 +159,7 @@ defineSuite([
         target.numberOfVerticalLines = numberOfVerticalLines;
         target.shadows = shadows;
         target.distanceDisplayCondition = distanceDisplayCondition;
+        target.classificationType = classificationType;
 
         target.merge(source);
 
@@ -170,6 +179,7 @@ defineSuite([
         expect(target.numberOfVerticalLines).toBe(numberOfVerticalLines);
         expect(target.shadows).toBe(shadows);
         expect(target.distanceDisplayCondition).toBe(distanceDisplayCondition);
+        expect(target.classificationType).toBe(classificationType);
     });
 
     it('clone works', function() {
@@ -190,6 +200,7 @@ defineSuite([
         source.numberOfVerticalLines = new ConstantProperty();
         source.shadows = new ConstantProperty();
         source.distanceDisplayCondition = new ConstantProperty();
+        source.classificationType = new ConstantProperty();
 
         var result = source.clone();
         expect(result.material).toBe(source.material);
@@ -208,6 +219,7 @@ defineSuite([
         expect(result.numberOfVerticalLines).toBe(source.numberOfVerticalLines);
         expect(result.shadows).toBe(source.shadows);
         expect(result.distanceDisplayCondition).toBe(source.distanceDisplayCondition);
+        expect(result.classificationType).toBe(source.classificationType);
     });
 
     it('merge throws if source undefined', function() {
@@ -235,5 +247,6 @@ defineSuite([
         testDefinitionChanged(property, 'numberOfVerticalLines', 16, 32);
         testDefinitionChanged(property, 'shadows', ShadowMode.ENABLED, ShadowMode.DISABLED);
         testDefinitionChanged(property, 'distanceDisplayCondition', new DistanceDisplayCondition(), new DistanceDisplayCondition(10.0, 100.0));
+        testDefinitionChanged(property, 'classificationType', ClassificationType.TERRAIN, ClassificationType.BOTH);
     });
 });

--- a/Specs/DataSources/PolygonGraphicsSpec.js
+++ b/Specs/DataSources/PolygonGraphicsSpec.js
@@ -5,6 +5,7 @@ defineSuite([
         'Core/PolygonHierarchy',
         'DataSources/ColorMaterialProperty',
         'DataSources/ConstantProperty',
+        'Scene/ClassificationType',
         'Scene/ShadowMode',
         'Specs/testDefinitionChanged',
         'Specs/testMaterialDefinitionChanged'
@@ -15,6 +16,7 @@ defineSuite([
         PolygonHierarchy,
         ColorMaterialProperty,
         ConstantProperty,
+        ClassificationType,
         ShadowMode,
         testDefinitionChanged,
         testMaterialDefinitionChanged) {
@@ -37,7 +39,8 @@ defineSuite([
             closeTop : true,
             closeBottom : true,
             shadows : ShadowMode.DISABLED,
-            distanceDisplayCondition : new DistanceDisplayCondition()
+            distanceDisplayCondition : new DistanceDisplayCondition(),
+            classificationType : ClassificationType.TERRAIN
         };
 
         var polygon = new PolygonGraphics(options);
@@ -57,6 +60,7 @@ defineSuite([
         expect(polygon.closeBottom).toBeInstanceOf(ConstantProperty);
         expect(polygon.shadows).toBeInstanceOf(ConstantProperty);
         expect(polygon.distanceDisplayCondition).toBeInstanceOf(ConstantProperty);
+        expect(polygon.classificationType).toBeInstanceOf(ConstantProperty);
 
         expect(polygon.material.color.getValue()).toEqual(options.material);
         expect(polygon.show.getValue()).toEqual(options.show);
@@ -74,6 +78,7 @@ defineSuite([
         expect(polygon.closeBottom.getValue()).toEqual(options.closeBottom);
         expect(polygon.shadows.getValue()).toEqual(options.shadows);
         expect(polygon.distanceDisplayCondition.getValue()).toEqual(options.distanceDisplayCondition);
+        expect(polygon.classificationType.getValue()).toEqual(options.classificationType);
     });
 
     it('merge assigns unassigned properties', function() {
@@ -94,6 +99,7 @@ defineSuite([
         source.closeBottom = new ConstantProperty();
         source.shadows = new ConstantProperty(ShadowMode.ENABLED);
         source.distanceDisplayCondition = new ConstantProperty(new DistanceDisplayCondition());
+        source.classificationType = new ConstantProperty(ClassificationType.TERRAIN);
 
         var target = new PolygonGraphics();
         target.merge(source);
@@ -114,6 +120,7 @@ defineSuite([
         expect(target.closeBottom).toBe(source.closeBottom);
         expect(target.shadows).toBe(source.shadows);
         expect(target.distanceDisplayCondition).toBe(source.distanceDisplayCondition);
+        expect(target.classificationType).toBe(source.classificationType);
     });
 
     it('merge does not assign assigned properties', function() {
@@ -135,6 +142,7 @@ defineSuite([
         var closeBottom = new ConstantProperty();
         var shadows = new ConstantProperty();
         var distanceDisplayCondition = new ConstantProperty();
+        var classificationType = new ConstantProperty();
 
         var target = new PolygonGraphics();
         target.material = material;
@@ -153,6 +161,7 @@ defineSuite([
         target.closeBottom = closeBottom;
         target.shadows = shadows;
         target.distanceDisplayCondition = distanceDisplayCondition;
+        target.classificationType = classificationType;
 
         target.merge(source);
 
@@ -172,6 +181,7 @@ defineSuite([
         expect(target.closeBottom).toBe(closeBottom);
         expect(target.shadows).toBe(shadows);
         expect(target.distanceDisplayCondition).toBe(distanceDisplayCondition);
+        expect(target.classificationType).toBe(classificationType);
     });
 
     it('clone works', function() {
@@ -192,6 +202,7 @@ defineSuite([
         source.closeBottom = new ConstantProperty();
         source.shadows = new ConstantProperty();
         source.distanceDisplayCondition = new ConstantProperty();
+        source.classificationType = new ConstantProperty();
 
         var result = source.clone();
         expect(result.material).toBe(source.material);
@@ -210,6 +221,7 @@ defineSuite([
         expect(result.closeBottom).toBe(source.closeBottom);
         expect(result.shadows).toBe(source.shadows);
         expect(result.distanceDisplayCondition).toBe(source.distanceDisplayCondition);
+        expect(result.classificationType).toBe(source.classificationType);
     });
 
     it('merge throws if source undefined', function() {
@@ -237,5 +249,6 @@ defineSuite([
         testDefinitionChanged(property, 'closeBottom', true, false);
         testDefinitionChanged(property, 'shadows', ShadowMode.ENABLED, ShadowMode.DISABLED);
         testDefinitionChanged(property, 'distanceDisplayCondition', new DistanceDisplayCondition(), new DistanceDisplayCondition(10.0, 100.0));
+        testDefinitionChanged(property, 'classificationType', ClassificationType.TERRAIN, ClassificationType.BOTH);
     });
 });

--- a/Specs/DataSources/RectangleGraphicsSpec.js
+++ b/Specs/DataSources/RectangleGraphicsSpec.js
@@ -5,6 +5,7 @@ defineSuite([
         'Core/Rectangle',
         'DataSources/ColorMaterialProperty',
         'DataSources/ConstantProperty',
+        'Scene/ClassificationType',
         'Scene/ShadowMode',
         'Specs/testDefinitionChanged',
         'Specs/testMaterialDefinitionChanged'
@@ -15,6 +16,7 @@ defineSuite([
         Rectangle,
         ColorMaterialProperty,
         ConstantProperty,
+        ClassificationType,
         ShadowMode,
         testDefinitionChanged,
         testMaterialDefinitionChanged) {
@@ -35,7 +37,8 @@ defineSuite([
             outlineColor : Color.RED,
             outlineWidth : 10,
             shadows : ShadowMode.DISABLED,
-            distanceDisplayCondition : new DistanceDisplayCondition()
+            distanceDisplayCondition : new DistanceDisplayCondition(),
+            classificationType : ClassificationType.TERRAIN
         };
 
         var rectangle = new RectangleGraphics(options);
@@ -53,6 +56,7 @@ defineSuite([
         expect(rectangle.outlineWidth).toBeInstanceOf(ConstantProperty);
         expect(rectangle.shadows).toBeInstanceOf(ConstantProperty);
         expect(rectangle.distanceDisplayCondition).toBeInstanceOf(ConstantProperty);
+        expect(rectangle.classificationType).toBeInstanceOf(ConstantProperty);
 
         expect(rectangle.material.color.getValue()).toEqual(options.material);
         expect(rectangle.show.getValue()).toEqual(options.show);
@@ -68,6 +72,7 @@ defineSuite([
         expect(rectangle.outlineWidth.getValue()).toEqual(options.outlineWidth);
         expect(rectangle.shadows.getValue()).toEqual(options.shadows);
         expect(rectangle.distanceDisplayCondition.getValue()).toEqual(options.distanceDisplayCondition);
+        expect(rectangle.classificationType.getValue()).toEqual(options.classificationType);
     });
 
     it('merge assigns unassigned properties', function() {
@@ -86,6 +91,7 @@ defineSuite([
         source.outlineWidth = new ConstantProperty();
         source.shadows = new ConstantProperty(ShadowMode.ENABLED);
         source.distanceDisplayCondition = new ConstantProperty();
+        source.classificationType = new ConstantProperty();
 
         var target = new RectangleGraphics();
         target.merge(source);
@@ -104,6 +110,7 @@ defineSuite([
         expect(target.outlineWidth).toBe(source.outlineWidth);
         expect(target.shadows).toBe(source.shadows);
         expect(target.distanceDisplayCondition).toBe(source.distanceDisplayCondition);
+        expect(target.classificationType).toBe(source.classificationType);
     });
 
     it('merge does not assign assigned properties', function() {
@@ -123,6 +130,7 @@ defineSuite([
         var outlineWidth = new ConstantProperty();
         var shadows = new ConstantProperty();
         var distanceDisplayCondition = new ConstantProperty();
+        var classificationType = new ConstantProperty();
 
         var target = new RectangleGraphics();
         target.material = material;
@@ -139,6 +147,7 @@ defineSuite([
         target.outlineWidth = outlineWidth;
         target.shadows = shadows;
         target.distanceDisplayCondition = distanceDisplayCondition;
+        target.classificationType = classificationType;
 
         target.merge(source);
 
@@ -156,6 +165,7 @@ defineSuite([
         expect(target.outlineWidth).toBe(outlineWidth);
         expect(target.shadows).toBe(shadows);
         expect(target.distanceDisplayCondition).toBe(distanceDisplayCondition);
+        expect(target.classificationType).toBe(classificationType);
     });
 
     it('clone works', function() {
@@ -174,6 +184,7 @@ defineSuite([
         source.outlineWidth = new ConstantProperty();
         source.shadows = new ConstantProperty();
         source.distanceDisplayCondition = new ConstantProperty();
+        source.classificationType = new ConstantProperty();
 
         var result = source.clone();
         expect(result.material).toBe(source.material);
@@ -190,6 +201,7 @@ defineSuite([
         expect(result.outlineWidth).toBe(source.outlineWidth);
         expect(result.shadows).toBe(source.shadows);
         expect(result.distanceDisplayCondition).toBe(source.distanceDisplayCondition);
+        expect(result.classificationType).toBe(source.classificationType);
     });
 
     it('merge throws if source undefined', function() {
@@ -215,5 +227,6 @@ defineSuite([
         testDefinitionChanged(property, 'outlineWidth', 2, 3);
         testDefinitionChanged(property, 'shadows', ShadowMode.ENABLED, ShadowMode.DISABLED);
         testDefinitionChanged(property, 'distanceDisplayCondition', new DistanceDisplayCondition(), new DistanceDisplayCondition(10.0, 100.0));
+        testDefinitionChanged(property, 'classificationType', ClassificationType.TERRAIN, ClassificationType.BOTH);
     });
 });

--- a/Specs/DataSources/StaticGroundGeometryColorBatchSpec.js
+++ b/Specs/DataSources/StaticGroundGeometryColorBatchSpec.js
@@ -6,6 +6,7 @@ defineSuite([
     'DataSources/CallbackProperty',
     'DataSources/EllipseGeometryUpdater',
     'DataSources/Entity',
+    'Scene/ClassificationType',
     'Scene/GroundPrimitive',
     'Specs/createScene',
     'Specs/pollToPromise'
@@ -17,6 +18,7 @@ defineSuite([
     CallbackProperty,
     EllipseGeometryUpdater,
     Entity,
+    ClassificationType,
     GroundPrimitive,
     createScene,
     pollToPromise) {
@@ -50,7 +52,7 @@ defineSuite([
             return;
         }
 
-        var batch = new StaticGroundGeometryColorBatch(scene.groundPrimitives);
+        var batch = new StaticGroundGeometryColorBatch(scene.groundPrimitives, ClassificationType.BOTH);
         var entity = new Entity({
             position : new Cartesian3(1234, 5678, 9101112),
             ellipse : {


### PR DESCRIPTION
Fixes #6195.

Adds `classificationType` property to entities that can be clamped to the ground.