### PR TITLE
Fix a couple issues with glTF tangent processing.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,11 @@
 Change Log
 ==========
 
+### 1.44 - 2018-04-02
+
+##### Fixes :wrench:
+* Fixed support of glTF-supplied tangent vectors. [#6302](https://github.com/AnalyticalGraphicsInc/cesium/pull/6302)
+
 ### 1.43 - 2018-03-01
 
 ##### Major Announcements :loudspeaker:


### PR DESCRIPTION
Recently I created a new model, [NormalTangentMirrorTest](https://github.com/KhronosGroup/glTF-Sample-Models/pull/149) to test what happens in a rendering engine when a glTF supplies tangent vectors.  A previous model called NormalTangentTest was testing an engine's ability to calculate missing tangent vectors.

Cesium does a great job of calculating any missing tangent vectors, but unfortunately, when the vectors are supplied in the model, things were very broken.  Looking at the code, I found these issues:

* Cesium was treating `'TANGENT'` as `VEC3` when the glTF spec says it's `VEC4`.
* Cesium was multiplying tangents by `u_modelViewMatrix` instead of `u_normalMatrix`.
* Cesium was not taking the `w` component of the tangent into account.

The glTF spec has [this to say](https://github.com/KhronosGroup/glTF/tree/master/specification/2.0#meshes) about using the `w` component of supplied tangent vectors:

> Client implementations should compute the bitangent by taking the cross product of the normal and tangent xyz vectors and multiplying against the w component of the tangent: `bitangent = cross(normal, tangent.xyz) * tangent.w`

On master, my new tangent test model looks like this:

![gltf-tangents-bad](https://user-images.githubusercontent.com/1235080/36919874-c8eef6d6-1e2c-11e8-99e3-0677a4172dd8.jpg)

On this branch, with the above-mentioned fixes applied, things look correct:

![gltf-tangents-good](https://user-images.githubusercontent.com/1235080/36919882-d6cc13ce-1e2c-11e8-83b0-a2cafdae0475.jpg)
