### PR TITLE
Fix docs

### DIFF
--- a/Source/Core/ScreenSpaceEventHandler.js
+++ b/Source/Core/ScreenSpaceEventHandler.js
@@ -569,14 +569,14 @@ define([
 
                 var dX = position2.x - position1.x;
                 var dY = position2.y - position1.y;
-                var dist = Math.sqrt(dX * dX + dY * dY) * 0.25;
+                var dist = Math.sqrt(dX * dX + dY * dY);
 
                 var prevDX = previousPosition2.x - previousPosition1.x;
                 var prevDY = previousPosition2.y - previousPosition1.y;
-                var prevDist = Math.sqrt(prevDX * prevDX + prevDY * prevDY) * 0.25;
+                var prevDist = Math.sqrt(prevDX * prevDX + prevDY * prevDY);
 
-                var cY = (position2.y + position1.y) * 0.125;
-                var prevCY = (previousPosition2.y + previousPosition1.y) * 0.125;
+                var cY = (position2.y + position1.y) * 0.5;
+                var prevCY = (previousPosition2.y + previousPosition1.y) * 0.5;
                 var angle = Math.atan2(dY, dX);
                 var prevAngle = Math.atan2(prevDY, prevDX);
 

--- a/Source/Scene/BillboardCollection.js
+++ b/Source/Scene/BillboardCollection.js
@@ -139,7 +139,7 @@ define([
      * @param {Scene} [options.scene] Must be passed in for billboards that use the height reference property or will be depth tested against the globe.
      * @param {BlendOption} [options.blendOption=BlendOption.OPAQUE_AND_TRANSLUCENT] The billboard blending option. The default
      * is used for rendering both opaque and translucent billboards. However, if either all of the billboards are completely opaque or all are completely translucent,
-     * setting the technique to BillboardRenderTechnique.OPAQUE or BillboardRenderTechnique.TRANSLUCENT can improve performance by up to 2x.
+     * setting the technique to BlendOption.OPAQUE or BlendOption.TRANSLUCENT can improve performance by up to 2x.
      *
      * @performance For best performance, prefer a few collections, each with many billboards, to
      * many collections with only a few billboards each.  Organize collections so that billboards
@@ -285,7 +285,7 @@ define([
         /**
          * The billboard blending option. The default is used for rendering both opaque and translucent billboards.
          * However, if either all of the billboards are completely opaque or all are completely translucent,
-         * setting the technique to BillboardRenderTechnique.OPAQUE or BillboardRenderTechnique.TRANSLUCENT can improve
+         * setting the technique to BlendOption.OPAQUE or BlendOption.TRANSLUCENT can improve
          * performance by up to 2x.
          * @type {BlendOption}
          * @default BlendOption.OPAQUE_AND_TRANSLUCENT

--- a/Source/Scene/LabelCollection.js
+++ b/Source/Scene/LabelCollection.js
@@ -450,7 +450,7 @@ define([
      * @param {Scene} [options.scene] Must be passed in for labels that use the height reference property or will be depth tested against the globe.
      * @param {BlendOption} [options.blendOption=BlendOption.OPAQUE_AND_TRANSLUCENT] The label blending option. The default
      * is used for rendering both opaque and translucent labels. However, if either all of the labels are completely opaque or all are completely translucent,
-     * setting the technique to BillboardRenderTechnique.OPAQUE or BillboardRenderTechnique.TRANSLUCENT can improve performance by up to 2x.
+     * setting the technique to BlendOption.OPAQUE or BlendOption.TRANSLUCENT can improve performance by up to 2x.
      *
      * @performance For best performance, prefer a few collections, each with many labels, to
      * many collections with only a few labels each.  Avoid having collections where some
@@ -552,7 +552,7 @@ define([
         /**
          * The label blending option. The default is used for rendering both opaque and translucent labels.
          * However, if either all of the labels are completely opaque or all are completely translucent,
-         * setting the technique to BillboardRenderTechnique.OPAQUE or BillboardRenderTechnique.TRANSLUCENT can improve
+         * setting the technique to BlendOption.OPAQUE or BlendOption.TRANSLUCENT can improve
          * performance by up to 2x.
          * @type {BlendOption}
          * @default BlendOption.OPAQUE_AND_TRANSLUCENT

--- a/Source/Scene/PointPrimitiveCollection.js
+++ b/Source/Scene/PointPrimitiveCollection.js
@@ -91,7 +91,7 @@ define([
      * @param {Boolean} [options.debugShowBoundingVolume=false] For debugging only. Determines if this primitive's commands' bounding spheres are shown.
      * @param {BlendOption} [options.blendOption=BlendOption.OPAQUE_AND_TRANSLUCENT] The point blending option. The default
      * is used for rendering both opaque and translucent points. However, if either all of the points are completely opaque or all are completely translucent,
-     * setting the technique to BillboardRenderTechnique.OPAQUE or BillboardRenderTechnique.TRANSLUCENT can improve performance by up to 2x.
+     * setting the technique to BlendOption.OPAQUE or BlendOption.TRANSLUCENT can improve performance by up to 2x.
      *
      * @performance For best performance, prefer a few collections, each with many points, to
      * many collections with only a few points each.  Organize collections so that points
@@ -211,7 +211,7 @@ define([
         /**
          * The point blending option. The default is used for rendering both opaque and translucent points.
          * However, if either all of the points are completely opaque or all are completely translucent,
-         * setting the technique to BillboardRenderTechnique.OPAQUE or BillboardRenderTechnique.TRANSLUCENT can improve
+         * setting the technique to BlendOption.OPAQUE or BlendOption.TRANSLUCENT can improve
          * performance by up to 2x.
          * @type {BlendOption}
          * @default BlendOption.OPAQUE_AND_TRANSLUCENT


### PR DESCRIPTION
This pr fixes a few documentation references to BlendOption.OPAQUE & BlendOption.TRANSPARENT.