### PR TITLE
Ground polyline cleanup

### DIFF
--- a/Source/DataSources/DataSourceDisplay.js
+++ b/Source/DataSources/DataSourceDisplay.js
@@ -6,6 +6,7 @@ define([
         '../Core/defineProperties',
         '../Core/destroyObject',
         '../Core/EventHelper',
+        '../Scene/GroundPolylinePrimitive',
         '../Scene/GroundPrimitive',
         '../Scene/OrderedGroundPrimitiveCollection',
         '../Scene/PrimitiveCollection',
@@ -26,6 +27,7 @@ define([
         defineProperties,
         destroyObject,
         EventHelper,
+        GroundPolylinePrimitive,
         GroundPrimitive,
         OrderedGroundPrimitiveCollection,
         PrimitiveCollection,
@@ -60,6 +62,7 @@ define([
         //>>includeEnd('debug');
 
         GroundPrimitive.initializeTerrainHeights();
+        GroundPolylinePrimitive.initializeTerrainHeights();
 
         var scene = options.scene;
         var dataSourceCollection = options.dataSourceCollection;
@@ -130,7 +133,7 @@ define([
                 new ModelVisualizer(scene, entities),
                 new PointVisualizer(entityCluster, entities),
                 new PathVisualizer(scene, entities),
-                new PolylineVisualizer(scene, entities, dataSource._groundPrimitives)];
+                new PolylineVisualizer(scene, entities, dataSource._primitives, dataSource._groundPrimitives)];
     };
 
     defineProperties(DataSourceDisplay.prototype, {

--- a/Source/DataSources/PolylineGeometryUpdater.js
+++ b/Source/DataSources/PolylineGeometryUpdater.js
@@ -566,7 +566,6 @@ define([
         this._material = undefined;
         this._geometryUpdater = geometryUpdater;
         this._positions = [];
-        this._terrainHeightsReady = false;
     }
 
     function getLine(dynamicGeometryUpdater) {
@@ -618,20 +617,6 @@ define([
 
             if (!defined(positions) || positions.length < 2) {
                 return;
-            }
-
-            var that = this;
-
-            // Load terrain heights
-            if (!this._terrainHeightsReady) {
-                if (!GroundPolylinePrimitive._isInitialized()) {
-                    GroundPolylinePrimitive.initializeTerrainHeights()
-                        .then(function() {
-                            that._terrainHeightsReady = true;
-                        });
-                    return;
-                }
-                this._terrainHeightsReady = true;
             }
 
             var fillMaterialProperty = geometryUpdater.fillMaterialProperty;

--- a/Source/DataSources/PolylineVisualizer.js
+++ b/Source/DataSources/PolylineVisualizer.js
@@ -87,17 +87,17 @@ define([
      *
      * @param {Scene} scene The scene the primitives will be rendered in.
      * @param {EntityCollection} entityCollection The entityCollection to visualize.
-     * @param {PrimitiveCollection|OrderedGroundPrimitiveCollection} [groundPrimitives] A collection to add ground primitives related to the entities
+     * @param {PrimitiveCollection} [primitives=scene.primitives] A collection to add primitives related to the entities
+     * @param {PrimitiveCollection} [groundPrimitives=scene.groundPrimitives] A collection to add ground primitives related to the entities
      */
-    function PolylineVisualizer(scene, entityCollection, groundPrimitives) {
+    function PolylineVisualizer(scene, entityCollection, primitives, groundPrimitives) {
         //>>includeStart('debug', pragmas.debug);
         Check.defined('scene', scene);
         Check.defined('entityCollection', entityCollection);
         //>>includeEnd('debug');
 
         groundPrimitives = defaultValue(groundPrimitives, scene.groundPrimitives);
-
-        var primitives = scene.primitives;
+        primitives = defaultValue(primitives, scene.primitives);
 
         this._scene = scene;
         this._primitives = primitives;

--- a/Source/Scene/GroundPolylinePrimitive.js
+++ b/Source/Scene/GroundPolylinePrimitive.js
@@ -62,6 +62,9 @@ define([
      *
      * Only to be used with GeometryInstances containing {@link GroundPolylineGeometry}.
      *
+     * @alias GroundPolylinePrimitive
+     * @constructor
+     *
      * @param {Object} [options] Object with the following properties:
      * @param {Array|GeometryInstance} [options.geometryInstances] GeometryInstances containing GroundPolylineGeometry
      * @param {Appearance} [options.appearance] The Appearance used to render the polyline. Defaults to a white color {@link Material} on a {@link PolylineMaterialAppearance}.
@@ -348,7 +351,6 @@ define([
      * GroundPolylinePrimitive synchronously.
      *
      * @returns {Promise} A promise that will resolve once the terrain heights have been loaded.
-     *
      */
     GroundPolylinePrimitive.initializeTerrainHeights = function() {
         var initPromise = GroundPolylinePrimitive._initPromise;
@@ -362,17 +364,6 @@ define([
             });
 
         return GroundPolylinePrimitive._initPromise;
-    };
-
-    /**
-     * Synchronous check for if GroundPolylinePrimitive is initialized and
-     * synchronous GroundPolylinePrimitives can be created.
-     *
-     * @returns {Boolean} Whether GroundPolylinePrimitive is initialized.
-     * @private
-     */
-    GroundPolylinePrimitive._isInitialized = function() {
-        return GroundPolylinePrimitive._initialized;
     };
 
     // For use with web workers.

--- a/Specs/DataSources/DataSourceDisplaySpec.js
+++ b/Specs/DataSources/DataSourceDisplaySpec.js
@@ -7,7 +7,9 @@ defineSuite([
         'DataSources/BoundingSphereState',
         'DataSources/DataSourceCollection',
         'DataSources/Entity',
+        'Scene/GroundPolylinePrimitive',
         'Scene/GroundPrimitive',
+        'ThirdParty/when',
         'Specs/createScene',
         'Specs/MockDataSource'
     ], function(
@@ -19,7 +21,9 @@ defineSuite([
         BoundingSphereState,
         DataSourceCollection,
         Entity,
+        GroundPolylinePrimitive,
         GroundPrimitive,
+        when,
         createScene,
         MockDataSource) {
     'use strict';
@@ -31,7 +35,7 @@ defineSuite([
         scene = createScene();
         dataSourceCollection = new DataSourceCollection();
 
-        return GroundPrimitive.initializeTerrainHeights();
+        return when.join(GroundPrimitive.initializeTerrainHeights(), GroundPolylinePrimitive.initializeTerrainHeights());
     });
 
     afterAll(function() {
@@ -40,6 +44,8 @@ defineSuite([
         // Leave ground primitive uninitialized
         GroundPrimitive._initialized = false;
         GroundPrimitive._initPromise = undefined;
+        GroundPolylinePrimitive._initialized = false;
+        GroundPolylinePrimitive._initPromise = undefined;
         ApproximateTerrainHeights._initPromise = undefined;
         ApproximateTerrainHeights._terrainHeights = undefined;
     });

--- a/Specs/DataSources/PolylineGeometryUpdaterSpec.js
+++ b/Specs/DataSources/PolylineGeometryUpdaterSpec.js
@@ -81,11 +81,6 @@ defineSuite([
         ApproximateTerrainHeights._terrainHeights = undefined;
     });
 
-    beforeEach(function() {
-        scene.primitives.removeAll();
-        scene.groundPrimitives.removeAll();
-    });
-
     var time = JulianDate.now();
 
     var basicPositions = Cartesian3.fromRadiansArray([
@@ -511,6 +506,7 @@ defineSuite([
 
         dynamicUpdater.destroy();
         expect(primitives.length).toBe(0);
+        expect(scene.groundPrimitives.length).toBe(0);
         updater.destroy();
     });
 
@@ -557,66 +553,12 @@ defineSuite([
         isClampedToGround = false;
         dynamicUpdater.update(time);
 
-        expect(groundPrimitives.length).toBe(0);
-
         dynamicUpdater.destroy();
-        updater.destroy();
-    });
 
-    it('initializes terrain heights when clampToGround is dynamic', function() {
-        if (!Entity.supportsPolylinesOnTerrain(scene)) {
-            return;
-        }
-
-        var approximateTerrainHeightsInitPromise = ApproximateTerrainHeights._initPromise;
-        var approximateTerrainHeightsTerrainHeights = ApproximateTerrainHeights._terrainHeights;
-        var groundPolylinePrimitiveInitPromise = GroundPolylinePrimitive._initPromise;
-
-        ApproximateTerrainHeights._initPromise = undefined;
-        ApproximateTerrainHeights._terrainHeights = undefined;
-        GroundPolylinePrimitive._initPromise = undefined;
-        GroundPolylinePrimitive._initialized = false;
-
-        var entity = new Entity();
-        var polyline = new PolylineGraphics();
-        entity.polyline = polyline;
-
-        var time = new JulianDate(0, 0);
-
-        var isClampedToGround = true;
-        var clampToGround = new CallbackProperty(function() {
-            return isClampedToGround;
-        }, false);
-
-        polyline.show = new ConstantProperty(true);
-        polyline.width = new ConstantProperty(1.0);
-        polyline.positions = new ConstantProperty([Cartesian3.fromDegrees(0, 0, 0), Cartesian3.fromDegrees(0, 1, 0)]);
-        polyline.material = new ColorMaterialProperty(Color.RED);
-        polyline.followSurface = new ConstantProperty(false);
-        polyline.granularity = new ConstantProperty(0.001);
-        polyline.clampToGround = clampToGround;
-
-        var updater = new PolylineGeometryUpdater(entity, scene);
-
-        var groundPrimitives = scene.groundPrimitives;
+        expect(scene.primitives.length).toBe(0);
         expect(groundPrimitives.length).toBe(0);
 
-        var dynamicUpdater = updater.createDynamicUpdater(scene.primitives, groundPrimitives);
-        expect(dynamicUpdater.isDestroyed()).toBe(false);
-        expect(groundPrimitives.length).toBe(0);
-
-        dynamicUpdater.update(time);
-
-        expect(ApproximateTerrainHeights._initPromise).toBeDefined();
-        expect(GroundPolylinePrimitive._initPromise).toBeDefined();
-
-        dynamicUpdater.destroy();
         updater.destroy();
-
-        ApproximateTerrainHeights._initPromise = approximateTerrainHeightsInitPromise;
-        ApproximateTerrainHeights._terrainHeights = approximateTerrainHeightsTerrainHeights;
-        GroundPolylinePrimitive._initPromise = groundPolylinePrimitiveInitPromise;
-        GroundPolylinePrimitive._initialized = true;
     });
 
     it('geometryChanged event is raised when expected', function() {
@@ -714,6 +656,7 @@ defineSuite([
         expect(function() {
             dynamicUpdater.update(undefined);
         }).toThrowDeveloperError();
+        dynamicUpdater.destroy();
         updater.destroy();
     });
 
@@ -746,8 +689,11 @@ defineSuite([
         var line = primitive.get(0);
         expect(result).toEqual(BoundingSphere.fromPoints(line.positions));
 
+        dynamicUpdater.destroy();
         updater.destroy();
-        scene.primitives.removeAll();
+
+        expect(scene.primitives.length).toBe(0);
+        expect(scene.groundPrimitives.length).toBe(0);
     });
 
     it('Computes dynamic geometry bounding sphere on terrain.', function() {
@@ -778,7 +724,11 @@ defineSuite([
             var attributes = primitive.getGeometryInstanceAttributes(entity);
             expect(result).toEqual(attributes.boundingSphere);
 
+            dynamicUpdater.destroy();
             updater.destroy();
+
+            expect(scene.primitives.length).toBe(0);
+            expect(scene.groundPrimitives.length).toBe(0);
         });
     });
 
@@ -792,8 +742,11 @@ defineSuite([
         var state = dynamicUpdater.getBoundingSphere(result);
         expect(state).toBe(BoundingSphereState.FAILED);
 
+        dynamicUpdater.destroy();
         updater.destroy();
-        scene.primitives.removeAll();
+
+        expect(scene.primitives.length).toBe(0);
+        expect(scene.groundPrimitives.length).toBe(0);
     });
 
     it('Compute dynamic geometry bounding sphere throws without result.', function() {
@@ -806,8 +759,11 @@ defineSuite([
             dynamicUpdater.getBoundingSphere(undefined);
         }).toThrowDeveloperError();
 
+        dynamicUpdater.destroy();
         updater.destroy();
-        scene.primitives.removeAll();
+
+        expect(scene.primitives.length).toBe(0);
+        expect(scene.groundPrimitives.length).toBe(0);
     });
 
     it('followSurface true with undefined globe does not call generateCartesianArc', function() {
@@ -819,8 +775,12 @@ defineSuite([
         spyOn(PolylinePipeline, 'generateCartesianArc').and.callThrough();
         dynamicUpdater.update(time);
         expect(PolylinePipeline.generateCartesianArc).not.toHaveBeenCalled();
+        dynamicUpdater.destroy();
         updater.destroy();
-        scene.primitives.removeAll();
+
+        expect(scene.primitives.length).toBe(0);
+        expect(scene.groundPrimitives.length).toBe(0);
+
         scene.globe = new Globe();
     });
 

--- a/Specs/DataSources/PolylineVisualizerSpec.js
+++ b/Specs/DataSources/PolylineVisualizerSpec.js
@@ -54,7 +54,7 @@ defineSuite([
     beforeAll(function() {
         scene = createScene();
 
-        ApproximateTerrainHeights.initialize();
+        return ApproximateTerrainHeights.initialize();
     });
 
     afterAll(function() {

--- a/Specs/DataSources/StaticGroundGeometryPerMaterialBatchSpec.js
+++ b/Specs/DataSources/StaticGroundGeometryPerMaterialBatchSpec.js
@@ -1,5 +1,6 @@
 defineSuite([
         'DataSources/StaticGroundGeometryPerMaterialBatch',
+        'Core/ApproximateTerrainHeights',
         'Core/Cartesian2',
         'Core/Cartesian3',
         'Core/Color',
@@ -27,6 +28,7 @@ defineSuite([
         'Specs/pollToPromise'
     ], function(
         StaticGroundGeometryPerMaterialBatch,
+        ApproximateTerrainHeights,
         Cartesian2,
         Cartesian3,
         Color,
@@ -58,10 +60,18 @@ defineSuite([
     var scene;
     beforeAll(function() {
         scene = createScene();
+
+        return GroundPrimitive.initializeTerrainHeights();
     });
 
     afterAll(function() {
         scene.destroyForSpecs();
+
+        // Leave ground primitive uninitialized
+        GroundPrimitive._initialized = false;
+        GroundPrimitive._initPromise = undefined;
+        ApproximateTerrainHeights._initPromise = undefined;
+        ApproximateTerrainHeights._terrainHeights = undefined;
     });
 
     it('handles shared material being invalidated with geometry', function() {

--- a/Specs/DataSources/StaticGroundPolylinePerMaterialBatchSpec.js
+++ b/Specs/DataSources/StaticGroundPolylinePerMaterialBatchSpec.js
@@ -1,5 +1,6 @@
 defineSuite([
         'DataSources/StaticGroundPolylinePerMaterialBatch',
+        'Core/ApproximateTerrainHeights',
         'Core/BoundingSphere',
         'Core/Cartesian3',
         'Core/Color',
@@ -21,6 +22,7 @@ defineSuite([
         'Specs/pollToPromise'
     ], function(
         StaticGroundPolylinePerMaterialBatch,
+        ApproximateTerrainHeights,
         BoundingSphere,
         Cartesian3,
         Color,
@@ -46,10 +48,18 @@ defineSuite([
     var scene;
     beforeAll(function() {
         scene = createScene();
+
+        return GroundPolylinePrimitive.initializeTerrainHeights();
     });
 
     afterAll(function() {
         scene.destroyForSpecs();
+
+        GroundPolylinePrimitive._initPromise = undefined;
+        GroundPolylinePrimitive._initialized = false;
+
+        ApproximateTerrainHeights._initPromise = undefined;
+        ApproximateTerrainHeights._terrainHeights = undefined;
     });
 
     function createGroundPolyline() {

--- a/Specs/Scene/GroundPolylinePrimitiveSpec.js
+++ b/Specs/Scene/GroundPolylinePrimitiveSpec.js
@@ -1,5 +1,6 @@
 defineSuite([
         'Scene/GroundPolylinePrimitive',
+        'Core/ApproximateTerrainHeights',
         'Core/Color',
         'Core/ColorGeometryInstanceAttribute',
         'Core/Cartesian3',
@@ -20,6 +21,7 @@ defineSuite([
         'Specs/pollToPromise'
     ], function(
         GroundPolylinePrimitive,
+        ApproximateTerrainHeights,
         Color,
         ColorGeometryInstanceAttribute,
         Cartesian3,
@@ -76,6 +78,8 @@ defineSuite([
         // Leave ground primitive uninitialized
         GroundPolylinePrimitive._initialized = false;
         GroundPolylinePrimitive._initPromise = undefined;
+        ApproximateTerrainHeights._initPromise = undefined;
+        ApproximateTerrainHeights._terrainHeights = undefined;
     });
 
     function MockGlobePrimitive(primitive) {

--- a/Specs/Scene/GroundPrimitiveSpec.js
+++ b/Specs/Scene/GroundPrimitiveSpec.js
@@ -79,6 +79,9 @@ defineSuite([
         // Leave ground primitive uninitialized
         GroundPrimitive._initialized = false;
         GroundPrimitive._initPromise = undefined;
+
+        ApproximateTerrainHeights._initPromise = undefined;
+        ApproximateTerrainHeights._terrainHeights = undefined;
     });
 
     function MockGlobePrimitive(primitive) {


### PR DESCRIPTION
I was seeing intermittent test failures depending on when and whether `GroundPolylinePrimitive.initialize` was being called and cleaned up.

I changed everything to be the same as `GroundPrimitive`