### PR TITLE
Use nearest sampling for the globe depth texture.

### DIFF
--- a/Source/Scene/GlobeDepth.js
+++ b/Source/Scene/GlobeDepth.js
@@ -138,7 +138,13 @@ define([
             width : width,
             height : height,
             pixelFormat : PixelFormat.RGBA,
-            pixelDatatype : PixelDatatype.UNSIGNED_BYTE
+            pixelDatatype : PixelDatatype.UNSIGNED_BYTE,
+            sampler : new Sampler({
+                wrapS : TextureWrap.CLAMP_TO_EDGE,
+                wrapT : TextureWrap.CLAMP_TO_EDGE,
+                minificationFilter : TextureMinificationFilter.NEAREST,
+                magnificationFilter : TextureMagnificationFilter.NEAREST
+            })
         });
     }
 

--- a/Source/Scene/SceneFramebuffer.js
+++ b/Source/Scene/SceneFramebuffer.js
@@ -115,14 +115,26 @@ define([
                 width : width,
                 height : height,
                 pixelFormat : PixelFormat.DEPTH_STENCIL,
-                pixelDatatype : PixelDatatype.UNSIGNED_INT_24_8
+                pixelDatatype : PixelDatatype.UNSIGNED_INT_24_8,
+                sampler : new Sampler({
+                    wrapS : TextureWrap.CLAMP_TO_EDGE,
+                    wrapT : TextureWrap.CLAMP_TO_EDGE,
+                    minificationFilter : TextureMinificationFilter.NEAREST,
+                    magnificationFilter : TextureMagnificationFilter.NEAREST
+                })
             });
             this._depthStencilIdTexture = new Texture({
                 context : context,
                 width : width,
                 height : height,
                 pixelFormat : PixelFormat.DEPTH_STENCIL,
-                pixelDatatype : PixelDatatype.UNSIGNED_INT_24_8
+                pixelDatatype : PixelDatatype.UNSIGNED_INT_24_8,
+                sampler : new Sampler({
+                    wrapS : TextureWrap.CLAMP_TO_EDGE,
+                    wrapT : TextureWrap.CLAMP_TO_EDGE,
+                    minificationFilter : TextureMinificationFilter.NEAREST,
+                    magnificationFilter : TextureMagnificationFilter.NEAREST
+                })
             });
         } else {
             this._depthStencilRenderbuffer = new Renderbuffer({


### PR DESCRIPTION
We should linearly interpolate packed depth values.

@likangning93 @lilleyse This will affect polygons and polylines on terrain. I didn't notice any problems when testing.

@hpinkos I think this fixes the issue with billboard depth. Let me know whether or not you can still reproduce it with this merged.