### PR TITLE
More careful splitting of glTF materials

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ Change Log
 ##### Fixes :wrench:
 * Fixed bugs in `TimeIntervalCollection.removeInterval`. [#6418](https://github.com/AnalyticalGraphicsInc/cesium/pull/6418).
 * Fixed glTF support to handle meshes with and without tangent vectors, and with/without morph targets, sharing one material. [#6421](https://github.com/AnalyticalGraphicsInc/cesium/pull/6421)
+* Fixed glTF support to handle skinned meshes when no skin is supplied. [#6421](https://github.com/AnalyticalGraphicsInc/cesium/pull/6421)
 
 ### 1.44 - 2018-04-02
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,7 +6,7 @@ Change Log
 ##### Fixes :wrench:
 * Fixed bugs in `TimeIntervalCollection.removeInterval`. [#6418](https://github.com/AnalyticalGraphicsInc/cesium/pull/6418).
 * Fixed glTF support to handle meshes with and without tangent vectors, and with/without morph targets, sharing one material. [#6421](https://github.com/AnalyticalGraphicsInc/cesium/pull/6421)
-* Fixed glTF support to handle skinned meshes when no skin is supplied. [#6421](https://github.com/AnalyticalGraphicsInc/cesium/pull/6421)
+* Fixed glTF support to handle skinned meshes when no skin is supplied. [#6061](https://github.com/AnalyticalGraphicsInc/cesium/issues/6061)
 
 ### 1.44 - 2018-04-02
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@ Change Log
 
 ##### Fixes :wrench:
 * Fixed bugs in `TimeIntervalCollection.removeInterval`. [#6418](https://github.com/AnalyticalGraphicsInc/cesium/pull/6418).
+* Fixed glTF support to handle meshes with and without tangent vectors, and with/without morph targets, sharing one material. [#6421](https://github.com/AnalyticalGraphicsInc/cesium/pull/6421)
 
 ### 1.44 - 2018-04-02
 

--- a/Source/ThirdParty/GltfPipeline/processPbrMetallicRoughness.js
+++ b/Source/ThirdParty/GltfPipeline/processPbrMetallicRoughness.js
@@ -101,7 +101,7 @@ define([
 
         if (defined(primitiveInfo)) {
             skinningInfo = primitiveInfo.skinning;
-            hasSkinning = skinningInfo.skinned;
+            hasSkinning = skinningInfo.skinned && (joints.length > 0);
             hasVertexColors = primitiveInfo.hasVertexColors;
         }
 


### PR DESCRIPTION
This addresses a bug found in #6412 where Polly, the robot dog, lost all her lighting, even emissive lights.

Some materials were used with and without tangents, or with and without morph targets, and needed to be split apart.  Also, the `hasTangents` and `hasMorphTargets` booleans needed to be isolated to their respective materials (after splitting).