### PR TITLE
Destroy scene in ClippingPlaneCollectionSpec

### DIFF
--- a/Specs/Core/ClippingPlaneCollectionSpec.js
+++ b/Specs/Core/ClippingPlaneCollectionSpec.js
@@ -259,6 +259,9 @@ defineSuite([
             // One RGBA uint8 clipping plane consume 2 pixels of texture, allocation to be double that
             expect(packedTexture.width).toEqual(4);
             expect(packedTexture.height).toEqual(1);
+
+            clippingPlanes.destroy();
+            scene.destroyForSpecs();
         });
     });
 
@@ -388,6 +391,9 @@ defineSuite([
             // One RGBA float clipping plane consume 1 pixels of texture, allocation to be double that
             expect(packedTexture.width).toEqual(2);
             expect(packedTexture.height).toEqual(1);
+
+            clippingPlanes.destroy();
+            scene.destroyForSpecs();
         });
     });
 


### PR DESCRIPTION
@likangning93 any time you call `createScene` in a spec, you need to call `scene.destroyForSpecs();` at the end.

I played around a little bit with hooking into Jasmine to try to detect this after a test suite completed, but I couldn't figure it out.