### PR TITLE
Fix Firefox tests, add it to travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ script:
   - echo -en 'travis_fold:end:script.deploy\\r'
 
   - echo 'test webgl-stub release' && echo -en 'travis_fold:start:script test.release\\r'
-  - npm run test -- --browsers FirefoxHeadless --failTaskOnError --webgl-stub --release --suppressPassed
+  - npm run test -- --browsers ChromeCI --failTaskOnError --webgl-stub --release --suppressPassed
   - echo -en 'travis_fold:end:script test.release\\r'
 
   - echo 'test node' && echo -en 'travis_fold:start:script test.node\\r'

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ node_js:
 sudo: false
 addons:
   chrome: stable
+  firefox: latest
 before_script:
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
@@ -19,7 +20,7 @@ script:
 
   - echo 'test webgl-stub' && echo -en 'travis_fold:start:script.test\\r'
   - npm run build
-  - npm run test -- --browsers ChromeCI --webgl-stub --failTaskOnError --suppressPassed
+  - npm run test -- --browsers FirefoxHeadless --webgl-stub --failTaskOnError --suppressPassed
   - echo -en 'travis_fold:end:script.test\\r'
 
   - echo 'makeZipFile' && echo -en 'travis_fold:start:script.makeZipFile\\r'
@@ -38,7 +39,7 @@ script:
   - echo -en 'travis_fold:end:script.deploy\\r'
 
   - echo 'test webgl-stub release' && echo -en 'travis_fold:start:script test.release\\r'
-  - npm run test -- --browsers ChromeCI --failTaskOnError --webgl-stub --release --suppressPassed
+  - npm run test -- --browsers FirefoxHeadless --failTaskOnError --webgl-stub --release --suppressPassed
   - echo -en 'travis_fold:end:script test.release\\r'
 
   - echo 'test node' && echo -en 'travis_fold:start:script test.node\\r'

--- a/Specs/Core/ScreenSpaceEventHandlerSpec.js
+++ b/Specs/Core/ScreenSpaceEventHandlerSpec.js
@@ -20,7 +20,7 @@ defineSuite([
         DomEventSimulator) {
     'use strict';
 
-    var usePointerEvents = FeatureDetection.supportsPointerEvents();
+    var usePointerEvents;
     var element;
     var handler;
 
@@ -62,6 +62,16 @@ defineSuite([
         event.stopPropagation();
         event.preventDefault();
     }
+
+    beforeAll(function(){
+        usePointerEvents = FeatureDetection.supportsPointerEvents();
+
+        //See https://github.com/AnalyticalGraphicsInc/cesium/issues/6539
+        if (FeatureDetection.isFirefox()) {
+            usePointerEvents = false;
+            spyOn(FeatureDetection, 'supportsPointerEvents').and.returnValue(false);
+        }
+    });
 
     beforeEach(function() {
         // ignore events that bubble up to the document.

--- a/Specs/Scene/CameraEventAggregatorSpec.js
+++ b/Specs/Scene/CameraEventAggregatorSpec.js
@@ -18,12 +18,19 @@ defineSuite([
         DomEventSimulator) {
     'use strict';
 
-    var usePointerEvents = FeatureDetection.supportsPointerEvents();
+    var usePointerEvents;
     var canvas;
     var handler;
     var handler2;
 
     beforeAll(function() {
+        usePointerEvents = FeatureDetection.supportsPointerEvents();
+
+        //See https://github.com/AnalyticalGraphicsInc/cesium/issues/6539
+        if (FeatureDetection.isFirefox()) {
+            usePointerEvents = false;
+            spyOn(FeatureDetection, 'supportsPointerEvents').and.returnValue(false);
+        }
         canvas = createCanvas(1024, 768);
     });
 

--- a/Specs/Scene/ScreenSpaceCameraControllerSpec.js
+++ b/Specs/Scene/ScreenSpaceCameraControllerSpec.js
@@ -44,7 +44,7 @@ defineSuite([
         DomEventSimulator) {
     'use strict';
 
-    var usePointerEvents = FeatureDetection.supportsPointerEvents();
+    var usePointerEvents;
     var scene;
     var canvas;
     var camera;
@@ -80,6 +80,13 @@ defineSuite([
         };
     }
     beforeAll(function() {
+        usePointerEvents = FeatureDetection.supportsPointerEvents();
+
+        //See https://github.com/AnalyticalGraphicsInc/cesium/issues/6539
+        if (FeatureDetection.isFirefox()) {
+            usePointerEvents = false;
+            spyOn(FeatureDetection, 'supportsPointerEvents').and.returnValue(false);
+        }
         canvas = createCanvas(1024, 768);
     });
 


### PR DESCRIPTION
Works around #6539 (which should stay open until the Firefox bug is fixed)

1. Don't use PointerEvents for tests in Firefox, see #6539.  This makes all tests but one pass.

2. Run built files against FirefhoxHeadless. This means we run unminified on Chrome and minified on Firefox.  This helps keep the build time down by not running everything twice on both browsers, but will still catch Firefox-specific bugs that we can then run locally.

@lilleyse can you check out this below Firefox only failure?

```
1) frames not loaded in sequential updates do not impact average load time
     Scene/TimeDynamicPointCloud
     Expected 0.007 not to be 0.007.
<Jasmine>
@Specs/Scene/TimeDynamicPointCloudSpec.js:690:17
fulfilled/p<@Source/ThirdParty/when.js:196:34
_then/<@Source/ThirdParty/when.js:297:5
processQueue@Source/ThirdParty/when.js:647:4
_resolve@Source/ThirdParty/when.js:333:4
promiseResolve@Source/ThirdParty/when.js:359:11
poller@Specs/pollToPromise.js:33:17
```

I still think Firefox has some WebGL test errors when running locally, but this should at least stop the bleeding.