### PR TITLE
 Geometry offset attribute cleanup

### DIFF
--- a/Source/Core/CorridorGeometry.js
+++ b/Source/Core/CorridorGeometry.js
@@ -1064,7 +1064,8 @@ define([
             attributes : attributes,
             indices : attr.indices,
             primitiveType : PrimitiveType.TRIANGLES,
-            boundingSphere : boundingSphere
+            boundingSphere : boundingSphere,
+            offsetAttribute : corridorGeometry._offsetAttribute
         });
     };
 

--- a/Source/Core/CorridorOutlineGeometry.js
+++ b/Source/Core/CorridorOutlineGeometry.js
@@ -546,7 +546,8 @@ define([
             attributes : attributes,
             indices : attr.indices,
             primitiveType : PrimitiveType.LINES,
-            boundingSphere : boundingSphere
+            boundingSphere : boundingSphere,
+            offsetAttribute : corridorOutlineGeometry._offsetAttribute
         });
     };
 

--- a/Source/Core/EllipseGeometry.js
+++ b/Source/Core/EllipseGeometry.js
@@ -1009,7 +1009,8 @@ define([
             attributes : geometry.attributes,
             indices : geometry.indices,
             primitiveType : PrimitiveType.TRIANGLES,
-            boundingSphere : geometry.boundingSphere
+            boundingSphere : geometry.boundingSphere,
+            offsetAttribute : ellipseGeometry._offsetAttribute
         });
     };
 

--- a/Source/Core/EllipseOutlineGeometry.js
+++ b/Source/Core/EllipseOutlineGeometry.js
@@ -389,7 +389,8 @@ define([
             attributes : geometry.attributes,
             indices : geometry.indices,
             primitiveType : PrimitiveType.LINES,
-            boundingSphere : geometry.boundingSphere
+            boundingSphere : geometry.boundingSphere,
+            offsetAttribute : ellipseGeometry._offsetAttribute
         });
     };
 

--- a/Source/Core/Geometry.js
+++ b/Source/Core/Geometry.js
@@ -6,6 +6,7 @@ define([
         './defaultValue',
         './defined',
         './DeveloperError',
+        './GeometryOffsetAttribute',
         './GeometryType',
         './Matrix2',
         './Matrix3',
@@ -22,6 +23,7 @@ define([
         defaultValue,
         defined,
         DeveloperError,
+        GeometryOffsetAttribute,
         GeometryType,
         Matrix2,
         Matrix3,
@@ -176,6 +178,12 @@ define([
          * @private
          */
         this.boundingSphereCV = options.boundingSphereCV;
+
+        /**
+         * @private
+         * Used for computing the bounding sphere for geometry using the applyOffset vertex attribute
+         */
+        this.offsetAttribute = options.offsetAttribute;
     }
 
     /**

--- a/Source/Core/PolygonGeometry.js
+++ b/Source/Core/PolygonGeometry.js
@@ -963,7 +963,8 @@ define([
             attributes : attributes,
             indices : geometry.indices,
             primitiveType : geometry.primitiveType,
-            boundingSphere : boundingSphere
+            boundingSphere : boundingSphere,
+            offsetAttribute : polygonGeometry._offsetAttribute
         });
     };
 

--- a/Source/Core/PolygonOutlineGeometry.js
+++ b/Source/Core/PolygonOutlineGeometry.js
@@ -591,7 +591,8 @@ define([
             attributes : geometry.attributes,
             indices : geometry.indices,
             primitiveType : geometry.primitiveType,
-            boundingSphere : boundingSphere
+            boundingSphere : boundingSphere,
+            offsetAttribute : polygonGeometry._offsetAttribute
         });
     };
 

--- a/Source/Core/RectangleGeometry.js
+++ b/Source/Core/RectangleGeometry.js
@@ -948,7 +948,8 @@ define([
             attributes : geometry.attributes,
             indices : geometry.indices,
             primitiveType : geometry.primitiveType,
-            boundingSphere : boundingSphere
+            boundingSphere : boundingSphere,
+            offsetAttribute : rectangleGeometry._offsetAttribute
         });
     };
 

--- a/Source/Core/RectangleOutlineGeometry.js
+++ b/Source/Core/RectangleOutlineGeometry.js
@@ -397,7 +397,8 @@ define([
             attributes : geometry.attributes,
             indices : geometry.indices,
             primitiveType : PrimitiveType.LINES,
-            boundingSphere : boundingSphere
+            boundingSphere : boundingSphere,
+            offsetAttribute : rectangleGeometry._offsetAttribute
         });
     };
 

--- a/Source/Scene/Primitive.js
+++ b/Source/Scene/Primitive.js
@@ -18,6 +18,7 @@ define([
         '../Core/Geometry',
         '../Core/GeometryAttribute',
         '../Core/GeometryAttributes',
+        '../Core/GeometryOffsetAttribute',
         '../Core/Intersect',
         '../Core/isArray',
         '../Core/Matrix4',
@@ -61,6 +62,7 @@ define([
         Geometry,
         GeometryAttribute,
         GeometryAttributes,
+        GeometryOffsetAttribute,
         Intersect,
         isArray,
         Matrix4,
@@ -526,7 +528,7 @@ define([
         var name;
 
         for (name in attributes0) {
-            if (attributes0.hasOwnProperty(name)) {
+            if (attributes0.hasOwnProperty(name) && defined(attributes0[name])) {
                 var attribute = attributes0[name];
                 var inAllInstances = true;
 
@@ -1893,13 +1895,13 @@ define([
 
     var offsetBoundingSphereScratch1 = new BoundingSphere();
     var offsetBoundingSphereScratch2 = new BoundingSphere();
-    function transformBoundingSphere(boundingSphere, offset, extend) {
-        if (extend) {
+    function transformBoundingSphere(boundingSphere, offset, offsetAttribute) {
+        if (offsetAttribute === GeometryOffsetAttribute.TOP) {
             var origBS = BoundingSphere.clone(boundingSphere, offsetBoundingSphereScratch1);
             var offsetBS = BoundingSphere.clone(boundingSphere, offsetBoundingSphereScratch2);
             offsetBS.center = Cartesian3.add(offsetBS.center, offset, offsetBS.center);
             boundingSphere = BoundingSphere.union(origBS, offsetBS, boundingSphere);
-        } else {
+        } else if (offsetAttribute === GeometryOffsetAttribute.ALL) {
             boundingSphere.center = Cartesian3.add(boundingSphere.center, offset, boundingSphere.center);
         }
 
@@ -1943,6 +1945,7 @@ define([
             get : function() {
                 var boundingSphere = primitive._instanceBoundingSpheres[index];
                 if (defined(boundingSphere)) {
+                    boundingSphere = boundingSphere.clone();
                     var modelMatrix = primitive.modelMatrix;
                     var offset = properties.offset;
                     if (defined(offset)) {

--- a/Source/Scene/PrimitivePipeline.js
+++ b/Source/Scene/PrimitivePipeline.js
@@ -1,6 +1,7 @@
 define([
         '../Core/BoundingSphere',
         '../Core/ComponentDatatype',
+        '../Core/defaultValue',
         '../Core/defined',
         '../Core/DeveloperError',
         '../Core/Ellipsoid',
@@ -17,6 +18,7 @@ define([
     ], function(
         BoundingSphere,
         ComponentDatatype,
+        defaultValue,
         defined,
         DeveloperError,
         Ellipsoid,
@@ -366,7 +368,7 @@ define([
 
             var attributes = geometry.attributes;
 
-            count += 6 + 2 * BoundingSphere.packedLength + (defined(geometry.indices) ? geometry.indices.length : 0);
+            count += 7 + 2 * BoundingSphere.packedLength + (defined(geometry.indices) ? geometry.indices.length : 0);
 
             for (var property in attributes) {
                 if (attributes.hasOwnProperty(property) && defined(attributes[property])) {
@@ -402,6 +404,7 @@ define([
 
             packedData[count++] = geometry.primitiveType;
             packedData[count++] = geometry.geometryType;
+            packedData[count++] = defaultValue(geometry.offsetAttribute, -1);
 
             var validBoundingSphere = defined(geometry.boundingSphere) ? 1.0 : 0.0;
             packedData[count++] = validBoundingSphere;
@@ -482,6 +485,10 @@ define([
 
             var primitiveType = packedGeometry[packedGeometryIndex++];
             var geometryType = packedGeometry[packedGeometryIndex++];
+            var offsetAttribute = packedGeometry[packedGeometryIndex++];
+            if (offsetAttribute === -1) {
+                offsetAttribute = undefined;
+            }
 
             var boundingSphere;
             var boundingSphereCV;
@@ -542,7 +549,8 @@ define([
                 boundingSphere : boundingSphere,
                 boundingSphereCV : boundingSphereCV,
                 indices : indices,
-                attributes : attributes
+                attributes : attributes,
+                offsetAttribute: offsetAttribute
             });
         }
 

--- a/Source/Scene/PrimitivePipeline.js
+++ b/Source/Scene/PrimitivePipeline.js
@@ -301,7 +301,7 @@ define([
                 boundingSpheres[i] = geometry.boundingSphere;
                 boundingSpheresCV[i] = geometry.boundingSphereCV;
                 if (hasOffset) {
-                    offsetInstanceExtend[i] = defined(instance.geometry.attributes) && defined(instance.geometry.attributes.applyOffset) && instance.geometry.attributes.applyOffset.values.indexOf(0) !== -1;
+                    offsetInstanceExtend[i] = instance.geometry.offsetAttribute;
                 }
             }
 


### PR DESCRIPTION
Cleanup from #6607

- Fix IE by passing the `offsetAttribute` through to the geometry instead of searching through the `applyOffset` per vertex to figure out if the geometry was  using `GeometryOffsetAttribute.TOP`
- Fix bounding sphere when using `GeometryOffsetAttribute.NONE`
- Fix bounding sphere when retrieving it from the geometry instance batch table
- Fix crash if instance attribute was `undefined`
  - ie. `attributes : { color : colorAttribute, offset : undefined }` instead of `attributes : {color : colorAttribute}`
