### PR TITLE
Add the .wasm MIME type.

### DIFF
--- a/server.js
+++ b/server.js
@@ -42,6 +42,7 @@
     var mime = express.static.mime;
     mime.define({
         'application/json' : ['czml', 'json', 'geojson', 'topojson'],
+        'application/wasm' : ['wasm'],
         'image/crn' : ['crn'],
         'image/ktx' : ['ktx'],
         'model/gltf+json' : ['gltf'],

--- a/web.config
+++ b/web.config
@@ -26,6 +26,8 @@
             <mimeMap fileExtension=".geojson" mimeType="application/json" />
             <remove fileExtension=".topojson" />
             <mimeMap fileExtension=".topojson" mimeType="application/json" />
+            <remove fileExtension=".wasm" />
+            <mimeMap fileExtension=".wasm" mimeType="application/wasm" />
             <remove fileExtension=".woff" />
             <mimeMap fileExtension=".woff" mimeType="application/font-woff" />
             <remove fileExtension=".woff2" />


### PR DESCRIPTION
This is needed by `Source/ThirdParty/draco_decoder.wasm`.  Specifically, IIS will not serve this file without it, breaking Draco support in IIS.