### PR TITLE
Fix PostProcessStageLibrary and Collection typos

### DIFF
--- a/Apps/Sandcastle/gallery/LensFlare.html
+++ b/Apps/Sandcastle/gallery/LensFlare.html
@@ -69,7 +69,7 @@ for (var name in viewModel) {
     }
 }
 
-var lensFlare = viewer.scene.postProcessStages.add(Cesium.PostProcessStageLibrary.createLensFlarStage());
+var lensFlare = viewer.scene.postProcessStages.add(Cesium.PostProcessStageLibrary.createLensFlareStage());
 
 function updatePostProcess() {
     lensFlare.enabled = Boolean(viewModel.show);

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@ Change Log
 ##### Deprecated :hourglass_flowing_sand:
 * Support for 3D Tiles `content.url` is deprecated to reflect updates to the [3D Tiles spec](https://github.com/AnalyticalGraphicsInc/3d-tiles/pull/301). Use `content.uri instead`. Support for `content.url` will remain for backwards compatibility. [#6744](https://github.com/AnalyticalGraphicsInc/cesium/pull/6744)
 * Support for the 3D Tiles pre-version 1.0 Batch Table Hierarchy is deprecated to reflect updates to the [3D Tiles spec](https://github.com/AnalyticalGraphicsInc/3d-tiles/pull/301). Use the [`3DTILES_batch_table_hierarchy`](https://github.com/AnalyticalGraphicsInc/3d-tiles/tree/1.0/extensions/3DTILES_batch_table_hierarchy) extension instead. Support for the deprecated batch table hierarchy will remain for backwards compatibility. [#6780](https://github.com/AnalyticalGraphicsInc/cesium/pull/6780)
+* `PostProcessStageLibrary.createLensFlarStage` is deprecated due to misspelling and will be removed in Cesium 1.49. Use `PostProcessStageLibrary.createLensFlareStage` instead.
 
 #### Fixes :wrench:
 * Fixed bug causing billboards and labels to appear the wrong size when switching scene modes [#6745](https://github.com/AnalyticalGraphicsInc/cesium/issues/6745)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -97,6 +97,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to Cesiu
 * [virtualcitySYSTEMS GmbH](https://www.virtualcitysystems.de)
    * [Jannes Bolling](https://github.com/jbo023)
    * [Arne Schilling](https://github.com/arneschilling)
+   * [Ben Kuster](https://github.com/bkuster)
 * [Logilab](https://www.logilab.fr/)
    * [Florent Cayré](https://github.com/fcayre/)
 * [webiks](https://www.webiks.com)

--- a/Source/Scene/PostProcessStageCollection.js
+++ b/Source/Scene/PostProcessStageCollection.js
@@ -160,7 +160,7 @@ define([
          * <p>
          * The uniforms have the following properties: <code>intensity</code>, <code>bias</code>, <code>lengthCap</code>,
          * <code>stepSize</code>, <code>frustumLength</code>, <code>ambientOcclusionOnly</code>,
-         * <code>delta</code>, <code>sigma</code>, and <code>kernelSize</code>.
+         * <code>delta</code>, <code>sigma</code>, and <code>blurStepSize</code>.
          * </p>
          * <ul>
          * <li><code>intensity</code> is a scalar value used to lighten or darken the shadows exponentially. Higher values make the shadows darker. The default value is <code>3.0</code>.</li>
@@ -180,7 +180,7 @@ define([
          * with the ambient occlusion. This is a useful debug option for seeing the effects of changing the uniform values. The default value is <code>false</code>.</li>
          * </ul>
          * <p>
-         * <code>delta</code>, <code>sigma</code>, and <code>kernelSize</code> are the same properties as {@link PostProcessStageLibrary#createBlurStage}.
+         * <code>delta</code>, <code>sigma</code>, and <code>blurStepSize</code> are the same properties as {@link PostProcessStageLibrary#createBlurStage}.
          * The blur is applied to the shadows generated from the image to make them smoother.
          * </p>
          * <p>
@@ -203,7 +203,7 @@ define([
          * </p>
          * <p>
          * This stage has the following uniforms: <code>contrast</code>, <code>brightness</code>, <code>glowOnly</code>,
-         * <code>delta</code>, <code>sigma</code>, and <code>kernelSize</code>.
+         * <code>delta</code>, <code>sigma</code>, and <code>stepSize</code>.
          * </p>
          * <ul>
          * <li><code>contrast</code> is a scalar value in the range [-255.0, 255.0] and affects the contract of the effect. The default value is <code>128.0</code>.</li>
@@ -215,7 +215,7 @@ define([
          * The default value is <code>false</code>. This is a debug option for viewing the effects when changing the other uniform values.</li>
          * </ul>
          * <p>
-         * <code>delta</code>, <code>sigma</code>, and <code>kernelSize</code> are the same properties as {@link PostProcessStageLibrary#createBlurStage}.
+         * <code>delta</code>, <code>sigma</code>, and <code>stepSize</code> are the same properties as {@link PostProcessStageLibrary#createBlurStage}.
          * The blur is applied to the shadows generated from the image to make them smoother.
          * </p>
          * <p>

--- a/Source/Scene/PostProcessStageLibrary.js
+++ b/Source/Scene/PostProcessStageLibrary.js
@@ -751,14 +751,14 @@ define([
      * <li><code>starTexture</code> is the texture sampled for the star pattern of the flare.</li>
      * <li><code>intensity</code> is a scalar multiplied by the result of the lens flare. The default value is <code>2.0</code>.</li>
      * <li><code>distortion</code> is a scalar value that affects the chromatic effect distortion. The default value is <code>10.0</code>.</li>
-     * <li><code>ghostDispesal</code> is a scalar indicating how far the halo effect is from the center of the texture. The default value is <code>0.4</code>.</li>
+     * <li><code>ghostDispersal</code> is a scalar indicating how far the halo effect is from the center of the texture. The default value is <code>0.4</code>.</li>
      * <li><code>haloWidth</code> is a scalar representing the width of the halo  from the ghost dispersal. The default value is <code>0.4</code>.</li>
      * <li><code>earthRadius</code> is the maximum radius of the earth. The default value is <code>Ellipsoid.WGS84.maximumRadius</code>.</li>
      * </ul>
      * </p>
      * @return {PostProcessStage} A post-process stage for applying a lens flare effect.
      */
-    PostProcessStageLibrary.createLensFlarStage = function() {
+    PostProcessStageLibrary.createLensFlareStage = function() {
         return new PostProcessStage({
             name : 'czm_lens_flare',
             fragmentShader : LensFlare,
@@ -773,6 +773,8 @@ define([
             }
         });
     };
+
+    PostProcessStageLibrary.createLensFlarStage = PostProcessStageLibrary.createLensFlareStage;
 
     return PostProcessStageLibrary;
 });

--- a/Source/Scene/PostProcessStageLibrary.js
+++ b/Source/Scene/PostProcessStageLibrary.js
@@ -4,6 +4,7 @@ define([
         '../Core/Color',
         '../Core/defined',
         '../Core/defineProperties',
+        '../Core/deprecationWarning',
         '../Core/destroyObject',
         '../Core/Ellipsoid',
         '../Shaders/PostProcessStages/AmbientOcclusionGenerate',
@@ -30,6 +31,7 @@ define([
         Color,
         defined,
         defineProperties,
+        deprecationWarning,
         destroyObject,
         Ellipsoid,
         AmbientOcclusionGenerate,
@@ -774,7 +776,18 @@ define([
         });
     };
 
-    PostProcessStageLibrary.createLensFlarStage = PostProcessStageLibrary.createLensFlareStage;
+    /**
+     * Renaming createLensFlarStage to createLensFlareStage would lead to breaking change
+     * @deprecated
+     * @private
+     */
+    PostProcessStageLibrary.createLensFlarStage = function() {
+        deprecationWarning(
+            'PostProcessStageLibrary.createLensFlarStage',
+            'createLensFlarStage has been renamed to createLensFlareStage and is now deprecated'
+        );
+        return PostProcessStageLibrary.createLensFlareStage();
+    };
 
     return PostProcessStageLibrary;
 });

--- a/Source/Scene/PostProcessStageLibrary.js
+++ b/Source/Scene/PostProcessStageLibrary.js
@@ -784,7 +784,7 @@ define([
     PostProcessStageLibrary.createLensFlarStage = function() {
         deprecationWarning(
             'PostProcessStageLibrary.createLensFlarStage',
-            'createLensFlarStage has been renamed to createLensFlareStage and is now deprecated'
+            'createLensFlarStage has been deprecated and will be removed in Cesium 1.49. Use createLensFlareStage instead'
         );
         return PostProcessStageLibrary.createLensFlareStage();
     };


### PR DESCRIPTION
This fixes some minor documentation errors and a typo:
- `stepSize`/`blurStepSize` instead of `kernelSize`
- `ghostDispersal` in `createLensFlareStage` documentation
- renamed `createLensFlarStage` to `createLensFlareStage`

To not break existing code, I added the following:
```javascript
    /**
     * Renaming createLensFlarStage to createLensFlareStage would lead to breaking change
     * @deprecated
     * @private
     */
    PostProcessStageLibrary.createLensFlarStage = function() {
        deprecationWarning(
            'PostProcessStageLibrary.createLensFlarStage',
            'createLensFlarStage has been renamed to createLensFlareStage and is now deprecated'
        );
        return PostProcessStageLibrary.createLensFlareStage();
    };
```
Or should this just be added to `CHANGES.md` as `breaking` and remove the function entirely?