### PR TITLE
Use png badge icons for CLA instead of svg.

### DIFF
--- a/.concierge/templates/pullRequestOpened.hbs
+++ b/.concierge/templates/pullRequestOpened.hbs
@@ -10,13 +10,13 @@ If this is your first contribution, please send in a [Contributor License Agreem
 ```
 {{else}}
 {{#if askForCla}}
-[![Please sign the CLA before we review this PR.](https://img.shields.io/badge/CLA-required-red.svg)](https://github.com/AnalyticalGraphicsInc/cesium/blob/master/CONTRIBUTING.md#contributor-license-agreement-cla)
+[![Please sign the CLA before we review this PR.](https://img.shields.io/badge/CLA-required-red.png)](https://github.com/AnalyticalGraphicsInc/cesium/blob/master/CONTRIBUTING.md#contributor-license-agreement-cla)
 
 Welcome to the Cesium community @{{ userName }}!
 
 Can you please send in a [Contributor License Agreement](https://github.com/AnalyticalGraphicsInc/cesium/blob/master/CONTRIBUTING.md#contributor-license-agreement-cla) (CLA) so that we can review and merge this pull request?
 {{else}}
-![Signed CLA is on file.](https://img.shields.io/badge/CLA-signed-brightgreen.svg)
+![Signed CLA is on file.](https://img.shields.io/badge/CLA-signed-brightgreen.png)
 
 @{{ userName }}, thanks for the pull request! Maintainers, we have a signed CLA from @{{ userName }}, so you can review this at any time.
 {{/if}}


### PR DESCRIPTION
Gmail proxies images contained in emails and does not support SVG.

the icon currently shows up as:
![image](https://user-images.githubusercontent.com/32828/41799720-8718dfda-7640-11e8-9cb3-94c60ca1b7e3.png)

A long-time annoyance with an easy fix.