### PR TITLE
Fix Sandcastle CZML example of glowPower.

### DIFF
--- a/Apps/Sandcastle/gallery/CZML Polyline.html
+++ b/Apps/Sandcastle/gallery/CZML Polyline.html
@@ -64,9 +64,9 @@ var czml = [{
         "material" : {
             "polylineGlow" : {
                 "color" : {
-                    "rgba" : [0, 0, 255, 255],
-                    "glowPower" : 0.2
-                }
+                    "rgba" : [0, 0, 255, 255]
+                },
+                "glowPower" : 0.2
             }
         },
         "width" : 10


### PR DESCRIPTION
`glowPower` was incorrectly nested under `color` which meant it was ignored.

(the default is 0.25 which is close enough that no one would have noticed it was ignored in the example)