### PR TITLE
Fix clamping when switching terrain providers

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,6 +23,7 @@ Change Log
 * Fixed an issue where glTF 2.0 models sometimes wouldn't be centered in the view after putting the camera on them. [#6784](https://github.com/AnalyticalGraphicsInc/cesium/issues/6784)
 * Fixed a bug that caused eye dome lighting for point clouds to fail in Safari on macOS and Edge on Windows by removing the dependency on floating point color textures. [#6792](https://github.com/AnalyticalGraphicsInc/cesium/issues/6792)
 * Fixed a bug that caused polylines on terrain to render incorrectly in 2D and Columbus View with a `WebMercatorProjection`. [#6809](https://github.com/AnalyticalGraphicsInc/cesium/issues/6809)
+* Fixed bug where entities with a height reference weren't being updated correctly when the terrain provider was chagned. [#6820](https://github.com/AnalyticalGraphicsInc/cesium/pull/6820)
 
 ### 1.47 - 2018-07-02
 

--- a/Source/Scene/QuadtreePrimitive.js
+++ b/Source/Scene/QuadtreePrimitive.js
@@ -833,9 +833,8 @@ define([
                     var position = tile.data.pick(scratchRay, mode, projection, false, scratchPosition);
                     if (defined(position)) {
                         data.callback(position);
+                        data.level = tile.level;
                     }
-
-                    data.level = tile.level;
                 } else if (tile.level === data.level) {
                     var children = tile.children;
                     var childrenLength = children.length;


### PR DESCRIPTION
Fixes #6818

If the tile wasn't loaded yet `tile.data.pick` would return `undefined` and `data.callback` wasn't called.  However, we were still setting `data.level` to the new tile level so on the next frame this whole block was skipped because it thinks it was already called for this LOD.  Moving `data.level = tile.level` into the block where `data.callback` is called assures that `data.level` matches the level the callback was called for.