### PR TITLE
Oct encoding fix for i3dm and pnts

### DIFF
--- a/Source/Scene/Instanced3DModel3DTileContent.js
+++ b/Source/Scene/Instanced3DModel3DTileContent.js
@@ -389,8 +389,8 @@ define([
                 Cartesian3.unpack(normalRight, 0, instanceNormalRight);
                 hasCustomOrientation = true;
             } else {
-                var octNormalUp = featureTable.getProperty('NORMAL_UP_OCT32P', ComponentDatatype.UNSIGNED_SHORT, 2, i, propertyScratch1);
-                var octNormalRight = featureTable.getProperty('NORMAL_RIGHT_OCT32P', ComponentDatatype.UNSIGNED_SHORT, 2, i, propertyScratch2);
+                var octNormalUp = featureTable.getProperty('NORMAL_UP_OCT32P', ComponentDatatype.SHORT, 2, i, propertyScratch1);
+                var octNormalRight = featureTable.getProperty('NORMAL_RIGHT_OCT32P', ComponentDatatype.SHORT, 2, i, propertyScratch2);
                 if (defined(octNormalUp)) {
                     if (!defined(octNormalRight)) {
                         throw new RuntimeError('To define a custom orientation with oct-encoded vectors, both NORMAL_UP_OCT32P and NORMAL_RIGHT_OCT32P must be defined.');

--- a/Source/Scene/PointCloud3DTileContent.js
+++ b/Source/Scene/PointCloud3DTileContent.js
@@ -406,7 +406,7 @@ define([
         if (defined(featureTableJson.NORMAL)) {
             normals = featureTable.getPropertyArray('NORMAL', ComponentDatatype.FLOAT, 3);
         } else if (defined(featureTableJson.NORMAL_OCT16P)) {
-            normals = featureTable.getPropertyArray('NORMAL_OCT16P', ComponentDatatype.UNSIGNED_BYTE, 2);
+            normals = featureTable.getPropertyArray('NORMAL_OCT16P', ComponentDatatype.BYTE, 2);
             isOctEncoded16P = true;
         }
 
@@ -695,7 +695,7 @@ define([
                     index : normalLocation,
                     vertexBuffer : normalsVertexBuffer,
                     componentsPerAttribute : 2,
-                    componentDatatype : ComponentDatatype.UNSIGNED_BYTE,
+                    componentDatatype : ComponentDatatype.BYTE,
                     normalize : false,
                     offsetInBytes : 0,
                     strideInBytes : 0


### PR DESCRIPTION
For i3dm and pnts some oct encoding areas were using unsigned values instead of signed values. This option isn't used super frequently so we just never caught it.

TODO : need to test that this fix works by trying out new sample data https://github.com/AnalyticalGraphicsInc/3d-tiles-tools/pull/143