### PR TITLE
Fix deprecated Credit usage in Sandcastle

### DIFF
--- a/Apps/Sandcastle/gallery/Imagery Layers Manipulation.html
+++ b/Apps/Sandcastle/gallery/Imagery Layers Manipulation.html
@@ -10,10 +10,12 @@
     <script type="text/javascript" src="../Sandcastle-header.js"></script>
     <script type="text/javascript" src="../../../ThirdParty/requirejs-2.1.20/require.js"></script>
     <script type="text/javascript">
-    require.config({
-        baseUrl : '../../../Source',
-        waitSeconds : 60
-    });
+        if(typeof require === "function") {
+            require.config({
+                baseUrl : '../../../Source',
+                waitSeconds : 120
+            });
+        }
     </script>
 </head>
 <body class="sandcastle-loading" data-sandcastle-bucket="bucket-requirejs.html">
@@ -47,13 +49,13 @@
 <div id="toolbar">
 <table><tbody data-bind="foreach: layers">
     <tr data-bind="css: { up: $parent.upLayer === $data, down: $parent.downLayer === $data }">
-        <td><input type="checkbox" data-bind="checked: show"/></td>
+        <td><input type="checkbox" data-bind="checked: show"></td>
         <td>
             <span data-bind="text: name, visible: !$parent.isSelectableLayer($data)"></span>
             <select data-bind="visible: $parent.isSelectableLayer($data), options: $parent.baseLayers, optionsText: 'name', value: $parent.selectedLayer"></select>
         </td>
         <td>
-            <input type="range" min="0" max="1" step="0.01" data-bind="value: alpha, valueUpdate: 'input'"/>
+            <input type="range" min="0" max="1" step="0.01" data-bind="value: alpha, valueUpdate: 'input'">
         </td>
         <td><button type="button" class="cesium-button" data-bind="click: function() { $parent.raise($data, $index()); }, visible: $parent.canRaise($index())">&#9650;</button></td>
         <td><button type="button" class="cesium-button" data-bind="click: function() { $parent.lower($data, $index()); }, visible: $parent.canLower($index())">&#9660;</button></td>
@@ -151,7 +153,7 @@ function setupLayers() {
                 format : 'image/jpeg',
                 tileMatrixSetID : 'default028mm',
                 maximumLevel: 19,
-                credit : new Cesium.Credit('U. S. Geological Survey')
+                credit : 'U. S. Geological Survey'
             }));
 
     // Create the additional layers

--- a/Apps/Sandcastle/gallery/Imagery Layers Manipulation.html
+++ b/Apps/Sandcastle/gallery/Imagery Layers Manipulation.html
@@ -151,7 +151,7 @@ function setupLayers() {
                 format : 'image/jpeg',
                 tileMatrixSetID : 'default028mm',
                 maximumLevel: 19,
-                credit : new Cesium.Credit({text: 'U. S. Geological Survey'})
+                credit : new Cesium.Credit('U. S. Geological Survey')
             }));
 
     // Create the additional layers

--- a/Apps/Sandcastle/gallery/Web Map Tile Service with Time.html
+++ b/Apps/Sandcastle/gallery/Web Map Tile Service with Time.html
@@ -62,7 +62,7 @@ var provider = new Cesium.WebMapTileServiceImageryProvider({
     format : 'image/png',
     clock: viewer.clock,
     times: times,
-    credit : new Cesium.Credit({text: 'NASA Global Imagery Browse Services for EOSDIS'})
+    credit : new Cesium.Credit('NASA Global Imagery Browse Services for EOSDIS')
 });
 var imageryLayers = viewer.imageryLayers;
 imageryLayers.addImageryProvider(provider);

--- a/Apps/Sandcastle/gallery/Web Map Tile Service with Time.html
+++ b/Apps/Sandcastle/gallery/Web Map Tile Service with Time.html
@@ -10,10 +10,12 @@
     <script type="text/javascript" src="../Sandcastle-header.js"></script>
     <script type="text/javascript" src="../../../ThirdParty/requirejs-2.1.20/require.js"></script>
     <script type="text/javascript">
-    require.config({
-        baseUrl : '../../../Source',
-        waitSeconds : 60
-    });
+        if(typeof require === "function") {
+            require.config({
+                baseUrl : '../../../Source',
+                waitSeconds : 120
+            });
+        }
     </script>
 </head>
 <body class="sandcastle-loading" data-sandcastle-bucket="bucket-requirejs.html">
@@ -62,7 +64,7 @@ var provider = new Cesium.WebMapTileServiceImageryProvider({
     format : 'image/png',
     clock: viewer.clock,
     times: times,
-    credit : new Cesium.Credit('NASA Global Imagery Browse Services for EOSDIS')
+    credit : 'NASA Global Imagery Browse Services for EOSDIS'
 });
 var imageryLayers = viewer.imageryLayers;
 imageryLayers.addImageryProvider(provider);

--- a/Source/Core/Credit.js
+++ b/Source/Core/Credit.js
@@ -29,7 +29,7 @@ define([
      *
      * @example
      * //Create a credit with a tooltip, image and link
-     * var credit = new Cesium.Credit('<a href="https://cesiumjs.org/" target="_blank"><img src="/images/cesium_logo.png" text="Cesium"/></a>');
+     * var credit = new Cesium.Credit('<a href="https://cesiumjs.org/" target="_blank"><img src="/images/cesium_logo.png" title="Cesium"/></a>');
      */
     function Credit(html, showOnScreen) {
         var id;

--- a/Source/Core/Credit.js
+++ b/Source/Core/Credit.js
@@ -29,11 +29,7 @@ define([
      *
      * @example
      * //Create a credit with a tooltip, image and link
-     * var credit = new Cesium.Credit({
-     *     text : 'Cesium',
-     *     imageUrl : '/images/cesium_logo.png',
-     *     link : 'https://cesiumjs.org/'
-     * });
+     * var credit = new Cesium.Credit('<a href="https://cesiumjs.org/" target="_blank"><img src="/images/cesium_logo.png" text="Cesium"/></a>');
      */
     function Credit(html, showOnScreen) {
         var id;


### PR DESCRIPTION
Fixed two Sandcastle demos that were using the deprecated `Credit` usage and fixed some documentation.

Let me know if the html string for the documentation needs any tweaking.

@hpinkos 