### PR TITLE
Do not write log depth in vertex shader for upsampled terrain.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,7 @@ Change Log
 ##### Fixes :wrench:
 * Fixed a bug causing crashes with custom vertex attributes on `Geometry` crossing the IDL. Attributes will be barycentrically interpolated. [#6644](https://github.com/AnalyticalGraphicsInc/cesium/pull/6644)
 * Fixed a bug with Draco encoded i3dm tiles, and loading two Draco models with the same url. [#6668](https://github.com/AnalyticalGraphicsInc/cesium/issues/6668)
+* Fixed terrain clipping when the camera was close to flat terrain and was using logarithmic depth. [#6701](https://github.com/AnalyticalGraphicsInc/cesium/pull/6701)
 
 ### 1.46.1 - 2018-06-01
 

--- a/Source/Scene/GlobeSurfaceShaderSet.js
+++ b/Source/Scene/GlobeSurfaceShaderSet.js
@@ -77,6 +77,13 @@ define([
             quantizationDefine = 'QUANTIZATION_BITS12';
         }
 
+        var vertexLogDepth = 0;
+        var vertexLogDepthDefine = '';
+        if (surfaceTile.terrainData._createdByUpsampling) {
+            vertexLogDepth = 1;
+            vertexLogDepthDefine = 'DISABLE_GL_POSITION_LOG_DEPTH';
+        }
+
         var sceneMode = frameState.mode;
         var flags = sceneMode |
                     (applyBrightness << 2) |
@@ -93,7 +100,8 @@ define([
                     (enableFog << 13) |
                     (quantization << 14) |
                     (applySplit << 15) |
-                    (enableClippingPlanes << 16);
+                    (enableClippingPlanes << 16) |
+                    (vertexLogDepth << 17);
 
         var currentClippingShaderState = 0;
         if (defined(clippingPlanes)) {
@@ -125,7 +133,7 @@ define([
                 fs.sources.unshift(getClippingFunction(clippingPlanes, frameState.context)); // Need to go before GlobeFS
             }
 
-            vs.defines.push(quantizationDefine);
+            vs.defines.push(quantizationDefine, vertexLogDepthDefine);
             fs.defines.push('TEXTURE_UNITS ' + numberOfDayTextures);
 
             if (applyBrightness) {


### PR DESCRIPTION
Fixes #6652.