### PR TITLE
fix ground primitive specs failing intermittently

### DIFF
--- a/Specs/Scene/GroundPrimitiveSpec.js
+++ b/Specs/Scene/GroundPrimitiveSpec.js
@@ -99,6 +99,7 @@ defineSuite([
 
     beforeEach(function() {
         scene.morphTo3D(0);
+        scene.render(); // clear any afterRender commands
 
         rectangle = Rectangle.fromDegrees(-80.0, 20.0, -70.0, 30.0);
 


### PR DESCRIPTION
On my system `Scene/GroundPrimitive renders in 2D when scene3DOnly is false` would fail unless run independently and `Scene/GroundPrimitive does not render when show is false` would fail when run independently, sometimes with different results. This PR fixes the problem by calling an extra `scene.render()` before each spec to clear out anything like `afterRender` events.