### PR TITLE
Fix several documentation errors.

### DIFF
--- a/Apps/Sandcastle/gallery/Custom Geocoder.html
+++ b/Apps/Sandcastle/gallery/Custom Geocoder.html
@@ -48,7 +48,7 @@ function OpenStreetMapNominatimGeocoder() {
  * The function called to geocode using this geocoder service.
  *
  * @param {String} input The query to be sent to the geocoder service
- * @returns {Promise<GeocoderResult[]>}
+ * @returns {Promise<GeocoderService~Result[]>}
  */
 OpenStreetMapNominatimGeocoder.prototype.geocode = function (input) {
     var endpoint = 'https://nominatim.openstreetmap.org/search';

--- a/Source/Core/BingMapsGeocoderService.js
+++ b/Source/Core/BingMapsGeocoderService.js
@@ -70,7 +70,7 @@ define([
      * @function
      *
      * @param {String} query The query to be sent to the geocoder service
-     * @returns {Promise<GeocoderResult[]>}
+     * @returns {Promise<GeocoderService~Result[]>}
      */
     BingMapsGeocoderService.prototype.geocode = function(query) {
         //>>includeStart('debug', pragmas.debug);

--- a/Source/Core/CartographicGeocoderService.js
+++ b/Source/Core/CartographicGeocoderService.js
@@ -22,7 +22,7 @@ define([
      * @function
      *
      * @param {String} query The query to be sent to the geocoder service
-     * @returns {Promise<GeocoderResult[]>}
+     * @returns {Promise<GeocoderService~Result[]>}
      */
     CartographicGeocoderService.prototype.geocode = function(query) {
         //>>includeStart('debug', pragmas.debug);

--- a/Source/Core/CompressedTextureBuffer.js
+++ b/Source/Core/CompressedTextureBuffer.js
@@ -8,6 +8,8 @@ define([
 
     /**
      * Describes a compressed texture and contains a compressed texture buffer.
+     * @alias CompressedTextureBuffer
+     * @constructor
      *
      * @param {PixelFormat} internalFormat The pixel format of the compressed texture.
      * @param {Number} width The width of the texture.
@@ -26,6 +28,7 @@ define([
          * The format of the compressed texture.
          * @type PixelFormat
          * @readonly
+         * @memberof CompressedTextureBuffer.prototype
          */
         internalFormat : {
             get : function() {
@@ -36,6 +39,7 @@ define([
          * The width of the texture.
          * @type Number
          * @readonly
+         * @memberof CompressedTextureBuffer.prototype
          */
         width : {
             get : function() {
@@ -46,6 +50,7 @@ define([
          * The height of the texture.
          * @type Number
          * @readonly
+         * @memberof CompressedTextureBuffer.prototype
          */
         height : {
             get : function() {
@@ -56,6 +61,7 @@ define([
          * The compressed texture buffer.
          * @type Uint8Array
          * @readonly
+         * @memberof CompressedTextureBuffer.prototype
          */
         bufferView : {
             get : function() {

--- a/Source/Core/GeocoderService.js
+++ b/Source/Core/GeocoderService.js
@@ -5,7 +5,7 @@ define([
     'use strict';
 
     /**
-     * @typedef {Object} GeocoderResult
+     * @typedef {Object} GeocoderService~Result
      * @property {String} displayName The display name for a location
      * @property {Rectangle|Cartesian3} destination The bounding box for a location
      */
@@ -27,7 +27,7 @@ define([
      *
      * @param {String} query The query to be sent to the geocoder service
      * @param {GeocodeType} [type=GeocodeType.SEARCH] The type of geocode to perform.
-     * @returns {Promise<GeocoderResult[]>}
+     * @returns {Promise<GeocoderService~Result[]>}
      */
     GeocoderService.prototype.geocode = DeveloperError.throwInstantiationError;
 

--- a/Source/Core/IonGeocoderService.js
+++ b/Source/Core/IonGeocoderService.js
@@ -65,7 +65,7 @@ define([
      *
      * @param {String} query The query to be sent to the geocoder service
      * @param {GeocodeType} [type=GeocodeType.SEARCH] The type of geocode to perform.
-     * @returns {Promise<GeocoderResult[]>}
+     * @returns {Promise<GeocoderService~Result[]>}
      */
     IonGeocoderService.prototype.geocode = function (query, geocodeType) {
         return this._pelias.geocode(query, geocodeType);

--- a/Source/Core/ManagedArray.js
+++ b/Source/Core/ManagedArray.js
@@ -28,6 +28,7 @@ define([
          * Gets or sets the length of the array.
          * If the set length is greater than the length of the internal array, the internal array is resized.
          *
+         * @memberof ManagedArray.prototype
          * @type Number
          */
         length : {
@@ -45,6 +46,7 @@ define([
         /**
          * Gets the internal array.
          *
+         * @memberof ManagedArray.prototype
          * @type Array
          * @readonly
          */

--- a/Source/Core/PeliasGeocoderService.js
+++ b/Source/Core/PeliasGeocoderService.js
@@ -60,7 +60,7 @@ define([
      *
      * @param {String} query The query to be sent to the geocoder service
      * @param {GeocodeType} [type=GeocodeType.SEARCH] The type of geocode to perform.
-     * @returns {Promise<GeocoderResult[]>}
+     * @returns {Promise<GeocoderService~Result[]>}
      */
     PeliasGeocoderService.prototype.geocode = function(query, type) {
         //>>includeStart('debug', pragmas.debug);

--- a/Source/Renderer/AutomaticUniforms.js
+++ b/Source/Renderer/AutomaticUniforms.js
@@ -68,7 +68,6 @@ define([
          * @alias czm_viewport
          * @glslUniform
          *
-         *
          * @example
          * // GLSL declaration
          * uniform vec4 czm_viewport;
@@ -101,7 +100,6 @@ define([
          *
          * @alias czm_viewportOrthographic
          * @glslUniform
-         *
          *
          * @example
          * // GLSL declaration
@@ -140,7 +138,6 @@ define([
          *
          * @alias czm_viewportTransformation
          * @glslUniform
-         *
          *
          * @example
          * // GLSL declaration
@@ -198,7 +195,6 @@ define([
          * @alias czm_model
          * @glslUniform
          *
-         *
          * @example
          * // GLSL declaration
          * uniform mat4 czm_model;
@@ -226,7 +222,6 @@ define([
          * @alias czm_inverseModel
          * @glslUniform
          *
-         *
          * @example
          * // GLSL declaration
          * uniform mat4 czm_inverseModel;
@@ -252,7 +247,6 @@ define([
          *
          * @alias czm_view
          * @glslUniform
-         *
          *
          * @example
          * // GLSL declaration
@@ -286,7 +280,6 @@ define([
          * @alias czm_view3D
          * @glslUniform
          *
-         *
          * @example
          * // GLSL declaration
          * uniform mat4 czm_view3D;
@@ -311,7 +304,6 @@ define([
          *
          * @alias czm_viewRotation
          * @glslUniform
-         *
          *
          * @example
          * // GLSL declaration
@@ -343,7 +335,6 @@ define([
          * @alias czm_viewRotation3D
          * @glslUniform
          *
-         *
          * @example
          * // GLSL declaration
          * uniform mat3 czm_viewRotation3D;
@@ -368,7 +359,6 @@ define([
          *
          * @alias czm_inverseView
          * @glslUniform
-         *
          *
          * @example
          * // GLSL declaration
@@ -399,7 +389,6 @@ define([
          * @alias czm_inverseView3D
          * @glslUniform
          *
-         *
          * @example
          * // GLSL declaration
          * uniform mat4 czm_inverseView3D;
@@ -424,7 +413,6 @@ define([
          *
          * @alias czm_inverseViewRotation
          * @glslUniform
-         *
          *
          * @example
          * // GLSL declaration
@@ -456,7 +444,6 @@ define([
          * @alias czm_inverseViewRotation3D
          * @glslUniform
          *
-         *
          * @example
          * // GLSL declaration
          * uniform mat3 czm_inverseViewRotation3D;
@@ -482,7 +469,6 @@ define([
          *
          * @alias czm_projection
          * @glslUniform
-         *
          *
          * @example
          * // GLSL declaration
@@ -512,7 +498,6 @@ define([
          * @alias czm_inverseProjection
          * @glslUniform
          *
-         *
          * @example
          * // GLSL declaration
          * uniform mat4 czm_inverseProjection;
@@ -540,7 +525,6 @@ define([
          *
          * @alias czm_infiniteProjection
          * @glslUniform
-         *
          *
          * @example
          * // GLSL declaration
@@ -570,7 +554,6 @@ define([
          *
          * @alias czm_modelView
          * @glslUniform
-         *
          *
          * @example
          * // GLSL declaration
@@ -608,7 +591,6 @@ define([
          *
          * @alias czm_modelView3D
          * @glslUniform
-         *
          *
          * @example
          * // GLSL declaration
@@ -672,7 +654,6 @@ define([
          * @alias czm_inverseModelView
          * @glslUniform
          *
-         *
          * @example
          * // GLSL declaration
          * uniform mat4 czm_inverseModelView;
@@ -701,7 +682,6 @@ define([
          * @alias czm_inverseModelView3D
          * @glslUniform
          *
-         *
          * @example
          * // GLSL declaration
          * uniform mat4 czm_inverseModelView3D;
@@ -728,7 +708,6 @@ define([
          *
          * @alias czm_viewProjection
          * @glslUniform
-         *
          *
          * @example
          * // GLSL declaration
@@ -762,7 +741,6 @@ define([
          * @alias czm_inverseViewProjection
          * @glslUniform
          *
-         *
          * @example
          * // GLSL declaration
          * uniform mat4 czm_inverseViewProjection;
@@ -788,7 +766,6 @@ define([
          *
          * @alias czm_modelViewProjection
          * @glslUniform
-         *
          *
          * @example
          * // GLSL declaration
@@ -824,7 +801,6 @@ define([
          *
          * @alias czm_inverseModelViewProjection
          * @glslUniform
-         *
          *
          * @example
          * // GLSL declaration
@@ -889,7 +865,6 @@ define([
          * @alias czm_modelViewInfiniteProjection
          * @glslUniform
          *
-         *
          * @example
          * // GLSL declaration
          * uniform mat4 czm_modelViewInfiniteProjection;
@@ -918,6 +893,7 @@ define([
          * An automatic GLSL uniform that indicates if the current camera is orthographic in 3D.
          *
          * @alias czm_orthographicIn3D
+         * @glslUniform
          * @see UniformState#orthographicIn3D
          */
         czm_orthographicIn3D : new AutomaticUniform({
@@ -937,7 +913,6 @@ define([
          *
          * @alias czm_normal
          * @glslUniform
-         *
          *
          * @example
          * // GLSL declaration
@@ -972,7 +947,6 @@ define([
          * @alias czm_normal3D
          * @glslUniform
          *
-         *
          * @example
          * // GLSL declaration
          * uniform mat3 czm_normal3D;
@@ -998,7 +972,6 @@ define([
          *
          * @alias czm_inverseNormal
          * @glslUniform
-         *
          *
          * @example
          * // GLSL declaration
@@ -1031,7 +1004,6 @@ define([
          *
          * @alias czm_inverseNormal3D
          * @glslUniform
-         *
          *
          * @example
          * // GLSL declaration
@@ -1076,7 +1048,6 @@ define([
          * @alias czm_entireFrustum
          * @glslUniform
          *
-         *
          * @example
          * // GLSL declaration
          * uniform vec2 czm_entireFrustum;
@@ -1102,7 +1073,6 @@ define([
          *
          * @alias czm_currentFrustum
          * @glslUniform
-         *
          *
          * @example
          * // GLSL declaration
@@ -1189,7 +1159,6 @@ define([
          * @alias czm_sunPositionWC
          * @glslUniform
          *
-         *
          * @example
          * // GLSL declaration
          * uniform vec3 czm_sunPositionWC;
@@ -1212,7 +1181,6 @@ define([
          * @alias czm_sunPositionColumbusView
          * @glslUniform
          *
-         *
          * @example
          * // GLSL declaration
          * uniform vec3 czm_sunPositionColumbusView;
@@ -1234,7 +1202,6 @@ define([
          *
          * @alias czm_sunDirectionEC
          * @glslUniform
-         *
          *
          * @example
          * // GLSL declaration
@@ -1262,7 +1229,6 @@ define([
          * @alias czm_sunDirectionWC
          * @glslUniform
          *
-         *
          * @example
          * // GLSL declaration
          * uniform vec3 czm_sunDirectionWC;
@@ -1285,7 +1251,6 @@ define([
          *
          * @alias czm_moonDirectionEC
          * @glslUniform
-         *
          *
          * @example
          * // GLSL declaration
@@ -1313,7 +1278,6 @@ define([
          * @alias czm_encodedCameraPositionMCHigh
          * @glslUniform
          *
-         *
          * @example
          * // GLSL declaration
          * uniform vec3 czm_encodedCameraPositionMCHigh;
@@ -1337,7 +1301,6 @@ define([
          *
          * @alias czm_encodedCameraPositionMCLow
          * @glslUniform
-         *
          *
          * @example
          * // GLSL declaration
@@ -1420,7 +1383,6 @@ define([
          *
          * @alias czm_sceneMode
          * @glslUniform
-         *
          *
          * @example
          * // GLSL declaration
@@ -1550,7 +1512,6 @@ define([
          * @alias czm_temeToPseudoFixed
          * @glslUniform
          *
-         *
          * @example
          * // GLSL declaration
          * uniform mat3 czm_temeToPseudoFixed;
@@ -1608,7 +1569,6 @@ define([
          *
          * @alias czm_imagerySplitPosition
          * @glslUniform
-         *
          *
          * @example
          * // GLSL declaration

--- a/Source/Scene/Batched3DModel3DTileContent.js
+++ b/Source/Scene/Batched3DModel3DTileContent.js
@@ -71,9 +71,6 @@ define([
         this._batchIdAttributeName = undefined;
         this._diffuseAttributeOrUniformName = {};
 
-        /**
-         * @inheritdoc Cesium3DTileContent#featurePropertiesDirty
-         */
         this.featurePropertiesDirty = false;
 
         initialize(this, arrayBuffer, byteOffset);
@@ -83,108 +80,72 @@ define([
     Batched3DModel3DTileContent._deprecationWarning = deprecationWarning;
 
     defineProperties(Batched3DModel3DTileContent.prototype, {
-        /**
-         * @inheritdoc Cesium3DTileContent#featuresLength
-         */
         featuresLength : {
             get : function() {
                 return this._batchTable.featuresLength;
             }
         },
 
-        /**
-         * @inheritdoc Cesium3DTileContent#pointsLength
-         */
         pointsLength : {
             get : function() {
                 return 0;
             }
         },
 
-        /**
-         * @inheritdoc Cesium3DTileContent#trianglesLength
-         */
         trianglesLength : {
             get : function() {
                 return this._model.trianglesLength;
             }
         },
 
-        /**
-         * @inheritdoc Cesium3DTileContent#geometryByteLength
-         */
         geometryByteLength : {
             get : function() {
                 return this._model.geometryByteLength;
             }
         },
 
-        /**
-         * @inheritdoc Cesium3DTileContent#texturesByteLength
-         */
         texturesByteLength : {
             get : function() {
                 return this._model.texturesByteLength;
             }
         },
 
-        /**
-         * @inheritdoc Cesium3DTileContent#batchTableByteLength
-         */
         batchTableByteLength : {
             get : function() {
                 return this._batchTable.memorySizeInBytes;
             }
         },
 
-        /**
-         * @inheritdoc Cesium3DTileContent#innerContents
-         */
         innerContents : {
             get : function() {
                 return undefined;
             }
         },
 
-        /**
-         * @inheritdoc Cesium3DTileContent#readyPromise
-         */
         readyPromise : {
             get : function() {
                 return this._model.readyPromise;
             }
         },
 
-        /**
-         * @inheritdoc Cesium3DTileContent#tileset
-         */
         tileset : {
             get : function() {
                 return this._tileset;
             }
         },
 
-        /**
-         * @inheritdoc Cesium3DTileContent#tile
-         */
         tile : {
             get : function() {
                 return this._tile;
             }
         },
 
-        /**
-         * @inheritdoc Cesium3DTileContent#url
-         */
         url: {
             get: function() {
                 return this._resource.getUrlComponent(true);
             }
         },
 
-        /**
-         * @inheritdoc Cesium3DTileContent#batchTable
-         */
         batchTable : {
             get : function() {
                 return this._batchTable;
@@ -449,16 +410,10 @@ define([
         }
     }
 
-    /**
-     * @inheritdoc Cesium3DTileContent#hasProperty
-     */
     Batched3DModel3DTileContent.prototype.hasProperty = function(batchId, name) {
         return this._batchTable.hasProperty(batchId, name);
     };
 
-    /**
-     * @inheritdoc Cesium3DTileContent#getFeature
-     */
     Batched3DModel3DTileContent.prototype.getFeature = function(batchId) {
         //>>includeStart('debug', pragmas.debug);
         var featuresLength = this.featuresLength;
@@ -471,9 +426,6 @@ define([
         return this._features[batchId];
     };
 
-    /**
-     * @inheritdoc Cesium3DTileContent#applyDebugSettings
-     */
     Batched3DModel3DTileContent.prototype.applyDebugSettings = function(enabled, color) {
         color = enabled ? color : Color.WHITE;
         if (this.featuresLength === 0) {
@@ -483,16 +435,10 @@ define([
         }
     };
 
-    /**
-     * @inheritdoc Cesium3DTileContent#applyStyle
-     */
     Batched3DModel3DTileContent.prototype.applyStyle = function(frameState, style) {
         this._batchTable.applyStyle(frameState, style);
     };
 
-    /**
-     * @inheritdoc Cesium3DTileContent#update
-     */
     Batched3DModel3DTileContent.prototype.update = function(tileset, frameState) {
         var commandStart = frameState.commandList.length;
 
@@ -523,16 +469,10 @@ define([
         }
    };
 
-    /**
-     * @inheritdoc Cesium3DTileContent#isDestroyed
-     */
     Batched3DModel3DTileContent.prototype.isDestroyed = function() {
         return false;
     };
 
-    /**
-     * @inheritdoc Cesium3DTileContent#destroy
-     */
     Batched3DModel3DTileContent.prototype.destroy = function() {
         this._model = this._model && this._model.destroy();
         this._batchTable = this._batchTable && this._batchTable.destroy();

--- a/Source/Scene/Cesium3DTileContent.js
+++ b/Source/Scene/Cesium3DTileContent.js
@@ -160,6 +160,8 @@ define([
         /**
          * Gets the tileset for this tile.
          *
+         * @memberof Cesium3DTileContent.prototype
+         *
          * @type {Cesium3DTileset}
          * @readonly
          */
@@ -171,6 +173,8 @@ define([
 
         /**
          * Gets the tile containing this content.
+         *
+         * @memberof Cesium3DTileContent.prototype
          *
          * @type {Cesium3DTile}
          * @readonly

--- a/Source/Scene/Cesium3DTileset.js
+++ b/Source/Scene/Cesium3DTileset.js
@@ -809,6 +809,8 @@ define([
         /**
          * The {@link ClippingPlaneCollection} used to selectively disable rendering the tileset.
          *
+         * @memberof Cesium3DTileset.prototype
+         *
          * @type {ClippingPlaneCollection}
          */
         clippingPlanes : {

--- a/Source/Scene/Composite3DTileContent.js
+++ b/Source/Scene/Composite3DTileContent.js
@@ -48,9 +48,6 @@ define([
     }
 
     defineProperties(Composite3DTileContent.prototype, {
-        /**
-         * @inheritdoc Cesium3DTileContent#featurePropertiesDirty
-         */
         featurePropertiesDirty : {
             get : function() {
                 var contents = this._contents;
@@ -75,6 +72,7 @@ define([
         /**
          * Part of the {@link Cesium3DTileContent} interface.  <code>Composite3DTileContent</code>
          * always returns <code>0</code>.  Instead call <code>featuresLength</code> for a tile in the composite.
+         * @memberof Composite3DTileContent.prototype
          */
         featuresLength : {
             get : function() {
@@ -85,6 +83,7 @@ define([
         /**
          * Part of the {@link Cesium3DTileContent} interface.  <code>Composite3DTileContent</code>
          * always returns <code>0</code>.  Instead call <code>pointsLength</code> for a tile in the composite.
+         * @memberof Composite3DTileContent.prototype
          */
         pointsLength : {
             get : function() {
@@ -95,6 +94,7 @@ define([
         /**
          * Part of the {@link Cesium3DTileContent} interface.  <code>Composite3DTileContent</code>
          * always returns <code>0</code>.  Instead call <code>trianglesLength</code> for a tile in the composite.
+         * @memberof Composite3DTileContent.prototype
          */
         trianglesLength : {
             get : function() {
@@ -105,6 +105,7 @@ define([
         /**
          * Part of the {@link Cesium3DTileContent} interface.  <code>Composite3DTileContent</code>
          * always returns <code>0</code>.  Instead call <code>geometryByteLength</code> for a tile in the composite.
+         * @memberof Composite3DTileContent.prototype
          */
         geometryByteLength : {
             get : function() {
@@ -115,6 +116,7 @@ define([
         /**
          * Part of the {@link Cesium3DTileContent} interface.   <code>Composite3DTileContent</code>
          * always returns <code>0</code>.  Instead call <code>texturesByteLength</code> for a tile in the composite.
+         * @memberof Composite3DTileContent.prototype
          */
         texturesByteLength : {
             get : function() {
@@ -125,6 +127,7 @@ define([
         /**
          * Part of the {@link Cesium3DTileContent} interface.  <code>Composite3DTileContent</code>
          * always returns <code>0</code>.  Instead call <code>batchTableByteLength</code> for a tile in the composite.
+         * @memberof Composite3DTileContent.prototype
          */
         batchTableByteLength : {
             get : function() {
@@ -132,45 +135,30 @@ define([
             }
         },
 
-        /**
-         * @inheritdoc Cesium3DTileContent#innerContents
-         */
         innerContents : {
             get : function() {
                 return this._contents;
             }
         },
 
-        /**
-         * @inheritdoc Cesium3DTileContent#readyPromise
-         */
         readyPromise : {
             get : function() {
                 return this._readyPromise.promise;
             }
         },
 
-        /**
-         * @inheritdoc Cesium3DTileContent#tileset
-         */
         tileset : {
             get : function() {
                 return this._tileset;
             }
         },
 
-        /**
-         * @inheritdoc Cesium3DTileContent#tile
-         */
         tile : {
             get : function() {
                 return this._tile;
             }
         },
 
-        /**
-         * @inheritdoc Cesium3DTileContent#url
-         */
         url : {
             get : function() {
                 return this._resource.getUrlComponent(true);
@@ -180,6 +168,7 @@ define([
         /**
          * Part of the {@link Cesium3DTileContent} interface. <code>Composite3DTileContent</code>
          * always returns <code>undefined</code>.  Instead call <code>batchTable</code> for a tile in the composite.
+         * @memberof Composite3DTileContent.prototype
          */
         batchTable : {
             get : function() {
@@ -253,9 +242,6 @@ define([
         return undefined;
     };
 
-    /**
-     * @inheritdoc Cesium3DTileContent#applyDebugSettings
-     */
     Composite3DTileContent.prototype.applyDebugSettings = function(enabled, color) {
         var contents = this._contents;
         var length = contents.length;
@@ -264,9 +250,6 @@ define([
         }
     };
 
-    /**
-     * @inheritdoc Cesium3DTileContent#applyStyle
-     */
     Composite3DTileContent.prototype.applyStyle = function(frameState, style) {
         var contents = this._contents;
         var length = contents.length;
@@ -275,9 +258,6 @@ define([
         }
     };
 
-    /**
-     * @inheritdoc Cesium3DTileContent#update
-     */
     Composite3DTileContent.prototype.update = function(tileset, frameState) {
         var contents = this._contents;
         var length = contents.length;
@@ -286,16 +266,10 @@ define([
         }
     };
 
-    /**
-     * @inheritdoc Cesium3DTileContent#isDestroyed
-     */
     Composite3DTileContent.prototype.isDestroyed = function() {
         return false;
     };
 
-    /**
-     * @inheritdoc Cesium3DTileContent#destroy
-     */
     Composite3DTileContent.prototype.destroy = function() {
         var contents = this._contents;
         var length = contents.length;

--- a/Source/Scene/Empty3DTileContent.js
+++ b/Source/Scene/Empty3DTileContent.js
@@ -23,115 +23,76 @@ define([
         this._tileset = tileset;
         this._tile = tile;
 
-        /**
-         * @inheritdoc Cesium3DTileContent#featurePropertiesDirty
-         */
         this.featurePropertiesDirty = false;
     }
 
     defineProperties(Empty3DTileContent.prototype, {
-        /**
-         * @inheritdoc Cesium3DTileContent#featuresLength
-         */
         featuresLength : {
             get : function() {
                 return 0;
             }
         },
 
-        /**
-         * @inheritdoc Cesium3DTileContent#pointsLength
-         */
         pointsLength : {
             get : function() {
                 return 0;
             }
         },
 
-        /**
-         * @inheritdoc Cesium3DTileContent#trianglesLength
-         */
         trianglesLength : {
             get : function() {
                 return 0;
             }
         },
 
-        /**
-         * @inheritdoc Cesium3DTileContent#geometryByteLength
-         */
         geometryByteLength : {
             get : function() {
                 return 0;
             }
         },
 
-        /**
-         * @inheritdoc Cesium3DTileContent#texturesByteLength
-         */
         texturesByteLength : {
             get : function() {
                 return 0;
             }
         },
 
-        /**
-         * @inheritdoc Cesium3DTileContent#batchTableByteLength
-         */
         batchTableByteLength : {
             get : function() {
                 return 0;
             }
         },
 
-        /**
-         * @inheritdoc Cesium3DTileContent#innerContents
-         */
         innerContents : {
             get : function() {
                 return undefined;
             }
         },
 
-        /**
-         * @inheritdoc Cesium3DTileContent#readyPromise
-         */
         readyPromise : {
             get : function() {
                 return undefined;
             }
         },
 
-        /**
-         * @inheritdoc Cesium3DTileContent#tileset
-         */
         tileset : {
             get : function() {
                 return this._tileset;
             }
         },
 
-        /**
-         * @inheritdoc Cesium3DTileContent#tile
-         */
         tile : {
             get : function() {
                 return this._tile;
             }
         },
 
-        /**
-         * @inheritdoc Cesium3DTileContent#url
-         */
         url: {
             get: function() {
                 return undefined;
             }
         },
 
-        /**
-         * @inheritdoc Cesium3DTileContent#batchTable
-         */
         batchTable : {
             get : function() {
                 return undefined;
@@ -155,34 +116,19 @@ define([
         return undefined;
     };
 
-    /**
-     * @inheritdoc Cesium3DTileContent#applyDebugSettings
-     */
     Empty3DTileContent.prototype.applyDebugSettings = function(enabled, color) {
     };
 
-    /**
-     * @inheritdoc Cesium3DTileContent#applyStyle
-     */
     Empty3DTileContent.prototype.applyStyle = function(frameState, style) {
     };
 
-    /**
-     * @inheritdoc Cesium3DTileContent#update
-     */
     Empty3DTileContent.prototype.update = function(tileset, frameState) {
     };
 
-    /**
-     * @inheritdoc Cesium3DTileContent#isDestroyed
-     */
     Empty3DTileContent.prototype.isDestroyed = function() {
         return false;
     };
 
-    /**
-     * @inheritdoc Cesium3DTileContent#destroy
-     */
     Empty3DTileContent.prototype.destroy = function() {
         return destroyObject(this);
     };

--- a/Source/Scene/Geometry3DTileContent.js
+++ b/Source/Scene/Geometry3DTileContent.js
@@ -73,27 +73,18 @@ define([
     }
 
     defineProperties(Geometry3DTileContent.prototype, {
-        /**
-         * @inheritdoc Cesium3DTileContent#featuresLength
-         */
         featuresLength : {
             get : function() {
                 return defined(this._batchTable) ? this._batchTable.featuresLength : 0;
             }
         },
 
-        /**
-         * @inheritdoc Cesium3DTileContent#pointsLength
-         */
         pointsLength : {
             get : function() {
                 return 0;
             }
         },
 
-        /**
-         * @inheritdoc Cesium3DTileContent#trianglesLength
-         */
         trianglesLength : {
             get : function() {
                 if (defined(this._geometries)) {
@@ -103,9 +94,6 @@ define([
             }
         },
 
-        /**
-         * @inheritdoc Cesium3DTileContent#geometryByteLength
-         */
         geometryByteLength : {
             get : function() {
                 if (defined(this._geometries)) {
@@ -115,72 +103,48 @@ define([
             }
         },
 
-        /**
-         * @inheritdoc Cesium3DTileContent#texturesByteLength
-         */
         texturesByteLength : {
             get : function() {
                 return 0;
             }
         },
 
-        /**
-         * @inheritdoc Cesium3DTileContent#batchTableByteLength
-         */
         batchTableByteLength : {
             get : function() {
                 return defined(this._batchTable) ? this._batchTable.memorySizeInBytes : 0;
             }
         },
 
-        /**
-         * @inheritdoc Cesium3DTileContent#innerContents
-         */
         innerContents : {
             get : function() {
                 return undefined;
             }
         },
 
-        /**
-         * @inheritdoc Cesium3DTileContent#readyPromise
-         */
         readyPromise : {
             get : function() {
                 return this._readyPromise.promise;
             }
         },
 
-        /**
-         * @inheritdoc Cesium3DTileContent#tileset
-         */
         tileset : {
             get : function() {
                 return this._tileset;
             }
         },
 
-        /**
-         * @inheritdoc Cesium3DTileContent#tile
-         */
         tile : {
             get : function() {
                 return this._tile;
             }
         },
 
-        /**
-         * @inheritdoc Cesium3DTileContent#url
-         */
         url : {
             get : function() {
                 return this._resource.getUrlComponent(true);
             }
         },
 
-        /**
-         * @inheritdoc Cesium3DTileContent#batchTable
-         */
         batchTable : {
             get : function() {
                 return this._batchTable;
@@ -417,16 +381,10 @@ define([
         }
     }
 
-    /**
-     * @inheritdoc Cesium3DTileContent#hasProperty
-     */
     Geometry3DTileContent.prototype.hasProperty = function(batchId, name) {
         return this._batchTable.hasProperty(batchId, name);
     };
 
-    /**
-     * @inheritdoc Cesium3DTileContent#getFeature
-     */
     Geometry3DTileContent.prototype.getFeature = function(batchId) {
         //>>includeStart('debug', pragmas.debug);
         var featuresLength = this.featuresLength;
@@ -439,18 +397,12 @@ define([
         return this._features[batchId];
     };
 
-    /**
-     * @inheritdoc Cesium3DTileContent#applyDebugSettings
-     */
     Geometry3DTileContent.prototype.applyDebugSettings = function(enabled, color) {
         if (defined(this._geometries)) {
             this._geometries.applyDebugSettings(enabled, color);
         }
     };
 
-    /**
-     * @inheritdoc Cesium3DTileContent#applyStyle
-     */
     Geometry3DTileContent.prototype.applyStyle = function(frameState, style) {
         createFeatures(this);
         if (defined(this._geometries)) {
@@ -458,9 +410,6 @@ define([
         }
     };
 
-    /**
-     * @inheritdoc Cesium3DTileContent#update
-     */
     Geometry3DTileContent.prototype.update = function(tileset, frameState) {
         if (defined(this._batchTable)) {
             this._batchTable.update(tileset, frameState);
@@ -479,16 +428,10 @@ define([
         }
     };
 
-    /**
-     * @inheritdoc Cesium3DTileContent#isDestroyed
-     */
     Geometry3DTileContent.prototype.isDestroyed = function() {
         return false;
     };
 
-    /**
-     * @inheritdoc Cesium3DTileContent#destroy
-     */
     Geometry3DTileContent.prototype.destroy = function() {
         this._geometries = this._geometries && this._geometries.destroy();
         this._batchTable = this._batchTable && this._batchTable.destroy();

--- a/Source/Scene/Instanced3DModel3DTileContent.js
+++ b/Source/Scene/Instanced3DModel3DTileContent.js
@@ -81,9 +81,6 @@ define([
         this._batchTable = undefined;
         this._features = undefined;
 
-        /**
-         * @inheritdoc Cesium3DTileContent#featurePropertiesDirty
-         */
         this.featurePropertiesDirty = false;
 
         initialize(this, arrayBuffer, byteOffset);
@@ -93,27 +90,18 @@ define([
     Instanced3DModel3DTileContent._deprecationWarning = deprecationWarning;
 
     defineProperties(Instanced3DModel3DTileContent.prototype, {
-        /**
-         * @inheritdoc Cesium3DTileContent#featuresLength
-         */
         featuresLength : {
             get : function() {
                 return this._batchTable.featuresLength;
             }
         },
 
-        /**
-         * @inheritdoc Cesium3DTileContent#pointsLength
-         */
         pointsLength : {
             get : function() {
                 return 0;
             }
         },
 
-        /**
-         * @inheritdoc Cesium3DTileContent#trianglesLength
-         */
         trianglesLength : {
             get : function() {
                 var model = this._modelInstanceCollection._model;
@@ -124,9 +112,6 @@ define([
             }
         },
 
-        /**
-         * @inheritdoc Cesium3DTileContent#geometryByteLength
-         */
         geometryByteLength : {
             get : function() {
                 var model = this._modelInstanceCollection._model;
@@ -137,9 +122,6 @@ define([
             }
         },
 
-        /**
-         * @inheritdoc Cesium3DTileContent#texturesByteLength
-         */
         texturesByteLength : {
             get : function() {
                 var model = this._modelInstanceCollection._model;
@@ -150,63 +132,42 @@ define([
             }
         },
 
-        /**
-         * @inheritdoc Cesium3DTileContent#batchTableByteLength
-         */
         batchTableByteLength : {
             get : function() {
                 return this._batchTable.memorySizeInBytes;
             }
         },
 
-        /**
-         * @inheritdoc Cesium3DTileContent#innerContents
-         */
         innerContents : {
             get : function() {
                 return undefined;
             }
         },
 
-        /**
-         * @inheritdoc Cesium3DTileContent#readyPromise
-         */
         readyPromise : {
             get : function() {
                 return this._modelInstanceCollection.readyPromise;
             }
         },
 
-        /**
-         * @inheritdoc Cesium3DTileContent#tileset
-         */
         tileset : {
             get : function() {
                 return this._tileset;
             }
         },
 
-        /**
-         * @inheritdoc Cesium3DTileContent#tile
-         */
         tile : {
             get : function() {
                 return this._tile;
             }
         },
 
-        /**
-         * @inheritdoc Cesium3DTileContent#url
-         */
         url: {
             get: function() {
                 return this._resource.getUrlComponent(true);
             }
         },
 
-        /**
-         * @inheritdoc Cesium3DTileContent#batchTable
-         */
         batchTable : {
             get : function() {
                 return this._batchTable;
@@ -459,16 +420,10 @@ define([
         }
     }
 
-    /**
-     * @inheritdoc Cesium3DTileContent#hasProperty
-     */
     Instanced3DModel3DTileContent.prototype.hasProperty = function(batchId, name) {
         return this._batchTable.hasProperty(batchId, name);
     };
 
-    /**
-     * @inheritdoc Cesium3DTileContent#getFeature
-     */
     Instanced3DModel3DTileContent.prototype.getFeature = function(batchId) {
         var featuresLength = this.featuresLength;
         //>>includeStart('debug', pragmas.debug);
@@ -481,24 +436,15 @@ define([
         return this._features[batchId];
     };
 
-    /**
-     * @inheritdoc Cesium3DTileContent#applyDebugSettings
-     */
     Instanced3DModel3DTileContent.prototype.applyDebugSettings = function(enabled, color) {
         color = enabled ? color : Color.WHITE;
         this._batchTable.setAllColor(color);
     };
 
-    /**
-     * @inheritdoc Cesium3DTileContent#applyStyle
-     */
     Instanced3DModel3DTileContent.prototype.applyStyle = function(frameState, style) {
         this._batchTable.applyStyle(frameState, style);
     };
 
-    /**
-     * @inheritdoc Cesium3DTileContent#update
-     */
     Instanced3DModel3DTileContent.prototype.update = function(tileset, frameState) {
         var commandStart = frameState.commandList.length;
 
@@ -531,16 +477,10 @@ define([
         }
     };
 
-    /**
-     * @inheritdoc Cesium3DTileContent#isDestroyed
-     */
     Instanced3DModel3DTileContent.prototype.isDestroyed = function() {
         return false;
     };
 
-    /**
-     * @inheritdoc Cesium3DTileContent#destroy
-     */
     Instanced3DModel3DTileContent.prototype.destroy = function() {
         this._modelInstanceCollection = this._modelInstanceCollection && this._modelInstanceCollection.destroy();
         this._batchTable = this._batchTable && this._batchTable.destroy();

--- a/Source/Scene/Particle.js
+++ b/Source/Scene/Particle.js
@@ -135,6 +135,7 @@ define([
         },
         /**
          * The dimensions of the particle in pixels. This has been deprecated. Use {@link Particle#imageSize} instead.
+         * @memberof Particle.prototype
          * @type {Cartesian2}
          * @default new Cartesian(1.0, 1.0)
          * @deprecated

--- a/Source/Scene/ParticleSystem.js
+++ b/Source/Scene/ParticleSystem.js
@@ -259,6 +259,7 @@ define([
         },
         /**
          * An array of {@link ParticleBurst}, emitting bursts of particles at periodic times.
+         * @memberof ParticleSystem.prototype
          * @type {ParticleBurst[]}
          * @default undefined
          */

--- a/Source/Scene/PointCloud3DTileContent.js
+++ b/Source/Scene/PointCloud3DTileContent.js
@@ -150,9 +150,6 @@ define([
 
         this._modelViewMatrix = Matrix4.clone(Matrix4.IDENTITY);
 
-        /**
-         * @inheritdoc Cesium3DTileContent#featurePropertiesDirty
-         */
         this.featurePropertiesDirty = false;
 
         // Options for geometric error based attenuation
@@ -166,9 +163,6 @@ define([
     }
 
     defineProperties(PointCloud3DTileContent.prototype, {
-        /**
-         * @inheritdoc Cesium3DTileContent#featuresLength
-         */
         featuresLength : {
             get : function() {
                 if (defined(this._batchTable)) {
@@ -178,45 +172,30 @@ define([
             }
         },
 
-        /**
-         * @inheritdoc Cesium3DTileContent#pointsLength
-         */
         pointsLength : {
             get : function() {
                 return this._pointsLength;
             }
         },
 
-        /**
-         * @inheritdoc Cesium3DTileContent#trianglesLength
-         */
         trianglesLength : {
             get : function() {
                 return 0;
             }
         },
 
-        /**
-         * @inheritdoc Cesium3DTileContent#geometryByteLength
-         */
         geometryByteLength : {
             get : function() {
                 return this._geometryByteLength;
             }
         },
 
-        /**
-         * @inheritdoc Cesium3DTileContent#texturesByteLength
-         */
         texturesByteLength : {
             get : function() {
                 return 0;
             }
         },
 
-        /**
-         * @inheritdoc Cesium3DTileContent#batchTableByteLength
-         */
         batchTableByteLength : {
             get : function() {
                 if (defined(this._batchTable)) {
@@ -226,54 +205,36 @@ define([
             }
         },
 
-        /**
-         * @inheritdoc Cesium3DTileContent#innerContents
-         */
         innerContents : {
             get : function() {
                 return undefined;
             }
         },
 
-        /**
-         * @inheritdoc Cesium3DTileContent#readyPromise
-         */
         readyPromise : {
             get : function() {
                 return this._readyPromise.promise;
             }
         },
 
-        /**
-         * @inheritdoc Cesium3DTileContent#tileset
-         */
         tileset : {
             get : function() {
                 return this._tileset;
             }
         },
 
-        /**
-         * @inheritdoc Cesium3DTileContent#tile
-         */
         tile : {
             get : function() {
                 return this._tile;
             }
         },
 
-        /**
-         * @inheritdoc Cesium3DTileContent#url
-         */
         url : {
             get : function() {
                 return this._resource.getUrlComponent(true);
             }
         },
 
-        /**
-         * @inheritdoc Cesium3DTileContent#batchTable
-         */
         batchTable : {
             get : function() {
                 return this._batchTable;
@@ -1203,9 +1164,6 @@ define([
         }
     }
 
-    /**
-     * @inheritdoc Cesium3DTileContent#hasProperty
-     */
     PointCloud3DTileContent.prototype.hasProperty = function(batchId, name) {
         if (defined(this._batchTable)) {
             return this._batchTable.hasProperty(batchId, name);
@@ -1239,16 +1197,10 @@ define([
         return this._features[batchId];
     };
 
-    /**
-     * @inheritdoc Cesium3DTileContent#applyDebugSettings
-     */
     PointCloud3DTileContent.prototype.applyDebugSettings = function(enabled, color) {
         this._highlightColor = enabled ? color : Color.WHITE;
     };
 
-    /**
-     * @inheritdoc Cesium3DTileContent#applyStyle
-     */
     PointCloud3DTileContent.prototype.applyStyle = function(frameState, style) {
         if (defined(this._batchTable)) {
             this._batchTable.applyStyle(frameState, style);
@@ -1260,9 +1212,6 @@ define([
     var scratchComputedTranslation = new Cartesian4();
     var scratchComputedMatrixIn2D = new Matrix4();
 
-    /**
-     * @inheritdoc Cesium3DTileContent#update
-     */
     PointCloud3DTileContent.prototype.update = function(tileset, frameState) {
         var modelMatrix = this._tile.computedTransform;
         var modelMatrixChanged = !Matrix4.equals(this._modelMatrix, modelMatrix);
@@ -1370,16 +1319,10 @@ define([
         }
     };
 
-    /**
-     * @inheritdoc Cesium3DTileContent#isDestroyed
-     */
     PointCloud3DTileContent.prototype.isDestroyed = function() {
         return false;
     };
 
-    /**
-     * @inheritdoc Cesium3DTileContent#destroy
-     */
     PointCloud3DTileContent.prototype.destroy = function() {
         var command = this._drawCommand;
         var pickCommand = this._pickCommand;

--- a/Source/Scene/Scene.js
+++ b/Source/Scene/Scene.js
@@ -1411,6 +1411,8 @@ define([
         /**
          * Whether or not to use a logarithmic depth buffer. Enabling this option will allow for less frustums in the multi-frustum,
          * increasing performance. This property relies on {@link Context#fragmentDepth} being supported.
+         * @memberof Scene.prototype
+         * @type {Boolean}
          */
         logarithmicDepthBuffer : {
             get : function() {

--- a/Source/Scene/Tileset3DTileContent.js
+++ b/Source/Scene/Tileset3DTileContent.js
@@ -33,117 +33,78 @@ define([
         this._resource = resource;
         this._readyPromise = when.defer();
 
-        /**
-         * @inheritdoc Cesium3DTileContent#featurePropertiesDirty
-         */
         this.featurePropertiesDirty = false;
 
         initialize(this, arrayBuffer, byteOffset);
     }
 
     defineProperties(Tileset3DTileContent.prototype, {
-        /**
-         * @inheritdoc Cesium3DTileContent#featuresLength
-         */
         featuresLength : {
             get : function() {
                 return 0;
             }
         },
 
-        /**
-         * @inheritdoc Cesium3DTileContent#pointsLength
-         */
         pointsLength : {
             get : function() {
                 return 0;
             }
         },
 
-        /**
-         * @inheritdoc Cesium3DTileContent#trianglesLength
-         */
         trianglesLength : {
             get : function() {
                 return 0;
             }
         },
 
-        /**
-         * @inheritdoc Cesium3DTileContent#geometryByteLength
-         */
         geometryByteLength : {
             get : function() {
                 return 0;
             }
         },
 
-        /**
-         * @inheritdoc Cesium3DTileContent#texturesByteLength
-         */
         texturesByteLength : {
             get : function() {
                 return 0;
             }
         },
 
-        /**
-         * @inheritdoc Cesium3DTileContent#batchTableByteLength
-         */
         batchTableByteLength : {
             get : function() {
                 return 0;
             }
         },
 
-        /**
-         * @inheritdoc Cesium3DTileContent#innerContents
-         */
         innerContents : {
             get : function() {
                 return undefined;
             }
         },
 
-        /**
-         * @inheritdoc Cesium3DTileContent#readyPromise
-         */
         readyPromise : {
             get : function() {
                 return this._readyPromise.promise;
             }
         },
 
-        /**
-         * @inheritdoc Cesium3DTileContent#tileset
-         */
         tileset : {
             get : function() {
                 return this._tileset;
             }
         },
 
-        /**
-         * @inheritdoc Cesium3DTileContent#tile
-         */
         tile : {
             get : function() {
                 return this._tile;
             }
         },
 
-        /**
-         * @inheritdoc Cesium3DTileContent#url
-         */
         url : {
             get : function() {
                 return this._resource.getUrlComponent(true);
             }
         },
 
-        /**
-         * @inheritdoc Cesium3DTileContent#batchTable
-         */
         batchTable : {
             get : function() {
                 return undefined;
@@ -184,34 +145,19 @@ define([
         return undefined;
     };
 
-    /**
-     * @inheritdoc Cesium3DTileContent#applyDebugSettings
-     */
     Tileset3DTileContent.prototype.applyDebugSettings = function(enabled, color) {
     };
 
-    /**
-     * @inheritdoc Cesium3DTileContent#applyStyle
-     */
     Tileset3DTileContent.prototype.applyStyle = function(frameState, style) {
     };
 
-    /**
-     * @inheritdoc Cesium3DTileContent#update
-     */
     Tileset3DTileContent.prototype.update = function(tileset, frameState) {
     };
 
-    /**
-     * @inheritdoc Cesium3DTileContent#isDestroyed
-     */
     Tileset3DTileContent.prototype.isDestroyed = function() {
         return false;
     };
 
-    /**
-     * @inheritdoc Cesium3DTileContent#destroy
-     */
     Tileset3DTileContent.prototype.destroy = function() {
         return destroyObject(this);
     };

--- a/Source/Scene/Vector3DTileContent.js
+++ b/Source/Scene/Vector3DTileContent.js
@@ -83,18 +83,12 @@ define([
     }
 
     defineProperties(Vector3DTileContent.prototype, {
-        /**
-         * @inheritdoc Cesium3DTileContent#featuresLength
-         */
         featuresLength : {
             get : function() {
                 return defined(this._batchTable) ? this._batchTable.featuresLength : 0;
             }
         },
 
-        /**
-         * @inheritdoc Cesium3DTileContent#pointsLength
-         */
         pointsLength : {
             get : function() {
                 if (defined(this._points)) {
@@ -104,9 +98,6 @@ define([
             }
         },
 
-        /**
-         * @inheritdoc Cesium3DTileContent#trianglesLength
-         */
         trianglesLength : {
             get : function() {
                 var trianglesLength = 0;
@@ -120,9 +111,6 @@ define([
             }
         },
 
-        /**
-         * @inheritdoc Cesium3DTileContent#geometryByteLength
-         */
         geometryByteLength : {
             get : function() {
                 var geometryByteLength = 0;
@@ -136,9 +124,6 @@ define([
             }
         },
 
-        /**
-         * @inheritdoc Cesium3DTileContent#texturesByteLength
-         */
         texturesByteLength : {
             get : function() {
                 if (defined(this._points)) {
@@ -148,63 +133,42 @@ define([
             }
         },
 
-        /**
-         * @inheritdoc Cesium3DTileContent#batchTableByteLength
-         */
         batchTableByteLength : {
             get : function() {
                 return defined(this._batchTable) ? this._batchTable.memorySizeInBytes : 0;
             }
         },
 
-        /**
-         * @inheritdoc Cesium3DTileContent#innerContents
-         */
         innerContents : {
             get : function() {
                 return undefined;
             }
         },
 
-        /**
-         * @inheritdoc Cesium3DTileContent#readyPromise
-         */
         readyPromise : {
             get : function() {
                 return this._readyPromise.promise;
             }
         },
 
-        /**
-         * @inheritdoc Cesium3DTileContent#tileset
-         */
         tileset : {
             get : function() {
                 return this._tileset;
             }
         },
 
-        /**
-         * @inheritdoc Cesium3DTileContent#tile
-         */
         tile : {
             get : function() {
                 return this._tile;
             }
         },
 
-        /**
-         * @inheritdoc Cesium3DTileContent#url
-         */
         url : {
             get : function() {
                 return this._resource.getUrlComponent(true);
             }
         },
 
-        /**
-         * @inheritdoc Cesium3DTileContent#batchTable
-         */
         batchTable : {
             get : function() {
                 return this._batchTable;
@@ -502,16 +466,10 @@ define([
         }
     }
 
-    /**
-     * @inheritdoc Cesium3DTileContent#hasProperty
-     */
     Vector3DTileContent.prototype.hasProperty = function(batchId, name) {
         return this._batchTable.hasProperty(batchId, name);
     };
 
-    /**
-     * @inheritdoc Cesium3DTileContent#getFeature
-     */
     Vector3DTileContent.prototype.getFeature = function(batchId) {
         //>>includeStart('debug', pragmas.debug);
         var featuresLength = this.featuresLength;
@@ -524,9 +482,6 @@ define([
         return this._features[batchId];
     };
 
-    /**
-     * @inheritdoc Cesium3DTileContent#applyDebugSettings
-     */
     Vector3DTileContent.prototype.applyDebugSettings = function(enabled, color) {
         if (defined(this._polygons)) {
             this._polygons.applyDebugSettings(enabled, color);
@@ -539,9 +494,6 @@ define([
         }
     };
 
-    /**
-     * @inheritdoc Cesium3DTileContent#applyStyle
-     */
     Vector3DTileContent.prototype.applyStyle = function(frameState, style) {
         createFeatures(this);
         if (defined(this._polygons)) {
@@ -555,9 +507,6 @@ define([
         }
     };
 
-    /**
-     * @inheritdoc Cesium3DTileContent#update
-     */
     Vector3DTileContent.prototype.update = function(tileset, frameState) {
         if (defined(this._batchTable)) {
             this._batchTable.update(tileset, frameState);
@@ -585,16 +534,10 @@ define([
         }
     };
 
-    /**
-     * @inheritdoc Cesium3DTileContent#isDestroyed
-     */
     Vector3DTileContent.prototype.isDestroyed = function() {
         return false;
     };
 
-    /**
-     * @inheritdoc Cesium3DTileContent#destroy
-     */
     Vector3DTileContent.prototype.destroy = function() {
         this._polygons = this._polygons && this._polygons.destroy();
         this._polylines = this._polylines && this._polylines.destroy();

--- a/Tools/jsdoc/cesium_template/static/styles/jsdoc-default.css
+++ b/Tools/jsdoc/cesium_template/static/styles/jsdoc-default.css
@@ -417,6 +417,11 @@ h6
     text-decoration: none;
 }
 
+.clear
+{
+    clear: both;
+}
+
 .important
 {
     font-weight: normal;

--- a/Tools/jsdoc/cesium_template/tmpl/augments.tmpl
+++ b/Tools/jsdoc/cesium_template/tmpl/augments.tmpl
@@ -1,0 +1,10 @@
+<?js
+    var data = obj;
+    var self = this;
+?>
+
+<?js if (data.augments && data.augments.length) { ?>
+    <ul><?js data.augments.forEach(function(a) { ?>
+        <li><?js= self.linkto(a, a) ?></li>
+    <?js }) ?></ul>
+<?js } ?>

--- a/Tools/jsdoc/cesium_template/tmpl/container.tmpl
+++ b/Tools/jsdoc/cesium_template/tmpl/container.tmpl
@@ -1,8 +1,16 @@
 <?js
     var self = this;
+    var isGlobalPage;
+
     docs.forEach(function(doc, i) {
 ?>
 
+<?js
+    // we only need to check this once
+    if (typeof isGlobalPage === 'undefined') {
+        isGlobalPage = (doc.kind === 'globalobj');
+    }
+?>
 <?js if (doc.kind === 'mainpage' || (doc.kind === 'package')) { ?>
     <?js= self.partial('mainpage.tmpl', doc) ?>
 <?js } else if (doc.kind === 'source') { ?>
@@ -39,9 +47,7 @@
     <?js if (doc.augments && doc.augments.length) { ?>
         <h3 class="subsection-title">Extends</h3>
 
-        <ul><?js doc.augments.forEach(function(a) { ?>
-            <li><?js= self.linkto(a, a) ?></li>
-        <?js }); ?></ul>
+        <?js= self.partial('augments.tmpl', doc) ?>
     <?js } ?>
 
     <?js if (doc.mixes && doc.mixes.length) { ?>
@@ -62,7 +68,7 @@
 
     <?js
         var classes = self.find({kind: 'class', memberof: doc.longname});
-        if (doc.kind !== 'globalobj' && classes && classes.length) {
+        if (!isGlobalPage && classes && classes.length) {
     ?>
         <h3 class="subsection-title">Classes</h3>
 
@@ -74,7 +80,7 @@
 
     <?js
         var namespaces = self.find({kind: 'namespace', memberof: doc.longname});
-        if (doc.kind !== 'globalobj' && namespaces && namespaces.length) {
+        if (!isGlobalPage && namespaces && namespaces.length) {
     ?>
         <h3 class="subsection-title">Namespaces</h3>
 
@@ -85,34 +91,34 @@
     <?js } ?>
 
     <?js
-        var members = self.find({kind: 'member', memberof: title === 'Global' ? {isUndefined: true} : doc.longname});
+        var members = self.find({kind: 'member', memberof: isGlobalPage ? {isUndefined: true} : doc.longname});
         if (members && members.length && members.forEach) {
     ?>
         <h3 class="subsection-title">Members</h3>
 
-        <dl><?js members.forEach(function(p) { ?>
+        <?js members.forEach(function(p) { ?>
             <?js= self.partial('members.tmpl', p) ?>
-        <?js }); ?></dl>
+        <?js }); ?>
     <?js } ?>
 
     <?js
-        var methods = self.find({kind: 'function', memberof: title === 'Global' ? {isUndefined: true} : doc.longname});
+        var methods = self.find({kind: 'function', memberof: isGlobalPage ? {isUndefined: true} : doc.longname});
         if (methods && methods.length && methods.forEach) {
     ?>
         <h3 class="subsection-title">Methods</h3>
 
-        <dl><?js methods.forEach(function(m) { ?>
+        <?js methods.forEach(function(m) { ?>
             <?js= self.partial('method.tmpl', m) ?>
-        <?js }); ?></dl>
+        <?js }); ?>
     <?js } ?>
 
     <?js
-        var typedefs = self.find({kind: 'typedef', memberof: title === 'Global' ? {isUndefined: true} : doc.longname});
+        var typedefs = self.find({kind: 'typedef', memberof: isGlobalPage ? {isUndefined: true} : doc.longname});
         if (typedefs && typedefs.length && typedefs.forEach) {
     ?>
         <h3 class="subsection-title">Type Definitions</h3>
 
-        <dl><?js typedefs.forEach(function(e) {
+        <?js typedefs.forEach(function(e) {
                 if (e.signature) {
             ?>
                 <?js= self.partial('method.tmpl', e) ?>
@@ -123,18 +129,18 @@
                 <?js= self.partial('members.tmpl', e) ?>
             <?js
                 }
-            }); ?></dl>
+            }); ?>
     <?js } ?>
 
     <?js
-        var events = self.find({kind: 'event', memberof: title === 'Global' ? {isUndefined: true} : doc.longname});
+        var events = self.find({kind: 'event', memberof: isGlobalPage ? {isUndefined: true} : doc.longname});
         if (events && events.length && events.forEach) {
     ?>
         <h3 class="subsection-title">Events</h3>
 
-        <dl><?js events.forEach(function(e) { ?>
+        <?js events.forEach(function(e) { ?>
             <?js= self.partial('method.tmpl', e) ?>
-        <?js }); ?></dl>
+        <?js }); ?>
     <?js } ?>
 </article>
 

--- a/Tools/jsdoc/cesium_template/tmpl/details.tmpl
+++ b/Tools/jsdoc/cesium_template/tmpl/details.tmpl
@@ -10,7 +10,7 @@ var self = this;
 
         <h5 class="subsection-title">Properties:</h5>
 
-        <dl><?js= this.partial('properties.tmpl', properties) ?></dl>
+        <dl><?js= this.partial('properties.tmpl', data) ?></dl>
 
     <?js } ?>
 

--- a/Tools/jsdoc/cesium_template/tmpl/details.tmpl
+++ b/Tools/jsdoc/cesium_template/tmpl/details.tmpl
@@ -3,16 +3,16 @@ var data = obj;
 var self = this;
 ?>
 <dl class="details">
-    <?js
-        var properties = data.properties;
-        if (properties && properties.length && properties.forEach) {
-    ?>
+<?js
+    var properties = data.properties;
+    if (properties && properties.length && properties.forEach) {
+?>
 
-        <h5 class="subsection-title">Properties:</h5>
+    <h5 class="subsection-title">Properties:</h5>
 
-        <dl><?js= this.partial('properties.tmpl', data) ?></dl>
+    <?js= this.partial('properties.tmpl', data) ?>
 
-    <?js } ?>
+<?js } ?>
 
     <?js if (data.version) {?>
     <dt class="tag-version">Version:</dt>

--- a/Tools/jsdoc/cesium_template/tmpl/members.tmpl
+++ b/Tools/jsdoc/cesium_template/tmpl/members.tmpl
@@ -2,33 +2,29 @@
 var data = obj;
 var self = this;
 ?>
-<dt>
-    <div class="nameContainer">
-    <h4 class="name" id="<?js= id ?>">
-        <a href="#<?js= id ?>" class="doc-link"></a>
-        <?js= data.attribs + (kind === 'class' ? 'new ' : '') + ((kind === 'class' || data.scope === 'static') ? 'Cesium.' : '') + (data.scope === 'static' ? longname : name) + (data.signature ? data.signature : '') ?>
-        <?js= this.partial('sourceLink.tmpl', data) ?>
-    </h4>
+<div class="nameContainer">
+<h4 class="name" id="<?js= id ?>">
+    <a href="#<?js= id ?>" class="doc-link"></a>
+    <?js= data.attribs + (kind === 'class' ? 'new ' : '') + ((kind === 'class' || data.scope === 'static') ? 'Cesium.' : '') + (data.scope === 'static' ? longname : name) + (data.signature ? data.signature : '') ?>
+    <?js= this.partial('sourceLink.tmpl', data) ?>
+</h4>
 
-    </div>
+</div>
 
-    <?js if (data.summary) { ?>
-    <p class="summary"><?js= summary ?></p>
-    <?js } ?>
-</dt>
-<dd>
-    <?js if (data.description) { ?>
-    <div class="description">
-        <?js= data.description ?>
-    </div>
-    <?js } ?>
+<?js if (data.summary) { ?>
+<p class="summary"><?js= summary ?></p>
+<?js } ?>
+<?js if (data.description) { ?>
+<div class="description">
+    <?js= data.description ?>
+</div>
+<?js } ?>
 
-    <?js if (data.fires && fires.length) { ?>
-        <h5>Fires:</h5>
-        <ul><?js fires.forEach(function(f) { ?>
-            <li><?js= self.linkto(f) ?></li>
-        <?js }); ?></ul>
-    <?js } ?>
+<?js if (data.fires && fires.length) { ?>
+    <h5>Fires:</h5>
+    <ul><?js fires.forEach(function(f) { ?>
+        <li><?js= self.linkto(f) ?></li>
+    <?js }); ?></ul>
+<?js } ?>
 
-    <?js= this.partial('details.tmpl', data) ?>
-</dd>
+<?js= this.partial('details.tmpl', data) ?>

--- a/Tools/jsdoc/cesium_template/tmpl/method.tmpl
+++ b/Tools/jsdoc/cesium_template/tmpl/method.tmpl
@@ -2,7 +2,6 @@
 var data = obj;
 var self = this;
 ?>
-<dt>
     <div class="nameContainer">
     <h4 class="name" id="<?js= id ?>">
         <a href="#<?js= id ?>" class="doc-link"></a>
@@ -15,86 +14,88 @@ var self = this;
     <?js if (data.summary) { ?>
     <p class="summary"><?js= summary ?></p>
     <?js } ?>
-</dt>
-<dd>
 
-    <?js if (data.description) { ?>
-    <div class="description">
-        <?js= data.description ?>
-    </div>
-    <?js } ?>
+<?js if (data.description) { ?>
+<div class="description">
+    <?js= data.description ?>
+</div>
+<?js } ?>
 
-    <?js if (data.performance) { ?>
-        <h5>Performance:</h5>
-        <p class="description"><?js= data.performance ?></p>
-    <?js } ?>
+<?js if (data.performance) { ?>
+    <h5>Performance:</h5>
+    <p class="description"><?js= data.performance ?></p>
+<?js } ?>
 
-    <?js if (kind === 'event' && data.type && data.type.names) {?>
-        <h5>Type:</h5>
-        <ul>
-            <li>
-                <?js= self.partial('type.tmpl', data.type.names) ?>
-            </li>
-        </ul>
-    <?js } ?>
+<?js if (data.augments && data.alias && data.alias.indexOf('module:') === 0) { ?>
+    <h5>Extends:</h5>
+    <?js= self.partial('augments.tmpl', data) ?>
+<?js } ?>
 
-    <?js if (data['this']) { ?>
-        <h5>This:</h5>
-        <ul><li><?js= this.linkto(data['this'], data['this']) ?></li></ul>
-    <?js } ?>
+<?js if (kind === 'event' && data.type && data.type.names) {?>
+    <h5>Type:</h5>
+    <ul>
+        <li>
+            <?js= self.partial('type.tmpl', data.type.names) ?>
+        </li>
+    </ul>
+<?js } ?>
 
-    <?js if (data.params && params.length) { ?>
-        <?js= this.partial('params.tmpl', params) ?>
-    <?js } ?>
+<?js if (data['this']) { ?>
+    <h5>This:</h5>
+    <ul><li><?js= this.linkto(data['this'], data['this']) ?></li></ul>
+<?js } ?>
 
-    <?js if (data.requires && data.requires.length) { ?>
-    <h5>Requires:</h5>
-    <ul><?js data.requires.forEach(function(r) { ?>
-        <li><?js= self.linkto(r) ?></li>
-    <?js }); ?></ul>
-    <?js } ?>
+<?js if (data.params && params.length) { ?>
+    <?js= this.partial('params.tmpl', params) ?>
+<?js } ?>
 
-    <?js if (data.fires && fires.length) { ?>
-    <h5>Fires:</h5>
-    <ul><?js fires.forEach(function(f) { ?>
-        <li><?js= self.linkto(f) ?></li>
-    <?js }); ?></ul>
-    <?js } ?>
+<?js if (data.requires && data.requires.length) { ?>
+<h5>Requires:</h5>
+<ul><?js data.requires.forEach(function(r) { ?>
+    <li><?js= self.linkto(r) ?></li>
+<?js }); ?></ul>
+<?js } ?>
 
-    <?js if (data.listens && listens.length) { ?>
-    <h5>Listens to Events:</h5>
-    <ul><?js listens.forEach(function(f) { ?>
-        <li><?js= self.linkto(f) ?></li>
-    <?js }); ?></ul>
-    <?js } ?>
+<?js if (data.fires && fires.length) { ?>
+<h5>Fires:</h5>
+<ul><?js fires.forEach(function(f) { ?>
+    <li><?js= self.linkto(f) ?></li>
+<?js }); ?></ul>
+<?js } ?>
 
-    <?js if (data.listeners && listeners.length) { ?>
-    <h5>Listeners of This Event:</h5>
-    <ul><?js listeners.forEach(function(f) { ?>
-        <li><?js= self.linkto(f) ?></li>
-    <?js }); ?></ul>
-    <?js } ?>
+<?js if (data.listens && listens.length) { ?>
+<h5>Listens to Events:</h5>
+<ul><?js listens.forEach(function(f) { ?>
+    <li><?js= self.linkto(f) ?></li>
+<?js }); ?></ul>
+<?js } ?>
 
-    <?js if (data.returns && returns.length) { ?>
-    <h5>Returns:</h5>
-    <?js if (returns.length > 1) { ?><ul><?js
-        returns.forEach(function(r) { ?>
-            <li><?js= self.partial('returns.tmpl', r) ?></li>
-        <?js });
-    ?></ul><?js } else {
-        returns.forEach(function(r) { ?>
-            <?js= self.partial('returns.tmpl', r) ?>
-        <?js });
-    } } ?>
+<?js if (data.listeners && listeners.length) { ?>
+<h5>Listeners of This Event:</h5>
+<ul><?js listeners.forEach(function(f) { ?>
+    <li><?js= self.linkto(f) ?></li>
+<?js }); ?></ul>
+<?js } ?>
 
-    <?js if (data.exceptions && exceptions.length) { ?>
-    <h5>Throws:</h5>
-    <ul><?js
-        exceptions.forEach(function(r) { ?>
-            <li><?js= self.partial('exceptions.tmpl', r) ?></li>
-        <?js });
-    ?></ul>
-    <?js } ?>
+<?js if (data.returns && returns.length) { ?>
+<h5>Returns:</h5>
+<?js if (returns.length > 1) { ?><ul><?js
+    returns.forEach(function(r) { ?>
+        <li><?js= self.partial('returns.tmpl', r) ?></li>
+    <?js });
+?></ul><?js } else {
+    returns.forEach(function(r) { ?>
+        <?js= self.partial('returns.tmpl', r) ?>
+    <?js });
+} } ?>
 
-    <?js= this.partial('details.tmpl', data) ?>
-</dd>
+<?js if (data.exceptions && exceptions.length) { ?>
+<h5>Throws:</h5>
+<ul><?js
+    exceptions.forEach(function(r) { ?>
+        <li><?js= self.partial('exceptions.tmpl', r) ?></li>
+    <?js });
+?></ul>
+<?js } ?>
+
+<?js= this.partial('details.tmpl', data) ?>

--- a/Tools/jsdoc/cesium_template/tmpl/params.tmpl
+++ b/Tools/jsdoc/cesium_template/tmpl/params.tmpl
@@ -4,12 +4,24 @@
     /* sort subparams under their parent params (like opts.classname) */
     var parentParam = null;
     params.forEach(function(param, i) {
-        if (!param) { return; }
-        if ( parentParam && param.name && param.name.indexOf(parentParam.name + '.') === 0 ) {
-            param.name = param.name.substr(parentParam.name.length+1);
-            parentParam.subparams = parentParam.subparams || [];
-            parentParam.subparams.push(param);
-            params[i] = null;
+        var paramRegExp;
+
+        if (!param) {
+            return;
+        }
+
+        if (parentParam && parentParam.name && param.name) {
+            paramRegExp = new RegExp('^(?:' + parentParam.name + '(?:\\[\\])*)\\.(.+)$');
+
+            if ( paramRegExp.test(param.name) ) {
+                param.name = RegExp.$1;
+                parentParam.subparams = parentParam.subparams || [];
+                parentParam.subparams.push(param);
+                params[i] = null;
+            }
+            else {
+                parentParam = param;
+            }
         }
         else {
             parentParam = param;

--- a/Tools/jsdoc/cesium_template/tmpl/properties.tmpl
+++ b/Tools/jsdoc/cesium_template/tmpl/properties.tmpl
@@ -1,5 +1,6 @@
 <?js
-    var props = obj;
+    var data = obj;
+    var props = data.subprops || data.properties;
 
     /* sort subprops under their parent props (like opts.classname) */
     var parentProp = null;
@@ -32,7 +33,7 @@
             props.hasName = true;
         }
 
-        if (typeof prop.defaultvalue !== 'undefined') {
+        if (typeof prop.defaultvalue !== 'undefined' && !data.isEnum) {
             props.hasDefault = true;
         }
     });
@@ -98,7 +99,7 @@
             <?js } ?>
 
             <td class="description last"><?js= prop.description ?><?js if (prop.subprops) { ?>
-                <h6>Properties</h6><?js= self.partial('properties.tmpl', prop.subprops) ?>
+                <h6>Properties</h6><?js= self.partial('properties.tmpl', prop) ?>
             <?js } ?></td>
         </tr>
 


### PR DESCRIPTION
I found most of these when I happened to look at https://cesiumjs.org/Cesium/Build/Documentation/global.html  

Normally this page should be empty - that is, every item on this page represents a documentation error.

* Most of these are a case of forgetting to document properties added via `defineProperties` using the `@memberof` tag.
* Geocoding response type should not be documented as a global, instead, should be a nested type for findability.
* One case of forgetting to mark a `@glslUniform`.
* Various misuse of `@inheritdoc`.  Despite the desires of whoever used it, it does not work the way they thought - it does not take the name of an item to inherit from.  In fact, it's largely useless.  All occurrences were in types that were supposed to be private anyway.
* Also includes a patch to the JSDoc template from upstream that suppresses the default column for `@enum` types.  We don't (yet) use this tag, though clearly I was looking into it for future use.
