### PR TITLE
Auto-generate a label of new demos since last minor version.

### DIFF
--- a/Apps/Sandcastle/CesiumSandcastle.js
+++ b/Apps/Sandcastle/CesiumSandcastle.js
@@ -1,6 +1,5 @@
 /*global require,Blob,JSHINT*/
-/*global gallery_demos*/// defined by gallery/gallery-index.js, created by build
-/*global hello_world_index*/// defined in gallery/gallery-index.js, created by build
+/*global gallery_demos, has_new_gallery_demos, hello_world_index*/// defined in gallery/gallery-index.js, created by build
 /*global sandcastleJsHintOptions*/// defined by jsHintOptions.js, created by build
 require({
     baseUrl: '../../Source',
@@ -1080,6 +1079,7 @@ require({
         });
     }
 
+    var newInLabel = 'New in ' + Cesium.VERSION;
     function loadDemoFromFile(demo) {
         return requestDemo(demo.name).then(function(value) {
             // Store the file contents for later searching.
@@ -1097,7 +1097,11 @@ require({
 
             var labelsMeta = doc.querySelector('meta[name="cesium-sandcastle-labels"]');
             var labels = labelsMeta && labelsMeta.getAttribute('content');
-            demo.label = labels ? labels : '';
+            if (demo.isNew) {
+                demo.label = labels ? labels + ',' + newInLabel : newInLabel;
+            } else {
+                demo.label = labels ? labels : '';
+            }
 
             // Select the demo to load upon opening based on the query parameter.
             if (defined(queryObject.src)) {
@@ -1248,6 +1252,18 @@ require({
         }).placeAt('innerPanel');
         subtabs[label] = cp;
         registerScroll(dom.byId('showcasesContainer'));
+
+        if (has_new_gallery_demos) {
+            var name = 'New in ' + Cesium.VERSION;
+            subtabs[name] = new ContentPane({
+                content: '<div id="' + name + 'Container" class="demosContainer"><div class="demos" id="' + name + 'Demos"></div></div>',
+                title: name,
+                onShow: function() {
+                    setSubtab(this.title);
+                }
+            }).placeAt('innerPanel');
+            registerScroll(dom.byId(name + 'Container'));
+        }
 
         var i;
         var len = gallery_demos.length;

--- a/Apps/Sandcastle/CesiumSandcastle.js
+++ b/Apps/Sandcastle/CesiumSandcastle.js
@@ -1079,7 +1079,7 @@ require({
         });
     }
 
-    var newInLabel = 'New in ' + Cesium.VERSION;
+    var newInLabel = 'New in ' + window.Cesium.VERSION;
     function loadDemoFromFile(demo) {
         return requestDemo(demo.name).then(function(value) {
             // Store the file contents for later searching.
@@ -1254,7 +1254,7 @@ require({
         registerScroll(dom.byId('showcasesContainer'));
 
         if (has_new_gallery_demos) {
-            var name = 'New in ' + Cesium.VERSION;
+            var name = 'New in ' + window.Cesium.VERSION;
             subtabs[name] = new ContentPane({
                 content: '<div id="' + name + 'Container" class="demosContainer"><div class="demos" id="' + name + 'Demos"></div></div>',
                 title: name,

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,7 @@ Change Log
 * `Credit.hasImage` and `Credit.hasLink` functions have been deprecated and will be removed in Cesium 1.46.
 
 ##### Additions :tada:
+* Added a new Sandcastle label, `New in X.X` which will include all new Sandcastle demos added for the current release. [#6384](https://github.com/AnalyticalGraphicsInc/cesium/issues/6384)
 * Fix Cesium ion browser caching [#6353](https://github.com/AnalyticalGraphicsInc/cesium/pull/6353).
 * Added support for glTF models with [Draco geometry compression](https://github.com/fanzhanggoogle/glTF/blob/KHR_mesh_compression/extensions/Khronos/KHR_draco_mesh_compression/README.md).
   * Added `dequantizeInShader` option parameter to `Model` and `Model.fromGltf` to specify if Draco compressed glTF assets should be dequantized on the GPU.

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1106,7 +1106,12 @@ function createGalleryList() {
 
     // Get an array of demos that were added since the last release.
     // This includes newly staged local demos as well.
-    var newDemos = child_process.execSync('git diff --name-only --diff-filter=A ' + tagVersion + ' Apps/Sandcastle/gallery/*.html').toString().trim().split('\n');
+    var newDemos = [];
+    try {
+        newDemos = child_process.execSync('git diff --name-only --diff-filter=A ' + tagVersion + ' Apps/Sandcastle/gallery/*.html').toString().trim().split('\n');
+    } catch (e) {
+        console.log('Failed to retrieve list of new Sandcastle demos from Git.');
+    }
 
     var helloWorld;
     globby.sync(fileList).forEach(function(file) {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1097,13 +1097,17 @@ function createGalleryList() {
         fileList.push('!Apps/Sandcastle/gallery/development/**/*.html');
     }
 
+    // Get an array of demos that were added since the last release.
+    // This includes newly staged local demos as well.
+    var newDemos = child_process.execSync('git diff --name-only --diff-filter=A ' + version + ' Apps/Sandcastle/gallery/*.html').toString().trim().split('\n');
+
     var helloWorld;
     globby.sync(fileList).forEach(function(file) {
         var demo = filePathToModuleId(path.relative('Apps/Sandcastle/gallery', file));
 
         var demoObject = {
             name : demo,
-            date : fs.statSync(file).mtime.getTime()
+            isNew: newDemos.includes(file)
         };
 
         if (fs.existsSync(file.replace('.html', '') + '.jpg')) {
@@ -1136,7 +1140,8 @@ function createGalleryList() {
     var contents = '\
 // This file is automatically rebuilt by the Cesium build process.\n\
 var hello_world_index = ' + helloWorldIndex + ';\n\
-var gallery_demos = [' + demoJSONs.join(', ') + '];';
+var gallery_demos = [' + demoJSONs.join(', ') + '];\n\
+var has_new_gallery_demos = ' + (newDemos.length > 0 ? 'true;' : 'false;');
 
     fs.writeFileSync(output, contents);
 }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1097,9 +1097,16 @@ function createGalleryList() {
         fileList.push('!Apps/Sandcastle/gallery/development/**/*.html');
     }
 
+    // On travis, the version is set to something like '1.43.0-branch-name-travisBuildNumber'
+    // We need to extract just the Major.Minor version
+    var majorMinor = packageJson.version.match(/^(.*)\.(.*)\./);
+    var major = majorMinor[1];
+    var minor = Number(majorMinor[2]) - 1; // We want the last release, not current release
+    var tagVersion = major + '.' + minor;
+
     // Get an array of demos that were added since the last release.
     // This includes newly staged local demos as well.
-    var newDemos = child_process.execSync('git diff --name-only --diff-filter=A ' + version + ' Apps/Sandcastle/gallery/*.html').toString().trim().split('\n');
+    var newDemos = child_process.execSync('git diff --name-only --diff-filter=A ' + tagVersion + ' Apps/Sandcastle/gallery/*.html').toString().trim().split('\n');
 
     var helloWorld;
     globby.sync(fileList).forEach(function(file) {


### PR DESCRIPTION
If a new demo has been added since the latest minor version (i.e. 1.43.x will include everything from 1.42.x as new) add it to a `New in 1.x` label. Make this label always be second in the list after Showcases.

Also got rid of generated `date` property, since it wasn't used.

Fixes #6384 