### PR TITLE
Support Floating Quantization for 3D Tiles

### DIFF
--- a/Source/Scene/Scene.js
+++ b/Source/Scene/Scene.js
@@ -2314,6 +2314,9 @@ define([
 
             if (clearGlobeDepth) {
                 clearDepth.execute(context, passState);
+                if (useDepthPlane) {
+                    depthPlane.execute(context, passState);
+                }
             }
 
             if (!environmentState.useInvertClassification || picking) {
@@ -2431,15 +2434,24 @@ define([
                 scene._stencilClearCommand.execute(context, passState);
             }
 
-            if (clearGlobeDepth && useDepthPlane) {
-                depthPlane.execute(context, passState);
-            }
-
-            us.updatePass(Pass.OPAQUE);
-            commands = frustumCommands.commands[Pass.OPAQUE];
-            length = frustumCommands.indices[Pass.OPAQUE];
+            us.updatePass(Pass.CESIUM_3D_TILE_CLASSIFICATION);
+            commands = frustumCommands.commands[Pass.CESIUM_3D_TILE_CLASSIFICATION];
+            length = frustumCommands.indices[Pass.CESIUM_3D_TILE_CLASSIFICATION];
             for (j = 0; j < length; ++j) {
                 executeCommand(commands[j], scene, context, passState);
+            }
+
+            // Execute commands in order by pass up to the translucent pass.
+            // Translucent geometry needs special handling (sorting/OIT).
+            var startPass = Pass.CESIUM_3D_TILE_CLASSIFICATION + 1;
+            var endPass = Pass.TRANSLUCENT;
+            for (var pass = startPass; pass < endPass; ++pass) {
+                us.updatePass(pass);
+                commands = frustumCommands.commands[pass];
+                length = frustumCommands.indices[pass];
+                for (j = 0; j < length; ++j) {
+                    executeCommand(commands[j], scene, context, passState);
+                }
             }
 
             if (index !== 0 && scene.mode !== SceneMode.SCENE2D) {


### PR DESCRIPTION
Currently quantization and points are limited in the level of precision they can contain; however, with floating 3d tiles points with large quantization volumes can also have high precision. This also maintains a distinction for the old tile format.

While this isn't the best solution in the sense of byte utilization it may be an interesting feature to offer.  