### PR TITLE
Fix to allow options.imageryProvider to be false.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -46,6 +46,7 @@ Change Log
 * Fixed an issue causing the Bing Maps key to be sent unnecessarily with every tile request. [#6250](https://github.com/AnalyticalGraphicsInc/cesium/pull/6250)
 * Fixed bug with zooming to dynamic geometry. [#6269](https://github.com/AnalyticalGraphicsInc/cesium/issues/6269)
 * Fixed documentation issue for the `Cesium.Math` class. [#6233](https://github.com/AnalyticalGraphicsInc/cesium/issues/6233)
+* Fixed a bug where `options.imageryProvider` could no longer be defined as `false`. [#6289](https://github.com/AnalyticalGraphicsInc/cesium/pull/6289)
 
 ### 1.42.1 - 2018-02-01
 _This is an npm-only release to fix an issue with using Cesium in Node.js.__

--- a/Source/Widgets/Viewer/Viewer.js
+++ b/Source/Widgets/Viewer/Viewer.js
@@ -555,7 +555,7 @@ Either specify options.terrainProvider instead or set options.baseLayerPicker to
         }
 
         // These need to be set after the BaseLayerPicker is created in order to take effect
-        if (defined(options.imageryProvider)) {
+        if (defined(options.imageryProvider) && options.imageryProvider !== false) {
             if (createBaseLayerPicker) {
                 baseLayerPicker.viewModel.selectedImagery = undefined;
             }


### PR DESCRIPTION
* Defining options.imageryProvider as "false" used to leave a blue globe. A recent change broke this and led to "TypeError: Cannot read property 'update' of undefined" because of new code that was adding "false" as an imageryProvider. (https://github.com/AnalyticalGraphicsInc/cesium/blob/master/Source/Widgets/Viewer/Viewer.js#L563)

![screen shot 2018-02-28 at 12 21 28 pm](https://user-images.githubusercontent.com/913068/36811332-a07a3af6-1c8a-11e8-845e-2d0aa69fa6f3.jpeg)

* This PR adds a comparison to allow options.imageryProvider to be defined as "false," restoring the blue globe functionality.

