### PR TITLE
Draco with dequantization in shader

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@ Change Log
 
 ##### Additions :tada:
 * Added support for glTF models with [Draco geometry compression](https://github.com/fanzhanggoogle/glTF/blob/KHR_mesh_compression/extensions/Khronos/KHR_draco_mesh_compression/README.md).
+  * Added `dequantizeInShader` option parameter to `Model` and `Model.fromGltf` to specify if Draco compressed glTF assets should be dequantized on the GPU.
 * `ClippingPlaneCollection` updates [#6201](https://github.com/AnalyticalGraphicsInc/cesium/pull/6201)
   * Removed the 6-clipping-plane limit.
   * Added support for Internet Explorer.

--- a/Source/Scene/DracoLoader.js
+++ b/Source/Scene/DracoLoader.js
@@ -136,7 +136,7 @@ define([
      * @private
      */
     DracoLoader.parse = function(model) {
-        if (!this.hasExtension(model)) {
+        if (!DracoLoader.hasExtension(model)) {
             return;
         }
 
@@ -173,7 +173,7 @@ define([
      * @private
      */
     DracoLoader.decode = function(model, context) {
-        if (!this.hasExtension(model)) {
+        if (!DracoLoader.hasExtension(model)) {
             return when.resolve();
         }
 

--- a/Source/Scene/DracoLoader.js
+++ b/Source/Scene/DracoLoader.js
@@ -38,10 +38,15 @@ define([
         return DracoLoader._decoderTaskProcessor;
     };
 
-    function hasExtension(model) {
+    /**
+     * Returns true if the model uses or requires KHR_draco_mesh_compression.
+     *
+     * @private
+     */
+    DracoLoader.hasExtension = function(model) {
         return (defined(model.extensionsRequired.KHR_draco_mesh_compression)
             || defined(model.extensionsUsed.KHR_draco_mesh_compression));
-    }
+    };
 
     function addBufferToLoadResources(loadResources, typedArray) {
         // Create a new id to differentiate from original glTF bufferViews
@@ -130,12 +135,13 @@ define([
      *
      * @private
      */
-    DracoLoader.parse = function(model, dequantizeInShader) {
-        if (!hasExtension(model)) {
+    DracoLoader.parse = function(model) {
+        if (!this.hasExtension(model)) {
             return;
         }
 
         var loadResources = model._loadResources;
+        var dequantizeInShader = model._dequantizeInShader;
         var gltf = model.gltf;
         ForEach.mesh(gltf, function(mesh, meshId) {
             ForEach.meshPrimitive(mesh, function(primitive, primitiveId) {
@@ -167,7 +173,7 @@ define([
      * @private
      */
     DracoLoader.decode = function(model, context) {
-        if (!hasExtension(model)) {
+        if (!this.hasExtension(model)) {
             return when.resolve();
         }
 

--- a/Source/Scene/DracoLoader.js
+++ b/Source/Scene/DracoLoader.js
@@ -25,7 +25,7 @@ define([
      */
     function DracoLoader() {}
 
-    // Maximum concurrency to use when deocding draco models
+    // Maximum concurrency to use when decoding draco models
     DracoLoader._maxDecodingConcurrency = Math.max(FeatureDetection.hardwareConcurrency - 1, 1);
 
     // Exposed for testing purposes

--- a/Source/Scene/DracoLoader.js
+++ b/Source/Scene/DracoLoader.js
@@ -130,7 +130,7 @@ define([
      *
      * @private
      */
-    DracoLoader.parse = function(model) {
+    DracoLoader.parse = function(model, dequantizeInShader) {
         if (!hasExtension(model)) {
             return;
         }
@@ -155,7 +155,8 @@ define([
                     primitive : primitiveId,
                     array : typedArray,
                     bufferView : bufferView,
-                    compressedAttributes : compressionData.attributes
+                    compressedAttributes : compressionData.attributes,
+                    dequantizeInShader : dequantizeInShader
                 });
             });
         });

--- a/Source/Scene/Model.js
+++ b/Source/Scene/Model.js
@@ -288,7 +288,7 @@ define([
      * @param {Color} [options.silhouetteColor=Color.RED] The silhouette color. If more than 256 models have silhouettes enabled, there is a small chance that overlapping models will have minor artifacts.
      * @param {Number} [options.silhouetteSize=0.0] The size of the silhouette in pixels.
      * @param {ClippingPlaneCollection} [options.clippingPlanes] The {@link ClippingPlaneCollection} used to selectively disable rendering the model.
-     * @param {String[]} [options.dequantizeInShader] The list of {@link https://github.com/KhronosGroup/glTF/blob/master/extensions/2.0/Khronos/KHR_draco_mesh_compression/README.md|KHR_draco_mesh_compression} encoded attributes to dequantize in the shader.
+     * @param {Boolean} [options.dequantizeInShader=true] Determines if a {@link https://github.com/google/draco|Draco} encoded model is dequantized on the GPU. This decreases total memory usage for encoded models.
      *
      * @exception {DeveloperError} bgltf is not a valid Binary glTF file.
      * @exception {DeveloperError} Only glTF Binary version 1 is supported.
@@ -638,8 +638,9 @@ define([
         this._cachedRendererResources = undefined;
         this._loadRendererResourcesFromCache = false;
         this._updatedGltfVersion = false;
+
+        this._dequantizeInShader = defaultValue(options.dequantizeInShader, true);
         this._decodedData = {};
-        this._dequantizeInShader = options.dequantizeInShader;
 
         this._cachedGeometryByteLength = 0;
         this._cachedTexturesByteLength = 0;
@@ -1132,7 +1133,7 @@ define([
      * @param {Color} [options.silhouetteColor=Color.RED] The silhouette color. If more than 256 models have silhouettes enabled, there is a small chance that overlapping models will have minor artifacts.
      * @param {Number} [options.silhouetteSize=0.0] The size of the silhouette in pixels.
      * @param {ClippingPlaneCollection} [options.clippingPlanes] The {@link ClippingPlaneCollection} used to selectively disable rendering the model.
-     * @param {String[]} [options.dequantizeInShader] The list of {@link https://github.com/KhronosGroup/glTF/blob/master/extensions/2.0/Khronos/KHR_draco_mesh_compression/README.md|KHR_draco_mesh_compression} encoded attributes to dequantize in the shader.
+     * @param {Boolean} [options.dequantizeInShader=true] Determines if a {@link https://github.com/google/draco|Draco} encoded model is dequantized on the GPU. This decreases total memory usage for encoded models.
      *
      * @returns {Model} The newly created model.
      *
@@ -1701,7 +1702,7 @@ define([
 
         ForEach.mesh(model.gltf, function(mesh, id) {
             runtimeMeshesByName[mesh.name] = new ModelMesh(mesh, runtimeMaterialsById, id);
-            if (defined(model.extensionsUsed.WEB3D_quantized_attributes) || defined(model._dequantizeInShader)) {
+            if (defined(model.extensionsUsed.WEB3D_quantized_attributes) || model._dequantizeInShader) {
                 // Cache primitives according to their program
                 var primitives = mesh.primitives;
                 var primitivesLength = primitives.length;
@@ -1710,11 +1711,10 @@ define([
                     var programId = getProgramForPrimitive(model, primitive);
                     var programPrimitives = model._programPrimitives[programId];
                     if (!defined(programPrimitives)) {
-                        programPrimitives = [];
+                        programPrimitives = {};
                         model._programPrimitives[programId] = programPrimitives;
                     }
-                    primitive.id = id + '.primitive.' + i;
-                    programPrimitives.push(primitive);
+                    programPrimitives[id + '.primitive.' + i] = primitive;
                 }
             }
         });
@@ -1887,14 +1887,18 @@ define([
         var primitive;
         var primitives = model._programPrimitives[programName];
 
+        // If no primitives were cached for this program, there's no need to modify the shader
         if (!defined(primitives)) {
             return shader;
         }
 
-        for (var i = 0; i < primitives.length; i++) {
-            primitive = primitives[i];
-            if (getProgramForPrimitive(model, primitive) === programName) {
-                break;
+        var primitiveId;
+        for (primitiveId in primitives) {
+            if (primitives.hasOwnProperty(primitiveId)) {
+                primitive = primitives[primitiveId];
+                if (getProgramForPrimitive(model, primitive) === programName) {
+                    break;
+                }
             }
         }
 
@@ -1903,7 +1907,7 @@ define([
             result = ModelUtility.modifyShaderForQuantizedAttributes(model.gltf, primitive, shader);
             model._quantizedUniforms[programName] = result.uniforms;
         } else {
-            var decodedData = model._decodedData[primitive.id];
+            var decodedData = model._decodedData[primitiveId];
             if (defined(decodedData)) {
                 result = ModelUtility.modifyShaderForDracoQuantizedAttributes(model.gltf, primitive, shader, decodedData.attributes);
             }
@@ -1988,7 +1992,7 @@ define([
         var vs = shaders[program.vertexShader].extras._pipeline.source;
         var fs = shaders[program.fragmentShader].extras._pipeline.source;
 
-        if (model.extensionsUsed.WEB3D_quantized_attributes || defined(model._dequantizeInShader)) {
+        if (model.extensionsUsed.WEB3D_quantized_attributes || model._dequantizeInShader) {
             var quantizedVS = quantizedVertexShaders[id];
             if (!defined(quantizedVS)) {
                 quantizedVS = modifyShaderForQuantizedAttributes(vs, id, model);
@@ -2024,7 +2028,7 @@ define([
         var vs = shaders[program.vertexShader].extras._pipeline.source;
         var fs = shaders[program.fragmentShader].extras._pipeline.source;
 
-        if (model.extensionsUsed.WEB3D_quantized_attributes || defined(model._dequantizeInShader)) {
+        if (model.extensionsUsed.WEB3D_quantized_attributes || model._dequantizeInShader) {
             vs = quantizedVertexShaders[id];
         }
 
@@ -2935,13 +2939,13 @@ define([
         }
     }
 
+    function createUniformsForDracoQuantizedAttributes(decodedData) {
+        return ModelUtility.createUniformsForDracoQuantizedAttributes(decodedData.attributes);
+    }
+
     function createUniformsForQuantizedAttributes(model, primitive) {
         var programId = getProgramForPrimitive(model, primitive);
         var quantizedUniforms = model._quantizedUniforms[programId];
-        var decodedData = model._decodedData[primitive.id];
-        if (defined(decodedData)) {
-            return ModelUtility.createUniformsForDracoQuantizedAttributes(decodedData.attributes);
-        }
         return ModelUtility.createUniformsForQuantizedAttributes(model.gltf, primitive, quantizedUniforms);
     }
 
@@ -3125,10 +3129,13 @@ define([
             }
 
             // Add uniforms for decoding quantized attributes if used
-            if (model.extensionsUsed.WEB3D_quantized_attributes || defined(model._dequantizeInShader)) {
-                var quantizedUniformMap = createUniformsForQuantizedAttributes(model, primitive);
-                uniformMap = combine(uniformMap, quantizedUniformMap);
+            var quantizedUniformMap = {};
+            if (model.extensionsUsed.WEB3D_quantized_attributes) {
+                quantizedUniformMap = createUniformsForQuantizedAttributes(model, primitive);
+            } else if (model._dequantizeInShader && defined(decodedData)) {
+                quantizedUniformMap = createUniformsForDracoQuantizedAttributes(decodedData);
             }
+            uniformMap = combine(uniformMap, quantizedUniformMap);
 
             var rs = rendererRenderStates[material.technique];
 
@@ -4265,6 +4272,9 @@ define([
                     processModelMaterialsCommon(this.gltf, options);
                     processPbrMetallicRoughness(this.gltf, options);
 
+                    // Skip dequantizing in the shader if not encoded
+                    this._dequantizeInShader = this._dequantizeInShader && DracoLoader.hasExtension(this);
+
                     // We do this after to make sure that the ids don't change
                     addBuffersToLoadResources(this);
                     if (!this._loadRendererResourcesFromCache) {
@@ -4278,7 +4288,7 @@ define([
                     parseNodes(this);
 
                     // Start draco decoding
-                    DracoLoader.parse(this, this._dequantizeInShader);
+                    DracoLoader.parse(this);
 
                     loadResources.initialized = true;
                 }

--- a/Source/Scene/Model.js
+++ b/Source/Scene/Model.js
@@ -1433,7 +1433,7 @@ define([
 
         // Only ARRAY_BUFFER here.  ELEMENT_ARRAY_BUFFER created below.
         ForEach.bufferView(model.gltf, function(bufferView, id) {
-            if (bufferView.target === WebGLConstants.ARRAY_BUFFER) {
+            if (bufferView.target === WebGLConstants.ARRAY_BUFFER && !DracoLoader.hasExtension(model)) {
                 vertexBuffersToCreate.enqueue(id);
             }
         });

--- a/Source/Scene/Model.js
+++ b/Source/Scene/Model.js
@@ -288,7 +288,7 @@ define([
      * @param {Color} [options.silhouetteColor=Color.RED] The silhouette color. If more than 256 models have silhouettes enabled, there is a small chance that overlapping models will have minor artifacts.
      * @param {Number} [options.silhouetteSize=0.0] The size of the silhouette in pixels.
      * @param {ClippingPlaneCollection} [options.clippingPlanes] The {@link ClippingPlaneCollection} used to selectively disable rendering the model.
-     * @param {[String]} [options.dequantizeInShader] The list of {@link https://github.com/KhronosGroup/glTF/blob/master/extensions/2.0/Khronos/KHR_draco_mesh_compression/README.md|KHR_draco_mesh_compression} encoded attributes to dequantize in the shader.
+     * @param {String[]} [options.dequantizeInShader] The list of {@link https://github.com/KhronosGroup/glTF/blob/master/extensions/2.0/Khronos/KHR_draco_mesh_compression/README.md|KHR_draco_mesh_compression} encoded attributes to dequantize in the shader.
      *
      * @exception {DeveloperError} bgltf is not a valid Binary glTF file.
      * @exception {DeveloperError} Only glTF Binary version 1 is supported.
@@ -1132,7 +1132,7 @@ define([
      * @param {Color} [options.silhouetteColor=Color.RED] The silhouette color. If more than 256 models have silhouettes enabled, there is a small chance that overlapping models will have minor artifacts.
      * @param {Number} [options.silhouetteSize=0.0] The size of the silhouette in pixels.
      * @param {ClippingPlaneCollection} [options.clippingPlanes] The {@link ClippingPlaneCollection} used to selectively disable rendering the model.
-     * @param {[String]} [options.dequantizeInShader] The list of {@link https://github.com/KhronosGroup/glTF/blob/master/extensions/2.0/Khronos/KHR_draco_mesh_compression/README.md|KHR_draco_mesh_compression} encoded attributes to dequantize in the shader.
+     * @param {String[]} [options.dequantizeInShader] The list of {@link https://github.com/KhronosGroup/glTF/blob/master/extensions/2.0/Khronos/KHR_draco_mesh_compression/README.md|KHR_draco_mesh_compression} encoded attributes to dequantize in the shader.
      *
      * @returns {Model} The newly created model.
      *
@@ -1898,17 +1898,16 @@ define([
             }
         }
 
-        var result;
+        var result = shader;
         if (model.extensionsUsed.WEB3D_quantized_attributes) {
             result = ModelUtility.modifyShaderForQuantizedAttributes(model.gltf, primitive, shader);
+            model._quantizedUniforms[programName] = result.uniforms;
         } else {
             var decodedData = model._decodedData[primitive.id];
-            if (!defined(decodedData)) {
-                return shader;
+            if (defined(decodedData)) {
+                result = ModelUtility.modifyShaderForDracoQuantizedAttributes(model.gltf, primitive, shader, decodedData.attributes);
             }
-            result = ModelUtility.modifyShaderForDracoQuantizedAttributes(model.gltf, primitive, shader, decodedData.attributes);
         }
-        model._quantizedUniforms[programName] = result.uniforms;
 
         // This is not needed after the program is processed, free the memory
         model._programPrimitives[programName] = undefined;

--- a/Source/Scene/Model.js
+++ b/Source/Scene/Model.js
@@ -2940,7 +2940,7 @@ define([
         var quantizedUniforms = model._quantizedUniforms[programId];
         var decodedData = model._decodedData[primitive.id];
         if (defined(decodedData)) {
-            return ModelUtility.createUniformsForDracoQuantizedAttributes(model.gltf, primitive, decodedData.attributes);
+            return ModelUtility.createUniformsForDracoQuantizedAttributes(decodedData.attributes);
         }
         return ModelUtility.createUniformsForQuantizedAttributes(model.gltf, primitive, quantizedUniforms);
     }

--- a/Source/Scene/Model.js
+++ b/Source/Scene/Model.js
@@ -1433,7 +1433,7 @@ define([
 
         // Only ARRAY_BUFFER here.  ELEMENT_ARRAY_BUFFER created below.
         ForEach.bufferView(model.gltf, function(bufferView, id) {
-            if (bufferView.target === WebGLConstants.ARRAY_BUFFER && !DracoLoader.hasExtension(model)) {
+            if (bufferView.target === WebGLConstants.ARRAY_BUFFER) {
                 vertexBuffersToCreate.enqueue(id);
             }
         });

--- a/Source/Scene/Model.js
+++ b/Source/Scene/Model.js
@@ -288,6 +288,7 @@ define([
      * @param {Color} [options.silhouetteColor=Color.RED] The silhouette color. If more than 256 models have silhouettes enabled, there is a small chance that overlapping models will have minor artifacts.
      * @param {Number} [options.silhouetteSize=0.0] The size of the silhouette in pixels.
      * @param {ClippingPlaneCollection} [options.clippingPlanes] The {@link ClippingPlaneCollection} used to selectively disable rendering the model.
+     * @param {[String]} [options.dequantizeInShader] The list of {@link https://github.com/KhronosGroup/glTF/blob/master/extensions/2.0/Khronos/KHR_draco_mesh_compression/README.md|KHR_draco_mesh_compression} encoded attributes to dequantize in the shader.
      *
      * @exception {DeveloperError} bgltf is not a valid Binary glTF file.
      * @exception {DeveloperError} Only glTF Binary version 1 is supported.
@@ -638,7 +639,7 @@ define([
         this._loadRendererResourcesFromCache = false;
         this._updatedGltfVersion = false;
         this._decodedData = {};
-        this._dequantizeInShader = true;
+        this._dequantizeInShader = options.dequantizeInShader;
 
         this._cachedGeometryByteLength = 0;
         this._cachedTexturesByteLength = 0;
@@ -1131,6 +1132,7 @@ define([
      * @param {Color} [options.silhouetteColor=Color.RED] The silhouette color. If more than 256 models have silhouettes enabled, there is a small chance that overlapping models will have minor artifacts.
      * @param {Number} [options.silhouetteSize=0.0] The size of the silhouette in pixels.
      * @param {ClippingPlaneCollection} [options.clippingPlanes] The {@link ClippingPlaneCollection} used to selectively disable rendering the model.
+     * @param {[String]} [options.dequantizeInShader] The list of {@link https://github.com/KhronosGroup/glTF/blob/master/extensions/2.0/Khronos/KHR_draco_mesh_compression/README.md|KHR_draco_mesh_compression} encoded attributes to dequantize in the shader.
      *
      * @returns {Model} The newly created model.
      *
@@ -1699,7 +1701,7 @@ define([
 
         ForEach.mesh(model.gltf, function(mesh, id) {
             runtimeMeshesByName[mesh.name] = new ModelMesh(mesh, runtimeMaterialsById, id);
-            if (defined(model.extensionsUsed.WEB3D_quantized_attributes || model._dequantizeInShader)) {
+            if (defined(model.extensionsUsed.WEB3D_quantized_attributes) || defined(model._dequantizeInShader)) {
                 // Cache primitives according to their program
                 var primitives = mesh.primitives;
                 var primitivesLength = primitives.length;
@@ -1987,7 +1989,7 @@ define([
         var vs = shaders[program.vertexShader].extras._pipeline.source;
         var fs = shaders[program.fragmentShader].extras._pipeline.source;
 
-        if (model.extensionsUsed.WEB3D_quantized_attributes || model._dequantizeInShader) {
+        if (model.extensionsUsed.WEB3D_quantized_attributes || defined(model._dequantizeInShader)) {
             var quantizedVS = quantizedVertexShaders[id];
             if (!defined(quantizedVS)) {
                 quantizedVS = modifyShaderForQuantizedAttributes(vs, id, model);
@@ -2023,7 +2025,7 @@ define([
         var vs = shaders[program.vertexShader].extras._pipeline.source;
         var fs = shaders[program.fragmentShader].extras._pipeline.source;
 
-        if (model.extensionsUsed.WEB3D_quantized_attributes || model._dequantizeInShader) {
+        if (model.extensionsUsed.WEB3D_quantized_attributes || defined(model._dequantizeInShader)) {
             vs = quantizedVertexShaders[id];
         }
 
@@ -3124,7 +3126,7 @@ define([
             }
 
             // Add uniforms for decoding quantized attributes if used
-            if (model.extensionsUsed.WEB3D_quantized_attributes || model._dequantizeInShader) {
+            if (model.extensionsUsed.WEB3D_quantized_attributes || defined(model._dequantizeInShader)) {
                 var quantizedUniformMap = createUniformsForQuantizedAttributes(model, primitive);
                 uniformMap = combine(uniformMap, quantizedUniformMap);
             }

--- a/Source/Scene/ModelUtility.js
+++ b/Source/Scene/ModelUtility.js
@@ -493,7 +493,7 @@ define([
         return [matrix[20], matrix[21], matrix[22], matrix[23]];
     }
 
-    ModelUtility.createUniformsForDracoQuantizedAttributes = function(gltf, primitive, decodedAttributes) {
+    ModelUtility.createUniformsForDracoQuantizedAttributes = function(decodedAttributes) {
         var uniformMap = {};
         for (var attribute in decodedAttributes) {
             if (decodedAttributes.hasOwnProperty(attribute)) {

--- a/Source/Scene/ModelUtility.js
+++ b/Source/Scene/ModelUtility.js
@@ -512,7 +512,8 @@ define([
         var uniformMap = {};
         for (var attribute in decodedAttributes) {
             if (decodedAttributes.hasOwnProperty(attribute)) {
-                var quantization = decodedAttributes[attribute].quantization;
+                var decodedData = decodedAttributes[attribute];
+                var quantization = decodedData.quantization;
 
                 if (!defined(quantization)) {
                     continue;
@@ -536,7 +537,7 @@ define([
                 uniformMap[uniformVarNameNormConstant] = getScalarUniformFunction(normConstant).func;
 
                 var uniformVarNameMin = uniformVarName + '_min';
-                switch (decodedAttributes[attribute].componentsPerAttribute) {
+                switch (decodedData.componentsPerAttribute) {
                     case 1:
                         uniformMap[uniformVarNameMin] = getScalarUniformFunction(quantization.minValues).func;
                         break;

--- a/Source/Scene/ModelUtility.js
+++ b/Source/Scene/ModelUtility.js
@@ -207,6 +207,60 @@ define([
         return undefined;
     }
 
+    ModelUtility.modifyShaderForDracoQuantizedAttributes = function(gltf, primitive, shader, decodedAttributes) {
+        var quantizedUniforms = {};
+        for (var attributeSemantic in decodedAttributes) {
+            if (decodedAttributes.hasOwnProperty(attributeSemantic)) {
+                var attribute = decodedAttributes[attributeSemantic];
+                var quantization = attribute.quantization;
+                if (!defined(quantization)) {
+                    continue;
+                }
+
+                var attributeVarName = getAttributeVariableName(gltf, primitive, attributeSemantic);
+
+                if (attributeSemantic.charAt(0) === '_') {
+                    attributeSemantic = attributeSemantic.substring(1);
+                }
+                var decodeUniformVarName = 'gltf_u_dec_' + attributeSemantic.toLowerCase();
+
+                var decodeUniformVarNameNormConstant = decodeUniformVarName + '_normConstant';
+                var decodeUniformVarNameMin = decodeUniformVarName + '_min';
+                if (!defined(quantizedUniforms[decodeUniformVarName])) {
+                    var newMain = 'gltf_decoded_' + attributeSemantic;
+                    var decodedAttributeVarName = attributeVarName.replace('a_', 'gltf_a_dec_');
+                    var size = attribute.componentsPerAttribute;
+
+                    // replace usages of the original attribute with the decoded version, but not the declaration
+                    shader = replaceAllButFirstInString(shader, attributeVarName, decodedAttributeVarName);
+                    // declare decoded attribute
+                    var variableType;
+                    if (size > 1) {
+                        variableType = 'vec' + size;
+                    } else {
+                        variableType = 'float';
+                    }
+                    shader = variableType + ' ' + decodedAttributeVarName + ';\n' + shader;
+                    // splice decode function into the shader
+                    var decode = '';
+                    shader = 'uniform float ' + decodeUniformVarNameNormConstant + ';\n' +
+                        'uniform ' + variableType + ' ' + decodeUniformVarNameMin + ';\n' + shader;
+                    decode = '\n' +
+                                'void main() {\n' +
+                                '    ' + decodedAttributeVarName + ' = ' + decodeUniformVarNameMin + ' + ' + attributeVarName + ' * ' + decodeUniformVarNameNormConstant + ';\n' +
+                                '    ' + newMain + '();\n' +
+                                '}\n';
+
+                    shader = ShaderSource.replaceMain(shader, newMain);
+                    shader += decode;
+                }
+            }
+        }
+        return {
+            shader : shader
+        };
+    };
+
     ModelUtility.modifyShaderForQuantizedAttributes = function(gltf, primitive, shader) {
         var quantizedUniforms = {};
         var attributes = primitive.attributes;
@@ -438,6 +492,47 @@ define([
     function translateFromMatrix5Array(matrix) {
         return [matrix[20], matrix[21], matrix[22], matrix[23]];
     }
+
+    ModelUtility.createUniformsForDracoQuantizedAttributes = function(gltf, primitive, decodedAttributes) {
+        var uniformMap = {};
+        for (var attribute in decodedAttributes) {
+            if (decodedAttributes.hasOwnProperty(attribute)) {
+                var quantization = decodedAttributes[attribute].quantization;
+
+                if (!defined(quantization)) {
+                    continue;
+                }
+
+                if (attribute.charAt(0) === '_'){
+                    attribute = attribute.substring(1);
+                }
+
+                var uniformVarName = 'gltf_u_dec_' + attribute.toLowerCase();
+                var uniformVarNameNormConstant = uniformVarName + '_normConstant';
+                var uniformVarNameMin = uniformVarName + '_min';
+
+                var normConstant = quantization.range / (1 << quantization.quantizationBits);
+                uniformMap[uniformVarNameNormConstant] = getScalarUniformFunction(normConstant).func;
+
+                switch (decodedAttributes[attribute].componentsPerAttribute) {
+                    case 1:
+                        uniformMap[uniformVarNameMin] = getScalarUniformFunction(quantization.minValues).func;
+                        break;
+                    case 2:
+                        uniformMap[uniformVarNameMin] = getVec2UniformFunction(quantization.minValues).func;
+                        break;
+                    case 3:
+                        uniformMap[uniformVarNameMin] = getVec3UniformFunction(quantization.minValues).func;
+                        break;
+                    case 4:
+                        uniformMap[uniformVarNameMin] = getVec4UniformFunction(quantization.minValues).func;
+                        break;
+                }
+            }
+        }
+
+        return uniformMap;
+    };
 
     ModelUtility.createUniformsForQuantizedAttributes = function(gltf, primitive, quantizedUniforms) {
         var accessors = gltf.accessors;

--- a/Source/Workers/decodeDraco.js
+++ b/Source/Workers/decodeDraco.js
@@ -4,7 +4,6 @@ define([
         '../Core/IndexDatatype',
         '../Core/RuntimeError',
         '../ThirdParty/draco-decoder-gltf',
-        '../ThirdParty/GltfPipeline/byteLengthForComponentType',
         './createTaskProcessorWorker'
     ], function(
         ComponentDatatype,
@@ -12,7 +11,6 @@ define([
         IndexDatatype,
         RuntimeError,
         draco,
-        byteLengthForComponentType,
         createTaskProcessorWorker) {
     'use strict';
 
@@ -85,7 +83,11 @@ define([
                 var vertexArrayLength = numPoints * numComponents;
                 if (defined(quantization)) {
                     attributeData = new draco.DracoInt32Array();
-                    vertexArray = new Int16Array(vertexArrayLength);
+                    if (quantization.octEncoded) {
+                        vertexArray = new Int16Array(vertexArrayLength);
+                    } else {
+                        vertexArray = new Uint16Array(vertexArrayLength);
+                    }
                     dracoDecoder.GetAttributeInt32ForAllPoints(dracoGeometry, attribute, attributeData);
                 } else if (attribute.data_type() === 4) {
                     attributeData = new draco.DracoInt32Array();
@@ -110,7 +112,7 @@ define([
                         componentsPerAttribute : numComponents,
                         componentDatatype : componentDatatype,
                         byteOffset : attribute.byte_offset(),
-                        byteStride : byteLengthForComponentType(componentDatatype) * numComponents,
+                        byteStride : ComponentDatatype.getSizeInBytes(componentDatatype) * numComponents,
                         normalized : attribute.normalized(),
                         quantization : quantization
                     }

--- a/Source/Workers/decodeDraco.js
+++ b/Source/Workers/decodeDraco.js
@@ -110,9 +110,11 @@ define([
             dracoDecoder = new draco.Decoder();
         }
 
-        if (parameters.dequantizeInShader) {
-            dracoDecoder.SkipAttributeTransform(draco.POSITION);
-            dracoDecoder.SkipAttributeTransform(draco.TEX_COORD);
+        var attributesToSkip = parameters.dequantizeInShader;
+        if (defined(attributesToSkip)) {
+            for (var i = 0; i < attributesToSkip.length; ++i) {
+                dracoDecoder.SkipAttributeTransform(draco[attributesToSkip[i]]);
+            }
         }
 
         var bufferView = parameters.bufferView;

--- a/Specs/Scene/ModelSpec.js
+++ b/Specs/Scene/ModelSpec.js
@@ -2473,6 +2473,15 @@ defineSuite([
         });
     });
 
+    it('loads a draco compressed glTF and dequantizes in the shader', function() {
+        return loadModel(dracoCompressedModelUrl, {
+            dequantizeInShader : ['POSITION']
+        }).then(function(m) {
+            verifyRender(m);
+            primitives.remove(m);
+        });
+    });
+
     it('does not issue draw commands when ignoreCommands is true', function() {
         return loadModel(texturedBoxUrl, {
             ignoreCommands : true

--- a/Specs/Scene/ModelSpec.js
+++ b/Specs/Scene/ModelSpec.js
@@ -2444,13 +2444,6 @@ defineSuite([
         });
     });
 
-    it('loads a glTF with KHR_draco_mesh_compression extension with integer attributes', function() {
-        return loadModel(dracoCompressedModelWithAnimationUrl).then(function(m) {
-            verifyRender(m);
-            primitives.remove(m);
-        });
-    });
-
     it('error decoding a draco compressed glTF causes model loading to fail', function() {
         var decoder = DracoLoader._getDecoderTaskProcessor();
         spyOn(decoder, 'scheduleTask').and.returnValue(when.reject({message : 'my error'}));
@@ -2475,9 +2468,15 @@ defineSuite([
 
     it('loads a draco compressed glTF and dequantizes in the shader', function() {
         return loadModel(dracoCompressedModelUrl, {
-            dequantizeInShader : ['POSITION']
+            dequantizeInShader : ['POSITION', 'TEX_COORD']
         }).then(function(m) {
             verifyRender(m);
+
+            var atrributeData = m._decodedData['0.primitive.0'].attributes;
+            expect(atrributeData['POSITION'].quantization).toBeDefined();
+            expect(atrributeData['TEXCOORD_0'].quantization).toBeDefined();
+            expect(atrributeData['NORMAL'].quantization).toBeUndefined();
+
             primitives.remove(m);
         });
     });


### PR DESCRIPTION
@lilleyse Addresses https://github.com/AnalyticalGraphicsInc/cesium/pull/6191#discussion_r175193468

Skip dequantization in the draco module and instead dequantizes in the shader, for an optionally specified list of attribute types to skip.