### PR TITLE
Use relative path for Bing metadata

### DIFF
--- a/Source/Scene/BingMapsImageryProvider.js
+++ b/Source/Scene/BingMapsImageryProvider.js
@@ -141,7 +141,7 @@ define([
         this._readyPromise = when.defer();
 
         var metadataResource = this._resource.getDerivedResource({
-            url:'/REST/v1/Imagery/Metadata/' + this._mapStyle,
+            url:'REST/v1/Imagery/Metadata/' + this._mapStyle,
             queryParameters: {
                 incl: 'ImageryProviders',
                 key: this._key


### PR DESCRIPTION
With the leading slash the url is always rooted. For example if I give the url `http://foo.bar/foo/bar/` it will query `http://foo.bar/REST/v1/Imagery/Metadata/...` instead of the expected `http://foo.bar/foo/bar/REST/v1/Imagery/Metadata/...`.