### PR TITLE
glTF BLEND mode didn't respect double-sided flag.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -30,7 +30,7 @@ Change Log
 * `Credit` has been modified to take an HTML string as the credit content [#6331](https://github.com/AnalyticalGraphicsInc/cesium/pull/6331)
 * Added support for ordering in `DataSourceCollection` [#6316](https://github.com/AnalyticalGraphicsInc/cesium/pull/6316)
   * All ground geometry from one `DataSource` will render in front of all ground geometry from another `DataSource` in the same collection with a lower index.
-  * Use `DataSourceCollection.raise`, `DataSourceCollection.lower`, `DataSourceCollection.raiseToTop` and `DataSourceCollection.lowerToBottom` functions to change the ordering of a `DataSource` in the collection. 
+  * Use `DataSourceCollection.raise`, `DataSourceCollection.lower`, `DataSourceCollection.raiseToTop` and `DataSourceCollection.lowerToBottom` functions to change the ordering of a `DataSource` in the collection.
 
 ##### Fixes :wrench:
 * Fixed support of glTF-supplied tangent vectors. [#6302](https://github.com/AnalyticalGraphicsInc/cesium/pull/6302)
@@ -40,6 +40,7 @@ Change Log
 * Fixed default value of `alphaCutoff` in glTF models. [#6346](https://github.com/AnalyticalGraphicsInc/cesium/pull/6346)
 * Fixed rendering vector tiles when using `invertClassification`. [#6349](https://github.com/AnalyticalGraphicsInc/cesium/pull/6349)
 * Fixed animation for glTF models with missing animation targets. [#6351](https://github.com/AnalyticalGraphicsInc/cesium/pull/6351)
+* Fixed double-sided flag for glTF materials with `BLEND` enabled. [#6371](https://github.com/AnalyticalGraphicsInc/cesium/pull/6371)
 
 
 ### 1.43 - 2018-03-01

--- a/Source/ThirdParty/GltfPipeline/processPbrMetallicRoughness.js
+++ b/Source/ThirdParty/GltfPipeline/processPbrMetallicRoughness.js
@@ -618,7 +618,11 @@ define([
         var techniqueStates;
         if (defined(alphaMode) && alphaMode !== 'OPAQUE') {
             techniqueStates = {
-                enable: [
+                enable: parameterValues.doubleSided ? [
+                    WebGLConstants.DEPTH_TEST,
+                    WebGLConstants.BLEND
+                ]: [
+                    WebGLConstants.CULL_FACE,
                     WebGLConstants.DEPTH_TEST,
                     WebGLConstants.BLEND
                 ],


### PR DESCRIPTION
Small fix to render states for blending glTF.