### PR TITLE
Special-case the ISO8601 formatting for `Iso8601.MAXIMUM_VALUE`.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,11 +12,11 @@ Change Log
 * Added support for polylines on terrain [#6689](https://github.com/AnalyticalGraphicsInc/cesium/pull/6689) [#6615](https://github.com/AnalyticalGraphicsInc/cesium/pull/6615)
   * Use the `clampToGround` option for `PolylineGraphics` (polyline entities).
   * Requires depth texture support (`WEBGL_depth_texture` or `WEBKIT_WEBGL_depth_texture`), otherwise `clampToGround` will be ignored.  Use `Entity.supportsPolylinesOnTerrain` to check for support.
-  * Added `GroundPolylinePrimitive` and `GroundPolylineGeometry` 
+  * Added `GroundPolylinePrimitive` and `GroundPolylineGeometry`.
 * `PostProcessStage` has a `selected` property which is an array of primitives used for selectively applying a post-process stage. [#6476](https://github.com/AnalyticalGraphicsInc/cesium/pull/6476)
    * The `PostProcessStageLibrary.createBlackAndWhiteStage` and `PostProcessStageLibrary.createSilhouetteStage` have per-feature support.
 * Added CZML support for `zIndex` for `corridor`, `ellipse`, `polygon`, `polyline` and `rectangle`. [#6708](https://github.com/AnalyticalGraphicsInc/cesium/pull/6708)
-* Added CZML `clampToGround` option for `polyline`. [#6706](https://github.com/AnalyticalGraphicsInc/cesium/pull/6706) 
+* Added CZML `clampToGround` option for `polyline`. [#6706](https://github.com/AnalyticalGraphicsInc/cesium/pull/6706)
 
 ##### Fixes :wrench:
 * Fixed a bug causing crashes with custom vertex attributes on `Geometry` crossing the IDL. Attributes will be barycentrically interpolated. [#6644](https://github.com/AnalyticalGraphicsInc/cesium/pull/6644)
@@ -26,6 +26,7 @@ Change Log
 * Fixed KML bug that constantly requested the same image if it failed to load. [#6710](https://github.com/AnalyticalGraphicsInc/cesium/pull/6710)
 * Improved billboard and label rendering so they no longer sink into terrain when clamped to ground. [#6621](https://github.com/AnalyticalGraphicsInc/cesium/pull/6621)
 * Fixed an issue where KMLs containing a `colorMode` of `random` could return the exact same color on successive calls to `Color.fromRandom()`.
+* `Iso8601.MAXIMUM_VALUE` now formats to a string which can be parsed by `fromIso8601`.
 
 ### 1.46.1 - 2018-06-01
 

--- a/Source/Core/JulianDate.js
+++ b/Source/Core/JulianDate.js
@@ -657,22 +657,39 @@ define([
         //>>includeEnd('debug');
 
         var gDate = JulianDate.toGregorianDate(julianDate, gregorianDateScratch);
+        var year = gDate.year;
+        var month = gDate.month;
+        var day = gDate.day;
+        var hour = gDate.hour;
+        var minute = gDate.minute;
+        var second = gDate.second;
+        var millisecond = gDate.millisecond;
+
+        // special case - Iso8601.MAXIMUM_VALUE produces a string which we can't parse unless we adjust.
+        // 10000-01-01T00:00:00 is the same instant as 9999-12-31T24:00:00
+        if (year === 10000 && month === 1 && day === 1 && hour === 0 && minute === 0 && second === 0 && millisecond === 0) {
+            year = 9999;
+            month = 12;
+            day = 31;
+            hour = 24;
+        }
+
         var millisecondStr;
 
-        if (!defined(precision) && gDate.millisecond !== 0) {
+        if (!defined(precision) && millisecond !== 0) {
             //Forces milliseconds into a number with at least 3 digits to whatever the default toString() precision is.
-            millisecondStr = (gDate.millisecond * 0.01).toString().replace('.', '');
-            return sprintf('%04d-%02d-%02dT%02d:%02d:%02d.%sZ', gDate.year, gDate.month, gDate.day, gDate.hour, gDate.minute, gDate.second, millisecondStr);
+            millisecondStr = (millisecond * 0.01).toString().replace('.', '');
+            return sprintf('%04d-%02d-%02dT%02d:%02d:%02d.%sZ', year, month, day, hour, minute, second, millisecondStr);
         }
 
         //Precision is either 0 or milliseconds is 0 with undefined precision, in either case, leave off milliseconds entirely
         if (!defined(precision) || precision === 0) {
-            return sprintf('%04d-%02d-%02dT%02d:%02d:%02dZ', gDate.year, gDate.month, gDate.day, gDate.hour, gDate.minute, gDate.second);
+            return sprintf('%04d-%02d-%02dT%02d:%02d:%02dZ', year, month, day, hour, minute, second);
         }
 
         //Forces milliseconds into a number with at least 3 digits to whatever the specified precision is.
-        millisecondStr = (gDate.millisecond * 0.01).toFixed(precision).replace('.', '').slice(0, precision);
-        return sprintf('%04d-%02d-%02dT%02d:%02d:%02d.%sZ', gDate.year, gDate.month, gDate.day, gDate.hour, gDate.minute, gDate.second, millisecondStr);
+        millisecondStr = (millisecond * 0.01).toFixed(precision).replace('.', '').slice(0, precision);
+        return sprintf('%04d-%02d-%02dT%02d:%02d:%02d.%sZ', year, month, day, hour, minute, second, millisecondStr);
     };
 
     /**

--- a/Specs/Core/JulianDateSpec.js
+++ b/Specs/Core/JulianDateSpec.js
@@ -1,10 +1,12 @@
 defineSuite([
         'Core/JulianDate',
+        'Core/Iso8601',
         'Core/Math',
         'Core/TimeConstants',
         'Core/TimeStandard'
     ], function(
         JulianDate,
+        Iso8601,
         CesiumMath,
         TimeConstants,
         TimeStandard) {
@@ -794,6 +796,16 @@ defineSuite([
         expect(date).toEqual('0950-01-02T03:04:05.012345Z');
         date = JulianDate.toIso8601(JulianDate.fromIso8601(isoDate), 7);
         expect(date).toEqual('0950-01-02T03:04:05.0123450Z');
+    });
+
+    it('can format Iso8601.MINIMUM_VALUE and MAXIMUM_VALUE to ISO strings', function() {
+        var minString = Iso8601.MINIMUM_VALUE.toString();
+        expect(minString).toEqual('0000-01-01T00:00:00Z');
+        expect(JulianDate.fromIso8601(minString)).toEqual(Iso8601.MINIMUM_VALUE);
+
+        var maxString = Iso8601.MAXIMUM_VALUE.toString();
+        expect(maxString).toEqual('9999-12-31T24:00:00Z');
+        expect(JulianDate.fromIso8601(maxString)).toEqual(Iso8601.MAXIMUM_VALUE);
     });
 
     it('secondsDifference works in UTC', function() {


### PR DESCRIPTION
`10000-01-01T00:00:00` is the same instant as `9999-12-31T24:00:00`
but our parsing code cannot handle more than 4 year digits.

Fixes #6718.