### PR TITLE
Don't call buildModuleUrl during module initialization.

### DIFF
--- a/Source/Scene/BingMapsImageryProvider.js
+++ b/Source/Scene/BingMapsImageryProvider.js
@@ -2,6 +2,7 @@ define([
         '../Core/BingMapsApi',
         '../Core/buildModuleUrl',
         '../Core/Cartesian2',
+        '../Core/Check',
         '../Core/Credit',
         '../Core/defaultValue',
         '../Core/defined',
@@ -22,6 +23,7 @@ define([
         BingMapsApi,
         buildModuleUrl,
         Cartesian2,
+        Check,
         Credit,
         defaultValue,
         defined,
@@ -110,8 +112,7 @@ define([
         this._culture = defaultValue(options.culture, '');
         this._tileDiscardPolicy = options.tileDiscardPolicy;
         this._proxy = options.proxy;
-        var logoUrl = buildModuleUrl('Assets/Images/bing_maps_credit.png');
-        this._credit = new Credit('<a href="http://www.bing.com"><img src="' + logoUrl + '" title="Bing Imagery"/></a>');
+        this._credit = new Credit('<a href="http://www.bing.com"><img src="' + BingMapsImageryProvider.logoUrl + '" title="Bing Imagery"/></a>');
 
         /**
          * The default {@link ImageryLayer#gamma} to use for imagery layers created for this provider.
@@ -622,6 +623,31 @@ define([
             level : level
         };
     };
+
+    BingMapsImageryProvider._logoUrl = undefined;
+
+    defineProperties(BingMapsImageryProvider, {
+        /**
+         * Gets or sets the URL to the Bing logo for display in the credit.
+         * @memberof BingMapsImageryProvider
+         * @type {String}
+         */
+        logoUrl: {
+            get: function() {
+                if (!defined(BingMapsImageryProvider._logoUrl)) {
+                    BingMapsImageryProvider._logoUrl = buildModuleUrl('Assets/Images/bing_maps_credit.png');
+                }
+                return BingMapsImageryProvider._logoUrl;
+            },
+            set: function(value) {
+                //>>includeStart('debug', pragmas.debug);
+                Check.defined('value', value);
+                //>>includeEnd('debug');
+
+                BingMapsImageryProvider._logoUrl = value;
+            }
+        }
+    });
 
     function buildImageResource(imageryProvider, x, y, level, request) {
         var imageUrl = imageryProvider._imageUrlTemplate;

--- a/Source/Scene/BingMapsImageryProvider.js
+++ b/Source/Scene/BingMapsImageryProvider.js
@@ -110,7 +110,8 @@ define([
         this._culture = defaultValue(options.culture, '');
         this._tileDiscardPolicy = options.tileDiscardPolicy;
         this._proxy = options.proxy;
-        this._credit = new Credit('<a href="http://www.bing.com"><img src="' + BingMapsImageryProvider._logoData + '" title="Bing Imagery"/></a>');
+        var logoUrl = buildModuleUrl('Assets/Images/bing_maps_credit.png');
+        this._credit = new Credit('<a href="http://www.bing.com"><img src="' + logoUrl + '" title="Bing Imagery"/></a>');
 
         /**
          * The default {@link ImageryLayer#gamma} to use for imagery layers created for this provider.
@@ -559,8 +560,6 @@ define([
     BingMapsImageryProvider.prototype.pickFeatures = function(x, y, level, longitude, latitude) {
         return undefined;
     };
-
-    BingMapsImageryProvider._logoData = buildModuleUrl('Assets/Images/bing_maps_credit.png');
 
     /**
      * Converts a tiles (x, y, level) position into a quadkey used to request an image

--- a/Source/Scene/CreditDisplay.js
+++ b/Source/Scene/CreditDisplay.js
@@ -4,6 +4,7 @@ define([
         '../Core/Credit',
         '../Core/defaultValue',
         '../Core/defined',
+        '../Core/defineProperties',
         '../Core/destroyObject'
     ], function(
         buildModuleUrl,
@@ -11,6 +12,7 @@ define([
         Credit,
         defaultValue,
         defined,
+        defineProperties,
         destroyObject) {
     'use strict';
 
@@ -271,9 +273,6 @@ define([
         head.insertBefore(css, head.firstChild);
     }
 
-    var cesiumLogo = buildModuleUrl('Assets/Images/cesium_credit.png');
-    var cesiumCredit = new Credit('<a href="https://cesiumjs.org/" target="_blank"><img src="' + cesiumLogo + '" title="CesiumJS"/></a>', true);
-
     /**
      * The credit display is responsible for displaying credits on screen.
      *
@@ -516,11 +515,31 @@ define([
         return false;
     };
 
-    /**
-     * Gets or sets the Cesium logo credit.
-     * @type {Credit}
-     */
-    CreditDisplay.cesiumCredit = cesiumCredit;
+    CreditDisplay._cesiumCredit = undefined;
+    CreditDisplay._cesiumCreditInitialized = false;
+
+    defineProperties(CreditDisplay, {
+        /**
+         * Gets or sets the Cesium logo credit.
+         * @memberof CreditDisplay
+         * @type {Credit}
+         */
+        cesiumCredit: {
+            get: function() {
+                if (!CreditDisplay._cesiumCreditInitialized) {
+                    var cesiumLogo = buildModuleUrl('Assets/Images/cesium_credit.png');
+                    CreditDisplay._cesiumCredit = new Credit('<a href="https://cesiumjs.org/" target="_blank"><img src="' + cesiumLogo + '" title="CesiumJS"/></a>', true);
+                    CreditDisplay._cesiumCreditInitialized = true;
+                }
+
+                return CreditDisplay._cesiumCredit;
+            },
+            set: function(value) {
+                CreditDisplay._cesiumCredit = value;
+                CreditDisplay._cesiumCreditInitialized = true;
+            }
+        }
+    });
 
     return CreditDisplay;
 });

--- a/Source/Scene/GoogleEarthEnterpriseMapsProvider.js
+++ b/Source/Scene/GoogleEarthEnterpriseMapsProvider.js
@@ -1,5 +1,6 @@
 define([
         '../Core/buildModuleUrl',
+        '../Core/Check',
         '../Core/Credit',
         '../Core/defaultValue',
         '../Core/defined',
@@ -16,6 +17,7 @@ define([
         './ImageryProvider'
     ], function(
         buildModuleUrl,
+        Check,
         Credit,
         defaultValue,
         defined,
@@ -128,8 +130,7 @@ define([
         this._tileDiscardPolicy = options.tileDiscardPolicy;
         this._channel = options.channel;
         this._requestType = 'ImageryMaps';
-        var logoUrl = buildModuleUrl('Assets/Images/google_earth_credit.png');
-        this._credit = new Credit('<a href="http://www.google.com/enterprise/mapsearth/products/earthenterprise.html"><img src="' + logoUrl + '" title="Google Imagery"/></a>');
+        this._credit = new Credit('<a href="http://www.google.com/enterprise/mapsearth/products/earthenterprise.html"><img src="' + GoogleEarthEnterpriseMapsProvider.logoUrl + '" title="Google Imagery"/></a>');
 
         /**
          * The default {@link ImageryLayer#gamma} to use for imagery layers created for this provider.
@@ -597,6 +598,31 @@ define([
     GoogleEarthEnterpriseMapsProvider.prototype.pickFeatures = function(x, y, level, longitude, latitude) {
         return undefined;
     };
+
+    GoogleEarthEnterpriseMapsProvider._logoUrl = undefined;
+
+    defineProperties(GoogleEarthEnterpriseMapsProvider, {
+        /**
+         * Gets or sets the URL to the Google Earth logo for display in the credit.
+         * @memberof GoogleEarthEnterpriseMapsProvider
+         * @type {String}
+         */
+        logoUrl: {
+            get: function() {
+                if (!defined(GoogleEarthEnterpriseMapsProvider._logoUrl)) {
+                    GoogleEarthEnterpriseMapsProvider._logoUrl = buildModuleUrl('Assets/Images/google_earth_credit.png');
+                }
+                return GoogleEarthEnterpriseMapsProvider._logoUrl;
+            },
+            set: function(value) {
+                //>>includeStart('debug', pragmas.debug);
+                Check.defined('value', value);
+                //>>includeEnd('debug');
+
+                GoogleEarthEnterpriseMapsProvider._logoUrl = value;
+            }
+        }
+    });
 
     return GoogleEarthEnterpriseMapsProvider;
 });

--- a/Source/Scene/GoogleEarthEnterpriseMapsProvider.js
+++ b/Source/Scene/GoogleEarthEnterpriseMapsProvider.js
@@ -128,7 +128,8 @@ define([
         this._tileDiscardPolicy = options.tileDiscardPolicy;
         this._channel = options.channel;
         this._requestType = 'ImageryMaps';
-        this._credit = new Credit('<a href="http://www.google.com/enterprise/mapsearth/products/earthenterprise.html"><img src="' + GoogleEarthEnterpriseMapsProvider._logoData + '" title="Google Imagery"/></a>');
+        var logoUrl = buildModuleUrl('Assets/Images/google_earth_credit.png');
+        this._credit = new Credit('<a href="http://www.google.com/enterprise/mapsearth/products/earthenterprise.html"><img src="' + logoUrl + '" title="Google Imagery"/></a>');
 
         /**
          * The default {@link ImageryLayer#gamma} to use for imagery layers created for this provider.
@@ -596,8 +597,6 @@ define([
     GoogleEarthEnterpriseMapsProvider.prototype.pickFeatures = function(x, y, level, longitude, latitude) {
         return undefined;
     };
-
-    GoogleEarthEnterpriseMapsProvider._logoData = buildModuleUrl('Assets/Images/google_earth_credit.png');
 
     return GoogleEarthEnterpriseMapsProvider;
 });


### PR DESCRIPTION
This breaks code that expects to be able to set CESIUM_BASE_URL
after loading the Cesium.js script but before using any API.