### PR TITLE
Fix Z-Indexing Geometry example label

### DIFF
--- a/Apps/Sandcastle/gallery/Z-Indexing Geometry.html
+++ b/Apps/Sandcastle/gallery/Z-Indexing Geometry.html
@@ -5,7 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no">
     <meta name="description" content="Draw a rectangle or extruded rectangle that conforms to the surface of the globe.">
-    <meta name="cesium-sandcastle-labels" content="Geometries,New in 1.45">
+    <meta name="cesium-sandcastle-labels" content="Geometries">
     <title>Cesium Demo</title>
     <script type="text/javascript" src="../Sandcastle-header.js"></script>
     <script type="text/javascript" src="../../../ThirdParty/requirejs-2.1.20/require.js"></script>


### PR DESCRIPTION
Z-Indexing Geometry was showing up twice in the `New in 1.45` list, this is because it had the label manually added to it in the HTML, which means it ended up getting labeled twice.  The `New in XXX` labels are auto-generated.

Fixes #6613

@hpinkos is unavailable so if someone else can do a quick test and merge before today's release, I'd appreciate it.

Thanks.