### PR TITLE
Check projection instead of tiling scheme

### DIFF
--- a/Source/Core/HeightmapTerrainData.js
+++ b/Source/Core/HeightmapTerrainData.js
@@ -4,7 +4,7 @@ define([
         './defined',
         './defineProperties',
         './DeveloperError',
-        './GeographicTilingScheme',
+        './GeographicProjection',
         './HeightmapTessellator',
         './Math',
         './Rectangle',
@@ -18,7 +18,7 @@ define([
         defined,
         defineProperties,
         DeveloperError,
-        GeographicTilingScheme,
+        GeographicProjection,
         HeightmapTessellator,
         CesiumMath,
         Rectangle,
@@ -222,7 +222,7 @@ define([
             relativeToCenter : center,
             ellipsoid : ellipsoid,
             skirtHeight : this._skirtHeight,
-            isGeographic : tilingScheme instanceof GeographicTilingScheme,
+            isGeographic : tilingScheme.projection instanceof GeographicProjection,
             exaggeration : exaggeration
         });
 

--- a/Source/Scene/ArcGisMapServerImageryProvider.js
+++ b/Source/Scene/ArcGisMapServerImageryProvider.js
@@ -8,6 +8,7 @@ define([
         '../Core/defineProperties',
         '../Core/DeveloperError',
         '../Core/Event',
+        '../Core/GeographicProjection',
         '../Core/GeographicTilingScheme',
         '../Core/Math',
         '../Core/Rectangle',
@@ -30,6 +31,7 @@ define([
         defineProperties,
         DeveloperError,
         Event,
+        GeographicProjection,
         GeographicTilingScheme,
         CesiumMath,
         Rectangle,
@@ -259,7 +261,7 @@ define([
                 f: 'image'
             };
 
-            if (imageryProvider._tilingScheme instanceof GeographicTilingScheme) {
+            if (imageryProvider._tilingScheme.projection instanceof GeographicProjection) {
                 query.bboxSR = 4326;
                 query.imageSR = 4326;
             } else {
@@ -622,7 +624,7 @@ define([
         var horizontal;
         var vertical;
         var sr;
-        if (this._tilingScheme instanceof GeographicTilingScheme) {
+        if (this._tilingScheme.projection instanceof GeographicProjection) {
             horizontal = CesiumMath.toDegrees(longitude);
             vertical = CesiumMath.toDegrees(latitude);
             sr = '4326';

--- a/Source/Scene/ImageryLayer.js
+++ b/Source/Scene/ImageryLayer.js
@@ -7,6 +7,7 @@ define([
         '../Core/destroyObject',
         '../Core/DeveloperError',
         '../Core/FeatureDetection',
+        '../Core/GeographicProjection',
         '../Core/GeographicTilingScheme',
         '../Core/IndexDatatype',
         '../Core/Math',
@@ -48,6 +49,7 @@ define([
         destroyObject,
         DeveloperError,
         FeatureDetection,
+        GeographicProjection,
         GeographicTilingScheme,
         IndexDatatype,
         CesiumMath,
@@ -480,7 +482,7 @@ define([
         // Use Web Mercator for our texture coordinate computations if this imagery layer uses
         // that projection and the terrain tile falls entirely inside the valid bounds of the
         // projection.
-        var useWebMercatorT = imageryProvider.tilingScheme instanceof WebMercatorTilingScheme &&
+        var useWebMercatorT = imageryProvider.tilingScheme.projection instanceof WebMercatorProjection &&
                               tile.rectangle.north < WebMercatorProjection.MaximumLatitude &&
                               tile.rectangle.south > -WebMercatorProjection.MaximumLatitude;
 
@@ -847,7 +849,7 @@ define([
             });
         }
 
-        if (imageryProvider.tilingScheme instanceof WebMercatorTilingScheme) {
+        if (imageryProvider.tilingScheme.projection instanceof WebMercatorProjection) {
             imagery.textureWebMercator = texture;
         } else {
             imagery.texture = texture;
@@ -932,7 +934,7 @@ define([
         // avoids precision problems in the reprojection transformation while making
         // no noticeable difference in the georeferencing of the image.
         if (needGeographicProjection &&
-            !(this._imageryProvider.tilingScheme instanceof GeographicTilingScheme) &&
+            !(this._imageryProvider.tilingScheme.projection instanceof GeographicProjection) &&
             rectangle.width / texture.width > 1e-5) {
                 var that = this;
                 imagery.addReference();
@@ -1210,7 +1212,7 @@ define([
         var imageryProvider = layer._imageryProvider;
         var tilingScheme = imageryProvider.tilingScheme;
         var ellipsoid = tilingScheme.ellipsoid;
-        var latitudeFactor = !(layer._imageryProvider.tilingScheme instanceof GeographicTilingScheme) ? Math.cos(latitudeClosestToEquator) : 1.0;
+        var latitudeFactor = !(layer._imageryProvider.tilingScheme.projection instanceof GeographicProjection) ? Math.cos(latitudeClosestToEquator) : 1.0;
         var tilingSchemeRectangle = tilingScheme.rectangle;
         var levelZeroMaximumTexelSpacing = ellipsoid.maximumRadius * tilingSchemeRectangle.width * latitudeFactor / (imageryProvider.tileWidth * tilingScheme.getNumberOfXTilesAtLevel(0));
 

--- a/Source/Scene/UrlTemplateImageryProvider.js
+++ b/Source/Scene/UrlTemplateImageryProvider.js
@@ -9,7 +9,7 @@ define([
         '../Core/defineProperties',
         '../Core/DeveloperError',
         '../Core/Event',
-        '../Core/GeographicTilingScheme',
+        '../Core/GeographicProjection',
         '../Core/isArray',
         '../Core/Math',
         '../Core/Rectangle',
@@ -28,7 +28,7 @@ define([
         defineProperties,
         DeveloperError,
         Event,
-        GeographicTilingScheme,
+        GeographicProjection,
         isArray,
         CesiumMath,
         Rectangle,
@@ -961,7 +961,7 @@ define([
             return;
         }
 
-        if (imageryProvider.tilingScheme instanceof GeographicTilingScheme) {
+        if (imageryProvider.tilingScheme.projection instanceof GeographicProjection) {
             longitudeLatitudeProjectedScratch.x = CesiumMath.toDegrees(longitude);
             longitudeLatitudeProjectedScratch.y = CesiumMath.toDegrees(latitude);
         } else {

--- a/Source/Scene/WebMapServiceImageryProvider.js
+++ b/Source/Scene/WebMapServiceImageryProvider.js
@@ -6,7 +6,7 @@ define([
         '../Core/freezeObject',
         '../Core/GeographicTilingScheme',
         '../Core/Resource',
-        '../Core/WebMercatorTilingScheme',
+        '../Core/WebMercatorProjection',
         './GetFeatureInfoFormat',
         './UrlTemplateImageryProvider'
     ], function(
@@ -17,7 +17,7 @@ define([
         freezeObject,
         GeographicTilingScheme,
         Resource,
-        WebMercatorTilingScheme,
+        WebMercatorProjection,
         GetFeatureInfoFormat,
         UrlTemplateImageryProvider) {
     'use strict';
@@ -118,10 +118,10 @@ define([
             // Use CRS with 1.3.0 and going forward.
             // For GeographicTilingScheme, use CRS:84 vice EPSG:4326 to specify lon, lat (x, y) ordering for
             // bbox requests.
-            parameters.crs = defaultValue(options.crs, options.tilingScheme instanceof WebMercatorTilingScheme ? 'EPSG:3857' : 'CRS:84');
+            parameters.crs = defaultValue(options.crs, options.tilingScheme && options.tilingScheme.projection instanceof WebMercatorProjection ? 'EPSG:3857' : 'CRS:84');
         } else {
             // SRS for WMS 1.1.0 or 1.1.1.
-            parameters.srs = defaultValue(options.srs, options.tilingScheme instanceof WebMercatorTilingScheme ? 'EPSG:3857' : 'EPSG:4326');
+            parameters.srs = defaultValue(options.srs, options.tilingScheme && options.tilingScheme.projection instanceof WebMercatorProjection ? 'EPSG:3857' : 'EPSG:4326');
         }
 
         resource.setQueryParameters(parameters, true);

--- a/Source/Scene/createTileMapServiceImageryProvider.js
+++ b/Source/Scene/createTileMapServiceImageryProvider.js
@@ -4,6 +4,7 @@ define([
         '../Core/defaultValue',
         '../Core/defined',
         '../Core/DeveloperError',
+        '../Core/GeographicProjection',
         '../Core/GeographicTilingScheme',
         '../Core/Rectangle',
         '../Core/Resource',
@@ -18,6 +19,7 @@ define([
         defaultValue,
         defined,
         DeveloperError,
+        GeographicProjection,
         GeographicTilingScheme,
         Rectangle,
         Resource,
@@ -198,7 +200,7 @@ define([
                 // 'global-mercator' and 'global-geodetic' profiles. In the gdal2Tiles case, X and Y are always in
                 // geodetic degrees.
                 var isGdal2tiles = tilingSchemeName === 'geodetic' || tilingSchemeName === 'mercator';
-                if (tilingScheme instanceof GeographicTilingScheme || isGdal2tiles) {
+                if (tilingScheme.projection instanceof GeographicProjection || isGdal2tiles) {
                     sw = Cartographic.fromDegrees(swXY.x, swXY.y);
                     ne = Cartographic.fromDegrees(neXY.x, neXY.y);
                 } else {


### PR DESCRIPTION
This allows custom tiling scheme classes by actually checking the projection in the tiling scheme rather than the tiling scheme class itself.

The use case was outlined in the forum [here](https://groups.google.com/forum/#!topic/cesium-dev/a8hNaDBnAEw). However, I went ahead and changed all the places that similar checks were being done, rather than just the one I mentioned in the forum.