### PR TITLE
Integration with tsd-jsdoc for generating typings

### DIFF
--- a/Source/Core/PolylinePipeline.js
+++ b/Source/Core/PolylinePipeline.js
@@ -201,6 +201,7 @@ define([
 
     /**
      * Subdivides polyline and raises all points to the specified height.  Returns an array of numbers to represent the positions.
+     * @param {Object} options Object with the following properties:
      * @param {Cartesian3[]} options.positions The array of type {Cartesian3} representing positions.
      * @param {Number|Number[]} [options.height=0.0] A number or array of numbers representing the heights of each position.
      * @param {Number} [options.granularity = CesiumMath.RADIANS_PER_DEGREE] The distance, in radians, between each latitude and longitude. Determines the number of positions in the buffer.
@@ -288,6 +289,7 @@ define([
 
     /**
      * Subdivides polyline and raises all points to the specified height. Returns an array of new {Cartesian3} positions.
+     * @param {Object} options Object with the following properties:
      * @param {Cartesian3[]} options.positions The array of type {Cartesian3} representing positions.
      * @param {Number|Number[]} [options.height=0.0] A number or array of numbers representing the heights of each position.
      * @param {Number} [options.granularity = CesiumMath.RADIANS_PER_DEGREE] The distance, in radians, between each latitude and longitude. Determines the number of positions in the buffer.

--- a/Source/Core/Tipsify.js
+++ b/Source/Core/Tipsify.js
@@ -105,6 +105,7 @@ define([
     /**
      * Optimizes triangles for the post-vertex shader cache.
      *
+     * @param {Object} options Object with the following properties:
      * @param {Number[]} options.indices Lists triads of numbers corresponding to the indices of the vertices
      *                        in the vertex buffer that define the geometry's triangles.
      * @param {Number} [options.maximumIndex] The maximum value of the elements in <code>args.indices</code>.

--- a/Source/Core/defaultValue.js
+++ b/Source/Core/defaultValue.js
@@ -27,6 +27,7 @@ define([
     /**
      * A frozen empty object that can be used as the default value for options passed as
      * an object literal.
+     * @type {Object}
      */
     defaultValue.EMPTY_OBJECT = freezeObject({});
 

--- a/Source/Renderer/AutomaticUniforms.js
+++ b/Source/Renderer/AutomaticUniforms.js
@@ -66,6 +66,7 @@ define([
          * and <code>w</code> components, respectively.
          *
          * @alias czm_viewport
+         * @namespace
          * @glslUniform
          *
          * @example
@@ -99,6 +100,7 @@ define([
          * from window coordinates to clip coordinates, and is often used to assign to <code>gl_Position</code>.
          *
          * @alias czm_viewportOrthographic
+         * @namespace
          * @glslUniform
          *
          * @example
@@ -137,6 +139,7 @@ define([
          * from window coordinates to clip coordinates, and is often used to assign to <code>gl_Position</code>.
          *
          * @alias czm_viewportTransformation
+         * @namespace
          * @glslUniform
          *
          * @example
@@ -170,6 +173,7 @@ define([
          * @private
          *
          * @alias czm_globeDepthTexture
+         * @namespace
          * @glslUniform
          *
          * @example
@@ -193,6 +197,7 @@ define([
          * transforms model coordinates to world coordinates.
          *
          * @alias czm_model
+         * @namespace
          * @glslUniform
          *
          * @example
@@ -220,6 +225,7 @@ define([
          * transforms world coordinates to model coordinates.
          *
          * @alias czm_inverseModel
+         * @namespace
          * @glslUniform
          *
          * @example
@@ -246,6 +252,7 @@ define([
          * transforms world coordinates to eye coordinates.
          *
          * @alias czm_view
+         * @namespace
          * @glslUniform
          *
          * @example
@@ -278,6 +285,7 @@ define([
          * 2D and Columbus View in the same way that 3D is lit.
          *
          * @alias czm_view3D
+         * @namespace
          * @glslUniform
          *
          * @example
@@ -303,6 +311,7 @@ define([
          * transforms vectors in world coordinates to eye coordinates.
          *
          * @alias czm_viewRotation
+         * @namespace
          * @glslUniform
          *
          * @example
@@ -333,6 +342,7 @@ define([
          * 2D and Columbus View in the same way that 3D is lit.
          *
          * @alias czm_viewRotation3D
+         * @namespace
          * @glslUniform
          *
          * @example
@@ -358,6 +368,7 @@ define([
          * transforms from eye coordinates to world coordinates.
          *
          * @alias czm_inverseView
+         * @namespace
          * @glslUniform
          *
          * @example
@@ -387,6 +398,7 @@ define([
          * 2D and Columbus View in the same way that 3D is lit.
          *
          * @alias czm_inverseView3D
+         * @namespace
          * @glslUniform
          *
          * @example
@@ -412,6 +424,7 @@ define([
          * transforms vectors from eye coordinates to world coordinates.
          *
          * @alias czm_inverseViewRotation
+         * @namespace
          * @glslUniform
          *
          * @example
@@ -442,6 +455,7 @@ define([
          * 2D and Columbus View in the same way that 3D is lit.
          *
          * @alias czm_inverseViewRotation3D
+         * @namespace
          * @glslUniform
          *
          * @example
@@ -468,6 +482,7 @@ define([
          * coordinate system for a vertex shader's <code>gl_Position</code> output.
          *
          * @alias czm_projection
+         * @namespace
          * @glslUniform
          *
          * @example
@@ -496,6 +511,7 @@ define([
          * coordinate system for a vertex shader's <code>gl_Position</code> output.
          *
          * @alias czm_inverseProjection
+         * @namespace
          * @glslUniform
          *
          * @example
@@ -524,6 +540,7 @@ define([
          * are not clipped by the far plane.
          *
          * @alias czm_infiniteProjection
+         * @namespace
          * @glslUniform
          *
          * @example
@@ -553,6 +570,7 @@ define([
          * normals should be transformed using {@link czm_normal}.
          *
          * @alias czm_modelView
+         * @namespace
          * @glslUniform
          *
          * @example
@@ -590,6 +608,7 @@ define([
          * normals should be transformed using {@link czm_normal3D}.
          *
          * @alias czm_modelView3D
+         * @namespace
          * @glslUniform
          *
          * @example
@@ -619,6 +638,7 @@ define([
          * in conjunction with {@link czm_translateRelativeToEye}.
          *
          * @alias czm_modelViewRelativeToEye
+         * @namespace
          * @glslUniform
          *
          * @example
@@ -652,6 +672,7 @@ define([
          * transforms from eye coordinates to model coordinates.
          *
          * @alias czm_inverseModelView
+         * @namespace
          * @glslUniform
          *
          * @example
@@ -680,6 +701,7 @@ define([
          * 2D and Columbus View in the same way that 3D is lit.
          *
          * @alias czm_inverseModelView3D
+         * @namespace
          * @glslUniform
          *
          * @example
@@ -707,6 +729,7 @@ define([
          * coordinate system for a vertex shader's <code>gl_Position</code> output.
          *
          * @alias czm_viewProjection
+         * @namespace
          * @glslUniform
          *
          * @example
@@ -739,6 +762,7 @@ define([
          * coordinate system for a vertex shader's <code>gl_Position</code> output.
          *
          * @alias czm_inverseViewProjection
+         * @namespace
          * @glslUniform
          *
          * @example
@@ -765,6 +789,7 @@ define([
          * coordinate system for a vertex shader's <code>gl_Position</code> output.
          *
          * @alias czm_modelViewProjection
+         * @namespace
          * @glslUniform
          *
          * @example
@@ -800,6 +825,7 @@ define([
          * coordinate system for a vertex shader's <code>gl_Position</code> output.
          *
          * @alias czm_inverseModelViewProjection
+         * @namespace
          * @glslUniform
          *
          * @example
@@ -827,6 +853,7 @@ define([
          * conjunction with {@link czm_translateRelativeToEye}.
          *
          * @alias czm_modelViewProjectionRelativeToEye
+         * @namespace
          * @glslUniform
          *
          * @example
@@ -863,6 +890,7 @@ define([
          * proxy geometry to ensure that triangles are not clipped by the far plane.
          *
          * @alias czm_modelViewInfiniteProjection
+         * @namespace
          * @glslUniform
          *
          * @example
@@ -893,6 +921,7 @@ define([
          * An automatic GLSL uniform that indicates if the current camera is orthographic in 3D.
          *
          * @alias czm_orthographicIn3D
+         * @namespace
          * @glslUniform
          * @see UniformState#orthographicIn3D
          */
@@ -912,6 +941,7 @@ define([
          * normals should be transformed using <code>czm_normal</code>.
          *
          * @alias czm_normal
+         * @namespace
          * @glslUniform
          *
          * @example
@@ -945,6 +975,7 @@ define([
          * normals should be transformed using <code>czm_normal3D</code>.
          *
          * @alias czm_normal3D
+         * @namespace
          * @glslUniform
          *
          * @example
@@ -971,6 +1002,7 @@ define([
          * the opposite of the transform provided by {@link czm_normal}.
          *
          * @alias czm_inverseNormal
+         * @namespace
          * @glslUniform
          *
          * @example
@@ -1003,6 +1035,7 @@ define([
          * 2D and Columbus View in the same way that 3D is lit.
          *
          * @alias czm_inverseNormal3D
+         * @namespace
          * @glslUniform
          *
          * @example
@@ -1028,6 +1061,7 @@ define([
          *  of the eye (camera) in the 2D scene in meters.
          *
          * @alias czm_eyeHeight2D
+         * @namespace
          * @glslUniform
          *
          * @see UniformState#eyeHeight2D
@@ -1046,6 +1080,7 @@ define([
          * frustum used for multi-frustum rendering.
          *
          * @alias czm_entireFrustum
+         * @namespace
          * @glslUniform
          *
          * @example
@@ -1072,6 +1107,7 @@ define([
          * frustum used for multi-frustum rendering.
          *
          * @alias czm_currentFrustum
+         * @namespace
          * @glslUniform
          *
          * @example
@@ -1097,6 +1133,7 @@ define([
          * the x, y, z, and w components, respectively.
          *
          * @alias czm_frustumPlanes
+         * @namespace
          * @glslUniform
          */
         czm_frustumPlanes : new AutomaticUniform({
@@ -1111,6 +1148,7 @@ define([
          * The log2 of the current frustums far plane. Used for computing the log depth.
          *
          * @alias czm_log2FarDistance
+         * @namespace
          * @glslUniform
          *
          * @private
@@ -1128,6 +1166,7 @@ define([
          * This is used when reversing log depth computations.
          *
          * @alias czm_log2FarPlusOne
+         * @namespace
          * @glslUniform
          */
         czm_log2FarPlusOne : new AutomaticUniform({
@@ -1143,6 +1182,7 @@ define([
          * This is used when writing log depth in the fragment shader.
          *
          * @alias czm_log2NearDistance
+         * @namespace
          * @glslUniform
          */
         czm_log2NearDistance : new AutomaticUniform({
@@ -1157,6 +1197,7 @@ define([
          * An automatic GLSL uniform representing the sun position in world coordinates.
          *
          * @alias czm_sunPositionWC
+         * @namespace
          * @glslUniform
          *
          * @example
@@ -1179,6 +1220,7 @@ define([
          * An automatic GLSL uniform representing the sun position in Columbus view world coordinates.
          *
          * @alias czm_sunPositionColumbusView
+         * @namespace
          * @glslUniform
          *
          * @example
@@ -1201,6 +1243,7 @@ define([
          * This is commonly used for directional lighting computations.
          *
          * @alias czm_sunDirectionEC
+         * @namespace
          * @glslUniform
          *
          * @example
@@ -1227,6 +1270,7 @@ define([
          * This is commonly used for directional lighting computations.
          *
          * @alias czm_sunDirectionWC
+         * @namespace
          * @glslUniform
          *
          * @example
@@ -1250,6 +1294,7 @@ define([
          * This is commonly used for directional lighting computations.
          *
          * @alias czm_moonDirectionEC
+         * @namespace
          * @glslUniform
          *
          * @example
@@ -1276,6 +1321,7 @@ define([
          * as described in {@link http://blogs.agi.com/insight3d/index.php/2008/09/03/precisions-precisions/|Precisions, Precisions}.
          *
          * @alias czm_encodedCameraPositionMCHigh
+         * @namespace
          * @glslUniform
          *
          * @example
@@ -1300,6 +1346,7 @@ define([
          * as described in {@link http://blogs.agi.com/insight3d/index.php/2008/09/03/precisions-precisions/|Precisions, Precisions}.
          *
          * @alias czm_encodedCameraPositionMCLow
+         * @namespace
          * @glslUniform
          *
          * @example
@@ -1322,6 +1369,7 @@ define([
          * An automatic GLSL uniform representing the position of the viewer (camera) in world coordinates.
          *
          * @alias czm_viewerPositionWC
+         * @namespace
          * @glslUniform
          *
          * @example
@@ -1341,6 +1389,7 @@ define([
          * every frame.
          *
          * @alias czm_frameNumber
+         * @namespace
          * @glslUniform
          *
          * @example
@@ -1360,6 +1409,7 @@ define([
          * 2D/Columbus View and 3D, with 0.0 being 2D or Columbus View and 1.0 being 3D.
          *
          * @alias czm_morphTime
+         * @namespace
          * @glslUniform
          *
          * @example
@@ -1382,6 +1432,7 @@ define([
          * as a float.
          *
          * @alias czm_sceneMode
+         * @namespace
          * @glslUniform
          *
          * @example
@@ -1411,6 +1462,7 @@ define([
          * An automatic GLSL uniform representing the current rendering pass.
          *
          * @alias czm_pass
+         * @namespace
          * @glslUniform
          *
          * @example
@@ -1435,6 +1487,7 @@ define([
          * An automatic GLSL uniform representing the current scene background color.
          *
          * @alias czm_backgroundColor
+         * @namespace
          * @glslUniform
          *
          * @example
@@ -1464,6 +1517,7 @@ define([
          * An automatic GLSL uniform containing the BRDF look up texture used for image-based lighting computations.
          *
          * @alias czm_brdfLut
+         * @namespace
          * @glslUniform
          *
          * @example
@@ -1487,6 +1541,7 @@ define([
          * An automatic GLSL uniform containing the environment map used within the scene.
          *
          * @alias czm_environmentMap
+         * @namespace
          * @glslUniform
          *
          * @example
@@ -1510,6 +1565,7 @@ define([
          * from True Equator Mean Equinox (TEME) axes to the pseudo-fixed axes at the current scene time.
          *
          * @alias czm_temeToPseudoFixed
+         * @namespace
          * @glslUniform
          *
          * @example
@@ -1534,6 +1590,7 @@ define([
          * An automatic GLSL uniform representing the ratio of canvas coordinate space to canvas pixel space.
          *
          * @alias czm_resolutionScale
+         * @namespace
          * @glslUniform
          *
          * @example
@@ -1551,6 +1608,7 @@ define([
          * An automatic GLSL uniform scalar used to mix a color with the fog color based on the distance to the camera.
          *
          * @alias czm_fogDensity
+         * @namespace
          * @glslUniform
          *
          * @see czm_fog
@@ -1568,6 +1626,7 @@ define([
          * This will be in pixel coordinates relative to the canvas.
          *
          * @alias czm_imagerySplitPosition
+         * @namespace
          * @glslUniform
          *
          * @example
@@ -1586,6 +1645,7 @@ define([
          * An automatic GLSL uniform scalar representing the geometric tolerance per meter
          *
          * @alias czm_geometricToleranceOverMeter
+         * @namespace
          * @glslUniform
          */
         czm_geometricToleranceOverMeter : new AutomaticUniform({
@@ -1602,6 +1662,7 @@ define([
          * the depth test should never be applied.
          *
          * @alias czm_minimumDisableDepthTestDistance
+         * @namespace
          * @glslUniform
          */
         czm_minimumDisableDepthTestDistance : new AutomaticUniform({
@@ -1616,6 +1677,7 @@ define([
          * An automatic GLSL uniform that will be the highlight color of unclassified 3D Tiles.
          *
          * @alias czm_invertClassificationColor
+         * @namespace
          * @glslUniform
          */
         czm_invertClassificationColor : new AutomaticUniform({

--- a/Source/Scene/Billboard.js
+++ b/Source/Scene/Billboard.js
@@ -71,6 +71,7 @@ define([
      * @see Label
      *
      * @internalConstructor
+     * @class
      *
      * @demo {@link https://cesiumjs.org/Cesium/Apps/Sandcastle/index.html?src=Billboards.html|Cesium Sandcastle Billboard Demo}
      */

--- a/Source/Scene/Label.js
+++ b/Source/Scene/Label.js
@@ -63,6 +63,7 @@ define([
      *
      * @alias Label
      * @internalConstructor
+     * @class
      *
      * @exception {DeveloperError} translucencyByDistance.far must be greater than translucencyByDistance.near
      * @exception {DeveloperError} pixelOffsetScaleByDistance.far must be greater than pixelOffsetScaleByDistance.near

--- a/Source/Scene/LabelCollection.js
+++ b/Source/Scene/LabelCollection.js
@@ -599,7 +599,7 @@ define([
      * calling <code>update</code>.
      *
      * @exception {DeveloperError} This object was destroyed, i.e., destroy() was called.
-     * @memberOf {LabelCollection.prototype}
+     *
      *
      * @example
      * // Example 1:  Add a label, specifying all the default values.
@@ -660,7 +660,7 @@ define([
      * {@link Label#show} instead of removing and re-adding the label.
      *
      * @exception {DeveloperError} This object was destroyed, i.e., destroy() was called.
-     * @memberOf {LabelCollection.prototype}
+     *
      *
      * @example
      * var l = labels.add(...);
@@ -689,7 +689,7 @@ define([
      * from a collection and then add new ones than to create a new collection entirely.
      *
      * @exception {DeveloperError} This object was destroyed, i.e., destroy() was called.
-     * @memberOf {LabelCollection.prototype}
+     *
      *
      * @example
      * labels.add(...);
@@ -716,7 +716,7 @@ define([
      * @returns {Boolean} true if this collection contains the label, false otherwise.
      *
      * @see LabelCollection#get
-     * @memberOf {LabelCollection.prototype}
+     *
      */
     LabelCollection.prototype.contains = function(label) {
         return defined(label) && label._labelCollection === this;
@@ -738,7 +738,7 @@ define([
      * operation is performed.
      *
      * @exception {DeveloperError} This object was destroyed, i.e., destroy() was called.
-     * @memberOf {LabelCollection.prototype}
+     *
      *
      * @example
      * // Toggle the show property of every label in the collection
@@ -762,7 +762,7 @@ define([
 
     /**
      * @private
-     * @memberOf {LabelCollection.prototype}
+     *
      */
     LabelCollection.prototype.update = function(frameState) {
         var billboardCollection = this._billboardCollection;
@@ -845,7 +845,7 @@ define([
      * <code>isDestroyed</code> will result in a {@link DeveloperError} exception.
      *
      * @returns {Boolean} True if this object was destroyed; otherwise, false.
-     * @memberOf {LabelCollection.prototype}
+     *
      * @see LabelCollection#destroy
      */
     LabelCollection.prototype.isDestroyed = function() {
@@ -861,7 +861,7 @@ define([
      * assign the return value (<code>undefined</code>) to the object as done in the example.
      *
      * @exception {DeveloperError} This object was destroyed, i.e., destroy() was called.
-     * @memberOf {LabelCollection.prototype}
+     *
      *
      * @example
      * labels = labels && labels.destroy();

--- a/Source/Scene/LabelCollection.js
+++ b/Source/Scene/LabelCollection.js
@@ -599,7 +599,7 @@ define([
      * calling <code>update</code>.
      *
      * @exception {DeveloperError} This object was destroyed, i.e., destroy() was called.
-     *
+     * @memberOf {LabelCollection.prototype}
      *
      * @example
      * // Example 1:  Add a label, specifying all the default values.
@@ -660,7 +660,7 @@ define([
      * {@link Label#show} instead of removing and re-adding the label.
      *
      * @exception {DeveloperError} This object was destroyed, i.e., destroy() was called.
-     *
+     * @memberOf {LabelCollection.prototype}
      *
      * @example
      * var l = labels.add(...);
@@ -689,7 +689,7 @@ define([
      * from a collection and then add new ones than to create a new collection entirely.
      *
      * @exception {DeveloperError} This object was destroyed, i.e., destroy() was called.
-     *
+     * @memberOf {LabelCollection.prototype}
      *
      * @example
      * labels.add(...);
@@ -716,6 +716,7 @@ define([
      * @returns {Boolean} true if this collection contains the label, false otherwise.
      *
      * @see LabelCollection#get
+     * @memberOf {LabelCollection.prototype}
      */
     LabelCollection.prototype.contains = function(label) {
         return defined(label) && label._labelCollection === this;
@@ -737,7 +738,7 @@ define([
      * operation is performed.
      *
      * @exception {DeveloperError} This object was destroyed, i.e., destroy() was called.
-     *
+     * @memberOf {LabelCollection.prototype}
      *
      * @example
      * // Toggle the show property of every label in the collection
@@ -761,6 +762,7 @@ define([
 
     /**
      * @private
+     * @memberOf {LabelCollection.prototype}
      */
     LabelCollection.prototype.update = function(frameState) {
         var billboardCollection = this._billboardCollection;
@@ -843,7 +845,7 @@ define([
      * <code>isDestroyed</code> will result in a {@link DeveloperError} exception.
      *
      * @returns {Boolean} True if this object was destroyed; otherwise, false.
-     *
+     * @memberOf {LabelCollection.prototype}
      * @see LabelCollection#destroy
      */
     LabelCollection.prototype.isDestroyed = function() {
@@ -859,7 +861,7 @@ define([
      * assign the return value (<code>undefined</code>) to the object as done in the example.
      *
      * @exception {DeveloperError} This object was destroyed, i.e., destroy() was called.
-     *
+     * @memberOf {LabelCollection.prototype}
      *
      * @example
      * labels = labels && labels.destroy();

--- a/Source/Scene/MaterialAppearance.js
+++ b/Source/Scene/MaterialAppearance.js
@@ -282,6 +282,7 @@ define([
      * {@link MaterialAppearance} instance.  This is a trade-off between
      * flexibility (a wide array of materials) and memory/performance
      * (required vertex format and GLSL shader complexity.
+     * @exports MaterialAppearance.MaterialSupport
      */
     MaterialAppearance.MaterialSupport = {
         /**

--- a/Source/Scene/ModelAnimation.js
+++ b/Source/Scene/ModelAnimation.js
@@ -26,6 +26,7 @@ define([
      *
      * @alias ModelAnimation
      * @internalConstructor
+     * @class
      *
      * @see ModelAnimationCollection#add
      */

--- a/Source/Scene/ModelAnimationCollection.js
+++ b/Source/Scene/ModelAnimationCollection.js
@@ -27,6 +27,7 @@ define([
      *
      * @alias ModelAnimationCollection
      * @internalConstructor
+     * @class
      *
      * @see Model#activeAnimations
      */

--- a/Source/Scene/ModelMaterial.js
+++ b/Source/Scene/ModelMaterial.js
@@ -19,6 +19,7 @@ define([
      *
      * @alias ModelMaterial
      * @internalConstructor
+     * @class
      *
      * @see Model#getMaterial
      */

--- a/Source/Scene/ModelMesh.js
+++ b/Source/Scene/ModelMesh.js
@@ -12,6 +12,7 @@ define([
      *
      * @alias ModelMesh
      * @internalConstructor
+     * @class
      *
      * @see Model#getMesh
      */

--- a/Source/Scene/ModelNode.js
+++ b/Source/Scene/ModelNode.js
@@ -17,7 +17,7 @@ define([
      *
      * @alias ModelNode
      * @internalConstructor
-     *
+     * @class
      *
      * @example
      * var node = model.getNode('LOD3sp');

--- a/Source/Scene/PointPrimitive.js
+++ b/Source/Scene/PointPrimitive.js
@@ -52,6 +52,7 @@ define([
      * @see PointPrimitiveCollection#add
      *
      * @internalConstructor
+     * @class
      *
      * @demo {@link https://cesiumjs.org/Cesium/Apps/Sandcastle/index.html?src=Points.html|Cesium Sandcastle Points Demo}
      */

--- a/Source/Scene/Polyline.js
+++ b/Source/Scene/Polyline.js
@@ -31,6 +31,7 @@ define([
      *
      * @alias Polyline
      * @internalConstructor
+     * @class
      *
      * @param {Object} [options] Object with the following properties:
      * @param {Boolean} [options.show=true] <code>true</code> if this polyline will be shown; otherwise, <code>false</code>.

--- a/Source/Scene/ShadowMap.js
+++ b/Source/Scene/ShadowMap.js
@@ -112,6 +112,7 @@ define([
      *
      * @alias ShadowMap
      * @internalConstructor
+     * @class
      *
      * @param {Object} options An object containing the following properties:
      * @param {Camera} options.lightCamera A camera representing the light source.

--- a/Source/Scene/WebMapServiceImageryProvider.js
+++ b/Source/Scene/WebMapServiceImageryProvider.js
@@ -435,6 +435,7 @@ define([
      *    format=image/jpeg
      *
      * @constant
+     * @type {Object}
      */
     WebMapServiceImageryProvider.DefaultParameters = freezeObject({
         service : 'WMS',
@@ -451,6 +452,7 @@ define([
      *     request=GetFeatureInfo
      *
      * @constant
+     * @type {Object}
      */
     WebMapServiceImageryProvider.GetFeatureInfoDefaultParameters = freezeObject({
         service : 'WMS',


### PR DESCRIPTION
References #5717 

This PR contains modifications in the `jsdoc `block tags so that we can nicely integrate with `tsd-jsdoc` and create a **typings** file for the library. Initially we are adding missing jsdoc block tags in order for tsd-jsdoc to have a first time pass from each subfolder of **Sources** directory and compile successfully.

- [x]  Core
- [x]  Renderer
- [x]  Scene
