### PR TITLE
Add additional query parameter options to CesiumViewer.

### DIFF
--- a/Apps/CesiumViewer/CesiumViewer.js
+++ b/Apps/CesiumViewer/CesiumViewer.js
@@ -32,20 +32,28 @@ define([
     'use strict';
 
     /*
-     * 'debug'  : true/false,   // Full WebGL error reporting at substantial performance cost.
-     * 'lookAt' : CZML id,      // The CZML ID of the object to track at startup.
-     * 'source' : 'file.czml',  // The relative URL of the CZML file to load at startup.
-     * 'stats'  : true,         // Enable the FPS performance display.
-     * 'theme'  : 'lighter',    // Use the dark-text-on-light-background theme.
-     * 'scene3DOnly' : false    // Enable 3D only mode
-     * 'view' : longitude,latitude,[height,heading,pitch,roll]
-     *    // Using degrees and meters
-     *    // [height,heading,pitch,roll] default is looking straight down, [300,0,-90,0]
+     Options parsed from query string:
+       source=url          The URL of a CZML/GeoJSON/KML data source to load at startup.
+                           Automatic data type detection uses file extension.
+       sourceType=czml/geojson/kml
+                           Override data type detection for source.
+       flyTo=false         Don't automatically fly to the loaded source.
+       tmsImageryUrl=url   Automatically use a TMS imagery provider.
+       lookAt=id           The ID of the entity to track at startup.
+       stats=true          Enable the FPS performance display.
+       inspector=true      Enable the inspector widget.
+       debug=true          Full WebGL error reporting at substantial performance cost.
+       theme=lighter       Use the dark-text-on-light-background theme.
+       scene3DOnly=true    Enable 3D only mode.
+       view=longitude,latitude,[height,heading,pitch,roll]
+                           Automatically set a camera view. Values in degrees and meters.
+                           [height,heading,pitch,roll] default is looking straight down, [300,0,-90,0]
+       saveCamera=false    Don't automatically update the camera view in the URL when it changes.
      */
     var endUserOptions = queryToObject(window.location.search.substring(1));
 
     var imageryProvider;
-    if (endUserOptions.tmsImageryUrl) {
+    if (defined(endUserOptions.tmsImageryUrl)) {
         imageryProvider = createTileMapServiceImageryProvider({
             url : endUserOptions.tmsImageryUrl
         });
@@ -108,13 +116,24 @@ define([
     var view = endUserOptions.view;
     var source = endUserOptions.source;
     if (defined(source)) {
-        var loadPromise;
+        var sourceType = endUserOptions.sourceType;
+        if (!defined(sourceType)) {
+            // autodetect using file extension if not specified
+            if (/\.czml$/i.test(source)) {
+                sourceType = 'czml';
+            } else if (/\.geojson$/i.test(source) || /\.json$/i.test(source) || /\.topojson$/i.test(source)) {
+                sourceType = 'geojson';
+            } else if (/\.kml$/i.test(source) || /\.kmz$/i.test(source)) {
+                sourceType = 'kml';
+            }
+        }
 
-        if (/\.czml$/i.test(source)) {
+        var loadPromise;
+        if (sourceType === 'czml') {
             loadPromise = CzmlDataSource.load(source);
-        } else if (/\.geojson$/i.test(source) || /\.json$/i.test(source) || /\.topojson$/i.test(source)) {
+        } else if (sourceType === 'geojson') {
             loadPromise = GeoJsonDataSource.load(source);
-        } else if (/\.kml$/i.test(source) || /\.kmz$/i.test(source)) {
+        } else if (sourceType === 'kml') {
             loadPromise = KmlDataSource.load(source, {
                 camera: scene.camera,
                 canvas: scene.canvas
@@ -134,7 +153,7 @@ define([
                         var error = 'No entity with id "' + lookAt + '" exists in the provided data source.';
                         showLoadError(source, error);
                     }
-                } else if (!defined(view)) {
+                } else if (!defined(view) && endUserOptions.flyTo !== 'false') {
                     viewer.flyTo(dataSource);
                 }
             }).otherwise(function(error) {

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,9 @@ Change Log
   * Added support for Internet Explorer.
   * Added a `ClippingPlane` object to be used with `ClippingPlaneCollection`.
 * Updated `WebMapServiceImageryProvider` so it can take an srs or crs string to pass to the resource query parameters based on the WMS version. [#6223](https://github.com/AnalyticalGraphicsInc/cesium/issues/6223)
+* Added additional query parameter options to the CesiumViewer demo application:
+  * sourceType specifies the type of data source if the URL doesn't have a known file extension.
+  * flyTo=false optionally disables the automatic flyTo after loading the data source.
 * Added a multi-part CZML example to Sandcastle. [#6320](https://github.com/AnalyticalGraphicsInc/cesium/pull/6320)
 
 ##### Fixes :wrench:


### PR DESCRIPTION
sourceType=czml/geojson/kml specifies the type of data to allow loading
URLs which don't have a file extension (such as a web service).

flyTo=false optionally disables the automatic flyTo after loading data.