### PR TITLE
Remove ClippingPlaneCollection.clone

### DIFF
--- a/Apps/Sandcastle/gallery/3D Tiles Clipping Planes.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Clipping Planes.html
@@ -67,6 +67,7 @@ var viewModel = {
 var targetY = 0.0;
 var planeEntities = [];
 var selectedPlane;
+var clippingPlanes;
 
 // Select plane when mouse down
 var downHandler = new Cesium.ScreenSpaceEventHandler(viewer.scene.canvas);
@@ -113,16 +114,16 @@ function createPlaneUpdateFunction(plane, transform) {
 
 var tileset;
 function loadTileset(url) {
-    var clippingPlanes = [
-        new Cesium.ClippingPlane(new Cesium.Cartesian3(0.0, 0.0, -1.0), -100.0)
-    ];
+    clippingPlanes = new Cesium.ClippingPlaneCollection({
+        planes : [
+            new Cesium.ClippingPlane(new Cesium.Cartesian3(0.0, 0.0, -1.0), -100.0)
+        ],
+        edgeWidth : viewModel.edgeStylingEnabled ? 1.0 : 0.0
+    });
 
     tileset = viewer.scene.primitives.add(new Cesium.Cesium3DTileset({
         url : url,
-        clippingPlanes : new Cesium.ClippingPlaneCollection({
-            planes : clippingPlanes,
-            edgeWidth : viewModel.edgeStylingEnabled ? 1.0 : 0.0
-        })
+        clippingPlanes : clippingPlanes
     }));
 
     tileset.debugShowBoundingVolume = viewModel.debugBoundingVolumesEnabled;
@@ -133,7 +134,7 @@ function loadTileset(url) {
         viewer.zoomTo(tileset, new Cesium.HeadingPitchRange(0.5, -0.2, radius * 4.0));
 
         for (var i = 0; i < clippingPlanes.length; ++i) {
-            var plane = clippingPlanes[i];
+            var plane = clippingPlanes.get(i);
             var planeEntity = viewer.entities.add({
                 position : boundingSphere.center,
                 plane : {
@@ -153,9 +154,8 @@ function loadTileset(url) {
     });
 }
 
-var modelEntityClippingPlanes;
 function loadModel(url) {
-    var clippingPlanes = new Cesium.ClippingPlaneCollection({
+    clippingPlanes = new Cesium.ClippingPlaneCollection({
         planes : [
             new Cesium.ClippingPlane(new Cesium.Cartesian3(0.0, 0.0, -1.0), -100.0)
         ],
@@ -239,13 +239,7 @@ Cesium.knockout.getObservable(viewModel, 'debugBoundingVolumesEnabled').subscrib
 Cesium.knockout.getObservable(viewModel, 'edgeStylingEnabled').subscribe(function(value) {
     var edgeWidth = value ? 1.0 : 0.0;
 
-    if (Cesium.defined(tileset)) {
-        tileset.clippingPlanes.edgeWidth = edgeWidth;
-    }
-
-    if (Cesium.defined(modelEntityClippingPlanes)) {
-        modelEntityClippingPlanes.edgeWidth = edgeWidth;
-    }
+    clippingPlanes.edgeWidth = edgeWidth;
 });
 
 function reset() {

--- a/Apps/Sandcastle/gallery/3D Tiles Clipping Planes.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Clipping Planes.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="utf-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=Edge,chrome=1">  <!-- Use Chrome Frame in IE -->
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no">
     <meta name="description" content="User-defined clipping planes applied to a batched 3D Tileset, point cloud, and model.">
     <meta name="cesium-sandcastle-labels" content="Showcases, 3D Tiles">
@@ -10,10 +10,12 @@
     <script type="text/javascript" src="../Sandcastle-header.js"></script>
     <script type="text/javascript" src="../../../ThirdParty/requirejs-2.1.20/require.js"></script>
     <script type="text/javascript">
-    require.config({
-        baseUrl : '../../../Source',
-        waitSeconds : 60
-    });
+        if(typeof require === 'function') {
+            require.config({
+                baseUrl : '../../../Source',
+                waitSeconds : 120
+            });
+        }
     </script>
 </head>
 <body class="sandcastle-loading" data-sandcastle-bucket="bucket-requirejs.html">
@@ -45,7 +47,6 @@
 function startup(Cesium) {
     'use strict';
 //Sandcastle_Begin
-
 // Add a clipping plane, a plane geometry to show the representation of the
 // plane, and control the magnitude of the plane distance with the mouse.
 
@@ -154,18 +155,12 @@ function loadTileset(url) {
 
 var modelEntityClippingPlanes;
 function loadModel(url) {
-    var clippingPlanes = [
-        new Cesium.ClippingPlane(new Cesium.Cartesian3(0.0, 0.0, -1.0), -100.0)
-    ];
-
-    modelEntityClippingPlanes = new Cesium.ClippingPlaneCollection({
-        planes : clippingPlanes,
+    var clippingPlanes = new Cesium.ClippingPlaneCollection({
+        planes : [
+            new Cesium.ClippingPlane(new Cesium.Cartesian3(0.0, 0.0, -1.0), -100.0)
+        ],
         edgeWidth : viewModel.edgeStylingEnabled ? 1.0 : 0.0
     });
-
-    function updateClippingPlanes() {
-        return modelEntityClippingPlanes;
-    }
 
     var position = Cesium.Cartesian3.fromDegrees(-123.0744619, 44.0503706, 100.0);
     var heading = Cesium.Math.toRadians(135.0);
@@ -181,14 +176,14 @@ function loadModel(url) {
             uri : url,
             scale : 8,
             minimumPixelSize : 100.0,
-            clippingPlanes : new Cesium.CallbackProperty(updateClippingPlanes, false)
+            clippingPlanes : clippingPlanes
         }
     });
 
     viewer.trackedEntity = entity;
 
     for (var i = 0; i < clippingPlanes.length; ++i) {
-        var plane = clippingPlanes[i];
+        var plane = clippingPlanes.get(i);
         var planeEntity = viewer.entities.add({
             position : position,
             plane : {
@@ -262,7 +257,7 @@ function reset() {
 }
 
 //Sandcastle_End
-Sandcastle.finishedLoading();
+    Sandcastle.finishedLoading();
 }
 if (typeof Cesium !== 'undefined') {
     startup(Cesium);

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,14 @@
 Change Log
 ==========
 
+### 1.49 - 2018-09-03
+
+##### Breaking Changes :mega:
+* Removed `ClippingPlaneCollection.clone`
+ 
+##### Fixes :wrench:
+* Fixed bug that caused a new `ClippingPlaneCollection` to be created every frame when used with a model entity [#6872](https://github.com/AnalyticalGraphicsInc/cesium/pull/6872)
+
 ### 1.48 - 2018-08-01
 
 ##### Additions :tada:
@@ -16,7 +24,7 @@ Change Log
 * Support for the 3D Tiles pre-version 1.0 Batch Table Hierarchy is deprecated to reflect updates to the [3D Tiles spec](https://github.com/AnalyticalGraphicsInc/3d-tiles/pull/301). Use the [`3DTILES_batch_table_hierarchy`](https://github.com/AnalyticalGraphicsInc/3d-tiles/tree/1.0/extensions/3DTILES_batch_table_hierarchy) extension instead. Support for the deprecated batch table hierarchy will remain for backwards compatibility. [#6780](https://github.com/AnalyticalGraphicsInc/cesium/pull/6780)
 * `PostProcessStageLibrary.createLensFlarStage` is deprecated due to misspelling and will be removed in Cesium 1.49. Use `PostProcessStageLibrary.createLensFlareStage` instead.
 
-#### Fixes :wrench:
+##### Fixes :wrench:
 * Fixed a bug where 3D Tilesets using the `region` bounding volume don't get transformed when the tileset's `modelMatrix` changes. [#6755](https://github.com/AnalyticalGraphicsInc/cesium/pull/6755)
 * Fixed a bug that caused eye dome lighting for point clouds to fail in Safari on macOS and Edge on Windows by removing the dependency on floating point color textures. [#6792](https://github.com/AnalyticalGraphicsInc/cesium/issues/6792)
 * Fixed a bug that caused polylines on terrain to render incorrectly in 2D and Columbus View with a `WebMercatorProjection`. [#6809](https://github.com/AnalyticalGraphicsInc/cesium/issues/6809)

--- a/Source/Scene/ClippingPlaneCollection.js
+++ b/Source/Scene/ClippingPlaneCollection.js
@@ -546,47 +546,6 @@ define([
         this._dirtyIndex = -1;
     };
 
-    /**
-     * Duplicates this ClippingPlaneCollection instance.
-     *
-     * @param {ClippingPlaneCollection} [result] The object onto which to store the result.
-     * @returns {ClippingPlaneCollection} The modified result parameter or a new ClippingPlaneCollection instance if one was not provided.
-     */
-    ClippingPlaneCollection.prototype.clone = function(result) {
-        if (!defined(result)) {
-            result = new ClippingPlaneCollection();
-        }
-
-        var length = this.length;
-        var i;
-        if (result.length !== length) {
-            var planes = result._planes;
-            var index = planes.length;
-
-            planes.length = length;
-            for (i = index; i < length; ++i) {
-                result._planes[i] = new ClippingPlane(Cartesian3.UNIT_X, 0.0);
-            }
-        }
-
-        for (i = 0; i < length; ++i) {
-            var resultPlane = result._planes[i];
-            resultPlane.index = i;
-            resultPlane.onChangeCallback = function(index) {
-                setIndexDirty(result, index);
-            };
-            ClippingPlane.clone(this._planes[i], resultPlane);
-        }
-
-        result.enabled = this.enabled;
-        Matrix4.clone(this.modelMatrix, result.modelMatrix);
-        result.unionClippingRegions = this.unionClippingRegions;
-        Color.clone(this.edgeColor, result.edgeColor);
-        result.edgeWidth = this.edgeWidth;
-
-        return result;
-    };
-
     var scratchMatrix = new Matrix4();
     var scratchPlane = new Plane(Cartesian3.UNIT_X, 0.0);
     /**

--- a/Specs/Scene/ClippingPlaneCollectionSpec.js
+++ b/Specs/Scene/ClippingPlaneCollectionSpec.js
@@ -576,56 +576,6 @@ defineSuite([
         }).toThrowDeveloperError();
     });
 
-    it('clone without a result parameter returns new copy', function() {
-        clippingPlanes = new ClippingPlaneCollection({
-            planes : planes,
-            enabled : false,
-            edgeColor : Color.RED,
-            modelMatrix : transform
-        });
-
-        var result = clippingPlanes.clone();
-        expect(result).not.toBe(clippingPlanes);
-        expect(Cartesian3.equals(result._planes[0].normal, planes[0].normal)).toBe(true);
-        expect(result._planes[0].distance).toEqual(planes[0].distance);
-        expect(Cartesian3.equals(result._planes[1].normal, planes[1].normal)).toBe(true);
-        expect(result._planes[1].distance).toEqual(planes[1].distance);
-        expect(result.enabled).toEqual(false);
-        expect(result.modelMatrix).toEqual(transform);
-        expect(result.edgeColor).toEqual(Color.RED);
-        expect(result.edgeWidth).toEqual(0.0);
-        expect(result.unionClippingRegions).toEqual(false);
-        expect(result._testIntersection).not.toBeUndefined();
-    });
-
-    it('clone stores copy in result parameter', function() {
-        clippingPlanes = new ClippingPlaneCollection({
-            planes : planes,
-            enabled : false,
-            edgeColor : Color.RED,
-            modelMatrix : transform
-        });
-        var result = new ClippingPlaneCollection();
-        var copy = clippingPlanes.clone(result);
-        expect(copy).toBe(result);
-        expect(result._planes).not.toBe(planes);
-        expect(Cartesian3.equals(result._planes[0].normal, planes[0].normal)).toBe(true);
-        expect(result._planes[0].distance).toEqual(planes[0].distance);
-        expect(Cartesian3.equals(result._planes[1].normal, planes[1].normal)).toBe(true);
-        expect(result._planes[1].distance).toEqual(planes[1].distance);
-        expect(result.enabled).toEqual(false);
-        expect(result.modelMatrix).toEqual(transform);
-        expect(result.edgeColor).toEqual(Color.RED);
-        expect(result.edgeWidth).toEqual(0.0);
-        expect(result.unionClippingRegions).toEqual(false);
-        expect(result._testIntersection).not.toBeUndefined();
-
-        // Only allocate a new array if needed
-        var previousPlanes = result._planes;
-        clippingPlanes.clone(result);
-        expect(result._planes).toBe(previousPlanes);
-    });
-
     it('setting unionClippingRegions updates testIntersection function', function() {
         clippingPlanes = new ClippingPlaneCollection();
         var originalIntersectFunction = clippingPlanes._testIntersection;


### PR DESCRIPTION
The presence of `ClippingPlaneCollection.clone` was causing a new `ClippingPlaneCollection` to be created every frame when it was the `value` of a `ConstantProperty` for a `ModelGraphics`.
This is also why we had to do this crazy `CallbackProperty` thing in the model clipping planes Sandcastle example.

None of our other collections like `BillboardCollection` and `PrimitiveCollection` have a clone method, and we weren't using it anywhere in our code, so I thought the best thing to do is remove it.  I made it a breaking change instead of deprecating it because I don't think many (if any) of our users were using this function either.