### PR TITLE
Billboard clamp to ground cleanup

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,6 +28,7 @@ Change Log
 * Fixed a bug that caused polylines on terrain to render incorrectly in 2D and Columbus View with a `WebMercatorProjection`. [#6809](https://github.com/AnalyticalGraphicsInc/cesium/issues/6809)
 * Fixed bug where entities with a height reference weren't being updated correctly when the terrain provider was changed. [#6820](https://github.com/AnalyticalGraphicsInc/cesium/pull/6820)
 * Fixed the geocoder when `Viewer` is passed the option `geocoder: true` [#6833](https://github.com/AnalyticalGraphicsInc/cesium/pull/6833)
+* Improved performance for billboards and labels clamped to terrain [#6781](https://github.com/AnalyticalGraphicsInc/cesium/pull/6781) [#6844](https://github.com/AnalyticalGraphicsInc/cesium/pull/6844)
 * Fixed a bug that caused billboard positions to be set incorrectly when using a `CallbackProperty`. [#6815](https://github.com/AnalyticalGraphicsInc/cesium/pull/6815)
 * Improved support for generating a TypeScript typings file using `tsd-jsdoc` [#6767](https://github.com/AnalyticalGraphicsInc/cesium/pull/6767)
 

--- a/Source/DataSources/BillboardVisualizer.js
+++ b/Source/DataSources/BillboardVisualizer.js
@@ -42,7 +42,6 @@ define([
     var defaultHorizontalOrigin = HorizontalOrigin.CENTER;
     var defaultVerticalOrigin = VerticalOrigin.CENTER;
     var defaultSizeInMeters = false;
-    var defaultDisableDepthTestDistance = 0.0;
 
     var positionScratch = new Cartesian3();
     var colorScratch = new Color();
@@ -156,7 +155,7 @@ define([
             billboard.pixelOffsetScaleByDistance = Property.getValueOrUndefined(billboardGraphics._pixelOffsetScaleByDistance, time, pixelOffsetScaleByDistanceScratch);
             billboard.sizeInMeters = Property.getValueOrDefault(billboardGraphics._sizeInMeters, time, defaultSizeInMeters);
             billboard.distanceDisplayCondition = Property.getValueOrUndefined(billboardGraphics._distanceDisplayCondition, time, distanceDisplayConditionScratch);
-            billboard.disableDepthTestDistance = Property.getValueOrDefault(billboardGraphics._disableDepthTestDistance, time, defaultDisableDepthTestDistance);
+            billboard.disableDepthTestDistance = Property.getValueOrUndefined(billboardGraphics._disableDepthTestDistance, time);
 
             var subRegion = Property.getValueOrUndefined(billboardGraphics._imageSubRegion, time, boundingRectangleScratch);
             if (defined(subRegion)) {

--- a/Source/DataSources/LabelVisualizer.js
+++ b/Source/DataSources/LabelVisualizer.js
@@ -48,7 +48,6 @@ define([
     var defaultHeightReference = HeightReference.NONE;
     var defaultHorizontalOrigin = HorizontalOrigin.CENTER;
     var defaultVerticalOrigin = VerticalOrigin.CENTER;
-    var defaultDisableDepthTestDistance = 0.0;
 
     var positionScratch = new Cartesian3();
     var fillColorScratch = new Color();
@@ -164,7 +163,7 @@ define([
             label.pixelOffsetScaleByDistance = Property.getValueOrUndefined(labelGraphics._pixelOffsetScaleByDistance, time, pixelOffsetScaleByDistanceScratch);
             label.scaleByDistance = Property.getValueOrUndefined(labelGraphics._scaleByDistance, time, scaleByDistanceScratch);
             label.distanceDisplayCondition = Property.getValueOrUndefined(labelGraphics._distanceDisplayCondition, time, distanceDisplayConditionScratch);
-            label.disableDepthTestDistance = Property.getValueOrDefault(labelGraphics._disableDepthTestDistance, time, defaultDisableDepthTestDistance);
+            label.disableDepthTestDistance = Property.getValueOrUndefined(labelGraphics._disableDepthTestDistance, time);
         }
         return true;
     };

--- a/Source/Scene/Billboard.js
+++ b/Source/Scene/Billboard.js
@@ -141,7 +141,7 @@ define([
         this._pixelOffsetScaleByDistance = pixelOffsetScaleByDistance;
         this._sizeInMeters = defaultValue(options.sizeInMeters, false);
         this._distanceDisplayCondition = distanceDisplayCondition;
-        this._disableDepthTestDistance = defaultValue(options.disableDepthTestDistance, 0.0);
+        this._disableDepthTestDistance = options.disableDepthTestDistance;
         this._id = options.id;
         this._collection = defaultValue(options.collection, billboardCollection);
 
@@ -790,7 +790,6 @@ define([
          * When set to zero, the depth test is always applied. When set to Number.POSITIVE_INFINITY, the depth test is never applied.
          * @memberof Billboard.prototype
          * @type {Number}
-         * @default 0.0
          */
         disableDepthTestDistance : {
             get : function() {
@@ -799,7 +798,7 @@ define([
             set : function(value) {
                 if (this._disableDepthTestDistance !== value) {
                     //>>includeStart('debug', pragmas.debug);
-                    if (!defined(value) || value < 0.0) {
+                    if (defined(value) && value < 0.0) {
                         throw new DeveloperError('disableDepthTestDistance must be greater than or equal to 0.0.');
                     }
                     //>>includeEnd('debug');

--- a/Source/Scene/BillboardCollection.js
+++ b/Source/Scene/BillboardCollection.js
@@ -331,7 +331,7 @@ define([
             this._removeCallbackFunc = scene.terrainProviderChanged.addEventListener(function() {
                 var billboards = this._billboards;
                 var length = billboards.length;
-                for (var i=0;i<length;++i) {
+                for (var i = 0; i < length; ++i) {
                     billboards[i]._updateClamping();
                 }
             }, this);
@@ -690,7 +690,7 @@ define([
         var usageChanged = false;
 
         var properties = this._propertiesChanged;
-        for ( var k = 0; k < NUMBER_OF_PROPERTIES; ++k) {
+        for (var k = 0; k < NUMBER_OF_PROPERTIES; ++k) {
             var newUsage = (properties[k] === 0) ? BufferUsage.STATIC_DRAW : BufferUsage.STREAM_DRAW;
             usageChanged = usageChanged || (buffersUsage[k] !== newUsage);
             buffersUsage[k] = newUsage;
@@ -1194,12 +1194,13 @@ define([
         }
 
         var disableDepthTestDistance = billboard.disableDepthTestDistance;
-        if (billboard.heightReference === HeightReference.CLAMP_TO_GROUND && disableDepthTestDistance === 0.0 && billboardCollection._scene.context.depthTexture) {
-            disableDepthTestDistance = 2000.0;
+        var clampToGround = billboard.heightReference === HeightReference.CLAMP_TO_GROUND && billboardCollection._scene.context.depthTexture;
+        if (!defined(disableDepthTestDistance)) {
+            disableDepthTestDistance = clampToGround ? 5000.0 : 0.0;
         }
 
         disableDepthTestDistance *= disableDepthTestDistance;
-        if (disableDepthTestDistance > 0.0) {
+        if (clampToGround || disableDepthTestDistance > 0.0) {
             billboardCollection._shaderDisableDepthDistance = true;
             if (disableDepthTestDistance === Number.POSITIVE_INFINITY) {
                 disableDepthTestDistance = -1.0;
@@ -1358,7 +1359,7 @@ define([
         }
 
         var positions = [];
-        for ( var i = 0; i < length; ++i) {
+        for (var i = 0; i < length; ++i) {
             var billboard = billboards[i];
             var position = billboard.position;
             var actualPosition = Billboard._computeActualPosition(billboard, position, frameState, modelMatrix);
@@ -1411,7 +1412,7 @@ define([
         }
 
         var size = pixelScale * collection._maxScale * collection._maxSize * 2.0;
-        if (collection._allHorizontalCenter && collection._allVerticalCenter ) {
+        if (collection._allHorizontalCenter && collection._allVerticalCenter) {
             size *= 0.5;
         }
 
@@ -1560,7 +1561,7 @@ define([
                     var b = billboardsToUpdate[m];
                     b._dirty = false;
 
-                    for ( var n = 0; n < numWriters; ++n) {
+                    for (var n = 0; n < numWriters; ++n) {
                         writers[n](this, context, textureAtlasCoordinates, vafWriters, b);
                     }
                 }
@@ -1570,7 +1571,7 @@ define([
                     var bb = billboardsToUpdate[h];
                     bb._dirty = false;
 
-                    for ( var o = 0; o < numWriters; ++o) {
+                    for (var o = 0; o < numWriters; ++o) {
                         writers[o](this, context, textureAtlasCoordinates, vafWriters, bb);
                     }
 

--- a/Source/Scene/Label.js
+++ b/Source/Scene/Label.js
@@ -143,7 +143,7 @@ define([
         this._scaleByDistance = scaleByDistance;
         this._heightReference = defaultValue(options.heightReference, HeightReference.NONE);
         this._distanceDisplayCondition = distanceDisplayCondition;
-        this._disableDepthTestDistance = defaultValue(options.disableDepthTestDistance, 0.0);
+        this._disableDepthTestDistance = options.disableDepthTestDistance;
 
         this._labelCollection = labelCollection;
         this._glyphs = [];
@@ -930,7 +930,6 @@ define([
          * When set to zero, the depth test is always applied. When set to Number.POSITIVE_INFINITY, the depth test is never applied.
          * @memberof Label.prototype
          * @type {Number}
-         * @default 0.0
          */
         disableDepthTestDistance : {
             get : function() {
@@ -939,7 +938,7 @@ define([
             set : function(value) {
                 if (this._disableDepthTestDistance !== value) {
                     //>>includeStart('debug', pragmas.debug);
-                    if (!defined(value) || value < 0.0) {
+                    if (defined(value) && value < 0.0) {
                         throw new DeveloperError('disableDepthTestDistance must be greater than 0.0.');
                     }
                     //>>includeEnd('debug');

--- a/Source/Shaders/BillboardCollectionVS.glsl
+++ b/Source/Shaders/BillboardCollectionVS.glsl
@@ -196,14 +196,6 @@ void main()
 
     depthOrigin = vec2(1.0) - (depthOrigin * 0.5);
 #endif
-#if defined(VERTEX_DEPTH_CHECK) || defined(FRAGMENT_DEPTH_CHECK)
-    temp = compressedAttribute3.w;
-    temp = temp * SHIFT_RIGHT12;
-
-    vec2 dimensions;
-    dimensions.y = (temp - floor(temp)) * SHIFT_LEFT12;
-    dimensions.x = floor(temp);
-#endif
 
 #ifdef EYE_DISTANCE_TRANSLUCENCY
     vec4 translucencyByDistance;
@@ -214,6 +206,15 @@ void main()
 
     temp = compressedAttribute1.y * SHIFT_RIGHT8;
     translucencyByDistance.w = ((temp - floor(temp)) * SHIFT_LEFT8) / 255.0;
+#endif
+
+#if defined(VERTEX_DEPTH_CHECK) || defined(FRAGMENT_DEPTH_CHECK)
+    temp = compressedAttribute3.w;
+    temp = temp * SHIFT_RIGHT12;
+
+    vec2 dimensions;
+    dimensions.y = (temp - floor(temp)) * SHIFT_LEFT12;
+    dimensions.x = floor(temp);
 #endif
 
 #ifdef ALIGNED_AXIS
@@ -324,20 +325,22 @@ void main()
 
 #ifdef VERTEX_DEPTH_CHECK
 if (lengthSq < disableDepthTestDistance) {
+    float depthsilon = 10.0;
+
     vec2 labelTranslate = textureCoordinateBoundsOrLabelTranslate.xy;
     vec4 pEC1 = addScreenSpaceOffset(positionEC, dimensions, scale, vec2(0.0), origin, labelTranslate, pixelOffset, alignedAxis, validAlignedAxis, rotation, sizeInMeters, rotationMatrix, mpp);
     float globeDepth1 = getGlobeDepth(pEC1);
 
-    if (globeDepth1 != 0.0 && pEC1.z < globeDepth1)
+    if (globeDepth1 != 0.0 && pEC1.z + depthsilon < globeDepth1)
     {
         vec4 pEC2 = addScreenSpaceOffset(positionEC, dimensions, scale, vec2(0.0, 1.0), origin, labelTranslate, pixelOffset, alignedAxis, validAlignedAxis, rotation, sizeInMeters, rotationMatrix, mpp);
         float globeDepth2 = getGlobeDepth(pEC2);
 
-        if (globeDepth2 != 0.0 && pEC2.z < globeDepth2)
+        if (globeDepth2 != 0.0 && pEC2.z + depthsilon < globeDepth2)
         {
             vec4 pEC3 = addScreenSpaceOffset(positionEC, dimensions, scale, vec2(1.0), origin, labelTranslate, pixelOffset, alignedAxis, validAlignedAxis, rotation, sizeInMeters, rotationMatrix, mpp);
             float globeDepth3 = getGlobeDepth(pEC3);
-            if (globeDepth3 != 0.0 && pEC3.z < globeDepth3)
+            if (globeDepth3 != 0.0 && pEC3.z + depthsilon < globeDepth3)
             {
                 positionEC.xyz = vec3(0.0);
             }

--- a/Specs/Scene/BillboardCollectionSpec.js
+++ b/Specs/Scene/BillboardCollectionSpec.js
@@ -113,23 +113,23 @@ defineSuite([
         expect(b.horizontalOrigin).toEqual(HorizontalOrigin.CENTER);
         expect(b.verticalOrigin).toEqual(VerticalOrigin.CENTER);
         expect(b.scale).toEqual(1.0);
-        expect(b.image).not.toBeDefined();
+        expect(b.image).toBeUndefined();
         expect(b.color.red).toEqual(1.0);
         expect(b.color.green).toEqual(1.0);
         expect(b.color.blue).toEqual(1.0);
         expect(b.color.alpha).toEqual(1.0);
         expect(b.rotation).toEqual(0.0);
         expect(b.alignedAxis).toEqual(Cartesian3.ZERO);
-        expect(b.scaleByDistance).not.toBeDefined();
-        expect(b.translucencyByDistance).not.toBeDefined();
-        expect(b.pixelOffsetScaleByDistance).not.toBeDefined();
-        expect(b.width).not.toBeDefined();
-        expect(b.height).not.toBeDefined();
-        expect(b.id).not.toBeDefined();
+        expect(b.scaleByDistance).toBeUndefined();
+        expect(b.translucencyByDistance).toBeUndefined();
+        expect(b.pixelOffsetScaleByDistance).toBeUndefined();
+        expect(b.width).toBeUndefined();
+        expect(b.height).toBeUndefined();
+        expect(b.id).toBeUndefined();
         expect(b.heightReference).toEqual(HeightReference.NONE);
         expect(b.sizeInMeters).toEqual(false);
-        expect(b.distanceDisplayCondition).not.toBeDefined();
-        expect(b.disableDepthTestDistance).toEqual(0.0);
+        expect(b.distanceDisplayCondition).toBeUndefined();
+        expect(b.disableDepthTestDistance).toBeUndefined();
     });
 
     it('can add and remove before first update.', function() {
@@ -287,7 +287,7 @@ defineSuite([
             scaleByDistance : new NearFarScalar(1.0, 3.0, 1.0e6, 0.0)
         });
         b.scaleByDistance = undefined;
-        expect(b.scaleByDistance).not.toBeDefined();
+        expect(b.scaleByDistance).toBeUndefined();
     });
 
     it('disables billboard translucencyByDistance', function() {
@@ -295,7 +295,7 @@ defineSuite([
             translucencyByDistance : new NearFarScalar(1.0, 1.0, 1.0e6, 0.0)
         });
         b.translucencyByDistance = undefined;
-        expect(b.translucencyByDistance).not.toBeDefined();
+        expect(b.translucencyByDistance).toBeUndefined();
     });
 
     it('disables billboard pixelOffsetScaleByDistance', function() {
@@ -303,7 +303,7 @@ defineSuite([
             pixelOffsetScaleByDistance : new NearFarScalar(1.0, 1.0, 1.0e6, 0.0)
         });
         b.pixelOffsetScaleByDistance = undefined;
-        expect(b.pixelOffsetScaleByDistance).not.toBeDefined();
+        expect(b.pixelOffsetScaleByDistance).toBeUndefined();
     });
 
     it('renders billboard with scaleByDistance', function() {
@@ -620,7 +620,7 @@ defineSuite([
     });
 
     it('sets and gets a texture atlas', function() {
-        expect(billboards.textureAtlas).not.toBeDefined();
+        expect(billboards.textureAtlas).toBeUndefined();
 
         var atlas = new TextureAtlas({ context : scene.context });
         billboards.textureAtlas = atlas;
@@ -1864,7 +1864,7 @@ defineSuite([
             scene.globe.removedCallback = false;
             b.heightReference = HeightReference.NONE;
             expect(scene.globe.removedCallback).toEqual(true);
-            expect(scene.globe.callback).not.toBeDefined();
+            expect(scene.globe.callback).toBeUndefined();
         });
 
         it('changing the position updates the callback', function() {

--- a/Specs/Scene/LabelCollectionSpec.js
+++ b/Specs/Scene/LabelCollectionSpec.js
@@ -94,12 +94,12 @@ defineSuite([
         expect(label.horizontalOrigin).toEqual(HorizontalOrigin.LEFT);
         expect(label.verticalOrigin).toEqual(VerticalOrigin.BASELINE);
         expect(label.scale).toEqual(1.0);
-        expect(label.id).not.toBeDefined();
-        expect(label.translucencyByDistance).not.toBeDefined();
-        expect(label.pixelOffsetScaleByDistance).not.toBeDefined();
-        expect(label.scaleByDistance).not.toBeDefined();
-        expect(label.distanceDisplayCondition).not.toBeDefined();
-        expect(label.disableDepthTestDistance).toEqual(0.0);
+        expect(label.id).toBeUndefined();
+        expect(label.translucencyByDistance).toBeUndefined();
+        expect(label.pixelOffsetScaleByDistance).toBeUndefined();
+        expect(label.scaleByDistance).toBeUndefined();
+        expect(label.distanceDisplayCondition).toBeUndefined();
+        expect(label.disableDepthTestDistance).toBeUndefined();
     });
 
     it('can add a label with specified values', function() {
@@ -2321,7 +2321,7 @@ defineSuite([
             scene.globe.removedCallback = false;
             l.heightReference = HeightReference.NONE;
             expect(scene.globe.removedCallback).toEqual(true);
-            expect(scene.globe.callback).not.toBeDefined();
+            expect(scene.globe.callback).toBeUndefined();
         });
 
         it('changing the position updates the callback', function() {
@@ -2384,7 +2384,7 @@ defineSuite([
             var spy = spyOn(billboard, '_removeCallbackFunc');
             labelsWithHeight.remove(l);
             expect(spy).toHaveBeenCalled();
-            expect(labelsWithHeight._spareBillboards[0]._removeCallbackFunc).not.toBeDefined();
+            expect(labelsWithHeight._spareBillboards[0]._removeCallbackFunc).toBeUndefined();
         });
     });
 


### PR DESCRIPTION
Cleanup from #6802

- Default `disableDepthTestDistance` to `undefined` instead of `0.0` so user can explicitly override the distance used for the clamp to ground depth testing with `0.0`
- Fix bug with clamped to ground billboards and `translucencyByDistance`
- Fix flickering with top down view

```js
var viewer = new Cesium.Viewer('cesiumContainer', {
    terrainProvider: Cesium.createWorldTerrain()
});
viewer.scene.globe.depthTestAgainstTerrain = true;

var lon = -122.1958;
var lat = 46.1915;
for (var i = 0; i < 20; i++) {
    for (var j = 0; j < 20; j++) {
        viewer.entities.add({
            position : Cesium.Cartesian3.fromDegrees(lon + i * -0.001, lat + j * -0.001),
            billboard : {
                image : '../images/facility.gif',
                heightReference : Cesium.HeightReference.CLAMP_TO_GROUND,
                verticalOrigin: Cesium.VerticalOrigin.BOTTOM
            }
        });
        
        viewer.entities.add({
            position : Cesium.Cartesian3.fromDegrees(lon + i * 0.001, lat + j * 0.001),
            billboard : {
                image : '../images/facility.gif',
                heightReference : Cesium.HeightReference.CLAMP_TO_GROUND,
                verticalOrigin: Cesium.VerticalOrigin.BOTTOM
            }
        });
    }
}

viewer.camera.flyTo({
    destination: Cesium.Cartesian3.fromDegrees(lon, lat, 10000)
});
```