### PR TITLE
Add clearer error message

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,7 @@ Change Log
 * Fix Cesium ion browser caching [#6353](https://github.com/AnalyticalGraphicsInc/cesium/pull/6353).
 * Added support for glTF models with [Draco geometry compression](https://github.com/fanzhanggoogle/glTF/blob/KHR_mesh_compression/extensions/Khronos/KHR_draco_mesh_compression/README.md).
   * Added `dequantizeInShader` option parameter to `Model` and `Model.fromGltf` to specify if Draco compressed glTF assets should be dequantized on the GPU.
+  * Decoding is currently not supported in Internet Explorer, adding support is planned [#6404](https://github.com/AnalyticalGraphicsInc/cesium/issues/6404).
 * `ClippingPlaneCollection` updates [#6201](https://github.com/AnalyticalGraphicsInc/cesium/pull/6201)
   * Removed the 6-clipping-plane limit.
   * Added support for Internet Explorer.

--- a/Source/Scene/DracoLoader.js
+++ b/Source/Scene/DracoLoader.js
@@ -3,6 +3,7 @@ define([
         '../Core/ComponentDatatype',
         '../Core/defined',
         '../Core/FeatureDetection',
+        '../Core/RuntimeError',
         '../Core/TaskProcessor',
         '../Renderer/Buffer',
         '../Renderer/BufferUsage',
@@ -13,6 +14,7 @@ define([
         ComponentDatatype,
         defined,
         FeatureDetection,
+        RuntimeError,
         TaskProcessor,
         Buffer,
         BufferUsage,
@@ -178,9 +180,7 @@ define([
         }
 
         if (FeatureDetection.isInternetExplorer()) {
-            return when.reject({
-                message : 'Draco decoding is not supported in Internet Explorer.'
-            });
+            return when.reject(new RuntimeError('Draco decoding is not currently supported in Internet Explorer.'));
         }
 
         var loadResources = model._loadResources;

--- a/Source/Scene/DracoLoader.js
+++ b/Source/Scene/DracoLoader.js
@@ -177,6 +177,12 @@ define([
             return when.resolve();
         }
 
+        if (FeatureDetection.isInternetExplorer()) {
+            return when.reject({
+                message : 'Draco decoding is not supported in legacy environments.'
+            });
+        }
+
         var loadResources = model._loadResources;
         if (loadResources.primitivesToDecode.length === 0) {
             // No more tasks to schedule

--- a/Source/Scene/DracoLoader.js
+++ b/Source/Scene/DracoLoader.js
@@ -179,7 +179,7 @@ define([
 
         if (FeatureDetection.isInternetExplorer()) {
             return when.reject({
-                message : 'Draco decoding is not supported in legacy environments.'
+                message : 'Draco decoding is not supported in Internet Explorer.'
             });
         }
 

--- a/Source/Scene/Model.js
+++ b/Source/Scene/Model.js
@@ -248,7 +248,7 @@ define([
      * </li><li>
      * {@link https://github.com/KhronosGroup/glTF/blob/master/extensions/1.0/Vendor/WEB3D_quantized_attributes/README.md|WEB3D_quantized_attributes}
      * </li><li>
-     * {@link https://github.com/KhronosGroup/glTF/blob/master/extensions/2.0/Khronos/KHR_draco_mesh_compression/README.md|KHR_draco_mesh_compression}
+     * {@link https://github.com/KhronosGroup/glTF/blob/master/extensions/2.0/Khronos/KHR_draco_mesh_compression/README.md|KHR_draco_mesh_compression} (Not supported in Internet Explorer)
      * </li>
      * </ul>
      * </p>
@@ -1096,7 +1096,7 @@ define([
      * </li><li>
      * {@link https://github.com/KhronosGroup/glTF/blob/master/extensions/1.0/Vendor/WEB3D_quantized_attributes/README.md|WEB3D_quantized_attributes}
      * </li><li>
-     * {@link https://github.com/KhronosGroup/glTF/blob/master/extensions/2.0/Khronos/KHR_draco_mesh_compression/README.md|KHR_draco_mesh_compression}
+     * {@link https://github.com/KhronosGroup/glTF/blob/master/extensions/2.0/Khronos/KHR_draco_mesh_compression/README.md|KHR_draco_mesh_compression} (Not supported in Internet Explorer)
      * </li>
      * </ul>
      * </p>


### PR DESCRIPTION
Fixes ##6399 with a clearer error.

Opened https://github.com/AnalyticalGraphicsInc/cesium/issues/6404 for a better fix by using the legacy enabled build of the draco decoder module.