### PR TITLE
Fix dynamic color for undefined interval

### DIFF
--- a/Source/DataSources/BoxGeometryUpdater.js
+++ b/Source/DataSources/BoxGeometryUpdater.js
@@ -39,6 +39,7 @@ define([
     'use strict';
 
     var positionScratch = new Cartesian3();
+    var scratchColor = new Color();
 
     function BoxGeometryOptions(entity) {
         this.id = entity;
@@ -97,9 +98,12 @@ define([
         var distanceDisplayCondition = this._distanceDisplayConditionProperty.getValue(time);
         var distanceDisplayConditionAttribute = DistanceDisplayConditionGeometryInstanceAttribute.fromDistanceDisplayCondition(distanceDisplayCondition);
         if (this._materialProperty instanceof ColorMaterialProperty) {
-            var currentColor = Color.WHITE;
+            var currentColor;
             if (defined(this._materialProperty.color) && (this._materialProperty.color.isConstant || isAvailable)) {
-                currentColor = this._materialProperty.color.getValue(time);
+                currentColor = this._materialProperty.color.getValue(time, scratchColor);
+            }
+            if (!defined(currentColor)) {
+                currentColor = Color.WHITE;
             }
             color = ColorGeometryInstanceAttribute.fromColor(currentColor);
             attributes = {
@@ -141,7 +145,7 @@ define([
 
         var entity = this._entity;
         var isAvailable = entity.isAvailable(time);
-        var outlineColor = Property.getValueOrDefault(this._outlineColorProperty, time, Color.BLACK);
+        var outlineColor = Property.getValueOrDefault(this._outlineColorProperty, time, Color.BLACK, scratchColor);
         var distanceDisplayCondition = this._distanceDisplayConditionProperty.getValue(time);
 
         return new GeometryInstance({

--- a/Source/DataSources/CorridorGeometryUpdater.js
+++ b/Source/DataSources/CorridorGeometryUpdater.js
@@ -38,6 +38,7 @@ define([
         Property) {
     'use strict';
 
+    var scratchColor = new Color();
 
     function CorridorGeometryOptions(entity) {
         this.id = entity;
@@ -100,9 +101,12 @@ define([
         var show = new ShowGeometryInstanceAttribute(isAvailable && entity.isShowing && this._showProperty.getValue(time) && this._fillProperty.getValue(time));
         var distanceDisplayCondition = DistanceDisplayConditionGeometryInstanceAttribute.fromDistanceDisplayCondition(this._distanceDisplayConditionProperty.getValue(time));
         if (this._materialProperty instanceof ColorMaterialProperty) {
-            var currentColor = Color.WHITE;
+            var currentColor;
             if (defined(this._materialProperty.color) && (this._materialProperty.color.isConstant || isAvailable)) {
-                currentColor = this._materialProperty.color.getValue(time);
+                currentColor = this._materialProperty.color.getValue(time, scratchColor);
+            }
+            if (!defined(currentColor)) {
+                currentColor = Color.WHITE;
             }
             color = ColorGeometryInstanceAttribute.fromColor(currentColor);
             attributes = {
@@ -143,7 +147,7 @@ define([
 
         var entity = this._entity;
         var isAvailable = entity.isAvailable(time);
-        var outlineColor = Property.getValueOrDefault(this._outlineColorProperty, time, Color.BLACK);
+        var outlineColor = Property.getValueOrDefault(this._outlineColorProperty, time, Color.BLACK, scratchColor);
 
         return new GeometryInstance({
             id : entity,

--- a/Source/DataSources/CylinderGeometryUpdater.js
+++ b/Source/DataSources/CylinderGeometryUpdater.js
@@ -39,6 +39,7 @@ define([
     'use strict';
 
     var positionScratch = new Cartesian3();
+    var scratchColor = new Color();
 
     function CylinderGeometryOptions(entity) {
         this.id = entity;
@@ -101,9 +102,12 @@ define([
         var distanceDisplayCondition = this._distanceDisplayConditionProperty.getValue(time);
         var distanceDisplayConditionAttribute = DistanceDisplayConditionGeometryInstanceAttribute.fromDistanceDisplayCondition(distanceDisplayCondition);
         if (this._materialProperty instanceof ColorMaterialProperty) {
-            var currentColor = Color.WHITE;
+            var currentColor;
             if (defined(this._materialProperty.color) && (this._materialProperty.color.isConstant || isAvailable)) {
-                currentColor = this._materialProperty.color.getValue(time);
+                currentColor = this._materialProperty.color.getValue(time, scratchColor);
+            }
+            if (!defined(currentColor)) {
+                currentColor = Color.WHITE;
             }
             color = ColorGeometryInstanceAttribute.fromColor(currentColor);
             attributes = {
@@ -145,7 +149,7 @@ define([
 
         var entity = this._entity;
         var isAvailable = entity.isAvailable(time);
-        var outlineColor = Property.getValueOrDefault(this._outlineColorProperty, time, Color.BLACK);
+        var outlineColor = Property.getValueOrDefault(this._outlineColorProperty, time, Color.BLACK, scratchColor);
         var distanceDisplayCondition = this._distanceDisplayConditionProperty.getValue(time);
 
         return new GeometryInstance({

--- a/Source/DataSources/EllipseGeometryUpdater.js
+++ b/Source/DataSources/EllipseGeometryUpdater.js
@@ -38,6 +38,7 @@ define([
         Property) {
     'use strict';
 
+    var scratchColor = new Color();
 
     function EllipseGeometryOptions(entity) {
         this.id = entity;
@@ -104,9 +105,12 @@ define([
         var distanceDisplayCondition = this._distanceDisplayConditionProperty.getValue(time);
         var distanceDisplayConditionAttribute = DistanceDisplayConditionGeometryInstanceAttribute.fromDistanceDisplayCondition(distanceDisplayCondition);
         if (this._materialProperty instanceof ColorMaterialProperty) {
-            var currentColor = Color.WHITE;
+            var currentColor;
             if (defined(this._materialProperty.color) && (this._materialProperty.color.isConstant || isAvailable)) {
-                currentColor = this._materialProperty.color.getValue(time);
+                currentColor = this._materialProperty.color.getValue(time, scratchColor);
+            }
+            if (!defined(currentColor)) {
+                currentColor = Color.WHITE;
             }
             color = ColorGeometryInstanceAttribute.fromColor(currentColor);
             attributes = {
@@ -147,7 +151,7 @@ define([
 
         var entity = this._entity;
         var isAvailable = entity.isAvailable(time);
-        var outlineColor = Property.getValueOrDefault(this._outlineColorProperty, time, Color.BLACK);
+        var outlineColor = Property.getValueOrDefault(this._outlineColorProperty, time, Color.BLACK, scratchColor);
         var distanceDisplayCondition = this._distanceDisplayConditionProperty.getValue(time);
 
         return new GeometryInstance({

--- a/Source/DataSources/EllipsoidGeometryUpdater.js
+++ b/Source/DataSources/EllipsoidGeometryUpdater.js
@@ -114,9 +114,12 @@ define([
         var distanceDisplayCondition = this._distanceDisplayConditionProperty.getValue(time);
         var distanceDisplayConditionAttribute = DistanceDisplayConditionGeometryInstanceAttribute.fromDistanceDisplayCondition(distanceDisplayCondition);
         if (this._materialProperty instanceof ColorMaterialProperty) {
-            var currentColor = Color.WHITE;
+            var currentColor;
             if (defined(this._materialProperty.color) && (this._materialProperty.color.isConstant || isAvailable)) {
-                currentColor = this._materialProperty.color.getValue(time);
+                currentColor = this._materialProperty.color.getValue(time, scratchColor);
+            }
+            if (!defined(currentColor)) {
+                currentColor = Color.WHITE;
             }
             color = ColorGeometryInstanceAttribute.fromColor(currentColor);
             attributes = {
@@ -157,7 +160,7 @@ define([
         var entity = this._entity;
         var isAvailable = entity.isAvailable(time);
 
-        var outlineColor = Property.getValueOrDefault(this._outlineColorProperty, time, Color.BLACK);
+        var outlineColor = Property.getValueOrDefault(this._outlineColorProperty, time, Color.BLACK, scratchColor);
         var distanceDisplayCondition = this._distanceDisplayConditionProperty.getValue(time);
 
         return new GeometryInstance({

--- a/Source/DataSources/PlaneGeometryUpdater.js
+++ b/Source/DataSources/PlaneGeometryUpdater.js
@@ -45,6 +45,7 @@ define([
     'use strict';
 
     var positionScratch = new Cartesian3();
+    var scratchColor = new Color();
 
     function PlaneGeometryOptions(entity) {
         this.id = entity;
@@ -104,9 +105,12 @@ define([
         var distanceDisplayCondition = this._distanceDisplayConditionProperty.getValue(time);
         var distanceDisplayConditionAttribute = DistanceDisplayConditionGeometryInstanceAttribute.fromDistanceDisplayCondition(distanceDisplayCondition);
         if (this._materialProperty instanceof ColorMaterialProperty) {
-            var currentColor = Color.WHITE;
+            var currentColor;
             if (defined(this._materialProperty.color) && (this._materialProperty.color.isConstant || isAvailable)) {
-                currentColor = this._materialProperty.color.getValue(time);
+                currentColor = this._materialProperty.color.getValue(time, scratchColor);
+            }
+            if (!defined(currentColor)) {
+                currentColor = Color.WHITE;
             }
             color = ColorGeometryInstanceAttribute.fromColor(currentColor);
             attributes = {
@@ -159,7 +163,7 @@ define([
 
         var entity = this._entity;
         var isAvailable = entity.isAvailable(time);
-        var outlineColor = Property.getValueOrDefault(this._outlineColorProperty, time, Color.BLACK);
+        var outlineColor = Property.getValueOrDefault(this._outlineColorProperty, time, Color.BLACK, scratchColor);
         var distanceDisplayCondition = this._distanceDisplayConditionProperty.getValue(time);
 
         var planeGraphics = entity.plane;

--- a/Source/DataSources/PolygonGeometryUpdater.js
+++ b/Source/DataSources/PolygonGeometryUpdater.js
@@ -42,6 +42,7 @@ define([
         Property) {
     'use strict';
 
+    var scratchColor = new Color();
 
     function PolygonGeometryOptions(entity) {
         this.id = entity;
@@ -107,9 +108,12 @@ define([
         var distanceDisplayCondition = this._distanceDisplayConditionProperty.getValue(time);
         var distanceDisplayConditionAttribute = DistanceDisplayConditionGeometryInstanceAttribute.fromDistanceDisplayCondition(distanceDisplayCondition);
         if (this._materialProperty instanceof ColorMaterialProperty) {
-            var currentColor = Color.WHITE;
+            var currentColor;
             if (defined(this._materialProperty.color) && (this._materialProperty.color.isConstant || isAvailable)) {
-                currentColor = this._materialProperty.color.getValue(time);
+                currentColor = this._materialProperty.color.getValue(time, scratchColor);
+            }
+            if (!defined(currentColor)) {
+                currentColor = Color.WHITE;
             }
             color = ColorGeometryInstanceAttribute.fromColor(currentColor);
             attributes = {
@@ -150,7 +154,7 @@ define([
 
         var entity = this._entity;
         var isAvailable = entity.isAvailable(time);
-        var outlineColor = Property.getValueOrDefault(this._outlineColorProperty, time, Color.BLACK);
+        var outlineColor = Property.getValueOrDefault(this._outlineColorProperty, time, Color.BLACK, scratchColor);
         var distanceDisplayCondition = this._distanceDisplayConditionProperty.getValue(time);
 
         return new GeometryInstance({

--- a/Source/DataSources/PolylineGeometryUpdater.js
+++ b/Source/DataSources/PolylineGeometryUpdater.js
@@ -57,6 +57,7 @@ define([
     //We use this object to create one polyline collection per-scene.
     var polylineCollections = {};
 
+    var scratchColor = new Color();
     var defaultMaterial = new ColorMaterialProperty(Color.WHITE);
     var defaultShow = new ConstantProperty(true);
     var defaultShadows = new ConstantProperty(ShadowMode.DISABLED);
@@ -327,17 +328,21 @@ define([
 
         var currentColor;
         if (this._materialProperty instanceof ColorMaterialProperty) {
-            currentColor = Color.WHITE;
             if (defined(this._materialProperty.color) && (this._materialProperty.color.isConstant || isAvailable)) {
-                currentColor = this._materialProperty.color.getValue(time);
+                currentColor = this._materialProperty.color.getValue(time, scratchColor);
+            }
+            if (!defined(currentColor)) {
+                currentColor = Color.WHITE;
             }
             attributes.color = ColorGeometryInstanceAttribute.fromColor(currentColor);
         }
 
         if (defined(this._depthFailMaterialProperty) && this._depthFailMaterialProperty instanceof ColorMaterialProperty) {
-            currentColor = Color.WHITE;
             if (defined(this._depthFailMaterialProperty.color) && (this._depthFailMaterialProperty.color.isConstant || isAvailable)) {
-                currentColor = this._depthFailMaterialProperty.color.getValue(time);
+                currentColor = this._depthFailMaterialProperty.color.getValue(time, scratchColor);
+            }
+            if (!defined(currentColor)) {
+                currentColor = Color.WHITE;
             }
             attributes.depthFailColor = ColorGeometryInstanceAttribute.fromColor(currentColor);
         }

--- a/Source/DataSources/PolylineVolumeGeometryUpdater.js
+++ b/Source/DataSources/PolylineVolumeGeometryUpdater.js
@@ -36,6 +36,7 @@ define([
         Property) {
     'use strict';
 
+    var scratchColor = new Color();
 
     function PolylineVolumeGeometryOptions(entity) {
         this.id = entity;
@@ -97,9 +98,12 @@ define([
         var distanceDisplayCondition = this._distanceDisplayConditionProperty.getValue(time);
         var distanceDisplayConditionAttribute = DistanceDisplayConditionGeometryInstanceAttribute.fromDistanceDisplayCondition(distanceDisplayCondition);
         if (this._materialProperty instanceof ColorMaterialProperty) {
-            var currentColor = Color.WHITE;
+            var currentColor;
             if (defined(this._materialProperty.color) && (this._materialProperty.color.isConstant || isAvailable)) {
-                currentColor = this._materialProperty.color.getValue(time);
+                currentColor = this._materialProperty.color.getValue(time, scratchColor);
+            }
+            if (!defined(currentColor)) {
+                currentColor = Color.WHITE;
             }
             color = ColorGeometryInstanceAttribute.fromColor(currentColor);
             attributes = {
@@ -140,7 +144,7 @@ define([
 
         var entity = this._entity;
         var isAvailable = entity.isAvailable(time);
-        var outlineColor = Property.getValueOrDefault(this._outlineColorProperty, time, Color.BLACK);
+        var outlineColor = Property.getValueOrDefault(this._outlineColorProperty, time, Color.BLACK, scratchColor);
         var distanceDisplayCondition = this._distanceDisplayConditionProperty.getValue(time);
 
         return new GeometryInstance({

--- a/Source/DataSources/RectangleGeometryUpdater.js
+++ b/Source/DataSources/RectangleGeometryUpdater.js
@@ -38,6 +38,7 @@ define([
         Property) {
     'use strict';
 
+    var scratchColor = new Color();
 
     function RectangleGeometryOptions(entity) {
         this.id = entity;
@@ -101,9 +102,12 @@ define([
         var distanceDisplayCondition = this._distanceDisplayConditionProperty.getValue(time);
         var distanceDisplayConditionAttribute = DistanceDisplayConditionGeometryInstanceAttribute.fromDistanceDisplayCondition(distanceDisplayCondition);
         if (this._materialProperty instanceof ColorMaterialProperty) {
-            var currentColor = Color.WHITE;
+            var currentColor;
             if (defined(this._materialProperty.color) && (this._materialProperty.color.isConstant || isAvailable)) {
-                currentColor = this._materialProperty.color.getValue(time);
+                currentColor = this._materialProperty.color.getValue(time, scratchColor);
+            }
+            if (!defined(currentColor)) {
+                currentColor = Color.WHITE;
             }
             color = ColorGeometryInstanceAttribute.fromColor(currentColor);
             attributes = {
@@ -144,7 +148,7 @@ define([
 
         var entity = this._entity;
         var isAvailable = entity.isAvailable(time);
-        var outlineColor = Property.getValueOrDefault(this._outlineColorProperty, time, Color.BLACK);
+        var outlineColor = Property.getValueOrDefault(this._outlineColorProperty, time, Color.BLACK, scratchColor);
         var distanceDisplayCondition = this._distanceDisplayConditionProperty.getValue(time);
 
         return new GeometryInstance({

--- a/Source/DataSources/WallGeometryUpdater.js
+++ b/Source/DataSources/WallGeometryUpdater.js
@@ -36,6 +36,7 @@ define([
         Property) {
     'use strict';
 
+    var scratchColor = new Color();
 
     function WallGeometryOptions(entity) {
         this.id = entity;
@@ -97,9 +98,12 @@ define([
         var distanceDisplayCondition = this._distanceDisplayConditionProperty.getValue(time);
         var distanceDisplayConditionAttribute = DistanceDisplayConditionGeometryInstanceAttribute.fromDistanceDisplayCondition(distanceDisplayCondition);
         if (this._materialProperty instanceof ColorMaterialProperty) {
-            var currentColor = Color.WHITE;
+            var currentColor;
             if (defined(this._materialProperty.color) && (this._materialProperty.color.isConstant || isAvailable)) {
-                currentColor = this._materialProperty.color.getValue(time);
+                currentColor = this._materialProperty.color.getValue(time, scratchColor);
+            }
+            if (!defined(currentColor)) {
+                currentColor = Color.WHITE;
             }
             color = ColorGeometryInstanceAttribute.fromColor(currentColor);
             attributes = {
@@ -140,7 +144,7 @@ define([
 
         var entity = this._entity;
         var isAvailable = entity.isAvailable(time);
-        var outlineColor = Property.getValueOrDefault(this._outlineColorProperty, time, Color.BLACK);
+        var outlineColor = Property.getValueOrDefault(this._outlineColorProperty, time, Color.BLACK, scratchColor);
         var distanceDisplayCondition = this._distanceDisplayConditionProperty.getValue(time);
 
         return new GeometryInstance({

--- a/Specs/createGeometryUpdaterSpecs.js
+++ b/Specs/createGeometryUpdaterSpecs.js
@@ -363,6 +363,60 @@ define([
             expect(attributes.color.value).toEqual(ColorGeometryInstanceAttribute.toValue(outlineColor.getValue(time2)));
             expect(attributes.show.value).toEqual(ShowGeometryInstanceAttribute.toValue(outline.getValue(time2)));
         });
+
+        it('Works with dynamic color with missing interval', function() {
+            var time1 = new JulianDate(0, 0);
+            var time2 = new JulianDate(10, 0);
+            var missingTime = new JulianDate(15, 0);
+            var time3 = new JulianDate(20, 0);
+            var time4 = new JulianDate(30, 0);
+
+            var colorMaterial = new ColorMaterialProperty();
+
+            var color = new TimeIntervalCollectionProperty();
+            color.intervals.addInterval(new TimeInterval({
+                start : time1,
+                stop : time2,
+                data : Color.BLUE
+            }));
+            color.intervals.addInterval(new TimeInterval({
+                start : time3,
+                stop : time4,
+                isStartIncluded : false,
+                data : Color.YELLOW
+            }));
+            colorMaterial.color = color;
+
+            var outlineColor = new TimeIntervalCollectionProperty();
+            outlineColor.intervals.addInterval(new TimeInterval({
+                start : time1,
+                stop : time2,
+                data : Color.RED
+            }));
+            outlineColor.intervals.addInterval(new TimeInterval({
+                start : time3,
+                stop : time4,
+                isStartIncluded : false,
+                data : Color.GREEN
+            }));
+
+            var entity = createEntity();
+            var geometry = entity[geometryPropertyName];
+            geometry.fill = true;
+            geometry.outline = true;
+            geometry.material = colorMaterial;
+            geometry.outlineColor = outlineColor;
+
+            var updater = new Updater(entity, getScene());
+
+            var instance = updater.createFillGeometryInstance(missingTime);
+            var attributes = instance.attributes;
+            expect(attributes.color.value).toEqual(ColorGeometryInstanceAttribute.toValue(Color.WHITE));
+
+            instance = updater.createOutlineGeometryInstance(missingTime);
+            attributes = instance.attributes;
+            expect(attributes.color.value).toEqual(ColorGeometryInstanceAttribute.toValue(Color.BLACK));
+        });
     }
 
     return createGeometryUpdaterSpecs;


### PR DESCRIPTION
This broke during my geometry updater refactoring.

`this._materialProperty.color.getValue(time)` was returning `undefined` when `time` was in an interval missing from the interval collection.

Also added a scratch variable for storing the color before it is converted to an attribute.

Test with the  `CZML Polygon - Interpolating References` sandcastle example