### PR TITLE
Fix uniform map name for color copy.

### DIFF
--- a/Source/Scene/GlobeDepth.js
+++ b/Source/Scene/GlobeDepth.js
@@ -207,7 +207,7 @@ define([
         if (!defined(globeDepth._copyColorCommand)) {
             globeDepth._copyColorCommand = context.createViewportQuadCommand(PassThrough, {
                 uniformMap : {
-                    u_colorTexture : function() {
+                    colorTexture : function() {
                         return globeDepth._colorTexture;
                     }
                 },


### PR DESCRIPTION
This was introduced in #5615, but didn't show until #6393. The color copy uniform name was wrong.

This is only a problem in master so no need to update CHANGES.