### PR TITLE
Add static computeRectangle function to CorridorGeometry, EllipseGeometry, PolygonGeometry and RectangleGeometry

### DIFF
--- a/Source/Core/CorridorGeometry.js
+++ b/Source/Core/CorridorGeometry.js
@@ -11,7 +11,6 @@ define([
         './defaultValue',
         './defined',
         './defineProperties',
-        './DeveloperError',
         './Ellipsoid',
         './Geometry',
         './GeometryAttribute',
@@ -36,7 +35,6 @@ define([
         defaultValue,
         defined,
         defineProperties,
-        DeveloperError,
         Ellipsoid,
         Geometry,
         GeometryAttribute,
@@ -725,7 +723,7 @@ define([
     var scratchCartographicMin = new Cartographic();
     var scratchCartographicMax = new Cartographic();
 
-    function computeRectangle(positions, ellipsoid, width, cornerType) {
+    function computeRectangle(positions, ellipsoid, width, cornerType, result) {
         positions = scaleToSurface(positions, ellipsoid);
         var cleanPositions = arrayRemoveDuplicates(positions, Cartesian3.equalsEpsilon);
         var length = cleanPositions.length;
@@ -783,7 +781,7 @@ define([
             scratchCartographicMax.longitude = Math.max(scratchCartographicMax.longitude, lon);
         }
 
-        var rectangle = new Rectangle();
+        var rectangle = defined(result) ? result : new Rectangle();
         rectangle.north = scratchCartographicMax.latitude;
         rectangle.south = scratchCartographicMin.latitude;
         rectangle.east = scratchCartographicMax.longitude;
@@ -826,12 +824,8 @@ define([
         var width = options.width;
 
         //>>includeStart('debug', pragmas.debug);
-        if (!defined(positions)) {
-            throw new DeveloperError('options.positions is required.');
-        }
-        if (!defined(width)) {
-            throw new DeveloperError('options.width is required.');
-        }
+        Check.defined('options.positions', positions);
+        Check.defined('options.width', width);
         //>>includeEnd('debug');
 
         var height = defaultValue(options.height, 0.0);
@@ -868,12 +862,8 @@ define([
      */
     CorridorGeometry.pack = function(value, array, startingIndex) {
         //>>includeStart('debug', pragmas.debug);
-        if (!defined(value)) {
-            throw new DeveloperError('value is required');
-        }
-        if (!defined(array)) {
-            throw new DeveloperError('array is required');
-        }
+        Check.defined('value', value);
+        Check.defined('array', array);
         //>>includeEnd('debug');
 
         startingIndex = defaultValue(startingIndex, 0);
@@ -928,9 +918,7 @@ define([
      */
     CorridorGeometry.unpack = function(array, startingIndex, result) {
         //>>includeStart('debug', pragmas.debug);
-        if (!defined(array)) {
-            throw new DeveloperError('array is required');
-        }
+        Check.defined('array', array);
         //>>includeEnd('debug');
 
         startingIndex = defaultValue(startingIndex, 0);
@@ -981,6 +969,34 @@ define([
         result._offsetAttribute = offsetAttribute === -1 ? undefined : offsetAttribute;
 
         return result;
+    };
+
+    /**
+     * Computes the bounding rectangle given the provided options
+     *
+     * @param {Object} options Object with the following properties:
+     * @param {Cartesian3[]} options.positions An array of positions that define the center of the corridor.
+     * @param {Number} options.width The distance between the edges of the corridor in meters.
+     * @param {Ellipsoid} [options.ellipsoid=Ellipsoid.WGS84] The ellipsoid to be used as a reference.
+     * @param {CornerType} [options.cornerType=CornerType.ROUNDED] Determines the style of the corners.
+     * @param {Rectangle} [result] An object in which to store the result.
+     *
+     * @returns {Rectangle} The result rectangle.
+     */
+    CorridorGeometry.computeRectangle = function(options, result) {
+        options = defaultValue(options, defaultValue.EMPTY_OBJECT);
+        var positions = options.positions;
+        var width = options.width;
+
+        //>>includeStart('debug', pragmas.debug);
+        Check.defined('options.positions', positions);
+        Check.defined('options.width', width);
+        //>>includeEnd('debug');
+
+        var ellipsoid = defaultValue(options.ellipsoid, Ellipsoid.WGS84);
+        var cornerType = defaultValue(options.cornerType, CornerType.ROUNDED);
+
+        return computeRectangle(positions, ellipsoid, width, cornerType, result);
     };
 
     /**

--- a/Source/Core/EllipseGeometry.js
+++ b/Source/Core/EllipseGeometry.js
@@ -4,6 +4,7 @@ define([
         './Cartesian2',
         './Cartesian3',
         './Cartographic',
+        './Check',
         './ComponentDatatype',
         './defaultValue',
         './defined',
@@ -31,6 +32,7 @@ define([
         Cartesian2,
         Cartesian3,
         Cartographic,
+        Check,
         ComponentDatatype,
         defaultValue,
         defined,
@@ -684,13 +686,13 @@ define([
         };
     }
 
-    function computeRectangle(ellipseGeometry) {
+    function computeRectangle(center, semiMajorAxis, semiMinorAxis, rotation, granularity, ellipsoid, result) {
         var cep = EllipseGeometryLibrary.computeEllipsePositions({
-            center : ellipseGeometry._center,
-            semiMajorAxis : ellipseGeometry._semiMajorAxis,
-            semiMinorAxis : ellipseGeometry._semiMinorAxis,
-            rotation : ellipseGeometry._rotation,
-            granularity : ellipseGeometry._granularity
+            center : center,
+            semiMajorAxis : semiMajorAxis,
+            semiMinorAxis : semiMinorAxis,
+            rotation : rotation,
+            granularity : granularity
         }, false, true);
         var positionsFlat = cep.outerPositions;
         var positionsCount = positionsFlat.length / 3;
@@ -698,7 +700,7 @@ define([
         for (var i = 0; i < positionsCount; ++i) {
             positions[i] = Cartesian3.fromArray(positionsFlat, i * 3);
         }
-        var rectangle = Rectangle.fromCartesianArray(positions, ellipseGeometry._ellipsoid);
+        var rectangle = Rectangle.fromCartesianArray(positions, ellipsoid, result);
         // Rectangle width goes beyond 180 degrees when the ellipse crosses a pole.
         // When this happens, make the rectangle into a "circle" around the pole
         if (rectangle.width > CesiumMath.PI) {
@@ -756,15 +758,9 @@ define([
         var vertexFormat = defaultValue(options.vertexFormat, VertexFormat.DEFAULT);
 
         //>>includeStart('debug', pragmas.debug);
-        if (!defined(center)) {
-            throw new DeveloperError('center is required.');
-        }
-        if (!defined(semiMajorAxis)) {
-            throw new DeveloperError('semiMajorAxis is required.');
-        }
-        if (!defined(semiMinorAxis)) {
-            throw new DeveloperError('semiMinorAxis is required.');
-        }
+        Check.defined('options.center', center);
+        Check.typeOf.number('options.semiMajorAxis', semiMajorAxis);
+        Check.typeOf.number('options.semiMinorAxis', semiMinorAxis);
         if (semiMajorAxis < semiMinorAxis) {
             throw new DeveloperError('semiMajorAxis must be greater than or equal to the semiMinorAxis.');
         }
@@ -811,12 +807,8 @@ define([
      */
     EllipseGeometry.pack = function(value, array, startingIndex) {
         //>>includeStart('debug', pragmas.debug);
-        if (!defined(value)) {
-            throw new DeveloperError('value is required');
-        }
-        if (!defined(array)) {
-            throw new DeveloperError('array is required');
-        }
+        Check.defined('value', value);
+        Check.defined('array', array);
         //>>includeEnd('debug');
 
         startingIndex = defaultValue(startingIndex, 0);
@@ -871,9 +863,7 @@ define([
      */
     EllipseGeometry.unpack = function(array, startingIndex, result) {
         //>>includeStart('debug', pragmas.debug);
-        if (!defined(array)) {
-            throw new DeveloperError('array is required');
-        }
+        Check.defined('array', array);
         //>>includeEnd('debug');
 
         startingIndex = defaultValue(startingIndex, 0);
@@ -925,6 +915,45 @@ define([
         result._offsetAttribute = offsetAttribute === -1 ? undefined : offsetAttribute;
 
         return result;
+    };
+
+    /**
+     * Computes the bounding rectangle based on the provided options
+     *
+     * @param {Object} options Object with the following properties:
+     * @param {Cartesian3} options.center The ellipse's center point in the fixed frame.
+     * @param {Number} options.semiMajorAxis The length of the ellipse's semi-major axis in meters.
+     * @param {Number} options.semiMinorAxis The length of the ellipse's semi-minor axis in meters.
+     * @param {Ellipsoid} [options.ellipsoid=Ellipsoid.WGS84] The ellipsoid the ellipse will be on.
+     * @param {Number} [options.rotation=0.0] The angle of rotation counter-clockwise from north.
+     * @param {Number} [options.granularity=CesiumMath.RADIANS_PER_DEGREE] The angular distance between points on the ellipse in radians.
+     * @param {Rectangle} [result] An object in which to store the result
+     *
+     * @returns {Rectangle} The result rectangle
+     */
+    EllipseGeometry.computeRectangle = function(options, result) {
+        options = defaultValue(options, defaultValue.EMPTY_OBJECT);
+
+        var center = options.center;
+        var ellipsoid = defaultValue(options.ellipsoid, Ellipsoid.WGS84);
+        var semiMajorAxis = options.semiMajorAxis;
+        var semiMinorAxis = options.semiMinorAxis;
+        var granularity = defaultValue(options.granularity, CesiumMath.RADIANS_PER_DEGREE);
+        var rotation = defaultValue(options.rotation, 0.0);
+
+        //>>includeStart('debug', pragmas.debug);
+        Check.defined('options.center', center);
+        Check.typeOf.number('options.semiMajorAxis', semiMajorAxis);
+        Check.typeOf.number('options.semiMinorAxis', semiMinorAxis);
+        if (semiMajorAxis < semiMinorAxis) {
+            throw new DeveloperError('semiMajorAxis must be greater than or equal to the semiMinorAxis.');
+        }
+        if (granularity <= 0.0) {
+            throw new DeveloperError('granularity must be greater than zero.');
+        }
+        //>>includeEnd('debug');
+
+        return computeRectangle(center, semiMajorAxis, semiMinorAxis, rotation, granularity, ellipsoid, result);
     };
 
     /**
@@ -1041,7 +1070,7 @@ define([
         rectangle : {
             get : function() {
                 if (!defined(this._rectangle)) {
-                    this._rectangle = computeRectangle(this);
+                    this._rectangle = computeRectangle(this._center, this._semiMajorAxis, this._semiMinorAxis, this._rotation, this._granularity, this._ellipsoid);
                 }
                 return this._rectangle;
             }

--- a/Source/Core/PolygonGeometry.js
+++ b/Source/Core/PolygonGeometry.js
@@ -395,6 +395,20 @@ define([
         return geometry;
     }
 
+    function computeRectangle(positions, ellipsoid, result) {
+        if (!defined(positions) || positions.length < 3) {
+            if (!defined(result)) {
+                return new Rectangle();
+            }
+            result.west = 0.0;
+            result.north = 0.0;
+            result.south = 0.0;
+            result.east = 0.0;
+            return result;
+        }
+        return Rectangle.fromCartesianArray(positions, ellipsoid, result);
+    }
+
     var createGeometryFromPositionsExtrudedPositions = [];
 
     function createGeometryFromPositionsExtruded(ellipsoid, polygon, granularity, hierarchy, perPositionHeight, closeTop, closeBottom, vertexFormat) {
@@ -795,6 +809,28 @@ define([
     };
 
     /**
+     * Returns the bounding rectangle given the provided options
+     *
+     * @param {Object} options Object with the following properties:
+     * @param {PolygonHierarchy} options.polygonHierarchy A polygon hierarchy that can include holes.
+     * @param {Ellipsoid} [options.ellipsoid=Ellipsoid.WGS84] The ellipsoid to be used as a reference.
+     * @param {Rectangle} [result] An object in which to store the result.
+     *
+     * @returns {Rectangle} The result rectangle
+     */
+    PolygonGeometry.computeRectangle = function(options, result) {
+        //>>includeStart('debug', pragmas.debug);
+        Check.typeOf.object('options', options);
+        Check.typeOf.object('options.polygonHierarchy', options.polygonHierarchy);
+        //>>includeEnd('debug');
+
+        var polygonHierarchy = options.polygonHierarchy;
+        var ellipsoid = defaultValue(options.ellipsoid, Ellipsoid.WGS84);
+
+        return computeRectangle(polygonHierarchy.positions, ellipsoid, result);
+    };
+
+    /**
      * Computes the geometric representation of a polygon, including its vertices, indices, and a bounding sphere.
      *
      * @param {PolygonGeometry} polygonGeometry A description of the polygon.
@@ -973,11 +1009,7 @@ define([
             get : function() {
                 if (!defined(this._rectangle)) {
                     var positions = this._polygonHierarchy.positions;
-                    if (!defined(positions) || positions.length < 3) {
-                        this._rectangle = new Rectangle();
-                    } else {
-                        this._rectangle = Rectangle.fromCartesianArray(positions, this._ellipsoid);
-                    }
+                    this._rectangle = computeRectangle(positions, this._ellipsoid);
                 }
 
                 return this._rectangle;

--- a/Source/Core/RectangleGeometry.js
+++ b/Source/Core/RectangleGeometry.js
@@ -234,12 +234,12 @@ define([
         });
     }
 
-    function constructRectangle(options) {
-        var vertexFormat = options.vertexFormat;
-        var ellipsoid = options.ellipsoid;
-        var size = options.size;
-        var height = options.height;
-        var width = options.width;
+    function constructRectangle(rectangleGeometry, computedOptions) {
+        var vertexFormat = rectangleGeometry._vertexFormat;
+        var ellipsoid = rectangleGeometry._ellipsoid;
+        var size = computedOptions.size;
+        var height = computedOptions.height;
+        var width = computedOptions.width;
 
         var positions = (vertexFormat.position) ? new Float64Array(size * 3) : undefined;
         var textureCoordinates = (vertexFormat.st) ? new Float32Array(size * 2) : undefined;
@@ -257,7 +257,7 @@ define([
 
         for (var row = 0; row < height; ++row) {
             for (var col = 0; col < width; ++col) {
-                RectangleGeometryLibrary.computePosition(options, row, col, position, st);
+                RectangleGeometryLibrary.computePosition(computedOptions, ellipsoid, vertexFormat.st, row, col, position, st);
 
                 positions[posIndex++] = position.x;
                 positions[posIndex++] = position.y;
@@ -282,7 +282,7 @@ define([
             }
         }
 
-        var geo = calculateAttributes(positions, vertexFormat, ellipsoid, options.tangentRotationMatrix);
+        var geo = calculateAttributes(positions, vertexFormat, ellipsoid, computedOptions.tangentRotationMatrix);
 
         var indicesSize = 6 * (width - 1) * (height - 1);
         var indices = IndexDatatype.createTypedArray(size, indicesSize);
@@ -337,23 +337,30 @@ define([
 
     var scratchVertexFormat = new VertexFormat();
 
-    function constructExtrudedRectangle(options) {
-        var shadowVolume = options.shadowVolume;
-        var offsetAttributeValue = options.offsetAttribute;
-        var vertexFormat = options.vertexFormat;
-        var minHeight = options.extrudedHeight;
-        var maxHeight = options.surfaceHeight;
+    function constructExtrudedRectangle(rectangleGeometry, computedOptions) {
+        var shadowVolume = rectangleGeometry._shadowVolume;
+        var offsetAttributeValue = rectangleGeometry._offsetAttribute;
+        var vertexFormat = rectangleGeometry._vertexFormat;
+        var minHeight = rectangleGeometry._extrudedHeight;
+        var maxHeight = rectangleGeometry._surfaceHeight;
+        var ellipsoid = rectangleGeometry._ellipsoid;
 
-        var height = options.height;
-        var width = options.width;
-        var ellipsoid = options.ellipsoid;
+        var height = computedOptions.height;
+        var width = computedOptions.width;
+
         var i;
 
         if (shadowVolume) {
-            options.vertexFormat = VertexFormat.clone(vertexFormat, scratchVertexFormat);
-            options.vertexFormat.normal = true;
+            var newVertexFormat = VertexFormat.clone(vertexFormat, scratchVertexFormat);
+            newVertexFormat.normal = true;
+            rectangleGeometry._vertexFormat = newVertexFormat;
         }
-        var topBottomGeo = constructRectangle(options);
+
+        var topBottomGeo = constructRectangle(rectangleGeometry, computedOptions);
+
+        if (shadowVolume) {
+            rectangleGeometry._vertexFormat = vertexFormat;
+        }
 
         var topPositions = PolygonPipeline.scaleToGeodeticHeight(topBottomGeo.attributes.position.values, maxHeight, ellipsoid, false);
         topPositions = new Float64Array(topPositions);
@@ -619,24 +626,23 @@ define([
     var scratchRectanglePoints = [new Cartesian3(), new Cartesian3(), new Cartesian3(), new Cartesian3()];
     var nwScratch = new Cartographic();
     var stNwScratch = new Cartographic();
-    function computeRectangle(rectangleGeometry) {
-        if (rectangleGeometry._rotation === 0.0) {
-            return Rectangle.clone(rectangleGeometry._rectangle);
+    function computeRectangle(rectangle, granularity, rotation, ellipsoid, result) {
+        if (rotation === 0.0) {
+            return Rectangle.clone(rectangle, result);
         }
 
-        var rectangle = Rectangle.clone(rectangleGeometry._rectangle, rectangleScratch);
-        var options = RectangleGeometryLibrary.computeOptions(rectangleGeometry, rectangle, nwScratch, stNwScratch);
+        var computedOptions = RectangleGeometryLibrary.computeOptions(rectangle, granularity, rotation, 0, rectangleScratch, nwScratch);
 
-        var height = options.height;
-        var width = options.width;
+        var height = computedOptions.height;
+        var width = computedOptions.width;
 
         var positions = scratchRectanglePoints;
-        RectangleGeometryLibrary.computePosition(options, 0, 0, positions[0], stScratch);
-        RectangleGeometryLibrary.computePosition(options, 0, width - 1, positions[1], stScratch);
-        RectangleGeometryLibrary.computePosition(options, height - 1, 0, positions[2], stScratch);
-        RectangleGeometryLibrary.computePosition(options, height - 1, width - 1, positions[3], stScratch);
+        RectangleGeometryLibrary.computePosition(computedOptions, ellipsoid, false, 0, 0, positions[0]);
+        RectangleGeometryLibrary.computePosition(computedOptions, ellipsoid, false, 0, width - 1, positions[1]);
+        RectangleGeometryLibrary.computePosition(computedOptions, ellipsoid, false, height - 1, 0, positions[2]);
+        RectangleGeometryLibrary.computePosition(computedOptions, ellipsoid, false, height - 1, width - 1, positions[3]);
 
-        return Rectangle.fromCartesianArray(positions, rectangleGeometry._ellipsoid);
+        return Rectangle.fromCartesianArray(positions, ellipsoid, result);
     }
 
     /**
@@ -699,7 +705,7 @@ define([
         var height = defaultValue(options.height, 0.0);
         var extrudedHeight = defaultValue(options.extrudedHeight, height);
 
-        this._rectangle = rectangle;
+        this._rectangle = Rectangle.clone(rectangle);
         this._granularity = defaultValue(options.granularity, CesiumMath.RADIANS_PER_DEGREE);
         this._ellipsoid = Ellipsoid.clone(defaultValue(options.ellipsoid, Ellipsoid.WGS84));
         this._surfaceHeight = Math.max(height, extrudedHeight);
@@ -831,6 +837,38 @@ define([
         return result;
     };
 
+    /**
+     * Computes the bounding rectangle based on the provided options
+     *
+     * @param {Object} options Object with the following properties:
+     * @param {Rectangle} options.rectangle A cartographic rectangle with north, south, east and west properties in radians.
+     * @param {Ellipsoid} [options.ellipsoid=Ellipsoid.WGS84] The ellipsoid on which the rectangle lies.
+     * @param {Number} [options.granularity=CesiumMath.RADIANS_PER_DEGREE] The distance, in radians, between each latitude and longitude. Determines the number of positions in the buffer.
+     * @param {Number} [options.rotation=0.0] The rotation of the rectangle, in radians. A positive rotation is counter-clockwise.
+     * @param {Rectangle} [result] An object in which to store the result.
+     *
+     * @returns {Rectangle} The result rectangle
+     */
+    RectangleGeometry.computeRectangle = function(options, result) {
+        options = defaultValue(options, defaultValue.EMPTY_OBJECT);
+
+        var rectangle = options.rectangle;
+
+        //>>includeStart('debug', pragmas.debug);
+        Check.typeOf.object('rectangle', rectangle);
+        Rectangle.validate(rectangle);
+        if (rectangle.north < rectangle.south) {
+            throw new DeveloperError('options.rectangle.north must be greater than or equal to options.rectangle.south');
+        }
+        //>>includeEnd('debug');
+
+        var granularity = defaultValue(options.granularity, CesiumMath.RADIANS_PER_DEGREE);
+        var ellipsoid = defaultValue(options.ellipsoid, Ellipsoid.WGS84);
+        var rotation = defaultValue(options.rotation, 0.0);
+
+        return computeRectangle(rectangle, granularity, rotation, ellipsoid, result);
+    };
+
     var tangentRotationMatrixScratch = new Matrix3();
     var quaternionScratch = new Quaternion();
     var centerScratch = new Cartographic();
@@ -848,13 +886,13 @@ define([
             return undefined;
         }
 
-        var rectangle = Rectangle.clone(rectangleGeometry._rectangle, rectangleScratch);
+        var rectangle = rectangleGeometry._rectangle;
         var ellipsoid = rectangleGeometry._ellipsoid;
         var rotation = rectangleGeometry._rotation;
         var stRotation = rectangleGeometry._stRotation;
         var vertexFormat = rectangleGeometry._vertexFormat;
 
-        var options = RectangleGeometryLibrary.computeOptions(rectangleGeometry, rectangle, nwScratch, stNwScratch);
+        var computedOptions = RectangleGeometryLibrary.computeOptions(rectangle, rectangleGeometry._granularity, rotation, stRotation, rectangleScratch, nwScratch, stNwScratch);
 
         var tangentRotationMatrix = tangentRotationMatrixScratch;
         if (stRotation !== 0 || rotation !== 0) {
@@ -870,26 +908,21 @@ define([
         var extrudedHeight = rectangleGeometry._extrudedHeight;
         var extrude = !CesiumMath.equalsEpsilon(surfaceHeight, extrudedHeight, 0, CesiumMath.EPSILON2);
 
-        options.lonScalar = 1.0 / rectangleGeometry._rectangle.width;
-        options.latScalar = 1.0 / rectangleGeometry._rectangle.height;
-        options.vertexFormat = vertexFormat;
-        options.rotation = rotation;
-        options.stRotation = stRotation;
-        options.tangentRotationMatrix = tangentRotationMatrix;
-        options.size = options.width * options.height;
+        computedOptions.lonScalar = 1.0 / rectangleGeometry._rectangle.width;
+        computedOptions.latScalar = 1.0 / rectangleGeometry._rectangle.height;
+        computedOptions.tangentRotationMatrix = tangentRotationMatrix;
+        computedOptions.size = computedOptions.width * computedOptions.height;
 
         var geometry;
         var boundingSphere;
         rectangle = rectangleGeometry._rectangle;
         if (extrude) {
-            options.shadowVolume = rectangleGeometry._shadowVolume;
-            options.offsetAttribute = rectangleGeometry._offsetAttribute;
-            geometry = constructExtrudedRectangle(options);
+            geometry = constructExtrudedRectangle(rectangleGeometry, computedOptions);
             var topBS = BoundingSphere.fromRectangle3D(rectangle, ellipsoid, surfaceHeight, topBoundingSphere);
             var bottomBS = BoundingSphere.fromRectangle3D(rectangle, ellipsoid, extrudedHeight, bottomBoundingSphere);
             boundingSphere = BoundingSphere.union(topBS, bottomBS);
         } else {
-            geometry = constructRectangle(options);
+            geometry = constructRectangle(rectangleGeometry, computedOptions);
             geometry.attributes.position.values = PolygonPipeline.scaleToGeodeticHeight(geometry.attributes.position.values, surfaceHeight, ellipsoid, false);
 
             if (defined(rectangleGeometry._offsetAttribute)) {
@@ -929,7 +962,6 @@ define([
         var minHeight = minHeightFunc(granularity, ellipsoid);
         var maxHeight = maxHeightFunc(granularity, ellipsoid);
 
-        // TODO: stRotation
         return new RectangleGeometry({
             rectangle : rectangleGeometry._rectangle,
             rotation : rectangleGeometry._rotation,
@@ -943,9 +975,6 @@ define([
         });
     };
 
-    var scratchRectangleGeometry = new RectangleGeometry({
-        rectangle : new Rectangle()
-    });
     var unrotatedTextureRectangleScratch = new Rectangle();
     var points2DScratch = [new Cartesian2(), new Cartesian2(), new Cartesian2()];
     var rotation2DScratch = new Matrix2();
@@ -955,18 +984,15 @@ define([
         if (rectangleGeometry._stRotation === 0.0) {
             return [0, 0, 0, 1, 1, 0];
         }
-        // Compute rectangle if rectangleGeometry was rotated so that the texture coordinate system lined up with ENU
-        var rotatedRectangle = scratchRectangleGeometry;
 
-        rotatedRectangle._rectangle = Rectangle.clone(rectangleGeometry._rectangle, rotatedRectangle._rectangle);
-        rotatedRectangle._granularity = rectangleGeometry._granularity;
-        rotatedRectangle._ellipsoid = Ellipsoid.clone(rectangleGeometry._ellipsoid, rotatedRectangle._ellipsoid);
-        rotatedRectangle._surfaceHeight = rectangleGeometry._surfaceHeight;
+        var rectangle = Rectangle.clone(rectangleGeometry._rectangle, unrotatedTextureRectangleScratch);
+        var granularity = rectangleGeometry._granularity;
+        var ellipsoid = rectangleGeometry._ellipsoid;
 
         // Rotate to align the texture coordinates with ENU
-        rotatedRectangle._rotation = rectangleGeometry._rotation - rectangleGeometry._stRotation;
+        var rotation = rectangleGeometry._rotation - rectangleGeometry._stRotation;
 
-        var unrotatedTextureRectangle = computeRectangle(rotatedRectangle, unrotatedTextureRectangleScratch);
+        var unrotatedTextureRectangle = computeRectangle(rectangle, granularity, rotation, ellipsoid, unrotatedTextureRectangleScratch);
 
         // Assume a computed "east-north" texture coordinate system based on spherical or planar tricks, bounded by `boundingRectangle`.
         // The "desired" texture coordinate system forms an oriented rectangle (un-oriented computed) around the geometry that completely and tightly bounds it.
@@ -1020,7 +1046,7 @@ define([
         rectangle : {
             get : function() {
                 if (!defined(this._rotatedRectangle)) {
-                    this._rotatedRectangle = computeRectangle(this);
+                    this._rotatedRectangle = computeRectangle(this._rectangle, this._granularity, this._rotation, this._ellipsoid);
                 }
                 return this._rotatedRectangle;
             }

--- a/Source/Core/RectangleOutlineGeometry.js
+++ b/Source/Core/RectangleOutlineGeometry.js
@@ -45,10 +45,11 @@ define([
     var positionScratch = new Cartesian3();
     var rectangleScratch = new Rectangle();
 
-    function constructRectangle(options) {
-        var size = options.size;
-        var height = options.height;
-        var width = options.width;
+    function constructRectangle(geometry, computedOptions) {
+        var ellipsoid = geometry._ellipsoid;
+        var size = computedOptions.size;
+        var height = computedOptions.height;
+        var width = computedOptions.width;
         var positions = new Float64Array(size * 3);
 
         var posIndex = 0;
@@ -56,7 +57,7 @@ define([
         var col;
         var position = positionScratch;
         for (col = 0; col < width; col++) {
-            RectangleGeometryLibrary.computePosition(options, row, col, position);
+            RectangleGeometryLibrary.computePosition(computedOptions, ellipsoid, false, row, col, position);
             positions[posIndex++] = position.x;
             positions[posIndex++] = position.y;
             positions[posIndex++] = position.z;
@@ -64,7 +65,7 @@ define([
 
         col = width - 1;
         for (row = 1; row < height; row++) {
-            RectangleGeometryLibrary.computePosition(options, row, col, position);
+            RectangleGeometryLibrary.computePosition(computedOptions, ellipsoid, false, row, col, position);
             positions[posIndex++] = position.x;
             positions[posIndex++] = position.y;
             positions[posIndex++] = position.z;
@@ -72,7 +73,7 @@ define([
 
         row = height - 1;
         for (col = width-2; col >=0; col--){
-            RectangleGeometryLibrary.computePosition(options, row, col, position);
+            RectangleGeometryLibrary.computePosition(computedOptions, ellipsoid, false, row, col, position);
             positions[posIndex++] = position.x;
             positions[posIndex++] = position.y;
             positions[posIndex++] = position.z;
@@ -80,7 +81,7 @@ define([
 
         col = 0;
         for (row = height - 2; row > 0; row--) {
-            RectangleGeometryLibrary.computePosition(options, row, col, position);
+            RectangleGeometryLibrary.computePosition(computedOptions, ellipsoid, false, row, col, position);
             positions[posIndex++] = position.x;
             positions[posIndex++] = position.y;
             positions[posIndex++] = position.z;
@@ -112,16 +113,16 @@ define([
         return geo;
     }
 
-    function constructExtrudedRectangle(options) {
-        var surfaceHeight = options.surfaceHeight;
-        var extrudedHeight = options.extrudedHeight;
-        var ellipsoid = options.ellipsoid;
+    function constructExtrudedRectangle(rectangleGeometry, computedOptions) {
+        var surfaceHeight = rectangleGeometry._surfaceHeight;
+        var extrudedHeight = rectangleGeometry._extrudedHeight;
+        var ellipsoid = rectangleGeometry._ellipsoid;
         var minHeight = extrudedHeight;
         var maxHeight = surfaceHeight;
-        var geo = constructRectangle(options);
+        var geo = constructRectangle(rectangleGeometry, computedOptions);
 
-        var height = options.height;
-        var width = options.width;
+        var height = computedOptions.height;
+        var width = computedOptions.width;
 
         var topPositions = PolygonPipeline.scaleToGeodeticHeight(geo.attributes.position.values, maxHeight, ellipsoid, false);
         var length = topPositions.length;
@@ -211,7 +212,7 @@ define([
         var height = defaultValue(options.height, 0.0);
         var extrudedHeight = defaultValue(options.extrudedHeight, height);
 
-        this._rectangle = rectangle;
+        this._rectangle = Rectangle.clone(rectangle);
         this._granularity = granularity;
         this._ellipsoid = ellipsoid;
         this._surfaceHeight = Math.max(height, extrudedHeight);
@@ -335,14 +336,13 @@ define([
      * @exception {DeveloperError} Rotated rectangle is invalid.
      */
     RectangleOutlineGeometry.createGeometry = function(rectangleGeometry) {
-        var rectangle = Rectangle.clone(rectangleGeometry._rectangle, rectangleScratch);
+        var rectangle = rectangleGeometry._rectangle;
         var ellipsoid = rectangleGeometry._ellipsoid;
-        var options = RectangleGeometryLibrary.computeOptions(rectangleGeometry, rectangle, nwScratch);
-        options.size =  2*options.width + 2*options.height - 4;
+        var computedOptions = RectangleGeometryLibrary.computeOptions(rectangle, rectangleGeometry._granularity, rectangleGeometry._rotation, 0, rectangleScratch, nwScratch);
+        computedOptions.size =  2 * computedOptions.width + 2 * computedOptions.height - 4;
 
         var geometry;
         var boundingSphere;
-        rectangle = rectangleGeometry._rectangle;
 
         if ((CesiumMath.equalsEpsilon(rectangle.north, rectangle.south, CesiumMath.EPSILON10) ||
              (CesiumMath.equalsEpsilon(rectangle.east, rectangle.west, CesiumMath.EPSILON10)))) {
@@ -354,7 +354,7 @@ define([
         var extrude = !CesiumMath.equalsEpsilon(surfaceHeight, extrudedHeight, 0, CesiumMath.EPSILON2);
         var offsetValue;
         if (extrude) {
-            geometry = constructExtrudedRectangle(options);
+            geometry = constructExtrudedRectangle(rectangleGeometry, computedOptions);
             if (defined(rectangleGeometry._offsetAttribute)) {
                 var size = geometry.attributes.position.values.length / 3;
                 var offsetAttribute = new Uint8Array(size);
@@ -375,7 +375,7 @@ define([
             var bottomBS = BoundingSphere.fromRectangle3D(rectangle, ellipsoid, extrudedHeight, bottomBoundingSphere);
             boundingSphere = BoundingSphere.union(topBS, bottomBS);
         } else {
-            geometry = constructRectangle(options);
+            geometry = constructRectangle(rectangleGeometry, computedOptions);
             geometry.attributes.position.values = PolygonPipeline.scaleToGeodeticHeight(geometry.attributes.position.values, surfaceHeight, ellipsoid, false);
 
             if (defined(rectangleGeometry._offsetAttribute)) {

--- a/Specs/Core/CorridorGeometrySpec.js
+++ b/Specs/Core/CorridorGeometrySpec.js
@@ -355,6 +355,44 @@ defineSuite([
         expect(CesiumMath.toDegrees(r.west)).toEqual(-67.6550047734171);
     });
 
+    it('computeRectangle', function() {
+        var options = {
+            vertexFormat : VertexFormat.POSITION_ONLY,
+            positions : Cartesian3.fromDegreesArray([
+                -67.655, 0.0,
+                -67.655, 15.0,
+                -67.655, 20.0
+            ]),
+            cornerType: CornerType.MITERED,
+            width : 1
+        };
+        var geometry = new CorridorGeometry(options);
+
+        var expected = geometry.rectangle;
+        var result = CorridorGeometry.computeRectangle(options);
+
+        expect(result).toEqual(expected);
+    });
+
+    it('computeRectangle with result parameter', function() {
+        var options = {
+            positions : Cartesian3.fromDegreesArray([
+                72.0, 0.0,
+                85.0, 15.0,
+                83.0, 20.0
+            ]),
+            width : 5
+        };
+        var geometry = new CorridorGeometry(options);
+
+        var result = new Rectangle();
+        var expected = geometry.rectangle;
+        var returned = CorridorGeometry.computeRectangle(options, result);
+
+        expect(returned).toEqual(expected);
+        expect(returned).toBe(result);
+    });
+
     it('computing textureCoordinateRotationPoints property', function() {
         var c = new CorridorGeometry({
             vertexFormat : VertexFormat.POSITION_ONLY,

--- a/Specs/Core/EllipseGeometrySpec.js
+++ b/Specs/Core/EllipseGeometrySpec.js
@@ -5,6 +5,7 @@ defineSuite([
         'Core/Ellipsoid',
         'Core/GeometryOffsetAttribute',
         'Core/Math',
+        'Core/Rectangle',
         'Core/VertexFormat',
         'Specs/createPackableSpecs'
     ], function(
@@ -14,6 +15,7 @@ defineSuite([
         Ellipsoid,
         GeometryOffsetAttribute,
         CesiumMath,
+        Rectangle,
         VertexFormat,
         createPackableSpecs) {
     'use strict';
@@ -333,6 +335,39 @@ defineSuite([
         expect(r.south).toEqualEpsilon(1.570483806950967, CesiumMath.EPSILON7);
         expect(r.east).toEqualEpsilon(CesiumMath.PI, CesiumMath.EPSILON7);
         expect(r.west).toEqualEpsilon(-CesiumMath.PI, CesiumMath.EPSILON7);
+    });
+
+    it('computeRectangle', function() {
+        var options = {
+            center : Cartesian3.fromDegrees(-30, 33),
+            semiMajorAxis : 2000.0,
+            semiMinorAxis : 1000.0,
+            rotation: CesiumMath.PI_OVER_TWO,
+            granularity: 0.5,
+            ellipsoid: Ellipsoid.UNIT_SPHERE
+        };
+        var geometry = new EllipseGeometry(options);
+
+        var expected = geometry.rectangle;
+        var result = EllipseGeometry.computeRectangle(options);
+
+        expect(result).toEqual(expected);
+    });
+
+    it('computeRectangle with result parameter', function() {
+        var options = {
+            center : Cartesian3.fromDegrees(30, -33),
+            semiMajorAxis : 500.0,
+            semiMinorAxis : 200.0
+        };
+        var geometry = new EllipseGeometry(options);
+
+        var result = new Rectangle();
+        var expected = geometry.rectangle;
+        var returned = EllipseGeometry.computeRectangle(options, result);
+
+        expect(returned).toEqual(expected);
+        expect(returned).toBe(result);
     });
 
     it('computing textureCoordinateRotationPoints property', function() {

--- a/Specs/Core/PolygonGeometrySpec.js
+++ b/Specs/Core/PolygonGeometrySpec.js
@@ -911,6 +911,48 @@ defineSuite([
         expect(CesiumMath.toDegrees(r.west)).toEqualEpsilon(-100.5, CesiumMath.EPSILON13);
     });
 
+    it('computeRectangle', function() {
+        var options = {
+            vertexFormat : VertexFormat.POSITION_AND_ST,
+            polygonHierarchy: {
+                positions : Cartesian3.fromDegreesArrayHeights([
+                    -100.5, 30.0, 92,
+                    -100.0, 30.0, 92,
+                    -100.0, 30.5, 92,
+                    -100.5, 30.5, 92
+                ])
+            },
+            ellipsoid: Ellipsoid.UNIT_SPHERE
+        };
+        var geometry = new PolygonGeometry(options);
+
+        var expected = geometry.rectangle;
+        var result = PolygonGeometry.computeRectangle(options);
+
+        expect(result).toEqual(expected);
+    });
+
+    it('computeRectangle with result parameter', function() {
+        var options = {
+            polygonHierarchy: {
+                positions : Cartesian3.fromDegreesArray([
+                    -10.5, 25.0,
+                    -10.0, 25.0,
+                    -10.0, 25.5,
+                    -10.5, 25.5
+                ])
+            }
+        };
+        var geometry = new PolygonGeometry(options);
+
+        var result = new Rectangle();
+        var expected = geometry.rectangle;
+        var returned = PolygonGeometry.computeRectangle(options, result);
+
+        expect(returned).toEqual(expected);
+        expect(returned).toBe(result);
+    });
+
     it('computing textureCoordinateRotationPoints property', function() {
         var p = new PolygonGeometry({
             vertexFormat : VertexFormat.POSITION_AND_ST,

--- a/Specs/Core/RectangleGeometrySpec.js
+++ b/Specs/Core/RectangleGeometrySpec.js
@@ -422,6 +422,37 @@ defineSuite([
         expect(textureCoordinateRotationPoints[5]).toEqualEpsilon(0, CesiumMath.EPSILON7);
     });
 
+    it('computeRectangle', function() {
+        var options = {
+            vertexFormat : VertexFormat.POSITION_ONLY,
+            rectangle : new Rectangle.fromDegrees(-1.0, -1.0, 1.0, 1.0),
+            granularity : 1.0,
+            ellipsoid: Ellipsoid.UNIT_SPHERE,
+            rotation: CesiumMath.PI
+        };
+        var geometry = new RectangleGeometry(options);
+
+        var expected = geometry.rectangle;
+        var result = RectangleGeometry.computeRectangle(options);
+
+        expect(result).toEqual(expected);
+    });
+
+    it('computeRectangle with result parameter', function() {
+        var options = {
+            vertexFormat : VertexFormat.POSITION_ONLY,
+            rectangle : new Rectangle.fromDegrees(-1.0, -1.0, 1.0, 1.0)
+        };
+        var geometry = new RectangleGeometry(options);
+
+        var result = new Rectangle();
+        var expected = geometry.rectangle;
+        var returned = RectangleGeometry.computeRectangle(options, result);
+
+        expect(returned).toEqual(expected);
+        expect(returned).toBe(result);
+    });
+
     it('computing rectangle property with zero rotation', function() {
         expect(function() {
             return RectangleGeometry.createGeometry(new RectangleGeometry({


### PR DESCRIPTION
Needed for #6717 
(https://github.com/AnalyticalGraphicsInc/cesium/pull/6717#discussion_r198137927)

I did a decent amount of code cleanup for `RectangleGeometry` because it was really confusing how we were passing different properties around.  By cleaning that up I was able to pass in options to `computeRectangle` instead of a `RectangleGeometry`.  No functionality changes.

@bagnell or @mramato or @likangning93 can you review?