### PR TITLE
Revert "Reduce the strength of some pinch gestures, for better usability"

### DIFF
--- a/Source/Core/ScreenSpaceEventHandler.js
+++ b/Source/Core/ScreenSpaceEventHandler.js
@@ -569,14 +569,14 @@ define([
 
                 var dX = position2.x - position1.x;
                 var dY = position2.y - position1.y;
-                var dist = Math.sqrt(dX * dX + dY * dY) * 0.25;
+                var dist = Math.sqrt(dX * dX + dY * dY);
 
                 var prevDX = previousPosition2.x - previousPosition1.x;
                 var prevDY = previousPosition2.y - previousPosition1.y;
-                var prevDist = Math.sqrt(prevDX * prevDX + prevDY * prevDY) * 0.25;
+                var prevDist = Math.sqrt(prevDX * prevDX + prevDY * prevDY);
 
-                var cY = (position2.y + position1.y) * 0.125;
-                var prevCY = (previousPosition2.y + previousPosition1.y) * 0.125;
+                var cY = (position2.y + position1.y) * 0.5;
+                var prevCY = (previousPosition2.y + previousPosition1.y) * 0.5;
                 var angle = Math.atan2(dY, dX);
                 var prevAngle = Math.atan2(prevDY, prevDX);
 

--- a/Specs/Core/ScreenSpaceEventHandlerSpec.js
+++ b/Specs/Core/ScreenSpaceEventHandlerSpec.js
@@ -994,22 +994,22 @@ defineSuite([
             // intermediate delta Y: -8
             expect(action).toHaveBeenCalledWith({
                 distance : {
-                    startPosition : new Cartesian2(0, Math.sqrt(3 * 3 + 1 * 1) * 0.25),
-                    endPosition : new Cartesian2(0, Math.sqrt(-6 * -6 + -8 * -8) * 0.25)
+                    startPosition : new Cartesian2(0, Math.sqrt(3 * 3 + 1 * 1)),
+                    endPosition : new Cartesian2(0, Math.sqrt(-6 * -6 + -8 * -8))
                 },
                 angleAndHeight : {
-                    startPosition : new Cartesian2(Math.atan2(1, 3), (3 + 2) * 0.125),
-                    endPosition : new Cartesian2(Math.atan2(-8, -6), (3 + 11) * 0.125)
+                    startPosition : new Cartesian2(Math.atan2(1, 3), (3 + 2) * 0.5),
+                    endPosition : new Cartesian2(Math.atan2(-8, -6), (3 + 11) * 0.5)
                 }
             });
             expect(action).toHaveBeenCalledWith({
                 distance : {
-                    startPosition : new Cartesian2(0, Math.sqrt(-6 * -6 + -8 * -8) * 0.25),
-                    endPosition : new Cartesian2(0, Math.sqrt(11 * 11 + 9 * 9) * 0.25)
+                    startPosition : new Cartesian2(0, Math.sqrt(-6 * -6 + -8 * -8)),
+                    endPosition : new Cartesian2(0, Math.sqrt(11 * 11 + 9 * 9))
                 },
                 angleAndHeight : {
-                    startPosition : new Cartesian2(Math.atan2(-8, -6), (3 + 11) * 0.125),
-                    endPosition : new Cartesian2(Math.atan2(9, 11), (11 + 20) * 0.125)
+                    startPosition : new Cartesian2(Math.atan2(-8, -6), (3 + 11) * 0.5),
+                    endPosition : new Cartesian2(Math.atan2(9, 11), (11 + 20) * 0.5)
                 }
             });
         } else {
@@ -1017,12 +1017,12 @@ defineSuite([
             expect(action.calls.count()).toEqual(1);
             expect(action).toHaveBeenCalledWith({
                 distance : {
-                    startPosition : new Cartesian2(0, Math.sqrt(3 * 3 + 1 * 1) * 0.25),
-                    endPosition : new Cartesian2(0, Math.sqrt(11 * 11 + 9 * 9) * 0.25)
+                    startPosition : new Cartesian2(0, Math.sqrt(3 * 3 + 1 * 1)),
+                    endPosition : new Cartesian2(0, Math.sqrt(11 * 11 + 9 * 9))
                 },
                 angleAndHeight : {
-                    startPosition : new Cartesian2(Math.atan2(1, 3), (3 + 2) * 0.125),
-                    endPosition : new Cartesian2(Math.atan2(9, 11), (11 + 20) * 0.125)
+                    startPosition : new Cartesian2(Math.atan2(1, 3), (3 + 2) * 0.5),
+                    endPosition : new Cartesian2(Math.atan2(9, 11), (11 + 20) * 0.5)
                 }
             });
         }


### PR DESCRIPTION
When using Cesium on mobile the pinch to zoom speed is very slow. You have to pinch multiple times to zoom in / out. I tracked this down this commit from 2012: https://github.com/AnalyticalGraphicsInc/cesium/commit/84927fbfd518fae17e024e1e1d2bce1e9b05ae93

When undoing this commit the motion feels correct again.