### PR TITLE
Fix tests crashing tabs in Firefox and Edge.

### DIFF
--- a/Source/Scene/Scene.js
+++ b/Source/Scene/Scene.js
@@ -2095,6 +2095,8 @@ define([
 
             var fb;
             if (scene.debugShowGlobeDepth && defined(globeDepth) && environmentState.useGlobeDepthFramebuffer) {
+                globeDepth.update(context, passState);
+                globeDepth.clear(context, passState, scene._clearColorCommand.color);
                 fb = passState.framebuffer;
                 passState.framebuffer = globeDepth.framebuffer;
             }


### PR DESCRIPTION
Fixes #5176 and #4942.

The tests now run to completion in Firefox and Edge, but I didn't fix the failures. There are 40 failures in Firefox and 24 failures in Edge.