### PR TITLE
Compute polygon centroid instead of average of positions

### DIFF
--- a/Source/DataSources/PolygonGeometryUpdater.js
+++ b/Source/DataSources/PolygonGeometryUpdater.js
@@ -243,7 +243,7 @@ define([
             area += f;
         }
 
-        var a = 1 / (area * 6);
+        var a = 1 / (area * 3);
         centroid2D = Cartesian2.multiplyByScalar(centroid2D, a, centroid2D);
         return tangentPlane.projectPointOntoEllipsoid(centroid2D, result);
     };

--- a/Source/DataSources/PolygonGeometryUpdater.js
+++ b/Source/DataSources/PolygonGeometryUpdater.js
@@ -243,7 +243,7 @@ define([
             area += f;
         }
 
-        var a = 1 / (area * 3);
+        var a = 1.0 / (area * 3.0);
         centroid2D = Cartesian2.multiplyByScalar(centroid2D, a, centroid2D);
         return tangentPlane.projectPointOntoEllipsoid(centroid2D, result);
     };

--- a/Specs/Core/EllipsoidTangentPlaneSpec.js
+++ b/Specs/Core/EllipsoidTangentPlaneSpec.js
@@ -11,7 +11,7 @@ defineSuite([
     'use strict';
 
     it('constructor defaults to WGS84', function() {
-        var origin = new Cartesian3(Ellipsoid.WGS84.radii.x, 0, 0);
+        var origin = new Cartesian3(Ellipsoid.WGS84.radii.x, 0.0, 0.0);
         var tangentPlane = new EllipsoidTangentPlane(origin);
         expect(tangentPlane.ellipsoid).toBe(Ellipsoid.WGS84);
         expect(tangentPlane.origin).toEqual(origin);
@@ -24,7 +24,7 @@ defineSuite([
     });
 
     it('fromPoints sets expected values', function() {
-        var points = [new Cartesian3(2, 0, 0), new Cartesian3(0, 0, 0)];
+            var points = [new Cartesian3(2.0, 0.0, 0.0), new Cartesian3(0.0, 0.0, 0.0)];
         var tangentPlane = EllipsoidTangentPlane.fromPoints(points, Ellipsoid.UNIT_SPHERE);
         expect(tangentPlane.ellipsoid).toBe(Ellipsoid.UNIT_SPHERE);
         expect(tangentPlane.origin).toEqual(Cartesian3.UNIT_X);
@@ -32,31 +32,31 @@ defineSuite([
 
     it('projectPointOntoPlane returns undefined for unsolvable projections', function () {
         var ellipsoid = Ellipsoid.UNIT_SPHERE;
-        var origin = new Cartesian3(1, 0, 0);
+        var origin = new Cartesian3(1.0, 0.0, 0.0);
         var tangentPlane = new EllipsoidTangentPlane(origin, ellipsoid);
-        var positions = new Cartesian3(0, 0, 1);
+        var positions = new Cartesian3(0.0, 0.0, 1.0);
         var returnedResult = tangentPlane.projectPointOntoPlane(positions);
         expect(returnedResult).toBeUndefined();
     });
 
     it('projectPointOntoPlane works without a result parameter', function () {
         var ellipsoid = Ellipsoid.UNIT_SPHERE;
-        var origin = new Cartesian3(1, 0, 0);
+        var origin = new Cartesian3(1.0, 0.0, 0.0);
         var tangentPlane = new EllipsoidTangentPlane(origin, ellipsoid);
 
-        var positions = new Cartesian3(1, 0, 1);
-        var expectedResult = new Cartesian2(0, 1);
+        var positions = new Cartesian3(1.0, 0.0, 1.0);
+        var expectedResult = new Cartesian2(0.0, 1.0);
         var returnedResult = tangentPlane.projectPointOntoPlane(positions);
         expect(returnedResult).toEqual(expectedResult);
     });
 
     it('projectPointOntoPlane works with a result parameter', function () {
         var ellipsoid = Ellipsoid.UNIT_SPHERE;
-        var origin = new Cartesian3(1, 0, 0);
+        var origin = new Cartesian3(1.0, 0.0, 0.0);
         var tangentPlane = new EllipsoidTangentPlane(origin, ellipsoid);
 
-        var positions = new Cartesian3(1, 0, 1);
-        var expectedResult = new Cartesian2(0, 1);
+        var positions = new Cartesian3(1.0, 0.0, 1.0);
+        var expectedResult = new Cartesian2(0.0, 1.0);
         var result = new Cartesian2();
         var returnedResult = tangentPlane.projectPointOntoPlane(positions, result);
         expect(result).toBe(returnedResult);
@@ -65,22 +65,22 @@ defineSuite([
 
     it('projectPointsOntoPlane works without a result parameter', function () {
         var ellipsoid = Ellipsoid.UNIT_SPHERE;
-        var origin = new Cartesian3(1, 0, 0);
+        var origin = new Cartesian3(1.0, 0.0, 0.0);
         var tangentPlane = new EllipsoidTangentPlane(origin, ellipsoid);
 
-        var positions = [new Cartesian3(1, 0, 1), new Cartesian3(1, 0, 0), new Cartesian3(1, 1, 0)];
-        var expectedResults = [new Cartesian2(0, 1), new Cartesian2(0, 0), new Cartesian2(1, 0)];
+        var positions = [new Cartesian3(1.0, 0.0, 1.0), new Cartesian3(1.0, 0.0, 0.0), new Cartesian3(1.0, 1.0, 0.0)];
+        var expectedResults = [new Cartesian2(0.0, 1.0), new Cartesian2(0.0, 0.0), new Cartesian2(1.0, 0.0)];
         var returnedResults = tangentPlane.projectPointsOntoPlane(positions);
         expect(returnedResults).toEqual(expectedResults);
     });
 
     it('projectPointsOntoPlane works with a result parameter', function () {
         var ellipsoid = Ellipsoid.UNIT_SPHERE;
-        var origin = new Cartesian3(1, 0, 0);
+        var origin = new Cartesian3(1.0, 0.0, 0.0);
         var tangentPlane = new EllipsoidTangentPlane(origin, ellipsoid);
 
-        var positions = [new Cartesian3(1, 0, 1), new Cartesian3(1, 0, 0), new Cartesian3(1, 1, 0)];
-        var expectedResults = [new Cartesian2(0, 1), new Cartesian2(0, 0), new Cartesian2(1, 0)];
+        var positions = [new Cartesian3(1.0, 0.0, 1.0), new Cartesian3(1.0, 0.0, 0.0), new Cartesian3(1.0, 1.0, 0.0)];
+        var expectedResults = [new Cartesian2(0.0, 1.0), new Cartesian2(0.0, 0.0), new Cartesian2(1.0, 0.0)];
 
         var index0 = new Cartesian2();
         var result = [index0];
@@ -92,33 +92,33 @@ defineSuite([
 
     it('projectPointsOntoPlane works when some points cannot be projected', function () {
         var ellipsoid = Ellipsoid.UNIT_SPHERE;
-        var origin = new Cartesian3(1, 0, 0);
+        var origin = new Cartesian3(1.0, 0.0, 0.0);
         var tangentPlane = new EllipsoidTangentPlane(origin, ellipsoid);
 
-        var positions = [new Cartesian3(1, 0, 1), new Cartesian3(1, 0, 0), new Cartesian3(0, 0, 1), new Cartesian3(1, 1, 0), new Cartesian3(0, 1, 0)];
-        var expectedResults = [new Cartesian2(0, 1), new Cartesian2(0, 0), new Cartesian2(1, 0)];
+        var positions = [new Cartesian3(1.0, 0.0, 1.0), new Cartesian3(1.0, 0.0, 0.0), new Cartesian3(0.0, 0.0, 1.0), new Cartesian3(1.0, 1.0, 0.0), new Cartesian3(0.0, 1.0, 0.0)];
+        var expectedResults = [new Cartesian2(0.0, 1.0), new Cartesian2(0.0, 0.0), new Cartesian2(1.0, 0.0)];
         var returnedResults = tangentPlane.projectPointsOntoPlane(positions);
         expect(returnedResults).toEqual(expectedResults);
     });
 
     it('projectPointOntoEllipsoid works without a result parameter', function () {
         var ellipsoid = Ellipsoid.UNIT_SPHERE;
-        var origin = new Cartesian3(1, 0, 0);
+        var origin = new Cartesian3(1.0, 0.0, 0.0);
         var tangentPlane = new EllipsoidTangentPlane(origin, ellipsoid);
 
-        var position = new Cartesian3(2, 2, 0);
-        var expectedResult = new Cartesian3(1/3, 2/3,  2/3);
+        var position = new Cartesian3(2.0, 2.0, 0.0);
+        var expectedResult = new Cartesian3(1.0/3.0, 2.0/3.0,  2.0/3.0);
         var returnedResult = tangentPlane.projectPointOntoEllipsoid(position);
         expect(returnedResult).toEqual(expectedResult);
     });
 
     it('projectPointOntoEllipsoid works with a result parameter', function () {
         var ellipsoid = Ellipsoid.UNIT_SPHERE;
-        var origin = new Cartesian3(1, 0, 0);
+        var origin = new Cartesian3(1.0, 0.0, 0.0);
         var tangentPlane = new EllipsoidTangentPlane(origin, ellipsoid);
 
-        var position = new Cartesian3(2, -2, 0);
-        var expectedResult = new Cartesian3(1/3, 2/3, -2/3);
+        var position = new Cartesian3(2.0, -2.0, 0.0);
+        var expectedResult = new Cartesian3(1.0/3.0, 2.0/3.0, -2.0/3.0);
         var result = new Cartesian3();
         var returnedResult = tangentPlane.projectPointOntoEllipsoid(position, result);
         expect(result).toBe(returnedResult);
@@ -127,22 +127,22 @@ defineSuite([
 
     it('projectPointsOntoEllipsoid works without a result parameter', function () {
         var ellipsoid = Ellipsoid.UNIT_SPHERE;
-        var origin = new Cartesian3(1, 0, 0);
+        var origin = new Cartesian3(1.0, 0.0, 0.0);
         var tangentPlane = new EllipsoidTangentPlane(origin, ellipsoid);
 
-        var positions = [new Cartesian3(2, -2, 0), new Cartesian3(2, 2, 0)];
-        var expectedResults = [new Cartesian3(1/3, 2/3, -2/3), new Cartesian3(1/3, 2/3,  2/3)];
+        var positions = [new Cartesian3(2.0, -2.0, 0.0), new Cartesian3(2.0, 2.0, 0.0)];
+        var expectedResults = [new Cartesian3(1.0/3.0, 2.0/3.0, -2.0/3.0), new Cartesian3(1.0/3.0, 2.0/3.0,  2.0/3.0)];
         var returnedResults = tangentPlane.projectPointsOntoEllipsoid(positions);
         expect(returnedResults).toEqual(expectedResults);
     });
 
     it('projectPointsOntoEllipsoid works with a result parameter', function () {
         var ellipsoid = Ellipsoid.UNIT_SPHERE;
-        var origin = new Cartesian3(1, 0, 0);
+        var origin = new Cartesian3(1.0, 0.0, 0.0);
         var tangentPlane = new EllipsoidTangentPlane(origin, ellipsoid);
 
-        var positions = [new Cartesian3(2, -2, 0), new Cartesian3(2, 2, 0)];
-        var expectedResults = [new Cartesian3(1/3, 2/3, -2/3), new Cartesian3(1/3, 2/3,  2/3)];
+        var positions = [new Cartesian3(2.0, -2.0, 0.0), new Cartesian3(2.0, 2.0, 0.0)];
+        var expectedResults = [new Cartesian3(1.0/3.0, 2.0/3.0, -2.0/3.0), new Cartesian3(1.0/3.0, 2.0/3.0,  2.0/3.0)];
         var index0 = new Cartesian3();
         var result = [index0];
         var returnedResults = tangentPlane.projectPointsOntoEllipsoid(positions, result);
@@ -153,33 +153,33 @@ defineSuite([
 
     it('projectPointToNearestOnPlane works without a result parameter', function () {
         var ellipsoid = Ellipsoid.UNIT_SPHERE;
-        var origin = new Cartesian3(1, 0, 0);
+        var origin = new Cartesian3(1.0, 0.0, 0.0);
         var tangentPlane = new EllipsoidTangentPlane(origin, ellipsoid);
 
-        var positions = new Cartesian3(1, 0, 1);
-        var expectedResult = new Cartesian2(0, 1);
+        var positions = new Cartesian3(1.0, 0.0, 1.0);
+        var expectedResult = new Cartesian2(0.0, 1.0);
         var returnedResult = tangentPlane.projectPointToNearestOnPlane(positions);
         expect(returnedResult).toEqual(expectedResult);
     });
 
     it('projectPointToNearestOnPlane works projecting from various distances', function () {
         var ellipsoid = Ellipsoid.ZERO;
-        var origin = new Cartesian3(1, 0, 0);
+        var origin = new Cartesian3(1.0, 0.0, 0.0);
         var tangentPlane = new EllipsoidTangentPlane(origin, ellipsoid);
 
-        expect(tangentPlane.projectPointToNearestOnPlane(new Cartesian3(2, 0, 0))).toEqual(new Cartesian2(0, 0));
-        expect(tangentPlane.projectPointToNearestOnPlane(new Cartesian3(1, 0, 0))).toEqual(new Cartesian2(0, 0));
-        expect(tangentPlane.projectPointToNearestOnPlane(new Cartesian3(0, 0, 0))).toEqual(new Cartesian2(0, 0));
-        expect(tangentPlane.projectPointToNearestOnPlane(new Cartesian3(-1, 0, 0))).toEqual(new Cartesian2(0, 0));
+        expect(tangentPlane.projectPointToNearestOnPlane(new Cartesian3(2.0, 0.0, 0.0))).toEqual(new Cartesian2(0.0, 0.0));
+        expect(tangentPlane.projectPointToNearestOnPlane(new Cartesian3(1.0, 0.0, 0.0))).toEqual(new Cartesian2(0.0, 0.0));
+        expect(tangentPlane.projectPointToNearestOnPlane(new Cartesian3(0.0, 0.0, 0.0))).toEqual(new Cartesian2(0.0, 0.0));
+        expect(tangentPlane.projectPointToNearestOnPlane(new Cartesian3(-1.0, 0.0, 0.0))).toEqual(new Cartesian2(0.0, 0.0));
     });
 
     it('projectPointToNearestOnPlane works with a result parameter', function () {
         var ellipsoid = Ellipsoid.UNIT_SPHERE;
-        var origin = new Cartesian3(1, 0, 0);
+        var origin = new Cartesian3(1.0, 0.0, 0.0);
         var tangentPlane = new EllipsoidTangentPlane(origin, ellipsoid);
 
-        var positions = new Cartesian3(1, 0, 1);
-        var expectedResult = new Cartesian2(0, 1);
+        var positions = new Cartesian3(1.0, 0.0, 1.0);
+        var expectedResult = new Cartesian2(0.0, 1.0);
         var result = new Cartesian2();
         var returnedResult = tangentPlane.projectPointToNearestOnPlane(positions, result);
         expect(result).toBe(returnedResult);
@@ -188,22 +188,22 @@ defineSuite([
 
     it('projectPointsToNearestOnPlane works without a result parameter', function () {
         var ellipsoid = Ellipsoid.UNIT_SPHERE;
-        var origin = new Cartesian3(1, 0, 0);
+        var origin = new Cartesian3(1.0, 0.0, 0.0);
         var tangentPlane = new EllipsoidTangentPlane(origin, ellipsoid);
 
-        var positions = [new Cartesian3(1, 0, 1), new Cartesian3(1, 0, 0), new Cartesian3(1, 1, 0)];
-        var expectedResults = [new Cartesian2(0, 1), new Cartesian2(0, 0), new Cartesian2(1, 0)];
+        var positions = [new Cartesian3(1.0, 0.0, 1.0), new Cartesian3(1.0, 0.0, 0.0), new Cartesian3(1.0, 1.0, 0.0)];
+        var expectedResults = [new Cartesian2(0.0, 1.0), new Cartesian2(0.0, 0.0), new Cartesian2(1.0, 0.0)];
         var returnedResults = tangentPlane.projectPointsToNearestOnPlane(positions);
         expect(returnedResults).toEqual(expectedResults);
     });
 
     it('projectPointsToNearestOnPlane works with a result parameter', function () {
         var ellipsoid = Ellipsoid.UNIT_SPHERE;
-        var origin = new Cartesian3(1, 0, 0);
+        var origin = new Cartesian3(1.0, 0.0, 0.0);
         var tangentPlane = new EllipsoidTangentPlane(origin, ellipsoid);
 
-        var positions = [new Cartesian3(1, 0, 1), new Cartesian3(1, 0, 0), new Cartesian3(1, 1, 0)];
-        var expectedResults = [new Cartesian2(0, 1), new Cartesian2(0, 0), new Cartesian2(1, 0)];
+        var positions = [new Cartesian3(1.0, 0.0, 1.0), new Cartesian3(1.0, 0.0, 0.0), new Cartesian3(1.0, 1.0, 0.0)];
+        var expectedResults = [new Cartesian2(0.0, 1.0), new Cartesian2(0.0, 0.0), new Cartesian2(1.0, 0.0)];
 
         var index0 = new Cartesian2();
         var result = [index0];

--- a/Specs/Core/EllipsoidTangentPlaneSpec.js
+++ b/Specs/Core/EllipsoidTangentPlaneSpec.js
@@ -101,6 +101,30 @@ defineSuite([
         expect(returnedResults).toEqual(expectedResults);
     });
 
+    it('projectPointOntoEllipsoid works without a result parameter', function () {
+        var ellipsoid = Ellipsoid.UNIT_SPHERE;
+        var origin = new Cartesian3(1, 0, 0);
+        var tangentPlane = new EllipsoidTangentPlane(origin, ellipsoid);
+
+        var position = new Cartesian3(2, 2, 0);
+        var expectedResult = new Cartesian3(1/3, 2/3,  2/3);
+        var returnedResult = tangentPlane.projectPointOntoEllipsoid(position);
+        expect(returnedResult).toEqual(expectedResult);
+    });
+
+    it('projectPointOntoEllipsoid works with a result parameter', function () {
+        var ellipsoid = Ellipsoid.UNIT_SPHERE;
+        var origin = new Cartesian3(1, 0, 0);
+        var tangentPlane = new EllipsoidTangentPlane(origin, ellipsoid);
+
+        var position = new Cartesian3(2, -2, 0);
+        var expectedResult = new Cartesian3(1/3, 2/3, -2/3);
+        var result = new Cartesian3();
+        var returnedResult = tangentPlane.projectPointOntoEllipsoid(position, result);
+        expect(result).toBe(returnedResult);
+        expect(returnedResult).toEqual(expectedResult);
+    });
+
     it('projectPointsOntoEllipsoid works without a result parameter', function () {
         var ellipsoid = Ellipsoid.UNIT_SPHERE;
         var origin = new Cartesian3(1, 0, 0);


### PR DESCRIPTION
For `PolygonGeometryUpdater._computeCenter` we were doing a fast approximation of the center by averaging the positions, but it was requested that we compute the true polygon centroid instead.

I also added `EllipsoidTangentPlane.projectPointOntoEllipsoid`.  We already had `projectPointsOntoEllipsoid` but I wanted to only project a single point.