### PR TITLE
Draco fix for #6523

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -54,6 +54,7 @@ Change Log
 * Fixed a bug causing Cesium 3D Tilesets to not clip properly when tiles were unloaded and reloaded. [#6484](https://github.com/AnalyticalGraphicsInc/cesium/issues/6484)
 * Improved rendering of glTF models that don't contain normals with a temporary unlit shader workaround. [#6501](https://github.com/AnalyticalGraphicsInc/cesium/pull/6501)
 * Fixed rendering of glTF models with emissive-only materials. [#6501](https://github.com/AnalyticalGraphicsInc/cesium/pull/6501)
+* Fixed a bug in shader modification for glTF 1.0 quantized attributes and Draco quantized attributes. [#6523](https://github.com/AnalyticalGraphicsInc/cesium/pull/6523)
 
 ### 1.44 - 2018-04-02
 

--- a/Source/Scene/ModelUtility.js
+++ b/Source/Scene/ModelUtility.js
@@ -167,9 +167,18 @@ define([
         }
     };
 
+    function regexIndexOf(text, regex, i) {
+        var indexInSuffix = text.slice(i).search(regex);
+        return indexInSuffix < 0 ? indexInSuffix : indexInSuffix + i;
+    }
+
     function replaceAllButFirstInString(string, find, replace) {
-        var index = string.indexOf(find);
-        return string.replace(new RegExp(find, 'g'), function(match, offset) {
+        // Limit search to strings that are not a subset of other tokens.
+        find += '(?![a-zA-Z_$])';
+        find = new RegExp(find, 'g');
+
+        var index = regexIndexOf(string, find, 0);
+        return string.replace(find, function(match, offset) {
             return index === offset ? match : replace;
         });
     }

--- a/Source/Scene/ModelUtility.js
+++ b/Source/Scene/ModelUtility.js
@@ -167,17 +167,12 @@ define([
         }
     };
 
-    function regexIndexOf(text, regex, i) {
-        var indexInSuffix = text.slice(i).search(regex);
-        return indexInSuffix < 0 ? indexInSuffix : indexInSuffix + i;
-    }
-
     function replaceAllButFirstInString(string, find, replace) {
         // Limit search to strings that are not a subset of other tokens.
-        find += '(?![a-zA-Z_$])';
+        find += '(?!\\w)';
         find = new RegExp(find, 'g');
 
-        var index = regexIndexOf(string, find, 0);
+        var index = string.search(find);
         return string.replace(find, function(match, offset) {
             return index === offset ? match : replace;
         });


### PR DESCRIPTION
Fixes #6523

`replaceAllButFirstInString` was replacing the variable name everywhere, even in subsets of other variables, (ex. `a_position` was replaced in both `a_position` and `a_position_1`).

