### PR TITLE
Fix normal calculation for CylinderGeometry

### DIFF
--- a/Source/Core/CylinderGeometry.js
+++ b/Source/Core/CylinderGeometry.js
@@ -223,15 +223,17 @@ define([
             var tangentIndex = 0;
             var bitangentIndex = 0;
 
+            var theta = Math.atan2(bottomRadius - topRadius, length);
             var normal = normalScratch;
-            normal.z = 0;
+            normal.z = Math.sin(theta);
+            var normalScale = Math.cos(theta);
             var tangent = tangentScratch;
             var bitangent = bitangentScratch;
 
             for (i = 0; i < slices; i++) {
                 var angle = i / slices * CesiumMath.TWO_PI;
-                var x = Math.cos(angle);
-                var y = Math.sin(angle);
+                var x = normalScale * Math.cos(angle);
+                var y = normalScale * Math.sin(angle);
                 if (computeNormal) {
                     normal.x = x;
                     normal.y = y;
@@ -241,12 +243,12 @@ define([
                     }
 
                     if (vertexFormat.normal) {
-                        normals[normalIndex++] = x;
-                        normals[normalIndex++] = y;
-                        normals[normalIndex++] = 0;
-                        normals[normalIndex++] = x;
-                        normals[normalIndex++] = y;
-                        normals[normalIndex++] = 0;
+                        normals[normalIndex++] = normal.x;
+                        normals[normalIndex++] = normal.y;
+                        normals[normalIndex++] = normal.z;
+                        normals[normalIndex++] = normal.x;
+                        normals[normalIndex++] = normal.y;
+                        normals[normalIndex++] = normal.z;
                     }
 
                     if (vertexFormat.tangent) {


### PR DESCRIPTION
The calculated normals of the curved side of the cylinder are wrong when the bottom and top radius are not equal, as the code assumes that the normal is always at right angles to the cylinder axis. This commit handles the more general case where the radii at the ends of the cylinder are not equal.