### PR TITLE
Update default Mapbox endpoint URL

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,9 @@ Change Log
 * Fixed glTF support to handle skinned meshes when no skin is supplied. [#6061](https://github.com/AnalyticalGraphicsInc/cesium/issues/6061)
 * Allow loadWithXhr to work with string URLs in a web worker.
 
+##### Additions :tada:
+* Improved `MapboxImageryProvider` performance by 300% via `tiles.mapbox.com` subdomain switching. [#6426](https://github.com/AnalyticalGraphicsInc/cesium/issues/6426)
+
 ### 1.44 - 2018-04-02
 
 ##### Highlights :sparkler:

--- a/Source/Scene/MapboxImageryProvider.js
+++ b/Source/Scene/MapboxImageryProvider.js
@@ -62,7 +62,7 @@ define([
 
         var url = options.url;
         if (!defined(url)) {
-            url = 'https://api.mapbox.com/v4/';
+            url = 'https://{s}.tiles.mapbox.com/v4/';
         }
         this._url = url;
 


### PR DESCRIPTION
Improved MapboxImageryProvider performance by 300% via `tiles.mapbox.com` subdomain switching.