### PR TITLE
Add categories to base layer picker

### DIFF
--- a/Source/Widgets/BaseLayerPicker/BaseLayerPicker.css
+++ b/Source/Widgets/BaseLayerPicker/BaseLayerPicker.css
@@ -49,6 +49,17 @@
 }
 
 .cesium-baseLayerPicker-choices {
+    margin-bottom: 5px;
+}
+
+.cesium-baseLayerPicker-categoryTitle {
+    color: #edffff;
+    border-bottom: 1px solid #888;
+    margin-bottom: 4px;
+    font-size: 10pt;
+}
+
+.cesium-baseLayerPicker-choices {
     display: block;
     position: relative;
     top: auto;

--- a/Source/Widgets/BaseLayerPicker/BaseLayerPicker.js
+++ b/Source/Widgets/BaseLayerPicker/BaseLayerPicker.js
@@ -138,10 +138,24 @@ css: { "cesium-baseLayerPicker-dropDown-visible" : dropDownVisible }');
         imageryTitle.innerHTML = 'Imagery';
         dropPanel.appendChild(imageryTitle);
 
+        var imagerySection = document.createElement('div');
+        imagerySection.className = 'cesium-baseLayerPicker-section';
+        imagerySection.setAttribute('data-bind', 'foreach: _imageryProviders');
+        dropPanel.appendChild(imagerySection);
+
+        var imageryCategories = document.createElement('div');
+        imageryCategories.className = 'cesium-baseLayerPicker-category';
+        imagerySection.appendChild(imageryCategories);
+
+        var categoryTitle = document.createElement('div');
+        categoryTitle.className = 'cesium-baseLayerPicker-categoryTitle';
+        categoryTitle.setAttribute('data-bind', 'text: name, visible: $parent._hasCategories');
+        imageryCategories.appendChild(categoryTitle);
+
         var imageryChoices = document.createElement('div');
         imageryChoices.className = 'cesium-baseLayerPicker-choices';
-        imageryChoices.setAttribute('data-bind', 'foreach: imageryProviderViewModels');
-        dropPanel.appendChild(imageryChoices);
+        imageryChoices.setAttribute('data-bind', 'foreach: providers');
+        imageryCategories.appendChild(imageryChoices);
 
         var imageryProvider = document.createElement('div');
         imageryProvider.className = 'cesium-baseLayerPicker-item';

--- a/Source/Widgets/BaseLayerPicker/BaseLayerPickerViewModel.js
+++ b/Source/Widgets/BaseLayerPicker/BaseLayerPickerViewModel.js
@@ -71,6 +71,38 @@ define([
 
         knockout.track(this, ['imageryProviderViewModels', 'terrainProviderViewModels', 'dropDownVisible']);
 
+        var imageryObservable = knockout.getObservable(this, 'imageryProviderViewModels');
+        var imageryProviders = knockout.pureComputed(function() {
+            var providers = imageryObservable();
+            var categories = {};
+            var i;
+            for (i = 0; i < providers.length; i++) {
+                var provider = providers[i];
+                var category = provider.category;
+                if (defined(categories[category])) {
+                    categories[category].push(provider);
+                } else {
+                    categories[category] = [provider];
+                }
+            }
+            var allCategoryNames = Object.keys(categories);
+
+            var result = [];
+            for (i = 0; i < allCategoryNames.length; i++) {
+                var name = allCategoryNames[i];
+                result.push({
+                    name: name,
+                    providers: categories[name]
+                });
+            }
+            return result;
+        });
+        this._imageryProviders = imageryProviders;
+
+        this._hasCategories = knockout.pureComputed(function() {
+            return imageryProviders().length > 1;
+        });
+
         /**
          * Gets the button tooltip.  This property is observable.
          * @type {String}

--- a/Source/Widgets/BaseLayerPicker/ProviderViewModel.js
+++ b/Source/Widgets/BaseLayerPicker/ProviderViewModel.js
@@ -1,10 +1,12 @@
 define([
+        '../../Core/defaultValue',
         '../../Core/defined',
         '../../Core/defineProperties',
         '../../Core/DeveloperError',
         '../../ThirdParty/knockout',
         '../createCommand'
     ], function(
+        defaultValue,
         defined,
         defineProperties,
         DeveloperError,
@@ -22,6 +24,7 @@ define([
      * @param {String} options.name The name of the layer.
      * @param {String} options.tooltip The tooltip to show when the item is moused over.
      * @param {String} options.iconUrl An icon representing the layer.
+     * @param {String} [options.category] A category for the layer.
      * @param {ProviderViewModel~CreationFunction|Command} options.creationFunction A function or Command
      *        that creates one or more providers which will be added to the globe when this item is selected.
      *
@@ -70,6 +73,8 @@ define([
          */
         this.iconUrl = options.iconUrl;
 
+        this._category = defaultValue(options.category, 'Other');
+
         knockout.track(this, ['name', 'tooltip', 'iconUrl']);
     }
 
@@ -78,12 +83,25 @@ define([
          * Gets the Command that creates one or more providers which will be added to
          * the globe when this item is selected.
          * @memberof ProviderViewModel.prototype
-         *
+         * @memberof ProviderViewModel.prototype
          * @type {Command}
+         * @readonly
          */
         creationCommand : {
             get : function() {
                 return this._creationCommand;
+            }
+        },
+
+        /**
+         * Gets the category
+         * @type {String}
+         * @memberof ProviderViewModel.prototype
+         * @readonly
+         */
+        category : {
+            get: function() {
+                return this._category;
             }
         }
     });

--- a/Source/Widgets/BaseLayerPicker/createDefaultImageryProviderViewModels.js
+++ b/Source/Widgets/BaseLayerPicker/createDefaultImageryProviderViewModels.js
@@ -29,6 +29,7 @@ define([
             name : 'Bing Maps Aerial',
             iconUrl : buildModuleUrl('Widgets/Images/ImageryProviders/bingAerial.png'),
             tooltip : 'Bing Maps aerial imagery, provided by Cesium ion',
+            category: 'Cesium ion',
             creationFunction : function() {
                 return createWorldImagery({
                     style : IonWorldImageryStyle.AERIAL
@@ -40,6 +41,7 @@ define([
             name : 'Bing Maps Aerial with Labels',
             iconUrl : buildModuleUrl('Widgets/Images/ImageryProviders/bingAerialLabels.png'),
             tooltip : 'Bing Maps aerial imagery with labels, provided by Cesium ion',
+            category : 'Cesium ion',
             creationFunction : function() {
                 return createWorldImagery({
                     style : IonWorldImageryStyle.AERIAL_WITH_LABELS
@@ -51,6 +53,7 @@ define([
             name : 'Bing Maps Roads',
             iconUrl : buildModuleUrl('Widgets/Images/ImageryProviders/bingRoads.png'),
             tooltip : 'Bing Maps standard road maps, provided by Cesium ion',
+            category : 'Cesium ion',
             creationFunction : function() {
                 return createWorldImagery({
                     style : IonWorldImageryStyle.ROAD
@@ -182,6 +185,7 @@ area washes and organic edges over a paper texture to add warm pop to any map.\n
             name : 'Sentinel-2',
             iconUrl : buildModuleUrl('Widgets/Images/ImageryProviders/sentinel-2.png'),
             tooltip : 'Sentinel-2 cloudless by EOX IT Services GmbH (Contains modified Copernicus Sentinel data 2016 and 2017).',
+            category : 'Cesium ion',
             creationFunction : function() {
                 return new IonImageryProvider({ assetId: 3954 });
             }
@@ -191,6 +195,7 @@ area washes and organic edges over a paper texture to add warm pop to any map.\n
             name : 'Blue Marble',
             iconUrl : buildModuleUrl('Widgets/Images/ImageryProviders/blueMarble.png'),
             tooltip : 'Blue Marble Next Generation July, 2004 imagery from NASA.',
+            category : 'Cesium ion',
             creationFunction : function() {
                 return new IonImageryProvider({ assetId: 3845 });
             }
@@ -200,6 +205,7 @@ area washes and organic edges over a paper texture to add warm pop to any map.\n
             name : 'Earth at night',
             iconUrl : buildModuleUrl('Widgets/Images/ImageryProviders/earthAtNight.png'),
             tooltip : 'The Earth at night, also known as The Black Marble, is a 500 meter resolution global composite imagery layer released by NASA.',
+            category : 'Cesium ion',
             creationFunction : function() {
                 return new IonImageryProvider({ assetId: 3812 });
             }
@@ -209,6 +215,7 @@ area washes and organic edges over a paper texture to add warm pop to any map.\n
             name : 'Natural Earth\u00a0II',
             iconUrl : buildModuleUrl('Widgets/Images/ImageryProviders/naturalEarthII.png'),
             tooltip : 'Natural Earth II, darkened for contrast.\nhttp://www.naturalearthdata.com/',
+            category : 'Cesium ion',
             creationFunction : function() {
                 return createTileMapServiceImageryProvider({
                     url : buildModuleUrl('Assets/Textures/NaturalEarthII')


### PR DESCRIPTION
Added the ability to defined a `category` in `ProviderViewModel`.  Then `BaseLayerPicker` separates each category into a section and uses the category name as the section title.

cc @mramato 