### PR TITLE
Fixed TileAvailability to not have all root tiles

### DIFF
--- a/Source/Core/TileAvailability.js
+++ b/Source/Core/TileAvailability.js
@@ -106,11 +106,9 @@ define([
             }
         }
 
-        //>>includeStart('debug', pragmas.debug);
         if (!defined(node)) {
-            throw new DeveloperError('The specified position does not exist in any root node of the tiling scheme.');
+            return -1;
         }
-        //>>includeEnd('debug');
 
         return findMaxLevelFromNode(undefined, node, position);
     };

--- a/Source/Core/TileAvailability.js
+++ b/Source/Core/TileAvailability.js
@@ -28,14 +28,21 @@ define([
         this._maximumLevel = maximumLevel;
 
         this._rootNodes = [];
-        for (var y = 0; y < tilingScheme.getNumberOfYTilesAtLevel(); ++y) {
-            for (var x = 0; x < tilingScheme.getNumberOfXTilesAtLevel(); ++x) {
-                this._rootNodes.push(new QuadtreeNode(tilingScheme, undefined, 0, x, y));
-            }
-        }
     }
 
     var rectangleScratch = new Rectangle();
+
+    function findNode(level, x, y, nodes) {
+        var count = nodes.length;
+        for (var i = 0; i < count; ++i) {
+            var node = nodes[i];
+            if (node.x === x && node.y === y && node.level === level) {
+                return true;
+            }
+        }
+
+        return false;
+    }
 
     /**
      * Marks a rectangular range of tiles in a particular level as being available.  For best performance,
@@ -50,6 +57,17 @@ define([
     TileAvailability.prototype.addAvailableTileRange = function(level, startX, startY, endX, endY) {
         var tilingScheme = this._tilingScheme;
 
+        var rootNodes = this._rootNodes;
+        if (level === 0) {
+            for (var y = startY; y <= endY; ++y) {
+                for (var x = startX; x <= endX; ++x) {
+                    if (!findNode(level, x, y, rootNodes)) {
+                        rootNodes.push(new QuadtreeNode(tilingScheme, undefined, 0, x, y));
+                    }
+                }
+            }
+        }
+
         tilingScheme.tileXYToRectangle(startX, startY, level, rectangleScratch);
         var west = rectangleScratch.west;
         var north = rectangleScratch.north;
@@ -60,8 +78,8 @@ define([
 
         var rectangleWithLevel = new RectangleWithLevel(level, west, south, east, north);
 
-        for (var i = 0; i < this._rootNodes.length; ++i) {
-            var rootNode = this._rootNodes[i];
+        for (var i = 0; i < rootNodes.length; ++i) {
+            var rootNode = rootNodes[i];
             if (rectanglesOverlap(rootNode.extent, rectangleWithLevel)) {
                 putRectangleInQuadtree(this._maximumLevel, rootNode, rectangleWithLevel);
             }

--- a/Specs/Core/TileAvailabilitySpec.js
+++ b/Specs/Core/TileAvailabilitySpec.js
@@ -15,34 +15,38 @@ defineSuite([
     var webMercator = new WebMercatorTilingScheme();
     var geographic = new GeographicTilingScheme();
 
+    function createAvailability(tilingScheme, maxLevel) {
+        var availability = new TileAvailability(tilingScheme, 15);
+        availability.addAvailableTileRange(0, 0, 0, tilingScheme.getNumberOfXTilesAtLevel(), tilingScheme.getNumberOfYTilesAtLevel());
+        return availability;
+    }
+
     describe('computeMaximumLevelAtPosition', function() {
-        it('throws if given a position outside the tiling scheme', function() {
-            var availability = new TileAvailability(webMercator, 15);
-            expect(function() {
-                availability.computeMaximumLevelAtPosition(Cartographic.fromDegrees(25.0, 88.0));
-            }).toThrowDeveloperError();
+        it('returns -1 if  position outside the tiling scheme', function() {
+            var availability = createAvailability(webMercator, 15);
+            expect(availability.computeMaximumLevelAtPosition(Cartographic.fromDegrees(25.0, 88.0))).toBe(-1);
         });
 
         it('returns 0 if there are no rectangles', function() {
-            var availability = new TileAvailability(geographic, 15);
+            var availability = createAvailability(geographic, 15);
             expect(availability.computeMaximumLevelAtPosition(Cartographic.fromDegrees(25.0, 88.0))).toBe(0);
         });
 
         it('returns the higher level when on a boundary at level 0', function() {
-            var availability = new TileAvailability(geographic, 15);
+            var availability = createAvailability(geographic, 15);
             availability.addAvailableTileRange(0, 0, 0, 0, 0);
             availability.addAvailableTileRange(1, 1, 0, 1, 0);
             expect(availability.computeMaximumLevelAtPosition(Cartographic.fromRadians(0.0, 0.0))).toBe(1);
 
             // Make sure it isn't dependent on the order we add the rectangles.
-            availability = new TileAvailability(geographic, 15);
+            availability = createAvailability(geographic, 15);
             availability.addAvailableTileRange(1, 1, 0, 1, 0);
             availability.addAvailableTileRange(0, 0, 0, 0, 0);
             expect(availability.computeMaximumLevelAtPosition(Cartographic.fromRadians(0.0, 0.0))).toBe(1);
         });
 
         it('returns the higher level when on a boundary at level 1', function() {
-            var availability = new TileAvailability(geographic, 15);
+            var availability = createAvailability(geographic, 15);
             availability.addAvailableTileRange(0, 0, 0, 1, 0);
             availability.addAvailableTileRange(1, 1, 1, 1, 1);
             expect(availability.computeMaximumLevelAtPosition(Cartographic.fromRadians(-Math.PI / 2.0, 0.0))).toBe(1);
@@ -51,19 +55,19 @@ defineSuite([
 
     describe('computeBestAvailableLevelOverRectangle', function() {
         it('returns 0 if there are no rectangles', function() {
-            var availability = new TileAvailability(geographic, 15);
+            var availability = createAvailability(geographic, 15);
             expect(availability.computeBestAvailableLevelOverRectangle(Rectangle.fromDegrees(1.0, 2.0, 3.0, 4.0))).toBe(0);
         });
 
         it('reports the correct level when entirely inside a worldwide rectangle of that level', function() {
-            var availability = new TileAvailability(geographic, 15);
+            var availability = createAvailability(geographic, 15);
             availability.addAvailableTileRange(5, 0, 0, geographic.getNumberOfXTilesAtLevel(5) - 1, geographic.getNumberOfYTilesAtLevel(5) - 1);
             availability.addAvailableTileRange(6, 7, 8, 9, 10);
             expect(availability.computeBestAvailableLevelOverRectangle(Rectangle.fromDegrees(1.0, 2.0, 3.0, 4.0))).toBe(5);
         });
 
         it('reports the correct level when entirely inside a smaller rectangle of that level', function() {
-            var availability = new TileAvailability(geographic, 15);
+            var availability = createAvailability(geographic, 15);
             availability.addAvailableTileRange(5, 0, 0, geographic.getNumberOfXTilesAtLevel(5) - 1, geographic.getNumberOfYTilesAtLevel(5) - 1);
             availability.addAvailableTileRange(6, 7, 8, 9, 10);
             var rectangle = geographic.tileXYToRectangle(8, 9, 6);
@@ -71,7 +75,7 @@ defineSuite([
         });
 
         it ('reports the correct level when partially overlapping a smaller rectangle', function() {
-            var availability = new TileAvailability(geographic, 15);
+            var availability = createAvailability(geographic, 15);
             availability.addAvailableTileRange(5, 0, 0, geographic.getNumberOfXTilesAtLevel(5) - 1, geographic.getNumberOfYTilesAtLevel(5) - 1);
             availability.addAvailableTileRange(6, 7, 8, 7, 8);
             var rectangle = geographic.tileXYToRectangle(7, 8, 6);
@@ -83,7 +87,7 @@ defineSuite([
         });
 
         it('works with a rectangle crossing 180 degrees longitude', function() {
-            var availability = new TileAvailability(geographic, 15);
+            var availability = createAvailability(geographic, 15);
             availability.addAvailableTileRange(5, 0, 0, geographic.getNumberOfXTilesAtLevel(5) - 1, geographic.getNumberOfYTilesAtLevel(5) - 1);
             availability.addAvailableTileRange(6, 0, 0, 10, geographic.getNumberOfYTilesAtLevel(6) - 1);
             availability.addAvailableTileRange(6, geographic.getNumberOfXTilesAtLevel(6) - 11, 0, geographic.getNumberOfXTilesAtLevel(6) - 1, geographic.getNumberOfYTilesAtLevel(6) - 1);
@@ -95,7 +99,7 @@ defineSuite([
         });
 
         it('works when four rectangles combine to cover the area', function() {
-            var availability = new TileAvailability(geographic, 15);
+            var availability = createAvailability(geographic, 15);
             availability.addAvailableTileRange(5, 0, 0, geographic.getNumberOfXTilesAtLevel(5) - 1, geographic.getNumberOfYTilesAtLevel(5) - 1);
             availability.addAvailableTileRange(6, 0, 2, 1, 3);
             availability.addAvailableTileRange(6, 2, 0, 3, 1);
@@ -108,13 +112,13 @@ defineSuite([
 
     describe('addAvailableTileRange', function() {
         it('keeps availability ranges sorted by rectangle', function() {
-            var availability = new TileAvailability(geographic, 15);
+            var availability = createAvailability(geographic, 15);
             availability.addAvailableTileRange(0, 0, 0, 1, 0);
             availability.addAvailableTileRange(1, 0, 0, 3, 1);
             expect(availability.computeMaximumLevelAtPosition(new Cartographic(-Math.PI / 2.0, 0.0))).toBe(1);
 
             // We should get the same result adding them in the opposite order.
-            availability = new TileAvailability(geographic, 15);
+            availability = createAvailability(geographic, 15);
             availability.addAvailableTileRange(1, 0, 0, 3, 1);
             availability.addAvailableTileRange(0, 0, 0, 1, 0);
             expect(availability.computeMaximumLevelAtPosition(new Cartographic(-Math.PI / 2.0, 0.0))).toBe(1);


### PR DESCRIPTION
We automatically added all root tiles in tiling scheme. With cutout terrain we don't always want this because if a tileset only had half the globe at level 0, it would never fall back to the parent.