### PR TITLE
Fix weird PolygonGeometry perPositionHeight edge case

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@ Change Log
 
 #### Fixes :wrench:
 * Fixed bug causing billboards and labels to appear the wrong size when switching scene modes [#6745](https://github.com/AnalyticalGraphicsInc/cesium/issues/6745)
+* Fixed `PolygonGeometry` when using `VertexFormat.POSITION_ONLY`, `perPositionHeight` and `extrudedHeight` [#6789](expect(https://github.com/AnalyticalGraphicsInc/cesium/pull/6789)
 * Fixed a bug that was preventing 3D Tilesets on the opposite side of the globe from being occluded [#6714](https://github.com/AnalyticalGraphicsInc/cesium/issues/6714)
 
 ### 1.47 - 2018-07-02

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,7 +12,7 @@ Change Log
 
 #### Fixes :wrench:
 * Fixed bug causing billboards and labels to appear the wrong size when switching scene modes [#6745](https://github.com/AnalyticalGraphicsInc/cesium/issues/6745)
-* Fixed `PolygonGeometry` when using `VertexFormat.POSITION_ONLY`, `perPositionHeight` and `extrudedHeight` [#6789](expect(https://github.com/AnalyticalGraphicsInc/cesium/pull/6789)
+* Fixed `PolygonGeometry` when using `VertexFormat.POSITION_ONLY`, `perPositionHeight` and `extrudedHeight` [#6790](expect(https://github.com/AnalyticalGraphicsInc/cesium/pull/6790)
 * Fixed a bug that was preventing 3D Tilesets on the opposite side of the globe from being occluded [#6714](https://github.com/AnalyticalGraphicsInc/cesium/issues/6714)
 
 ### 1.47 - 2018-07-02

--- a/Source/Core/PolygonGeometry.js
+++ b/Source/Core/PolygonGeometry.js
@@ -447,7 +447,7 @@ define([
                 }
 
                 topGeo.attributes.position.values = topBottomPositions;
-                if (perPositionHeight) {
+                if (perPositionHeight && vertexFormat.normal) {
                     var normals = topGeo.attributes.normal.values;
                     topGeo.attributes.normal.values = new Float32Array(topBottomPositions.length);
                     topGeo.attributes.normal.values.set(normals);

--- a/Specs/Core/PolygonGeometrySpec.js
+++ b/Specs/Core/PolygonGeometrySpec.js
@@ -891,6 +891,24 @@ defineSuite([
         expect(notEqualCount).toEqual(6);
     });
 
+    it('computes geometry with position only vertex format with perPositionHeight and extrudedHeight', function() {
+        var positions = Cartesian3.fromDegreesArrayHeights([
+            -1.0, -1.0, 100.0,
+            1.0, -1.0, 0.0,
+            1.0, 1.0, 100.0,
+            -1.0, 1.0, 0.0
+        ]);
+        var geometry = PolygonGeometry.createGeometry(PolygonGeometry.fromPositions({
+            positions : positions,
+            extrudedHeight: 0,
+            vertexFormat : VertexFormat.POSITION_ONLY,
+            perPositionHeight : true
+        }));
+        expect(geometry).toBeDefined();
+        expect(geometry.attributes.position).toBeDefined();
+        expect(geometry.attributes.normal).toBeUndefined();
+    });
+
     it('computing rectangle property', function() {
         var p = new PolygonGeometry({
             vertexFormat : VertexFormat.POSITION_AND_ST,


### PR DESCRIPTION
Fixes crash when `perPositionHeight: true`, `extrudedHeight` is defined, and `vertexFormat: VertexFormat.POSITION_ONLY`.

```js
var viewer = new Cesium.Viewer('cesiumContainer');
var scene = viewer.scene;

var positions = Cesium.Cartesian3.fromDegreesArrayHeights([
    -108.0, 25.0, 100000,
    -100.0, 25.0, 100000,
    -100.0, 30.0, 100000,
    -108.0, 30.0, 300000
]);
var orangePolygonInstance = new Cesium.GeometryInstance({
    geometry : Cesium.PolygonGeometry.fromPositions({
        positions : positions,
        extrudedHeight: 0,
        vertexFormat : Cesium.PerInstanceColorAppearance.FLAT_VERTEX_FORMAT,
        perPositionHeight : true
    }),
    attributes: {
        color: Cesium.ColorGeometryInstanceAttribute.fromColor(Cesium.Color.ORANGE)
    }
});

scene.primitives.add(new Cesium.Primitive({
    geometryInstances : [orangePolygonInstance],
    appearance : new Cesium.PerInstanceColorAppearance({
        flat: true,
        closed : true,
        translucent : false
    })
}));
```