### PR TITLE
Use promises for requestTileGeometry

### DIFF
--- a/Source/Core/EllipsoidTerrainProvider.js
+++ b/Source/Core/EllipsoidTerrainProvider.js
@@ -160,11 +160,11 @@ define([
     EllipsoidTerrainProvider.prototype.requestTileGeometry = function(x, y, level, request) {
         var width = 16;
         var height = 16;
-        return new HeightmapTerrainData({
+        return when.resolve(new HeightmapTerrainData({
             buffer : new Uint8Array(width * height),
             width : width,
             height : height
-        });
+        }));
     };
 
     /**

--- a/Source/Core/GoogleEarthEnterpriseTerrainProvider.js
+++ b/Source/Core/GoogleEarthEnterpriseTerrainProvider.js
@@ -374,13 +374,13 @@ define([
         var buffer = terrainCache.get(quadKey);
         if (defined(buffer)) {
             var credit = metadata.providers[info.terrainProvider];
-            return new GoogleEarthEnterpriseTerrainData({
+            return when.resolve(new GoogleEarthEnterpriseTerrainData({
                 buffer : buffer,
                 childTileMask : computeChildMask(quadKey, info, metadata),
                 credits : defined(credit) ? [credit] : undefined,
                 negativeAltitudeExponentBias: metadata.negativeAltitudeExponentBias,
                 negativeElevationThreshold: metadata.negativeAltitudeThreshold
-            });
+            }));
         }
 
         // Clean up the cache
@@ -389,11 +389,11 @@ define([
         // We have a tile, check to see if no ancestors have terrain or that we know for sure it doesn't
         if (!info.ancestorHasTerrain) {
             // We haven't reached a level with terrain, so return the ellipsoid
-            return new HeightmapTerrainData({
+            return when.resovle(new HeightmapTerrainData({
                 buffer : new Uint8Array(16 * 16),
                 width : 16,
                 height : 16
-            });
+            }));
         } else if (terrainState === TerrainState.NONE) {
             // Already have info and there isn't any terrain here
             return when.reject(new RuntimeError('Terrain tile doesn\'t exist'));

--- a/Source/Core/VRTheWorldTerrainProvider.js
+++ b/Source/Core/VRTheWorldTerrainProvider.js
@@ -78,15 +78,15 @@ define([
         this._readyPromise = when.defer();
 
         this._terrainDataStructure = {
-                heightScale : 1.0 / 1000.0,
-                heightOffset : -1000.0,
-                elementsPerHeight : 3,
-                stride : 4,
-                elementMultiplier : 256.0,
-                isBigEndian : true,
-                lowestEncodedHeight : 0,
-                highestEncodedHeight : 256 * 256 * 256 - 1
-            };
+            heightScale : 1.0 / 1000.0,
+            heightOffset : -1000.0,
+            elementsPerHeight : 3,
+            stride : 4,
+            elementMultiplier : 256.0,
+            isBigEndian : true,
+            lowestEncodedHeight : 0,
+            highestEncodedHeight : 256 * 256 * 256 - 1
+        };
 
         var credit = options.credit;
         if (typeof credit === 'string') {
@@ -104,7 +104,7 @@ define([
         function metadataSuccess(xml) {
             var srs = xml.getElementsByTagName('SRS')[0].textContent;
             if (srs === 'EPSG:4326') {
-                that._tilingScheme = new GeographicTilingScheme({ ellipsoid : ellipsoid });
+                that._tilingScheme = new GeographicTilingScheme({ellipsoid : ellipsoid});
             } else {
                 metadataFailure('SRS ' + srs + ' is not supported.');
                 return;
@@ -261,11 +261,11 @@ define([
 
         var yTiles = this._tilingScheme.getNumberOfYTilesAtLevel(level);
         var resource = this._resource.getDerivedResource({
-            url: level + '/' + x + '/' + (yTiles - y - 1) + '.tif',
-            queryParameters: {
-                cesium: true
+            url : level + '/' + x + '/' + (yTiles - y - 1) + '.tif',
+            queryParameters : {
+                cesium : true
             },
-            request: request
+            request : request
         });
         var promise = resource.fetchImage();
         if (!defined(promise)) {
@@ -273,15 +273,16 @@ define([
         }
 
         var that = this;
-        return when(promise, function(image) {
-            return new HeightmapTerrainData({
-                buffer : getImagePixels(image),
-                width : that._heightmapWidth,
-                height : that._heightmapHeight,
-                childTileMask : getChildMask(that, x, y, level),
-                structure : that._terrainDataStructure
+        return when(promise)
+            .then(function(image) {
+                return new HeightmapTerrainData({
+                    buffer : getImagePixels(image),
+                    width : that._heightmapWidth,
+                    height : that._heightmapHeight,
+                    childTileMask : getChildMask(that, x, y, level),
+                    structure : that._terrainDataStructure
+                });
             });
-        });
     };
 
     /**


### PR DESCRIPTION
Fixes #6823

The interface for `TerrainProvider` says that `requestTileGeometry` should return either a `Promise` or `undefined`.