### PR TITLE
Remove extra “terrainProvider :” in example.

### DIFF
--- a/Source/Core/createWorldTerrain.js
+++ b/Source/Core/createWorldTerrain.js
@@ -22,13 +22,13 @@ define([
      * @example
      * // Create Cesium World Terrain with default settings
      * var viewer = new Cesium.Viewer('cesiumContainer', {
-     *     terrainProvider : terrainProvider : Cesium.createWorldTerrain();
+     *     terrainProvider : Cesium.createWorldTerrain();
      * });
      *
      * @example
      * // Create Cesium World Terrain with water and normals.
      * var viewer = new Cesium.Viewer('cesiumContainer', {
-     *     terrainProvider : terrainProvider : Cesium.createWorldTerrain({
+     *     terrainProvider : Cesium.createWorldTerrain({
      *         requestWaterMask : true,
      *         requestVertexNormals : true
      *     });


### PR DESCRIPTION
Verbatim example leads to "Uncaught SyntaxError: Unexpected token :"

This fixes the example to remove the extra "terrainProvider :"