### PR TITLE
Require full tileset JSON path

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@ Change Log
 
 ##### Breaking Changes :mega:
 * glTF 2.0 models corrected to face +Z forwards per specification.  Internally Cesium uses +X as forward, so a new +Z to +X rotation was added for 2.0 models only.  [#6632](https://github.com/AnalyticalGraphicsInc/cesium/pull/6632)
+* Dropped support for directory URLs when loading tilesets to match the updated [3D Tiles spec](https://github.com/AnalyticalGraphicsInc/3d-tiles/issues/272). [#6502](https://github.com/AnalyticalGraphicsInc/cesium/issues/6502)
 
 ##### Additions :tada:
 * `PostProcessStage` has a `selectedFeatures` property which is an array of primitives used for selectively applying a post-process stage. In the fragment shader, use the function `bool czm_selected(vec2 textureCoordinates` to determine whether or not the stage should be applied at that fragment.

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -46,6 +46,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to Cesiu
    * [Hannah Bollar](https://github.com/hanbollar)
    * [Luke San Antonio Bialecki](https://github.com/lukesanantonio)
    * [Josh Lawrence](https://github.com/loshjawrence)
+   * [Omar Shehata](https://github.com/OmarShehata)
 * [NICTA](http://www.nicta.com.au/)
    * [Chris Cooper](https://github.com/chris-cooper)
    * [Kevin Ring](https://github.com/kring)

--- a/Source/Scene/Cesium3DTile.js
+++ b/Source/Scene/Cesium3DTile.js
@@ -166,9 +166,9 @@ define([
         /**
          * This tile's parent or <code>undefined</code> if this tile is the root.
          * <p>
-         * When a tile's content points to an external tileset.json, the external tileset's
+         * When a tile's content points to an external tileset JSON file, the external tileset's
          * root tile's parent is not <code>undefined</code>; instead, the parent references
-         * the tile (with its content pointing to an external tileset.json) as if the two tilesets were merged.
+         * the tile (with its content pointing to an external tileset JSON file) as if the two tilesets were merged.
          * </p>
          *
          * @type {Cesium3DTile}
@@ -371,7 +371,7 @@ define([
 
         /**
          * The tile's content.  This represents the actual tile's payload,
-         * not the content's metadata in tileset.json.
+         * not the content's metadata in the tileset JSON file.
          *
          * @memberof Cesium3DTile.prototype
          *

--- a/Source/Scene/Cesium3DTileset.js
+++ b/Source/Scene/Cesium3DTileset.js
@@ -126,13 +126,13 @@ define([
      *
      * @example
      * var tileset = scene.primitives.add(new Cesium.Cesium3DTileset({
-     *      url : 'http://localhost:8002/tilesets/Seattle'
+     *      url : 'http://localhost:8002/tilesets/Seattle/tileset.json'
      * }));
      *
      * @example
      * // Common setting for the skipLevelOfDetail optimization
      * var tileset = scene.primitives.add(new Cesium.Cesium3DTileset({
-     *      url : 'http://localhost:8002/tilesets/Seattle',
+     *      url : 'http://localhost:8002/tilesets/Seattle/tileset.json',
      *      skipLevelOfDetail : true,
      *      baseScreenSpaceError : 1024,
      *      skipScreenSpaceErrorFactor : 16,
@@ -145,7 +145,7 @@ define([
      * @example
      * // Common settings for the dynamicScreenSpaceError optimization
      * var tileset = scene.primitives.add(new Cesium.Cesium3DTileset({
-     *      url : 'http://localhost:8002/tilesets/Seattle',
+     *      url : 'http://localhost:8002/tilesets/Seattle/tileset.json',
      *      dynamicScreenSpaceError : true,
      *      dynamicScreenSpaceErrorDensity : 0.00278,
      *      dynamicScreenSpaceErrorFactor : 4.0,
@@ -162,7 +162,6 @@ define([
         //>>includeEnd('debug');
 
         this._url = undefined;
-        this._tilesetUrl = undefined;
         this._basePath = undefined;
         this._root = undefined;
         this._asset = undefined; // Metadata for the entire tileset
@@ -694,7 +693,6 @@ define([
                 }
 
                 that._url = resource.url;
-                that._tilesetUrl = tilesetResource.url;
                 that._basePath = basePath;
 
                 // We don't know the distance of the tileset until tileset JSON file is loaded, so use the default distance for now
@@ -1075,7 +1073,7 @@ define([
          *
          * @example
          * var tileset = viewer.scene.primitives.add(new Cesium.Cesium3DTileset({
-         *     url : 'http://localhost:8002/tilesets/Seattle'
+         *     url : 'http://localhost:8002/tilesets/Seattle/tileset.json'
          * }));
          *
          * tileset.readyPromise.then(function(tileset) {

--- a/Source/Scene/Cesium3DTileset.js
+++ b/Source/Scene/Cesium3DTileset.js
@@ -90,7 +90,7 @@ define([
      * @constructor
      *
      * @param {Object} options Object with the following properties:
-     * @param {Resource|String|Promise<Resource>|Promise<String>} options.url The url to a tileset.json file or to a directory containing a tileset.json file.
+     * @param {Resource|String|Promise<Resource>|Promise<String>} options.url The url to a tileset JSON file.
      * @param {Boolean} [options.show=true] Determines if the tileset will be shown.
      * @param {Matrix4} [options.modelMatrix=Matrix4.IDENTITY] A 4x4 transformation matrix that transforms the tileset's root tile.
      * @param {ShadowMode} [options.shadows=ShadowMode.ENABLED] Determines whether the tileset casts or receives shadows from each light source.
@@ -668,7 +668,7 @@ define([
          */
         this.debugShowUrl = defaultValue(options.debugShowUrl, false);
 
-        // A bunch of tilesets were generated that have a leading / in front of all URLs in the tileset.json. If the tiles aren't
+        // A bunch of tilesets were generated that have a leading / in front of all URLs in the tileset JSON file. If the tiles aren't
         //  at the root of the domain they will not load anymore. If we find a b3dm file with a leading slash, we test load a tile.
         //  If it succeeds we continue on. If it fails, we set this to true so we know to strip the slash when loading tiles.
         this._brokenUrlWorkaround = false;
@@ -691,19 +691,13 @@ define([
                     basePath = resource.getBaseUri(true);
                 } else if (resource.isDataUri) {
                     basePath = '';
-                } else {
-                    resource.appendForwardSlash();
-                    tilesetResource = resource.getDerivedResource({
-                        url: 'tileset.json'
-                    });
-                    basePath = resource.url;
                 }
 
                 that._url = resource.url;
                 that._tilesetUrl = tilesetResource.url;
                 that._basePath = basePath;
 
-                // We don't know the distance of the tileset until tileset.json is loaded, so use the default distance for now
+                // We don't know the distance of the tileset until tileset JSON file is loaded, so use the default distance for now
                 return Cesium3DTileset.loadJson(tilesetResource);
             })
             .then(function(tilesetJson) {
@@ -711,7 +705,7 @@ define([
             })
             .then(function(tilesetJson) {
                 if (that._brokenUrlWorkaround) {
-                    deprecationWarning('Cesium3DTileset.leadingSlash', 'Having a leading slash in a tile URL that is actually relative to the tileset.json is deprecated.');
+                    deprecationWarning('Cesium3DTileset.leadingSlash', 'Having a leading slash in a tile URL that is actually relative to the tileset JSON file is deprecated.');
                 }
 
                 that._root = that.loadTileset(tilesetResource, tilesetJson);
@@ -920,7 +914,7 @@ define([
         },
 
         /**
-         * The url to a tileset.json file or to a directory containing a tileset.json file.
+         * The url to a tileset JSON file.
          *
          * @memberof Cesium3DTileset.prototype
          *
@@ -934,7 +928,7 @@ define([
         },
 
         /**
-         * The base path that non-absolute paths in tileset.json are relative to.
+         * The base path that non-absolute paths in tileset JSON file are relative to.
          *
          * @memberof Cesium3DTileset.prototype
          *
@@ -944,7 +938,7 @@ define([
          */
         basePath : {
             get : function() {
-                deprecationWarning('Cesium3DTileset.basePath', 'Cesium3DTileset.basePath has been deprecated. All tiles are relative to the url of the tileset.json that contains them. Use the url property instead.');
+                deprecationWarning('Cesium3DTileset.basePath', 'Cesium3DTileset.basePath has been deprecated. All tiles are relative to the url of the tileset JSON file that contains them. Use the url property instead.');
                 return this._basePath;
             }
         },
@@ -1252,7 +1246,7 @@ define([
     };
 
     /**
-     * Loads the main tileset.json or a tileset.json referenced from a tile.
+     * Loads the main tileset JSON file or a tileset JSON file referenced from a tile.
      *
      * @private
      */
@@ -1276,7 +1270,7 @@ define([
             tilesetResource.setQueryParameters(versionQuery);
         }
 
-        // A tileset.json referenced from a tile may exist in a different directory than the root tileset.
+        // A tileset JSON file referenced from a tile may exist in a different directory than the root tileset.
         // Get the basePath relative to the external tileset.
         var rootTile = new Cesium3DTile(this, tilesetResource, tilesetJson.root, parentTile);
 

--- a/Source/Scene/Cesium3DTilesetStatistics.js
+++ b/Source/Scene/Cesium3DTilesetStatistics.js
@@ -17,7 +17,7 @@ define([
         this.numberOfPendingRequests = 0;
         this.numberOfTilesProcessing = 0;
         this.numberOfTilesWithContentReady = 0; // Number of tiles with content loaded, does not include empty tiles
-        this.numberOfTilesTotal = 0; // Number of tiles in tileset.json (and other tileset.json files as they are loaded)
+        this.numberOfTilesTotal = 0; // Number of tiles in tileset JSON (and other tileset JSON files as they are loaded)
         // Features statistics
         this.numberOfFeaturesSelected = 0; // Number of features rendered
         this.numberOfFeaturesLoaded = 0; // Number of features in memory

--- a/Source/Widgets/Cesium3DTilesInspector/Cesium3DTilesInspectorViewModel.js
+++ b/Source/Widgets/Cesium3DTilesInspector/Cesium3DTilesInspectorViewModel.js
@@ -95,7 +95,7 @@ define([
                 '<li><strong>Processing: </strong>' + statistics.numberOfTilesProcessing.toLocaleString() + '</li>' +
                 '<li><strong>Content Ready: </strong>' + statistics.numberOfTilesWithContentReady.toLocaleString() + '</li>' +
                 // Total number of tiles includes tiles without content, so "Ready" may never reach
-                // "Total."  Total also will increase when a tile with a tileset.json content is loaded.
+                // "Total."  Total also will increase when a tile with a tileset JSON content is loaded.
                 '<li><strong>Total: </strong>' + statistics.numberOfTilesTotal.toLocaleString() + '</li>';
             s += '</ul>';
             s += '<ul class="cesium-cesiumInspector-statistics">';

--- a/Specs/Scene/Batched3DModel3DTileContentClassificationSpec.js
+++ b/Specs/Scene/Batched3DModel3DTileContentClassificationSpec.js
@@ -46,9 +46,9 @@ defineSuite([
     var centerLongitude = -1.31968;
     var centerLatitude = 0.698874;
 
-    var withBatchTableUrl = './Data/Cesium3DTiles/Batched/BatchedWithBatchTable/';
-    var withBatchTableBinaryUrl = './Data/Cesium3DTiles/Batched/BatchedWithBatchTableBinary/';
-    var withQuantizationUrl = './Data/Cesium3DTiles/Batched/BatchedWithQuantization/';
+    var withBatchTableUrl = './Data/Cesium3DTiles/Batched/BatchedWithBatchTable/tileset.json';
+    var withBatchTableBinaryUrl = './Data/Cesium3DTiles/Batched/BatchedWithBatchTableBinary/tileset.json';
+    var withQuantizationUrl = './Data/Cesium3DTiles/Batched/BatchedWithQuantization/tileset.json';
 
     function setCamera(longitude, latitude) {
         // One feature is located at the center, point the camera there

--- a/Specs/Scene/Batched3DModel3DTileContentSpec.js
+++ b/Specs/Scene/Batched3DModel3DTileContentSpec.js
@@ -28,20 +28,20 @@ defineSuite([
     var centerLongitude = -1.31968;
     var centerLatitude = 0.698874;
 
-    var withBatchTableUrl = './Data/Cesium3DTiles/Batched/BatchedWithBatchTable/';
-    var withBatchTableBinaryUrl = './Data/Cesium3DTiles/Batched/BatchedWithBatchTableBinary/';
-    var withoutBatchTableUrl = './Data/Cesium3DTiles/Batched/BatchedWithoutBatchTable/';
-    var translucentUrl = './Data/Cesium3DTiles/Batched/BatchedTranslucent/';
-    var translucentOpaqueMixUrl = './Data/Cesium3DTiles/Batched/BatchedTranslucentOpaqueMix/';
-    var withKHRMaterialsCommonUrl = './Data/Cesium3DTiles/Batched/BatchedWithKHRMaterialsCommon/';
-    var withTransformBoxUrl = './Data/Cesium3DTiles/Batched/BatchedWithTransformBox/';
-    var withTransformSphereUrl = './Data/Cesium3DTiles/Batched/BatchedWithTransformSphere/';
-    var withTransformRegionUrl = './Data/Cesium3DTiles/Batched/BatchedWithTransformRegion/';
-    var texturedUrl = './Data/Cesium3DTiles/Batched/BatchedTextured/';
-    var compressedTexturesUrl = './Data/Cesium3DTiles/Batched/BatchedCompressedTextures/';
-    var deprecated1Url = './Data/Cesium3DTiles/Batched/BatchedDeprecated1/';
-    var deprecated2Url = './Data/Cesium3DTiles/Batched/BatchedDeprecated2/';
-    var gltfZUpUrl = './Data/Cesium3DTiles/Batched/BatchedGltfZUp';
+    var withBatchTableUrl = './Data/Cesium3DTiles/Batched/BatchedWithBatchTable/tileset.json';
+    var withBatchTableBinaryUrl = './Data/Cesium3DTiles/Batched/BatchedWithBatchTableBinary/tileset.json';
+    var withoutBatchTableUrl = './Data/Cesium3DTiles/Batched/BatchedWithoutBatchTable/tileset.json';
+    var translucentUrl = './Data/Cesium3DTiles/Batched/BatchedTranslucent/tileset.json';
+    var translucentOpaqueMixUrl = './Data/Cesium3DTiles/Batched/BatchedTranslucentOpaqueMix/tileset.json';
+    var withKHRMaterialsCommonUrl = './Data/Cesium3DTiles/Batched/BatchedWithKHRMaterialsCommon/tileset.json';
+    var withTransformBoxUrl = './Data/Cesium3DTiles/Batched/BatchedWithTransformBox/tileset.json';
+    var withTransformSphereUrl = './Data/Cesium3DTiles/Batched/BatchedWithTransformSphere/tileset.json';
+    var withTransformRegionUrl = './Data/Cesium3DTiles/Batched/BatchedWithTransformRegion/tileset.json';
+    var texturedUrl = './Data/Cesium3DTiles/Batched/BatchedTextured/tileset.json';
+    var compressedTexturesUrl = './Data/Cesium3DTiles/Batched/BatchedCompressedTextures/tileset.json';
+    var deprecated1Url = './Data/Cesium3DTiles/Batched/BatchedDeprecated1/tileset.json';
+    var deprecated2Url = './Data/Cesium3DTiles/Batched/BatchedDeprecated2/tileset.json';
+    var gltfZUpUrl = './Data/Cesium3DTiles/Batched/BatchedGltfZUp/tileset.json';
 
     function setCamera(longitude, latitude) {
         // One feature is located at the center, point the camera there

--- a/Specs/Scene/Cesium3DTileBatchTableSpec.js
+++ b/Specs/Scene/Cesium3DTileBatchTableSpec.js
@@ -32,13 +32,13 @@ defineSuite([
     var centerLongitude = -1.31968;
     var centerLatitude = 0.698874;
 
-    var withBatchTableUrl = './Data/Cesium3DTiles/Batched/BatchedWithBatchTable/';
-    var withoutBatchTableUrl = './Data/Cesium3DTiles/Batched/BatchedWithoutBatchTable/';
-    var noBatchIdsUrl = './Data/Cesium3DTiles/Batched/BatchedNoBatchIds/';
-    var batchTableHierarchyUrl = './Data/Cesium3DTiles/Hierarchy/BatchTableHierarchy/';
-    var batchTableHierarchyBinaryUrl = './Data/Cesium3DTiles/Hierarchy/BatchTableHierarchyBinary/';
-    var batchTableHierarchyMultipleParentsUrl = './Data/Cesium3DTiles/Hierarchy/BatchTableHierarchyMultipleParents/';
-    var batchTableHierarchyNoParentsUrl = './Data/Cesium3DTiles/Hierarchy/BatchTableHierarchyNoParents/';
+    var withBatchTableUrl = './Data/Cesium3DTiles/Batched/BatchedWithBatchTable/tileset.json';
+    var withoutBatchTableUrl = './Data/Cesium3DTiles/Batched/BatchedWithoutBatchTable/tileset.json';
+    var noBatchIdsUrl = './Data/Cesium3DTiles/Batched/BatchedNoBatchIds/tileset.json';
+    var batchTableHierarchyUrl = './Data/Cesium3DTiles/Hierarchy/BatchTableHierarchy/tileset.json';
+    var batchTableHierarchyBinaryUrl = './Data/Cesium3DTiles/Hierarchy/BatchTableHierarchyBinary/tileset.json';
+    var batchTableHierarchyMultipleParentsUrl = './Data/Cesium3DTiles/Hierarchy/BatchTableHierarchyMultipleParents/tileset.json';
+    var batchTableHierarchyNoParentsUrl = './Data/Cesium3DTiles/Hierarchy/BatchTableHierarchyNoParents/tileset.json';
 
     var result = new Color();
 

--- a/Specs/Scene/Cesium3DTilesetSpec.js
+++ b/Specs/Scene/Cesium3DTilesetSpec.js
@@ -65,70 +65,70 @@ defineSuite([
     var centerLatitude = 0.698874;
 
     // Parent tile with content and four child tiles with content
-    var tilesetUrl = 'Data/Cesium3DTiles/Tilesets/Tileset/';
+    var tilesetUrl = 'Data/Cesium3DTiles/Tilesets/Tileset/tileset.json';
 
     // Parent tile with no content and four child tiles with content
-    var tilesetEmptyRootUrl = 'Data/Cesium3DTiles/Tilesets/TilesetEmptyRoot/';
+    var tilesetEmptyRootUrl = 'Data/Cesium3DTiles/Tilesets/TilesetEmptyRoot/tileset.json';
 
-    var tilesetReplacement1Url = 'Data/Cesium3DTiles/Tilesets/TilesetReplacement1/';
-    var tilesetReplacement2Url = 'Data/Cesium3DTiles/Tilesets/TilesetReplacement2/';
-    var tilesetReplacement3Url = 'Data/Cesium3DTiles/Tilesets/TilesetReplacement3/';
+    var tilesetReplacement1Url = 'Data/Cesium3DTiles/Tilesets/TilesetReplacement1/tileset.json';
+    var tilesetReplacement2Url = 'Data/Cesium3DTiles/Tilesets/TilesetReplacement2/tileset.json';
+    var tilesetReplacement3Url = 'Data/Cesium3DTiles/Tilesets/TilesetReplacement3/tileset.json';
 
     // 3 level tree with mix of additive and replacement refinement
-    var tilesetRefinementMix = 'Data/Cesium3DTiles/Tilesets/TilesetRefinementMix/';
+    var tilesetRefinementMix = 'Data/Cesium3DTiles/Tilesets/TilesetRefinementMix/tileset.json';
 
     // tileset.json : root content points to tiles2.json
     // tiles2.json: root with b3dm content, three children with b3dm content, one child points to tiles3.json
     // tiles3.json: root with b3dm content
-    var tilesetOfTilesetsUrl = 'Data/Cesium3DTiles/Tilesets/TilesetOfTilesets/';
+    var tilesetOfTilesetsUrl = 'Data/Cesium3DTiles/Tilesets/TilesetOfTilesets/tileset.json';
 
-    var withoutBatchTableUrl = 'Data/Cesium3DTiles/Batched/BatchedWithoutBatchTable/';
-    var withBatchTableUrl = 'Data/Cesium3DTiles/Batched/BatchedWithBatchTable/';
-    var noBatchIdsUrl = 'Data/Cesium3DTiles/Batched/BatchedNoBatchIds/';
+    var withoutBatchTableUrl = 'Data/Cesium3DTiles/Batched/BatchedWithoutBatchTable/tileset.json';
+    var withBatchTableUrl = 'Data/Cesium3DTiles/Batched/BatchedWithBatchTable/tileset.json';
+    var noBatchIdsUrl = 'Data/Cesium3DTiles/Batched/BatchedNoBatchIds/tileset.json';
 
-    var withTransformBoxUrl = 'Data/Cesium3DTiles/Batched/BatchedWithTransformBox/';
-    var withTransformSphereUrl = 'Data/Cesium3DTiles/Batched/BatchedWithTransformSphere/';
-    var withTransformRegionUrl = 'Data/Cesium3DTiles/Batched/BatchedWithTransformRegion/';
-    var withBoundingSphereUrl = 'Data/Cesium3DTiles/Batched/BatchedWithBoundingSphere/';
+    var withTransformBoxUrl = 'Data/Cesium3DTiles/Batched/BatchedWithTransformBox/tileset.json';
+    var withTransformSphereUrl = 'Data/Cesium3DTiles/Batched/BatchedWithTransformSphere/tileset.json';
+    var withTransformRegionUrl = 'Data/Cesium3DTiles/Batched/BatchedWithTransformRegion/tileset.json';
+    var withBoundingSphereUrl = 'Data/Cesium3DTiles/Batched/BatchedWithBoundingSphere/tileset.json';
 
-    var compositeUrl = 'Data/Cesium3DTiles/Composite/Composite/';
-    var instancedUrl = 'Data/Cesium3DTiles/Instanced/InstancedWithBatchTable/';
-    var instancedRedMaterialUrl = 'Data/Cesium3DTiles/Instanced/InstancedRedMaterial';
+    var compositeUrl = 'Data/Cesium3DTiles/Composite/Composite/tileset.json';
+    var instancedUrl = 'Data/Cesium3DTiles/Instanced/InstancedWithBatchTable/tileset.json';
+    var instancedRedMaterialUrl = 'Data/Cesium3DTiles/Instanced/InstancedRedMaterial/tileset.json';
 
     // 1 tile where each feature is a different source color
-    var colorsUrl = 'Data/Cesium3DTiles/Batched/BatchedColors/';
+    var colorsUrl = 'Data/Cesium3DTiles/Batched/BatchedColors/tileset.json';
 
     // 1 tile where each feature has a reddish texture
-    var texturedUrl = 'Data/Cesium3DTiles/Batched/BatchedTextured/';
+    var texturedUrl = 'Data/Cesium3DTiles/Batched/BatchedTextured/tileset.json';
 
     // 1 tile with translucent features
-    var translucentUrl = 'Data/Cesium3DTiles/Batched/BatchedTranslucent/';
+    var translucentUrl = 'Data/Cesium3DTiles/Batched/BatchedTranslucent/tileset.json';
 
     // 1 tile with opaque and translucent features
-    var translucentOpaqueMixUrl = 'Data/Cesium3DTiles/Batched/BatchedTranslucentOpaqueMix/';
+    var translucentOpaqueMixUrl = 'Data/Cesium3DTiles/Batched/BatchedTranslucentOpaqueMix/tileset.json';
 
     // Root tile is transformed from local space to wgs84, child tile is rotated, scaled, and translated locally
-    var tilesetWithTransformsUrl = 'Data/Cesium3DTiles/Tilesets/TilesetWithTransforms';
+    var tilesetWithTransformsUrl = 'Data/Cesium3DTiles/Tilesets/TilesetWithTransforms/tileset.json';
 
     // Root tile with 4 b3dm children and 1 pnts child with a viewer request volume
-    var tilesetWithViewerRequestVolumeUrl = 'Data/Cesium3DTiles/Tilesets/TilesetWithViewerRequestVolume';
+    var tilesetWithViewerRequestVolumeUrl = 'Data/Cesium3DTiles/Tilesets/TilesetWithViewerRequestVolume/tileset.json';
 
     // Parent tile with content and four child tiles with content with viewer request volume for each child
-    var tilesetReplacementWithViewerRequestVolumeUrl = 'Data/Cesium3DTiles/Tilesets/TilesetReplacementWithViewerRequestVolume';
+    var tilesetReplacementWithViewerRequestVolumeUrl = 'Data/Cesium3DTiles/Tilesets/TilesetReplacementWithViewerRequestVolume/tileset.json';
 
-    var tilesetWithExternalResourcesUrl = 'Data/Cesium3DTiles/Tilesets/TilesetWithExternalResources';
-    var tilesetSubtreeExpirationUrl = 'Data/Cesium3DTiles/Tilesets/TilesetSubtreeExpiration';
+    var tilesetWithExternalResourcesUrl = 'Data/Cesium3DTiles/Tilesets/TilesetWithExternalResources/tileset.json';
+    var tilesetSubtreeExpirationUrl = 'Data/Cesium3DTiles/Tilesets/TilesetSubtreeExpiration/tileset.json';
     var tilesetSubtreeUrl = 'Data/Cesium3DTiles/Tilesets/TilesetSubtreeExpiration/subtree.json';
-    var batchedExpirationUrl = 'Data/Cesium3DTiles/Batched/BatchedExpiration';
+    var batchedExpirationUrl = 'Data/Cesium3DTiles/Batched/BatchedExpiration/tileset.json';
     var batchedColorsB3dmUrl = 'Data/Cesium3DTiles/Batched/BatchedColors/batchedColors.b3dm';
-    var batchedVertexColorsUrl = 'Data/Cesium3DTiles/Batched/BatchedWithVertexColors';
+    var batchedVertexColorsUrl = 'Data/Cesium3DTiles/Batched/BatchedWithVertexColors/tileset.json';
 
     var styleUrl = 'Data/Cesium3DTiles/Style/style.json';
 
-    var pointCloudUrl = 'Data/Cesium3DTiles/PointCloud/PointCloudRGB';
-    var pointCloudBatchedUrl = 'Data/Cesium3DTiles/PointCloud/PointCloudBatched';
+    var pointCloudUrl = 'Data/Cesium3DTiles/PointCloud/PointCloudRGB/tileset.json';
+    var pointCloudBatchedUrl = 'Data/Cesium3DTiles/PointCloud/PointCloudBatched/tileset.json';
 
-    var invalidTileset = './Data/Cesium3DTiles/Tilesets/TilesetInvalid/';
+    var invalidTileset = './Data/Cesium3DTiles/Tilesets/TilesetInvalid/tileset.json';
 
     beforeAll(function() {
         scene = createScene();
@@ -203,7 +203,7 @@ defineSuite([
         }).toThrowDeveloperError();
     });
 
-    it('rejects readyPromise with invalid tileset.json', function() {
+    it('rejects readyPromise with invalid tileset JSON fiile', function() {
         spyOn(Resource._Implementations, 'loadWithXhr').and.callFake(function(url, responseType, method, data, headers, deferred, overrideMimeType) {
             deferred.reject();
         });
@@ -261,29 +261,12 @@ defineSuite([
 
     it('Constructor works with promise to resource', function() {
         var resource = new Resource({
-            url: 'Data/Cesium3DTiles/Tilesets/TilesetOfTilesets'
+            url: 'Data/Cesium3DTiles/Tilesets/TilesetOfTilesets/tileset.json'
         });
 
         // setup tileset with invalid url (overridden loadJson should replace invalid url with correct url)
         var tileset = new Cesium3DTileset({
             url : when.resolve(resource)
-        });
-
-        return tileset.readyPromise.then(function() {
-            expect(tileset.ready).toEqual(true);
-        }).otherwise(function(error) {
-            fail('should not fail');
-        });
-    });
-
-    it('Constructor works with directory resource', function() {
-        var resource = new Resource({
-            url: 'Data/Cesium3DTiles/Tilesets/TilesetOfTilesets'
-        });
-
-        // setup tileset with invalid url (overridden loadJson should replace invalid url with correct url)
-        var tileset = new Cesium3DTileset({
-            url : resource
         });
 
         return tileset.readyPromise.then(function() {
@@ -329,7 +312,7 @@ defineSuite([
         });
     });
 
-    it('url and tilesetUrl set up correctly given tileset.json path', function() {
+    it('url and tilesetUrl set up correctly given tileset JSON filepath', function() {
         var path = 'Data/Cesium3DTiles/Tilesets/TilesetOfTilesets/tileset.json';
         var tileset = new Cesium3DTileset({
             url : path
@@ -338,32 +321,14 @@ defineSuite([
         expect(tileset._tilesetUrl).toEqual(path);
     });
 
-    it('url and tilesetUrl set up correctly given directory without trailing slash', function() {
-        var path = 'Data/Cesium3DTiles/Tilesets/TilesetOfTilesets';
-        var tileset = new Cesium3DTileset({
-            url : path
-        });
-        expect(tileset.url).toEqual(path + '/');
-        expect(tileset._tilesetUrl).toEqual(getAbsoluteUri(path + '/tileset.json'));
-    });
-
-    it('url and tilesetUrl set up correctly given directory with trailing slash', function() {
-        var path = 'Data/Cesium3DTiles/Tilesets/TilesetOfTilesets/';
-        var tileset = new Cesium3DTileset({
-            url : path
-        });
-        expect(tileset.url).toEqual(path);
-        expect(tileset._tilesetUrl).toEqual(getAbsoluteUri(path + 'tileset.json'));
-    });
-
     it('url and tilesetUrl set up correctly given path with query string', function() {
-        var path = 'Data/Cesium3DTiles/Tilesets/TilesetOfTilesets';
+        var path = 'Data/Cesium3DTiles/Tilesets/TilesetOfTilesets/tileset.json';
         var param = '?param1=1&param2=2';
         var tileset = new Cesium3DTileset({
             url : path + param
         });
-        expect(tileset.url).toEqual(path + '/' + param);
-        expect(tileset._tilesetUrl).toEqual(getAbsoluteUri(path + '/tileset.json' + param));
+        expect(tileset.url).toEqual(path + param);
+        expect(tileset._tilesetUrl).toEqual(path + param);
     });
 
     it('resolves readyPromise', function() {
@@ -374,7 +339,7 @@ defineSuite([
         });
     });
 
-    it('loads tileset.json', function() {
+    it('loads tileset JSON file', function() {
         return Cesium3DTilesTester.loadTileset(scene, tilesetUrl).then(function(tileset) {
             var asset = tileset.asset;
             expect(asset).toBeDefined();
@@ -395,7 +360,7 @@ defineSuite([
 
     it('passes version in query string to tiles', function() {
         return Cesium3DTilesTester.loadTileset(scene, tilesetUrl).then(function(tileset) {
-            expect(tileset._root.content._resource.url).toEqual(getAbsoluteUri(tilesetUrl + 'parent.b3dm?v=1.2.3'));
+            expect(tileset._root.content._resource.url).toEqual(getAbsoluteUri(tilesetUrl.replace('tileset.json','parent.b3dm?v=1.2.3')));
         });
     });
 
@@ -1265,12 +1230,12 @@ defineSuite([
         });
     });
 
-    it('loads tileset with external tileset.json', function() {
+    it('loads tileset with external tileset JSON file', function() {
         // Set view so that no tiles are loaded initially
         viewNothing();
 
         return Cesium3DTilesTester.loadTileset(scene, tilesetOfTilesetsUrl).then(function(tileset) {
-            // Root points to an external tileset.json and has no children until it is requested
+            // Root points to an external tileset JSON file and has no children until it is requested
             var root = tileset._root;
             expect(root.children.length).toEqual(0);
 
@@ -1296,7 +1261,7 @@ defineSuite([
         });
     });
 
-    it('preserves query string with external tileset.json', function() {
+    it('preserves query string with external tileset JSON file', function() {
         // Set view so that no tiles are loaded initially
         viewNothing();
 
@@ -1304,9 +1269,9 @@ defineSuite([
         spyOn(Resource._Implementations, 'loadWithXhr').and.callThrough();
 
         var queryParams = 'a=1&b=boy';
-        var expectedUrl = getAbsoluteUri('Data/Cesium3DTiles/Tilesets/TilesetOfTilesets/tileset.json?' + queryParams);
+        var expectedUrl = 'Data/Cesium3DTiles/Tilesets/TilesetOfTilesets/tileset.json?' + queryParams;
         return Cesium3DTilesTester.loadTileset(scene, tilesetOfTilesetsUrl + '?' + queryParams).then(function(tileset) {
-            //Make sure tileset.json was requested with query parameters
+            //Make sure tileset JSON file was requested with query parameters
             expect(Resource._Implementations.loadWithXhr.calls.argsFor(0)[0]).toEqual(expectedUrl);
 
             Resource._Implementations.loadWithXhr.calls.reset();
@@ -1324,7 +1289,7 @@ defineSuite([
         });
     });
 
-    it('renders tileset with external tileset.json', function() {
+    it('renders tileset with external tileset JSON file', function() {
         return Cesium3DTilesTester.loadTileset(scene, tilesetOfTilesetsUrl).then(function(tileset) {
             var statistics = tileset._statistics;
             expect(statistics.visited).toEqual(7); // Visits two tiles with tileset content, five tiles with b3dm content
@@ -1812,13 +1777,13 @@ defineSuite([
         });
     });
 
-    it('destroys before external tileset.json finishes loading', function() {
+    it('destroys before external tileset JSON file finishes loading', function() {
         viewNothing();
         return Cesium3DTilesTester.loadTileset(scene, tilesetOfTilesetsUrl).then(function(tileset) {
             var root = tileset._root;
 
             viewRootOnly();
-            scene.renderForSpecs(); // Request external tileset.json
+            scene.renderForSpecs(); // Request external tileset JSON file
 
             var statistics = tileset._statistics;
             expect(statistics.numberOfPendingRequests).toEqual(1);
@@ -1827,7 +1792,7 @@ defineSuite([
             return root.contentReadyPromise.then(function(root) {
                 fail('should not resolve');
             }).otherwise(function(error) {
-                // Expect the root to not have added any children from the external tileset.json
+                // Expect the root to not have added any children from the external tileset JSON file
                 expect(root.children.length).toEqual(0);
             });
         });
@@ -2328,7 +2293,7 @@ defineSuite([
         });
     });
 
-    it('Unloads cached tiles in a tileset with external tileset.json using maximumMemoryUsage', function() {
+    it('Unloads cached tiles in a tileset with external tileset JSON file using maximumMemoryUsage', function() {
         return Cesium3DTilesTester.loadTileset(scene, tilesetOfTilesetsUrl).then(function(tileset) {
             var statistics = tileset._statistics;
             var replacementList = tileset._replacementList;

--- a/Specs/Scene/Cesium3DTilesetSpec.js
+++ b/Specs/Scene/Cesium3DTilesetSpec.js
@@ -318,7 +318,6 @@ defineSuite([
             url : path
         });
         expect(tileset.url).toEqual(path);
-        expect(tileset._tilesetUrl).toEqual(path);
     });
 
     it('url and tilesetUrl set up correctly given path with query string', function() {
@@ -328,7 +327,6 @@ defineSuite([
             url : path + param
         });
         expect(tileset.url).toEqual(path + param);
-        expect(tileset._tilesetUrl).toEqual(path + param);
     });
 
     it('resolves readyPromise', function() {

--- a/Specs/Scene/Composite3DTileContentSpec.js
+++ b/Specs/Scene/Composite3DTileContentSpec.js
@@ -16,9 +16,9 @@ defineSuite([
     var centerLongitude = -1.31968;
     var centerLatitude = 0.698874;
 
-    var compositeUrl = './Data/Cesium3DTiles/Composite/Composite/';
-    var compositeOfComposite = './Data/Cesium3DTiles/Composite/CompositeOfComposite/';
-    var compositeOfInstanced = './Data/Cesium3DTiles/Composite/CompositeOfInstanced/';
+    var compositeUrl = './Data/Cesium3DTiles/Composite/Composite/tileset.json';
+    var compositeOfComposite = './Data/Cesium3DTiles/Composite/CompositeOfComposite/tileset.json';
+    var compositeOfInstanced = './Data/Cesium3DTiles/Composite/CompositeOfInstanced/tileset.json';
 
     beforeAll(function() {
         scene = createScene();

--- a/Specs/Scene/Geometry3DTileContentSpec.js
+++ b/Specs/Scene/Geometry3DTileContentSpec.js
@@ -50,35 +50,35 @@ defineSuite([
 
     var tilesetRectangle = Rectangle.fromDegrees(-0.01, -0.01, 0.01, 0.01);
 
-    var geometryAll = './Data/Cesium3DTiles/Geometry/GeometryTileAll';
-    var geometryAllBatchedChildren = './Data/Cesium3DTiles/Geometry/GeometryTileAllBatchedChildren';
-    var geometryAllBatchedChildrenWithBatchTable = './Data/Cesium3DTiles/Geometry/GeometryTileAllBatchedChildrenWithBatchTable';
-    var geometryAllWithBatchTable = './Data/Cesium3DTiles/Geometry/GeometryTileAllWithBatchTable';
-    var geometryAllWithBatchIds = './Data/Cesium3DTiles/Geometry/GeometryTileAllWithBatchIds';
+    var geometryAll = './Data/Cesium3DTiles/Geometry/GeometryTileAll/tileset.json';
+    var geometryAllBatchedChildren = './Data/Cesium3DTiles/Geometry/GeometryTileAllBatchedChildren/tileset.json';
+    var geometryAllBatchedChildrenWithBatchTable = './Data/Cesium3DTiles/Geometry/GeometryTileAllBatchedChildrenWithBatchTable/tileset.json';
+    var geometryAllWithBatchTable = './Data/Cesium3DTiles/Geometry/GeometryTileAllWithBatchTable/tileset.json';
+    var geometryAllWithBatchIds = './Data/Cesium3DTiles/Geometry/GeometryTileAllWithBatchIds/tileset.json';
 
-    var geometryBoxes = './Data/Cesium3DTiles/Geometry/GeometryTileBoxes';
-    var geometryBoxesBatchedChildren = './Data/Cesium3DTiles/Geometry/GeometryTileBoxesBatchedChildren';
-    var geometryBoxesBatchedChildrenWithBatchTable = './Data/Cesium3DTiles/Geometry/GeometryTileBoxesBatchedChildrenWithBatchTable';
-    var geometryBoxesWithBatchTable = './Data/Cesium3DTiles/Geometry/GeometryTileBoxesWithBatchTable';
-    var geometryBoxesWithBatchIds = './Data/Cesium3DTiles/Geometry/GeometryTileBoxesWithBatchIds';
+    var geometryBoxes = './Data/Cesium3DTiles/Geometry/GeometryTileBoxes/tileset.json';
+    var geometryBoxesBatchedChildren = './Data/Cesium3DTiles/Geometry/GeometryTileBoxesBatchedChildren/tileset.json';
+    var geometryBoxesBatchedChildrenWithBatchTable = './Data/Cesium3DTiles/Geometry/GeometryTileBoxesBatchedChildrenWithBatchTable/tileset.json';
+    var geometryBoxesWithBatchTable = './Data/Cesium3DTiles/Geometry/GeometryTileBoxesWithBatchTable/tileset.json';
+    var geometryBoxesWithBatchIds = './Data/Cesium3DTiles/Geometry/GeometryTileBoxesWithBatchIds/tileset.json';
 
-    var geometryCylinders = './Data/Cesium3DTiles/Geometry/GeometryTileCylinders';
-    var geometryCylindersBatchedChildren = './Data/Cesium3DTiles/Geometry/GeometryTileCylindersBatchedChildren';
-    var geometryCylindersBatchedChildrenWithBatchTable = './Data/Cesium3DTiles/Geometry/GeometryTileCylindersBatchedChildrenWithBatchTable';
-    var geometryCylindersWithBatchTable = './Data/Cesium3DTiles/Geometry/GeometryTileCylindersWithBatchTable';
-    var geometryCylindersWithBatchIds = './Data/Cesium3DTiles/Geometry/GeometryTileCylindersWithBatchIds';
+    var geometryCylinders = './Data/Cesium3DTiles/Geometry/GeometryTileCylinders/tileset.json';
+    var geometryCylindersBatchedChildren = './Data/Cesium3DTiles/Geometry/GeometryTileCylindersBatchedChildren/tileset.json';
+    var geometryCylindersBatchedChildrenWithBatchTable = './Data/Cesium3DTiles/Geometry/GeometryTileCylindersBatchedChildrenWithBatchTable/tileset.json';
+    var geometryCylindersWithBatchTable = './Data/Cesium3DTiles/Geometry/GeometryTileCylindersWithBatchTable/tileset.json';
+    var geometryCylindersWithBatchIds = './Data/Cesium3DTiles/Geometry/GeometryTileCylindersWithBatchIds/tileset.json';
 
-    var geometryEllipsoids = './Data/Cesium3DTiles/Geometry/GeometryTileEllipsoids';
-    var geometryEllipsoidsBatchedChildren = './Data/Cesium3DTiles/Geometry/GeometryTileEllipsoidsBatchedChildren';
-    var geometryEllipsoidsBatchedChildrenWithBatchTable = './Data/Cesium3DTiles/Geometry/GeometryTileEllipsoidsBatchedChildrenWithBatchTable';
-    var geometryEllipsoidsWithBatchTable = './Data/Cesium3DTiles/Geometry/GeometryTileEllipsoidsWithBatchTable';
-    var geometryEllipsoidsWithBatchIds = './Data/Cesium3DTiles/Geometry/GeometryTileEllipsoidsWithBatchIds';
+    var geometryEllipsoids = './Data/Cesium3DTiles/Geometry/GeometryTileEllipsoids/tileset.json';
+    var geometryEllipsoidsBatchedChildren = './Data/Cesium3DTiles/Geometry/GeometryTileEllipsoidsBatchedChildren/tileset.json';
+    var geometryEllipsoidsBatchedChildrenWithBatchTable = './Data/Cesium3DTiles/Geometry/GeometryTileEllipsoidsBatchedChildrenWithBatchTable/tileset.json';
+    var geometryEllipsoidsWithBatchTable = './Data/Cesium3DTiles/Geometry/GeometryTileEllipsoidsWithBatchTable/tileset.json';
+    var geometryEllipsoidsWithBatchIds = './Data/Cesium3DTiles/Geometry/GeometryTileEllipsoidsWithBatchIds/tileset.json';
 
-    var geometrySpheres = './Data/Cesium3DTiles/Geometry/GeometryTileSpheres';
-    var geometrySpheresBatchedChildren = './Data/Cesium3DTiles/Geometry/GeometryTileSpheresBatchedChildren';
-    var geometrySpheresBatchedChildrenWithBatchTable = './Data/Cesium3DTiles/Geometry/GeometryTileSpheresBatchedChildrenWithBatchTable';
-    var geometrySpheresWithBatchTable = './Data/Cesium3DTiles/Geometry/GeometryTileSpheresWithBatchTable';
-    var geometrySpheresWithBatchIds = './Data/Cesium3DTiles/Geometry/GeometryTileSpheresWithBatchIds';
+    var geometrySpheres = './Data/Cesium3DTiles/Geometry/GeometryTileSpheres/tileset.json';
+    var geometrySpheresBatchedChildren = './Data/Cesium3DTiles/Geometry/GeometryTileSpheresBatchedChildren/tileset.json';
+    var geometrySpheresBatchedChildrenWithBatchTable = './Data/Cesium3DTiles/Geometry/GeometryTileSpheresBatchedChildrenWithBatchTable/tileset.json';
+    var geometrySpheresWithBatchTable = './Data/Cesium3DTiles/Geometry/GeometryTileSpheresWithBatchTable/tileset.json';
+    var geometrySpheresWithBatchIds = './Data/Cesium3DTiles/Geometry/GeometryTileSpheresWithBatchIds/tileset.json';
 
     var scene;
     var rectangle;

--- a/Specs/Scene/Instanced3DModel3DTileContentSpec.js
+++ b/Specs/Scene/Instanced3DModel3DTileContentSpec.js
@@ -28,22 +28,22 @@ defineSuite([
     var centerLongitude = -1.31968;
     var centerLatitude = 0.698874;
 
-    var gltfExternalUrl = './Data/Cesium3DTiles/Instanced/InstancedGltfExternal/';
-    var withBatchTableUrl = './Data/Cesium3DTiles/Instanced/InstancedWithBatchTable/';
-    var withBatchTableBinaryUrl = './Data/Cesium3DTiles/Instanced/InstancedWithBatchTableBinary/';
-    var withoutBatchTableUrl = './Data/Cesium3DTiles/Instanced/InstancedWithoutBatchTable/';
-    var orientationUrl = './Data/Cesium3DTiles/Instanced/InstancedOrientation/';
-    var oct16POrientationUrl = './Data/Cesium3DTiles/Instanced/InstancedOct32POrientation/';
-    var scaleUrl = './Data/Cesium3DTiles/Instanced/InstancedScale/';
-    var scaleNonUniformUrl = './Data/Cesium3DTiles/Instanced/InstancedScaleNonUniform/';
-    var rtcUrl = './Data/Cesium3DTiles/Instanced/InstancedRTC';
-    var quantizedUrl = './Data/Cesium3DTiles/Instanced/InstancedQuantized/';
-    var quantizedOct32POrientationUrl = './Data/Cesium3DTiles/Instanced/InstancedQuantizedOct32POrientation/';
-    var withTransformUrl = './Data/Cesium3DTiles/Instanced/InstancedWithTransform/';
-    var withBatchIdsUrl = './Data/Cesium3DTiles/Instanced/InstancedWithBatchIds/';
-    var texturedUrl = './Data/Cesium3DTiles/Instanced/InstancedTextured/';
-    var compressedTexturesUrl = './Data/Cesium3DTiles/Instanced/InstancedCompressedTextures/';
-    var gltfZUpUrl = './Data/Cesium3DTiles/Instanced/InstancedGltfZUp';
+    var gltfExternalUrl = './Data/Cesium3DTiles/Instanced/InstancedGltfExternal/tileset.json';
+    var withBatchTableUrl = './Data/Cesium3DTiles/Instanced/InstancedWithBatchTable/tileset.json';
+    var withBatchTableBinaryUrl = './Data/Cesium3DTiles/Instanced/InstancedWithBatchTableBinary/tileset.json';
+    var withoutBatchTableUrl = './Data/Cesium3DTiles/Instanced/InstancedWithoutBatchTable/tileset.json';
+    var orientationUrl = './Data/Cesium3DTiles/Instanced/InstancedOrientation/tileset.json';
+    var oct16POrientationUrl = './Data/Cesium3DTiles/Instanced/InstancedOct32POrientation/tileset.json';
+    var scaleUrl = './Data/Cesium3DTiles/Instanced/InstancedScale/tileset.json';
+    var scaleNonUniformUrl = './Data/Cesium3DTiles/Instanced/InstancedScaleNonUniform/tileset.json';
+    var rtcUrl = './Data/Cesium3DTiles/Instanced/InstancedRTC/tileset.json';
+    var quantizedUrl = './Data/Cesium3DTiles/Instanced/InstancedQuantized/tileset.json';
+    var quantizedOct32POrientationUrl = './Data/Cesium3DTiles/Instanced/InstancedQuantizedOct32POrientation/tileset.json';
+    var withTransformUrl = './Data/Cesium3DTiles/Instanced/InstancedWithTransform/tileset.json';
+    var withBatchIdsUrl = './Data/Cesium3DTiles/Instanced/InstancedWithBatchIds/tileset.json';
+    var texturedUrl = './Data/Cesium3DTiles/Instanced/InstancedTextured/tileset.json';
+    var compressedTexturesUrl = './Data/Cesium3DTiles/Instanced/InstancedCompressedTextures/tileset.json';
+    var gltfZUpUrl = './Data/Cesium3DTiles/Instanced/InstancedGltfZUp/tileset.json';
 
     function setCamera(longitude, latitude) {
         // One instance is located at the center, point the camera there

--- a/Specs/Scene/PointCloud3DTileContentSpec.js
+++ b/Specs/Scene/PointCloud3DTileContentSpec.js
@@ -654,7 +654,7 @@ defineSuite([
             tileset.makeStyleDirty();
             expect(scene).toRender([0, 255, 0, 255]);
 
-            tileset.style.color = new Expression('color("blue", 1.0)');
+            tileset.style.color = new Expression('color("blue", 0.5)');
             tileset.makeStyleDirty();
             expect(scene).toRender([0, 0, 255, 255]);
 

--- a/Specs/Scene/PointCloud3DTileContentSpec.js
+++ b/Specs/Scene/PointCloud3DTileContentSpec.js
@@ -44,20 +44,20 @@ defineSuite([
     var centerLongitude = -1.31968;
     var centerLatitude = 0.698874;
 
-    var pointCloudRGBUrl = './Data/Cesium3DTiles/PointCloud/PointCloudRGB';
-    var pointCloudRGBAUrl = './Data/Cesium3DTiles/PointCloud/PointCloudRGBA';
-    var pointCloudRGB565Url = './Data/Cesium3DTiles/PointCloud/PointCloudRGB565';
-    var pointCloudNoColorUrl = './Data/Cesium3DTiles/PointCloud/PointCloudNoColor';
-    var pointCloudConstantColorUrl = './Data/Cesium3DTiles/PointCloud/PointCloudConstantColor';
-    var pointCloudNormalsUrl = './Data/Cesium3DTiles/PointCloud/PointCloudNormals';
-    var pointCloudNormalsOctEncodedUrl = './Data/Cesium3DTiles/PointCloud/PointCloudNormalsOctEncoded';
-    var pointCloudQuantizedUrl = './Data/Cesium3DTiles/PointCloud/PointCloudQuantized';
-    var pointCloudQuantizedOctEncodedUrl = './Data/Cesium3DTiles/PointCloud/PointCloudQuantizedOctEncoded';
-    var pointCloudWGS84Url = './Data/Cesium3DTiles/PointCloud/PointCloudWGS84';
-    var pointCloudBatchedUrl = './Data/Cesium3DTiles/PointCloud/PointCloudBatched';
-    var pointCloudWithPerPointPropertiesUrl = './Data/Cesium3DTiles/PointCloud/PointCloudWithPerPointProperties';
-    var pointCloudWithTransformUrl = './Data/Cesium3DTiles/PointCloud/PointCloudWithTransform';
-    var pointCloudTilesetUrl = './Data/Cesium3DTiles/Tilesets/TilesetPoints';
+    var pointCloudRGBUrl = './Data/Cesium3DTiles/PointCloud/PointCloudRGB/tileset.json';
+    var pointCloudRGBAUrl = './Data/Cesium3DTiles/PointCloud/PointCloudRGBA/tileset.json';
+    var pointCloudRGB565Url = './Data/Cesium3DTiles/PointCloud/PointCloudRGB565/tileset.json';
+    var pointCloudNoColorUrl = './Data/Cesium3DTiles/PointCloud/PointCloudNoColor/tileset.json';
+    var pointCloudConstantColorUrl = './Data/Cesium3DTiles/PointCloud/PointCloudConstantColor/tileset.json';
+    var pointCloudNormalsUrl = './Data/Cesium3DTiles/PointCloud/PointCloudNormals/tileset.json';
+    var pointCloudNormalsOctEncodedUrl = './Data/Cesium3DTiles/PointCloud/PointCloudNormalsOctEncoded/tileset.json';
+    var pointCloudQuantizedUrl = './Data/Cesium3DTiles/PointCloud/PointCloudQuantized/tileset.json';
+    var pointCloudQuantizedOctEncodedUrl = './Data/Cesium3DTiles/PointCloud/PointCloudQuantizedOctEncoded/tileset.json';
+    var pointCloudWGS84Url = './Data/Cesium3DTiles/PointCloud/PointCloudWGS84/tileset.json';
+    var pointCloudBatchedUrl = './Data/Cesium3DTiles/PointCloud/PointCloudBatched/tileset.json';
+    var pointCloudWithPerPointPropertiesUrl = './Data/Cesium3DTiles/PointCloud/PointCloudWithPerPointProperties/tileset.json';
+    var pointCloudWithTransformUrl = './Data/Cesium3DTiles/PointCloud/PointCloudWithTransform/tileset.json';
+    var pointCloudTilesetUrl = './Data/Cesium3DTiles/Tilesets/TilesetPoints/tileset.json';
 
     function setCamera(longitude, latitude) {
         // Point the camera to the center of the tile
@@ -654,7 +654,7 @@ defineSuite([
             tileset.makeStyleDirty();
             expect(scene).toRender([0, 255, 0, 255]);
 
-            tileset.style.color = new Expression('color("blue", 0.5)');
+            tileset.style.color = new Expression('color("blue", 1.0)');
             tileset.makeStyleDirty();
             expect(scene).toRender([0, 0, 255, 255]);
 

--- a/Specs/Scene/PointCloudEyeDomeLightingSpec.js
+++ b/Specs/Scene/PointCloudEyeDomeLightingSpec.js
@@ -30,7 +30,7 @@ defineSuite([
     var centerLongitude = -1.31968;
     var centerLatitude = 0.698874;
 
-    var pointCloudNoColorUrl = './Data/Cesium3DTiles/PointCloud/PointCloudNoColor';
+    var pointCloudNoColorUrl = './Data/Cesium3DTiles/PointCloud/PointCloudNoColor/tileset.json';
 
     function setCamera(longitude, latitude) {
         // Point the camera to the center of the tile

--- a/Specs/Scene/Tileset3DTileContentSpec.js
+++ b/Specs/Scene/Tileset3DTileContentSpec.js
@@ -14,7 +14,7 @@ defineSuite([
     var centerLongitude = -1.31968;
     var centerLatitude = 0.698874;
 
-    var tilesetOfTilesetsUrl = './Data/Cesium3DTiles/Tilesets/TilesetOfTilesets/';
+    var tilesetOfTilesetsUrl = './Data/Cesium3DTiles/Tilesets/TilesetOfTilesets/tileset.json';
 
     beforeAll(function() {
         scene = createScene();

--- a/Specs/Scene/Vector3DTileContentSpec.js
+++ b/Specs/Scene/Vector3DTileContentSpec.js
@@ -51,26 +51,26 @@ defineSuite([
     var tilesetRectangle = Rectangle.fromDegrees(-0.01, -0.01, 0.01, 0.01);
     var combinedRectangle = Rectangle.fromDegrees(-0.02, -0.01, 0.02, 0.01);
 
-    var vectorPoints = './Data/Cesium3DTiles/Vector/VectorTilePoints';
-    var vectorPointsBatchedChildren = './Data/Cesium3DTiles/Vector/VectorTilePointsBatchedChildren';
-    var vectorPointsBatchedChildrenWithBatchTable = './Data/Cesium3DTiles/Vector/VectorTilePointsBatchedChildrenWithBatchTable';
-    var vectorPointsWithBatchTable = './Data/Cesium3DTiles/Vector/VectorTilePointsWithBatchTable';
-    var vectorPointsWithBatchIds = './Data/Cesium3DTiles/Vector/VectorTilePointsWithBatchIds';
+    var vectorPoints = './Data/Cesium3DTiles/Vector/VectorTilePoints/tileset.json';
+    var vectorPointsBatchedChildren = './Data/Cesium3DTiles/Vector/VectorTilePointsBatchedChildren/tileset.json';
+    var vectorPointsBatchedChildrenWithBatchTable = './Data/Cesium3DTiles/Vector/VectorTilePointsBatchedChildrenWithBatchTable/tileset.json';
+    var vectorPointsWithBatchTable = './Data/Cesium3DTiles/Vector/VectorTilePointsWithBatchTable/tileset.json';
+    var vectorPointsWithBatchIds = './Data/Cesium3DTiles/Vector/VectorTilePointsWithBatchIds/tileset.json';
 
-    var vectorPolygons = './Data/Cesium3DTiles/Vector/VectorTilePolygons';
-    var vectorPolygonsBatchedChildren = './Data/Cesium3DTiles/Vector/VectorTilePolygonsBatchedChildren';
-    var vectorPolygonsBatchedChildrenWithBatchTable = './Data/Cesium3DTiles/Vector/VectorTilePolygonsBatchedChildrenWithBatchTable';
-    var vectorPolygonsWithBatchTable = './Data/Cesium3DTiles/Vector/VectorTilePolygonsWithBatchTable';
-    var vectorPolygonsWithBatchIds = './Data/Cesium3DTiles/Vector/VectorTilePolygonsWithBatchIds';
+    var vectorPolygons = './Data/Cesium3DTiles/Vector/VectorTilePolygons/tileset.json';
+    var vectorPolygonsBatchedChildren = './Data/Cesium3DTiles/Vector/VectorTilePolygonsBatchedChildren/tileset.json';
+    var vectorPolygonsBatchedChildrenWithBatchTable = './Data/Cesium3DTiles/Vector/VectorTilePolygonsBatchedChildrenWithBatchTable/tileset.json';
+    var vectorPolygonsWithBatchTable = './Data/Cesium3DTiles/Vector/VectorTilePolygonsWithBatchTable/tileset.json';
+    var vectorPolygonsWithBatchIds = './Data/Cesium3DTiles/Vector/VectorTilePolygonsWithBatchIds/tileset.json';
 
-    var vectorPolylines = './Data/Cesium3DTiles/Vector/VectorTilePolylines';
-    var vectorPolylinesBatchedChildren = './Data/Cesium3DTiles/Vector/VectorTilePolylinesBatchedChildren';
-    var vectorPolylinesBatchedChildrenWithBatchTable = './Data/Cesium3DTiles/Vector/VectorTilePolylinesBatchedChildrenWithBatchTable';
-    var vectorPolylinesWithBatchTable = './Data/Cesium3DTiles/Vector/VectorTilePolylinesWithBatchTable';
-    var vectorPolylinesWithBatchIds = './Data/Cesium3DTiles/Vector/VectorTilePolylinesWithBatchIds';
+    var vectorPolylines = './Data/Cesium3DTiles/Vector/VectorTilePolylines/tileset.json';
+    var vectorPolylinesBatchedChildren = './Data/Cesium3DTiles/Vector/VectorTilePolylinesBatchedChildren/tileset.json';
+    var vectorPolylinesBatchedChildrenWithBatchTable = './Data/Cesium3DTiles/Vector/VectorTilePolylinesBatchedChildrenWithBatchTable/tileset.json';
+    var vectorPolylinesWithBatchTable = './Data/Cesium3DTiles/Vector/VectorTilePolylinesWithBatchTable/tileset.json';
+    var vectorPolylinesWithBatchIds = './Data/Cesium3DTiles/Vector/VectorTilePolylinesWithBatchIds/tileset.json';
 
-    var vectorCombined = './Data/Cesium3DTiles/Vector/VectorTileCombined';
-    var vectorCombinedWithBatchIds = './Data/Cesium3DTiles/Vector/VectorTileCombinedWithBatchIds';
+    var vectorCombined = './Data/Cesium3DTiles/Vector/VectorTileCombined/tileset.json';
+    var vectorCombinedWithBatchIds = './Data/Cesium3DTiles/Vector/VectorTileCombinedWithBatchIds/tileset.json';
 
     var scene;
     var rectangle;

--- a/Specs/Widgets/Cesium3DTilesInspector/Cesium3DTilesInspectorSpec.js
+++ b/Specs/Widgets/Cesium3DTilesInspector/Cesium3DTilesInspectorSpec.js
@@ -13,7 +13,7 @@ defineSuite([
     'use strict';
 
     // Parent tile with content and four child tiles with content
-    var tilesetUrl = './Data/Cesium3DTiles/Tilesets/Tileset/';
+    var tilesetUrl = './Data/Cesium3DTiles/Tilesets/Tileset/tileset.json';
 
     var scene;
     beforeAll(function() {

--- a/Specs/Widgets/Cesium3DTilesInspector/Cesium3DTilesInspectorViewModelSpec.js
+++ b/Specs/Widgets/Cesium3DTilesInspector/Cesium3DTilesInspectorViewModelSpec.js
@@ -15,7 +15,7 @@ defineSuite([
     'use strict';
 
     // Parent tile with content and four child tiles with content
-    var tilesetUrl = './Data/Cesium3DTiles/Tilesets/Tileset/';
+    var tilesetUrl = './Data/Cesium3DTiles/Tilesets/Tileset/tileset.json';
 
     var scene;
     var viewModel;

--- a/Specs/Widgets/Viewer/ViewerSpec.js
+++ b/Specs/Widgets/Viewer/ViewerSpec.js
@@ -1053,7 +1053,7 @@ defineSuite([
     it('zoomTo zooms to Cesium3DTileset with default offset when offset not defined', function() {
         viewer = createViewer(container);
 
-        var path = './Data/Cesium3DTiles/Tilesets/TilesetOfTilesets';
+        var path = './Data/Cesium3DTiles/Tilesets/TilesetOfTilesets/tileset.json';
         var tileset = new Cesium3DTileset({
             url : path
         });
@@ -1082,7 +1082,7 @@ defineSuite([
     it('zoomTo zooms to Cesium3DTileset with offset', function() {
         viewer = createViewer(container);
 
-        var path = './Data/Cesium3DTiles/Tilesets/TilesetOfTilesets';
+        var path = './Data/Cesium3DTiles/Tilesets/TilesetOfTilesets/tileset.json';
         var tileset = new Cesium3DTileset({
             url : path
         });
@@ -1184,7 +1184,7 @@ defineSuite([
     it('flyTo flies to Cesium3DTileset with default offset when options not defined', function() {
         viewer = createViewer(container);
 
-        var path = './Data/Cesium3DTiles/Tilesets/TilesetOfTilesets';
+        var path = './Data/Cesium3DTiles/Tilesets/TilesetOfTilesets/tileset.json';
         var tileset = new Cesium3DTileset({
             url : path
         });
@@ -1214,7 +1214,7 @@ defineSuite([
     it('flyTo flies to Cesium3DTileset with default offset when offset not defined', function() {
         viewer = createViewer(container);
 
-        var path = './Data/Cesium3DTiles/Tilesets/TilesetOfTilesets';
+        var path = './Data/Cesium3DTiles/Tilesets/TilesetOfTilesets/tileset.json';
         var tileset = new Cesium3DTileset({
             url : path
         });
@@ -1246,7 +1246,7 @@ defineSuite([
     it('flyTo flies to target when target is Cesium3DTileset and options are defined', function() {
         viewer = createViewer(container);
 
-        var path = './Data/Cesium3DTiles/Tilesets/TilesetOfTilesets';
+        var path = './Data/Cesium3DTiles/Tilesets/TilesetOfTilesets/tileset.json';
         var tileset = new Cesium3DTileset({
             url : path
         });


### PR DESCRIPTION
This PR drops support for directory URLs when loading tilesets to match the updated [3D Tiles spec](https://github.com/AnalyticalGraphicsInc/3d-tiles/issues/272). Updated documentation to remove references to "tileset.json" and to just say "tileset JSON files" instead. 

Fixes #6502 

@lilleyse can you review when you get a chance? 