### PR TITLE
Model instancing demo should animate.

### DIFF
--- a/Apps/Sandcastle/gallery/development/3D Models Instancing.html
+++ b/Apps/Sandcastle/gallery/development/3D Models Instancing.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="utf-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=Edge,chrome=1">  <!-- Use Chrome Frame in IE -->
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no">
     <meta name="description" content="Create instanced 3D models.">
     <meta name="cesium-sandcastle-labels" content="Development">
@@ -10,10 +10,12 @@
     <script type="text/javascript" src="../Sandcastle-header.js"></script>
     <script type="text/javascript" src="../../../ThirdParty/requirejs-2.1.20/require.js"></script>
     <script type="text/javascript">
-    require.config({
-        baseUrl : '../../../Source',
-        waitSeconds : 60
-    });
+        if(typeof require === "function") {
+            require.config({
+                baseUrl : '../../../Source',
+                waitSeconds : 120
+            });
+        }
     </script>
 </head>
 <body class="sandcastle-loading" data-sandcastle-bucket="bucket-requirejs.html">
@@ -27,8 +29,9 @@
 function startup(Cesium) {
     'use strict';
 //Sandcastle_Begin
-
-var viewer = new Cesium.Viewer('cesiumContainer');
+var viewer = new Cesium.Viewer('cesiumContainer', {
+    shouldAnimate: true
+});
 var scene = viewer.scene;
 var context = scene.context;
 var camera = viewer.camera;
@@ -247,7 +250,7 @@ Sandcastle.addToolbarButton('3D', function() {
 });
 
 //Sandcastle_End
-Sandcastle.finishedLoading();
+    Sandcastle.finishedLoading();
 }
 if (typeof Cesium !== "undefined") {
     startup(Cesium);


### PR DESCRIPTION
The propellers spin on all the instances, and the demo contains code to enable those animations, so I set "shouldAnimate: true".

The other changes here are just from re-saving the demo directly from a Sandcastle instance.  Would be great to have an intern go through and re-save all the demos at some point, so the boilerplate code all matches what Sandcastle produces (or write a build script to do it).