### PR TITLE
Update New York CityGML 3D Tileset

### DIFF
--- a/Apps/Sandcastle/gallery/3D Tiles Feature Picking.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Feature Picking.html
@@ -40,7 +40,7 @@ viewer.scene.camera.setView({
 });
 
 // Load the NYC buildings tileset
-var tileset = new Cesium.Cesium3DTileset({ url: Cesium.IonResource.fromAssetId(3839) });
+var tileset = new Cesium.Cesium3DTileset({ url: Cesium.IonResource.fromAssetId(4258) });
 viewer.scene.primitives.add(tileset);
 
 // HTML overlay for showing feature name on mouseover
@@ -145,6 +145,9 @@ viewer.screenSpaceEventHandler.setInputAction(function onLeftClick(movement) {
                                  '<tr><th>BIN</th><td>' + pickedFeature.getProperty('BIN') + '</td></tr>' +
                                  '<tr><th>DOITT ID</th><td>' + pickedFeature.getProperty('DOITT_ID') + '</td></tr>' +
                                  '<tr><th>SOURCE ID</th><td>' + pickedFeature.getProperty('SOURCE_ID') + '</td></tr>' +
+                                 '<tr><th>Longitude</th><td>' + pickedFeature.getProperty('longitude') + '</td></tr>' +
+                                 '<tr><th>Latitude</th><td>' + pickedFeature.getProperty('latitude') + '</td></tr>' +
+                                 '<tr><th>Height</th><td>' + pickedFeature.getProperty('height') + '</td></tr>' +
                                  '</tbody></table>';
 }, Cesium.ScreenSpaceEventType.LEFT_CLICK);
 //Sandcastle_End

--- a/Apps/Sandcastle/gallery/3D Tiles Feature Picking.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Feature Picking.html
@@ -28,7 +28,11 @@ function startup(Cesium) {
 //Sandcastle_Begin
 // A simple demo of 3D Tiles feature picking with hover and select behavior
 // Building data courtesy of NYC OpenData portal: http://www1.nyc.gov/site/doitt/initiatives/3d-building.page
-var viewer = new Cesium.Viewer('cesiumContainer');
+var viewer = new Cesium.Viewer('cesiumContainer', {
+    terrainProvider: Cesium.createWorldTerrain()
+});
+
+viewer.scene.globe.depthTestAgainstTerrain = true;
 
 // Set the initial camera view to look at Manhattan
 var initialPosition = Cesium.Cartesian3.fromDegrees(-74.01881302800248, 40.69114333714821, 753);
@@ -148,6 +152,7 @@ viewer.screenSpaceEventHandler.setInputAction(function onLeftClick(movement) {
                                  '<tr><th>Longitude</th><td>' + pickedFeature.getProperty('longitude') + '</td></tr>' +
                                  '<tr><th>Latitude</th><td>' + pickedFeature.getProperty('latitude') + '</td></tr>' +
                                  '<tr><th>Height</th><td>' + pickedFeature.getProperty('height') + '</td></tr>' +
+                                 '<tr><th>Terrain Height (Ellipsoid)</th><td>' + pickedFeature.getProperty('TerrainHeight') + '</td></tr>' +
                                  '</tbody></table>';
 }, Cesium.ScreenSpaceEventType.LEFT_CLICK);
 //Sandcastle_End

--- a/Apps/Sandcastle/gallery/3D Tiles Feature Picking.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Feature Picking.html
@@ -44,7 +44,7 @@ viewer.scene.camera.setView({
 });
 
 // Load the NYC buildings tileset
-var tileset = new Cesium.Cesium3DTileset({ url: Cesium.IonResource.fromAssetId(4258) });
+var tileset = new Cesium.Cesium3DTileset({ url: Cesium.IonResource.fromAssetId(4693) });
 viewer.scene.primitives.add(tileset);
 
 // HTML overlay for showing feature name on mouseover

--- a/Apps/Sandcastle/gallery/3D Tiles Feature Styling.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Feature Styling.html
@@ -46,7 +46,7 @@ viewer.scene.camera.setView({
 });
 
 // Load the NYC buildings tileset.
-var tileset = new Cesium.Cesium3DTileset({ url: Cesium.IonResource.fromAssetId(4258) });
+var tileset = new Cesium.Cesium3DTileset({ url: Cesium.IonResource.fromAssetId(4693) });
 viewer.scene.primitives.add(tileset);
 
 // Color buildings based on their height.
@@ -54,13 +54,13 @@ function colorByHeight() {
     tileset.style = new Cesium.Cesium3DTileStyle({
         color: {
             conditions: [
-                ["Number(${height}) >= 300", "rgba(45, 0, 75, 0.5)"],
-                ["Number(${height}) >= 200", "rgb(102, 71, 151)"],
-                ["Number(${height}) >= 100", "rgb(170, 162, 204)"],
-                ["Number(${height}) >= 50", "rgb(224, 226, 238)"],
-                ["Number(${height}) >= 25", "rgb(252, 230, 200)"],
-                ["Number(${height}) >= 10", "rgb(248, 176, 87)"],
-                ["Number(${height}) >= 5", "rgb(198, 106, 11)"],
+                ["${height} >= 300", "rgba(45, 0, 75, 0.5)"],
+                ["${height} >= 200", "rgb(102, 71, 151)"],
+                ["${height} >= 100", "rgb(170, 162, 204)"],
+                ["${height} >= 50", "rgb(224, 226, 238)"],
+                ["${height} >= 25", "rgb(252, 230, 200)"],
+                ["${height} >= 10", "rgb(248, 176, 87)"],
+                ["${height} >= 5", "rgb(198, 106, 11)"],
                 ["true", "rgb(127, 59, 8)"]
             ]
         }
@@ -71,7 +71,7 @@ function colorByHeight() {
 function colorByLatitude() {
     tileset.style = new Cesium.Cesium3DTileStyle({
         defines: {
-            latitudeRadians: "radians(Number(${latitude}))"
+            latitudeRadians: "radians(${latitude})"
         },
         color: {
             conditions: [
@@ -91,12 +91,15 @@ function colorByLatitude() {
 function colorByDistance() {
     tileset.style = new Cesium.Cesium3DTileStyle({
         defines : {
-            distance : "distance(vec2(radians(Number(${longitude})), radians(Number(${latitude}))), vec2(-1.291777521, 0.7105706624))"
+            distance : "distance(vec2(radians(${longitude}), radians(${latitude})), vec2(-1.291777521, 0.7105706624))"
         },
         color : {
             conditions : [
-                ["${distance} > 0.0002", "color('gray')"],
-                ["true", "mix(color('yellow'), color('green'), ${distance} / 0.0002)"]
+                ["${distance} > 0.0012","color('gray')"],
+                ["${distance} > 0.0008", "mix(color('yellow'), color('red'), (${distance} - 0.008) / 0.0004)"],
+                ["${distance} > 0.0004", "mix(color('green'), color('yellow'), (${distance} - 0.0004) / 0.0004)"],
+                ["${distance} < 0.00001", "color('white')"],
+                ["true", "mix(color('blue'), color('green'), ${distance} / 0.0004)"]
             ]
         }
     });
@@ -112,7 +115,7 @@ function colorByNameRegex() {
 // Show only buildings greater than 200 meters in height.
 function hideByHeight() {
     tileset.style = new Cesium.Cesium3DTileStyle({
-        show : "Number(${height}) > 200"
+        show : "${height} > 200"
     });
 }
 

--- a/Apps/Sandcastle/gallery/3D Tiles Feature Styling.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Feature Styling.html
@@ -42,7 +42,7 @@ viewer.scene.camera.setView({
 });
 
 // Load the NYC buildings tileset.
-var tileset = new Cesium.Cesium3DTileset({ url: Cesium.IonResource.fromAssetId(3839) });
+var tileset = new Cesium.Cesium3DTileset({ url: Cesium.IonResource.fromAssetId(4258) });
 viewer.scene.primitives.add(tileset);
 
 // Color buildings based on their height.
@@ -50,37 +50,33 @@ function colorByHeight() {
     tileset.style = new Cesium.Cesium3DTileStyle({
         color: {
             conditions: [
-                ["${height} >= 300", "rgba(45, 0, 75, 0.5)"],
-                ["${height} >= 200", "rgb(102, 71, 151)"],
-                ["${height} >= 100", "rgb(170, 162, 204)"],
-                ["${height} >= 50", "rgb(224, 226, 238)"],
-                ["${height} >= 25", "rgb(252, 230, 200)"],
-                ["${height} >= 10", "rgb(248, 176, 87)"],
-                ["${height} >= 5", "rgb(198, 106, 11)"],
+                ["Number(${height}) >= 300", "rgba(45, 0, 75, 0.5)"],
+                ["Number(${height}) >= 200", "rgb(102, 71, 151)"],
+                ["Number(${height}) >= 100", "rgb(170, 162, 204)"],
+                ["Number(${height}) >= 50", "rgb(224, 226, 238)"],
+                ["Number(${height}) >= 25", "rgb(252, 230, 200)"],
+                ["Number(${height}) >= 10", "rgb(248, 176, 87)"],
+                ["Number(${height}) >= 5", "rgb(198, 106, 11)"],
                 ["true", "rgb(127, 59, 8)"]
             ]
         }
     });
 }
 
-// Color buildings by their total area.
-function colorByArea() {
-    tileset.style = new Cesium.Cesium3DTileStyle({
-        color: "mix(color('yellow'), color('red'), min(${area} / 10000.0, 1.0))"
-    });
-}
-
 // Color buildings by their latitude coordinate.
 function colorByLatitude() {
     tileset.style = new Cesium.Cesium3DTileStyle({
+        defines: {
+            latitudeRadians: "Number(${latitude}) * 0.0174532925"
+        },
         color: {
             conditions: [
-                ["${latitude} >= 0.7125", "color('purple')"],
-                ["${latitude} >= 0.712", "color('red')"],
-                ["${latitude} >= 0.7115", "color('orange')"],
-                ["${latitude} >= 0.711", "color('yellow')"],
-                ["${latitude} >= 0.7105", "color('lime')"],
-                ["${latitude} >= 0.710", "color('cyan')"],
+                ["${latitudeRadians} >= 0.7125", "color('purple')"],
+                ["${latitudeRadians} >= 0.712", "color('red')"],
+                ["${latitudeRadians} >= 0.7115", "color('orange')"],
+                ["${latitudeRadians} >= 0.711", "color('yellow')"],
+                ["${latitudeRadians} >= 0.7105", "color('lime')"],
+                ["${latitudeRadians} >= 0.710", "color('cyan')"],
                 ["true", "color('blue')"]
             ]
         }
@@ -91,7 +87,7 @@ function colorByLatitude() {
 function colorByDistance() {
     tileset.style = new Cesium.Cesium3DTileStyle({
         defines : {
-            distance : "distance(vec2(${longitude}, ${latitude}), vec2(-1.291777521, 0.7105706624))"
+            distance : "distance(vec2(Number(${longitude}) * 0.0174532925, Number(${latitude}) * 0.0174532925), vec2(-1.291777521, 0.7105706624))"
         },
         color : {
             conditions : [
@@ -105,14 +101,14 @@ function colorByDistance() {
 // Color buildings with a '3' in their name.
 function colorByNameRegex() {
     tileset.style = new Cesium.Cesium3DTileStyle({
-        color : "(regExp('3').test(${name})) ? color('cyan', 0.9) : color('purple', 0.1)"
+        color : "(regExp('3').test(String(${name}))) ? color('cyan', 0.9) : color('purple', 0.1)"
     });
 }
 
 // Show only buildings greater than 200 meters in height.
 function hideByHeight() {
     tileset.style = new Cesium.Cesium3DTileStyle({
-        show : "${height} > 200"
+        show : "Number(${height}) > 200"
     });
 }
 
@@ -120,11 +116,6 @@ Sandcastle.addToolbarMenu([{
     text : 'Color By Height',
     onselect : function() {
         colorByHeight();
-    }
-}, {
-    text : 'Color By Area',
-    onselect : function() {
-        colorByArea();
     }
 }, {
     text : 'Color By Latitude',

--- a/Apps/Sandcastle/gallery/3D Tiles Feature Styling.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Feature Styling.html
@@ -71,7 +71,7 @@ function colorByHeight() {
 function colorByLatitude() {
     tileset.style = new Cesium.Cesium3DTileStyle({
         defines: {
-            latitudeRadians: "Number(${latitude}) * 0.0174532925"
+            latitudeRadians: "radians(Number(${latitude}))"
         },
         color: {
             conditions: [
@@ -91,7 +91,7 @@ function colorByLatitude() {
 function colorByDistance() {
     tileset.style = new Cesium.Cesium3DTileStyle({
         defines : {
-            distance : "distance(vec2(Number(${longitude}) * 0.0174532925, Number(${latitude}) * 0.0174532925), vec2(-1.291777521, 0.7105706624))"
+            distance : "distance(vec2(radians(Number(${longitude})), radians(Number(${latitude}))), vec2(-1.291777521, 0.7105706624))"
         },
         color : {
             conditions : [

--- a/Apps/Sandcastle/gallery/3D Tiles Feature Styling.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Feature Styling.html
@@ -30,7 +30,11 @@ function startup(Cesium) {
 // A demo of interactive 3D Tiles styling
 // Styling language Documentation: https://github.com/AnalyticalGraphicsInc/3d-tiles/tree/master/Styling
 // Building data courtesy of NYC OpenData portal: http://www1.nyc.gov/site/doitt/initiatives/3d-building.page
-var viewer = new Cesium.Viewer('cesiumContainer');
+var viewer = new Cesium.Viewer('cesiumContainer', {
+    terrainProvider: Cesium.createWorldTerrain()
+});
+
+viewer.scene.globe.depthTestAgainstTerrain = true;
 
 // Set the initial camera view to look at Manhattan
 var initialPosition = Cesium.Cartesian3.fromDegrees(-74.01881302800248, 40.69114333714821, 753);

--- a/Apps/Sandcastle/gallery/3D Tiles Inspector.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Inspector.html
@@ -36,7 +36,7 @@ viewer.scene.globe.depthTestAgainstTerrain = true;
 viewer.extend(Cesium.viewerCesium3DTilesInspectorMixin);
 var inspectorViewModel = viewer.cesium3DTilesInspector.viewModel;
 
-var tileset = new Cesium.Cesium3DTileset({ url: Cesium.IonResource.fromAssetId(4258) });
+var tileset = new Cesium.Cesium3DTileset({ url: Cesium.IonResource.fromAssetId(4693) });
 viewer.scene.primitives.add(tileset);
 
 tileset.readyPromise.then(function(){

--- a/Apps/Sandcastle/gallery/3D Tiles Inspector.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Inspector.html
@@ -31,7 +31,7 @@ var viewer = new Cesium.Viewer('cesiumContainer');
 viewer.extend(Cesium.viewerCesium3DTilesInspectorMixin);
 var inspectorViewModel = viewer.cesium3DTilesInspector.viewModel;
 
-var tileset = new Cesium.Cesium3DTileset({ url: Cesium.IonResource.fromAssetId(3839) });
+var tileset = new Cesium.Cesium3DTileset({ url: Cesium.IonResource.fromAssetId(4258) });
 viewer.scene.primitives.add(tileset);
 
 tileset.readyPromise.then(function(){

--- a/Apps/Sandcastle/gallery/3D Tiles Inspector.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Inspector.html
@@ -27,7 +27,12 @@ function startup(Cesium) {
     'use strict';
 //Sandcastle_Begin
 // Building data courtesy of NYC OpenData portal: http://www1.nyc.gov/site/doitt/initiatives/3d-building.page
-var viewer = new Cesium.Viewer('cesiumContainer');
+var viewer = new Cesium.Viewer('cesiumContainer', {
+    terrainProvider: Cesium.createWorldTerrain()
+});
+
+viewer.scene.globe.depthTestAgainstTerrain = true;
+
 viewer.extend(Cesium.viewerCesium3DTilesInspectorMixin);
 var inspectorViewModel = viewer.cesium3DTilesInspector.viewModel;
 

--- a/Apps/Sandcastle/gallery/3D Tiles Interactivity.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Interactivity.html
@@ -73,7 +73,7 @@ viewer.scene.camera.setView({
 });
 
 // Load the NYC buildings tileset.
-var tileset = new Cesium.Cesium3DTileset({ url: Cesium.IonResource.fromAssetId(4258) });
+var tileset = new Cesium.Cesium3DTileset({ url: Cesium.IonResource.fromAssetId(4693) });
 scene.primitives.add(tileset);
 tileset.style = new Cesium.Cesium3DTileStyle({
     meta: {

--- a/Apps/Sandcastle/gallery/3D Tiles Interactivity.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Interactivity.html
@@ -44,7 +44,11 @@
 function startup(Cesium) {
     'use strict';
 //Sandcastle_Begin
-var viewer = new Cesium.Viewer('cesiumContainer');
+var viewer = new Cesium.Viewer('cesiumContainer', {
+    terrainProvider: Cesium.createWorldTerrain()
+});
+
+viewer.scene.globe.depthTestAgainstTerrain = true;
 
 var viewModel = {
     rightClickAction: 'annotate',

--- a/Apps/Sandcastle/gallery/3D Tiles Interactivity.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Interactivity.html
@@ -69,7 +69,7 @@ viewer.scene.camera.setView({
 });
 
 // Load the NYC buildings tileset.
-var tileset = new Cesium.Cesium3DTileset({ url: Cesium.IonResource.fromAssetId(3839) });
+var tileset = new Cesium.Cesium3DTileset({ url: Cesium.IonResource.fromAssetId(4258) });
 scene.primitives.add(tileset);
 tileset.style = new Cesium.Cesium3DTileStyle({
     meta: {
@@ -141,8 +141,8 @@ function printProperties(movement, feature) {
 }
 
 function zoom(movement, feature) {
-    var longitude = feature.getProperty('longitude');
-    var latitude = feature.getProperty('latitude');
+    var longitude = Cesium.Math.toRadians(feature.getProperty('longitude'));
+    var latitude = Cesium.Math.toRadians(feature.getProperty('latitude'));
     var height = feature.getProperty('height');
 
     var positionCartographic = new Cesium.Cartographic(longitude, latitude, height * 0.5);


### PR DESCRIPTION
* Better streaming performance with draco compressed tiles.
* Uses new tiling algorithm with smarter tiling.
* Longitude/Latitude are in degrees so there is a conversion in styling.
* Add lon/lat/height to the feature picking table.
* Remove the area styling - no longer a property of the tileset.