### PR TITLE
Minor fix to procedural reflection map calculation.

### DIFF
--- a/Source/ThirdParty/GltfPipeline/processPbrMetallicRoughness.js
+++ b/Source/ThirdParty/GltfPipeline/processPbrMetallicRoughness.js
@@ -538,7 +538,7 @@ define([
             // Figure out if the reflection vector hits the ellipsoid
             fragmentShader += '    czm_ellipsoid ellipsoid = czm_getWgs84EllipsoidEC();\n';
             fragmentShader += '    float vertexRadius = length(v_positionWC);\n';
-            fragmentShader += '    float horizonDotNadir = 1.0 - ellipsoid.radii.x / vertexRadius;\n';
+            fragmentShader += '    float horizonDotNadir = 1.0 - min(1.0, ellipsoid.radii.x / vertexRadius);\n';
             fragmentShader += '    float reflectionDotNadir = dot(r, normalize(v_positionWC));\n';
             // Flipping the X vector is a cheap way to get the inverse of czm_temeToPseudoFixed, since that's a rotation about Z.
             fragmentShader += '    r.x = -r.x;\n';


### PR DESCRIPTION
Clamp horizonDotNadir calculation to effectively push any subsurface position up to the surface.  Without this, geometry positioned close to the center of the Earth will turn white.

Note this does not target master.  This change builds on @emackey's current pbr-lighting branch.