### PR TITLE
Fix missing tiles in VR

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,7 +17,7 @@ Change Log
 * Fixed a bug that was preventing 3D Tilesets on the opposite side of the globe from being occluded [#6714](https://github.com/AnalyticalGraphicsInc/cesium/issues/6714)
 * Fixed a bug where 3D Tilesets using the `region` bounding volume don't get transformed when the tileset's `modelMatrix` changes. [6755](https://github.com/AnalyticalGraphicsInc/cesium/pull/6755)
 * Fixed `PolygonGeometry` and `EllipseGeometry` tangent and bitangent attributes when a texture rotation is used [#6788](https://github.com/AnalyticalGraphicsInc/cesium/pull/6788)
-* Fixed an issue where tiles were missing in VR mode. (#6612)[https://github.com/AnalyticalGraphicsInc/cesium/issues/6612]
+* Fixed an issue where tiles were missing in VR mode. [#6612](https://github.com/AnalyticalGraphicsInc/cesium/issues/6612)
 
 ### 1.47 - 2018-07-02
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,7 @@ Change Log
 * Fixed a bug that was preventing 3D Tilesets on the opposite side of the globe from being occluded [#6714](https://github.com/AnalyticalGraphicsInc/cesium/issues/6714)
 * Fixed a bug where 3D Tilesets using the `region` bounding volume don't get transformed when the tileset's `modelMatrix` changes. [6755](https://github.com/AnalyticalGraphicsInc/cesium/pull/6755)
 * Fixed `PolygonGeometry` and `EllipseGeometry` tangent and bitangent attributes when a texture rotation is used [#6788](https://github.com/AnalyticalGraphicsInc/cesium/pull/6788)
+* Fixed an issue where tiles were missing in VR mode. (#6612)[https://github.com/AnalyticalGraphicsInc/cesium/issues/6612]
 
 ### 1.47 - 2018-07-02
 

--- a/Source/Scene/Scene.js
+++ b/Source/Scene/Scene.js
@@ -2673,6 +2673,7 @@ define([
             viewport.height = context.drawingBufferHeight;
 
             var savedCamera = Camera.clone(camera, scene._cameraVR);
+            savedCamera.frustum = camera.frustum;
 
             var near = camera.frustum.near;
             var fo = near * defaultValue(scene.focalLength, 5.0);


### PR DESCRIPTION
The line here was the problem:
https://github.com/AnalyticalGraphicsInc/cesium/commit/d681755611f2fc47f28e33db61a9ec0583a4abe3#diff-6298b280e4e0977bedd881b65b769863L3232

The setup for each view for the eye was expecting the frustum to be a reference.

Fixes #6612.