### PR TITLE
Revert #6779

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,7 +19,6 @@ Change Log
 #### Fixes :wrench:
 * Fixed bug causing billboards and labels to appear the wrong size when switching scene modes [#6745](https://github.com/AnalyticalGraphicsInc/cesium/issues/6745)
 * Fixed `PolygonGeometry` when using `VertexFormat.POSITION_ONLY`, `perPositionHeight` and `extrudedHeight` [#6790](expect(https://github.com/AnalyticalGraphicsInc/cesium/pull/6790)
-* Fixed a bug that was preventing 3D Tilesets on the opposite side of the globe from being occluded [#6714](https://github.com/AnalyticalGraphicsInc/cesium/issues/6714)
 * Fixed a bug where 3D Tilesets using the `region` bounding volume don't get transformed when the tileset's `modelMatrix` changes. [#6755](https://github.com/AnalyticalGraphicsInc/cesium/pull/6755)
 * Fixed issues related to updating entity show and geometry color [#6835](https://github.com/AnalyticalGraphicsInc/cesium/pull/6835)
 * Fixed `PolygonGeometry` and `EllipseGeometry` tangent and bitangent attributes when a texture rotation is used [#6788](https://github.com/AnalyticalGraphicsInc/cesium/pull/6788)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -186,4 +186,3 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to Cesiu
 * [Jonathan Puckey](https://github.com/puckey)
 * [Mark Erikson](https://github.com/markerikson)
 * [Hannah Bollar](https://github.com/hanbollar)
-* [Brandon Barker](https://github.com/ProjectBarks)

--- a/Source/Scene/DepthPlane.js
+++ b/Source/Scene/DepthPlane.js
@@ -51,22 +51,14 @@ define([
     }
 
     var depthQuadScratch = FeatureDetection.supportsTypedArrays() ? new Float32Array(12) : [];
-    var scratchRadii = new Cartesian3();
     var scratchCartesian1 = new Cartesian3();
     var scratchCartesian2 = new Cartesian3();
     var scratchCartesian3 = new Cartesian3();
     var scratchCartesian4 = new Cartesian3();
 
     function computeDepthQuad(ellipsoid, frameState) {
-        var radii = Cartesian3.clone(ellipsoid.radii, scratchRadii);
+        var radii = ellipsoid.radii;
         var p = frameState.camera.positionWC;
-
-        // Where did this magical number come from? It's how far a GroundPrimitive will be extruded below the surface
-        // of the Earth. This effectively pushes the depth plane farther from the camera so that classifications on
-        // 3D Tiles do not intersect the depth plane. This can be removed when depth testing is enabled by default.
-        radii.x -= 11000.0;
-        radii.y -= 11000.0;
-        radii.z -= 11000.0;
 
         // Find the corresponding position in the scaled space of the ellipsoid.
         var q = Cartesian3.multiplyComponents(ellipsoid.oneOverRadii, p, scratchCartesian1);

--- a/Source/Scene/Scene.js
+++ b/Source/Scene/Scene.js
@@ -2315,9 +2315,6 @@ define([
 
             if (clearGlobeDepth) {
                 clearDepth.execute(context, passState);
-                if (useDepthPlane) {
-                    depthPlane.execute(context, passState);
-                }
             }
 
             if (!environmentState.useInvertClassification || picking) {
@@ -2433,6 +2430,10 @@ define([
 
             if (length > 0 && context.stencilBuffer) {
                 scene._stencilClearCommand.execute(context, passState);
+            }
+
+            if (clearGlobeDepth && useDepthPlane) {
+                depthPlane.execute(context, passState);
             }
 
             us.updatePass(Pass.OPAQUE);


### PR DESCRIPTION
Fixes https://github.com/AnalyticalGraphicsInc/cesium/issues/6814

#6779 fixed a bug that caused tilesets to show through the globe but introduced a different bug that caused `pickPosition` to fail when picking the globe when `globe.depthTestAgainstTerrain` is false. For the sake of not introducing a different bug we decided to revert #6779 for now.