### PR TITLE
Fix StaticGroundGeometryXXXBatch.remove

### DIFF
--- a/Source/DataSources/StaticGroundGeometryColorBatch.js
+++ b/Source/DataSources/StaticGroundGeometryColorBatch.js
@@ -71,7 +71,9 @@ define([
                 this.subscriptions.remove(id);
                 this.showsUpdated.remove(id);
             }
+            return true;
         }
+        return false;
     };
 
     var scratchArray = new Array(4);

--- a/Source/DataSources/StaticGroundGeometryPerMaterialBatch.js
+++ b/Source/DataSources/StaticGroundGeometryPerMaterialBatch.js
@@ -106,8 +106,9 @@ define([
                 unsubscribe();
                 this.subscriptions.remove(id);
             }
+            return true;
         }
-        return this.createPrimitive;
+        return false;
     };
 
     Batch.prototype.update = function(time) {


### PR DESCRIPTION
- `StaticGroundGeometryColorBatch.remove` was relying on the value returned from `Batch.remove` to exit the for loop early, but `Batch.remove` wasn't returning anything
- `Batch.remove` in `StaticGroundGeometryPerMaterialBatch` was returning the wrong thing