### PR TITLE
Don't overwrite scratch variables in entity visualizers

### DIFF
--- a/Source/DataSources/BillboardVisualizer.js
+++ b/Source/DataSources/BillboardVisualizer.js
@@ -44,15 +44,15 @@ define([
     var defaultSizeInMeters = false;
     var defaultDisableDepthTestDistance = 0.0;
 
-    var position = new Cartesian3();
-    var color = new Color();
-    var eyeOffset = new Cartesian3();
-    var pixelOffset = new Cartesian2();
-    var scaleByDistance = new NearFarScalar();
-    var translucencyByDistance = new NearFarScalar();
-    var pixelOffsetScaleByDistance = new NearFarScalar();
-    var boundingRectangle = new BoundingRectangle();
-    var distanceDisplayCondition = new DistanceDisplayCondition();
+    var positionScratch = new Cartesian3();
+    var colorScratch = new Color();
+    var eyeOffsetScratch = new Cartesian3();
+    var pixelOffsetScratch = new Cartesian2();
+    var scaleByDistanceScratch = new NearFarScalar();
+    var translucencyByDistanceScratch = new NearFarScalar();
+    var pixelOffsetScaleByDistanceScratch = new NearFarScalar();
+    var boundingRectangleScratch = new BoundingRectangle();
+    var distanceDisplayConditionScratch = new DistanceDisplayCondition();
 
     function EntityData(entity) {
         this.entity = entity;
@@ -110,9 +110,9 @@ define([
             var textureValue;
             var billboard = item.billboard;
             var show = entity.isShowing && entity.isAvailable(time) && Property.getValueOrDefault(billboardGraphics._show, time, true);
-
+            var position;
             if (show) {
-                position = Property.getValueOrUndefined(entity._position, time, position);
+                position = Property.getValueOrUndefined(entity._position, time, positionScratch);
                 textureValue = Property.getValueOrUndefined(billboardGraphics._image, time);
                 show = defined(position) && defined(textureValue);
             }
@@ -140,10 +140,10 @@ define([
                 item.textureValue = textureValue;
             }
             billboard.position = position;
-            billboard.color = Property.getValueOrDefault(billboardGraphics._color, time, defaultColor, color);
-            billboard.eyeOffset = Property.getValueOrDefault(billboardGraphics._eyeOffset, time, defaultEyeOffset, eyeOffset);
+            billboard.color = Property.getValueOrDefault(billboardGraphics._color, time, defaultColor, colorScratch);
+            billboard.eyeOffset = Property.getValueOrDefault(billboardGraphics._eyeOffset, time, defaultEyeOffset, eyeOffsetScratch);
             billboard.heightReference = Property.getValueOrDefault(billboardGraphics._heightReference, time, defaultHeightReference);
-            billboard.pixelOffset = Property.getValueOrDefault(billboardGraphics._pixelOffset, time, defaultPixelOffset, pixelOffset);
+            billboard.pixelOffset = Property.getValueOrDefault(billboardGraphics._pixelOffset, time, defaultPixelOffset, pixelOffsetScratch);
             billboard.scale = Property.getValueOrDefault(billboardGraphics._scale, time, defaultScale);
             billboard.rotation = Property.getValueOrDefault(billboardGraphics._rotation, time, defaultRotation);
             billboard.alignedAxis = Property.getValueOrDefault(billboardGraphics._alignedAxis, time, defaultAlignedAxis);
@@ -151,14 +151,14 @@ define([
             billboard.verticalOrigin = Property.getValueOrDefault(billboardGraphics._verticalOrigin, time, defaultVerticalOrigin);
             billboard.width = Property.getValueOrUndefined(billboardGraphics._width, time);
             billboard.height = Property.getValueOrUndefined(billboardGraphics._height, time);
-            billboard.scaleByDistance = Property.getValueOrUndefined(billboardGraphics._scaleByDistance, time, scaleByDistance);
-            billboard.translucencyByDistance = Property.getValueOrUndefined(billboardGraphics._translucencyByDistance, time, translucencyByDistance);
-            billboard.pixelOffsetScaleByDistance = Property.getValueOrUndefined(billboardGraphics._pixelOffsetScaleByDistance, time, pixelOffsetScaleByDistance);
+            billboard.scaleByDistance = Property.getValueOrUndefined(billboardGraphics._scaleByDistance, time, scaleByDistanceScratch);
+            billboard.translucencyByDistance = Property.getValueOrUndefined(billboardGraphics._translucencyByDistance, time, translucencyByDistanceScratch);
+            billboard.pixelOffsetScaleByDistance = Property.getValueOrUndefined(billboardGraphics._pixelOffsetScaleByDistance, time, pixelOffsetScaleByDistanceScratch);
             billboard.sizeInMeters = Property.getValueOrDefault(billboardGraphics._sizeInMeters, time, defaultSizeInMeters);
-            billboard.distanceDisplayCondition = Property.getValueOrUndefined(billboardGraphics._distanceDisplayCondition, time, distanceDisplayCondition);
+            billboard.distanceDisplayCondition = Property.getValueOrUndefined(billboardGraphics._distanceDisplayCondition, time, distanceDisplayConditionScratch);
             billboard.disableDepthTestDistance = Property.getValueOrDefault(billboardGraphics._disableDepthTestDistance, time, defaultDisableDepthTestDistance);
 
-            var subRegion = Property.getValueOrUndefined(billboardGraphics._imageSubRegion, time, boundingRectangle);
+            var subRegion = Property.getValueOrUndefined(billboardGraphics._imageSubRegion, time, boundingRectangleScratch);
             if (defined(subRegion)) {
                 billboard.setImageSubRegion(billboard._imageId, subRegion);
             }

--- a/Source/DataSources/LabelVisualizer.js
+++ b/Source/DataSources/LabelVisualizer.js
@@ -50,17 +50,17 @@ define([
     var defaultVerticalOrigin = VerticalOrigin.CENTER;
     var defaultDisableDepthTestDistance = 0.0;
 
-    var position = new Cartesian3();
-    var fillColor = new Color();
-    var outlineColor = new Color();
-    var backgroundColor = new Color();
-    var backgroundPadding = new Cartesian2();
-    var eyeOffset = new Cartesian3();
-    var pixelOffset = new Cartesian2();
-    var translucencyByDistance = new NearFarScalar();
-    var pixelOffsetScaleByDistance = new NearFarScalar();
-    var scaleByDistance = new NearFarScalar();
-    var distanceDisplayCondition = new DistanceDisplayCondition();
+    var positionScratch = new Cartesian3();
+    var fillColorScratch = new Color();
+    var outlineColorScratch = new Color();
+    var backgroundColorScratch = new Color();
+    var backgroundPaddingScratch = new Cartesian2();
+    var eyeOffsetScratch = new Cartesian3();
+    var pixelOffsetScratch = new Cartesian2();
+    var translucencyByDistanceScratch = new NearFarScalar();
+    var pixelOffsetScaleByDistanceScratch = new NearFarScalar();
+    var scaleByDistanceScratch = new NearFarScalar();
+    var distanceDisplayConditionScratch = new DistanceDisplayCondition();
 
     function EntityData(entity) {
         this.entity = entity;
@@ -120,9 +120,9 @@ define([
             var text;
             var label = item.label;
             var show = entity.isShowing && entity.isAvailable(time) && Property.getValueOrDefault(labelGraphics._show, time, true);
-
+            var position;
             if (show) {
-                position = Property.getValueOrUndefined(entity._position, time, position);
+                position = Property.getValueOrUndefined(entity._position, time, positionScratch);
                 text = Property.getValueOrUndefined(labelGraphics._text, time);
                 show = defined(position) && defined(text);
             }
@@ -149,21 +149,21 @@ define([
             label.scale = Property.getValueOrDefault(labelGraphics._scale, time, defaultScale);
             label.font = Property.getValueOrDefault(labelGraphics._font, time, defaultFont);
             label.style = Property.getValueOrDefault(labelGraphics._style, time, defaultStyle);
-            label.fillColor = Property.getValueOrDefault(labelGraphics._fillColor, time, defaultFillColor, fillColor);
-            label.outlineColor = Property.getValueOrDefault(labelGraphics._outlineColor, time, defaultOutlineColor, outlineColor);
+            label.fillColor = Property.getValueOrDefault(labelGraphics._fillColor, time, defaultFillColor, fillColorScratch);
+            label.outlineColor = Property.getValueOrDefault(labelGraphics._outlineColor, time, defaultOutlineColor, outlineColorScratch);
             label.outlineWidth = Property.getValueOrDefault(labelGraphics._outlineWidth, time, defaultOutlineWidth);
             label.showBackground = Property.getValueOrDefault(labelGraphics._showBackground, time, defaultShowBackground);
-            label.backgroundColor = Property.getValueOrDefault(labelGraphics._backgroundColor, time, defaultBackgroundColor, backgroundColor);
-            label.backgroundPadding = Property.getValueOrDefault(labelGraphics._backgroundPadding, time, defaultBackgroundPadding, backgroundPadding);
-            label.pixelOffset = Property.getValueOrDefault(labelGraphics._pixelOffset, time, defaultPixelOffset, pixelOffset);
-            label.eyeOffset = Property.getValueOrDefault(labelGraphics._eyeOffset, time, defaultEyeOffset, eyeOffset);
+            label.backgroundColor = Property.getValueOrDefault(labelGraphics._backgroundColor, time, defaultBackgroundColor, backgroundColorScratch);
+            label.backgroundPadding = Property.getValueOrDefault(labelGraphics._backgroundPadding, time, defaultBackgroundPadding, backgroundPaddingScratch);
+            label.pixelOffset = Property.getValueOrDefault(labelGraphics._pixelOffset, time, defaultPixelOffset, pixelOffsetScratch);
+            label.eyeOffset = Property.getValueOrDefault(labelGraphics._eyeOffset, time, defaultEyeOffset, eyeOffsetScratch);
             label.heightReference = Property.getValueOrDefault(labelGraphics._heightReference, time, defaultHeightReference);
             label.horizontalOrigin = Property.getValueOrDefault(labelGraphics._horizontalOrigin, time, defaultHorizontalOrigin);
             label.verticalOrigin = Property.getValueOrDefault(labelGraphics._verticalOrigin, time, defaultVerticalOrigin);
-            label.translucencyByDistance = Property.getValueOrUndefined(labelGraphics._translucencyByDistance, time, translucencyByDistance);
-            label.pixelOffsetScaleByDistance = Property.getValueOrUndefined(labelGraphics._pixelOffsetScaleByDistance, time, pixelOffsetScaleByDistance);
-            label.scaleByDistance = Property.getValueOrUndefined(labelGraphics._scaleByDistance, time, scaleByDistance);
-            label.distanceDisplayCondition = Property.getValueOrUndefined(labelGraphics._distanceDisplayCondition, time, distanceDisplayCondition);
+            label.translucencyByDistance = Property.getValueOrUndefined(labelGraphics._translucencyByDistance, time, translucencyByDistanceScratch);
+            label.pixelOffsetScaleByDistance = Property.getValueOrUndefined(labelGraphics._pixelOffsetScaleByDistance, time, pixelOffsetScaleByDistanceScratch);
+            label.scaleByDistance = Property.getValueOrUndefined(labelGraphics._scaleByDistance, time, scaleByDistanceScratch);
+            label.distanceDisplayCondition = Property.getValueOrUndefined(labelGraphics._distanceDisplayCondition, time, distanceDisplayConditionScratch);
             label.disableDepthTestDistance = Property.getValueOrDefault(labelGraphics._disableDepthTestDistance, time, defaultDisableDepthTestDistance);
         }
         return true;

--- a/Source/DataSources/PointVisualizer.js
+++ b/Source/DataSources/PointVisualizer.js
@@ -32,12 +32,12 @@ define([
     var defaultPixelSize = 1.0;
     var defaultDisableDepthTestDistance = 0.0;
 
-    var color = new Color();
-    var position = new Cartesian3();
-    var outlineColor = new Color();
-    var scaleByDistance = new NearFarScalar();
-    var translucencyByDistance = new NearFarScalar();
-    var distanceDisplayCondition = new DistanceDisplayCondition();
+    var colorScratch = new Color();
+    var positionScratch = new Cartesian3();
+    var outlineColorScratch = new Color();
+    var scaleByDistanceScratch = new NearFarScalar();
+    var translucencyByDistanceScratch = new NearFarScalar();
+    var distanceDisplayConditionScratch = new DistanceDisplayCondition();
 
     function EntityData(entity) {
         this.entity = entity;
@@ -99,8 +99,9 @@ define([
             var billboard = item.billboard;
             var heightReference = Property.getValueOrDefault(pointGraphics._heightReference, time, HeightReference.NONE);
             var show = entity.isShowing && entity.isAvailable(time) && Property.getValueOrDefault(pointGraphics._show, time, true);
+            var position;
             if (show) {
-                position = Property.getValueOrUndefined(entity._position, time, position);
+                position = Property.getValueOrUndefined(entity._position, time, positionScratch);
                 show = defined(position);
             }
             if (!show) {
@@ -138,25 +139,25 @@ define([
             if (defined(pointPrimitive)) {
                 pointPrimitive.show = true;
                 pointPrimitive.position = position;
-                pointPrimitive.scaleByDistance = Property.getValueOrUndefined(pointGraphics._scaleByDistance, time, scaleByDistance);
-                pointPrimitive.translucencyByDistance = Property.getValueOrUndefined(pointGraphics._translucencyByDistance, time, translucencyByDistance);
-                pointPrimitive.color = Property.getValueOrDefault(pointGraphics._color, time, defaultColor, color);
-                pointPrimitive.outlineColor = Property.getValueOrDefault(pointGraphics._outlineColor, time, defaultOutlineColor, outlineColor);
+                pointPrimitive.scaleByDistance = Property.getValueOrUndefined(pointGraphics._scaleByDistance, time, scaleByDistanceScratch);
+                pointPrimitive.translucencyByDistance = Property.getValueOrUndefined(pointGraphics._translucencyByDistance, time, translucencyByDistanceScratch);
+                pointPrimitive.color = Property.getValueOrDefault(pointGraphics._color, time, defaultColor, colorScratch);
+                pointPrimitive.outlineColor = Property.getValueOrDefault(pointGraphics._outlineColor, time, defaultOutlineColor, outlineColorScratch);
                 pointPrimitive.outlineWidth = Property.getValueOrDefault(pointGraphics._outlineWidth, time, defaultOutlineWidth);
                 pointPrimitive.pixelSize = Property.getValueOrDefault(pointGraphics._pixelSize, time, defaultPixelSize);
-                pointPrimitive.distanceDisplayCondition = Property.getValueOrUndefined(pointGraphics._distanceDisplayCondition, time, distanceDisplayCondition);
+                pointPrimitive.distanceDisplayCondition = Property.getValueOrUndefined(pointGraphics._distanceDisplayCondition, time, distanceDisplayConditionScratch);
                 pointPrimitive.disableDepthTestDistance = Property.getValueOrDefault(pointGraphics._disableDepthTestDistance, time, defaultDisableDepthTestDistance);
             } else if (defined(billboard)) {
                 billboard.show = true;
                 billboard.position = position;
-                billboard.scaleByDistance = Property.getValueOrUndefined(pointGraphics._scaleByDistance, time, scaleByDistance);
-                billboard.translucencyByDistance = Property.getValueOrUndefined(pointGraphics._translucencyByDistance, time, translucencyByDistance);
-                billboard.distanceDisplayCondition = Property.getValueOrUndefined(pointGraphics._distanceDisplayCondition, time, distanceDisplayCondition);
+                billboard.scaleByDistance = Property.getValueOrUndefined(pointGraphics._scaleByDistance, time, scaleByDistanceScratch);
+                billboard.translucencyByDistance = Property.getValueOrUndefined(pointGraphics._translucencyByDistance, time, translucencyByDistanceScratch);
+                billboard.distanceDisplayCondition = Property.getValueOrUndefined(pointGraphics._distanceDisplayCondition, time, distanceDisplayConditionScratch);
                 billboard.disableDepthTestDistance = Property.getValueOrDefault(pointGraphics._disableDepthTestDistance, time, defaultDisableDepthTestDistance);
                 billboard.heightReference = heightReference;
 
-                var newColor = Property.getValueOrDefault(pointGraphics._color, time, defaultColor, color);
-                var newOutlineColor = Property.getValueOrDefault(pointGraphics._outlineColor, time, defaultOutlineColor, outlineColor);
+                var newColor = Property.getValueOrDefault(pointGraphics._color, time, defaultColor, colorScratch);
+                var newOutlineColor = Property.getValueOrDefault(pointGraphics._outlineColor, time, defaultOutlineColor, outlineColorScratch);
                 var newOutlineWidth = Math.round(Property.getValueOrDefault(pointGraphics._outlineWidth, time, defaultOutlineWidth));
                 var newPixelSize = Math.max(1, Math.round(Property.getValueOrDefault(pointGraphics._pixelSize, time, defaultPixelSize)));
 


### PR DESCRIPTION
Fixes #6813

The example provided in #6813 was using a `CallbackProperty` for `position` and not using the `result` parameter.  We were then overwriting the class scoped `position` scratch variable with the position returned from the `CallbackProperty`. `BillboardVisualizer`, `LabelVisualizer` and `PointVisualizer` all had this problem.  None of the other visualizers did.

I changed the `position` variable to be in the function scope, and renamed all of the scratch variables to `xxxScratch` to avoid this kind of problem in the future.

I had no idea how to add a unit tests for this, but I think this kind of fix is unlikely to break again so I think it's okay without a new unit test.