### PR TITLE
Fix ion asset caching

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@ Change Log
 * `ClippingPlaneCollection` should now be used with `ClippingPlane` objects instead of `Plane`. Use of `Plane` objects has been deprecated and will be removed in Cesium 1.45.
 
 ##### Additions :tada:
+* Fix Cesium ion browser caching [#6353](https://github.com/AnalyticalGraphicsInc/cesium/pull/6353).
 * Added support for glTF models with [Draco geometry compression](https://github.com/fanzhanggoogle/glTF/blob/KHR_mesh_compression/extensions/Khronos/KHR_draco_mesh_compression/README.md).
 * `ClippingPlaneCollection` updates [#6201](https://github.com/AnalyticalGraphicsInc/cesium/pull/6201)
   * Removed the 6-clipping-plane limit.

--- a/Source/Core/Resource.js
+++ b/Source/Core/Resource.js
@@ -1240,7 +1240,8 @@ define([
     /**
      * @private
      */
-    Resource._makeRequest = function(resource, options) {
+    Resource.prototype._makeRequest = function(options) {
+        var resource = this;
         checkAndResetRequest(resource.request);
 
         var request = resource.request;
@@ -1248,7 +1249,7 @@ define([
 
         request.requestFunction = function() {
             var responseType = options.responseType;
-            var headers = combine(resource.headers, options.headers);
+            var headers = combine(options.headers, resource.headers);
             var overrideMimeType = options.overrideMimeType;
             var method = options.method;
             var data = options.data;
@@ -1369,7 +1370,7 @@ define([
         options = defaultClone(options, {});
         options.method = 'GET';
 
-        return Resource._makeRequest(this, options);
+        return this._makeRequest(options);
     };
 
     /**
@@ -1425,7 +1426,7 @@ define([
         options = defaultClone(options, {});
         options.method = 'DELETE';
 
-        return Resource._makeRequest(this, options);
+        return this._makeRequest(options);
     };
 
     /**
@@ -1481,7 +1482,7 @@ define([
         options = defaultClone(options, {});
         options.method = 'HEAD';
 
-        return Resource._makeRequest(this, options);
+        return this._makeRequest(options);
     };
 
     /**
@@ -1537,7 +1538,7 @@ define([
         options = defaultClone(options, {});
         options.method = 'OPTIONS';
 
-        return Resource._makeRequest(this, options);
+        return this._makeRequest(options);
     };
 
     /**
@@ -1597,7 +1598,7 @@ define([
         options.method = 'POST';
         options.data = data;
 
-        return Resource._makeRequest(this, options);
+        return this._makeRequest(options);
     };
 
     /**
@@ -1658,7 +1659,7 @@ define([
         options.method = 'PUT';
         options.data = data;
 
-        return Resource._makeRequest(this, options);
+        return this._makeRequest(options);
     };
 
     /**
@@ -1719,7 +1720,7 @@ define([
         options.method = 'PATCH';
         options.data = data;
 
-        return Resource._makeRequest(this, options);
+        return this._makeRequest(options);
     };
 
     /**

--- a/Source/Core/loadWithXhr.js
+++ b/Source/Core/loadWithXhr.js
@@ -63,7 +63,7 @@ define([
         // Take advantage that most parameters are the same
         var resource = new Resource(options);
 
-        return Resource._makeRequest(resource, {
+        return resource._makeRequest({
             responseType: options.responseType,
             overrideMimeType: options.overrideMimeType,
             method: defaultValue(options.method, 'GET'),

--- a/Specs/Core/CesiumTerrainProviderSpec.js
+++ b/Specs/Core/CesiumTerrainProviderSpec.js
@@ -5,6 +5,7 @@ defineSuite([
         'Core/GeographicTilingScheme',
         'Core/getAbsoluteUri',
         'Core/HeightmapTerrainData',
+        'Core/IonResource',
         'Core/Math',
         'Core/QuantizedMeshTerrainData',
         'Core/Request',
@@ -20,6 +21,7 @@ defineSuite([
         GeographicTilingScheme,
         getAbsoluteUri,
         HeightmapTerrainData,
+        IonResource,
         CesiumMath,
         QuantizedMeshTerrainData,
         Request,
@@ -744,6 +746,23 @@ defineSuite([
 
             return waitForTile(0, 0, 0, false, false, function(loadedData) {
                 expect(loadedData).toBeInstanceOf(HeightmapTerrainData);
+            });
+        });
+
+        it('Uses query parameter extensions for ion resource', function() {
+            var terrainProvider = new CesiumTerrainProvider({
+                url: IonResource.fromAssetId(1),
+                requestVertexNormals: true,
+                requestWaterMask: true
+            });
+
+            return pollToPromise(function() {
+                return terrainProvider.ready;
+            }).then(function() {
+                var getDerivedResource = spyOn(IonResource.prototype, 'getDerivedResource').and.callThrough();
+                terrainProvider.requestTileGeometry(0, 0, 0);
+                var options = getDerivedResource.calls.argsFor(0)[0];
+                expect(options.queryParameters.extensions).toEqual('octvertexnormals-watermask');
             });
         });
     });


### PR DESCRIPTION
ion asset caching was essentially broken because sending the access token in the query string would bust the cache. The initial fix was to allow the token in the Authorization header, which fixed caching but triggered a preflight request for every tile request (due to CORS), this adds unnecessary overhead. To work around this CORS limitation, the ion servers also support including the token in the `Accept` header, which is non-standard but perfectly legal and does not trigger a pre-flight.

Unfortunately, including token in the Accept header means we can no longer vary the accept header to handle terrain extensions. Cesium ion supports passing extensions via query parameters, so `CesiumTerrainProvider` now detects an ion resource and uses query parameters for them.

Also turned the private and static function `Resource._makeRequest` into a prototype function so that I could override it `IonResource`.  This actually opens the way for some future simplification of `IonResource`, but that's definitely a separate PR.

CC @shunter @tfili 