### PR TITLE
Fix bugs in TimeIntervalCollection.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,11 @@
 Change Log
 ==========
 
+### 1.45 - 2018-05-01
+
+##### Fixes :wrench:
+* Fixed bugs in `TimeIntervalCollection.removeInterval`. [#6418](https://github.com/AnalyticalGraphicsInc/cesium/pull/6418).
+
 ### 1.44 - 2018-04-02
 
 ##### Highlights :sparkler:


### PR DESCRIPTION
* Undid extraction of local variable for intervals[index] in `removeInterval` which was not done correctly.
* Several places compared JulianDates incorrectly using TimeInterval.equals.

I also made the structure of the code match our original C# source as closely as
possible, given the language differences.  Both of the above errors were a
result of the code diverging, in an attempt to clean it up.

I also added another unit test ported from our original source, and kept
the new unit tests added in #6398 (after fixing them to be correct).