### PR TITLE
Fix shader compilation error in Edge

### DIFF
--- a/Source/Scene/EllipsoidPrimitive.js
+++ b/Source/Scene/EllipsoidPrimitive.js
@@ -378,7 +378,7 @@ define([
                 fs.defines.push('WRITE_DEPTH');
             }
             if (this._useLogDepth) {
-                vs.defines.push('LOG_DEPTH');
+                vs.defines.push('LOG_DEPTH', 'DISABLE_GL_POSITION_LOG_DEPTH');
                 fs.defines.push('LOG_DEPTH');
                 fs.sources.push(logDepthExtension);
             }

--- a/Source/Shaders/EllipsoidVS.glsl
+++ b/Source/Shaders/EllipsoidVS.glsl
@@ -23,4 +23,6 @@ void main()
     // artifacts since some fragments can be alpha blended twice.  This is solved by only rendering
     // the ellipsoid in the closest frustum to the viewer.
     gl_Position.z = clamp(gl_Position.z, czm_depthRange.near, czm_depthRange.far);
+
+    czm_vertexLogDepth();
 }


### PR DESCRIPTION
Fix shader in Edge where a varying wasn't being removed when unused. Fixes #6535.