### PR TITLE
Fix terrain clipping planes sandcastle example

### DIFF
--- a/Apps/Sandcastle/gallery/Terrain Clipping Planes.html
+++ b/Apps/Sandcastle/gallery/Terrain Clipping Planes.html
@@ -10,10 +10,12 @@
     <script type="text/javascript" src="../Sandcastle-header.js"></script>
     <script type="text/javascript" src="../../../ThirdParty/requirejs-2.1.20/require.js"></script>
     <script type="text/javascript">
-    require.config({
-        baseUrl : '../../../Source',
-        waitSeconds : 60
-    });
+        if(typeof require === "function") {
+            require.config({
+                baseUrl : '../../../Source',
+                waitSeconds : 120
+            });
+        }
     </script>
 </head>
 <body class="sandcastle-loading" data-sandcastle-bucket="bucket-requirejs.html">
@@ -69,7 +71,6 @@ loadCesiumMan();
 
 function reset() {
     viewer.entities.removeAll();
-    viewer.scene.primitives.removeAll();
 }
 
 function loadCesiumMan() {


### PR DESCRIPTION
Fixes #6366

Users should **never** `scene.primitives.removeAll` when they're using the entity layer.

I'm worried this might be a common problem though.  The reason this crash was introduced is because `DataSource`s have their own `PrimitiveCollection` now.  Calling `scene.primitives.removeAll` removes and destroys the data source's primitive collection from `primitives`.  Then later on `StaticOutlineGeometryBatch` tried to remove a primitive from the destroyed `PrimitiveCollection` on the `DataSource` and that's where the error came from.

I don't know a way around this.  Do you think we should add a private `PrimitiveCollection` on `scene` that all the entitiy primitives get dumped into?  That way the end users wouldn't accidentally delete them out from underneath the entity layer.