### PR TITLE
Revert 1fda8c0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@ Change Log
 
 #### Fixes :wrench:
 * Fixed bug causing billboards and labels to appear the wrong size when switching scene modes [#6745](https://github.com/AnalyticalGraphicsInc/cesium/issues/6745)
+* Fixed occlusion bug for tiles use a depth pane [#6714](https://github.com/AnalyticalGraphicsInc/cesium/issues/6714)
 
 ### 1.47 - 2018-07-02
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,7 +8,7 @@ Change Log
 
 #### Fixes :wrench:
 * Fixed bug causing billboards and labels to appear the wrong size when switching scene modes [#6745](https://github.com/AnalyticalGraphicsInc/cesium/issues/6745)
-* Fixed occlusion bug for tiles use a depth pane [#6714](https://github.com/AnalyticalGraphicsInc/cesium/issues/6714)
+* Fixed a bug that was preventing 3D Tilesets on the opposite side of the globe from being occluded [#6714](https://github.com/AnalyticalGraphicsInc/cesium/issues/6714)
 
 ### 1.47 - 2018-07-02
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -184,3 +184,4 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to Cesiu
 * [Jonathan Puckey](https://github.com/puckey)
 * [Mark Erikson](https://github.com/markerikson)
 * [Hannah Bollar](https://github.com/hanbollar)
+* [Brandon Barker](https://github.com/ProjectBarks)

--- a/Source/Scene/DepthPlane.js
+++ b/Source/Scene/DepthPlane.js
@@ -51,14 +51,22 @@ define([
     }
 
     var depthQuadScratch = FeatureDetection.supportsTypedArrays() ? new Float32Array(12) : [];
+    var scratchRadii = new Cartesian3();
     var scratchCartesian1 = new Cartesian3();
     var scratchCartesian2 = new Cartesian3();
     var scratchCartesian3 = new Cartesian3();
     var scratchCartesian4 = new Cartesian3();
 
     function computeDepthQuad(ellipsoid, frameState) {
-        var radii = ellipsoid.radii;
+        var radii = Cartesian3.clone(ellipsoid.radii, scratchRadii);
         var p = frameState.camera.positionWC;
+
+        // Where did this magical number come from? It's how far a GroundPrimitive will be extruded below the surface
+        // of the Earth. This effectively pushes the depth plane farther from the camera so that classifications on
+        // 3D Tiles do not intersect the depth plane. This can be removed when depth testing is enabled by default.
+        radii.x -= 11000.0;
+        radii.y -= 11000.0;
+        radii.z -= 11000.0;
 
         // Find the corresponding position in the scaled space of the ellipsoid.
         var q = Cartesian3.multiplyComponents(ellipsoid.oneOverRadii, p, scratchCartesian1);

--- a/Source/Scene/Scene.js
+++ b/Source/Scene/Scene.js
@@ -2314,6 +2314,9 @@ define([
 
             if (clearGlobeDepth) {
                 clearDepth.execute(context, passState);
+                if (useDepthPlane) {
+                    depthPlane.execute(context, passState);
+                }
             }
 
             if (!environmentState.useInvertClassification || picking) {
@@ -2429,10 +2432,6 @@ define([
 
             if (length > 0 && context.stencilBuffer) {
                 scene._stencilClearCommand.execute(context, passState);
-            }
-
-            if (clearGlobeDepth && useDepthPlane) {
-                depthPlane.execute(context, passState);
             }
 
             us.updatePass(Pass.OPAQUE);

--- a/Source/Scene/Scene.js
+++ b/Source/Scene/Scene.js
@@ -2314,9 +2314,6 @@ define([
 
             if (clearGlobeDepth) {
                 clearDepth.execute(context, passState);
-                if (useDepthPlane) {
-                    depthPlane.execute(context, passState);
-                }
             }
 
             if (!environmentState.useInvertClassification || picking) {
@@ -2434,24 +2431,15 @@ define([
                 scene._stencilClearCommand.execute(context, passState);
             }
 
-            us.updatePass(Pass.CESIUM_3D_TILE_CLASSIFICATION);
-            commands = frustumCommands.commands[Pass.CESIUM_3D_TILE_CLASSIFICATION];
-            length = frustumCommands.indices[Pass.CESIUM_3D_TILE_CLASSIFICATION];
-            for (j = 0; j < length; ++j) {
-                executeCommand(commands[j], scene, context, passState);
+            if (clearGlobeDepth && useDepthPlane) {
+                depthPlane.execute(context, passState);
             }
 
-            // Execute commands in order by pass up to the translucent pass.
-            // Translucent geometry needs special handling (sorting/OIT).
-            var startPass = Pass.CESIUM_3D_TILE_CLASSIFICATION + 1;
-            var endPass = Pass.TRANSLUCENT;
-            for (var pass = startPass; pass < endPass; ++pass) {
-                us.updatePass(pass);
-                commands = frustumCommands.commands[pass];
-                length = frustumCommands.indices[pass];
-                for (j = 0; j < length; ++j) {
-                    executeCommand(commands[j], scene, context, passState);
-                }
+            us.updatePass(Pass.OPAQUE);
+            commands = frustumCommands.commands[Pass.OPAQUE];
+            length = frustumCommands.indices[Pass.OPAQUE];
+            for (j = 0; j < length; ++j) {
+                executeCommand(commands[j], scene, context, passState);
             }
 
             if (index !== 0 && scene.mode !== SceneMode.SCENE2D) {

--- a/Source/Scene/Scene.js
+++ b/Source/Scene/Scene.js
@@ -2314,6 +2314,9 @@ define([
 
             if (clearGlobeDepth) {
                 clearDepth.execute(context, passState);
+                if (useDepthPlane) {
+                    depthPlane.execute(context, passState);
+                }
             }
 
             if (!environmentState.useInvertClassification || picking) {
@@ -2431,15 +2434,24 @@ define([
                 scene._stencilClearCommand.execute(context, passState);
             }
 
-            if (clearGlobeDepth && useDepthPlane) {
-                depthPlane.execute(context, passState);
-            }
-
-            us.updatePass(Pass.OPAQUE);
-            commands = frustumCommands.commands[Pass.OPAQUE];
-            length = frustumCommands.indices[Pass.OPAQUE];
+            us.updatePass(Pass.CESIUM_3D_TILE_CLASSIFICATION);
+            commands = frustumCommands.commands[Pass.CESIUM_3D_TILE_CLASSIFICATION];
+            length = frustumCommands.indices[Pass.CESIUM_3D_TILE_CLASSIFICATION];
             for (j = 0; j < length; ++j) {
                 executeCommand(commands[j], scene, context, passState);
+            }
+
+            // Execute commands in order by pass up to the translucent pass.
+            // Translucent geometry needs special handling (sorting/OIT).
+            var startPass = Pass.CESIUM_3D_TILE_CLASSIFICATION + 1;
+            var endPass = Pass.TRANSLUCENT;
+            for (var pass = startPass; pass < endPass; ++pass) {
+                us.updatePass(pass);
+                commands = frustumCommands.commands[pass];
+                length = frustumCommands.indices[pass];
+                for (j = 0; j < length; ++j) {
+                    executeCommand(commands[j], scene, context, passState);
+                }
             }
 
             if (index !== 0 && scene.mode !== SceneMode.SCENE2D) {


### PR DESCRIPTION
This should fix a bug that was preventing 3D Tilesets from being occluded when they were not using the depth testing. There is still a outstanding logarithmic depth bug bit this seems connected to an already documented [bug](https://github.com/AnalyticalGraphicsInc/cesium/issues/6756).  

Related to https://github.com/AnalyticalGraphicsInc/cesium/issues/6714 