### PR TITLE
Use default value when entity geometry attributes are undefined

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -44,6 +44,7 @@ Change Log
 * Fixed animation for glTF models with missing animation targets. [#6351](https://github.com/AnalyticalGraphicsInc/cesium/pull/6351)
 * Fixed occlusion when `globe.show` is `false`. [#6374](https://github.com/AnalyticalGraphicsInc/cesium/pull/6374)
 * Fixed double-sided flag for glTF materials with `BLEND` enabled. [#6371](https://github.com/AnalyticalGraphicsInc/cesium/pull/6371)
+* Fixed crash for entities with static geometry and time-dynamic attributes [#6377](https://github.com/AnalyticalGraphicsInc/cesium/pull/6377)
 
 ### 1.43 - 2018-03-01
 

--- a/Source/DataSources/StaticGeometryColorBatch.js
+++ b/Source/DataSources/StaticGeometryColorBatch.js
@@ -28,6 +28,7 @@ define([
 
     var colorScratch = new Color();
     var distanceDisplayConditionScratch = new DistanceDisplayCondition();
+    var defaultDistanceDisplayCondition = new DistanceDisplayCondition();
 
     function Batch(primitives, translucent, appearanceType, depthFailAppearanceType, depthFailMaterialProperty, closed, shadows) {
         this.translucent = translucent;
@@ -208,7 +209,7 @@ define([
 
                 if (!updater.fillMaterialProperty.isConstant || waitingOnCreate) {
                     var colorProperty = updater.fillMaterialProperty.color;
-                    var resultColor = colorProperty.getValue(time, colorScratch);
+                    var resultColor = Property.getValueOrDefault(colorProperty, time, Color.WHITE, colorScratch);
                     if (!Color.equals(attributes._lastColor, resultColor)) {
                         attributes._lastColor = Color.clone(resultColor, attributes._lastColor);
                         attributes.color = ColorGeometryInstanceAttribute.toValue(resultColor, attributes.color);
@@ -220,7 +221,7 @@ define([
 
                 if (defined(this.depthFailAppearanceType) && updater.depthFailMaterialProperty instanceof ColorMaterialProperty && (!updater.depthFailMaterialProperty.isConstant || waitingOnCreate)) {
                     var depthFailColorProperty = updater.depthFailMaterialProperty.color;
-                    var depthColor = depthFailColorProperty.getValue(time, colorScratch);
+                    var depthColor = Property.getValueOrDefault(depthFailColorProperty, time, Color.WHITE, colorScratch);
                     if (!Color.equals(attributes._lastDepthFailColor, depthColor)) {
                         attributes._lastDepthFailColor = Color.clone(depthColor, attributes._lastDepthFailColor);
                         attributes.depthFailColor = ColorGeometryInstanceAttribute.toValue(depthColor, attributes.depthFailColor);
@@ -235,7 +236,7 @@ define([
 
                 var distanceDisplayConditionProperty = updater.distanceDisplayConditionProperty;
                 if (!Property.isConstant(distanceDisplayConditionProperty)) {
-                    var distanceDisplayCondition = distanceDisplayConditionProperty.getValue(time, distanceDisplayConditionScratch);
+                    var distanceDisplayCondition = Property.getValueOrDefault(distanceDisplayConditionProperty, time, defaultDistanceDisplayCondition, distanceDisplayConditionScratch);
                     if (!DistanceDisplayCondition.equals(distanceDisplayCondition, attributes._lastDistanceDisplayCondition)) {
                         attributes._lastDistanceDisplayCondition = DistanceDisplayCondition.clone(distanceDisplayCondition, attributes._lastDistanceDisplayCondition);
                         attributes.distanceDisplayCondition = DistanceDisplayConditionGeometryInstanceAttribute.toValue(distanceDisplayCondition, attributes.distanceDisplayCondition);

--- a/Source/DataSources/StaticGeometryPerMaterialBatch.js
+++ b/Source/DataSources/StaticGeometryPerMaterialBatch.js
@@ -27,6 +27,7 @@ define([
     'use strict';
 
     var distanceDisplayConditionScratch = new DistanceDisplayCondition();
+    var defaultDistanceDisplayCondition = new DistanceDisplayCondition();
 
     function Batch(primitives, appearanceType, materialProperty, depthFailAppearanceType, depthFailMaterialProperty, closed, shadows) {
         this.primitives = primitives;
@@ -213,12 +214,12 @@ define([
                     this.attributes.set(instance.id.id, attributes);
                 }
 
-                if (defined(this.depthFailAppearanceType) && this.depthFailAppearanceType instanceof ColorMaterialProperty && !updater.depthFailMaterialProperty.isConstant) {
+                if (defined(this.depthFailAppearanceType) && this.depthFailMaterialProperty instanceof ColorMaterialProperty && !updater.depthFailMaterialProperty.isConstant) {
                     var depthFailColorProperty = updater.depthFailMaterialProperty.color;
-                    depthFailColorProperty.getValue(time, colorScratch);
-                    if (!Color.equals(attributes._lastDepthFailColor, colorScratch)) {
-                        attributes._lastDepthFailColor = Color.clone(colorScratch, attributes._lastDepthFailColor);
-                        attributes.depthFailColor = ColorGeometryInstanceAttribute.toValue(colorScratch, attributes.depthFailColor);
+                    var depthFailColor = Property.getValueOrDefault(depthFailColorProperty, time, Color.WHITE, colorScratch);
+                    if (!Color.equals(attributes._lastDepthFailColor, depthFailColor)) {
+                        attributes._lastDepthFailColor = Color.clone(depthFailColor, attributes._lastDepthFailColor);
+                        attributes.depthFailColor = ColorGeometryInstanceAttribute.toValue(depthFailColor, attributes.depthFailColor);
                     }
                 }
 
@@ -230,7 +231,7 @@ define([
 
                 var distanceDisplayConditionProperty = updater.distanceDisplayConditionProperty;
                 if (!Property.isConstant(distanceDisplayConditionProperty)) {
-                    var distanceDisplayCondition = distanceDisplayConditionProperty.getValue(time, distanceDisplayConditionScratch);
+                    var distanceDisplayCondition = Property.getValueOrDefault(distanceDisplayConditionProperty, time, defaultDistanceDisplayCondition, distanceDisplayConditionScratch);
                     if (!DistanceDisplayCondition.equals(distanceDisplayCondition, attributes._lastDistanceDisplayCondition)) {
                         attributes._lastDistanceDisplayCondition = DistanceDisplayCondition.clone(distanceDisplayCondition, attributes._lastDistanceDisplayCondition);
                         attributes.distanceDisplayCondition = DistanceDisplayConditionGeometryInstanceAttribute.toValue(distanceDisplayCondition, attributes.distanceDisplayCondition);

--- a/Source/DataSources/StaticGroundGeometryColorBatch.js
+++ b/Source/DataSources/StaticGroundGeometryColorBatch.js
@@ -22,6 +22,7 @@ define([
 
     var colorScratch = new Color();
     var distanceDisplayConditionScratch = new DistanceDisplayCondition();
+    var defaultDistanceDisplayCondition = new DistanceDisplayCondition();
 
     function Batch(primitives, classificationType, color, key) {
         this.primitives = primitives;
@@ -152,12 +153,12 @@ define([
 
                 if (!updater.fillMaterialProperty.isConstant || waitingOnCreate) {
                     var colorProperty = updater.fillMaterialProperty.color;
-                    colorProperty.getValue(time, colorScratch);
+                    var fillColor = Property.getValueOrDefault(colorProperty, time, Color.WHITE, colorScratch);
 
-                    if (!Color.equals(attributes._lastColor, colorScratch)) {
-                        attributes._lastColor = Color.clone(colorScratch, attributes._lastColor);
+                    if (!Color.equals(attributes._lastColor, fillColor)) {
+                        attributes._lastColor = Color.clone(fillColor, attributes._lastColor);
                         var color = this.color;
-                        var newColor = colorScratch.toBytes(scratchArray);
+                        var newColor = fillColor.toBytes(scratchArray);
                         if (color[0] !== newColor[0] || color[1] !== newColor[1] ||
                             color[2] !== newColor[2] || color[3] !== newColor[3]) {
                            this.itemsToRemove[removedCount++] = updater;
@@ -173,7 +174,7 @@ define([
 
                 var distanceDisplayConditionProperty = updater.distanceDisplayConditionProperty;
                 if (!Property.isConstant(distanceDisplayConditionProperty)) {
-                    var distanceDisplayCondition = distanceDisplayConditionProperty.getValue(time, distanceDisplayConditionScratch);
+                    var distanceDisplayCondition = Property.getValueOrDefault(distanceDisplayConditionProperty, time, defaultDistanceDisplayCondition, distanceDisplayConditionScratch);
                     if (!DistanceDisplayCondition.equals(distanceDisplayCondition, attributes._lastDistanceDisplayCondition)) {
                         attributes._lastDistanceDisplayCondition = DistanceDisplayCondition.clone(distanceDisplayCondition, attributes._lastDistanceDisplayCondition);
                         attributes.distanceDisplayCondition = DistanceDisplayConditionGeometryInstanceAttribute.toValue(distanceDisplayCondition, attributes.distanceDisplayCondition);

--- a/Source/DataSources/StaticOutlineGeometryBatch.js
+++ b/Source/DataSources/StaticOutlineGeometryBatch.js
@@ -24,6 +24,10 @@ define([
         Property) {
     'use strict';
 
+    var colorScratch = new Color();
+    var distanceDisplayConditionScratch = new DistanceDisplayCondition();
+    var defaultDistanceDisplayCondition = new DistanceDisplayCondition();
+
     function Batch(primitives, translucent, width, shadows) {
         this.translucent = translucent;
         this.width = width;
@@ -70,9 +74,6 @@ define([
             }
         }
     };
-
-    var colorScratch = new Color();
-    var distanceDisplayConditionScratch = new DistanceDisplayCondition();
 
     Batch.prototype.update = function(time) {
         var isUpdated = true;
@@ -161,10 +162,10 @@ define([
 
                 if (!updater.outlineColorProperty.isConstant || waitingOnCreate) {
                     var outlineColorProperty = updater.outlineColorProperty;
-                    outlineColorProperty.getValue(time, colorScratch);
-                    if (!Color.equals(attributes._lastColor, colorScratch)) {
-                        attributes._lastColor = Color.clone(colorScratch, attributes._lastColor);
-                        attributes.color = ColorGeometryInstanceAttribute.toValue(colorScratch, attributes.color);
+                    var outlineColor = Property.getValueOrDefault(outlineColorProperty, time, Color.WHITE, colorScratch);
+                    if (!Color.equals(attributes._lastColor, outlineColor)) {
+                        attributes._lastColor = Color.clone(outlineColor, attributes._lastColor);
+                        attributes.color = ColorGeometryInstanceAttribute.toValue(outlineColor, attributes.color);
                         if ((this.translucent && attributes.color[3] === 255) || (!this.translucent && attributes.color[3] !== 255)) {
                             this.itemsToRemove[removedCount++] = updater;
                         }
@@ -179,7 +180,7 @@ define([
 
                 var distanceDisplayConditionProperty = updater.distanceDisplayConditionProperty;
                 if (!Property.isConstant(distanceDisplayConditionProperty)) {
-                    var distanceDisplayCondition = distanceDisplayConditionProperty.getValue(time, distanceDisplayConditionScratch);
+                    var distanceDisplayCondition = Property.getValueOrDefault(distanceDisplayConditionProperty, time, defaultDistanceDisplayCondition, distanceDisplayConditionScratch);
                     if (!DistanceDisplayCondition.equals(distanceDisplayCondition, attributes._lastDistanceDisplayCondition)) {
                         attributes._lastDistanceDisplayCondition = DistanceDisplayCondition.clone(distanceDisplayCondition, attributes._lastDistanceDisplayCondition);
                         attributes.distanceDisplayCondition = DistanceDisplayConditionGeometryInstanceAttribute.toValue(distanceDisplayCondition, attributes.distanceDisplayCondition);

--- a/Specs/DataSources/StaticGeometryColorBatchSpec.js
+++ b/Specs/DataSources/StaticGeometryColorBatchSpec.js
@@ -2,11 +2,17 @@ defineSuite([
         'DataSources/StaticGeometryColorBatch',
         'Core/Cartesian3',
         'Core/Color',
+        'Core/DistanceDisplayCondition',
         'Core/JulianDate',
+        'Core/Math',
+        'Core/TimeInterval',
+        'Core/TimeIntervalCollection',
         'DataSources/CallbackProperty',
+        'DataSources/ColorMaterialProperty',
         'DataSources/EllipseGeometryUpdater',
         'DataSources/Entity',
         'DataSources/PolylineGeometryUpdater',
+        'DataSources/TimeIntervalCollectionProperty',
         'Scene/PerInstanceColorAppearance',
         'Scene/PolylineColorAppearance',
         'Scene/ShadowMode',
@@ -16,11 +22,17 @@ defineSuite([
         StaticGeometryColorBatch,
         Cartesian3,
         Color,
+        DistanceDisplayCondition,
         JulianDate,
+        CesiumMath,
+        TimeInterval,
+        TimeIntervalCollection,
         CallbackProperty,
+        ColorMaterialProperty,
         EllipseGeometryUpdater,
         Entity,
         PolylineGeometryUpdater,
+        TimeIntervalCollectionProperty,
         PerInstanceColorAppearance,
         PolylineColorAppearance,
         ShadowMode,
@@ -87,6 +99,97 @@ defineSuite([
         });
     });
 
+    it('updates with sampled color out of range', function() {
+        var validTime = JulianDate.fromIso8601('2018-02-14T04:10:00+1100');
+        var color = new TimeIntervalCollectionProperty();
+        color.intervals.addInterval(TimeInterval.fromIso8601({
+            iso8601: '2018-02-14T04:00:00+1100/2018-02-14T04:15:00+1100',
+            data: Color.RED
+        }));
+        var entity = new Entity({
+            availability: new TimeIntervalCollection([TimeInterval.fromIso8601({iso8601: '2018-02-14T04:00:00+1100/2018-02-14T04:30:00+1100'})]),
+            position : new Cartesian3(1234, 5678, 9101112),
+            ellipse: {
+                semiMajorAxis : 2,
+                semiMinorAxis : 1,
+                extrudedHeight: 20,
+                material: new ColorMaterialProperty(color)
+            }
+        });
+
+        var batch = new StaticGeometryColorBatch(scene.primitives, PerInstanceColorAppearance, undefined, false, ShadowMode.DISABLED);
+
+        var updater = new EllipseGeometryUpdater(entity, scene);
+        batch.add(validTime, updater);
+
+        return pollToPromise(function() {
+            scene.initializeFrame();
+            var isUpdated = batch.update(validTime);
+            scene.render(validTime);
+            return isUpdated;
+        }).then(function() {
+            expect(scene.primitives.length).toEqual(1);
+            var primitive = scene.primitives.get(0);
+            var attributes = primitive.getGeometryInstanceAttributes(entity);
+            expect(attributes.color).toEqual([255, 0, 0, 255]);
+
+            batch.update(time);
+            scene.render(time);
+
+            primitive = scene.primitives.get(0);
+            attributes = primitive.getGeometryInstanceAttributes(entity);
+            expect(attributes.color).toEqual([255, 255, 255, 255]);
+
+            batch.removeAllPrimitives();
+        });
+    });
+
+    it('updates with sampled distance display condition out of range', function() {
+        var validTime = JulianDate.fromIso8601('2018-02-14T04:10:00+1100');
+        var ddc = new TimeIntervalCollectionProperty();
+        ddc.intervals.addInterval(TimeInterval.fromIso8601({
+            iso8601: '2018-02-14T04:00:00+1100/2018-02-14T04:15:00+1100',
+            data: new DistanceDisplayCondition(1.0, 2.0)
+        }));
+        var entity = new Entity({
+            availability: new TimeIntervalCollection([TimeInterval.fromIso8601({iso8601: '2018-02-14T04:00:00+1100/2018-02-14T04:30:00+1100'})]),
+            position : new Cartesian3(1234, 5678, 9101112),
+            ellipse: {
+                semiMajorAxis : 2,
+                semiMinorAxis : 1,
+                extrudedHeight: 20,
+                material: Color.RED,
+                distanceDisplayCondition: ddc
+            }
+        });
+
+        var batch = new StaticGeometryColorBatch(scene.primitives, PerInstanceColorAppearance, undefined, false, ShadowMode.DISABLED);
+
+        var updater = new EllipseGeometryUpdater(entity, scene);
+        batch.add(validTime, updater);
+
+        return pollToPromise(function() {
+            scene.initializeFrame();
+            var isUpdated = batch.update(validTime);
+            scene.render(validTime);
+            return isUpdated;
+        }).then(function() {
+            expect(scene.primitives.length).toEqual(1);
+            var primitive = scene.primitives.get(0);
+            var attributes = primitive.getGeometryInstanceAttributes(entity);
+            expect(attributes.distanceDisplayCondition).toEqualEpsilon([1.0, 2.0], CesiumMath.EPSILON6);
+
+            batch.update(time);
+            scene.render(time);
+
+            primitive = scene.primitives.get(0);
+            attributes = primitive.getGeometryInstanceAttributes(entity);
+            expect(attributes.distanceDisplayCondition).toEqual([0.0, Infinity]);
+
+            batch.removeAllPrimitives();
+        });
+    });
+
     it('updates color attribute after rebuilding polyline primitive', function() {
         var batch = new StaticGeometryColorBatch(scene.primitives, PolylineColorAppearance, undefined, false, ShadowMode.DISABLED);
 
@@ -126,6 +229,49 @@ defineSuite([
                 expect(attributes.color).toEqual([0, 128, 0, 255]);
                 batch.removeAllPrimitives();
             });
+        });
+    });
+
+    it('updates with sampled depth fail color out of range', function() {
+        var validTime = JulianDate.fromIso8601('2018-02-14T04:10:00+1100');
+        var color = new TimeIntervalCollectionProperty();
+        color.intervals.addInterval(TimeInterval.fromIso8601({
+            iso8601: '2018-02-14T04:00:00+1100/2018-02-14T04:15:00+1100',
+            data: Color.RED
+        }));
+        var entity = new Entity({
+            availability: new TimeIntervalCollection([TimeInterval.fromIso8601({iso8601: '2018-02-14T04:00:00+1100/2018-02-14T04:30:00+1100'})]),
+            polyline : {
+                positions : [Cartesian3.fromDegrees(0.0, 0.0), Cartesian3.fromDegrees(0.0, 1.0)],
+                material : Color.BLUE,
+                depthFailMaterial: new ColorMaterialProperty(color)
+            }
+        });
+
+        var batch = new StaticGeometryColorBatch(scene.primitives, PolylineColorAppearance, PolylineColorAppearance, false, ShadowMode.DISABLED);
+
+        var updater = new PolylineGeometryUpdater(entity, scene);
+        batch.add(validTime, updater);
+
+        return pollToPromise(function() {
+            scene.initializeFrame();
+            var isUpdated = batch.update(validTime);
+            scene.render(validTime);
+            return isUpdated;
+        }).then(function() {
+            expect(scene.primitives.length).toEqual(1);
+            var primitive = scene.primitives.get(0);
+            var attributes = primitive.getGeometryInstanceAttributes(entity);
+            expect(attributes.depthFailColor).toEqual([255, 0, 0, 255]);
+
+            batch.update(time);
+            scene.render(time);
+
+            primitive = scene.primitives.get(0);
+            attributes = primitive.getGeometryInstanceAttributes(entity);
+            expect(attributes.depthFailColor).toEqual([255, 255, 255, 255]);
+
+            batch.removeAllPrimitives();
         });
     });
 });

--- a/Specs/DataSources/StaticGeometryPerMaterialBatchSpec.js
+++ b/Specs/DataSources/StaticGeometryPerMaterialBatchSpec.js
@@ -2,7 +2,12 @@ defineSuite([
         'DataSources/StaticGeometryPerMaterialBatch',
         'Core/Cartesian3',
         'Core/Color',
+        'Core/DistanceDisplayCondition',
         'Core/JulianDate',
+        'Core/Math',
+        'Core/TimeInterval',
+        'Core/TimeIntervalCollection',
+        'DataSources/ColorMaterialProperty',
         'DataSources/ConstantPositionProperty',
         'DataSources/ConstantProperty',
         'DataSources/EllipseGeometryUpdater',
@@ -12,7 +17,9 @@ defineSuite([
         'DataSources/PolylineArrowMaterialProperty',
         'DataSources/PolylineGeometryUpdater',
         'DataSources/PolylineGraphics',
+        'DataSources/TimeIntervalCollectionProperty',
         'Scene/MaterialAppearance',
+        'Scene/PolylineColorAppearance',
         'Scene/PolylineMaterialAppearance',
         'Scene/ShadowMode',
         'Specs/createScene',
@@ -21,7 +28,12 @@ defineSuite([
         StaticGeometryPerMaterialBatch,
         Cartesian3,
         Color,
+        DistanceDisplayCondition,
         JulianDate,
+        CesiumMath,
+        TimeInterval,
+        TimeIntervalCollection,
+        ColorMaterialProperty,
         ConstantPositionProperty,
         ConstantProperty,
         EllipseGeometryUpdater,
@@ -31,7 +43,9 @@ defineSuite([
         PolylineArrowMaterialProperty,
         PolylineGeometryUpdater,
         PolylineGraphics,
+        TimeIntervalCollectionProperty,
         MaterialAppearance,
+        PolylineColorAppearance,
         PolylineMaterialAppearance,
         ShadowMode,
         createScene,
@@ -95,6 +109,52 @@ defineSuite([
         });
     });
 
+    it('updates with sampled distance display condition out of range', function() {
+        var validTime = JulianDate.fromIso8601('2018-02-14T04:10:00+1100');
+        var ddc = new TimeIntervalCollectionProperty();
+        ddc.intervals.addInterval(TimeInterval.fromIso8601({
+            iso8601: '2018-02-14T04:00:00+1100/2018-02-14T04:15:00+1100',
+            data: new DistanceDisplayCondition(1.0, 2.0)
+        }));
+        var entity = new Entity({
+            availability: new TimeIntervalCollection([TimeInterval.fromIso8601({iso8601: '2018-02-14T04:00:00+1100/2018-02-14T04:30:00+1100'})]),
+            position : new Cartesian3(1234, 5678, 9101112),
+            ellipse: {
+                semiMajorAxis : 2,
+                semiMinorAxis : 1,
+                extrudedHeight: 20,
+                material : new GridMaterialProperty(),
+                distanceDisplayCondition : ddc
+            }
+        });
+
+        var batch = new StaticGeometryPerMaterialBatch(scene.primitives, MaterialAppearance, undefined, false, ShadowMode.DISABLED);
+
+        var updater = new EllipseGeometryUpdater(entity, scene);
+        batch.add(validTime, updater);
+
+        return pollToPromise(function() {
+            scene.initializeFrame();
+            var isUpdated = batch.update(validTime);
+            scene.render(validTime);
+            return isUpdated;
+        }).then(function() {
+            expect(scene.primitives.length).toEqual(1);
+            var primitive = scene.primitives.get(0);
+            var attributes = primitive.getGeometryInstanceAttributes(entity);
+            expect(attributes.distanceDisplayCondition).toEqualEpsilon([1.0, 2.0], CesiumMath.EPSILON6);
+
+            batch.update(time);
+            scene.render(time);
+
+            primitive = scene.primitives.get(0);
+            attributes = primitive.getGeometryInstanceAttributes(entity);
+            expect(attributes.distanceDisplayCondition).toEqual([0.0, Infinity]);
+
+            batch.removeAllPrimitives();
+        });
+    });
+
     it('handles shared material being invalidated for polyline', function() {
         var batch = new StaticGeometryPerMaterialBatch(scene.primitives, PolylineMaterialAppearance, undefined, false, ShadowMode.DISABLED);
 
@@ -135,6 +195,49 @@ defineSuite([
                 expect(scene.primitives.length).toEqual(2);
                 batch.removeAllPrimitives();
             });
+        });
+    });
+
+    it('updates with sampled depth fail color out of range', function() {
+        var validTime = JulianDate.fromIso8601('2018-02-14T04:10:00+1100');
+        var color = new TimeIntervalCollectionProperty();
+        color.intervals.addInterval(TimeInterval.fromIso8601({
+            iso8601: '2018-02-14T04:00:00+1100/2018-02-14T04:15:00+1100',
+            data: Color.RED
+        }));
+        var entity = new Entity({
+            availability: new TimeIntervalCollection([TimeInterval.fromIso8601({iso8601: '2018-02-14T04:00:00+1100/2018-02-14T04:30:00+1100'})]),
+            polyline : {
+                positions : [Cartesian3.fromDegrees(0.0, 0.0), Cartesian3.fromDegrees(0.0, 1.0)],
+                material : new PolylineArrowMaterialProperty(),
+                depthFailMaterial: new ColorMaterialProperty(color)
+            }
+        });
+
+        var batch = new StaticGeometryPerMaterialBatch(scene.primitives, PolylineMaterialAppearance, PolylineColorAppearance, false, ShadowMode.DISABLED);
+
+        var updater = new PolylineGeometryUpdater(entity, scene);
+        batch.add(validTime, updater);
+
+        return pollToPromise(function() {
+            scene.initializeFrame();
+            var isUpdated = batch.update(validTime);
+            scene.render(validTime);
+            return isUpdated;
+        }).then(function() {
+            expect(scene.primitives.length).toEqual(1);
+            var primitive = scene.primitives.get(0);
+            var attributes = primitive.getGeometryInstanceAttributes(entity);
+            expect(attributes.depthFailColor).toEqual([255, 0, 0, 255]);
+
+            batch.update(time);
+            scene.render(time);
+
+            primitive = scene.primitives.get(0);
+            attributes = primitive.getGeometryInstanceAttributes(entity);
+            expect(attributes.depthFailColor).toEqual([255, 255, 255, 255]);
+
+            batch.removeAllPrimitives();
         });
     });
 });

--- a/Specs/DataSources/StaticGroundGeometryColorBatchSpec.js
+++ b/Specs/DataSources/StaticGroundGeometryColorBatchSpec.js
@@ -2,10 +2,16 @@ defineSuite([
         'DataSources/StaticGroundGeometryColorBatch',
         'Core/Cartesian3',
         'Core/Color',
+        'Core/DistanceDisplayCondition',
         'Core/JulianDate',
+        'Core/Math',
+        'Core/TimeInterval',
+        'Core/TimeIntervalCollection',
         'DataSources/CallbackProperty',
+        'DataSources/ColorMaterialProperty',
         'DataSources/EllipseGeometryUpdater',
         'DataSources/Entity',
+        'DataSources/TimeIntervalCollectionProperty',
         'Scene/ClassificationType',
         'Scene/GroundPrimitive',
         'Specs/createScene',
@@ -14,10 +20,16 @@ defineSuite([
         StaticGroundGeometryColorBatch,
         Cartesian3,
         Color,
+        DistanceDisplayCondition,
         JulianDate,
+        CesiumMath,
+        TimeInterval,
+        TimeIntervalCollection,
         CallbackProperty,
+        ColorMaterialProperty,
         EllipseGeometryUpdater,
         Entity,
+        TimeIntervalCollectionProperty,
         ClassificationType,
         GroundPrimitive,
         createScene,
@@ -110,6 +122,51 @@ defineSuite([
 
                 batch.removeAllPrimitives();
             });
+        });
+    });
+
+    it('updates with sampled distance display condition out of range', function() {
+        var validTime = JulianDate.fromIso8601('2018-02-14T04:10:00+1100');
+        var ddc = new TimeIntervalCollectionProperty();
+        ddc.intervals.addInterval(TimeInterval.fromIso8601({
+            iso8601: '2018-02-14T04:00:00+1100/2018-02-14T04:15:00+1100',
+            data: new DistanceDisplayCondition(1.0, 2.0)
+        }));
+        var entity = new Entity({
+            availability: new TimeIntervalCollection([TimeInterval.fromIso8601({iso8601: '2018-02-14T04:00:00+1100/2018-02-14T04:30:00+1100'})]),
+            position : new Cartesian3(1234, 5678, 9101112),
+            ellipse: {
+                semiMajorAxis : 2,
+                semiMinorAxis : 1,
+                material: Color.RED,
+                distanceDisplayCondition: ddc
+            }
+        });
+
+        var batch = new StaticGroundGeometryColorBatch(scene.groundPrimitives, ClassificationType.BOTH);
+
+        var updater = new EllipseGeometryUpdater(entity, scene);
+        batch.add(validTime, updater);
+
+        return pollToPromise(function() {
+            scene.initializeFrame();
+            var isUpdated = batch.update(validTime);
+            scene.render(validTime);
+            return isUpdated;
+        }).then(function() {
+            expect(scene.groundPrimitives.length).toEqual(1);
+            var primitive = scene.groundPrimitives.get(0);
+            var attributes = primitive.getGeometryInstanceAttributes(entity);
+            expect(attributes.distanceDisplayCondition).toEqualEpsilon([1.0, 2.0], CesiumMath.EPSILON6);
+
+            batch.update(time);
+            scene.render(time);
+
+            primitive = scene.groundPrimitives.get(0);
+            attributes = primitive.getGeometryInstanceAttributes(entity);
+            expect(attributes.distanceDisplayCondition).toEqual([0.0, Infinity]);
+
+            batch.removeAllPrimitives();
         });
     });
 });

--- a/Specs/DataSources/StaticOutlineGeometryBatchSpec.js
+++ b/Specs/DataSources/StaticOutlineGeometryBatchSpec.js
@@ -2,10 +2,15 @@ defineSuite([
         'DataSources/StaticOutlineGeometryBatch',
         'Core/Cartesian3',
         'Core/Color',
+        'Core/DistanceDisplayCondition',
         'Core/JulianDate',
+        'Core/Math',
+        'Core/TimeInterval',
+        'Core/TimeIntervalCollection',
         'DataSources/CallbackProperty',
         'DataSources/EllipseGeometryUpdater',
         'DataSources/Entity',
+        'DataSources/TimeIntervalCollectionProperty',
         'Scene/ShadowMode',
         'Specs/createScene',
         'Specs/pollToPromise'
@@ -13,10 +18,15 @@ defineSuite([
         StaticOutlineGeometryBatch,
         Cartesian3,
         Color,
+        DistanceDisplayCondition,
         JulianDate,
+        CesiumMath,
+        TimeInterval,
+        TimeIntervalCollection,
         CallbackProperty,
         EllipseGeometryUpdater,
         Entity,
+        TimeIntervalCollectionProperty,
         ShadowMode,
         createScene,
         pollToPromise) {
@@ -79,6 +89,99 @@ defineSuite([
                 expect(attributes.color).toEqual([0, 128, 0, 255]);
                 batch.removeAllPrimitives();
             });
+        });
+    });
+
+    it('updates with sampled color out of range', function() {
+        var validTime = JulianDate.fromIso8601('2018-02-14T04:10:00+1100');
+        var color = new TimeIntervalCollectionProperty();
+        color.intervals.addInterval(TimeInterval.fromIso8601({
+            iso8601: '2018-02-14T04:00:00+1100/2018-02-14T04:15:00+1100',
+            data: Color.RED
+        }));
+        var entity = new Entity({
+            availability: new TimeIntervalCollection([TimeInterval.fromIso8601({iso8601: '2018-02-14T04:00:00+1100/2018-02-14T04:30:00+1100'})]),
+            position : new Cartesian3(1234, 5678, 9101112),
+            ellipse: {
+                semiMajorAxis : 2,
+                semiMinorAxis : 1,
+                extrudedHeight: 20,
+                outline : true,
+                outlineColor : color
+            }
+        });
+
+        var batch = new StaticOutlineGeometryBatch(scene.primitives, scene, false, ShadowMode.DISABLED);
+
+        var updater = new EllipseGeometryUpdater(entity, scene);
+        batch.add(validTime, updater);
+
+        return pollToPromise(function() {
+            scene.initializeFrame();
+            var isUpdated = batch.update(validTime);
+            scene.render(validTime);
+            return isUpdated;
+        }).then(function() {
+            expect(scene.primitives.length).toEqual(1);
+            var primitive = scene.primitives.get(0);
+            var attributes = primitive.getGeometryInstanceAttributes(entity);
+            expect(attributes.color).toEqual([255, 0, 0, 255]);
+
+            batch.update(time);
+            scene.render(time);
+
+            primitive = scene.primitives.get(0);
+            attributes = primitive.getGeometryInstanceAttributes(entity);
+            expect(attributes.color).toEqual([255, 255, 255, 255]);
+
+            batch.removeAllPrimitives();
+        });
+    });
+
+    it('updates with sampled distance display condition out of range', function() {
+        var validTime = JulianDate.fromIso8601('2018-02-14T04:10:00+1100');
+        var ddc = new TimeIntervalCollectionProperty();
+        ddc.intervals.addInterval(TimeInterval.fromIso8601({
+            iso8601: '2018-02-14T04:00:00+1100/2018-02-14T04:15:00+1100',
+            data: new DistanceDisplayCondition(1.0, 2.0)
+        }));
+        var entity = new Entity({
+            availability: new TimeIntervalCollection([TimeInterval.fromIso8601({iso8601: '2018-02-14T04:00:00+1100/2018-02-14T04:30:00+1100'})]),
+            position : new Cartesian3(1234, 5678, 9101112),
+            ellipse: {
+                semiMajorAxis : 2,
+                semiMinorAxis : 1,
+                extrudedHeight: 20,
+                outline : true,
+                outlineColor : Color.RED,
+                distanceDisplayCondition : ddc
+            }
+        });
+
+        var batch = new StaticOutlineGeometryBatch(scene.primitives, scene, false, ShadowMode.DISABLED);
+
+        var updater = new EllipseGeometryUpdater(entity, scene);
+        batch.add(validTime, updater);
+
+        return pollToPromise(function() {
+            scene.initializeFrame();
+            var isUpdated = batch.update(validTime);
+            scene.render(validTime);
+            return isUpdated;
+        }).then(function() {
+            expect(scene.primitives.length).toEqual(1);
+            var primitive = scene.primitives.get(0);
+            var attributes = primitive.getGeometryInstanceAttributes(entity);
+            expect(attributes.distanceDisplayCondition).toEqualEpsilon([1.0, 2.0], CesiumMath.EPSILON6);
+
+            batch.update(time);
+            scene.render(time);
+
+            primitive = scene.primitives.get(0);
+            attributes = primitive.getGeometryInstanceAttributes(entity);
+            expect(attributes.distanceDisplayCondition).toEqual([0.0, Infinity]);
+
+            batch.removeAllPrimitives();
         });
     });
 });


### PR DESCRIPTION
Fixes #6369

The crash was happening because `color` was undefined for half the interval.  This change uses `Property.getValueOrUndefined` to make sure we're not trying to set attributes to an undefined value.

Also added specs because we're missing a ton of unit test coverage for entity geometry batches