### PR TITLE
Don't create a bunch of scenes in PlaneGeometryUpdaterSpec

### DIFF
--- a/Specs/DataSources/PlaneGeometryUpdaterSpec.js
+++ b/Specs/DataSources/PlaneGeometryUpdaterSpec.js
@@ -117,7 +117,10 @@ defineSuite([
         expect(listener.calls.count()).toEqual(3);
     });
 
-    createGeometryUpdaterSpecs(PlaneGeometryUpdater, 'plane', createBasicPlane, createScene);
+    function getScene() {
+        return scene;
+    }
+    createGeometryUpdaterSpecs(PlaneGeometryUpdater, 'plane', createBasicPlane, getScene);
 
-    createDynamicGeometryUpdaterSpecs(PlaneGeometryUpdater, 'plane', createDynamicPlane, createScene);
+    createDynamicGeometryUpdaterSpecs(PlaneGeometryUpdater, 'plane', createDynamicPlane, getScene);
 }, 'WebGL');


### PR DESCRIPTION
This gets rid of the extra `Data attribution` div that was getting left over when running the specs

I'm going to merge this so I can keep going with the release