### PR TITLE
Fixed issue where we constantly fail to load the same image.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,6 +23,7 @@ Change Log
 * Fixed a bug causing Point Cloud tiles with unsigned int batch-ids to not load. [#6666](https://github.com/AnalyticalGraphicsInc/cesium/pull/6666)
 * Fixed a bug with Draco encoded i3dm tiles, and loading two Draco models with the same url. [#6668](https://github.com/AnalyticalGraphicsInc/cesium/issues/6668)
 * Fixed terrain clipping when the camera was close to flat terrain and was using logarithmic depth. [#6701](https://github.com/AnalyticalGraphicsInc/cesium/pull/6701)
+* Fixed KML bug that constantly requested the same image if it failed to load. [#6710](https://github.com/AnalyticalGraphicsInc/cesium/pull/6710)
 
 ### 1.46.1 - 2018-06-01
 

--- a/Source/Scene/Material.js
+++ b/Source/Scene/Material.js
@@ -788,9 +788,17 @@ define([
                 return;
             }
 
-            if (uniformValue !== material._texturePaths[uniformId]) {
-                if (typeof uniformValue === 'string' || uniformValue instanceof Resource) {
-                    var resource = Resource.createIfNeeded(uniformValue);
+            // When using the entity layer, the Resource objects get recreated on getValue because
+            //  they are clonable. That's why we check the url property for Resources
+            //  because the instances aren't the same and we keep trying to load the same
+            //  image if it fails to load.
+            var isResource = (uniformValue instanceof Resource);
+            if (!defined(material._texturePaths[uniformId]) ||
+                (isResource && uniformValue.url !== material._texturePaths[uniformId].url) ||
+                (!isResource && uniformValue !== material._texturePaths[uniformId])) {
+                if (typeof uniformValue === 'string' || isResource) {
+                    var resource = isResource ? uniformValue : Resource.createIfNeeded(uniformValue);
+
                     var promise;
                     if (ktxRegex.test(uniformValue)) {
                         promise = loadKTX(resource);
@@ -801,14 +809,14 @@ define([
                     }
                     when(promise, function(image) {
                         material._loadedImages.push({
-                            id : uniformId,
-                            image : image
+                            id: uniformId,
+                            image: image
                         });
                     });
                 } else if (uniformValue instanceof HTMLCanvasElement) {
                     material._loadedImages.push({
-                        id : uniformId,
-                        image : uniformValue
+                        id: uniformId,
+                        image: uniformValue
                     });
                 }
 


### PR DESCRIPTION
Fixes #6567 

Can easily be tested with the following. Before this fix it tries to load `etna.jpg` hundreds of times.

```javascript
var viewer = new Cesium.Viewer('cesiumContainer');
var options = {
    camera : viewer.scene.camera,
    canvas : viewer.scene.canvas
};

viewer.dataSources.add(Cesium.KmlDataSource.load('https://gist.githubusercontent.com/shunter/03d24977213616ae9992f443d3c051ea/raw/6d2aeffc8e667b9100a2875388d19e9c64b945fd/KML_Samples.kml', options));
```