### PR TITLE
Fix crash caused by reverse video playback and VideoSynchronizer tests

### DIFF
--- a/Apps/Sandcastle/gallery/Video.html
+++ b/Apps/Sandcastle/gallery/Video.html
@@ -33,7 +33,7 @@
 <div id="loadingOverlay"><h1>Loading...</h1></div>
 <div id="toolbar"></div>
 
-<video id="trailer" style="display: none;" muted autoplay loop crossorigin controls>
+<video id="trailer" muted autoplay loop crossorigin controls>
     <source src="https://cesiumjs.org/videos/Sandcastle/big-buck-bunny_trailer.webm" type="video/webm">
     <source src="https://cesiumjs.org/videos/Sandcastle/big-buck-bunny_trailer.mp4" type="video/mp4">
     <source src="https://cesiumjs.org/videos/Sandcastle/big-buck-bunny_trailer.mov" type="video/quicktime">
@@ -103,7 +103,7 @@ sphere.ellipsoid.material.repeat = new Cesium.CallbackProperty(function(time, re
 
 // Like Image, the video element doesn't have to be part of the DOM or
 // otherwise on the screen to be used as a texture.
-Sandcastle.addToggleButton('Video Overlay', false, function(checked) {
+Sandcastle.addToggleButton('Video Overlay', true, function(checked) {
     if (checked){
         videoElement.style.display = '';
     } else {

--- a/Apps/Sandcastle/gallery/Video.html
+++ b/Apps/Sandcastle/gallery/Video.html
@@ -33,7 +33,7 @@
 <div id="loadingOverlay"><h1>Loading...</h1></div>
 <div id="toolbar"></div>
 
-<video id="trailer" style="display: none;" autoplay loop crossorigin controls>
+<video id="trailer" style="display: none;" muted autoplay loop crossorigin controls>
     <source src="https://cesiumjs.org/videos/Sandcastle/big-buck-bunny_trailer.webm" type="video/webm">
     <source src="https://cesiumjs.org/videos/Sandcastle/big-buck-bunny_trailer.mp4" type="video/mp4">
     <source src="https://cesiumjs.org/videos/Sandcastle/big-buck-bunny_trailer.mov" type="video/quicktime">
@@ -75,7 +75,8 @@ Sandcastle.addToggleButton('Clock synchronization', false, function(checked) {
 
     synchronizer = new Cesium.VideoSynchronizer({
         clock : viewer.clock,
-        element : videoElement
+        element : videoElement,
+        tolerance : 0.1
     });
 });
 

--- a/Apps/Sandcastle/gallery/Video.html
+++ b/Apps/Sandcastle/gallery/Video.html
@@ -75,8 +75,7 @@ Sandcastle.addToggleButton('Clock synchronization', false, function(checked) {
 
     synchronizer = new Cesium.VideoSynchronizer({
         clock : viewer.clock,
-        element : videoElement,
-        tolerance : 0.1
+        element : videoElement
     });
 });
 

--- a/Source/Core/VideoSynchronizer.js
+++ b/Source/Core/VideoSynchronizer.js
@@ -172,7 +172,12 @@ define([
             return;
         }
 
-        element.playbackRate = clock.multiplier;
+        try {
+            element.playbackRate = clock.multiplier;
+        } catch(error) {
+            // Seek manually for unsupported playbackRates.
+            element.playbackRate = 0.0;
+        }
 
         var clockTime = clock.currentTime;
         var epoch = defaultValue(this.epoch, Iso8601.MINIMUM_VALUE);

--- a/Source/Core/VideoSynchronizer.js
+++ b/Source/Core/VideoSynchronizer.js
@@ -35,6 +35,7 @@ define([
         this._element = undefined;
         this._clockSubscription = undefined;
         this._seekFunction = undefined;
+        this._lastPlaybackRate = undefined;
 
         this.clock = options.clock;
         this.element = options.element;
@@ -146,6 +147,21 @@ define([
         return false;
     };
 
+    VideoSynchronizer.prototype._trySetPlaybackRate = function(clock) {
+        if (this._lastPlaybackRate === clock.multiplier) {
+            return;
+        }
+
+        var element = this._element;
+        try {
+            element.playbackRate = clock.multiplier;
+        } catch(error) {
+            // Seek manually for unsupported playbackRates.
+            element.playbackRate = 0.0;
+        }
+        this._lastPlaybackRate = clock.multiplier;
+    };
+
     VideoSynchronizer.prototype._onTick = function(clock) {
         var element = this._element;
         if (!defined(element) || element.readyState < 2) {
@@ -172,12 +188,7 @@ define([
             return;
         }
 
-        try {
-            element.playbackRate = clock.multiplier;
-        } catch(error) {
-            // Seek manually for unsupported playbackRates.
-            element.playbackRate = 0.0;
-        }
+        this._trySetPlaybackRate(clock);
 
         var clockTime = clock.currentTime;
         var epoch = defaultValue(this.epoch, Iso8601.MINIMUM_VALUE);

--- a/Specs/Core/VideoSynchronizerSpec.js
+++ b/Specs/Core/VideoSynchronizerSpec.js
@@ -75,7 +75,7 @@ defineSuite([
         expect(videoSynchronizer.isDestroyed()).toBe(true);
     });
 
-    xit('Syncs time when looping', function() {
+    it('Syncs time when looping', function() {
         var epoch = JulianDate.fromIso8601('2015-11-01T00:00:00Z');
         var clock = new Clock();
         clock.shouldAnimate = false;
@@ -116,7 +116,7 @@ defineSuite([
         });
     });
 
-    xit('Syncs time when not looping', function() {
+    it('Syncs time when not looping', function() {
         var epoch = JulianDate.fromIso8601('2015-11-01T00:00:00Z');
         var clock = new Clock();
         clock.shouldAnimate = false;


### PR DESCRIPTION
To follow up on #6765, I muted the sandcastle video and handled the `NotSupportedError` that's thrown when setting `playbackRate` to a bad value (this is what was causing the context freezes in both Firefox and Chrome).

I added a sync tolerance of 0.1 to the sandcastle so that seeking backwards isn't insanely choppy. I would have made it smaller but this seemed like a good middle ground value for all the browsers that I tested (Safari, Firefox, and Chrome). Chrome was overall very smooth for both normal and reverse playback.

As for Safari and Firefox, things get a little funky 🎸. When clock synchronization is enabled and there is a low tolerance set on the video sync, Safari and Firefox are both very choppy. At least during reverse playback, the choppiness is of the same degree. On the other hand, when a large tolerance is used, normal playback is smooth in both browsers, but reverse playback behaves completely differently! Safari is smooth because it handles negative playbackRate just fine and there is minimal hand-holding. Since Firefox doesn't support negative playbackRates, it becomes _very_ choppy because the `VideoSynchronizer` reverts to manual seeking. The minimal hand-holding has the opposite effect because the video is paused unlike Safari. I don't really like how the same tolerance value can mean very different things for each browser, but we have to handle the `NotSupportedError` somehow in order to stop the cesium viewer from crashing.

TL;DR

🎉 The context no longer freezes at all, so this should fix #6765! (Tested in Firefox, Chrome, and Safari). 😕 I don't know what's going on in Edge, but maybe lowering the tolerance would help.

🎉 I re-enabled the failing tests from #6772 and they _seem_ to be passing both locally and on Travis. 😕 I might be missing something here, but we'll see!

🤔 Another possibility is to add an optional `reverseTolerance` to `VideoSynchronizer` that applies only when syncing in reverse. It can be a bit tighter by default and would improve the choppiness in Firefox.