### PR TITLE
Fix base layer picker categories

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,7 @@ Change Log
 
 ##### Fixes :wrench:
 * Fixed a bug causing custom TilingScheme classes to not be able to use a GeographicProjection. [#6524](https://github.com/AnalyticalGraphicsInc/cesium/pull/6524)
+* `ProviderViewModel`s with no category are displayed in an untitled group in `BaseLayerPicker` instead of being labeled as `'Other'` [#6574](https://github.com/AnalyticalGraphicsInc/cesium/pull/6574)
 
 ### 1.45 - 2018-05-01
 

--- a/Source/Widgets/BaseLayerPicker/ProviderViewModel.js
+++ b/Source/Widgets/BaseLayerPicker/ProviderViewModel.js
@@ -73,7 +73,7 @@ define([
          */
         this.iconUrl = options.iconUrl;
 
-        this._category = defaultValue(options.category, 'Other');
+        this._category = defaultValue(options.category, '');
 
         knockout.track(this, ['name', 'tooltip', 'iconUrl']);
     }

--- a/Source/Widgets/BaseLayerPicker/createDefaultImageryProviderViewModels.js
+++ b/Source/Widgets/BaseLayerPicker/createDefaultImageryProviderViewModels.js
@@ -65,6 +65,7 @@ define([
             name: 'Mapbox Satellite',
             tooltip: 'Mapbox satellite imagery https://www.mapbox.com/maps/',
             iconUrl: buildModuleUrl('Widgets/Images/ImageryProviders/mapboxSatellite.png'),
+            category : 'Other',
             creationFunction: function() {
                 return new MapboxImageryProvider({
                     mapId: 'mapbox.satellite'
@@ -76,6 +77,7 @@ define([
             name: 'Mapbox Streets',
             tooltip: 'Mapbox streets imagery https://www.mapbox.com/maps/',
             iconUrl: buildModuleUrl('Widgets/Images/ImageryProviders/mapboxTerrain.png'),
+            category : 'Other',
             creationFunction: function() {
                 return new MapboxImageryProvider({
                     mapId: 'mapbox.streets'
@@ -87,6 +89,7 @@ define([
             name: 'Mapbox Streets Classic',
             tooltip: 'Mapbox streets basic imagery https://www.mapbox.com/maps/',
             iconUrl: buildModuleUrl('Widgets/Images/ImageryProviders/mapboxStreets.png'),
+            category : 'Other',
             creationFunction: function() {
                 return new MapboxImageryProvider({
                     mapId: 'mapbox.streets-basic'
@@ -105,6 +108,7 @@ imagery for Antarctica. The map features 0.3m resolution imagery in the continen
 parts of Western Europe from DigitalGlobe. In other parts of the world, 1 meter resolution imagery is available from GeoEye IKONOS, \
 i-cubed Nationwide Prime, Getmapping, AeroGRID, IGN Spain, and IGP Portugal.  Additionally, imagery at different resolutions has been \
 contributed by the GIS User Community.\nhttp://www.esri.com',
+            category : 'Other',
             creationFunction : function() {
                 return new ArcGisMapServerImageryProvider({
                     url : 'https://services.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer',
@@ -121,6 +125,7 @@ This worldwide street map presents highway-level data for the world. Street-leve
 Canada; Japan; most countries in Europe; Australia and New Zealand; India; parts of South America including Argentina, Brazil, \
 Chile, Colombia, and Venezuela; Ghana; and parts of southern Africa including Botswana, Lesotho, Namibia, South Africa, and Swaziland.\n\
 http://www.esri.com',
+            category : 'Other',
             creationFunction : function() {
                 return new ArcGisMapServerImageryProvider({
                     url : 'https://services.arcgisonline.com/ArcGIS/rest/services/World_Street_Map/MapServer',
@@ -136,6 +141,7 @@ http://www.esri.com',
 This web map contains the National Geographic World Map service. This map service is designed to be used as a general reference map \
 for informational and educational purposes as well as a basemap by GIS professionals and other users for creating web maps and web \
 mapping applications.\nhttp://www.esri.com',
+            category : 'Other',
             creationFunction : function() {
                 return new ArcGisMapServerImageryProvider({
                     url : 'https://services.arcgisonline.com/ArcGIS/rest/services/NatGeo_World_Map/MapServer/',
@@ -149,6 +155,7 @@ mapping applications.\nhttp://www.esri.com',
             iconUrl : buildModuleUrl('Widgets/Images/ImageryProviders/openStreetMap.png'),
             tooltip : 'OpenStreetMap (OSM) is a collaborative project to create a free editable map \
 of the world.\nhttp://www.openstreetmap.org',
+            category : 'Other',
             creationFunction : function() {
                 return createOpenStreetMapImageryProvider({
                     url : 'https://a.tile.openstreetmap.org/'
@@ -161,6 +168,7 @@ of the world.\nhttp://www.openstreetmap.org',
             iconUrl : buildModuleUrl('Widgets/Images/ImageryProviders/stamenWatercolor.png'),
             tooltip : 'Reminiscent of hand drawn maps, Stamen watercolor maps apply raster effect \
 area washes and organic edges over a paper texture to add warm pop to any map.\nhttp://maps.stamen.com',
+            category : 'Other',
             creationFunction : function() {
                 return createOpenStreetMapImageryProvider({
                     url : 'https://stamen-tiles.a.ssl.fastly.net/watercolor/',
@@ -173,6 +181,7 @@ area washes and organic edges over a paper texture to add warm pop to any map.\n
             name : 'Stamen Toner',
             iconUrl : buildModuleUrl('Widgets/Images/ImageryProviders/stamenToner.png'),
             tooltip : 'A high contrast black and white map.\nhttp://maps.stamen.com',
+            category : 'Other',
             creationFunction : function() {
                 return createOpenStreetMapImageryProvider({
                     url : 'https://stamen-tiles.a.ssl.fastly.net/toner/',


### PR DESCRIPTION
Fixes #6572

If no category is specified in the `ProviderViewModel`, it now looks like this:
![image](https://user-images.githubusercontent.com/3451886/39774353-99328cb6-52c8-11e8-8862-2dd08f5c898b.png)
