### PR TITLE
Add HTMLImageElement for Material uniform

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,6 +28,7 @@ Change Log
 * Improved billboard and label rendering so they no longer sink into terrain when clamped to ground. [#6621](https://github.com/AnalyticalGraphicsInc/cesium/pull/6621)
 * Fixed an issue where KMLs containing a `colorMode` of `random` could return the exact same color on successive calls to `Color.fromRandom()`.
 * `Iso8601.MAXIMUM_VALUE` now formats to a string which can be parsed by `fromIso8601`.
+* Fixed material support when using an image that is already loaded [#6729](https://github.com/AnalyticalGraphicsInc/cesium/pull/6729)
 
 ### 1.46.1 - 2018-06-01
 

--- a/Source/Scene/Material.js
+++ b/Source/Scene/Material.js
@@ -813,7 +813,7 @@ define([
                             image: image
                         });
                     });
-                } else if (uniformValue instanceof HTMLCanvasElement) {
+                } else if (uniformValue instanceof HTMLCanvasElement || uniformValue instanceof HTMLImageElement) {
                     material._loadedImages.push({
                         id: uniformId,
                         image: uniformValue
@@ -971,7 +971,7 @@ define([
                 uniformType = 'float';
             } else if (type === 'boolean') {
                 uniformType = 'bool';
-            } else if (type === 'string' || uniformValue instanceof Resource ||uniformValue instanceof HTMLCanvasElement) {
+            } else if (type === 'string' || uniformValue instanceof Resource ||uniformValue instanceof HTMLCanvasElement || uniformValue instanceof HTMLImageElement) {
                 if (/^([rgba]){1,4}$/i.test(uniformValue)) {
                     uniformType = 'channels';
                 } else if (uniformValue === Material.DefaultCubeMapId) {


### PR DESCRIPTION
Replaces #5857

---

From #5857:  In order to make an animation by many images,we must know every image status in the process,so I change the timeline to the next time after the current image loaded.

material.uniforms.image = loadedImage;