### PR TITLE
Don't hide so many files in VS Code

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,21 +6,16 @@
         "**/Thumbs.db": true,
         ".idea": true,
         ".metadata": true,
-        "Build": true,
-        "Instrumented": true,
-        "node_modules": true,
         ".settings": true,
         ".externalToolBuilders": true,
         ".project": true,
-        "launches": true,
-        "Cesium-*.zip": true,
-        "cesium-*.tgz": true,
-        "Apps/Sandcastle/jsHintOptions.js": true,
-        "Apps/Sandcastle/gallery/gallery-index.js": true,
-        "Source/Cesium.js": true,
-        "Source/Shaders/**/*.js": true,
-        "Specs/SpecList.js": true,
-        "npm-debug.log": true
+        "launches": true
+    },
+    "search.exclude": {
+        "Build": true,
+        "Instrumented": true,
+        "node_modules": true,
+        "Source/Shaders/**/*.js": true
     },
     "files.trimTrailingWhitespace": true,
     "files.insertFinalNewline": true,


### PR DESCRIPTION
Our VS Code setting were overly aggressive in hiding files in the directory tree (which also hides them from quick open shortcuts like CTRL+P.)  We often need to look at the Build folder and other generated files while debugging dev processes and other tooling.

We can actually exclude these things from search (to avoid tons of unwanted results) but keep them in the directory tree.