### PR TITLE
Remove empty directories from release zip

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -913,7 +913,7 @@ function combineJavaScript(options) {
             everythingElse.push('!**/*.css');
         }
 
-        stream = gulp.src(everythingElse).pipe(gulp.dest(outputDirectory));
+        stream = gulp.src(everythingElse, { nodir: true }).pipe(gulp.dest(outputDirectory));
         promises.push(streamToPromise(stream));
 
         return Promise.all(promises).then(function() {
@@ -1260,7 +1260,8 @@ function buildCesiumViewer() {
                       'Build/Cesium/Widgets/**',
                       '!Build/Cesium/Widgets/**/*.css'],
                 {
-                    base : 'Build/Cesium'
+                    base : 'Build/Cesium',
+                    nodir : true
                 }),
 
             gulp.src(['Build/Cesium/Widgets/InfoBox/InfoBoxDescription.css'], {


### PR DESCRIPTION
This was a regression from #6383, when nodir was removed from globby but I accidentally removed it from direct `gulp.src` calls as well.

Reported on the forum: https://groups.google.com/d/msg/cesium-dev/709bHz4P_nQ/JMauc6bjAwAJ