### PR TITLE
fix bounding volumes for polylines on terrain

### DIFF
--- a/Specs/Core/GroundPolylineGeometrySpec.js
+++ b/Specs/Core/GroundPolylineGeometrySpec.js
@@ -499,6 +499,26 @@ defineSuite([
         expect(Cartesian3.equalsEpsilon(result, new Cartesian3(1.0, 0.0, 0.0), CesiumMath.EPSILON7)).toBe(true);
     });
 
+    it('creates bounding spheres that cover the entire polyline volume height', function() {
+        var positions = Cartesian3.fromDegreesArray([
+            -122.17580380403314, 46.19984918190237,
+            -122.17581380403314, 46.19984918190237
+        ]);
+
+        // Mt. St. Helens - provided coordinates are a few meters apart
+        var groundPolylineGeometry = new GroundPolylineGeometry({
+            positions : positions,
+            granularity : 0.0 // no interpolative subdivision
+        });
+
+        var geometry = GroundPolylineGeometry.createGeometry(groundPolylineGeometry);
+
+        var boundingSphere = geometry.boundingSphere;
+        var pointsDistance = Cartesian3.distance(positions[0], positions[1]);
+
+        expect(boundingSphere.radius > pointsDistance).toBe(true);
+    });
+
     var packedInstance = [positions.length];
     Cartesian3.pack(positions[0], packedInstance, packedInstance.length);
     Cartesian3.pack(positions[1], packedInstance, packedInstance.length);


### PR DESCRIPTION
```javascript
var viewer = new Cesium.Viewer('cesiumContainer');

var positions = Cesium.Cartesian3.fromDegreesArray([
    -122.17580380403314, 46.19984918190237,
    -122.17671567204553, 46.196577275143326
]);

var instance = new Cesium.GeometryInstance({
        geometry : new Cesium.GroundPolylineGeometry({
            positions : positions,
            loop : false,
            width : 32.0
        }),
        attributes : {
            show : new Cesium.ShowGeometryInstanceAttribute(),
            color : Cesium.ColorGeometryInstanceAttribute.fromColor(Cesium.Color.fromCssColorString('#67ADDF').withAlpha(0.5))
        }
    });

var polylineOnTerrainPrimitive = new Cesium.GroundPolylinePrimitive({
    geometryInstances : instance,
    debugShowShadowVolume : true,
    debugShowBoundingVolume : true,
    appearance : new Cesium.PolylineColorAppearance()
});

viewer.scene.groundPrimitives.add(polylineOnTerrainPrimitive);


viewer.camera.lookAt(positions[0], new Cesium.Cartesian3(0.0, 0.0, 5000.0));
viewer.camera.lookAtTransform(Cesium.Matrix4.IDENTITY);
```

Bounding spheres used to be computed just based on the polyline's positions as if they were on the ellipsoid. This lead to culling problems for small-ish distance polylines because the bounding sphere would be too low.

This PR makes the bounding sphere cover roughly the whole volume height. It's a little inefficient, but just raising the bounding spheres would have caused the same culling problem except when the polylines are drawn on the ellipsoid instead of terrain.