### PR TITLE
Fix geometry extrusion epsilon check

### DIFF
--- a/Source/Core/CorridorGeometry.js
+++ b/Source/Core/CorridorGeometry.js
@@ -975,7 +975,7 @@ define([
 
         var height = corridorGeometry._height;
         var extrudedHeight = corridorGeometry._extrudedHeight;
-        var extrude = !CesiumMath.equalsEpsilon(height, extrudedHeight, CesiumMath.EPSILON2);
+        var extrude = !CesiumMath.equalsEpsilon(height, extrudedHeight, 0, CesiumMath.EPSILON2);
 
         var vertexFormat = corridorGeometry._vertexFormat;
         var params = {

--- a/Source/Core/CorridorOutlineGeometry.js
+++ b/Source/Core/CorridorOutlineGeometry.js
@@ -480,7 +480,7 @@ define([
 
         var height = corridorOutlineGeometry._height;
         var extrudedHeight = corridorOutlineGeometry._extrudedHeight;
-        var extrude = !CesiumMath.equalsEpsilon(height, extrudedHeight, CesiumMath.EPSILON2);
+        var extrude = !CesiumMath.equalsEpsilon(height, extrudedHeight, 0, CesiumMath.EPSILON2);
 
         var params = {
             ellipsoid : ellipsoid,

--- a/Source/Core/EllipseGeometry.js
+++ b/Source/Core/EllipseGeometry.js
@@ -897,7 +897,7 @@ define([
 
         var height = ellipseGeometry._height;
         var extrudedHeight = ellipseGeometry._extrudedHeight;
-        var extrude = !CesiumMath.equalsEpsilon(height, extrudedHeight, CesiumMath.EPSILON2);
+        var extrude = !CesiumMath.equalsEpsilon(height, extrudedHeight, 0, CesiumMath.EPSILON2);
 
         ellipseGeometry._center = ellipseGeometry._ellipsoid.scaleToGeodeticSurface(ellipseGeometry._center, ellipseGeometry._center);
         var options = {

--- a/Source/Core/EllipseOutlineGeometry.js
+++ b/Source/Core/EllipseOutlineGeometry.js
@@ -323,7 +323,7 @@ define([
 
         var height = ellipseGeometry._height;
         var extrudedHeight = ellipseGeometry._extrudedHeight;
-        var extrude = !CesiumMath.equalsEpsilon(height, extrudedHeight, CesiumMath.EPSILON2);
+        var extrude = !CesiumMath.equalsEpsilon(height, extrudedHeight, 0, CesiumMath.EPSILON2);
 
         ellipseGeometry._center = ellipseGeometry._ellipsoid.scaleToGeodeticSurface(ellipseGeometry._center, ellipseGeometry._center);
         var options = {

--- a/Source/Core/PolygonGeometry.js
+++ b/Source/Core/PolygonGeometry.js
@@ -800,7 +800,7 @@ define([
 
         var height = polygonGeometry._height;
         var extrudedHeight = polygonGeometry._extrudedHeight;
-        var extrude = polygonGeometry._perPositionHeightExtrude || !CesiumMath.equalsEpsilon(height, extrudedHeight, CesiumMath.EPSILON2);
+        var extrude = polygonGeometry._perPositionHeightExtrude || !CesiumMath.equalsEpsilon(height, extrudedHeight, 0, CesiumMath.EPSILON2);
 
         var options = {
             perPositionHeight: perPositionHeight,

--- a/Source/Core/PolygonOutlineGeometry.js
+++ b/Source/Core/PolygonOutlineGeometry.js
@@ -509,7 +509,7 @@ define([
 
         var height = polygonGeometry._height;
         var extrudedHeight = polygonGeometry._extrudedHeight;
-        var extrude = polygonGeometry._perPositionHeightExtrude || !CesiumMath.equalsEpsilon(height, extrudedHeight, CesiumMath.EPSILON2);
+        var extrude = polygonGeometry._perPositionHeightExtrude || !CesiumMath.equalsEpsilon(height, extrudedHeight, 0, CesiumMath.EPSILON2);
 
         if (extrude) {
             for (i = 0; i < polygons.length; i++) {

--- a/Source/Core/RectangleGeometry.js
+++ b/Source/Core/RectangleGeometry.js
@@ -800,7 +800,7 @@ define([
 
         var surfaceHeight = rectangleGeometry._surfaceHeight;
         var extrudedHeight = rectangleGeometry._extrudedHeight;
-        var extrude = !CesiumMath.equalsEpsilon(surfaceHeight, extrudedHeight, CesiumMath.EPSILON2);
+        var extrude = !CesiumMath.equalsEpsilon(surfaceHeight, extrudedHeight, 0, CesiumMath.EPSILON2);
 
         options.lonScalar = 1.0 / rectangleGeometry._rectangle.width;
         options.latScalar = 1.0 / rectangleGeometry._rectangle.height;

--- a/Source/Core/RectangleOutlineGeometry.js
+++ b/Source/Core/RectangleOutlineGeometry.js
@@ -340,7 +340,7 @@ define([
 
         var surfaceHeight = rectangleGeometry._surfaceHeight;
         var extrudedHeight = rectangleGeometry._extrudedHeight;
-        var extrude = !CesiumMath.equalsEpsilon(surfaceHeight, extrudedHeight, CesiumMath.EPSILON2);
+        var extrude = !CesiumMath.equalsEpsilon(surfaceHeight, extrudedHeight, 0, CesiumMath.EPSILON2);
 
         if (extrude) {
             geometry = constructExtrudedRectangle(options);


### PR DESCRIPTION
Fixes #6528

Passing in `0` for the relative epsilon check forces it to only check if the values are absolutely `EPSILON2` different

Side note: I find it confusing that `CesiumMath.equalsEpsilon` defaults to using a relative epsilon instead of an absolute.  But I guess we probably want that to be the default for Cartesian values and that's what most of our epsilon checks are for.