### PR TITLE
Add default translation, rotation, scale to node targeted for animation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,6 +27,7 @@ Change Log
 * Fixed model loading failure when containing unused materials. [6315](https://github.com/AnalyticalGraphicsInc/cesium/pull/6315)
 * Fixed default value of `alphaCutoff` in glTF models. [#6346](https://github.com/AnalyticalGraphicsInc/cesium/pull/6346)
 * Fixed rendering vector tiles when using `invertClassification`. [#6349](https://github.com/AnalyticalGraphicsInc/cesium/pull/6349)
+* Fixed animation for glTF models with missing animation targets. [#6351](https://github.com/AnalyticalGraphicsInc/cesium/pull/6351)
 
 ### 1.43 - 2018-03-01
 

--- a/Source/ThirdParty/GltfPipeline/ForEach.js
+++ b/Source/ThirdParty/GltfPipeline/ForEach.js
@@ -49,6 +49,11 @@ define([
         ForEach.topLevel(gltf, 'animations', handler);
     };
 
+    ForEach.animationChannel = function(animation, handler) {
+        var channels = animation.channels;
+        ForEach.object(channels, handler);
+    };
+
     ForEach.animationSampler = function(animation, handler) {
         var samplers = animation.samplers;
         if (defined(samplers)) {

--- a/Source/ThirdParty/GltfPipeline/addDefaults.js
+++ b/Source/ThirdParty/GltfPipeline/addDefaults.js
@@ -214,6 +214,34 @@ define([
         }
     }
 
+    function getAnimatedNodes(gltf) {
+        var nodes = {};
+        ForEach.animation(gltf, function(animation) {
+            ForEach.animationChannel(animation, function(channel) {
+                var target = channel.target;
+                var node = target.node;
+                var path = target.path;
+                // Ignore animations that target 'weights'
+                if (path === 'translation' || path === 'rotation' || path === 'scale') {
+                    nodes[node] = true;
+                }
+            });
+        });
+        return nodes;
+    }
+
+    function addDefaultTransformToAnimatedNodes(gltf) {
+        var animatedNodes = getAnimatedNodes(gltf);
+        ForEach.node(gltf, function(node, id) {
+            if (defined(animatedNodes[id])) {
+                delete node.matrix;
+                node.translation = defaultValue(node.translation, [0.0, 0.0, 0.0]);
+                node.rotation = defaultValue(node.rotation, [0.0, 0.0, 0.0, 1.0]);
+                node.scale = defaultValue(node.scale, [1.0, 1.0, 1.0]);
+            }
+        });
+    }
+
     var defaultMaterial = {
         values : {
             emission : [
@@ -479,6 +507,7 @@ define([
     function addDefaults(gltf, options) {
         options = defaultValue(options, {});
         addDefaultsFromTemplate(gltf, gltfTemplate);
+        addDefaultTransformToAnimatedNodes(gltf);
         addDefaultMaterial(gltf);
         addDefaultTechnique(gltf);
         addDefaultByteOffsets(gltf);

--- a/Source/ThirdParty/GltfPipeline/addDefaults.js
+++ b/Source/ThirdParty/GltfPipeline/addDefaults.js
@@ -219,11 +219,11 @@ define([
         ForEach.animation(gltf, function(animation) {
             ForEach.animationChannel(animation, function(channel) {
                 var target = channel.target;
-                var node = target.node;
+                var nodeId = target.node;
                 var path = target.path;
                 // Ignore animations that target 'weights'
                 if (path === 'translation' || path === 'rotation' || path === 'scale') {
-                    nodes[node] = true;
+                    nodes[nodeId] = true;
                 }
             });
         });


### PR DESCRIPTION
Fixes #6323 

The animated triangle model (after modifications) now works.

@emackey can you take a look?

`gltf-pipeline`: https://github.com/AnalyticalGraphicsInc/gltf-pipeline/pull/356. A test is in that PR.