### PR TITLE
Fix ion specs to run locally

### DIFF
--- a/Source/Scene/IonImageryProvider.js
+++ b/Source/Scene/IonImageryProvider.js
@@ -179,9 +179,6 @@ define([
 
                 that._tileCredits = endpoint.attributions.map(Credit.getIonCredit);
 
-                return imageryProvider;
-            })
-            .then(function(imageryProvider) {
                 imageryProvider.errorEvent.addEventListener(function(tileProviderError) {
                     //Propagate the errorEvent but set the provider to this instance instead
                     //of the inner instance.

--- a/Specs/Core/IonResourceSpec.js
+++ b/Specs/Core/IonResourceSpec.js
@@ -98,7 +98,7 @@ defineSuite([
         return testNonImageryExternalResource({
             type: '3DTILES',
             externalType: '3DTILES',
-            options: { url: 'https://test.invalid/tileset.json' },
+            options: { url: 'http://test.invalid/tileset.json' },
             attributions: []
         });
     });
@@ -107,7 +107,7 @@ defineSuite([
         return testNonImageryExternalResource({
             type: 'TERRAIN',
             externalType: 'STK_TERRAIN_SERVER',
-            options: { url: 'https://test.invalid/world' },
+            options: { url: 'http://test.invalid/world' },
             attributions: []
         });
     });
@@ -116,7 +116,7 @@ defineSuite([
         return testNonImageryExternalResource({
             type: 'IMAGERY',
             externalType: 'URL_TEMPLATE',
-            url: 'https://test.invalid/world',
+            url: 'http://test.invalid/world',
             attributions: []
         })
         .then(fail)
@@ -209,7 +209,7 @@ defineSuite([
         var externalEndpoint = {
             type: '3DTILES',
             externalType: '3DTILES',
-            options: { url: 'https://test.invalid/tileset.json' },
+            options: { url: 'http://test.invalid/tileset.json' },
             attributions: []
         };
         var options = {};
@@ -233,7 +233,7 @@ defineSuite([
         var externalEndpoint = {
             type: '3DTILES',
             externalType: '3DTILES',
-            options: { url: 'https://test.invalid/tileset.json' },
+            options: { url: 'http://test.invalid/tileset.json' },
             attributions: []
         };
 

--- a/Specs/Scene/IonImageryProviderSpec.js
+++ b/Specs/Scene/IonImageryProviderSpec.js
@@ -39,7 +39,7 @@ defineSuite([
     function createTestProvider(endpointData) {
         endpointData = defaultValue(endpointData, {
             type: 'IMAGERY',
-            url: 'https://test.invalid/layer',
+            url: 'http://test.invalid/layer',
             accessToken: 'not_really_a_refresh_token',
             attributions: []
         });
@@ -74,7 +74,7 @@ defineSuite([
     it('readyPromise rejects with non-imagery asset', function(done) {
         var provider = createTestProvider({
             type: '3DTILES',
-            url: 'https://test.invalid/layer',
+            url: 'http://test.invalid/layer',
             accessToken: 'not_really_a_refresh_token',
             attributions: []
         });
@@ -93,7 +93,7 @@ defineSuite([
         var provider = createTestProvider({
             type: 'IMAGERY',
             externalType: 'TUBELCANE',
-            options: { url: 'https://test.invalid/layer' },
+            options: { url: 'http://test.invalid/layer' },
             attributions: []
         });
 
@@ -181,7 +181,7 @@ defineSuite([
         var serverCredit = { text: 'Text', image: 'http://test.invalid/image', url: 'http://test.invalid/', collapsible: false };
         var provider = createTestProvider({
             type: 'IMAGERY',
-            url: 'https://test.invalid/layer',
+            url: 'http://test.invalid/layer',
             accessToken: 'not_really_a_refresh_token',
             attributions: [serverCredit]
         });
@@ -212,14 +212,14 @@ defineSuite([
         spyOn(Resource._Implementations, 'loadAndExecuteScript').and.callFake(function(url, name, deffered) {
             deffered.resolve({ resourceSets: [{ resources: [{ imageUrl: '', imageUrlSubdomains: [], zoomMax: 0 }] }] });
         });
-        return testExternalImagery('ARCGIS_MAPSERVER', { url: 'https://test.invalid' }, ArcGisMapServerImageryProvider);
+        return testExternalImagery('ARCGIS_MAPSERVER', { url: 'http://test.invalid' }, ArcGisMapServerImageryProvider);
     });
 
     it('createImageryProvider works with BING', function() {
         spyOn(Resource._Implementations, 'loadAndExecuteScript').and.callFake(function(url, name, deffered) {
             deffered.resolve({ resourceSets: [{ resources: [{ imageUrl: '', imageUrlSubdomains: [], zoomMax: 0 }] }] });
         });
-        return testExternalImagery('BING', { url: 'https://test.invalid' }, BingMapsImageryProvider);
+        return testExternalImagery('BING', { url: 'http://test.invalid' }, BingMapsImageryProvider);
     });
 
     it('createImageryProvider works with GOOGLE_EARTH', function() {
@@ -227,11 +227,11 @@ defineSuite([
             deferred.resolve(JSON.stringify({ layers: [{ id: 0, version: '' }] }));
         });
 
-        return testExternalImagery('GOOGLE_EARTH', { url: 'https://test.invalid', channel: 0 }, GoogleEarthEnterpriseMapsProvider);
+        return testExternalImagery('GOOGLE_EARTH', { url: 'http://test.invalid', channel: 0 }, GoogleEarthEnterpriseMapsProvider);
     });
 
     it('createImageryProvider works with MAPBOX', function() {
-        return testExternalImagery('MAPBOX', { url: 'https://test.invalid', mapId: 1 }, MapboxImageryProvider);
+        return testExternalImagery('MAPBOX', { url: 'http://test.invalid', mapId: 1 }, MapboxImageryProvider);
     });
 
     it('createImageryProvider works with SINGLE_TILE', function() {
@@ -239,22 +239,22 @@ defineSuite([
             deferred.resolve({});
         });
 
-        return testExternalImagery('SINGLE_TILE', { url: 'https://test.invalid' }, SingleTileImageryProvider);
+        return testExternalImagery('SINGLE_TILE', { url: 'http://test.invalid' }, SingleTileImageryProvider);
     });
 
     it('createImageryProvider works with TMS', function() {
-        return testExternalImagery('TMS', { url: 'https://test.invalid' }, UrlTemplateImageryProvider);
+        return testExternalImagery('TMS', { url: 'http://test.invalid' }, UrlTemplateImageryProvider);
     });
 
     it('createImageryProvider works with URL_TEMPLATE', function() {
-        return testExternalImagery('URL_TEMPLATE', { url: 'https://test.invalid' }, UrlTemplateImageryProvider);
+        return testExternalImagery('URL_TEMPLATE', { url: 'http://test.invalid' }, UrlTemplateImageryProvider);
     });
 
     it('createImageryProvider works with WMS', function() {
-        return testExternalImagery('WMS', { url: 'https://test.invalid', layers: [] }, WebMapServiceImageryProvider);
+        return testExternalImagery('WMS', { url: 'http://test.invalid', layers: [] }, WebMapServiceImageryProvider);
     });
 
     it('createImageryProvider works with WMTS', function() {
-        return testExternalImagery('WMTS', { url: 'https://test.invalid', layer: '', style: '', tileMatrixSetID: 1 }, WebMapTileServiceImageryProvider);
+        return testExternalImagery('WMTS', { url: 'http://test.invalid', layer: '', style: '', tileMatrixSetID: 1 }, WebMapTileServiceImageryProvider);
     });
 });


### PR DESCRIPTION
Not sure if anyone else was having this problem, but on my Linux machine, a bunch of tests were timing out because calls to fake https/test.invalid urls weren't rejecting fast enough while calls to http ones were. 99% of our tests already used the http ones but these failing ones didn't.

I'm still seeing 2 test failures locally, but I think they are a different issue and will require a different PR.