### PR TITLE
Fix polygon outline when using perPositionHeight and extrudedHeight

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,6 +24,7 @@ Change Log
 * Fixed race condition causing intermittent crash when changing geometry show value [#3061](https://github.com/AnalyticalGraphicsInc/cesium/issues/3061)
 * `ProviderViewModel`s with no category are displayed in an untitled group in `BaseLayerPicker` instead of being labeled as `'Other'` [#6574](https://github.com/AnalyticalGraphicsInc/cesium/pull/6574)
 * Added a workaround for clipping planes causing a picking shader compilation failure for gltf models and 3D Tilesets in Internet Explorer [#6575](https://github.com/AnalyticalGraphicsInc/cesium/issues/6575)
+* Fixed polygon outline when using `perPositionHeight` and `extrudedHeight` [#6595](https://github.com/AnalyticalGraphicsInc/cesium/issues/6595) 
 
 ##### Breaking Changes :mega:
 * Removed `Scene.copyGlobeDepth`. Globe depth will now be copied by default when supported. [#6393](https://github.com/AnalyticalGraphicsInc/cesium/pull/6393)

--- a/Source/Core/PolygonOutlineGeometry.js
+++ b/Source/Core/PolygonOutlineGeometry.js
@@ -304,10 +304,16 @@ define([
         var height = defaultValue(options.height, 0.0);
         var extrudedHeight = defaultValue(options.extrudedHeight, height);
 
+        if (!perPositionHeightExtrude) {
+            var h = Math.max(height, extrudedHeight);
+            extrudedHeight = Math.min(height, extrudedHeight);
+            height = h;
+        }
+
         this._ellipsoid = Ellipsoid.clone(ellipsoid);
         this._granularity = granularity;
-        this._height = Math.max(height, extrudedHeight);
-        this._extrudedHeight = Math.min(extrudedHeight, height);
+        this._height = height;
+        this._extrudedHeight = extrudedHeight;
         this._polygonHierarchy = polygonHierarchy;
         this._perPositionHeight = perPositionHeight;
         this._perPositionHeightExtrude = perPositionHeightExtrude;

--- a/Specs/Core/PolygonOutlineGeometrySpec.js
+++ b/Specs/Core/PolygonOutlineGeometrySpec.js
@@ -124,6 +124,28 @@ defineSuite([
         expect(ellipsoid.cartesianToCartographic(Cartesian3.fromArray(p.attributes.position.values, 3)).height).toEqualEpsilon(0, CesiumMath.EPSILON6);
     });
 
+    it('uses correct value with extrudedHeight and perPositionHeight', function() {
+        var ellipsoid = Ellipsoid.WGS84;
+        var maxHeight = 100.0;
+        var minHeight = 60.0;
+        var extrudedHeight = 50.0;
+        var positions = Cartesian3.fromDegreesArrayHeights([
+            -1.0, -1.0, maxHeight,
+            1.0, -1.0, minHeight,
+            1.0, 1.0, minHeight,
+            -1.0, 1.0, minHeight
+        ]);
+        var p = PolygonOutlineGeometry.createGeometry(PolygonOutlineGeometry.fromPositions({
+            positions : positions,
+            perPositionHeight : true,
+            extrudedHeight: extrudedHeight
+        }));
+
+        expect(ellipsoid.cartesianToCartographic(Cartesian3.fromArray(p.attributes.position.values, 0)).height).toEqualEpsilon(maxHeight, CesiumMath.EPSILON6);
+        expect(ellipsoid.cartesianToCartographic(Cartesian3.fromArray(p.attributes.position.values, 3)).height).toEqualEpsilon(minHeight, CesiumMath.EPSILON6);
+        expect(ellipsoid.cartesianToCartographic(Cartesian3.fromArray(p.attributes.position.values, 24)).height).toEqualEpsilon(extrudedHeight, CesiumMath.EPSILON6);
+    });
+
     it('creates a polygon from hierarchy', function() {
         var hierarchy = {
             positions : Cartesian3.fromDegreesArray([


### PR DESCRIPTION
Fixes #6595

I fixed this for `PolygonGeometry` before my PR was merged, but forgot to make the same change for `PolygonOutlineGeometry`