### PR TITLE
ESLint updates

### DIFF
--- a/Source/Core/buildModuleUrl.js
+++ b/Source/Core/buildModuleUrl.js
@@ -37,7 +37,9 @@ define([
             a = document.createElement('a');
         }
         a.href = url;
-        a.href = a.href; // IE only absolutizes href on get, not set
+
+        // IE only absolutizes href on get, not set
+        a.href = a.href; // eslint-disable-line no-self-assign
         return a.href;
     }
 

--- a/Source/Core/isCrossOriginUrl.js
+++ b/Source/Core/isCrossOriginUrl.js
@@ -25,7 +25,8 @@ define([
         var protocol = a.protocol;
 
         a.href = url;
-        a.href = a.href; // IE only absolutizes href on get, not set
+        // IE only absolutizes href on get, not set
+        a.href = a.href; // eslint-disable-line no-self-assign
 
         return protocol !== a.protocol || host !== a.host;
     }

--- a/Source/Widgets/Cesium3DTilesInspector/Cesium3DTilesInspectorViewModel.js
+++ b/Source/Widgets/Cesium3DTilesInspector/Cesium3DTilesInspectorViewModel.js
@@ -50,7 +50,7 @@ define([
             viewModel._eventHandler.removeInputAction(ScreenSpaceEventType.MOUSE_MOVE);
 
             // Restore hover-over selection to its current value
-            viewModel.picking = viewModel.picking;
+            viewModel.picking = viewModel.picking; // eslint-disable-line no-self-assign
         }
     }
 
@@ -998,7 +998,7 @@ define([
         var loadSiblings = knockout.observable();
         knockout.defineProperty(this, 'loadSiblings', {
             get : function() {
-                loadSiblings();
+                return loadSiblings();
             },
             set : function(value) {
                 loadSiblings(value);

--- a/Specs/.eslintrc.json
+++ b/Specs/.eslintrc.json
@@ -7,6 +7,7 @@
         "defineSuite": true
     },
     "rules": {
-        "quotes": "off"
+        "quotes": "off",
+        "no-self-assign": "off"
     }
 }

--- a/Tools/eslint-config-cesium/CHANGES.md
+++ b/Tools/eslint-config-cesium/CHANGES.md
@@ -1,6 +1,12 @@
 Change Log
 ==========
 
+### 6.0.0 - 2018-05-01
+* Upgrade to eslint 5.x and it's new default rules.
+* Set ecmaVersion to 2017 for Node.js code.
+* Enable [no-var](https://eslint.org/docs/rules/no-var) in Node.js code.
+* Enable [prefer-const](https://eslint.org/docs/rules/prefer-const) in Node.js code.
+
 ### 5.0.0 - 2018-05-01
 * Enable [eol-last](https://eslint.org/docs/rules/eol-last).
 

--- a/Tools/eslint-config-cesium/node.js
+++ b/Tools/eslint-config-cesium/node.js
@@ -6,11 +6,13 @@ module.exports = {
         node: true
     },
     parserOptions: {
-        ecmaVersion: 6
+        ecmaVersion: 2017
     },
     rules: {
-        'global-require' : 'error',
-        'no-buffer-constructor' : 'error',
-        'no-new-require' : 'error'
+        'global-require': 'error',
+        'no-buffer-constructor': 'error',
+        'no-new-require': 'error',
+        'no-var': 'error',
+        'prefer-const': 'error'
     }
 };

--- a/Tools/eslint-config-cesium/package.json
+++ b/Tools/eslint-config-cesium/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-cesium",
-  "version": "5.0.0",
+  "version": "6.0.0",
   "description": "ESLint shareable configs for Cesium",
   "homepage": "http://cesiumjs.org",
   "license": "Apache-2.0",
@@ -19,6 +19,6 @@
     "cesium"
   ],
   "peerDependencies": {
-    "eslint": ">= 4"
+    "eslint": ">= 5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "compressible": "^2.0.9",
     "compression": "^1.6.2",
     "electron": "^1.6.1",
-    "eslint": "^4.0.0",
+    "eslint": "^5.2.0",
     "eslint-plugin-html": "^4.0.2",
     "event-stream": "^3.3.4",
     "express": "^4.15.0",


### PR DESCRIPTION
1. Update to eslint 5.2.0, which has some new default rules.
2. Disable `no-self-assign` in Cesium tests, this new rule is useful but not in our specs.
3. Allow ES 2017 in node code, this includes async/await, which we have started using in Cesium-related Node projects
4. Add `no-var` and `prefer-const` as rules for Node code, we've already have been using them with success in other projects.
5. Bump eslint-config-cesium to 6.0.0 and update CHANGES so I can release once this is merged.