### PR TITLE
Fix shadow map test

### DIFF
--- a/Specs/Scene/ShadowMapSpec.js
+++ b/Specs/Scene/ShadowMapSpec.js
@@ -717,6 +717,7 @@ defineSuite([
             scene.render(); // Model is pre-loaded, render one frame to make it ready
 
             scene.camera.lookAt(origins[i], offsets[i]);
+            scene.camera.moveForward(0.5);
 
             // Render without shadows
             scene.shadowMap.enabled = false;


### PR DESCRIPTION
Fixes https://github.com/AnalyticalGraphicsInc/cesium/issues/6582

The failure was caused by the default near plane changing from 1.0 to 0.1 that went along with log depth, but was really a problem with how the test was written.

The fix was to push the camera forward slightly in order to see the shadow and not the box casting the shadow. Previously the camera must have seen through the box due to the larger near plane.