### PR TITLE
Fix back button in Sandcastle.

### DIFF
--- a/Apps/Sandcastle/CesiumSandcastle.js
+++ b/Apps/Sandcastle/CesiumSandcastle.js
@@ -178,7 +178,9 @@ require({
     var searchTerm = '';
     var searchRegExp;
     var hintTimer;
-    var currentTab = '';
+    var defaultDemo = 'Hello World';
+    var defaultLabel = 'Showcases';
+    var currentTab = defaultLabel;
     var newDemo;
     var demoHtml = '';
     var demoCode = '';
@@ -700,10 +702,10 @@ require({
         queryObject = ioQuery.queryToObject(window.location.search.substring(1));
     }
     if (!defined(queryObject.src)) {
-        queryObject.src = 'Hello World.html';
+        queryObject.src = defaultDemo + '.html';
     }
     if (!defined(queryObject.label)) {
-        queryObject.label = 'Showcases';
+        queryObject.label = defaultLabel;
     }
 
     function loadFromGallery(demo) {
@@ -956,6 +958,18 @@ require({
         window.location.href = getBaseUrl() + '?gist=' + gistId;
     });
 
+    function getPushStateUrl(demo) {
+        var obj = {};
+        if (demo.name !== defaultDemo) {
+            obj.src = demo.name + '.html';
+        }
+        if (currentTab !== defaultLabel) {
+            obj.label = currentTab;
+        }
+        var query = ioQuery.objectToQuery(obj);
+        return query === '' ? query : '?' + query;
+    }
+
     registry.byId('buttonNew').on('click', function() {
         var htmlText = (htmlEditor.getValue()).replace(/\s/g, '');
         var jsText = (jsEditor.getValue()).replace(/\s/g, '');
@@ -964,17 +978,8 @@ require({
             confirmChange = window.confirm('You have unsaved changes. Are you sure you want to navigate away from this demo?');
         }
         if (confirmChange) {
+            window.history.pushState(newDemo, newDemo.name, getPushStateUrl(newDemo));
             loadFromGallery(newDemo).then(function() {
-                var demoSrc = newDemo.name + '.html';
-                var queries = window.location.search.substring(1).split('&');
-                for (var i = 0; i < queries.length; i++) {
-                    var key = queries[i].split('=')[0];
-                    if (key === "src") {
-                        if (demoSrc !== queries[i].split('=')[1].replace('%20', ' ')) {
-                            window.history.pushState(newDemo, newDemo.name, '?src=' + demoSrc + '&label=' + currentTab);
-                        }
-                    }
-                }
                 document.title = newDemo.name + ' - Cesium Sandcastle';
             });
         }
@@ -1068,13 +1073,12 @@ require({
 
     function requestDemo(name) {
         return xhr.get({
-            url : 'gallery/' + name + '.html',
-            handleAs : 'text',
-            error : function(error) {
-                    loadFromGallery(gallery_demos[hello_world_index])
-                        .then(function() {
-                            deferredLoadError = true;
-                        });
+            url: 'gallery/' + name + '.html',
+            handleAs: 'text',
+            error: function(error) {
+                loadFromGallery(gallery_demos[hello_world_index]).then(function() {
+                    deferredLoadError = true;
+                });
             }
         });
     }
@@ -1107,6 +1111,7 @@ require({
             if (defined(queryObject.src)) {
                 if (demo.name === queryObject.src.replace('.html', '')) {
                     loadFromGallery(demo).then(function() {
+                        window.history.replaceState(demo, demo.name, getPushStateUrl(demo));
                         if (defined(queryObject.gist)) {
                             document.title = 'Gist Import - Cesium Sandcastle';
                         } else {
@@ -1207,13 +1212,9 @@ require({
                 if (confirmChange) {
                     delete queryObject.gist;
                     delete queryObject.code;
-                    history.replaceState(null, document.title, window.location.pathname + window.location.search);
 
+                    window.history.pushState(demo, demo.name, getPushStateUrl(demo));
                     loadFromGallery(demo).then(function() {
-                        var demoSrc = demo.name + '.html';
-                        if (demoSrc !== window.location.search.substring(1)) {
-                            window.history.pushState(demo, demo.name, '?src=' + demoSrc + '&label=' + currentTab);
-                        }
                         document.title = demo.name + ' - Cesium Sandcastle';
                     });
                 }


### PR DESCRIPTION
We store information in history state objects about the loaded demo.

Navigating to new demos calls pushState, and a fresh load
stores the demo specified via URL using replaceState.

Fixes #6509