### PR TITLE
Rework credit display.

### DIFF
--- a/Source/Core/Credit.js
+++ b/Source/Core/Credit.js
@@ -201,10 +201,10 @@ define([
         element: {
             get: function() {
                 if (!defined(this._element)) {
-                    var html = this.html;
-                    html = xss(html);
+                    var html = xss(this._html);
 
                     var div = document.createElement('div');
+                    div._creditId = this._id;
                     div.style.display = 'inline';
                     div.innerHTML = html;
 

--- a/Specs/Core/TaskProcessorSpec.js
+++ b/Specs/Core/TaskProcessorSpec.js
@@ -2,22 +2,17 @@ defineSuite([
         'Core/TaskProcessor',
         'require',
         'Core/FeatureDetection',
-        'ThirdParty/when'
+        'ThirdParty/when',
+        'Specs/absolutize'
     ], function(
         TaskProcessor,
         require,
         FeatureDetection,
-        when) {
+        when,
+        absolutize) {
     'use strict';
 
     var taskProcessor;
-
-    function absolutize(url) {
-        var a = document.createElement('a');
-        a.href = url;
-        a.href = a.href; // IE only absolutizes href on get, not set
-        return a.href;
-    }
 
     beforeEach(function() {
         TaskProcessor._workerModulePrefix = '../Specs/TestWorkers/';

--- a/Specs/Scene/CreditDisplaySpec.js
+++ b/Specs/Scene/CreditDisplaySpec.js
@@ -1,22 +1,28 @@
 defineSuite([
         'Scene/CreditDisplay',
         'Core/Credit',
-        'Core/defined'
+        'Core/defined',
+        'Specs/absolutize'
     ], function(
         CreditDisplay,
         Credit,
-        defined) {
+        defined,
+        absolutize) {
     'use strict';
 
     var container;
     var creditDisplay;
+    var imageUrl;
 
     beforeEach(function() {
+        imageUrl = absolutize('./Data/Images/Green.png');
         container = document.createElement('div');
         container.id = 'credit-container';
+        document.body.appendChild(container);
     });
 
-    afterEach(function(){
+    afterEach(function() {
+        document.body.removeChild(container);
         CreditDisplay.cesiumCredit = undefined;
         CreditDisplay._cesiumCreditInitialized = false;
         if (defined(creditDisplay)) {
@@ -85,33 +91,43 @@ defineSuite([
         var credit2 = new Credit('credit2', true);
 
         creditDisplay = new CreditDisplay(container);
+
+        // add only credit1 during the frame
         beginFrame(creditDisplay);
         creditDisplay.addCredit(credit1);
         creditDisplay.endFrame();
-        var innerHTML = container.innerHTML;
+        var innerHTMLWithCredit1 = container.innerHTML;
         var creditContainer = container.childNodes[1];
         expect(creditContainer.childNodes.length).toEqual(1);
         expect(creditContainer.childNodes[0].innerHTML).toEqual('credit1');
 
+        // add only credit2 during the frame
         beginFrame(creditDisplay);
         creditDisplay.addCredit(credit2);
         creditDisplay.endFrame();
-        expect(container.innerHTML).not.toEqual(innerHTML);
-        innerHTML = container.innerHTML;
+        var innerHTMLWithCredit2 = container.innerHTML;
+        expect(innerHTMLWithCredit2).not.toEqual(innerHTMLWithCredit1);
         expect(creditContainer.childNodes.length).toEqual(1);
         expect(creditContainer.childNodes[0].innerHTML).toEqual('credit2');
 
+        // add both credit1 and credit2 during the frame
         beginFrame(creditDisplay);
         creditDisplay.addCredit(credit1);
         creditDisplay.addCredit(credit2);
         creditDisplay.endFrame();
-        expect(container.innerHTML).not.toEqual(innerHTML);
-        innerHTML = container.innerHTML;
+        var innerHTMLWithCredit1AndCredit2 = container.innerHTML;
+        expect(innerHTMLWithCredit1AndCredit2).not.toEqual(innerHTMLWithCredit1);
+        expect(innerHTMLWithCredit1AndCredit2).not.toEqual(innerHTMLWithCredit2);
         expect(creditContainer.childNodes.length).toEqual(3);
+        expect(creditContainer.childNodes[0].innerHTML).toEqual('credit1');
+        expect(creditContainer.childNodes[2].innerHTML).toEqual('credit2');
 
+        // add neither credit during the frame
         beginFrame(creditDisplay);
         creditDisplay.endFrame();
-        expect(container.innerHTML).not.toEqual(innerHTML);
+        expect(container.innerHTML).not.toEqual(innerHTMLWithCredit1);
+        expect(container.innerHTML).not.toEqual(innerHTMLWithCredit2);
+        expect(container.innerHTML).not.toEqual(innerHTMLWithCredit1AndCredit2);
         expect(creditContainer.childNodes.length).toEqual(0);
     });
 
@@ -236,7 +252,7 @@ defineSuite([
 
     it('displays credits in a lightbox', function() {
         var credit1 = new Credit('credit1');
-        var credit2 = new Credit('<img src="/path/to/image"/>');
+        var credit2 = new Credit('<img src="' + imageUrl + '"/>');
 
         creditDisplay = new CreditDisplay(container);
         var creditList = creditDisplay._creditList;
@@ -282,9 +298,9 @@ defineSuite([
         creditDisplay.hideLightbox();
     });
 
-    it('only renders lightbox credits when lightbox is visible', function() {
+    it('renders lightbox credits', function() {
         var credit1 = new Credit('credit1');
-        var credit2 = new Credit('<img src="/path/to/image"/>');
+        var credit2 = new Credit('<img src="' + imageUrl + '"/>');
 
         creditDisplay = new CreditDisplay(container);
         var creditList = creditDisplay._creditList;
@@ -295,7 +311,7 @@ defineSuite([
         creditDisplay.endFrame();
         creditDisplay.update();
 
-        expect(creditList.childNodes.length).toEqual(0);
+        expect(creditList.childNodes.length).toEqual(2);
 
         creditDisplay.showLightbox();
 
@@ -312,7 +328,7 @@ defineSuite([
 
     it('updates lightbox when a new frames are not rendered', function() {
         var credit1 = new Credit('credit1');
-        var credit2 = new Credit('<img src="/path/to/image"/>');
+        var credit2 = new Credit('<img src="' + imageUrl + '"/>');
 
         creditDisplay = new CreditDisplay(container);
         var creditList = creditDisplay._creditList;
@@ -327,7 +343,7 @@ defineSuite([
         creditDisplay.endFrame();
         creditDisplay.update();
 
-        expect(creditList.childNodes.length).toEqual(0);
+        expect(creditList.childNodes.length).toEqual(2);
 
         creditDisplay.showLightbox();
         creditDisplay.update();
@@ -337,7 +353,7 @@ defineSuite([
         creditDisplay.hideLightbox();
         creditDisplay.update();
 
-        expect(creditList.childNodes.length).toEqual(0);
+        expect(creditList.childNodes.length).toEqual(2);
 
         creditDisplay.hideLightbox();
     });
@@ -370,9 +386,8 @@ defineSuite([
 
     it('credit display displays image credit', function() {
         creditDisplay = new CreditDisplay(container);
-        var imgSrc = '/path/to/image.png';
         var credit = new Credit({
-            imageUrl: imgSrc,
+            imageUrl: imageUrl,
             showOnScreen: true
         });
         beginFrame(creditDisplay);
@@ -383,7 +398,7 @@ defineSuite([
         expect(creditContainer.childNodes.length).toEqual(1);
         var creditSpan = creditContainer.childNodes[0];
         expect(creditSpan.childNodes.length).toEqual(1);
-        expect(creditSpan.childNodes[0].childNodes[0].src).toContain(imgSrc);
+        expect(creditSpan.childNodes[0].childNodes[0].src).toContain(imageUrl);
     });
 
     it('credit display displays hyperlink credit', function() {
@@ -406,10 +421,9 @@ defineSuite([
     });
 
     it('credit display uses text as title for image credit', function() {
-        var imgSrc = '/path/to/image.png';
         var credit1 = new Credit({
             text: 'credit text',
-            imageUrl: imgSrc,
+            imageUrl: imageUrl,
             showOnScreen: true
         });
         creditDisplay = new CreditDisplay(container);
@@ -422,15 +436,14 @@ defineSuite([
         var creditSpan = creditContainer.childNodes[0];
         expect(creditSpan.childNodes.length).toEqual(1);
         creditSpan = creditSpan.childNodes[0];
-        expect(creditSpan.childNodes[0].src).toContain(imgSrc);
+        expect(creditSpan.childNodes[0].src).toContain(imageUrl);
         expect(creditSpan.childNodes[0].alt).toEqual('credit text');
         expect(creditSpan.childNodes[0].title).toEqual('credit text');
     });
 
     it('credit display creates image credit with hyperlink', function() {
-        var imgSrc = '/path/to/image.png';
         var credit1 = new Credit({
-            imageUrl: imgSrc,
+            imageUrl: imageUrl,
             link: 'http://link.com',
             showOnScreen: true
         });
@@ -446,6 +459,6 @@ defineSuite([
         var creditContent = creditSpan.childNodes[0].childNodes[0];
         expect(creditContent.href).toContain('link.com');
         expect(creditContent.childNodes.length).toEqual(1);
-        expect(creditContent.childNodes[0].src).toContain(imgSrc);
+        expect(creditContent.childNodes[0].src).toContain(imageUrl);
     });
 });

--- a/Specs/Scene/GlobeSurfaceTileProviderSpec.js
+++ b/Specs/Scene/GlobeSurfaceTileProviderSpec.js
@@ -662,8 +662,8 @@ defineSuite([
         return updateUntilDone(scene.globe).then(function() {
             var creditDisplay = scene.frameState.creditDisplay;
             creditDisplay.showLightbox();
-            expect(creditDisplay._currentFrameCredits.lightboxCredits).toContain(imageryCredit);
-            expect(creditDisplay._currentFrameCredits.lightboxCredits).toContain(terrainCredit);
+            expect(creditDisplay._currentFrameCredits.lightboxCredits.values).toContain(imageryCredit);
+            expect(creditDisplay._currentFrameCredits.lightboxCredits.values).toContain(terrainCredit);
             creditDisplay.hideLightbox();
         });
     });

--- a/Specs/absolutize.js
+++ b/Specs/absolutize.js
@@ -1,0 +1,11 @@
+define(function() {
+    'use strict';
+
+    function absolutize(url) {
+        var a = document.createElement('a');
+        a.href = url;
+        a.href = a.href; // IE only absolutizes href on get, not set
+        return a.href;
+    }
+    return absolutize;
+});


### PR DESCRIPTION
Fixes intermittent issue where delimiters appear in the wrong location
when multiple credits are added.

Eliminate extra array tracking credits that should be displayed (_displayedCredits).
Instead we compare against the actual DOM nodes,
storing the credit ID directly on the DOM object for comparison.
Use an AssociativeArray rather than a sparse array for per-frame credit tracking.