### PR TITLE
fix small bug in TimeIntervalCollection

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -174,3 +174,4 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to Cesiu
 * [Tamar Cohen](https://github.com/tamarmot)
 * [Stephen Wiseman](https://github.com/srwiseman)
 * [Gabriel Macario](https://github.com/gabriel-macario)
+* [Daniel Leone](https://github.com/danielleone)

--- a/Source/Core/TimeIntervalCollection.js
+++ b/Source/Core/TimeIntervalCollection.js
@@ -566,14 +566,12 @@ define([
                 // Interval is completely overlapped
                 intervals.splice(index, 1);
             }
-        }
-
-        // Truncate any partially-overlapped intervals.
-        if (index < intervals.length &&
+        } else if (index < intervals.length &&
             (JulianDate.greaterThan(intervalStop, indexInterval.start) ||
              (intervalStop.equals(indexInterval.start) &&
               intervalIsStopIncluded &&
               indexInterval.isStartIncluded))) {
+            // Truncate any partially-overlapped intervals.
             result = true;
             intervals[index] = new TimeInterval({
                 start : intervalStop,

--- a/Specs/Core/TimeIntervalCollectionSpec.js
+++ b/Specs/Core/TimeIntervalCollectionSpec.js
@@ -723,14 +723,8 @@ defineSuite([
         }
 
         function expectCollection(collection, count, expectation) {
-            // log the collection for debugging
-            for (var i = 0; i < collection.length; i++) {
-                var interval = collection.get(i);
-                console.log(interval.data, interval.start.toString(), interval.stop.toString());
-            }
-
             expectation.forEach(function(item) {
-                var i = collection.findIntervalContainingDate(new JulianDate(CONST_DAY_NUM, item.t));
+                var i = collection.findIntervalContainingDate(new JulianDate(CONST_DAY_NUM, item.sec));
                 if (item.data === null) {
                     // expect the interval at this time not to exist
                     if (i !== undefined) {


### PR DESCRIPTION
Hi!

I found this bug up a little while back, finally got around to making a PR for it.
Bug seems to be that if you remove an interval of the exact same size as an interval you added. Then the interval AFTER it gets removed.

Literally all I changed was I added an `else` to an`if` block so it became an `else if`.
Problem being, both `if` blocks were being executed, now only 1 of them does.

This bug should be captured specifically by the first test I added.
The second test I mostly copied over from the test code I used to find the bug the first time. If it doesn't appear to be of any value, happy to remove it.
