### PR TITLE
adding the same pickPositionSupported check to the remaining Apps (Pi…

### DIFF
--- a/Apps/Sandcastle/gallery/Picking.html
+++ b/Apps/Sandcastle/gallery/Picking.html
@@ -33,6 +33,10 @@ var viewer = new Cesium.Viewer('cesiumContainer', {
 });
 
 var scene = viewer.scene;
+if (!scene.pickPositionSupported) {
+    console.log('This browser does not support pickPosition.');
+}
+
 var handler;
 
 Sandcastle.addDefaultToolbarButton('Show Cartographic Position on Mouse Over', function() {


### PR DESCRIPTION
Related To: #6078 

Perform the same pickPositionSupported check on any Sandcastle apps that require the use of pickPosition and notify the user through console that their browser doesn't support it.
