### PR TITLE
Fix hidden Sandcastle scrollbar on smaller screens

### DIFF
--- a/Apps/Sandcastle/CesiumSandcastle.css
+++ b/Apps/Sandcastle/CesiumSandcastle.css
@@ -69,7 +69,7 @@ html, body {
     white-space: nowrap;
 }
 
-.demoTileThumbnail {	
+.demoTileThumbnail {
     max-height: 150px;
     max-width: 225px;
     height: 100px;
@@ -172,6 +172,17 @@ a.linkButton:focus, a.linkButton:hover {
 .claro .bottomPanel {
     padding: 0;
     overflow: hidden;
+}
+
+.bottomPanel #innerPanel_tablist {
+    overflow-y: hidden!important;
+    max-height: 34px;
+}
+
+@media (max-width: 1064px){
+    .bottomPanel #innerPanel_tablist {
+        overflow-y: scroll!important;
+    }
 }
 
 .claro .dijitTabContainerTop-tabs .dijitTabChecked .dijitTabContent {

--- a/Apps/Sandcastle/CesiumSandcastle.css
+++ b/Apps/Sandcastle/CesiumSandcastle.css
@@ -175,14 +175,8 @@ a.linkButton:focus, a.linkButton:hover {
 }
 
 .bottomPanel #innerPanel_tablist {
-    overflow-y: hidden!important;
-    max-height: 34px;
-}
-
-@media (max-width: 1064px){
-    .bottomPanel #innerPanel_tablist {
-        overflow-y: scroll!important;
-    }
+    max-height: 28px;
+    overflow: auto !important;
 }
 
 .claro .dijitTabContainerTop-tabs .dijitTabChecked .dijitTabContent {


### PR DESCRIPTION
Fixes https://github.com/AnalyticalGraphicsInc/cesium/issues/6650. 

When the screen is large enough, it will work just as before. When the screen is smaller, the labels will have a scrollbar. See [GIF below](https://image.ibb.co/eHXZZo/overflow.gif).

![scrollbar](https://image.ibb.co/eHXZZo/overflow.gif)

It's usually bad practice to use `!important`, but the `dijit` library uses it internally, so even though my new CSS rule should take priority because it's more specific, it does not without `!important`. 