### PR TITLE
Add half float texture support.

### DIFF
--- a/Source/Core/WebGLConstants.js
+++ b/Source/Core/WebGLConstants.js
@@ -329,6 +329,9 @@ define([
         // WEBGL_compressed_texture_etc1
         COMPRESSED_RGB_ETC1_WEBGL : 0x8D64,
 
+        // EXT_color_buffer_half_float
+        HALF_FLOAT_OES : 0x8D61,
+
         // Desktop OpenGL
         DOUBLE : 0x140A,
 

--- a/Source/Renderer/Context.js
+++ b/Source/Renderer/Context.js
@@ -12,6 +12,7 @@ define([
         '../Core/Geometry',
         '../Core/GeometryAttribute',
         '../Core/Matrix4',
+        '../Core/PixelFormat',
         '../Core/PrimitiveType',
         '../Core/RuntimeError',
         '../Core/WebGLConstants',
@@ -23,6 +24,7 @@ define([
         './DrawCommand',
         './PassState',
         './PickFramebuffer',
+        './PixelDatatype',
         './RenderState',
         './ShaderCache',
         './ShaderProgram',
@@ -43,6 +45,7 @@ define([
         Geometry,
         GeometryAttribute,
         Matrix4,
+        PixelFormat,
         PrimitiveType,
         RuntimeError,
         WebGLConstants,
@@ -54,6 +57,7 @@ define([
         DrawCommand,
         PassState,
         PickFramebuffer,
+        PixelDatatype,
         RenderState,
         ShaderCache,
         ShaderProgram,
@@ -273,10 +277,12 @@ define([
         this._elementIndexUint = !!getExtension(gl, ['OES_element_index_uint']);
         this._depthTexture = !!getExtension(gl, ['WEBGL_depth_texture', 'WEBKIT_WEBGL_depth_texture']);
         this._textureFloat = !!getExtension(gl, ['OES_texture_float']);
+        this._textureHalfFloat = !!getExtension(gl, ['OES_texture_half_float']);
         this._fragDepth = !!getExtension(gl, ['EXT_frag_depth']);
         this._debugShaders = getExtension(gl, ['WEBGL_debug_shaders']);
 
-        this._colorBufferFloat = this._webgl2 && !!getExtension(gl, ['EXT_color_buffer_float']);
+        this._colorBufferFloat = !!getExtension(gl, ['EXT_color_buffer_float', 'WEBGL_color_buffer_float']);
+        this._colorBufferHalfFloat = !!getExtension(gl, ['EXT_color_buffer_half_float']);
 
         this._s3tc = !!getExtension(gl, ['WEBGL_compressed_texture_s3tc', 'MOZ_WEBGL_compressed_texture_s3tc', 'WEBKIT_WEBGL_compressed_texture_s3tc']);
         this._pvrtc = !!getExtension(gl, ['WEBGL_compressed_texture_pvrtc', 'WEBKIT_WEBGL_compressed_texture_pvrtc']);
@@ -564,11 +570,24 @@ define([
          * access to floating point textures that, for example, can be attached to framebuffers for high dynamic range.
          * @memberof Context.prototype
          * @type {Boolean}
-         * @see {@link http://www.khronos.org/registry/gles/extensions/OES/OES_texture_float.txt|OES_texture_float}
+         * @see {@link https://www.khronos.org/registry/webgl/extensions/OES_texture_float/}
          */
         floatingPointTexture : {
             get : function() {
-                return this._textureFloat || this._colorBufferFloat;
+                return this._webgl2 || this._textureFloat;
+            }
+        },
+
+        /**
+         * <code>true</code> if OES_texture_half_float is supported.  This extension provides
+         * access to floating point textures that, for example, can be attached to framebuffers for high dynamic range.
+         * @memberof Context.prototype
+         * @type {Boolean}
+         * @see {@link https://www.khronos.org/registry/webgl/extensions/OES_texture_float/}
+         */
+        halfFloatingPointTexture : {
+            get : function() {
+                return this._webgl2 || this._textureHalfFloat;
             }
         },
 
@@ -661,15 +680,29 @@ define([
 
         /**
          * <code>true</code> if the EXT_color_buffer_float extension is supported.  This
-         * extension makes the formats gl.R16F, gl.RG16F, gl.RGBA16F, gl.R32F, gl.RG32F,
-         * gl.RGBA32F, gl.R11F_G11F_B10F color renderable.
+         * extension makes the gl.RGBA32F format color renderable.
          * @memberof Context.prototype
          * @type {Boolean}
+         * @see {@link https://www.khronos.org/registry/webgl/extensions/WEBGL_color_buffer_float/}
          * @see {@link https://www.khronos.org/registry/webgl/extensions/EXT_color_buffer_float/}
          */
         colorBufferFloat : {
             get : function() {
                 return this._colorBufferFloat;
+            }
+        },
+
+        /**
+         * <code>true</code> if the EXT_color_buffer_half_float extension is supported.  This
+         * extension makes the format gl.RGBA16F format color renderable.
+         * @memberof Context.prototype
+         * @type {Boolean}
+         * @see {@link https://www.khronos.org/registry/webgl/extensions/EXT_color_buffer_half_float/}
+         * @see {@link https://www.khronos.org/registry/webgl/extensions/EXT_color_buffer_float/}
+         */
+        colorBufferHalfFloat : {
+            get : function() {
+                return (this._webgl2 && this._colorBufferFloat) || (!this._webgl2 && this._colorBufferHalfFloat);
             }
         },
 
@@ -1040,11 +1073,16 @@ define([
         Check.typeOf.number.greaterThan('readState.height', height, 0);
         //>>includeEnd('debug');
 
-        var pixels = new Uint8Array(4 * width * height);
+        var pixelDatatype = PixelDatatype.UNSIGNED_BYTE;
+        if (defined(framebuffer) && framebuffer.numberOfColorAttachments > 0) {
+            pixelDatatype = framebuffer.getColorTexture(0).pixelDatatype;
+        }
+
+        var pixels = PixelFormat.createTypedArray(PixelFormat.RGBA, pixelDatatype, width, height);
 
         bindFramebuffer(this, framebuffer);
 
-        gl.readPixels(x, y, width, height, gl.RGBA, gl.UNSIGNED_BYTE, pixels);
+        gl.readPixels(x, y, width, height, PixelFormat.RGBA, pixelDatatype, pixels);
 
         return pixels;
     };

--- a/Source/Renderer/Context.js
+++ b/Source/Renderer/Context.js
@@ -1061,11 +1061,11 @@ define([
     Context.prototype.readPixels = function(readState) {
         var gl = this._gl;
 
-        readState = readState || {};
-        var x = Math.max(readState.x || 0, 0);
-        var y = Math.max(readState.y || 0, 0);
-        var width = readState.width || gl.drawingBufferWidth;
-        var height = readState.height || gl.drawingBufferHeight;
+        readState = defaultValue(readState, defaultValue.EMPTY_OBJECT);
+        var x = Math.max(defaultValue(readState.x, 0), 0);
+        var y = Math.max(defaultValue(readState.y, 0), 0);
+        var width = defaultValue(readState.width, gl.drawingBufferWidth);
+        var height = defaultValue(readState.height, gl.drawingBufferHeight);
         var framebuffer = readState.framebuffer;
 
         //>>includeStart('debug', pragmas.debug);

--- a/Source/Renderer/CubeMap.js
+++ b/Source/Renderer/CubeMap.js
@@ -104,6 +104,10 @@ define([
         if ((pixelDatatype === PixelDatatype.FLOAT) && !context.floatingPointTexture) {
             throw new DeveloperError('When options.pixelDatatype is FLOAT, this WebGL implementation must support the OES_texture_float extension.');
         }
+
+        if ((pixelDatatype === PixelDatatype.HALF_FLOAT) && !context.halfFloatingPointTexture) {
+            throw new DeveloperError('When options.pixelDatatype is HALF_FLOAT, this WebGL implementation must support the OES_texture_half_float extension.');
+        }
         //>>includeEnd('debug');
 
         var sizeInBytes = PixelFormat.textureSizeInBytes(pixelFormat, pixelDatatype, size, size) * 6;
@@ -228,7 +232,7 @@ define([
                     (minificationFilter === TextureMinificationFilter.LINEAR_MIPMAP_LINEAR);
 
                 // float textures only support nearest filtering, so override the sampler's settings
-                if (this._pixelDatatype === PixelDatatype.FLOAT) {
+                if (this._pixelDatatype === PixelDatatype.FLOAT || this._pixelDatatype === PixelDatatype.HALF_FLOAT) {
                     minificationFilter = mipmap ? TextureMinificationFilter.NEAREST_MIPMAP_NEAREST : TextureMinificationFilter.NEAREST;
                     magnificationFilter = TextureMagnificationFilter.NEAREST;
                 }

--- a/Source/Renderer/CubeMapFace.js
+++ b/Source/Renderer/CubeMapFace.js
@@ -176,6 +176,7 @@ define([
      * @param {Number} [height=CubeMap's height] The height of the subimage to copy.
      *
      * @exception {DeveloperError} Cannot call copyFromFramebuffer when the texture pixel data type is FLOAT.
+     * @exception {DeveloperError} Cannot call copyFromFramebuffer when the texture pixel data type is HALF_FLOAT.
      * @exception {DeveloperError} This CubeMap was destroyed, i.e., destroy() was called.
      * @exception {DeveloperError} xOffset must be greater than or equal to zero.
      * @exception {DeveloperError} yOffset must be greater than or equal to zero.
@@ -210,6 +211,9 @@ define([
         }
         if (this._pixelDatatype === PixelDatatype.FLOAT) {
             throw new DeveloperError('Cannot call copyFromFramebuffer when the texture pixel data type is FLOAT.');
+        }
+        if (this._pixelDatatype === PixelDatatype.HALF_FLOAT) {
+            throw new DeveloperError('Cannot call copyFromFramebuffer when the texture pixel data type is HALF_FLOAT.');
         }
         //>>includeEnd('debug');
 

--- a/Source/Renderer/Framebuffer.js
+++ b/Source/Renderer/Framebuffer.js
@@ -6,7 +6,8 @@ define([
         '../Core/destroyObject',
         '../Core/DeveloperError',
         '../Core/PixelFormat',
-        './ContextLimits'
+        './ContextLimits',
+        './PixelDatatype'
     ], function(
         Check,
         defaultValue,
@@ -15,7 +16,8 @@ define([
         destroyObject,
         DeveloperError,
         PixelFormat,
-        ContextLimits) {
+        ContextLimits,
+        PixelDatatype) {
     'use strict';
 
     function attachTexture(framebuffer, attachment, texture) {
@@ -45,6 +47,8 @@ define([
      * @exception {DeveloperError} The depth-texture pixel-format must be DEPTH_COMPONENT.
      * @exception {DeveloperError} The depth-stencil-texture pixel-format must be DEPTH_STENCIL.
      * @exception {DeveloperError} The number of color attachments exceeds the number supported.
+     * @exception {DeveloperError} The color-texture pixel datatype is HALF_FLOAT and the WebGL implementation does not support the EXT_color_buffer_half_float extension.
+     * @exception {DeveloperError} The color-texture pixel datatype is FLOAT and the WebGL implementation does not support the EXT_color_buffer_float or WEBGL_color_buffer_float extensions.
      *
      * @example
      * // Create a framebuffer with color and depth texture attachments.
@@ -72,11 +76,12 @@ define([
     function Framebuffer(options) {
         options = defaultValue(options, defaultValue.EMPTY_OBJECT);
 
+        var context = options.context;
         //>>includeStart('debug', pragmas.debug);
-        Check.defined('options.context', options.context);
+        Check.defined('options.context', context);
         //>>includeEnd('debug');
 
-        var gl = options.context._gl;
+        var gl = context._gl;
         var maximumColorAttachments = ContextLimits.maximumColorAttachments;
 
         this._gl = gl;
@@ -161,6 +166,12 @@ define([
                 //>>includeStart('debug', pragmas.debug);
                 if (!PixelFormat.isColorFormat(texture.pixelFormat)) {
                     throw new DeveloperError('The color-texture pixel-format must be a color format.');
+                }
+                if (texture.pixelDatatype === PixelDatatype.FLOAT && !context.colorBufferFloat) {
+                    throw new DeveloperError('The color texture pixel datatype is FLOAT and the WebGL implementation does not support the EXT_color_buffer_float or WEBGL_color_buffer_float extensions. See Context.colorBufferFloat.');
+                }
+                if (texture.pixelDatatype === PixelDatatype.HALF_FLOAT && !context.colorBufferHalfFloat) {
+                    throw new DeveloperError('The color texture pixel datatype is HALF_FLOAT and the WebGL implementation does not support the EXT_color_buffer_half_float extension. See Context.colorBufferHalfFloat.');
                 }
                 //>>includeEnd('debug');
 

--- a/Source/Renderer/PixelDatatype.js
+++ b/Source/Renderer/PixelDatatype.js
@@ -14,6 +14,7 @@ define([
         UNSIGNED_SHORT : WebGLConstants.UNSIGNED_SHORT,
         UNSIGNED_INT : WebGLConstants.UNSIGNED_INT,
         FLOAT : WebGLConstants.FLOAT,
+        HALF_FLOAT : WebGLConstants.HALF_FLOAT_OES,
         UNSIGNED_INT_24_8 : WebGLConstants.UNSIGNED_INT_24_8,
         UNSIGNED_SHORT_4_4_4_4 : WebGLConstants.UNSIGNED_SHORT_4_4_4_4,
         UNSIGNED_SHORT_5_5_5_1 : WebGLConstants.UNSIGNED_SHORT_5_5_5_1,
@@ -34,6 +35,7 @@ define([
                 case PixelDatatype.UNSIGNED_SHORT_4_4_4_4:
                 case PixelDatatype.UNSIGNED_SHORT_5_5_5_1:
                 case PixelDatatype.UNSIGNED_SHORT_5_6_5:
+                case PixelDatatype.HALF_FLOAT:
                     return 2;
                 case PixelDatatype.UNSIGNED_INT:
                 case PixelDatatype.FLOAT:
@@ -47,6 +49,7 @@ define([
                     (pixelDatatype === PixelDatatype.UNSIGNED_SHORT) ||
                     (pixelDatatype === PixelDatatype.UNSIGNED_INT) ||
                     (pixelDatatype === PixelDatatype.FLOAT) ||
+                    (pixelDatatype === PixelDatatype.HALF_FLOAT) ||
                     (pixelDatatype === PixelDatatype.UNSIGNED_INT_24_8) ||
                     (pixelDatatype === PixelDatatype.UNSIGNED_SHORT_4_4_4_4) ||
                     (pixelDatatype === PixelDatatype.UNSIGNED_SHORT_5_5_5_1) ||

--- a/Source/Renderer/Texture.js
+++ b/Source/Renderer/Texture.js
@@ -89,6 +89,21 @@ define([
                         internalFormat = WebGLConstants.R32F;
                         break;
                 }
+            } else if (pixelDatatype === PixelDatatype.HALF_FLOAT) {
+                switch (pixelFormat) {
+                    case PixelFormat.RGBA:
+                        internalFormat = WebGLConstants.RGBA16F;
+                        break;
+                    case PixelFormat.RGB:
+                        internalFormat = WebGLConstants.RGB16F;
+                        break;
+                    case PixelFormat.RG:
+                        internalFormat = WebGLConstants.RG16F;
+                        break;
+                    case PixelFormat.R:
+                        internalFormat = WebGLConstants.R16F;
+                        break;
+                }
             }
         }
 
@@ -128,6 +143,10 @@ define([
 
         if ((pixelDatatype === PixelDatatype.FLOAT) && !context.floatingPointTexture) {
             throw new DeveloperError('When options.pixelDatatype is FLOAT, this WebGL implementation must support the OES_texture_float extension.  Check context.floatingPointTexture.');
+        }
+
+        if ((pixelDatatype === PixelDatatype.HALF_FLOAT) && !context.halfFloatingPointTexture) {
+            throw new DeveloperError('When options.pixelDatatype is HALF_FLOAT, this WebGL implementation must support the OES_texture_half_float extension. Check context.halfFloatingPointTexture.');
         }
 
         if (PixelFormat.isDepthFormat(pixelFormat)) {
@@ -367,7 +386,7 @@ define([
                     (minificationFilter === TextureMinificationFilter.LINEAR_MIPMAP_LINEAR);
 
                 // float textures only support nearest filtering, so override the sampler's settings
-                if (this._pixelDatatype === PixelDatatype.FLOAT) {
+                if (this._pixelDatatype === PixelDatatype.FLOAT || this._pixelDatatype === PixelDatatype.HALF_FLOAT) {
                     minificationFilter = mipmap ? TextureMinificationFilter.NEAREST_MIPMAP_NEAREST : TextureMinificationFilter.NEAREST;
                     magnificationFilter = TextureMagnificationFilter.NEAREST;
                 }
@@ -563,6 +582,7 @@ define([
      *
      * @exception {DeveloperError} Cannot call copyFromFramebuffer when the texture pixel format is DEPTH_COMPONENT or DEPTH_STENCIL.
      * @exception {DeveloperError} Cannot call copyFromFramebuffer when the texture pixel data type is FLOAT.
+     * @exception {DeveloperError} Cannot call copyFromFramebuffer when the texture pixel data type is HALF_FLOAT.
      * @exception {DeveloperError} Cannot call copyFrom with a compressed texture pixel format.
      * @exception {DeveloperError} This texture was destroyed, i.e., destroy() was called.
      * @exception {DeveloperError} xOffset must be greater than or equal to zero.
@@ -586,6 +606,9 @@ define([
         }
         if (this._pixelDatatype === PixelDatatype.FLOAT) {
             throw new DeveloperError('Cannot call copyFromFramebuffer when the texture pixel data type is FLOAT.');
+        }
+        if (this._pixelDatatype === PixelDatatype.HALF_FLOAT) {
+            throw new DeveloperError('Cannot call copyFromFramebuffer when the texture pixel data type is HALF_FLOAT.');
         }
         if (PixelFormat.isCompressedFormat(this._pixelFormat)) {
             throw new DeveloperError('Cannot call copyFrom with a compressed texture pixel format.');

--- a/Source/Scene/OIT.js
+++ b/Source/Scene/OIT.js
@@ -44,7 +44,7 @@ define([
         this._translucentMultipassSupport = false;
         this._translucentMRTSupport = false;
 
-        var extensionsSupported = context.floatingPointTexture && context.depthTexture;
+        var extensionsSupported = context.colorBufferFloat && context.depthTexture;
         this._translucentMRTSupport = context.drawBuffers && extensionsSupported;
         this._translucentMultipassSupport = !this._translucentMRTSupport && extensionsSupported;
 

--- a/Specs/Renderer/CubeMapSpec.js
+++ b/Specs/Renderer/CubeMapSpec.js
@@ -384,6 +384,75 @@ defineSuite([
         });
     });
 
+    it('creates a cube map with half floating-point textures', function() {
+        if (!context.halfFloatingPointTexture) {
+            return;
+        }
+
+        var positiveXFloats = [12902, 13926, 14541, 15360];
+        var negativeXFloats = [13926, 12902, 14541, 15360];
+        var positiveYFloats = [14541, 13926, 12902, 15360];
+        var negativeYFloats = [12902, 14541, 13926, 15360];
+        var positiveZFloats = [13926, 14541, 12902, 15360];
+        var negativeZFloats = [14541, 12902, 13926, 15360];
+
+        var positiveXColor = new Color(0.2, 0.4, 0.6, 1.0);
+        var negativeXColor = new Color(0.4, 0.2, 0.6, 1.0);
+        var positiveYColor = new Color(0.6, 0.4, 0.2, 1.0);
+        var negativeYColor = new Color(0.2, 0.6, 0.4, 1.0);
+        var positiveZColor = new Color(0.4, 0.6, 0.2, 1.0);
+        var negativeZColor = new Color(0.6, 0.2, 0.4, 1.0);
+
+        cubeMap = new CubeMap({
+            context : context,
+            source : {
+                positiveX : {
+                    width : 1,
+                    height : 1,
+                    arrayBufferView : new Uint16Array(positiveXFloats)
+                },
+                negativeX : {
+                    width : 1,
+                    height : 1,
+                    arrayBufferView : new Uint16Array(negativeXFloats)
+                },
+                positiveY : {
+                    width : 1,
+                    height : 1,
+                    arrayBufferView : new Uint16Array(positiveYFloats)
+                },
+                negativeY : {
+                    width : 1,
+                    height : 1,
+                    arrayBufferView : new Uint16Array(negativeYFloats)
+                },
+                positiveZ : {
+                    width : 1,
+                    height : 1,
+                    arrayBufferView : new Uint16Array(positiveZFloats)
+                },
+                negativeZ : {
+                    width : 1,
+                    height : 1,
+                    arrayBufferView : new Uint16Array(negativeZFloats)
+                }
+            },
+            pixelDatatype : PixelDatatype.HALF_FLOAT
+        });
+
+        expectCubeMapFaces({
+            cubeMap : cubeMap,
+            expectedColors : [
+                positiveXColor.toBytes(),
+                negativeXColor.toBytes(),
+                positiveYColor.toBytes(),
+                negativeYColor.toBytes(),
+                positiveZColor.toBytes(),
+                negativeZColor.toBytes()
+            ]
+        });
+    });
+
     it('creates a cube map with typed arrays and images', function() {
         cubeMap = new CubeMap({
             context : context,
@@ -847,6 +916,19 @@ defineSuite([
         }
     });
 
+    it('throws during creation if pixelDatatype is HALF_FLOAT, and OES_texture_half_float is not supported', function() {
+        if (!context.halfFloatingPointTexture) {
+            expect(function() {
+                cubeMap = new CubeMap({
+                    context : context,
+                    width : 16,
+                    height : 16,
+                    pixelDatatype : PixelDatatype.HALF_FLOAT
+                });
+            }).toThrowDeveloperError();
+        }
+    });
+
     it('fails to create (pixelDatatype)', function() {
         expect(function() {
             cubeMap = new CubeMap({
@@ -1034,6 +1116,40 @@ defineSuite([
 
         expect(function() {
             cubeMap.negativeZ.copyFromFramebuffer(0, 0, 0, 0, 0, cubeMap.height + 1);
+        }).toThrowDeveloperError();
+    });
+
+    it('fails to copy from the framebuffer (FLOAT', function() {
+        if (!context.floatingPointTexture) {
+            return;
+        }
+
+        cubeMap = new CubeMap({
+            context : context,
+            width : 1,
+            height : 1,
+            pixelDatatype : PixelDatatype.FLOAT
+        });
+
+        expect(function() {
+            cubeMap.negativeX.copyFromFramebuffer(0, 0, 0, 0, 0, 0);
+        }).toThrowDeveloperError();
+    });
+
+    it('fails to copy from the framebuffer (HALF_FLOAT', function() {
+        if (!context.halfFloatingPointTexture) {
+            return;
+        }
+
+        cubeMap = new CubeMap({
+            context : context,
+            width : 1,
+            height : 1,
+            pixelDatatype : PixelDatatype.HALF_FLOAT
+        });
+
+        expect(function() {
+            cubeMap.negativeX.copyFromFramebuffer(0, 0, 0, 0, 0, 0);
         }).toThrowDeveloperError();
     });
 

--- a/Specs/Renderer/TextureSpec.js
+++ b/Specs/Renderer/TextureSpec.js
@@ -213,6 +213,36 @@ defineSuite([
         }
     });
 
+    it('draws the expected half floating-point texture color', function() {
+        if (context.halfFloatingPointTexture) {
+            context.throwOnWebGLError = true;
+            var color = new Color(0.2, 0.4, 0.6, 1.0);
+            var floats = new Uint16Array([12902, 13926, 14541, 15360]);
+
+            texture = new Texture({
+                context : context,
+                pixelFormat : PixelFormat.RGBA,
+                pixelDatatype : PixelDatatype.HALF_FLOAT,
+                source : {
+                    width : 1,
+                    height : 1,
+                    arrayBufferView : floats
+                },
+                flipY : false
+            });
+
+            expect(texture.sizeInBytes).toEqual(8);
+
+            expect({
+                context : context,
+                fragmentShader : fs,
+                uniformMap : uniformMap
+            }).contextToRender(color.toBytes());
+
+            context.throwOnWebGLError = false;
+        }
+    });
+
     it('draws the expected DXT compressed texture color', function() {
         if (!context.s3tc) {
             return;
@@ -772,6 +802,20 @@ defineSuite([
         }
     });
 
+    it('throws when creating if pixelDatatype = HALF_FLOAT, and OES_texture_half_float is not supported', function() {
+        if (!context.halfFloatingPointTexture) {
+            expect(function() {
+                texture = new Texture({
+                    context : context,
+                    width : 1,
+                    height : 1,
+                    pixelFormat : PixelDatatype.RGBA,
+                    pixelDatatype : PixelDatatype.HALF_FLOAT
+                });
+            }).toThrowDeveloperError();
+        }
+    });
+
     it('throws when creating compressed texture and the array buffer source is undefined', function() {
         expect(function() {
             texture = new Texture({
@@ -953,6 +997,22 @@ defineSuite([
                 height : 1,
                 pixelFormat : PixelFormat.RGBA,
                 pixelDatatype : PixelDatatype.FLOAT
+            });
+
+            expect(function() {
+                texture.copyFromFramebuffer();
+            }).toThrowDeveloperError();
+        }
+    });
+
+    it('throws when copying to a texture from the framebuffer with a HALF_FLOAT pixel data type', function() {
+        if (context.halfFloatingPointTexture) {
+            texture = new Texture({
+                context : context,
+                width : 1,
+                height : 1,
+                pixelFormat : PixelFormat.RGBA,
+                pixelDatatype : PixelDatatype.HALF_FLOAT
             });
 
             expect(function() {

--- a/Specs/Renderer/TextureSpec.js
+++ b/Specs/Renderer/TextureSpec.js
@@ -215,7 +215,6 @@ defineSuite([
 
     it('draws the expected half floating-point texture color', function() {
         if (context.halfFloatingPointTexture) {
-            context.throwOnWebGLError = true;
             var color = new Color(0.2, 0.4, 0.6, 1.0);
             var floats = new Uint16Array([12902, 13926, 14541, 15360]);
 
@@ -238,8 +237,6 @@ defineSuite([
                 fragmentShader : fs,
                 uniformMap : uniformMap
             }).contextToRender(color.toBytes());
-
-            context.throwOnWebGLError = false;
         }
     });
 


### PR DESCRIPTION
Add support for half float textures and render targets which will be useful for HDR.

For WebGL 1 see:
[OES_texture_half_float](https://www.khronos.org/registry/webgl/extensions/OES_texture_half_float/)
[EXT_color_buffer_half_float](https://www.khronos.org/registry/webgl/extensions/EXT_color_buffer_half_float/)

For WebGL 2, all floating-point texture formats are supported, but there is an extension for whether they are color renderable. [EXT_color_buffer_float](https://www.khronos.org/registry/webgl/extensions/EXT_color_buffer_float/)