### PR TITLE
Added IonGeocoderService

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@ Change Log
 ### 1.45 - 2018-05-01
 
 ##### Additions :tada:
+* Added `IonGeocoderService` and made it the default geocoding service for the `Geocoder` widget.
 * Added option `logarithmicDepthBuffer` to `Scene`. With this option there is typically a single frustum using logarithmic depth rendered. This increases performance by issuing less draw calls to the GPU and helps to avoid artifacts on the connection of two frustums. [#5851](https://github.com/AnalyticalGraphicsInc/cesium/pull/5851)
 * When a log depth buffer is supported, the frustum near and far planes default to `0.1` and `1e10` respectively.
 * Added `Math.log2` to compute the base 2 logarithm of a number.

--- a/Source/Core/IonGeocoderService.js
+++ b/Source/Core/IonGeocoderService.js
@@ -1,0 +1,64 @@
+define([
+    './Check',
+    './defaultValue',
+    './defined',
+    './defineProperties',
+    './Ion',
+    './PeliasGeocoderService',
+    './Rectangle',
+    './Resource'
+], function (
+    Check,
+    defaultValue,
+    defined,
+    defineProperties,
+    Ion,
+    PeliasGeocoderService,
+    Rectangle,
+    Resource) {
+    'use strict';
+
+    /**
+     * Provides geocoding through Cesium ion.
+     * @alias IonGeocoderService
+     * @constructor
+     *
+     * @param {Object} [options] Object with the following properties:
+     * @param {String} [options.accessToken=Ion.defaultAccessToken] The access token to use.
+     * @param {String|Resource} [options.server=Ion.defaultServer] The resource to the Cesium ion API server.
+     *
+     * @see Ion
+     */
+    function IonGeocoderService(options) {
+        options = defaultValue(options, defaultValue.EMPTY_OBJECT);
+
+        var accessToken = defaultValue(options.accessToken, Ion.defaultAccessToken);
+        var server = Resource.createIfNeeded(defaultValue(options.server, Ion.defaultServer));
+        server.appendForwardSlash();
+
+        var searchEndpoint = server.getDerivedResource({
+            url: 'v1/geocode'
+        });
+
+        if (defined(accessToken)) {
+            searchEndpoint.appendQueryParameters({ access_token: accessToken });
+        }
+
+        this._accessToken = accessToken;
+        this._server = server;
+        this._pelias = new PeliasGeocoderService(searchEndpoint);
+    }
+
+    /**
+     * @function
+     *
+     * @param {String} query The query to be sent to the geocoder service
+     * @param {GeocodeType} [type=GeocodeType.SEARCH] The type of geocode to perform.
+     * @returns {Promise<GeocoderResult[]>}
+     */
+    IonGeocoderService.prototype.geocode = function (query, geocodeType) {
+        return this._pelias.geocode(query, geocodeType);
+    };
+
+    return IonGeocoderService;
+});

--- a/Source/Core/PeliasGeocoderService.js
+++ b/Source/Core/PeliasGeocoderService.js
@@ -38,6 +38,7 @@ define([
         //>>includeEnd('debug');
 
         this._url = Resource.createIfNeeded(url);
+        this._url.appendForwardSlash();
     }
 
     defineProperties(PeliasGeocoderService.prototype, {

--- a/Source/Widgets/Geocoder/GeocoderViewModel.js
+++ b/Source/Widgets/Geocoder/GeocoderViewModel.js
@@ -1,5 +1,5 @@
 define([
-        '../../Core/BingMapsGeocoderService',
+        '../../Core/IonGeocoderService',
         '../../Core/CartographicGeocoderService',
         '../../Core/defaultValue',
         '../../Core/defined',
@@ -13,7 +13,7 @@ define([
         '../createCommand',
         '../getElement'
     ], function(
-        BingMapsGeocoderService,
+        IonGeocoderService,
         CartographicGeocoderService,
         defaultValue,
         defined,
@@ -52,7 +52,7 @@ define([
         } else {
             this._geocoderServices = [
                 new CartographicGeocoderService(),
-                new BingMapsGeocoderService({scene: options.scene})
+                new IonGeocoderService()
             ];
         }
 

--- a/Specs/Core/IonGeocoderServiceSpec.js
+++ b/Specs/Core/IonGeocoderServiceSpec.js
@@ -1,0 +1,48 @@
+defineSuite([
+        'Core/IonGeocoderService',
+        'Core/Ion',
+        'Core/GeocodeType',
+        'Core/Rectangle',
+        'Core/Resource',
+        'ThirdParty/when'
+    ], function(
+        IonGeocoderService,
+        Ion,
+        GeocodeType,
+        Rectangle,
+        Resource,
+        when) {
+    'use strict';
+
+    it('Creates with default parameters', function() {
+        var service = new IonGeocoderService();
+
+        expect(service._accessToken).toEqual(Ion.defaultAccessToken);
+        expect(service._server.url).toEqual(Ion.defaultServer.url);
+    });
+
+    it('Creates with specified parameters', function() {
+        var accessToken = '123456';
+        var server = 'http://not.ion.invalid/';
+
+        var service = new IonGeocoderService({
+            accessToken: accessToken,
+            server: server
+        });
+
+        expect(service._accessToken).toEqual(accessToken);
+        expect(service._server.url).toEqual(server);
+    });
+
+    it('calls inner geocoder and returns result', function () {
+        var service = new IonGeocoderService();
+
+        var expectedResult = when.resolve();
+        spyOn(service._pelias, 'geocode').and.returnValue(expectedResult);
+
+        var query = 'some query';
+        var result = service.geocode(query, GeocodeType.SEARCH);
+        expect(result).toBe(expectedResult);
+        expect(service._pelias.geocode).toHaveBeenCalledWith(query, GeocodeType.SEARCH);
+   });
+});


### PR DESCRIPTION
Added `IonGeocoderService` and made it the default for the `Geocoder` widget. Also fixed a minor issue in `PeliasGeocoderService` where a url did not have a trailing `/`.

I added a note to CHANGES, but we'll probably have a more cohesive set of ion related bullets before the next release.

CC @pjcozzi 