### PR TITLE
Removes frameState parameter from evaluate and evaluateColor

### DIFF
--- a/Apps/Sandcastle/gallery/3D Tiles Interactivity.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Interactivity.html
@@ -145,7 +145,7 @@ function printProperties(movement, feature) {
     }
 
     // Evaluate feature description
-    console.log('Description : ' + tileset.style.meta.description.evaluate(scene.frameState, feature));
+    console.log('Description : ' + tileset.style.meta.description.evaluate(feature));
 }
 
 function zoom(movement, feature) {

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,7 +6,7 @@ Change Log
 ##### Breaking Changes :mega:
 * Removed `ClippingPlaneCollection.clone` [#6872](https://github.com/AnalyticalGraphicsInc/cesium/pull/6872)
 * Changed `Globe.pick` to return a position in ECEF coordinates regardless of the current scene mode.  This will only effect you if you were working around a bug to make `Globe.pick` work in 2D and Columbus View.  Use `Globe.pickWorldCoordinates` to get the position in world coordinates that correlate to the current scene mode. [#6859](https://github.com/AnalyticalGraphicsInc/cesium/pull/6859)
-* Removed the unused `frameState` parameter in `evaluate` and `evaluateColor` functions in Expression, StyleExpression, ConditionsExpression and all other places that call the functions. [#6890](https://github.com/AnalyticalGraphicsInc/cesium/pull/6890).
+* Removed the unused `frameState` parameter in `evaluate` and `evaluateColor` functions in `Expression`, `StyleExpression`, `ConditionsExpression` and all other places that call the functions. [#6890](https://github.com/AnalyticalGraphicsInc/cesium/pull/6890).
 
 ##### Additions :tada:
 * Added `ClippingPlaneCollection.planeAdded` and `ClippingPlaneCollection.planeRemoved` events.  `planeAdded` is raised when a new plane is added to the collection and `planeRemoved` is raised when a plane is removed. [#6875](https://github.com/AnalyticalGraphicsInc/cesium/pull/6875)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ Change Log
 ##### Breaking Changes :mega:
 * Removed `ClippingPlaneCollection.clone` [#6872](https://github.com/AnalyticalGraphicsInc/cesium/pull/6872)
 * Changed `Globe.pick` to return a position in ECEF coordinates regardless of the current scene mode.  This will only effect you if you were working around a bug to make `Globe.pick` work in 2D and Columbus View.  Use `Globe.pickWorldCoordinates` to get the position in world coordinates that correlate to the current scene mode. [#6859](https://github.com/AnalyticalGraphicsInc/cesium/pull/6859)
+* Removed the unused `frameState` parameter in `evaluate` and `evaluateColor` functions [#6890](https://github.com/AnalyticalGraphicsInc/cesium/pull/6890).
 
 ##### Additions :tada:
 * Added `ClippingPlaneCollection.planeAdded` and `ClippingPlaneCollection.planeRemoved` events.  `planeAdded` is raised when a new plane is added to the collection and `planeRemoved` is raised when a plane is removed. [#6875](https://github.com/AnalyticalGraphicsInc/cesium/pull/6875)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,7 +6,7 @@ Change Log
 ##### Breaking Changes :mega:
 * Removed `ClippingPlaneCollection.clone` [#6872](https://github.com/AnalyticalGraphicsInc/cesium/pull/6872)
 * Changed `Globe.pick` to return a position in ECEF coordinates regardless of the current scene mode.  This will only effect you if you were working around a bug to make `Globe.pick` work in 2D and Columbus View.  Use `Globe.pickWorldCoordinates` to get the position in world coordinates that correlate to the current scene mode. [#6859](https://github.com/AnalyticalGraphicsInc/cesium/pull/6859)
-* Removed the unused `frameState` parameter in `evaluate` and `evaluateColor` functions [#6890](https://github.com/AnalyticalGraphicsInc/cesium/pull/6890).
+* Removed the unused `frameState` parameter in `evaluate` and `evaluateColor` functions in Expression, StyleExpression, ConditionsExpression and all other places that call the functions. [#6890](https://github.com/AnalyticalGraphicsInc/cesium/pull/6890).
 
 ##### Additions :tada:
 * Added `ClippingPlaneCollection.planeAdded` and `ClippingPlaneCollection.planeRemoved` events.  `planeAdded` is raised when a new plane is added to the collection and `planeRemoved` is raised when a plane is removed. [#6875](https://github.com/AnalyticalGraphicsInc/cesium/pull/6875)

--- a/Source/Scene/Batched3DModel3DTileContent.js
+++ b/Source/Scene/Batched3DModel3DTileContent.js
@@ -444,8 +444,8 @@ define([
         }
     };
 
-    Batched3DModel3DTileContent.prototype.applyStyle = function(frameState, style) {
-        this._batchTable.applyStyle(frameState, style);
+    Batched3DModel3DTileContent.prototype.applyStyle = function(style) {
+        this._batchTable.applyStyle(style);
     };
 
     Batched3DModel3DTileContent.prototype.update = function(tileset, frameState) {

--- a/Source/Scene/Cesium3DTileBatchTable.js
+++ b/Source/Scene/Cesium3DTileBatchTable.js
@@ -544,7 +544,7 @@ define([
 
     var scratchColor = new Color();
 
-    Cesium3DTileBatchTable.prototype.applyStyle = function(frameState, style) {
+    Cesium3DTileBatchTable.prototype.applyStyle = function(style) {
         if (!defined(style)) {
             this.setAllColor(DEFAULT_COLOR_VALUE);
             this.setAllShow(true);

--- a/Source/Scene/Cesium3DTileBatchTable.js
+++ b/Source/Scene/Cesium3DTileBatchTable.js
@@ -555,8 +555,8 @@ define([
         var length = this.featuresLength;
         for (var i = 0; i < length; ++i) {
             var feature = content.getFeature(i);
-            var color = defined(style.color) ? style.color.evaluateColor(frameState, feature, scratchColor) : DEFAULT_COLOR_VALUE;
-            var show = defined(style.show) ? style.show.evaluate(frameState, feature) : DEFAULT_SHOW_VALUE;
+            var color = defined(style.color) ? style.color.evaluateColor(feature, scratchColor) : DEFAULT_COLOR_VALUE;
+            var show = defined(style.show) ? style.show.evaluate(feature) : DEFAULT_SHOW_VALUE;
             this.setColor(i, color);
             this.setShow(i, show);
         }

--- a/Source/Scene/Cesium3DTileContent.js
+++ b/Source/Scene/Cesium3DTileContent.js
@@ -271,7 +271,7 @@ define([
      * not part of the public Cesium API.
      * </p>
      *
-     * @param {FrameSate} frameState The frame state.
+     * @param {FrameState} frameState The frame state.
      * @param {Cesium3DTileStyle} style The style.
      *
      * @private

--- a/Source/Scene/Cesium3DTileContent.js
+++ b/Source/Scene/Cesium3DTileContent.js
@@ -271,12 +271,11 @@ define([
      * not part of the public Cesium API.
      * </p>
      *
-     * @param {FrameState} frameState The frame state.
      * @param {Cesium3DTileStyle} style The style.
      *
      * @private
      */
-    Cesium3DTileContent.prototype.applyStyle = function(frameState, style) {
+    Cesium3DTileContent.prototype.applyStyle = function(style) {
         DeveloperError.throwInstantiationError();
     };
 

--- a/Source/Scene/Cesium3DTileStyle.js
+++ b/Source/Scene/Cesium3DTileStyle.js
@@ -250,13 +250,13 @@ define([
          * var style = new Cesium3DTileStyle({
          *     show : '(regExp("^Chest").test(${County})) && (${YearBuilt} >= 1970)'
          * });
-         * style.show.evaluate(frameState, feature); // returns true or false depending on the feature's properties
+         * style.show.evaluate(feature); // returns true or false depending on the feature's properties
          *
          * @example
          * var style = new Cesium.Cesium3DTileStyle();
          * // Override show expression with a custom function
          * style.show = {
-         *     evaluate : function(frameState, feature) {
+         *     evaluate : function(feature) {
          *         return true;
          *     }
          * };
@@ -319,13 +319,13 @@ define([
          * var style = new Cesium3DTileStyle({
          *     color : '(${Temperature} > 90) ? color("red") : color("white")'
          * });
-         * style.color.evaluateColor(frameState, feature, result); // returns a Cesium.Color object
+         * style.color.evaluateColor(feature, result); // returns a Cesium.Color object
          *
          * @example
          * var style = new Cesium.Cesium3DTileStyle();
          * // Override color expression with a custom function
          * style.color = {
-         *     evaluateColor : function(frameState, feature, result) {
+         *     evaluateColor : function(feature, result) {
          *         return Cesium.Color.clone(Cesium.Color.WHITE, result);
          *     }
          * };
@@ -381,13 +381,13 @@ define([
          * var style = new Cesium3DTileStyle({
          *     pointSize : '(${Temperature} > 90) ? 2.0 : 1.0'
          * });
-         * style.pointSize.evaluate(frameState, feature); // returns a Number
+         * style.pointSize.evaluate(feature); // returns a Number
          *
          * @example
          * var style = new Cesium.Cesium3DTileStyle();
          * // Override pointSize expression with a custom function
          * style.pointSize = {
-         *     evaluate : function(frameState, feature) {
+         *     evaluate : function(feature) {
          *         return 1.0;
          *     }
          * };
@@ -690,13 +690,13 @@ define([
          * var style = new Cesium3DTileStyle({
          *     font : '(${Temperature} > 90) ? "30px Helvetica" : "24px Helvetica"'
          * });
-         * style.font.evaluate(frameState, feature); // returns a String
+         * style.font.evaluate(feature); // returns a String
          *
          * @example
          * var style = new Cesium.Cesium3DTileStyle();
          * // Override font expression with a custom function
          * style.font = {
-         *     evaluate : function(frameState, feature) {
+         *     evaluate : function(feature) {
          *         return '24px Helvetica';
          *     }
          * };
@@ -738,13 +738,13 @@ define([
          * var style = new Cesium3DTileStyle({
          *     labelStyle : '(${Temperature} > 90) ? ' + LabelStyle.FILL_AND_OUTLINE + ' : ' + LabelStyle.FILL
          * });
-         * style.labelStyle.evaluate(frameState, feature); // returns a LabelStyle
+         * style.labelStyle.evaluate(feature); // returns a LabelStyle
          *
          * @example
          * var style = new Cesium.Cesium3DTileStyle();
          * // Override labelStyle expression with a custom function
          * style.labelStyle = {
-         *     evaluate : function(frameState, feature) {
+         *     evaluate : function(feature) {
          *         return LabelStyle.FILL;
          *     }
          * };
@@ -786,13 +786,13 @@ define([
          * var style = new Cesium3DTileStyle({
          *     labelText : '(${Temperature} > 90) ? ">90" : "<=90"'
          * });
-         * style.labelText.evaluate(frameState, feature); // returns a String
+         * style.labelText.evaluate(feature); // returns a String
          *
          * @example
          * var style = new Cesium.Cesium3DTileStyle();
          * // Override labelText expression with a custom function
          * style.labelText = {
-         *     evaluate : function(frameState, feature) {
+         *     evaluate : function(feature) {
          *         return 'Example label text';
          *     }
          * };
@@ -882,7 +882,7 @@ define([
          * var style = new Cesium.Cesium3DTileStyle();
          * // Override backgroundPadding expression with a string
          * style.backgroundPadding = 'vec2(5.0, 7.0)';
-         * style.backgroundPadding.evaluate(frameState, feature); // returns a Cartesian2
+         * style.backgroundPadding.evaluate(feature); // returns a Cartesian2
          */
         backgroundPadding : {
             get : function() {
@@ -969,7 +969,7 @@ define([
          * var style = new Cesium.Cesium3DTileStyle();
          * // Override scaleByDistance expression with a string
          * style.scaleByDistance = 'vec4(1.5e2, 2.0, 1.5e7, 0.5)';
-         * style.scaleByDistance.evaluate(frameState, feature); // returns a Cartesian4
+         * style.scaleByDistance.evaluate(feature); // returns a Cartesian4
          */
         scaleByDistance : {
             get : function() {
@@ -1008,7 +1008,7 @@ define([
          * var style = new Cesium.Cesium3DTileStyle();
          * // Override translucencyByDistance expression with a string
          * style.translucencyByDistance = 'vec4(1.5e2, 1.0, 1.5e7, 0.2)';
-         * style.translucencyByDistance.evaluate(frameState, feature); // returns a Cartesian4
+         * style.translucencyByDistance.evaluate(feature); // returns a Cartesian4
          */
         translucencyByDistance : {
             get : function() {
@@ -1047,7 +1047,7 @@ define([
          * var style = new Cesium.Cesium3DTileStyle();
          * // Override distanceDisplayCondition expression with a string
          * style.distanceDisplayCondition = 'vec2(0.0, 5.5e6)';
-         * style.distanceDisplayCondition.evaluate(frameState, feature); // returns a Cartesian2
+         * style.distanceDisplayCondition.evaluate(feature); // returns a Cartesian2
          */
         distanceDisplayCondition : {
             get : function() {
@@ -1230,13 +1230,13 @@ define([
          * var style = new Cesium3DTileStyle({
          *     image : '(${Temperature} > 90) ? "/url/to/image1" : "/url/to/image2"'
          * });
-         * style.image.evaluate(frameState, feature); // returns a String
+         * style.image.evaluate(feature); // returns a String
          *
          * @example
          * var style = new Cesium.Cesium3DTileStyle();
          * // Override image expression with a custom function
          * style.image = {
-         *     evaluate : function(frameState, feature) {
+         *     evaluate : function(feature) {
          *         return '/url/to/image';
          *     }
          * };
@@ -1278,7 +1278,7 @@ define([
          * var style = new Cesium.Cesium3DTileStyle();
          * // Override disableDepthTestDistance expression with a string
          * style.disableDepthTestDistance = '1000.0';
-         * style.disableDepthTestDistance.evaluate(frameState, feature); // returns a Number
+         * style.disableDepthTestDistance.evaluate(feature); // returns a Number
          */
         disableDepthTestDistance : {
             get : function() {
@@ -1317,13 +1317,13 @@ define([
          * var style = new Cesium3DTileStyle({
          *     horizontalOrigin : HorizontalOrigin.LEFT
          * });
-         * style.horizontalOrigin.evaluate(frameState, feature); // returns a HorizontalOrigin
+         * style.horizontalOrigin.evaluate(feature); // returns a HorizontalOrigin
          *
          * @example
          * var style = new Cesium.Cesium3DTileStyle();
          * // Override horizontalOrigin expression with a custom function
          * style.horizontalOrigin = {
-         *     evaluate : function(frameState, feature) {
+         *     evaluate : function(feature) {
          *         return HorizontalOrigin.CENTER;
          *     }
          * };
@@ -1365,13 +1365,13 @@ define([
          * var style = new Cesium3DTileStyle({
          *     verticalOrigin : VerticalOrigin.TOP
          * });
-         * style.verticalOrigin.evaluate(frameState, feature); // returns a VerticalOrigin
+         * style.verticalOrigin.evaluate(feature); // returns a VerticalOrigin
          *
          * @example
          * var style = new Cesium.Cesium3DTileStyle();
          * // Override verticalOrigin expression with a custom function
          * style.verticalOrigin = {
-         *     evaluate : function(frameState, feature) {
+         *     evaluate : function(feature) {
          *         return VerticalOrigin.CENTER;
          *     }
          * };
@@ -1413,13 +1413,13 @@ define([
          * var style = new Cesium3DTileStyle({
          *     labelHorizontalOrigin : HorizontalOrigin.LEFT
          * });
-         * style.labelHorizontalOrigin.evaluate(frameState, feature); // returns a HorizontalOrigin
+         * style.labelHorizontalOrigin.evaluate(feature); // returns a HorizontalOrigin
          *
          * @example
          * var style = new Cesium.Cesium3DTileStyle();
          * // Override labelHorizontalOrigin expression with a custom function
          * style.labelHorizontalOrigin = {
-         *     evaluate : function(frameState, feature) {
+         *     evaluate : function(feature) {
          *         return HorizontalOrigin.CENTER;
          *     }
          * };
@@ -1461,13 +1461,13 @@ define([
          * var style = new Cesium3DTileStyle({
          *     labelVerticalOrigin : VerticalOrigin.TOP
          * });
-         * style.labelVerticalOrigin.evaluate(frameState, feature); // returns a VerticalOrigin
+         * style.labelVerticalOrigin.evaluate(feature); // returns a VerticalOrigin
          *
          * @example
          * var style = new Cesium.Cesium3DTileStyle();
          * // Override labelVerticalOrigin expression with a custom function
          * style.labelVerticalOrigin = {
-         *     evaluate : function(frameState, feature) {
+         *     evaluate : function(feature) {
          *         return VerticalOrigin.CENTER;
          *     }
          * };
@@ -1503,7 +1503,7 @@ define([
          *         description : '"Building id ${id} has height ${Height}."'
          *     }
          * });
-         * style.meta.description.evaluate(frameState, feature); // returns a String with the substituted variables
+         * style.meta.description.evaluate(feature); // returns a String with the substituted variables
          */
         meta : {
             get : function() {

--- a/Source/Scene/Cesium3DTileStyleEngine.js
+++ b/Source/Scene/Cesium3DTileStyleEngine.js
@@ -71,7 +71,7 @@ define([
                 //   2) this tile is now visible, but it wasn't visible when the style was first assigned
                 var content = tile.content;
                 tile.lastStyleTime = lastStyleTime;
-                content.applyStyle(frameState, this._style);
+                content.applyStyle(this._style);
                 statistics.numberOfFeaturesStyled += content.featuresLength;
                 ++statistics.numberOfTilesStyled;
             }

--- a/Source/Scene/Composite3DTileContent.js
+++ b/Source/Scene/Composite3DTileContent.js
@@ -250,11 +250,11 @@ define([
         }
     };
 
-    Composite3DTileContent.prototype.applyStyle = function(frameState, style) {
+    Composite3DTileContent.prototype.applyStyle = function(style) {
         var contents = this._contents;
         var length = contents.length;
         for (var i = 0; i < length; ++i) {
-            contents[i].applyStyle(frameState, style);
+            contents[i].applyStyle(style);
         }
     };
 

--- a/Source/Scene/ConditionsExpression.js
+++ b/Source/Scene/ConditionsExpression.js
@@ -34,7 +34,7 @@ define([
      *         ['true', 'color("#FFFFFF")']
      *     ]
      * });
-     * expression.evaluateColor(frameState, feature, result); // returns a Cesium.Color object
+     * expression.evaluateColor(feature, result); // returns a Cesium.Color object
      */
     function ConditionsExpression(conditionsExpression, defines) {
         this._conditionsExpression = clone(conditionsExpression, true);
@@ -96,12 +96,11 @@ define([
      * a {@link Cartesian2}, {@link Cartesian3}, or {@link Cartesian4} object will be returned. If the <code>result</code> argument is
      * a {@link Color}, the {@link Cartesian4} value is converted to a {@link Color} and then returned.
      *
-     * @param {FrameState} frameState The frame state.
      * @param {Cesium3DTileFeature} feature The feature whose properties may be used as variables in the expression.
      * @param {Object} [result] The object onto which to store the result.
      * @returns {Boolean|Number|String|RegExp|Cartesian2|Cartesian3|Cartesian4|Color} The result of evaluating the expression.
      */
-    ConditionsExpression.prototype.evaluate = function(frameState, feature, result) {
+    ConditionsExpression.prototype.evaluate = function(feature, result) {
         var conditions = this._runtimeConditions;
         if (!defined(conditions)) {
             return undefined;
@@ -109,8 +108,8 @@ define([
         var length = conditions.length;
         for (var i = 0; i < length; ++i) {
             var statement = conditions[i];
-            if (statement.condition.evaluate(frameState, feature)) {
-                return statement.expression.evaluate(frameState, feature, result);
+            if (statement.condition.evaluate(feature)) {
+                return statement.expression.evaluate(feature, result);
             }
         }
     };
@@ -120,12 +119,11 @@ define([
      * <p>
      * This is equivalent to {@link ConditionsExpression#evaluate} but always returns a {@link Color} object.
      * </p>
-     * @param {FrameState} frameState The frame state.
      * @param {Cesium3DTileFeature} feature The feature whose properties may be used as variables in the expression.
      * @param {Color} [result] The object in which to store the result
      * @returns {Color} The modified result parameter or a new Color instance if one was not provided.
      */
-    ConditionsExpression.prototype.evaluateColor = function(frameState, feature, result) {
+    ConditionsExpression.prototype.evaluateColor = function(feature, result) {
         var conditions = this._runtimeConditions;
         if (!defined(conditions)) {
             return undefined;
@@ -133,8 +131,8 @@ define([
         var length = conditions.length;
         for (var i = 0; i < length; ++i) {
             var statement = conditions[i];
-            if (statement.condition.evaluate(frameState, feature)) {
-                return statement.expression.evaluateColor(frameState, feature, result);
+            if (statement.condition.evaluate(feature)) {
+                return statement.expression.evaluateColor(feature, result);
             }
         }
     };

--- a/Source/Scene/Empty3DTileContent.js
+++ b/Source/Scene/Empty3DTileContent.js
@@ -119,7 +119,7 @@ define([
     Empty3DTileContent.prototype.applyDebugSettings = function(enabled, color) {
     };
 
-    Empty3DTileContent.prototype.applyStyle = function(frameState, style) {
+    Empty3DTileContent.prototype.applyStyle = function(style) {
     };
 
     Empty3DTileContent.prototype.update = function(tileset, frameState) {

--- a/Source/Scene/Expression.js
+++ b/Source/Scene/Expression.js
@@ -46,11 +46,11 @@ define([
      *
      * @example
      * var expression = new Cesium.Expression('(regExp("^Chest").test(${County})) && (${YearBuilt} >= 1970)');
-     * expression.evaluate(frameState, feature); // returns true or false depending on the feature's properties
+     * expression.evaluate(feature); // returns true or false depending on the feature's properties
      *
      * @example
      * var expression = new Cesium.Expression('(${Temperature} > 90) ? color("red") : color("white")');
-     * expression.evaluateColor(frameState, feature, result); // returns a Cesium.Color object
+     * expression.evaluateColor(feature, result); // returns a Cesium.Color object
      */
     function Expression(expression, defines) {
         //>>includeStart('debug', pragmas.debug);
@@ -148,14 +148,13 @@ define([
      * a {@link Cartesian2}, {@link Cartesian3}, or {@link Cartesian4} object will be returned. If the <code>result</code> argument is
      * a {@link Color}, the {@link Cartesian4} value is converted to a {@link Color} and then returned.
      *
-     * @param {FrameState} frameState The frame state.
      * @param {Cesium3DTileFeature} feature The feature whose properties may be used as variables in the expression.
      * @param {Object} [result] The object onto which to store the result.
      * @returns {Boolean|Number|String|RegExp|Cartesian2|Cartesian3|Cartesian4|Color} The result of evaluating the expression.
      */
-    Expression.prototype.evaluate = function(frameState, feature, result) {
+    Expression.prototype.evaluate = function(feature, result) {
         scratchStorage.reset();
-        var value = this._runtimeAst.evaluate(frameState, feature);
+        var value = this._runtimeAst.evaluate(feature);
         if ((result instanceof Color) && (value instanceof Cartesian4)) {
             return Color.fromCartesian4(value, result);
         }
@@ -171,14 +170,13 @@ define([
      * This is equivalent to {@link Expression#evaluate} but always returns a {@link Color} object.
      * </p>
      *
-     * @param {FrameState} frameState The frame state.
      * @param {Cesium3DTileFeature} feature The feature whose properties may be used as variables in the expression.
      * @param {Color} [result] The object in which to store the result
      * @returns {Color} The modified result parameter or a new Color instance if one was not provided.
      */
-    Expression.prototype.evaluateColor = function(frameState, feature, result) {
+    Expression.prototype.evaluateColor = function(feature, result) {
         scratchStorage.reset();
-        var color = this._runtimeAst.evaluate(frameState, feature);
+        var color = this._runtimeAst.evaluate(feature);
         return Color.fromCartesian4(color, result);
     };
 
@@ -256,18 +254,18 @@ define([
     };
 
     var binaryFunctions = {
-        atan2 : getEvaluateBinaryCommponentwise(Math.atan2, false),
-        pow : getEvaluateBinaryCommponentwise(Math.pow, false),
-        min : getEvaluateBinaryCommponentwise(Math.min, true),
-        max : getEvaluateBinaryCommponentwise(Math.max, true),
+        atan2 : getEvaluateBinaryComponentwise(Math.atan2, false),
+        pow : getEvaluateBinaryComponentwise(Math.pow, false),
+        min : getEvaluateBinaryComponentwise(Math.min, true),
+        max : getEvaluateBinaryComponentwise(Math.max, true),
         distance : distance,
         dot : dot,
         cross : cross
     };
 
     var ternaryFunctions = {
-        clamp : getEvaluateTernaryCommponentwise(CesiumMath.clamp, true),
-        mix : getEvaluateTernaryCommponentwise(CesiumMath.lerp, true)
+        clamp : getEvaluateTernaryComponentwise(CesiumMath.clamp, true),
+        mix : getEvaluateTernaryComponentwise(CesiumMath.lerp, true)
     };
 
     function fract(number) {
@@ -297,7 +295,7 @@ define([
         };
     }
 
-    function getEvaluateBinaryCommponentwise(operation, allowScalar) {
+    function getEvaluateBinaryComponentwise(operation, allowScalar) {
         return function(call, left, right) {
             if (allowScalar && typeof right === 'number') {
                 if (typeof left === 'number') {
@@ -325,7 +323,7 @@ define([
         };
     }
 
-    function getEvaluateTernaryCommponentwise(operation, allowScalar) {
+    function getEvaluateTernaryComponentwise(operation, allowScalar) {
         return function(call, left, right, test) {
             if (allowScalar && typeof test === 'number') {
                 if (typeof left === 'number' && typeof right === 'number') {
@@ -901,85 +899,85 @@ define([
         }
     }
 
-    function evaluateTilesetTime(frameState, feature) {
+    function evaluateTilesetTime(feature) {
         return feature.content.tileset.timeSinceLoad;
     }
 
     function getEvaluateUnaryFunction(call) {
         var evaluate = unaryFunctions[call];
-        return function(frameState, feature) {
-            var left = this._left.evaluate(frameState, feature);
+        return function(feature) {
+            var left = this._left.evaluate(feature);
             return evaluate(call, left);
         };
     }
 
     function getEvaluateBinaryFunction(call) {
         var evaluate = binaryFunctions[call];
-        return function(frameState, feature) {
-            var left = this._left.evaluate(frameState, feature);
-            var right = this._right.evaluate(frameState, feature);
+        return function(feature) {
+            var left = this._left.evaluate(feature);
+            var right = this._right.evaluate(feature);
             return evaluate(call, left, right);
         };
     }
 
     function getEvaluateTernaryFunction(call) {
         var evaluate = ternaryFunctions[call];
-        return function(frameState, feature) {
-            var left = this._left.evaluate(frameState, feature);
-            var right = this._right.evaluate(frameState, feature);
-            var test = this._test.evaluate(frameState, feature);
+        return function(feature) {
+            var left = this._left.evaluate(feature);
+            var right = this._right.evaluate(feature);
+            var test = this._test.evaluate(feature);
             return evaluate(call, left, right, test);
         };
     }
 
-    Node.prototype._evaluateLiteral = function(frameState, feature) {
+    Node.prototype._evaluateLiteral = function() {
         return this._value;
     };
 
-    Node.prototype._evaluateLiteralColor = function(frameState, feature) {
+    Node.prototype._evaluateLiteralColor = function(feature) {
         var color = scratchColor;
         var args = this._left;
         if (this._value === 'color') {
             if (!defined(args)) {
                 Color.fromBytes(255, 255, 255, 255, color);
             } else if (args.length > 1) {
-                Color.fromCssColorString(args[0].evaluate(frameState, feature), color);
-                color.alpha = args[1].evaluate(frameState, feature);
+                Color.fromCssColorString(args[0].evaluate(feature), color);
+                color.alpha = args[1].evaluate(feature);
             } else {
-                Color.fromCssColorString(args[0].evaluate(frameState, feature), color);
+                Color.fromCssColorString(args[0].evaluate(feature), color);
             }
         } else if (this._value === 'rgb') {
             Color.fromBytes(
-                args[0].evaluate(frameState, feature),
-                args[1].evaluate(frameState, feature),
-                args[2].evaluate(frameState, feature),
+                args[0].evaluate(feature),
+                args[1].evaluate(feature),
+                args[2].evaluate(feature),
                 255, color);
         } else if (this._value === 'rgba') {
             // convert between css alpha (0 to 1) and cesium alpha (0 to 255)
-            var a = args[3].evaluate(frameState, feature) * 255;
+            var a = args[3].evaluate(feature) * 255;
             Color.fromBytes(
-                args[0].evaluate(frameState, feature),
-                args[1].evaluate(frameState, feature),
-                args[2].evaluate(frameState, feature),
+                args[0].evaluate(feature),
+                args[1].evaluate(feature),
+                args[2].evaluate(feature),
                 a, color);
         } else if (this._value === 'hsl') {
             Color.fromHsl(
-                args[0].evaluate(frameState, feature),
-                args[1].evaluate(frameState, feature),
-                args[2].evaluate(frameState, feature),
+                args[0].evaluate(feature),
+                args[1].evaluate(feature),
+                args[2].evaluate(feature),
                 1.0, color);
         } else if (this._value === 'hsla') {
             Color.fromHsl(
-                args[0].evaluate(frameState, feature),
-                args[1].evaluate(frameState, feature),
-                args[2].evaluate(frameState, feature),
-                args[3].evaluate(frameState, feature),
+                args[0].evaluate(feature),
+                args[1].evaluate(feature),
+                args[2].evaluate(feature),
+                args[3].evaluate(feature),
                 color);
         }
         return Cartesian4.fromColor(color, scratchStorage.getCartesian4());
     };
 
-    Node.prototype._evaluateLiteralVector = function(frameState, feature) {
+    Node.prototype._evaluateLiteralVector = function(feature) {
         // Gather the components that make up the vector, which includes components from interior vectors.
         // For example vec3(1, 2, 3) or vec3(vec2(1, 2), 3) are both valid.
         //
@@ -998,7 +996,7 @@ define([
         var args = this._left;
         var argsLength = args.length;
         for (var i = 0; i < argsLength; ++i) {
-            var value = args[i].evaluate(frameState, feature);
+            var value = args[i].evaluate(feature);
             if (typeof value === 'number') {
                 components.push(value);
             } else if (value instanceof Cartesian2) {
@@ -1038,11 +1036,11 @@ define([
         }
     };
 
-    Node.prototype._evaluateLiteralString = function(frameState, feature) {
+    Node.prototype._evaluateLiteralString = function() {
         return this._value;
     };
 
-    Node.prototype._evaluateVariableString = function(frameState, feature) {
+    Node.prototype._evaluateVariableString = function(feature) {
         var result = this._value;
         var match = variableRegex.exec(result);
         while (match !== null) {
@@ -1058,7 +1056,7 @@ define([
         return result;
     };
 
-    Node.prototype._evaluateVariable = function(frameState, feature) {
+    Node.prototype._evaluateVariable = function(feature) {
         // evaluates to undefined if the property name is not defined for that feature
         return feature.getProperty(this._value);
     };
@@ -1068,16 +1066,16 @@ define([
     }
 
     // PERFORMANCE_IDEA: Determine if parent property needs to be computed before runtime
-    Node.prototype._evaluateMemberDot = function(frameState, feature) {
+    Node.prototype._evaluateMemberDot = function(feature) {
         if (checkFeature(this._left)) {
-            return feature.getProperty(this._right.evaluate(frameState, feature));
+            return feature.getProperty(this._right.evaluate(feature));
         }
-        var property = this._left.evaluate(frameState, feature);
+        var property = this._left.evaluate(feature);
         if (!defined(property)) {
             return undefined;
         }
 
-        var member = this._right.evaluate(frameState, feature);
+        var member = this._right.evaluate(feature);
         if ((property instanceof Cartesian2) || (property instanceof Cartesian3) || (property instanceof Cartesian4)) {
             // Vector components may be accessed with .r, .g, .b, .a and implicitly with .x, .y, .z, .w
             if (member === 'r') {
@@ -1093,16 +1091,16 @@ define([
         return property[member];
     };
 
-    Node.prototype._evaluateMemberBrackets = function(frameState, feature) {
+    Node.prototype._evaluateMemberBrackets = function(feature) {
         if (checkFeature(this._left)) {
-            return feature.getProperty(this._right.evaluate(frameState, feature));
+            return feature.getProperty(this._right.evaluate(feature));
         }
-        var property = this._left.evaluate(frameState, feature);
+        var property = this._left.evaluate(feature);
         if (!defined(property)) {
             return undefined;
         }
 
-        var member = this._right.evaluate(frameState, feature);
+        var member = this._right.evaluate(feature);
         if ((property instanceof Cartesian2) || (property instanceof Cartesian3) || (property instanceof Cartesian4)) {
             // Vector components may be accessed with [0][1][2][3], ['r']['g']['b']['a'] and implicitly with ['x']['y']['z']['w']
             // For Cartesian2 and Cartesian3 out-of-range components will just return undefined
@@ -1119,10 +1117,10 @@ define([
         return property[member];
     };
 
-    Node.prototype._evaluateArray = function(frameState, feature) {
+    Node.prototype._evaluateArray = function(feature) {
         var array = [];
         for (var i = 0; i < this._value.length; i++) {
-            array[i] = this._value[i].evaluate(frameState, feature);
+            array[i] = this._value[i].evaluate(feature);
         }
         return array;
     };
@@ -1130,16 +1128,16 @@ define([
     // PERFORMANCE_IDEA: Have "fast path" functions that deal only with specific types
     // that we can assign if we know the types before runtime
 
-    Node.prototype._evaluateNot = function(frameState, feature) {
-        var left = this._left.evaluate(frameState, feature);
+    Node.prototype._evaluateNot = function(feature) {
+        var left = this._left.evaluate(feature);
         if (typeof left !== 'boolean') {
             throw new RuntimeError('Operator "!" requires a boolean argument. Argument is ' + left + '.');
         }
         return !left;
     };
 
-    Node.prototype._evaluateNegative = function(frameState, feature) {
-        var left = this._left.evaluate(frameState, feature);
+    Node.prototype._evaluateNegative = function(feature) {
+        var left = this._left.evaluate(feature);
         if (left instanceof Cartesian2) {
             return Cartesian2.negate(left, scratchStorage.getCartesian2());
         } else if (left instanceof Cartesian3) {
@@ -1153,8 +1151,8 @@ define([
         throw new RuntimeError('Operator "-" requires a vector or number argument. Argument is ' + left + '.');
     };
 
-    Node.prototype._evaluatePositive = function(frameState, feature) {
-        var left = this._left.evaluate(frameState, feature);
+    Node.prototype._evaluatePositive = function(feature) {
+        var left = this._left.evaluate(feature);
 
         if (!((left instanceof Cartesian2) || (left instanceof Cartesian3) || (left instanceof Cartesian4) || (typeof left === 'number'))) {
             throw new RuntimeError('Operator "+" requires a vector or number argument. Argument is ' + left + '.');
@@ -1163,9 +1161,9 @@ define([
         return left;
     };
 
-    Node.prototype._evaluateLessThan = function(frameState, feature) {
-        var left = this._left.evaluate(frameState, feature);
-        var right = this._right.evaluate(frameState, feature);
+    Node.prototype._evaluateLessThan = function(feature) {
+        var left = this._left.evaluate(feature);
+        var right = this._right.evaluate(feature);
 
         if ((typeof left !== 'number') || (typeof right !== 'number')) {
             throw new RuntimeError('Operator "<" requires number arguments. Arguments are ' + left + ' and ' + right + '.');
@@ -1174,9 +1172,9 @@ define([
         return left < right;
     };
 
-    Node.prototype._evaluateLessThanOrEquals = function(frameState, feature) {
-        var left = this._left.evaluate(frameState, feature);
-        var right = this._right.evaluate(frameState, feature);
+    Node.prototype._evaluateLessThanOrEquals = function(feature) {
+        var left = this._left.evaluate(feature);
+        var right = this._right.evaluate(feature);
 
         if ((typeof left !== 'number') || (typeof right !== 'number')) {
             throw new RuntimeError('Operator "<=" requires number arguments. Arguments are ' + left + ' and ' + right + '.');
@@ -1185,9 +1183,9 @@ define([
         return left <= right;
     };
 
-    Node.prototype._evaluateGreaterThan = function(frameState, feature) {
-        var left = this._left.evaluate(frameState, feature);
-        var right = this._right.evaluate(frameState, feature);
+    Node.prototype._evaluateGreaterThan = function(feature) {
+        var left = this._left.evaluate(feature);
+        var right = this._right.evaluate(feature);
 
         if ((typeof left !== 'number') || (typeof right !== 'number')) {
             throw new RuntimeError('Operator ">" requires number arguments. Arguments are ' + left + ' and ' + right + '.');
@@ -1196,9 +1194,9 @@ define([
         return left > right;
     };
 
-    Node.prototype._evaluateGreaterThanOrEquals = function(frameState, feature) {
-        var left = this._left.evaluate(frameState, feature);
-        var right = this._right.evaluate(frameState, feature);
+    Node.prototype._evaluateGreaterThanOrEquals = function(feature) {
+        var left = this._left.evaluate(feature);
+        var right = this._right.evaluate(feature);
 
         if ((typeof left !== 'number') || (typeof right !== 'number')) {
             throw new RuntimeError('Operator ">=" requires number arguments. Arguments are ' + left + ' and ' + right + '.');
@@ -1207,8 +1205,8 @@ define([
         return left >= right;
     };
 
-    Node.prototype._evaluateOr = function(frameState, feature) {
-        var left = this._left.evaluate(frameState, feature);
+    Node.prototype._evaluateOr = function(feature) {
+        var left = this._left.evaluate(feature);
         if (typeof left !== 'boolean') {
             throw new RuntimeError('Operator "||" requires boolean arguments. First argument is ' + left + '.');
         }
@@ -1218,7 +1216,7 @@ define([
             return true;
         }
 
-        var right = this._right.evaluate(frameState, feature);
+        var right = this._right.evaluate(feature);
         if (typeof right !== 'boolean') {
             throw new RuntimeError('Operator "||" requires boolean arguments. Second argument is ' + right + '.');
         }
@@ -1226,8 +1224,8 @@ define([
         return left || right;
     };
 
-    Node.prototype._evaluateAnd = function(frameState, feature) {
-        var left = this._left.evaluate(frameState, feature);
+    Node.prototype._evaluateAnd = function(feature) {
+        var left = this._left.evaluate(feature);
         if (typeof left !== 'boolean') {
             throw new RuntimeError('Operator "&&" requires boolean arguments. First argument is ' + left + '.');
         }
@@ -1237,7 +1235,7 @@ define([
             return false;
         }
 
-        var right = this._right.evaluate(frameState, feature);
+        var right = this._right.evaluate(feature);
         if (typeof right !== 'boolean') {
             throw new RuntimeError('Operator "&&" requires boolean arguments. Second argument is ' + right + '.');
         }
@@ -1245,9 +1243,9 @@ define([
         return left && right;
     };
 
-    Node.prototype._evaluatePlus = function(frameState, feature) {
-        var left = this._left.evaluate(frameState, feature);
-        var right = this._right.evaluate(frameState, feature);
+    Node.prototype._evaluatePlus = function(feature) {
+        var left = this._left.evaluate(feature);
+        var right = this._right.evaluate(feature);
         if ((right instanceof Cartesian2) && (left instanceof Cartesian2)) {
             return Cartesian2.add(left, right, scratchStorage.getCartesian2());
         } else if ((right instanceof Cartesian3) && (left instanceof Cartesian3)) {
@@ -1264,9 +1262,9 @@ define([
         throw new RuntimeError('Operator "+" requires vector or number arguments of matching types, or at least one string argument. Arguments are ' + left + ' and ' + right + '.');
     };
 
-    Node.prototype._evaluateMinus = function(frameState, feature) {
-        var left = this._left.evaluate(frameState, feature);
-        var right = this._right.evaluate(frameState, feature);
+    Node.prototype._evaluateMinus = function(feature) {
+        var left = this._left.evaluate(feature);
+        var right = this._right.evaluate(feature);
         if ((right instanceof Cartesian2) && (left instanceof Cartesian2)) {
             return Cartesian2.subtract(left, right, scratchStorage.getCartesian2());
         } else if ((right instanceof Cartesian3) && (left instanceof Cartesian3)) {
@@ -1280,9 +1278,9 @@ define([
         throw new RuntimeError('Operator "-" requires vector or number arguments of matching types. Arguments are ' + left + ' and ' + right + '.');
     };
 
-    Node.prototype._evaluateTimes = function(frameState, feature) {
-        var left = this._left.evaluate(frameState, feature);
-        var right = this._right.evaluate(frameState, feature);
+    Node.prototype._evaluateTimes = function(feature) {
+        var left = this._left.evaluate(feature);
+        var right = this._right.evaluate(feature);
         if ((right instanceof Cartesian2) && (left instanceof Cartesian2)) {
             return Cartesian2.multiplyComponents(left, right, scratchStorage.getCartesian2());
         } else if ((right instanceof Cartesian2) && (typeof left === 'number')) {
@@ -1308,9 +1306,9 @@ define([
         throw new RuntimeError('Operator "*" requires vector or number arguments. If both arguments are vectors they must be matching types. Arguments are ' + left + ' and ' + right + '.');
     };
 
-    Node.prototype._evaluateDivide = function(frameState, feature) {
-        var left = this._left.evaluate(frameState, feature);
-        var right = this._right.evaluate(frameState, feature);
+    Node.prototype._evaluateDivide = function(feature) {
+        var left = this._left.evaluate(feature);
+        var right = this._right.evaluate(feature);
         if ((right instanceof Cartesian2) && (left instanceof Cartesian2)) {
             return Cartesian2.divideComponents(left, right, scratchStorage.getCartesian2());
         } else if ((left instanceof Cartesian2) && (typeof right === 'number')) {
@@ -1330,9 +1328,9 @@ define([
         throw new RuntimeError('Operator "/" requires vector or number arguments of matching types, or a number as the second argument. Arguments are ' + left + ' and ' + right + '.');
     };
 
-    Node.prototype._evaluateMod = function(frameState, feature) {
-        var left = this._left.evaluate(frameState, feature);
-        var right = this._right.evaluate(frameState, feature);
+    Node.prototype._evaluateMod = function(feature) {
+        var left = this._left.evaluate(feature);
+        var right = this._right.evaluate(feature);
         if ((right instanceof Cartesian2) && (left instanceof Cartesian2)) {
             return Cartesian2.fromElements(left.x % right.x, left.y % right.y, scratchStorage.getCartesian2());
         } else if ((right instanceof Cartesian3) && (left instanceof Cartesian3)) {
@@ -1346,9 +1344,9 @@ define([
         throw new RuntimeError('Operator "%" requires vector or number arguments of matching types. Arguments are ' + left + ' and ' + right + '.');
     };
 
-    Node.prototype._evaluateEqualsStrict = function(frameState, feature) {
-        var left = this._left.evaluate(frameState, feature);
-        var right = this._right.evaluate(frameState, feature);
+    Node.prototype._evaluateEqualsStrict = function(feature) {
+        var left = this._left.evaluate(feature);
+        var right = this._right.evaluate(feature);
         if ((right instanceof Cartesian2) && (left instanceof Cartesian2) ||
             (right instanceof Cartesian3) && (left instanceof Cartesian3) ||
             (right instanceof Cartesian4) && (left instanceof Cartesian4)) {
@@ -1357,9 +1355,9 @@ define([
         return left === right;
     };
 
-    Node.prototype._evaluateNotEqualsStrict = function(frameState, feature) {
-        var left = this._left.evaluate(frameState, feature);
-        var right = this._right.evaluate(frameState, feature);
+    Node.prototype._evaluateNotEqualsStrict = function(feature) {
+        var left = this._left.evaluate(feature);
+        var right = this._right.evaluate(feature);
         if ((right instanceof Cartesian2) && (left instanceof Cartesian2) ||
             (right instanceof Cartesian3) && (left instanceof Cartesian3) ||
             (right instanceof Cartesian4) && (left instanceof Cartesian4)) {
@@ -1368,57 +1366,57 @@ define([
         return left !== right;
     };
 
-    Node.prototype._evaluateConditional = function(frameState, feature) {
-        var test = this._test.evaluate(frameState, feature);
+    Node.prototype._evaluateConditional = function(feature) {
+        var test = this._test.evaluate(feature);
 
         if (typeof test !== 'boolean') {
             throw new RuntimeError('Conditional argument of conditional expression must be a boolean. Argument is ' + test + '.');
         }
 
         if (test) {
-            return this._left.evaluate(frameState, feature);
+            return this._left.evaluate(feature);
         }
-        return this._right.evaluate(frameState, feature);
+        return this._right.evaluate(feature);
     };
 
-    Node.prototype._evaluateNaN = function(frameState, feature) {
-        return isNaN(this._left.evaluate(frameState, feature));
+    Node.prototype._evaluateNaN = function(feature) {
+        return isNaN(this._left.evaluate(feature));
     };
 
-    Node.prototype._evaluateIsFinite = function(frameState, feature) {
-        return isFinite(this._left.evaluate(frameState, feature));
+    Node.prototype._evaluateIsFinite = function(feature) {
+        return isFinite(this._left.evaluate(feature));
     };
 
-    Node.prototype._evaluateIsExactClass = function(frameState, feature) {
-        return feature.isExactClass(this._left.evaluate(frameState, feature));
+    Node.prototype._evaluateIsExactClass = function(feature) {
+        return feature.isExactClass(this._left.evaluate(feature));
     };
 
-    Node.prototype._evaluateIsClass = function(frameState, feature) {
-        return feature.isClass(this._left.evaluate(frameState, feature));
+    Node.prototype._evaluateIsClass = function(feature) {
+        return feature.isClass(this._left.evaluate(feature));
     };
 
-    Node.prototype._evaluategetExactClassName = function(frameState, feature) {
+    Node.prototype._evaluategetExactClassName = function(feature) {
         return feature.getExactClassName();
     };
 
-    Node.prototype._evaluateBooleanConversion = function(frameState, feature) {
-        return Boolean(this._left.evaluate(frameState, feature));
+    Node.prototype._evaluateBooleanConversion = function(feature) {
+        return Boolean(this._left.evaluate(feature));
     };
 
-    Node.prototype._evaluateNumberConversion = function(frameState, feature) {
-        return Number(this._left.evaluate(frameState, feature));
+    Node.prototype._evaluateNumberConversion = function(feature) {
+        return Number(this._left.evaluate(feature));
     };
 
-    Node.prototype._evaluateStringConversion = function(frameState, feature) {
-        return String(this._left.evaluate(frameState, feature));
+    Node.prototype._evaluateStringConversion = function(feature) {
+        return String(this._left.evaluate(feature));
     };
 
-    Node.prototype._evaluateRegExp = function(frameState, feature) {
-        var pattern = this._value.evaluate(frameState, feature);
+    Node.prototype._evaluateRegExp = function(feature) {
+        var pattern = this._value.evaluate(feature);
         var flags = '';
 
         if (defined(this._left)) {
-            flags = this._left.evaluate(frameState, feature);
+            flags = this._left.evaluate(feature);
         }
 
         var exp;
@@ -1430,9 +1428,9 @@ define([
         return exp;
     };
 
-    Node.prototype._evaluateRegExpTest = function(frameState, feature) {
-        var left = this._left.evaluate(frameState, feature);
-        var right = this._right.evaluate(frameState, feature);
+    Node.prototype._evaluateRegExpTest = function(feature) {
+        var left = this._left.evaluate(feature);
+        var right = this._right.evaluate(feature);
 
         if (!((left instanceof RegExp) && (typeof right === 'string'))) {
             throw new RuntimeError('RegExp.test requires the first argument to be a RegExp and the second argument to be a string. Arguments are ' + left + ' and ' + right + '.');
@@ -1441,9 +1439,9 @@ define([
         return left.test(right);
     };
 
-    Node.prototype._evaluateRegExpMatch = function(frameState, feature) {
-        var left = this._left.evaluate(frameState, feature);
-        var right = this._right.evaluate(frameState, feature);
+    Node.prototype._evaluateRegExpMatch = function(feature) {
+        var left = this._left.evaluate(feature);
+        var right = this._right.evaluate(feature);
 
         if ((left instanceof RegExp) && (typeof right === 'string')) {
             return left.test(right);
@@ -1454,9 +1452,9 @@ define([
         throw new RuntimeError('Operator "=~" requires one RegExp argument and one string argument. Arguments are ' + left + ' and ' + right + '.');
     };
 
-    Node.prototype._evaluateRegExpNotMatch = function(frameState, feature) {
-        var left = this._left.evaluate(frameState, feature);
-        var right = this._right.evaluate(frameState, feature);
+    Node.prototype._evaluateRegExpNotMatch = function(feature) {
+        var left = this._left.evaluate(feature);
+        var right = this._right.evaluate(feature);
 
         if ((left instanceof RegExp) && (typeof right === 'string')) {
             return !(left.test(right));
@@ -1467,9 +1465,9 @@ define([
         throw new RuntimeError('Operator "!~" requires one RegExp argument and one string argument. Arguments are ' + left + ' and ' + right + '.');
     };
 
-    Node.prototype._evaluateRegExpExec = function(frameState, feature) {
-        var left = this._left.evaluate(frameState, feature);
-        var right = this._right.evaluate(frameState, feature);
+    Node.prototype._evaluateRegExpExec = function(feature) {
+        var left = this._left.evaluate(feature);
+        var right = this._right.evaluate(feature);
 
         if (!((left instanceof RegExp) && (typeof right === 'string'))) {
             throw new RuntimeError('RegExp.exec requires the first argument to be a RegExp and the second argument to be a string. Arguments are ' + left + ' and ' + right + '.');
@@ -1482,8 +1480,8 @@ define([
         return exec[1];
     };
 
-    Node.prototype._evaluateToString = function(frameState, feature) {
-        var left = this._left.evaluate(frameState, feature);
+    Node.prototype._evaluateToString = function(feature) {
+        var left = this._left.evaluate(feature);
         if ((left instanceof RegExp) || (left instanceof Cartesian2) || (left instanceof Cartesian3) || (left instanceof Cartesian4)) {
             return String(left);
         }

--- a/Source/Scene/Geometry3DTileContent.js
+++ b/Source/Scene/Geometry3DTileContent.js
@@ -403,10 +403,10 @@ define([
         }
     };
 
-    Geometry3DTileContent.prototype.applyStyle = function(frameState, style) {
+    Geometry3DTileContent.prototype.applyStyle = function(style) {
         createFeatures(this);
         if (defined(this._geometries)) {
-            this._geometries.applyStyle(frameState, style, this._features);
+            this._geometries.applyStyle(style, this._features);
         }
     };
 

--- a/Source/Scene/Instanced3DModel3DTileContent.js
+++ b/Source/Scene/Instanced3DModel3DTileContent.js
@@ -451,8 +451,8 @@ define([
         this._batchTable.setAllColor(color);
     };
 
-    Instanced3DModel3DTileContent.prototype.applyStyle = function(frameState, style) {
-        this._batchTable.applyStyle(frameState, style);
+    Instanced3DModel3DTileContent.prototype.applyStyle = function(style) {
+        this._batchTable.applyStyle(style);
     };
 
     Instanced3DModel3DTileContent.prototype.update = function(tileset, frameState) {

--- a/Source/Scene/PointCloud3DTileContent.js
+++ b/Source/Scene/PointCloud3DTileContent.js
@@ -260,9 +260,9 @@ define([
         this._pointCloud.color = enabled ? color : Color.WHITE;
     };
 
-    PointCloud3DTileContent.prototype.applyStyle = function(frameState, style) {
+    PointCloud3DTileContent.prototype.applyStyle = function(style) {
         if (defined(this._batchTable)) {
-            this._batchTable.applyStyle(frameState, style);
+            this._batchTable.applyStyle(style);
         } else {
             this._styleDirty = true;
         }

--- a/Source/Scene/StyleExpression.js
+++ b/Source/Scene/StyleExpression.js
@@ -33,12 +33,11 @@ define([
      * a {@link Cartesian2}, {@link Cartesian3}, or {@link Cartesian4} object will be returned. If the <code>result</code> argument is
      * a {@link Color}, the {@link Cartesian4} value is converted to a {@link Color} and then returned.
      *
-     * @param {FrameState} frameState The frame state.
      * @param {Cesium3DTileFeature} feature The feature whose properties may be used as variables in the expression.
      * @param {Object} [result] The object onto which to store the result.
      * @returns {Boolean|Number|String|RegExp|Cartesian2|Cartesian3|Cartesian4|Color} The result of evaluating the expression.
      */
-    StyleExpression.prototype.evaluate = function(frameState, feature, result) {
+    StyleExpression.prototype.evaluate = function(feature, result) {
         DeveloperError.throwInstantiationError();
     };
 
@@ -48,12 +47,11 @@ define([
      * This is equivalent to {@link StyleExpression#evaluate} but always returns a {@link Color} object.
      * </p>
      *
-     * @param {FrameState} frameState The frame state.
      * @param {Cesium3DTileFeature} feature The feature whose properties may be used as variables in the expression.
      * @param {Color} [result] The object in which to store the result.
      * @returns {Color} The modified result parameter or a new Color instance if one was not provided.
      */
-    StyleExpression.prototype.evaluateColor = function(frameState, feature, result) {
+    StyleExpression.prototype.evaluateColor = function(feature, result) {
         DeveloperError.throwInstantiationError();
     };
 

--- a/Source/Scene/Tileset3DTileContent.js
+++ b/Source/Scene/Tileset3DTileContent.js
@@ -148,7 +148,7 @@ define([
     Tileset3DTileContent.prototype.applyDebugSettings = function(enabled, color) {
     };
 
-    Tileset3DTileContent.prototype.applyStyle = function(frameState, style) {
+    Tileset3DTileContent.prototype.applyStyle = function(style) {
     };
 
     Tileset3DTileContent.prototype.update = function(tileset, frameState) {

--- a/Source/Scene/Vector3DTileContent.js
+++ b/Source/Scene/Vector3DTileContent.js
@@ -494,16 +494,16 @@ define([
         }
     };
 
-    Vector3DTileContent.prototype.applyStyle = function(frameState, style) {
+    Vector3DTileContent.prototype.applyStyle = function(style) {
         createFeatures(this);
         if (defined(this._polygons)) {
-            this._polygons.applyStyle(frameState, style, this._features);
+            this._polygons.applyStyle(style, this._features);
         }
         if (defined(this._polylines)) {
-            this._polylines.applyStyle(frameState, style, this._features);
+            this._polylines.applyStyle(style, this._features);
         }
         if (defined(this._points)) {
-            this._points.applyStyle(frameState, style, this._features);
+            this._points.applyStyle(style, this._features);
         }
     };
 

--- a/Source/Scene/Vector3DTileGeometry.js
+++ b/Source/Scene/Vector3DTileGeometry.js
@@ -408,12 +408,11 @@ define([
     /**
      * Apply a style to the content.
      *
-     * @param {FrameState} frameState The frame state.
      * @param {Cesium3DTileStyle} style The style.
      * @param {Cesium3DTileFeature[]} features The array of features.
      */
-    Vector3DTileGeometry.prototype.applyStyle = function(frameState, style, features) {
-        this._primitive.applyStyle(frameState, style, features);
+    Vector3DTileGeometry.prototype.applyStyle = function(style, features) {
+        this._primitive.applyStyle(style, features);
     };
 
     /**

--- a/Source/Scene/Vector3DTilePoints.js
+++ b/Source/Scene/Vector3DTilePoints.js
@@ -309,11 +309,10 @@ define([
     /**
      * Apply a style to the content.
      *
-     * @param {FrameState} frameState The frame state.
      * @param {Cesium3DTileStyle} style The style.
      * @param {Cesium3DTileFeature[]} features The array of features.
      */
-    Vector3DTilePoints.prototype.applyStyle = function(frameState, style, features) {
+    Vector3DTilePoints.prototype.applyStyle = function(style, features) {
         if (!defined(style)) {
             clearStyle(this, features);
             return;

--- a/Source/Scene/Vector3DTilePoints.js
+++ b/Source/Scene/Vector3DTilePoints.js
@@ -326,65 +326,65 @@ define([
             var feature = features[batchId];
 
             if (defined(style.show)) {
-                feature.show = style.show.evaluate(frameState, feature);
+                feature.show = style.show.evaluate(feature);
             }
 
             if (defined(style.pointSize)) {
-                feature.pointSize = style.pointSize.evaluate(frameState, feature);
+                feature.pointSize = style.pointSize.evaluate(feature);
             }
 
             if (defined(style.color)) {
-                feature.color = style.color.evaluateColor(frameState, feature, scratchColor);
+                feature.color = style.color.evaluateColor(feature, scratchColor);
             }
 
             if (defined(style.pointOutlineColor)) {
-                feature.pointOutlineColor = style.pointOutlineColor.evaluateColor(frameState, feature, scratchColor2);
+                feature.pointOutlineColor = style.pointOutlineColor.evaluateColor(feature, scratchColor2);
             }
 
             if (defined(style.pointOutlineWidth)) {
-                feature.pointOutlineWidth = style.pointOutlineWidth.evaluate(frameState, feature);
+                feature.pointOutlineWidth = style.pointOutlineWidth.evaluate(feature);
             }
 
             if (defined(style.labelColor)) {
-                feature.labelColor = style.labelColor.evaluateColor(frameState, feature, scratchColor3);
+                feature.labelColor = style.labelColor.evaluateColor(feature, scratchColor3);
             }
 
             if (defined(style.labelOutlineColor)) {
-                feature.labelOutlineColor = style.labelOutlineColor.evaluateColor(frameState, feature, scratchColor4);
+                feature.labelOutlineColor = style.labelOutlineColor.evaluateColor(feature, scratchColor4);
             }
 
             if (defined(style.labelOutlineWidth)) {
-                feature.labelOutlineWidth = style.labelOutlineWidth.evaluate(frameState, feature);
+                feature.labelOutlineWidth = style.labelOutlineWidth.evaluate(feature);
             }
 
             if (defined(style.font)) {
-                feature.font = style.font.evaluate(frameState, feature);
+                feature.font = style.font.evaluate(feature);
             }
 
             if (defined(style.labelStyle)) {
-                feature.labelStyle = style.labelStyle.evaluate(frameState, feature);
+                feature.labelStyle = style.labelStyle.evaluate(feature);
             }
 
             if (defined(style.labelText)) {
-                feature.labelText = style.labelText.evaluate(frameState, feature);
+                feature.labelText = style.labelText.evaluate(feature);
             } else {
                 feature.labelText = undefined;
             }
 
             if (defined(style.backgroundColor)) {
-                feature.backgroundColor = style.backgroundColor.evaluateColor(frameState, feature, scratchColor5);
+                feature.backgroundColor = style.backgroundColor.evaluateColor(feature, scratchColor5);
             }
 
             if (defined(style.backgroundPadding)) {
-                feature.backgroundPadding = style.backgroundPadding.evaluate(frameState, feature);
+                feature.backgroundPadding = style.backgroundPadding.evaluate(feature);
             }
 
             if (defined(style.backgroundEnabled)) {
-                feature.backgroundEnabled = style.backgroundEnabled.evaluate(frameState, feature);
+                feature.backgroundEnabled = style.backgroundEnabled.evaluate(feature);
             }
 
             if (defined(style.scaleByDistance)) {
-                var scaleByDistanceCart4 = style.scaleByDistance.evaluate(frameState, feature);
+                var scaleByDistanceCart4 = style.scaleByDistance.evaluate(feature);
                 scratchScaleByDistance.near = scaleByDistanceCart4.x;
                 scratchScaleByDistance.nearValue = scaleByDistanceCart4.y;
                 scratchScaleByDistance.far = scaleByDistanceCart4.z;
@@ -395,7 +395,7 @@ define([
             }
 
             if (defined(style.translucencyByDistance)) {
-                var translucencyByDistanceCart4 = style.translucencyByDistance.evaluate(frameState, feature);
+                var translucencyByDistanceCart4 = style.translucencyByDistance.evaluate(feature);
                 scratchTranslucencyByDistance.near = translucencyByDistanceCart4.x;
                 scratchTranslucencyByDistance.nearValue = translucencyByDistanceCart4.y;
                 scratchTranslucencyByDistance.far = translucencyByDistanceCart4.z;
@@ -406,7 +406,7 @@ define([
             }
 
             if (defined(style.distanceDisplayCondition)) {
-                var distanceDisplayConditionCart2 = style.distanceDisplayCondition.evaluate(frameState, feature);
+                var distanceDisplayConditionCart2 = style.distanceDisplayCondition.evaluate(feature);
                 scratchDistanceDisplayCondition.near = distanceDisplayConditionCart2.x;
                 scratchDistanceDisplayCondition.far = distanceDisplayConditionCart2.y;
                 feature.distanceDisplayCondition = scratchDistanceDisplayCondition;
@@ -415,41 +415,41 @@ define([
             }
 
             if (defined(style.heightOffset)) {
-                feature.heightOffset = style.heightOffset.evaluate(frameState, feature);
+                feature.heightOffset = style.heightOffset.evaluate(feature);
             }
 
             if (defined(style.anchorLineEnabled)) {
-                feature.anchorLineEnabled = style.anchorLineEnabled.evaluate(frameState, feature);
+                feature.anchorLineEnabled = style.anchorLineEnabled.evaluate(feature);
             }
 
             if (defined(style.anchorLineColor)) {
-                feature.anchorLineColor = style.anchorLineColor.evaluateColor(frameState, feature, scratchColor6);
+                feature.anchorLineColor = style.anchorLineColor.evaluateColor(feature, scratchColor6);
             }
 
             if (defined(style.image)) {
-                feature.image = style.image.evaluate(frameState, feature);
+                feature.image = style.image.evaluate(feature);
             } else {
                 feature.image = undefined;
             }
 
             if (defined(style.disableDepthTestDistance)) {
-                feature.disableDepthTestDistance = style.disableDepthTestDistance.evaluate(frameState, feature);
+                feature.disableDepthTestDistance = style.disableDepthTestDistance.evaluate(feature);
             }
 
             if (defined(style.horizontalOrigin)) {
-                feature.horizontalOrigin = style.horizontalOrigin.evaluate(frameState, feature);
+                feature.horizontalOrigin = style.horizontalOrigin.evaluate(feature);
             }
 
             if (defined(style.verticalOrigin)) {
-                feature.verticalOrigin = style.verticalOrigin.evaluate(frameState, feature);
+                feature.verticalOrigin = style.verticalOrigin.evaluate(feature);
             }
 
             if (defined(style.labelHorizontalOrigin)) {
-                feature.labelHorizontalOrigin = style.labelHorizontalOrigin.evaluate(frameState, feature);
+                feature.labelHorizontalOrigin = style.labelHorizontalOrigin.evaluate(feature);
             }
 
             if (defined(style.labelVerticalOrigin)) {
-                feature.labelVerticalOrigin = style.labelVerticalOrigin.evaluate(frameState, feature);
+                feature.labelVerticalOrigin = style.labelVerticalOrigin.evaluate(feature);
             }
         }
     };

--- a/Source/Scene/Vector3DTilePolygons.js
+++ b/Source/Scene/Vector3DTilePolygons.js
@@ -384,12 +384,11 @@ define([
     /**
      * Apply a style to the content.
      *
-     * @param {FrameState} frameState The frame state.
      * @param {Cesium3DTileStyle} style The style.
      * @param {Cesium3DTileFeature[]} features The array of features.
      */
-    Vector3DTilePolygons.prototype.applyStyle = function(frameState, style, features) {
-        this._primitive.applyStyle(frameState, style, features);
+    Vector3DTilePolygons.prototype.applyStyle = function(style, features) {
+        this._primitive.applyStyle(style, features);
     };
 
     /**

--- a/Source/Scene/Vector3DTilePolylines.js
+++ b/Source/Scene/Vector3DTilePolylines.js
@@ -489,11 +489,10 @@ define([
     /**
      * Apply a style to the content.
      *
-     * @param {FrameState} frameState The frame state.
      * @param {Cesium3DTileStyle} style The style.
      * @param {Cesium3DTileFeature[]} features The array of features.
      */
-    Vector3DTilePolylines.prototype.applyStyle = function(frameState, style, features) {
+    Vector3DTilePolylines.prototype.applyStyle = function(style, features) {
         if (!defined(style)) {
             clearStyle(this, features);
             return;

--- a/Source/Scene/Vector3DTilePolylines.js
+++ b/Source/Scene/Vector3DTilePolylines.js
@@ -505,8 +505,8 @@ define([
             var batchId = batchIds[i];
             var feature = features[batchId];
 
-            feature.color = defined(style.color) ? style.color.evaluateColor(frameState, feature, scratchColor) : DEFAULT_COLOR_VALUE;
-            feature.show = defined(style.show) ? style.show.evaluate(frameState, feature) : DEFAULT_SHOW_VALUE;
+            feature.color = defined(style.color) ? style.color.evaluateColor(feature, scratchColor) : DEFAULT_COLOR_VALUE;
+            feature.show = defined(style.show) ? style.show.evaluate(feature) : DEFAULT_SHOW_VALUE;
         }
     };
 

--- a/Source/Scene/Vector3DTilePrimitive.js
+++ b/Source/Scene/Vector3DTilePrimitive.js
@@ -951,8 +951,8 @@ define([
             var batchId = batchIds[i];
             var feature = features[batchId];
 
-            feature.color = defined(style.color) ? style.color.evaluateColor(frameState, feature, scratchColor) : DEFAULT_COLOR_VALUE;
-            feature.show = defined(style.show) ? style.show.evaluate(frameState, feature) : DEFAULT_SHOW_VALUE;
+            feature.color = defined(style.color) ? style.color.evaluateColor(feature, scratchColor) : DEFAULT_COLOR_VALUE;
+            feature.show = defined(style.show) ? style.show.evaluate(feature) : DEFAULT_SHOW_VALUE;
         }
 
         if (isSimpleStyle) {

--- a/Source/Scene/Vector3DTilePrimitive.js
+++ b/Source/Scene/Vector3DTilePrimitive.js
@@ -929,11 +929,10 @@ define([
     /**
      * Apply a style to the content.
      *
-     * @param {FrameState} frameState The frame state.
      * @param {Cesium3DTileStyle} style The style.
      * @param {Cesium3DTileFeature[]} features The array of features.
      */
-    Vector3DTilePrimitive.prototype.applyStyle = function(frameState, style, features) {
+    Vector3DTilePrimitive.prototype.applyStyle = function(style, features) {
         if (!defined(style)) {
             clearStyle(this, features);
             return;

--- a/Source/Widgets/Cesium3DTilesInspector/Cesium3DTilesInspectorViewModel.js
+++ b/Source/Widgets/Cesium3DTilesInspector/Cesium3DTilesInspectorViewModel.js
@@ -1193,9 +1193,8 @@ define([
                 var currentFeature = this._feature;
                 if (defined(currentFeature) && !currentFeature.content.isDestroyed()) {
                     // Restore original color to feature that is no longer selected
-                    var frameState = this._scene.frameState;
                     if (!this.colorize && defined(this._style)) {
-                        currentFeature.color = defined(this._style.color) ? this._style.color.evaluateColor(frameState, currentFeature, scratchColor) : Color.WHITE;
+                        currentFeature.color = defined(this._style.color) ? this._style.color.evaluateColor(currentFeature, scratchColor) : Color.WHITE;
                     } else {
                         currentFeature.color = oldColor;
                     }

--- a/Specs/Scene/Cesium3DTileStyleSpec.js
+++ b/Specs/Scene/Cesium3DTileStyleSpec.js
@@ -12,8 +12,6 @@ defineSuite([
         Expression) {
     'use strict';
 
-    var frameState = {};
-
     function MockFeature() {
         this._properties = {};
     }
@@ -2512,7 +2510,7 @@ defineSuite([
                 description : '"Hello, ${name}"'
             }
         });
-        expect(style.meta.description.evaluate(frameState, feature1)).toEqual('Hello, Hello');
+        expect(style.meta.description.evaluate(feature1)).toEqual('Hello, Hello');
 
         style = new Cesium3DTileStyle({
             meta : {
@@ -2520,8 +2518,8 @@ defineSuite([
                 volume : '${Height} * ${Width} * ${Depth}'
             }
         });
-        expect(style.meta.featureColor.evaluateColor(frameState, feature1)).toEqual(Color.fromBytes(38, 255, 82));
-        expect(style.meta.volume.evaluate(frameState, feature1)).toEqual(20 * 20 * 100);
+        expect(style.meta.featureColor.evaluateColor(feature1)).toEqual(Color.fromBytes(38, 255, 82));
+        expect(style.meta.volume.evaluate(feature1)).toEqual(20 * 20 * 100);
     });
 
     it('default meta has no properties', function() {
@@ -2562,9 +2560,9 @@ defineSuite([
             'pointSize' : '1.0'
         });
 
-        expect(style.show.evaluate(frameState, undefined)).toEqual(true);
-        expect(style.color.evaluateColor(frameState, undefined)).toEqual(Color.WHITE);
-        expect(style.pointSize.evaluate(frameState, undefined)).toEqual(1.0);
+        expect(style.show.evaluate(undefined)).toEqual(true);
+        expect(style.color.evaluateColor(undefined)).toEqual(Color.WHITE);
+        expect(style.pointSize.evaluate(undefined)).toEqual(1.0);
     });
 
     it('applies show style with variable', function() {
@@ -2572,8 +2570,8 @@ defineSuite([
             'show' : "${ZipCode} === '19341'"
         });
 
-        expect(style.show.evaluate(frameState, feature1)).toEqual(true);
-        expect(style.show.evaluate(frameState, feature2)).toEqual(false);
+        expect(style.show.evaluate(feature1)).toEqual(true);
+        expect(style.show.evaluate(feature2)).toEqual(false);
     });
 
     it('applies show style with regexp and variables', function() {
@@ -2581,8 +2579,8 @@ defineSuite([
             'show' : "(regExp('^Chest').test(${County})) && (${YearBuilt} >= 1970)"
         });
 
-        expect(style.show.evaluate(frameState, feature1)).toEqual(true);
-        expect(style.show.evaluate(frameState, feature2)).toEqual(false);
+        expect(style.show.evaluate(feature1)).toEqual(true);
+        expect(style.show.evaluate(feature2)).toEqual(false);
     });
 
     it('applies show style with conditional', function() {
@@ -2598,24 +2596,24 @@ defineSuite([
                 ]
             }
         });
-        expect(style.show.evaluate(frameState, feature1)).toEqual(false);
-        expect(style.show.evaluate(frameState, feature2)).toEqual(true);
+        expect(style.show.evaluate(feature1)).toEqual(false);
+        expect(style.show.evaluate(feature2)).toEqual(true);
     });
 
     it('applies color style variables', function() {
         var style = new Cesium3DTileStyle({
             'color' : "(${Temperature} > 90) ? color('red') : color('white')"
         });
-        expect(style.color.evaluateColor(frameState, feature1)).toEqual(Color.WHITE);
-        expect(style.color.evaluateColor(frameState, feature2)).toEqual(Color.RED);
+        expect(style.color.evaluateColor(feature1)).toEqual(Color.WHITE);
+        expect(style.color.evaluateColor(feature2)).toEqual(Color.RED);
     });
 
     it('applies color style with new color', function() {
         var style = new Cesium3DTileStyle({
             'color' : 'rgba(${red}, ${green}, ${blue}, (${volume} > 100 ? 0.5 : 1.0))'
         });
-        expect(style.color.evaluateColor(frameState, feature1)).toEqual(new Color(38/255, 255/255, 82/255, 0.5));
-        expect(style.color.evaluateColor(frameState, feature2)).toEqual(new Color(255/255, 30/255, 30/255, 1.0));
+        expect(style.color.evaluateColor(feature1)).toEqual(new Color(38/255, 255/255, 82/255, 0.5));
+        expect(style.color.evaluateColor(feature2)).toEqual(new Color(255/255, 30/255, 30/255, 1.0));
     });
 
     it('applies color style that maps id to color', function() {
@@ -2631,8 +2629,8 @@ defineSuite([
                 ]
             }
         });
-        expect(style.color.evaluateColor(frameState, feature1)).toEqual(Color.RED);
-        expect(style.color.evaluateColor(frameState, feature2)).toEqual(Color.LIME);
+        expect(style.color.evaluateColor(feature1)).toEqual(Color.RED);
+        expect(style.color.evaluateColor(feature2)).toEqual(Color.LIME);
     });
 
     it('applies color style with conditional', function() {
@@ -2648,8 +2646,8 @@ defineSuite([
                 ]
             }
         });
-        expect(style.color.evaluateColor(frameState, feature1)).toEqual(Color.BLUE);
-        expect(style.color.evaluateColor(frameState, feature2)).toEqual(Color.YELLOW);
+        expect(style.color.evaluateColor(feature1)).toEqual(Color.BLUE);
+        expect(style.color.evaluateColor(feature2)).toEqual(Color.YELLOW);
     });
 
     it('applies pointSize style with variable', function() {
@@ -2657,8 +2655,8 @@ defineSuite([
             'pointSize' : '${Temperature} / 10.0'
         });
 
-        expect(style.pointSize.evaluate(frameState, feature1)).toEqual(7.8);
-        expect(style.pointSize.evaluate(frameState, feature2)).toEqual(9.2);
+        expect(style.pointSize.evaluate(feature1)).toEqual(7.8);
+        expect(style.pointSize.evaluate(feature2)).toEqual(9.2);
     });
 
     it('applies pointSize style with regexp and variables', function() {
@@ -2666,8 +2664,8 @@ defineSuite([
             'pointSize' : "(regExp('^Chest').test(${County})) ? 2.0 : 1.0"
         });
 
-        expect(style.pointSize.evaluate(frameState, feature1)).toEqual(2.0);
-        expect(style.pointSize.evaluate(frameState, feature2)).toEqual(1.0);
+        expect(style.pointSize.evaluate(feature1)).toEqual(2.0);
+        expect(style.pointSize.evaluate(feature2)).toEqual(1.0);
     });
 
     it('applies pointSize style with conditional', function() {
@@ -2683,8 +2681,8 @@ defineSuite([
                 ]
             }
         });
-        expect(style.pointSize.evaluate(frameState, feature1)).toEqual(6);
-        expect(style.pointSize.evaluate(frameState, feature2)).toEqual(3);
+        expect(style.pointSize.evaluate(feature1)).toEqual(6);
+        expect(style.pointSize.evaluate(feature2)).toEqual(3);
     });
 
     it('applies with defines', function() {
@@ -2707,14 +2705,14 @@ defineSuite([
             }
         });
 
-        expect(style.color.evaluateColor(frameState, feature1)).toEqual(Color.RED);
-        expect(style.color.evaluateColor(frameState, feature2)).toEqual(Color.BLUE);
-        expect(style.show.evaluate(frameState, feature1)).toEqual(true);
-        expect(style.show.evaluate(frameState, feature2)).toEqual(false);
-        expect(style.pointSize.evaluate(frameState, feature1)).toEqual(114);
-        expect(style.pointSize.evaluate(frameState, feature2)).toEqual(44);
-        expect(style.meta.description.evaluate(frameState, feature1)).toEqual('Half height is 50');
-        expect(style.meta.description.evaluate(frameState, feature2)).toEqual('Half height is 19');
+        expect(style.color.evaluateColor(feature1)).toEqual(Color.RED);
+        expect(style.color.evaluateColor(feature2)).toEqual(Color.BLUE);
+        expect(style.show.evaluate(feature1)).toEqual(true);
+        expect(style.show.evaluate(feature2)).toEqual(false);
+        expect(style.pointSize.evaluate(feature1)).toEqual(114);
+        expect(style.pointSize.evaluate(feature2)).toEqual(44);
+        expect(style.meta.description.evaluate(feature1)).toEqual('Half height is 50');
+        expect(style.meta.description.evaluate(feature2)).toEqual('Half height is 19');
     });
 
     it('return undefined shader functions when the style is empty', function() {

--- a/Specs/Scene/Cesium3DTilesetSpec.js
+++ b/Specs/Scene/Cesium3DTilesetSpec.js
@@ -2016,13 +2016,13 @@ defineSuite([
     it('applies custom style to a tileset', function() {
         var style = new Cesium3DTileStyle();
         style.show = {
-            evaluate : function(frameState, feature) {
+            evaluate : function(feature) {
                 return this._value;
             },
             _value : false
         };
         style.color = {
-            evaluateColor : function(frameState, feature, result) {
+            evaluateColor : function(feature, result) {
                 return Color.clone(Color.WHITE, result);
             }
         };

--- a/Specs/Scene/ConditionsExpressionSpec.js
+++ b/Specs/Scene/ConditionsExpressionSpec.js
@@ -8,8 +8,6 @@ defineSuite([
         Color) {
     'use strict';
 
-    var frameState = {};
-
     function MockFeature(value) {
         this._value = value;
     }
@@ -46,22 +44,22 @@ defineSuite([
 
     it('evaluates conditional', function() {
         var expression = new ConditionsExpression(jsonExp);
-        expect(expression.evaluateColor(frameState, new MockFeature(101))).toEqual(Color.BLUE);
-        expect(expression.evaluateColor(frameState, new MockFeature(52))).toEqual(Color.RED);
-        expect(expression.evaluateColor(frameState, new MockFeature(3))).toEqual(Color.LIME);
+        expect(expression.evaluateColor(new MockFeature(101))).toEqual(Color.BLUE);
+        expect(expression.evaluateColor(new MockFeature(52))).toEqual(Color.RED);
+        expect(expression.evaluateColor(new MockFeature(3))).toEqual(Color.LIME);
     });
 
     it('evaluates conditional with defines', function() {
         var expression = new ConditionsExpression(jsonExpWithDefines, defines);
-        expect(expression.evaluateColor(frameState, new MockFeature(101))).toEqual(Color.BLUE);
-        expect(expression.evaluateColor(frameState, new MockFeature(52))).toEqual(Color.LIME);
-        expect(expression.evaluateColor(frameState, new MockFeature(3))).toEqual(Color.LIME);
+        expect(expression.evaluateColor(new MockFeature(101))).toEqual(Color.BLUE);
+        expect(expression.evaluateColor(new MockFeature(52))).toEqual(Color.LIME);
+        expect(expression.evaluateColor(new MockFeature(3))).toEqual(Color.LIME);
     });
 
     it('evaluate takes result argument', function() {
         var result = new Cartesian4();
         var expression = new ConditionsExpression(jsonExpWithDefines, defines, result);
-        var value = expression.evaluate(frameState, new MockFeature(101), result);
+        var value = expression.evaluate(new MockFeature(101), result);
         expect(value).toEqual(new Cartesian4(0.0, 0.0, 1.0, 1.0));
         expect(value).toBe(result);
     });
@@ -69,7 +67,7 @@ defineSuite([
     it('evaluate takes a color result argument', function() {
         var result = new Color();
         var expression = new ConditionsExpression(jsonExpWithDefines, defines, result);
-        var value = expression.evaluate(frameState, new MockFeature(101), result);
+        var value = expression.evaluate(new MockFeature(101), result);
         expect(value).toEqual(Color.BLUE);
         expect(value).toBe(result);
     });
@@ -79,17 +77,17 @@ defineSuite([
             'conditions' : []
         });
         expect(expression._conditions).toEqual([]);
-        expect(expression.evaluate(frameState, new MockFeature(101))).toEqual(undefined);
-        expect(expression.evaluate(frameState, new MockFeature(52))).toEqual(undefined);
-        expect(expression.evaluate(frameState, new MockFeature(3))).toEqual(undefined);
+        expect(expression.evaluate(new MockFeature(101))).toEqual(undefined);
+        expect(expression.evaluate(new MockFeature(52))).toEqual(undefined);
+        expect(expression.evaluate(new MockFeature(3))).toEqual(undefined);
     });
 
     it('constructs and evaluates empty', function() {
         var expression = new ConditionsExpression([]);
         expect(expression._conditions).toEqual(undefined);
-        expect(expression.evaluate(frameState, new MockFeature(101))).toEqual(undefined);
-        expect(expression.evaluate(frameState, new MockFeature(52))).toEqual(undefined);
-        expect(expression.evaluate(frameState, new MockFeature(3))).toEqual(undefined);
+        expect(expression.evaluate(new MockFeature(101))).toEqual(undefined);
+        expect(expression.evaluate(new MockFeature(52))).toEqual(undefined);
+        expect(expression.evaluate(new MockFeature(3))).toEqual(undefined);
     });
 
     it('gets shader function', function() {

--- a/Specs/Scene/ExpressionSpec.js
+++ b/Specs/Scene/ExpressionSpec.js
@@ -16,8 +16,6 @@ defineSuite([
         ExpressionNodeType) {
     'use strict';
 
-    var frameState = {};
-
     function MockFeature() {
         this._properties = {};
         this._className = undefined;
@@ -59,7 +57,7 @@ defineSuite([
 
     it('parses backslashes', function() {
         var expression = new Expression('"\\he\\\\\\ll\\\\o"');
-        expect(expression.evaluate(frameState, undefined)).toEqual('\\he\\\\\\ll\\\\o');
+        expect(expression.evaluate(undefined)).toEqual('\\he\\\\\\ll\\\\o');
     });
 
     it('evaluates variable', function() {
@@ -73,55 +71,55 @@ defineSuite([
         feature.addProperty('undefined', undefined);
 
         var expression = new Expression('${height}');
-        expect(expression.evaluate(frameState, feature)).toEqual(10);
+        expect(expression.evaluate(feature)).toEqual(10);
 
         expression = new Expression('\'${height}\'');
-        expect(expression.evaluate(frameState, feature)).toEqual('10');
+        expect(expression.evaluate(feature)).toEqual('10');
 
         expression = new Expression('${height}/${width}');
-        expect(expression.evaluate(frameState, feature)).toEqual(2);
+        expect(expression.evaluate(feature)).toEqual(2);
 
         expression = new Expression('${string}');
-        expect(expression.evaluate(frameState, feature)).toEqual('hello');
+        expect(expression.evaluate(feature)).toEqual('hello');
 
         expression = new Expression('\'replace ${string}\'');
-        expect(expression.evaluate(frameState, feature)).toEqual('replace hello');
+        expect(expression.evaluate(feature)).toEqual('replace hello');
 
         expression = new Expression('\'replace ${string} multiple ${height}\'');
-        expect(expression.evaluate(frameState, feature)).toEqual('replace hello multiple 10');
+        expect(expression.evaluate(feature)).toEqual('replace hello multiple 10');
 
         expression = new Expression('"replace ${string}"');
-        expect(expression.evaluate(frameState, feature)).toEqual('replace hello');
+        expect(expression.evaluate(feature)).toEqual('replace hello');
 
         expression = new Expression('\'replace ${string\'');
-        expect(expression.evaluate(frameState, feature)).toEqual('replace ${string');
+        expect(expression.evaluate(feature)).toEqual('replace ${string');
 
         expression = new Expression('${boolean}');
-        expect(expression.evaluate(frameState, feature)).toEqual(true);
+        expect(expression.evaluate(feature)).toEqual(true);
 
         expression = new Expression('\'${boolean}\'');
-        expect(expression.evaluate(frameState, feature)).toEqual('true');
+        expect(expression.evaluate(feature)).toEqual('true');
 
         expression = new Expression('${vector}');
-        expect(expression.evaluate(frameState, feature)).toEqual(Cartesian3.UNIT_X);
+        expect(expression.evaluate(feature)).toEqual(Cartesian3.UNIT_X);
 
         expression = new Expression('\'${vector}\'');
-        expect(expression.evaluate(frameState, feature)).toEqual(Cartesian3.UNIT_X.toString());
+        expect(expression.evaluate(feature)).toEqual(Cartesian3.UNIT_X.toString());
 
         expression = new Expression('${null}');
-        expect(expression.evaluate(frameState, feature)).toEqual(null);
+        expect(expression.evaluate(feature)).toEqual(null);
 
         expression = new Expression('\'${null}\'');
-        expect(expression.evaluate(frameState, feature)).toEqual('');
+        expect(expression.evaluate(feature)).toEqual('');
 
         expression = new Expression('${undefined}');
-        expect(expression.evaluate(frameState, feature)).toEqual(undefined);
+        expect(expression.evaluate(feature)).toEqual(undefined);
 
         expression = new Expression('\'${undefined}\'');
-        expect(expression.evaluate(frameState, feature)).toEqual('');
+        expect(expression.evaluate(feature)).toEqual('');
 
         expression = new Expression('abs(-${height}) + max(${height}, ${width}) + clamp(${height}, 0, 2)');
-        expect(expression.evaluate(frameState, feature)).toEqual(22);
+        expect(expression.evaluate(feature)).toEqual(22);
 
         expect(function() {
             return new Expression('${height');
@@ -136,7 +134,7 @@ defineSuite([
         feature.addProperty('Height', 10);
 
         var expression = new Expression('${halfHeight}', defines);
-        expect(expression.evaluate(frameState, feature)).toEqual(5);
+        expect(expression.evaluate(feature)).toEqual(5);
     });
 
     it('evaluates with defines, honoring order of operations', function() {
@@ -144,13 +142,13 @@ defineSuite([
             value: '1 + 2'
         };
         var expression = new Expression('5.0 * ${value}', defines);
-        expect(expression.evaluate(frameState, undefined)).toEqual(15);
+        expect(expression.evaluate(undefined)).toEqual(15);
     });
 
     it('evaluate takes result argument', function() {
         var expression = new Expression('vec3(1.0)');
         var result = new Cartesian3();
-        var value = expression.evaluate(frameState, undefined, result);
+        var value = expression.evaluate(undefined, result);
         expect(value).toEqual(new Cartesian3(1.0, 1.0, 1.0));
         expect(value).toBe(result);
     });
@@ -158,7 +156,7 @@ defineSuite([
     it('evaluate takes a color result argument', function() {
         var expression = new Expression('color("red")');
         var result = new Color();
-        var value = expression.evaluate(frameState, undefined, result);
+        var value = expression.evaluate(undefined, result);
         expect(value).toEqual(Color.RED);
         expect(value).toBe(result);
     });
@@ -249,180 +247,180 @@ defineSuite([
 
     it('evaluates literal null', function() {
         var expression = new Expression('null');
-        expect(expression.evaluate(frameState, undefined)).toEqual(null);
+        expect(expression.evaluate(undefined)).toEqual(null);
     });
 
     it('evaluates literal undefined', function() {
         var expression = new Expression('undefined');
-        expect(expression.evaluate(frameState, undefined)).toEqual(undefined);
+        expect(expression.evaluate(undefined)).toEqual(undefined);
     });
 
     it('evaluates literal boolean', function() {
         var expression = new Expression('true');
-        expect(expression.evaluate(frameState, undefined)).toEqual(true);
+        expect(expression.evaluate(undefined)).toEqual(true);
 
         expression = new Expression('false');
-        expect(expression.evaluate(frameState, undefined)).toEqual(false);
+        expect(expression.evaluate(undefined)).toEqual(false);
     });
 
     it('converts to literal boolean', function() {
         var expression = new Expression('Boolean()');
-        expect(expression.evaluate(frameState, undefined)).toEqual(false);
+        expect(expression.evaluate(undefined)).toEqual(false);
 
         expression = new Expression('Boolean(1)');
-        expect(expression.evaluate(frameState, undefined)).toEqual(true);
+        expect(expression.evaluate(undefined)).toEqual(true);
 
         expression = new Expression('Boolean("true")');
-        expect(expression.evaluate(frameState, undefined)).toEqual(true);
+        expect(expression.evaluate(undefined)).toEqual(true);
     });
 
     it('evaluates literal number', function() {
         var expression = new Expression('1');
-        expect(expression.evaluate(frameState, undefined)).toEqual(1);
+        expect(expression.evaluate(undefined)).toEqual(1);
 
         expression = new Expression('0');
-        expect(expression.evaluate(frameState, undefined)).toEqual(0);
+        expect(expression.evaluate(undefined)).toEqual(0);
 
         expression = new Expression('NaN');
-        expect(expression.evaluate(frameState, undefined)).toEqual(NaN);
+        expect(expression.evaluate(undefined)).toEqual(NaN);
 
         expression = new Expression('Infinity');
-        expect(expression.evaluate(frameState, undefined)).toEqual(Infinity);
+        expect(expression.evaluate(undefined)).toEqual(Infinity);
     });
 
     it('evaluates math constants', function() {
         var expression = new Expression('Math.PI');
-        expect(expression.evaluate(frameState, undefined)).toEqual(Math.PI);
+        expect(expression.evaluate(undefined)).toEqual(Math.PI);
 
         expression = new Expression('Math.E');
-        expect(expression.evaluate(frameState, undefined)).toEqual(Math.E);
+        expect(expression.evaluate(undefined)).toEqual(Math.E);
     });
 
     it('evaluates number constants', function() {
         var expression = new Expression('Number.POSITIVE_INFINITY');
-        expect(expression.evaluate(frameState, undefined)).toEqual(Number.POSITIVE_INFINITY);
+        expect(expression.evaluate(undefined)).toEqual(Number.POSITIVE_INFINITY);
     });
 
     it('converts to literal number', function() {
         var expression = new Expression('Number()');
-        expect(expression.evaluate(frameState, undefined)).toEqual(0);
+        expect(expression.evaluate(undefined)).toEqual(0);
 
         expression = new Expression('Number("1")');
-        expect(expression.evaluate(frameState, undefined)).toEqual(1);
+        expect(expression.evaluate(undefined)).toEqual(1);
 
         expression = new Expression('Number(true)');
-        expect(expression.evaluate(frameState, undefined)).toEqual(1);
+        expect(expression.evaluate(undefined)).toEqual(1);
     });
 
     it('evaluates literal string', function() {
         var expression = new Expression('\'hello\'');
-        expect(expression.evaluate(frameState, undefined)).toEqual('hello');
+        expect(expression.evaluate(undefined)).toEqual('hello');
 
         expression = new Expression('\'Cesium\'');
-        expect(expression.evaluate(frameState, undefined)).toEqual('Cesium');
+        expect(expression.evaluate(undefined)).toEqual('Cesium');
 
         expression = new Expression('"Cesium"');
-        expect(expression.evaluate(frameState, undefined)).toEqual('Cesium');
+        expect(expression.evaluate(undefined)).toEqual('Cesium');
     });
 
     it('converts to literal string', function() {
         var expression = new Expression('String()');
-        expect(expression.evaluate(frameState, undefined)).toEqual('');
+        expect(expression.evaluate(undefined)).toEqual('');
 
         expression = new Expression('String(1)');
-        expect(expression.evaluate(frameState, undefined)).toEqual('1');
+        expect(expression.evaluate(undefined)).toEqual('1');
 
         expression = new Expression('String(true)');
-        expect(expression.evaluate(frameState, undefined)).toEqual('true');
+        expect(expression.evaluate(undefined)).toEqual('true');
     });
 
     it('evaluates literal color', function() {
         var expression = new Expression('color(\'#ffffff\')');
-        expect(expression.evaluate(frameState, undefined)).toEqual(Cartesian4.fromColor(Color.WHITE));
+        expect(expression.evaluate(undefined)).toEqual(Cartesian4.fromColor(Color.WHITE));
 
         expression = new Expression('color(\'#00FFFF\')');
-        expect(expression.evaluate(frameState, undefined)).toEqual(Cartesian4.fromColor(Color.CYAN));
+        expect(expression.evaluate(undefined)).toEqual(Cartesian4.fromColor(Color.CYAN));
 
         expression = new Expression('color(\'#fff\')');
-        expect(expression.evaluate(frameState, undefined)).toEqual(Cartesian4.fromColor(Color.WHITE));
+        expect(expression.evaluate(undefined)).toEqual(Cartesian4.fromColor(Color.WHITE));
 
         expression = new Expression('color(\'#0FF\')');
-        expect(expression.evaluate(frameState, undefined)).toEqual(Cartesian4.fromColor(Color.CYAN));
+        expect(expression.evaluate(undefined)).toEqual(Cartesian4.fromColor(Color.CYAN));
 
         expression = new Expression('color(\'white\')');
-        expect(expression.evaluate(frameState, undefined)).toEqual(Cartesian4.fromColor(Color.WHITE));
+        expect(expression.evaluate(undefined)).toEqual(Cartesian4.fromColor(Color.WHITE));
 
         expression = new Expression('color(\'cyan\')');
-        expect(expression.evaluate(frameState, undefined)).toEqual(Cartesian4.fromColor(Color.CYAN));
+        expect(expression.evaluate(undefined)).toEqual(Cartesian4.fromColor(Color.CYAN));
 
         expression = new Expression('color(\'white\', 0.5)');
-        expect(expression.evaluate(frameState, undefined)).toEqual(Cartesian4.fromColor(Color.fromAlpha(Color.WHITE, 0.5)));
+        expect(expression.evaluate(undefined)).toEqual(Cartesian4.fromColor(Color.fromAlpha(Color.WHITE, 0.5)));
 
         expression = new Expression('rgb(255, 255, 255)');
-        expect(expression.evaluate(frameState, undefined)).toEqual(Cartesian4.fromColor(Color.WHITE));
+        expect(expression.evaluate(undefined)).toEqual(Cartesian4.fromColor(Color.WHITE));
 
         expression = new Expression('rgb(100, 255, 190)');
-        expect(expression.evaluate(frameState, undefined)).toEqual(Cartesian4.fromColor(Color.fromBytes(100, 255, 190)));
+        expect(expression.evaluate(undefined)).toEqual(Cartesian4.fromColor(Color.fromBytes(100, 255, 190)));
 
         expression = new Expression('hsl(0, 0, 1)');
-        expect(expression.evaluate(frameState, undefined)).toEqual(Cartesian4.fromColor(Color.WHITE));
+        expect(expression.evaluate(undefined)).toEqual(Cartesian4.fromColor(Color.WHITE));
 
         expression = new Expression('hsl(1.0, 0.6, 0.7)');
-        expect(expression.evaluate(frameState, undefined)).toEqual(Cartesian4.fromColor(Color.fromHsl(1.0, 0.6, 0.7)));
+        expect(expression.evaluate(undefined)).toEqual(Cartesian4.fromColor(Color.fromHsl(1.0, 0.6, 0.7)));
 
         expression = new Expression('rgba(255, 255, 255, 0.5)');
-        expect(expression.evaluate(frameState, undefined)).toEqual(Cartesian4.fromColor(Color.fromAlpha(Color.WHITE, 0.5)));
+        expect(expression.evaluate(undefined)).toEqual(Cartesian4.fromColor(Color.fromAlpha(Color.WHITE, 0.5)));
 
         expression = new Expression('rgba(100, 255, 190, 0.25)');
-        expect(expression.evaluate(frameState, undefined)).toEqual(Cartesian4.fromColor(Color.fromBytes(100, 255, 190, 0.25 * 255)));
+        expect(expression.evaluate(undefined)).toEqual(Cartesian4.fromColor(Color.fromBytes(100, 255, 190, 0.25 * 255)));
 
         expression = new Expression('hsla(0, 0, 1, 0.5)');
-        expect(expression.evaluate(frameState, undefined)).toEqual(Cartesian4.fromColor(new Color(1.0, 1.0, 1.0, 0.5)));
+        expect(expression.evaluate(undefined)).toEqual(Cartesian4.fromColor(new Color(1.0, 1.0, 1.0, 0.5)));
 
         expression = new Expression('hsla(1.0, 0.6, 0.7, 0.75)');
-        expect(expression.evaluate(frameState, undefined)).toEqual(Cartesian4.fromColor(Color.fromHsl(1.0, 0.6, 0.7, 0.75)));
+        expect(expression.evaluate(undefined)).toEqual(Cartesian4.fromColor(Color.fromHsl(1.0, 0.6, 0.7, 0.75)));
 
         expression = new Expression('color()');
-        expect(expression.evaluate(frameState, undefined)).toEqual(Cartesian4.fromColor(Color.WHITE));
+        expect(expression.evaluate(undefined)).toEqual(Cartesian4.fromColor(Color.WHITE));
     });
 
     it('evaluates literal color with result parameter', function() {
         var color = new Color();
 
         var expression = new Expression('color(\'#0000ff\')');
-        expect(expression.evaluate(frameState, undefined, color)).toEqual(Color.BLUE);
+        expect(expression.evaluate(undefined, color)).toEqual(Color.BLUE);
         expect(color).toEqual(Color.BLUE);
 
         expression = new Expression('color(\'#f00\')');
-        expect(expression.evaluate(frameState, undefined, color)).toEqual(Color.RED);
+        expect(expression.evaluate(undefined, color)).toEqual(Color.RED);
         expect(color).toEqual(Color.RED);
 
         expression = new Expression('color(\'cyan\')');
-        expect(expression.evaluate(frameState, undefined, color)).toEqual(Color.CYAN);
+        expect(expression.evaluate(undefined, color)).toEqual(Color.CYAN);
         expect(color).toEqual(Color.CYAN);
 
         expression = new Expression('color(\'white\', 0.5)');
-        expect(expression.evaluate(frameState, undefined, color)).toEqual(new Color(1.0, 1.0, 1.0, 0.5));
+        expect(expression.evaluate(undefined, color)).toEqual(new Color(1.0, 1.0, 1.0, 0.5));
         expect(color).toEqual(new Color(1.0, 1.0, 1.0, 0.5));
 
         expression = new Expression('rgb(0, 0, 0)');
-        expect(expression.evaluate(frameState, undefined, color)).toEqual(Color.BLACK);
+        expect(expression.evaluate(undefined, color)).toEqual(Color.BLACK);
         expect(color).toEqual(Color.BLACK);
 
         expression = new Expression('hsl(0, 0, 1)');
-        expect(expression.evaluate(frameState, undefined, color)).toEqual(Color.WHITE);
+        expect(expression.evaluate(undefined, color)).toEqual(Color.WHITE);
         expect(color).toEqual(Color.WHITE);
 
         expression = new Expression('rgba(255, 0, 255, 0.5)');
-        expect(expression.evaluate(frameState, undefined, color)).toEqual(new Color(1.0, 0, 1.0, 0.5));
+        expect(expression.evaluate(undefined, color)).toEqual(new Color(1.0, 0, 1.0, 0.5));
         expect(color).toEqual(new Color(1.0, 0, 1.0, 0.5));
 
         expression = new Expression('hsla(0, 0, 1, 0.5)');
-        expect(expression.evaluate(frameState, undefined, color)).toEqual(new Color(1.0, 1.0, 1.0, 0.5));
+        expect(expression.evaluate(undefined, color)).toEqual(new Color(1.0, 1.0, 1.0, 0.5));
         expect(color).toEqual(new Color(1.0, 1.0, 1.0, 0.5));
 
         expression = new Expression('color()');
-        expect(expression.evaluate(frameState, undefined, color)).toEqual(Color.WHITE);
+        expect(expression.evaluate(undefined, color)).toEqual(Color.WHITE);
         expect(color).toEqual(Color.WHITE);
     });
 
@@ -434,19 +432,19 @@ defineSuite([
         feature.addProperty('alpha', 0.2);
 
         var expression = new Expression('color(${hex6})');
-        expect(expression.evaluate(frameState, feature)).toEqual(Cartesian4.fromColor(Color.WHITE));
+        expect(expression.evaluate(feature)).toEqual(Cartesian4.fromColor(Color.WHITE));
 
         expression = new Expression('color(${hex3})');
-        expect(expression.evaluate(frameState, feature)).toEqual(Cartesian4.fromColor(Color.WHITE));
+        expect(expression.evaluate(feature)).toEqual(Cartesian4.fromColor(Color.WHITE));
 
         expression = new Expression('color(${keyword})');
-        expect(expression.evaluate(frameState, feature)).toEqual(Cartesian4.fromColor(Color.WHITE));
+        expect(expression.evaluate(feature)).toEqual(Cartesian4.fromColor(Color.WHITE));
 
         expression = new Expression('color(${keyword}, ${alpha} + 0.6)');
-        expect(expression.evaluate(frameState, feature).x).toEqual(1.0);
-        expect(expression.evaluate(frameState, feature).y).toEqual(1.0);
-        expect(expression.evaluate(frameState, feature).z).toEqual(1.0);
-        expect(expression.evaluate(frameState, feature).w).toEqual(0.8);
+        expect(expression.evaluate(feature).x).toEqual(1.0);
+        expect(expression.evaluate(feature).y).toEqual(1.0);
+        expect(expression.evaluate(feature).z).toEqual(1.0);
+        expect(expression.evaluate(feature).w).toEqual(0.8);
     });
 
     it('evaluates rgb with expressions as arguments', function() {
@@ -456,10 +454,10 @@ defineSuite([
         feature.addProperty('blue', 255);
 
         var expression = new Expression('rgb(${red}, ${green}, ${blue})');
-        expect(expression.evaluate(frameState, feature)).toEqual(Cartesian4.fromColor(Color.fromBytes(100, 200, 255)));
+        expect(expression.evaluate(feature)).toEqual(Cartesian4.fromColor(Color.fromBytes(100, 200, 255)));
 
         expression = new Expression('rgb(${red}/2, ${green}/2, ${blue})');
-        expect(expression.evaluate(frameState, feature)).toEqual(Cartesian4.fromColor(Color.fromBytes(50, 100, 255)));
+        expect(expression.evaluate(feature)).toEqual(Cartesian4.fromColor(Color.fromBytes(50, 100, 255)));
     });
 
     it('evaluates hsl with expressions as arguments', function() {
@@ -469,10 +467,10 @@ defineSuite([
         feature.addProperty('l', 1.0);
 
         var expression = new Expression('hsl(${h}, ${s}, ${l})');
-        expect(expression.evaluate(frameState, feature)).toEqual(Cartesian4.fromColor(Color.WHITE));
+        expect(expression.evaluate(feature)).toEqual(Cartesian4.fromColor(Color.WHITE));
 
         expression = new Expression('hsl(${h} + 0.2, ${s} + 1.0, ${l} - 0.5)');
-        expect(expression.evaluate(frameState, feature)).toEqual(Cartesian4.fromColor(Color.fromHsl(0.2, 1.0, 0.5)));
+        expect(expression.evaluate(feature)).toEqual(Cartesian4.fromColor(Color.fromHsl(0.2, 1.0, 0.5)));
     });
 
     it('evaluates rgba with expressions as arguments', function() {
@@ -483,10 +481,10 @@ defineSuite([
         feature.addProperty('a', 0.3);
 
         var expression = new Expression('rgba(${red}, ${green}, ${blue}, ${a})');
-        expect(expression.evaluate(frameState, feature)).toEqual(Cartesian4.fromColor(Color.fromBytes(100, 200, 255, 0.3*255)));
+        expect(expression.evaluate(feature)).toEqual(Cartesian4.fromColor(Color.fromBytes(100, 200, 255, 0.3*255)));
 
         expression = new Expression('rgba(${red}/2, ${green}/2, ${blue}, ${a} * 2)');
-        expect(expression.evaluate(frameState, feature)).toEqual(Cartesian4.fromColor(Color.fromBytes(50, 100, 255, 0.6*255)));
+        expect(expression.evaluate(feature)).toEqual(Cartesian4.fromColor(Color.fromBytes(50, 100, 255, 0.6*255)));
     });
 
     it('evaluates hsla with expressions as arguments', function() {
@@ -497,10 +495,10 @@ defineSuite([
         feature.addProperty('a', 1.0);
 
         var expression = new Expression('hsla(${h}, ${s}, ${l}, ${a})');
-        expect(expression.evaluate(frameState, feature)).toEqual(Cartesian4.fromColor(Color.WHITE));
+        expect(expression.evaluate(feature)).toEqual(Cartesian4.fromColor(Color.WHITE));
 
         expression = new Expression('hsla(${h} + 0.2, ${s} + 1.0, ${l} - 0.5, ${a} / 4)');
-        expect(expression.evaluate(frameState, feature)).toEqual(Cartesian4.fromColor(Color.fromHsl(0.2, 1.0, 0.5, 0.25)));
+        expect(expression.evaluate(feature)).toEqual(Cartesian4.fromColor(Color.fromHsl(0.2, 1.0, 0.5, 0.25)));
     });
 
     it('evaluates rgba with expressions as arguments', function() {
@@ -511,10 +509,10 @@ defineSuite([
         feature.addProperty('alpha', 0.5);
 
         var expression = new Expression('rgba(${red}, ${green}, ${blue}, ${alpha})');
-        expect(expression.evaluate(frameState, feature)).toEqual(Cartesian4.fromColor(Color.fromBytes(100, 200, 255, 0.5 * 255)));
+        expect(expression.evaluate(feature)).toEqual(Cartesian4.fromColor(Color.fromBytes(100, 200, 255, 0.5 * 255)));
 
         expression = new Expression('rgba(${red}/2, ${green}/2, ${blue}, ${alpha} + 0.1)');
-        expect(expression.evaluate(frameState, feature)).toEqual(Cartesian4.fromColor(Color.fromBytes(50, 100, 255, 0.6 * 255)));
+        expect(expression.evaluate(feature)).toEqual(Cartesian4.fromColor(Color.fromBytes(50, 100, 255, 0.6 * 255)));
     });
 
     it('color constructors throw with wrong number of arguments', function() {
@@ -537,226 +535,226 @@ defineSuite([
 
     it('evaluates color properties (r, g, b, a)', function() {
         var expression = new Expression('color(\'#ffffff\').r');
-        expect(expression.evaluate(frameState, undefined)).toEqual(1);
+        expect(expression.evaluate(undefined)).toEqual(1);
 
         expression = new Expression('rgb(255, 255, 0).g');
-        expect(expression.evaluate(frameState, undefined)).toEqual(1);
+        expect(expression.evaluate(undefined)).toEqual(1);
 
         expression = new Expression('color("cyan").b');
-        expect(expression.evaluate(frameState, undefined)).toEqual(1);
+        expect(expression.evaluate(undefined)).toEqual(1);
 
         expression = new Expression('rgba(255, 255, 0, 0.5).a');
-        expect(expression.evaluate(frameState, undefined)).toEqual(0.5);
+        expect(expression.evaluate(undefined)).toEqual(0.5);
     });
 
     it('evaluates color properties (x, y, z, w)', function() {
         var expression = new Expression('color(\'#ffffff\').x');
-        expect(expression.evaluate(frameState, undefined)).toEqual(1);
+        expect(expression.evaluate(undefined)).toEqual(1);
 
         expression = new Expression('rgb(255, 255, 0).y');
-        expect(expression.evaluate(frameState, undefined)).toEqual(1);
+        expect(expression.evaluate(undefined)).toEqual(1);
 
         expression = new Expression('color("cyan").z');
-        expect(expression.evaluate(frameState, undefined)).toEqual(1);
+        expect(expression.evaluate(undefined)).toEqual(1);
 
         expression = new Expression('rgba(255, 255, 0, 0.5).w');
-        expect(expression.evaluate(frameState, undefined)).toEqual(0.5);
+        expect(expression.evaluate(undefined)).toEqual(0.5);
     });
 
     it('evaluates color properties ([0], [1], [2]. [3])', function() {
         var expression = new Expression('color(\'#ffffff\')[0]');
-        expect(expression.evaluate(frameState, undefined)).toEqual(1);
+        expect(expression.evaluate(undefined)).toEqual(1);
 
         expression = new Expression('rgb(255, 255, 0)[1]');
-        expect(expression.evaluate(frameState, undefined)).toEqual(1);
+        expect(expression.evaluate(undefined)).toEqual(1);
 
         expression = new Expression('color("cyan")[2]');
-        expect(expression.evaluate(frameState, undefined)).toEqual(1);
+        expect(expression.evaluate(undefined)).toEqual(1);
 
         expression = new Expression('rgba(255, 255, 0, 0.5)[3]');
-        expect(expression.evaluate(frameState, undefined)).toEqual(0.5);
+        expect(expression.evaluate(undefined)).toEqual(0.5);
     });
 
     it('evaluates color properties (["r"], ["g"], ["b"], ["a"])', function() {
         var expression = new Expression('color(\'#ffffff\')["r"]');
-        expect(expression.evaluate(frameState, undefined)).toEqual(1);
+        expect(expression.evaluate(undefined)).toEqual(1);
 
         expression = new Expression('rgb(255, 255, 0)["g"]');
-        expect(expression.evaluate(frameState, undefined)).toEqual(1);
+        expect(expression.evaluate(undefined)).toEqual(1);
 
         expression = new Expression('color("cyan")["b"]');
-        expect(expression.evaluate(frameState, undefined)).toEqual(1);
+        expect(expression.evaluate(undefined)).toEqual(1);
 
         expression = new Expression('rgba(255, 255, 0, 0.5)["a"]');
-        expect(expression.evaluate(frameState, undefined)).toEqual(0.5);
+        expect(expression.evaluate(undefined)).toEqual(0.5);
     });
 
     it('evaluates color properties (["x"], ["y"], ["z"], ["w"])', function() {
         var expression = new Expression('color(\'#ffffff\')["x"]');
-        expect(expression.evaluate(frameState, undefined)).toEqual(1);
+        expect(expression.evaluate(undefined)).toEqual(1);
 
         expression = new Expression('rgb(255, 255, 0)["y"]');
-        expect(expression.evaluate(frameState, undefined)).toEqual(1);
+        expect(expression.evaluate(undefined)).toEqual(1);
 
         expression = new Expression('color("cyan")["z"]');
-        expect(expression.evaluate(frameState, undefined)).toEqual(1);
+        expect(expression.evaluate(undefined)).toEqual(1);
 
         expression = new Expression('rgba(255, 255, 0, 0.5)["w"]');
-        expect(expression.evaluate(frameState, undefined)).toEqual(0.5);
+        expect(expression.evaluate(undefined)).toEqual(0.5);
     });
 
     it('evaluates vec2', function() {
         var expression = new Expression('vec2(2.0)');
-        expect(expression.evaluate(frameState, undefined)).toEqual(new Cartesian2(2.0, 2.0));
+        expect(expression.evaluate(undefined)).toEqual(new Cartesian2(2.0, 2.0));
 
         expression = new Expression('vec2(3.0, 4.0)');
-        expect(expression.evaluate(frameState, undefined)).toEqual(new Cartesian2(3.0, 4.0));
+        expect(expression.evaluate(undefined)).toEqual(new Cartesian2(3.0, 4.0));
 
         expression = new Expression('vec2(vec2(3.0, 4.0))');
-        expect(expression.evaluate(frameState, undefined)).toEqual(new Cartesian2(3.0, 4.0));
+        expect(expression.evaluate(undefined)).toEqual(new Cartesian2(3.0, 4.0));
 
         expression = new Expression('vec2(vec3(3.0, 4.0, 5.0))');
-        expect(expression.evaluate(frameState, undefined)).toEqual(new Cartesian2(3.0, 4.0));
+        expect(expression.evaluate(undefined)).toEqual(new Cartesian2(3.0, 4.0));
 
         expression = new Expression('vec2(vec4(3.0, 4.0, 5.0, 6.0))');
-        expect(expression.evaluate(frameState, undefined)).toEqual(new Cartesian2(3.0, 4.0));
+        expect(expression.evaluate(undefined)).toEqual(new Cartesian2(3.0, 4.0));
     });
 
     it('throws if vec2 has invalid number of arguments', function() {
         var expression = new Expression('vec2()');
         expect(function() {
-            expression.evaluate(frameState, undefined);
+            expression.evaluate(undefined);
         }).toThrowRuntimeError();
 
         expression = new Expression('vec2(3.0, 4.0, 5.0)');
         expect(function() {
-            expression.evaluate(frameState, undefined);
+            expression.evaluate(undefined);
         }).toThrowRuntimeError();
 
         expression = new Expression('vec2(vec2(3.0, 4.0), 5.0)');
         expect(function() {
-            expression.evaluate(frameState, undefined);
+            expression.evaluate(undefined);
         }).toThrowRuntimeError();
     });
 
     it('throws if vec2 has invalid argument', function() {
         var expression = new Expression('vec2("1")');
         expect(function() {
-            expression.evaluate(frameState, undefined);
+            expression.evaluate(undefined);
         }).toThrowRuntimeError();
     });
 
     it('evaluates vec3', function() {
         var expression = new Expression('vec3(2.0)');
-        expect(expression.evaluate(frameState, undefined)).toEqual(new Cartesian3(2.0, 2.0, 2.0));
+        expect(expression.evaluate(undefined)).toEqual(new Cartesian3(2.0, 2.0, 2.0));
 
         expression = new Expression('vec3(3.0, 4.0, 5.0)');
-        expect(expression.evaluate(frameState, undefined)).toEqual(new Cartesian3(3.0, 4.0, 5.0));
+        expect(expression.evaluate(undefined)).toEqual(new Cartesian3(3.0, 4.0, 5.0));
 
         expression = new Expression('vec3(vec2(3.0, 4.0), 5.0)');
-        expect(expression.evaluate(frameState, undefined)).toEqual(new Cartesian3(3.0, 4.0, 5.0));
+        expect(expression.evaluate(undefined)).toEqual(new Cartesian3(3.0, 4.0, 5.0));
 
         expression = new Expression('vec3(3.0, vec2(4.0, 5.0))');
-        expect(expression.evaluate(frameState, undefined)).toEqual(new Cartesian3(3.0, 4.0, 5.0));
+        expect(expression.evaluate(undefined)).toEqual(new Cartesian3(3.0, 4.0, 5.0));
 
         expression = new Expression('vec3(vec3(3.0, 4.0, 5.0))');
-        expect(expression.evaluate(frameState, undefined)).toEqual(new Cartesian3(3.0, 4.0, 5.0));
+        expect(expression.evaluate(undefined)).toEqual(new Cartesian3(3.0, 4.0, 5.0));
 
         expression = new Expression('vec3(vec4(3.0, 4.0, 5.0, 6.0))');
-        expect(expression.evaluate(frameState, undefined)).toEqual(new Cartesian3(3.0, 4.0, 5.0));
+        expect(expression.evaluate(undefined)).toEqual(new Cartesian3(3.0, 4.0, 5.0));
     });
 
     it ('throws if vec3 has invalid number of arguments', function() {
         var expression = new Expression('vec3()');
         expect(function() {
-            expression.evaluate(frameState, undefined);
+            expression.evaluate(undefined);
         }).toThrowRuntimeError();
 
         expression = new Expression('vec3(3.0, 4.0)');
         expect(function() {
-            expression.evaluate(frameState, undefined);
+            expression.evaluate(undefined);
         }).toThrowRuntimeError();
 
         expression = new Expression('vec3(3.0, 4.0, 5.0, 6.0)');
         expect(function() {
-            expression.evaluate(frameState, undefined);
+            expression.evaluate(undefined);
         }).toThrowRuntimeError();
 
         expression = new Expression('vec3(vec2(3.0, 4.0), vec2(5.0, 6.0))');
         expect(function() {
-            expression.evaluate(frameState, undefined);
+            expression.evaluate(undefined);
         }).toThrowRuntimeError();
 
         expression = new Expression('vec3(vec4(3.0, 4.0, 5.0, 6.0), 1.0)');
         expect(function() {
-            expression.evaluate(frameState, undefined);
+            expression.evaluate(undefined);
         }).toThrowRuntimeError();
     });
 
     it('throws if vec3 has invalid argument', function() {
         var expression = new Expression('vec3(1.0, "1.0", 2.0)');
         expect(function() {
-            expression.evaluate(frameState, undefined);
+            expression.evaluate(undefined);
         }).toThrowRuntimeError();
     });
 
     it('evaluates vec4', function() {
         var expression = new Expression('vec4(2.0)');
-        expect(expression.evaluate(frameState, undefined)).toEqual(new Cartesian4(2.0, 2.0, 2.0, 2.0));
+        expect(expression.evaluate(undefined)).toEqual(new Cartesian4(2.0, 2.0, 2.0, 2.0));
 
         expression = new Expression('vec4(3.0, 4.0, 5.0, 6.0)');
-        expect(expression.evaluate(frameState, undefined)).toEqual(new Cartesian4(3.0, 4.0, 5.0, 6.0));
+        expect(expression.evaluate(undefined)).toEqual(new Cartesian4(3.0, 4.0, 5.0, 6.0));
 
         expression = new Expression('vec4(vec2(3.0, 4.0), 5.0, 6.0)');
-        expect(expression.evaluate(frameState, undefined)).toEqual(new Cartesian4(3.0, 4.0, 5.0, 6.0));
+        expect(expression.evaluate(undefined)).toEqual(new Cartesian4(3.0, 4.0, 5.0, 6.0));
 
         expression = new Expression('vec4(3.0, vec2(4.0, 5.0), 6.0)');
-        expect(expression.evaluate(frameState, undefined)).toEqual(new Cartesian4(3.0, 4.0, 5.0, 6.0));
+        expect(expression.evaluate(undefined)).toEqual(new Cartesian4(3.0, 4.0, 5.0, 6.0));
 
         expression = new Expression('vec4(3.0, 4.0, vec2(5.0, 6.0))');
-        expect(expression.evaluate(frameState, undefined)).toEqual(new Cartesian4(3.0, 4.0, 5.0, 6.0));
+        expect(expression.evaluate(undefined)).toEqual(new Cartesian4(3.0, 4.0, 5.0, 6.0));
 
         expression = new Expression('vec4(vec3(3.0, 4.0, 5.0), 6.0)');
-        expect(expression.evaluate(frameState, undefined)).toEqual(new Cartesian4(3.0, 4.0, 5.0, 6.0));
+        expect(expression.evaluate(undefined)).toEqual(new Cartesian4(3.0, 4.0, 5.0, 6.0));
 
         expression = new Expression('vec4(3.0, vec3(4.0, 5.0, 6.0))');
-        expect(expression.evaluate(frameState, undefined)).toEqual(new Cartesian4(3.0, 4.0, 5.0, 6.0));
+        expect(expression.evaluate(undefined)).toEqual(new Cartesian4(3.0, 4.0, 5.0, 6.0));
 
         expression = new Expression('vec4(vec4(3.0, 4.0, 5.0, 6.0))');
-        expect(expression.evaluate(frameState, undefined)).toEqual(new Cartesian4(3.0, 4.0, 5.0, 6.0));
+        expect(expression.evaluate(undefined)).toEqual(new Cartesian4(3.0, 4.0, 5.0, 6.0));
     });
 
     it ('throws if vec4 has invalid number of arguments', function() {
         var expression = new Expression('vec4()');
         expect(function() {
-            expression.evaluate(frameState, undefined);
+            expression.evaluate(undefined);
         }).toThrowRuntimeError();
 
         expression = new Expression('vec4(3.0, 4.0)');
         expect(function() {
-            expression.evaluate(frameState, undefined);
+            expression.evaluate(undefined);
         }).toThrowRuntimeError();
 
         expression = new Expression('vec4(3.0, 4.0, 5.0)');
         expect(function() {
-            expression.evaluate(frameState, undefined);
+            expression.evaluate(undefined);
         }).toThrowRuntimeError();
 
         expression = new Expression('vec4(3.0, 4.0, 5.0, 6.0, 7.0)');
         expect(function() {
-            expression.evaluate(frameState, undefined);
+            expression.evaluate(undefined);
         }).toThrowRuntimeError();
 
         expression = new Expression('vec4(vec3(3.0, 4.0, 5.0))');
         expect(function() {
-            expression.evaluate(frameState, undefined);
+            expression.evaluate(undefined);
         }).toThrowRuntimeError();
     });
 
     it('throws if vec4 has invalid argument', function() {
         var expression = new Expression('vec4(1.0, "2.0", 3.0, 4.0)');
         expect(function() {
-            expression.evaluate(frameState, undefined);
+            expression.evaluate(undefined);
         }).toThrowRuntimeError();
     });
 
@@ -768,653 +766,653 @@ defineSuite([
         feature.addProperty('scale', 1);
 
         var expression = new Expression('vec4(${height}, ${width}, ${depth}, ${scale})');
-        expect(expression.evaluate(frameState, feature)).toEqual(new Cartesian4(2.0, 4.0, 3.0, 1.0));
+        expect(expression.evaluate(feature)).toEqual(new Cartesian4(2.0, 4.0, 3.0, 1.0));
     });
 
     it('evaluates expression with multiple nested vectors', function() {
         var expression = new Expression('vec4(vec2(1, 2)[vec3(6, 1, 5).y], 2, vec4(1.0).w, 5)');
-        expect(expression.evaluate(frameState, undefined)).toEqual(new Cartesian4(2.0, 2.0, 1.0, 5.0));
+        expect(expression.evaluate(undefined)).toEqual(new Cartesian4(2.0, 2.0, 1.0, 5.0));
     });
 
     it('evaluates vector properties (x, y, z, w)', function() {
         var expression = new Expression('vec4(1.0, 2.0, 3.0, 4.0).x');
-        expect(expression.evaluate(frameState, undefined)).toEqual(1.0);
+        expect(expression.evaluate(undefined)).toEqual(1.0);
 
         expression = new Expression('vec4(1.0, 2.0, 3.0, 4.0).y');
-        expect(expression.evaluate(frameState, undefined)).toEqual(2.0);
+        expect(expression.evaluate(undefined)).toEqual(2.0);
 
         expression = new Expression('vec4(1.0, 2.0, 3.0, 4.0).z');
-        expect(expression.evaluate(frameState, undefined)).toEqual(3.0);
+        expect(expression.evaluate(undefined)).toEqual(3.0);
 
         expression = new Expression('vec4(1.0, 2.0, 3.0, 4.0).w');
-        expect(expression.evaluate(frameState, undefined)).toEqual(4.0);
+        expect(expression.evaluate(undefined)).toEqual(4.0);
     });
 
     it('evaluates vector properties (r, g, b, a)', function() {
         var expression = new Expression('vec4(1.0, 2.0, 3.0, 4.0).r');
-        expect(expression.evaluate(frameState, undefined)).toEqual(1.0);
+        expect(expression.evaluate(undefined)).toEqual(1.0);
 
         expression = new Expression('vec4(1.0, 2.0, 3.0, 4.0).g');
-        expect(expression.evaluate(frameState, undefined)).toEqual(2.0);
+        expect(expression.evaluate(undefined)).toEqual(2.0);
 
         expression = new Expression('vec4(1.0, 2.0, 3.0, 4.0).b');
-        expect(expression.evaluate(frameState, undefined)).toEqual(3.0);
+        expect(expression.evaluate(undefined)).toEqual(3.0);
 
         expression = new Expression('vec4(1.0, 2.0, 3.0, 4.0).a');
-        expect(expression.evaluate(frameState, undefined)).toEqual(4.0);
+        expect(expression.evaluate(undefined)).toEqual(4.0);
     });
 
     it('evaluates vector properties ([0], [1], [2], [3])', function() {
         var expression = new Expression('vec4(1.0, 2.0, 3.0, 4.0)[0]');
-        expect(expression.evaluate(frameState, undefined)).toEqual(1.0);
+        expect(expression.evaluate(undefined)).toEqual(1.0);
 
         expression = new Expression('vec4(1.0, 2.0, 3.0, 4.0)[1]');
-        expect(expression.evaluate(frameState, undefined)).toEqual(2.0);
+        expect(expression.evaluate(undefined)).toEqual(2.0);
 
         expression = new Expression('vec4(1.0, 2.0, 3.0, 4.0)[2]');
-        expect(expression.evaluate(frameState, undefined)).toEqual(3.0);
+        expect(expression.evaluate(undefined)).toEqual(3.0);
 
         expression = new Expression('vec4(1.0, 2.0, 3.0, 4.0)[3]');
-        expect(expression.evaluate(frameState, undefined)).toEqual(4.0);
+        expect(expression.evaluate(undefined)).toEqual(4.0);
     });
 
     it('evaluates vector properties (["x"], ["y"], ["z"]. ["w"])', function() {
         var expression = new Expression('vec4(1.0, 2.0, 3.0, 4.0)["x"]');
-        expect(expression.evaluate(frameState, undefined)).toEqual(1.0);
+        expect(expression.evaluate(undefined)).toEqual(1.0);
 
         expression = new Expression('vec4(1.0, 2.0, 3.0, 4.0)["y"]');
-        expect(expression.evaluate(frameState, undefined)).toEqual(2.0);
+        expect(expression.evaluate(undefined)).toEqual(2.0);
 
         expression = new Expression('vec4(1.0, 2.0, 3.0, 4.0)["z"]');
-        expect(expression.evaluate(frameState, undefined)).toEqual(3.0);
+        expect(expression.evaluate(undefined)).toEqual(3.0);
 
         expression = new Expression('vec4(1.0, 2.0, 3.0, 4.0)["w"]');
-        expect(expression.evaluate(frameState, undefined)).toEqual(4.0);
+        expect(expression.evaluate(undefined)).toEqual(4.0);
     });
 
     it('evaluates vector properties (["r"], ["g"], ["b"]. ["a"])', function() {
         var expression = new Expression('vec4(1.0, 2.0, 3.0, 4.0)["r"]');
-        expect(expression.evaluate(frameState, undefined)).toEqual(1.0);
+        expect(expression.evaluate(undefined)).toEqual(1.0);
 
         expression = new Expression('vec4(1.0, 2.0, 3.0, 4.0)["g"]');
-        expect(expression.evaluate(frameState, undefined)).toEqual(2.0);
+        expect(expression.evaluate(undefined)).toEqual(2.0);
 
         expression = new Expression('vec4(1.0, 2.0, 3.0, 4.0)["b"]');
-        expect(expression.evaluate(frameState, undefined)).toEqual(3.0);
+        expect(expression.evaluate(undefined)).toEqual(3.0);
 
         expression = new Expression('vec4(1.0, 2.0, 3.0, 4.0)["a"]');
-        expect(expression.evaluate(frameState, undefined)).toEqual(4.0);
+        expect(expression.evaluate(undefined)).toEqual(4.0);
     });
 
     it('evaluates unary not', function() {
         var expression = new Expression('!true');
-        expect(expression.evaluate(frameState, undefined)).toEqual(false);
+        expect(expression.evaluate(undefined)).toEqual(false);
 
         expression = new Expression('!!true');
-        expect(expression.evaluate(frameState, undefined)).toEqual(true);
+        expect(expression.evaluate(undefined)).toEqual(true);
     });
 
     it('throws if unary not takes invalid argument', function() {
         var expression = new Expression('!"true"');
         expect(function() {
-            expression.evaluate(frameState, undefined);
+            expression.evaluate(undefined);
         }).toThrowRuntimeError();
     });
 
     it('evaluates unary negative', function() {
         var expression = new Expression('-5');
-        expect(expression.evaluate(frameState, undefined)).toEqual(-5);
+        expect(expression.evaluate(undefined)).toEqual(-5);
 
         expression = new Expression('-(-5)');
-        expect(expression.evaluate(frameState, undefined)).toEqual(5);
+        expect(expression.evaluate(undefined)).toEqual(5);
     });
 
     it('throws if unary negative takes invalid argument', function() {
         var expression = new Expression('-"56"');
         expect(function() {
-            expression.evaluate(frameState, undefined);
+            expression.evaluate(undefined);
         }).toThrowRuntimeError();
     });
 
     it('evaluates unary positive', function() {
         var expression = new Expression('+5');
-        expect(expression.evaluate(frameState, undefined)).toEqual(5);
+        expect(expression.evaluate(undefined)).toEqual(5);
     });
 
     it('throws if unary positive takes invalid argument', function() {
         var expression = new Expression('+"56"');
         expect(function() {
-            expression.evaluate(frameState, undefined);
+            expression.evaluate(undefined);
         }).toThrowRuntimeError();
     });
 
     it('evaluates binary addition', function() {
         var expression = new Expression('1 + 2');
-        expect(expression.evaluate(frameState, undefined)).toEqual(3);
+        expect(expression.evaluate(undefined)).toEqual(3);
 
         expression = new Expression('1 + 2 + 3 + 4');
-        expect(expression.evaluate(frameState, undefined)).toEqual(10);
+        expect(expression.evaluate(undefined)).toEqual(10);
     });
 
     it('evaluates binary addition with strings', function() {
         var expression = new Expression('1 + "10"');
-        expect(expression.evaluate(frameState, undefined)).toEqual('110');
+        expect(expression.evaluate(undefined)).toEqual('110');
 
         expression = new Expression('"10" + 1');
-        expect(expression.evaluate(frameState, undefined)).toEqual('101');
+        expect(expression.evaluate(undefined)).toEqual('101');
 
         expression = new Expression('"name_" + "building"');
-        expect(expression.evaluate(frameState, undefined)).toEqual('name_building');
+        expect(expression.evaluate(undefined)).toEqual('name_building');
 
         expression = new Expression('"name_" + true');
-        expect(expression.evaluate(frameState, undefined)).toEqual('name_true');
+        expect(expression.evaluate(undefined)).toEqual('name_true');
 
         expression = new Expression('"name_" + null');
-        expect(expression.evaluate(frameState, undefined)).toEqual('name_null');
+        expect(expression.evaluate(undefined)).toEqual('name_null');
 
         expression = new Expression('"name_" + undefined');
-        expect(expression.evaluate(frameState, undefined)).toEqual('name_undefined');
+        expect(expression.evaluate(undefined)).toEqual('name_undefined');
 
         expression = new Expression('"name_" + vec2(1.1)');
-        expect(expression.evaluate(frameState, undefined)).toEqual('name_(1.1, 1.1)');
+        expect(expression.evaluate(undefined)).toEqual('name_(1.1, 1.1)');
 
         expression = new Expression('"name_" + vec3(1.1)');
-        expect(expression.evaluate(frameState, undefined)).toEqual('name_(1.1, 1.1, 1.1)');
+        expect(expression.evaluate(undefined)).toEqual('name_(1.1, 1.1, 1.1)');
 
         expression = new Expression('"name_" + vec4(1.1)');
-        expect(expression.evaluate(frameState, undefined)).toEqual('name_(1.1, 1.1, 1.1, 1.1)');
+        expect(expression.evaluate(undefined)).toEqual('name_(1.1, 1.1, 1.1, 1.1)');
 
         expression = new Expression('"name_" + regExp("a")');
-        expect(expression.evaluate(frameState, undefined)).toEqual('name_/a/');
+        expect(expression.evaluate(undefined)).toEqual('name_/a/');
     });
 
     it('throws if binary addition takes invalid arguments', function() {
         var expression = new Expression('vec2(1.0) + vec3(1.0)');
         expect(function() {
-            expression.evaluate(frameState, undefined);
+            expression.evaluate(undefined);
         }).toThrowRuntimeError();
 
         expression = new Expression('1.0 + vec3(1.0)');
         expect(function() {
-            expression.evaluate(frameState, undefined);
+            expression.evaluate(undefined);
         }).toThrowRuntimeError();
     });
 
     it('evaluates binary subtraction', function() {
         var expression = new Expression('2 - 1');
-        expect(expression.evaluate(frameState, undefined)).toEqual(1);
+        expect(expression.evaluate(undefined)).toEqual(1);
 
         expression = new Expression('4 - 3 - 2 - 1');
-        expect(expression.evaluate(frameState, undefined)).toEqual(-2);
+        expect(expression.evaluate(undefined)).toEqual(-2);
     });
 
     it('throws if binary subtraction takes invalid arguments', function() {
         var expression = new Expression('vec2(1.0) - vec3(1.0)');
         expect(function() {
-            expression.evaluate(frameState, undefined);
+            expression.evaluate(undefined);
         }).toThrowRuntimeError();
 
         expression = new Expression('1.0 - vec3(1.0)');
         expect(function() {
-            expression.evaluate(frameState, undefined);
+            expression.evaluate(undefined);
         }).toThrowRuntimeError();
 
         expression = new Expression('"name1" - "name2"');
         expect(function() {
-            expression.evaluate(frameState, undefined);
+            expression.evaluate(undefined);
         }).toThrowRuntimeError();
     });
 
     it('evaluates binary multiplication', function() {
         var expression = new Expression('1 * 2');
-        expect(expression.evaluate(frameState, undefined)).toEqual(2);
+        expect(expression.evaluate(undefined)).toEqual(2);
 
         expression = new Expression('1 * 2 * 3 * 4');
-        expect(expression.evaluate(frameState, undefined)).toEqual(24);
+        expect(expression.evaluate(undefined)).toEqual(24);
     });
 
     it('throws if binary multiplication takes invalid arguments', function() {
         var expression = new Expression('vec2(1.0) * vec3(1.0)');
         expect(function() {
-            expression.evaluate(frameState, undefined);
+            expression.evaluate(undefined);
         }).toThrowRuntimeError();
 
         expression = new Expression('vec2(1.0) * "name"');
         expect(function() {
-            expression.evaluate(frameState, undefined);
+            expression.evaluate(undefined);
         }).toThrowRuntimeError();
     });
 
     it('evaluates binary division', function() {
         var expression = new Expression('2 / 1');
-        expect(expression.evaluate(frameState, undefined)).toEqual(2);
+        expect(expression.evaluate(undefined)).toEqual(2);
 
         expression = new Expression('1/2');
-        expect(expression.evaluate(frameState, undefined)).toEqual(0.5);
+        expect(expression.evaluate(undefined)).toEqual(0.5);
 
         expression = new Expression('24 / -4 / 2');
-        expect(expression.evaluate(frameState, undefined)).toEqual(-3);
+        expect(expression.evaluate(undefined)).toEqual(-3);
     });
 
     it('throws if binary division takes invalid arguments', function() {
         var expression = new Expression('vec2(1.0) / vec3(1.0)');
         expect(function() {
-            expression.evaluate(frameState, undefined);
+            expression.evaluate(undefined);
         }).toThrowRuntimeError();
 
         expression = new Expression('vec2(1.0) / "2.0"');
         expect(function() {
-            expression.evaluate(frameState, undefined);
+            expression.evaluate(undefined);
         }).toThrowRuntimeError();
 
         expression = new Expression('1.0 / vec4(1.0)');
         expect(function() {
-            expression.evaluate(frameState, undefined);
+            expression.evaluate(undefined);
         }).toThrowRuntimeError();
     });
 
     it('evaluates binary modulus', function() {
         var expression = new Expression('2 % 1');
-        expect(expression.evaluate(frameState, undefined)).toEqual(0);
+        expect(expression.evaluate(undefined)).toEqual(0);
 
         expression = new Expression('6 % 4 % 3');
-        expect(expression.evaluate(frameState, undefined)).toEqual(2);
+        expect(expression.evaluate(undefined)).toEqual(2);
     });
 
     it('throws if binary modulus takes invalid arguments', function() {
         var expression = new Expression('vec2(1.0) % vec3(1.0)');
         expect(function() {
-            expression.evaluate(frameState, undefined);
+            expression.evaluate(undefined);
         }).toThrowRuntimeError();
 
         expression = new Expression('vec2(1.0) % "2.0"');
         expect(function() {
-            expression.evaluate(frameState, undefined);
+            expression.evaluate(undefined);
         }).toThrowRuntimeError();
 
         expression = new Expression('1.0 % vec4(1.0)');
         expect(function() {
-            expression.evaluate(frameState, undefined);
+            expression.evaluate(undefined);
         }).toThrowRuntimeError();
     });
 
     it('evaluates binary equals strict', function() {
         var expression = new Expression('\'hello\' === \'hello\'');
-        expect(expression.evaluate(frameState, undefined)).toEqual(true);
+        expect(expression.evaluate(undefined)).toEqual(true);
 
         expression = new Expression('1 === 2');
-        expect(expression.evaluate(frameState, undefined)).toEqual(false);
+        expect(expression.evaluate(undefined)).toEqual(false);
 
         expression = new Expression('false === true === false');
-        expect(expression.evaluate(frameState, undefined)).toEqual(true);
+        expect(expression.evaluate(undefined)).toEqual(true);
 
         expression = new Expression('1 === "1"');
-        expect(expression.evaluate(frameState, undefined)).toEqual(false);
+        expect(expression.evaluate(undefined)).toEqual(false);
     });
 
     it('evaluates binary not equals strict', function() {
         var expression = new Expression('\'hello\' !== \'hello\'');
-        expect(expression.evaluate(frameState, undefined)).toEqual(false);
+        expect(expression.evaluate(undefined)).toEqual(false);
 
         expression = new Expression('1 !== 2');
-        expect(expression.evaluate(frameState, undefined)).toEqual(true);
+        expect(expression.evaluate(undefined)).toEqual(true);
 
         expression = new Expression('false !== true !== false');
-        expect(expression.evaluate(frameState, undefined)).toEqual(true);
+        expect(expression.evaluate(undefined)).toEqual(true);
 
         expression = new Expression('1 !== "1"');
-        expect(expression.evaluate(frameState, undefined)).toEqual(true);
+        expect(expression.evaluate(undefined)).toEqual(true);
     });
 
     it('evaluates binary less than', function() {
         var expression = new Expression('2 < 3');
-        expect(expression.evaluate(frameState, undefined)).toEqual(true);
+        expect(expression.evaluate(undefined)).toEqual(true);
 
         expression = new Expression('2 < 2');
-        expect(expression.evaluate(frameState, undefined)).toEqual(false);
+        expect(expression.evaluate(undefined)).toEqual(false);
 
         expression = new Expression('3 < 2');
-        expect(expression.evaluate(frameState, undefined)).toEqual(false);
+        expect(expression.evaluate(undefined)).toEqual(false);
     });
 
     it('throws if binary less than takes invalid arguments', function() {
         var expression = new Expression('vec2(1.0) < vec2(2.0)');
         expect(function() {
-            expression.evaluate(frameState, undefined);
+            expression.evaluate(undefined);
         }).toThrowRuntimeError();
 
         expression = new Expression('1 < vec3(1.0)');
         expect(function() {
-            expression.evaluate(frameState, undefined);
+            expression.evaluate(undefined);
         }).toThrowRuntimeError();
 
         expression = new Expression('true < false');
         expect(function() {
-            expression.evaluate(frameState, undefined);
+            expression.evaluate(undefined);
         }).toThrowRuntimeError();
 
         expression = new Expression('color(\'blue\') < 10');
         expect(function() {
-            expression.evaluate(frameState, undefined);
+            expression.evaluate(undefined);
         }).toThrowRuntimeError();
     });
 
     it('evaluates binary less than or equals', function() {
         var expression = new Expression('2 <= 3');
-        expect(expression.evaluate(frameState, undefined)).toEqual(true);
+        expect(expression.evaluate(undefined)).toEqual(true);
 
         expression = new Expression('2 <= 2');
-        expect(expression.evaluate(frameState, undefined)).toEqual(true);
+        expect(expression.evaluate(undefined)).toEqual(true);
 
         expression = new Expression('3 <= 2');
-        expect(expression.evaluate(frameState, undefined)).toEqual(false);
+        expect(expression.evaluate(undefined)).toEqual(false);
     });
 
     it('throws if binary less than or equals takes invalid arguments', function() {
         var expression = new Expression('vec2(1.0) <= vec2(2.0)');
         expect(function() {
-            expression.evaluate(frameState, undefined);
+            expression.evaluate(undefined);
         }).toThrowRuntimeError();
 
         expression = new Expression('1 <= vec3(1.0)');
         expect(function() {
-            expression.evaluate(frameState, undefined);
+            expression.evaluate(undefined);
         }).toThrowRuntimeError();
 
         expression = new Expression('1.0 <= "5"');
         expect(function() {
-            expression.evaluate(frameState, undefined);
+            expression.evaluate(undefined);
         }).toThrowRuntimeError();
 
         expression = new Expression('true <= false');
         expect(function() {
-            expression.evaluate(frameState, undefined);
+            expression.evaluate(undefined);
         }).toThrowRuntimeError();
 
         expression = new Expression('color(\'blue\') <= 10');
         expect(function() {
-            expression.evaluate(frameState, undefined);
+            expression.evaluate(undefined);
         }).toThrowRuntimeError();
     });
 
     it('evaluates binary greater than', function() {
         var expression = new Expression('2 > 3');
-        expect(expression.evaluate(frameState, undefined)).toEqual(false);
+        expect(expression.evaluate(undefined)).toEqual(false);
 
         expression = new Expression('2 > 2');
-        expect(expression.evaluate(frameState, undefined)).toEqual(false);
+        expect(expression.evaluate(undefined)).toEqual(false);
 
         expression = new Expression('3 > 2');
-        expect(expression.evaluate(frameState, undefined)).toEqual(true);
+        expect(expression.evaluate(undefined)).toEqual(true);
     });
 
     it('throws if binary greater than takes invalid arguments', function() {
         var expression = new Expression('vec2(1.0) > vec2(2.0)');
         expect(function() {
-            expression.evaluate(frameState, undefined);
+            expression.evaluate(undefined);
         }).toThrowRuntimeError();
 
         expression = new Expression('1 > vec3(1.0)');
         expect(function() {
-            expression.evaluate(frameState, undefined);
+            expression.evaluate(undefined);
         }).toThrowRuntimeError();
 
         expression = new Expression('1.0 > "5"');
         expect(function() {
-            expression.evaluate(frameState, undefined);
+            expression.evaluate(undefined);
         }).toThrowRuntimeError();
 
         expression = new Expression('true > false');
         expect(function() {
-            expression.evaluate(frameState, undefined);
+            expression.evaluate(undefined);
         }).toThrowRuntimeError();
 
         expression = new Expression('color(\'blue\') > 10');
         expect(function() {
-            expression.evaluate(frameState, undefined);
+            expression.evaluate(undefined);
         }).toThrowRuntimeError();
     });
 
     it('evaluates binary greater than or equals', function() {
         var expression = new Expression('2 >= 3');
-        expect(expression.evaluate(frameState, undefined)).toEqual(false);
+        expect(expression.evaluate(undefined)).toEqual(false);
 
         expression = new Expression('2 >= 2');
-        expect(expression.evaluate(frameState, undefined)).toEqual(true);
+        expect(expression.evaluate(undefined)).toEqual(true);
 
         expression = new Expression('3 >= 2');
-        expect(expression.evaluate(frameState, undefined)).toEqual(true);
+        expect(expression.evaluate(undefined)).toEqual(true);
     });
 
     it('throws if binary greater than or equals takes invalid arguments', function() {
         var expression = new Expression('vec2(1.0) >= vec2(2.0)');
         expect(function() {
-            expression.evaluate(frameState, undefined);
+            expression.evaluate(undefined);
         }).toThrowRuntimeError();
 
         expression = new Expression('1 >= vec3(1.0)');
         expect(function() {
-            expression.evaluate(frameState, undefined);
+            expression.evaluate(undefined);
         }).toThrowRuntimeError();
 
         expression = new Expression('1.0 >= "5"');
         expect(function() {
-            expression.evaluate(frameState, undefined);
+            expression.evaluate(undefined);
         }).toThrowRuntimeError();
 
         expression = new Expression('true >= false');
         expect(function() {
-            expression.evaluate(frameState, undefined);
+            expression.evaluate(undefined);
         }).toThrowRuntimeError();
 
         expression = new Expression('color(\'blue\') >= 10');
         expect(function() {
-            expression.evaluate(frameState, undefined);
+            expression.evaluate(undefined);
         }).toThrowRuntimeError();
     });
 
     it('evaluates logical and', function() {
         var expression = new Expression('false && false');
-        expect(expression.evaluate(frameState, undefined)).toEqual(false);
+        expect(expression.evaluate(undefined)).toEqual(false);
 
         expression = new Expression('false && true');
-        expect(expression.evaluate(frameState, undefined)).toEqual(false);
+        expect(expression.evaluate(undefined)).toEqual(false);
 
         expression = new Expression('true && true');
-        expect(expression.evaluate(frameState, undefined)).toEqual(true);
+        expect(expression.evaluate(undefined)).toEqual(true);
 
         expression = new Expression('2 && color(\'red\')');
         expect(function() {
-            expression.evaluate(frameState, undefined);
+            expression.evaluate(undefined);
         }).toThrowRuntimeError();
     });
 
     it('throws with invalid and operands', function() {
         var expression = new Expression('2 && true');
         expect(function() {
-            expression.evaluate(frameState, undefined);
+            expression.evaluate(undefined);
         }).toThrowRuntimeError();
 
         expression = new Expression('true && color(\'red\')');
         expect(function() {
-            expression.evaluate(frameState, undefined);
+            expression.evaluate(undefined);
         }).toThrowRuntimeError();
     });
 
     it('evaluates logical or', function() {
         var expression = new Expression('false || false');
-        expect(expression.evaluate(frameState, undefined)).toEqual(false);
+        expect(expression.evaluate(undefined)).toEqual(false);
 
         expression = new Expression('false || true');
-        expect(expression.evaluate(frameState, undefined)).toEqual(true);
+        expect(expression.evaluate(undefined)).toEqual(true);
 
         expression = new Expression('true || true');
-        expect(expression.evaluate(frameState, undefined)).toEqual(true);
+        expect(expression.evaluate(undefined)).toEqual(true);
     });
 
     it('throws with invalid or operands', function() {
         var expression = new Expression('2 || false');
         expect(function() {
-            expression.evaluate(frameState, undefined);
+            expression.evaluate(undefined);
         }).toThrowRuntimeError();
 
         expression = new Expression('false || color(\'red\')');
         expect(function() {
-            expression.evaluate(frameState, undefined);
+            expression.evaluate(undefined);
         }).toThrowRuntimeError();
     });
 
     it('evaluates color operations', function() {
         var expression = new Expression('+rgba(255, 0, 0, 1.0)');
-        expect(expression.evaluate(frameState, undefined)).toEqual(Cartesian4.fromColor(Color.RED));
+        expect(expression.evaluate(undefined)).toEqual(Cartesian4.fromColor(Color.RED));
 
         expression = new Expression('rgba(255, 0, 0, 0.5) + rgba(0, 0, 255, 0.5)');
-        expect(expression.evaluate(frameState, undefined)).toEqual(Cartesian4.fromColor(Color.MAGENTA));
+        expect(expression.evaluate(undefined)).toEqual(Cartesian4.fromColor(Color.MAGENTA));
 
         expression = new Expression('rgba(0, 255, 255, 1.0) - rgba(0, 255, 0, 0)');
-        expect(expression.evaluate(frameState, undefined)).toEqual(Cartesian4.fromColor(Color.BLUE));
+        expect(expression.evaluate(undefined)).toEqual(Cartesian4.fromColor(Color.BLUE));
 
         expression = new Expression('rgba(255, 255, 255, 1.0) * rgba(255, 0, 0, 1.0)');
-        expect(expression.evaluate(frameState, undefined)).toEqual(Cartesian4.fromColor(Color.RED));
+        expect(expression.evaluate(undefined)).toEqual(Cartesian4.fromColor(Color.RED));
 
         expression = new Expression('rgba(255, 255, 0, 1.0) * 1.0');
-        expect(expression.evaluate(frameState, undefined)).toEqual(Cartesian4.fromColor(Color.YELLOW));
+        expect(expression.evaluate(undefined)).toEqual(Cartesian4.fromColor(Color.YELLOW));
 
         expression = new Expression('1 * rgba(255, 255, 0, 1.0)');
-        expect(expression.evaluate(frameState, undefined)).toEqual(Cartesian4.fromColor(Color.YELLOW));
+        expect(expression.evaluate(undefined)).toEqual(Cartesian4.fromColor(Color.YELLOW));
 
         expression = new Expression('rgba(255, 255, 255, 1.0) / rgba(255, 255, 255, 1.0)');
-        expect(expression.evaluate(frameState, undefined)).toEqual(Cartesian4.fromColor(Color.WHITE));
+        expect(expression.evaluate(undefined)).toEqual(Cartesian4.fromColor(Color.WHITE));
 
         expression = new Expression('rgba(255, 255, 255, 1.0) / 2');
-        expect(expression.evaluate(frameState, undefined)).toEqual(Cartesian4.fromColor(new Color(0.5, 0.5, 0.5, 0.5)));
+        expect(expression.evaluate(undefined)).toEqual(Cartesian4.fromColor(new Color(0.5, 0.5, 0.5, 0.5)));
 
         expression = new Expression('rgba(255, 255, 255, 1.0) % rgba(255, 255, 255, 1.0)');
-        expect(expression.evaluate(frameState, undefined)).toEqual(Cartesian4.fromColor(new Color(0, 0, 0, 0)));
+        expect(expression.evaluate(undefined)).toEqual(Cartesian4.fromColor(new Color(0, 0, 0, 0)));
 
         expression = new Expression('color(\'green\') === color(\'green\')');
-        expect(expression.evaluate(frameState, undefined)).toEqual(true);
+        expect(expression.evaluate(undefined)).toEqual(true);
 
         expression = new Expression('color(\'green\') !== color(\'green\')');
-        expect(expression.evaluate(frameState, undefined)).toEqual(false);
+        expect(expression.evaluate(undefined)).toEqual(false);
     });
 
     it('evaluates vector operations', function() {
         var expression = new Expression('+vec2(1, 2)');
-        expect(expression.evaluate(frameState, undefined)).toEqual(new Cartesian2(1, 2));
+        expect(expression.evaluate(undefined)).toEqual(new Cartesian2(1, 2));
 
         expression = new Expression('+vec3(1, 2, 3)');
-        expect(expression.evaluate(frameState, undefined)).toEqual(new Cartesian3(1, 2, 3));
+        expect(expression.evaluate(undefined)).toEqual(new Cartesian3(1, 2, 3));
 
         expression = new Expression('+vec4(1, 2, 3, 4)');
-        expect(expression.evaluate(frameState, undefined)).toEqual(new Cartesian4(1, 2, 3, 4));
+        expect(expression.evaluate(undefined)).toEqual(new Cartesian4(1, 2, 3, 4));
 
         expression = new Expression('-vec2(1, 2)');
-        expect(expression.evaluate(frameState, undefined)).toEqual(new Cartesian2(-1, -2));
+        expect(expression.evaluate(undefined)).toEqual(new Cartesian2(-1, -2));
 
         expression = new Expression('-vec3(1, 2, 3)');
-        expect(expression.evaluate(frameState, undefined)).toEqual(new Cartesian3(-1, -2, -3));
+        expect(expression.evaluate(undefined)).toEqual(new Cartesian3(-1, -2, -3));
 
         expression = new Expression('-vec4(1, 2, 3, 4)');
-        expect(expression.evaluate(frameState, undefined)).toEqual(new Cartesian4(-1, -2, -3, -4));
+        expect(expression.evaluate(undefined)).toEqual(new Cartesian4(-1, -2, -3, -4));
 
         expression = new Expression('vec2(1, 2) + vec2(3, 4)');
-        expect(expression.evaluate(frameState, undefined)).toEqual(new Cartesian2(4, 6));
+        expect(expression.evaluate(undefined)).toEqual(new Cartesian2(4, 6));
 
         expression = new Expression('vec3(1, 2, 3) + vec3(3, 4, 5)');
-        expect(expression.evaluate(frameState, undefined)).toEqual(new Cartesian3(4, 6, 8));
+        expect(expression.evaluate(undefined)).toEqual(new Cartesian3(4, 6, 8));
 
         expression = new Expression('vec4(1, 2, 3, 4) + vec4(3, 4, 5, 6)');
-        expect(expression.evaluate(frameState, undefined)).toEqual(new Cartesian4(4, 6, 8, 10));
+        expect(expression.evaluate(undefined)).toEqual(new Cartesian4(4, 6, 8, 10));
 
         expression = new Expression('vec2(1, 2) - vec2(3, 4)');
-        expect(expression.evaluate(frameState, undefined)).toEqual(new Cartesian2(-2, -2));
+        expect(expression.evaluate(undefined)).toEqual(new Cartesian2(-2, -2));
 
         expression = new Expression('vec3(1, 2, 3) - vec3(3, 4, 5)');
-        expect(expression.evaluate(frameState, undefined)).toEqual(new Cartesian3(-2, -2, -2));
+        expect(expression.evaluate(undefined)).toEqual(new Cartesian3(-2, -2, -2));
 
         expression = new Expression('vec4(1, 2, 3, 4) - vec4(3, 4, 5, 6)');
-        expect(expression.evaluate(frameState, undefined)).toEqual(new Cartesian4(-2, -2, -2, -2));
+        expect(expression.evaluate(undefined)).toEqual(new Cartesian4(-2, -2, -2, -2));
 
         expression = new Expression('vec2(1, 2) * vec2(3, 4)');
-        expect(expression.evaluate(frameState, undefined)).toEqual(new Cartesian2(3, 8));
+        expect(expression.evaluate(undefined)).toEqual(new Cartesian2(3, 8));
 
         expression = new Expression('vec2(1, 2) * 3.0');
-        expect(expression.evaluate(frameState, undefined)).toEqual(new Cartesian2(3, 6));
+        expect(expression.evaluate(undefined)).toEqual(new Cartesian2(3, 6));
 
         expression = new Expression('3.0 * vec2(1, 2)');
-        expect(expression.evaluate(frameState, undefined)).toEqual(new Cartesian2(3, 6));
+        expect(expression.evaluate(undefined)).toEqual(new Cartesian2(3, 6));
 
         expression = new Expression('vec3(1, 2, 3) * vec3(3, 4, 5)');
-        expect(expression.evaluate(frameState, undefined)).toEqual(new Cartesian3(3, 8, 15));
+        expect(expression.evaluate(undefined)).toEqual(new Cartesian3(3, 8, 15));
 
         expression = new Expression('vec3(1, 2, 3) * 3.0');
-        expect(expression.evaluate(frameState, undefined)).toEqual(new Cartesian3(3, 6, 9));
+        expect(expression.evaluate(undefined)).toEqual(new Cartesian3(3, 6, 9));
 
         expression = new Expression('3.0 * vec3(1, 2, 3)');
-        expect(expression.evaluate(frameState, undefined)).toEqual(new Cartesian3(3, 6, 9));
+        expect(expression.evaluate(undefined)).toEqual(new Cartesian3(3, 6, 9));
 
         expression = new Expression('vec4(1, 2, 3, 4) * vec4(3, 4, 5, 6)');
-        expect(expression.evaluate(frameState, undefined)).toEqual(new Cartesian4(3, 8, 15, 24));
+        expect(expression.evaluate(undefined)).toEqual(new Cartesian4(3, 8, 15, 24));
 
         expression = new Expression('vec4(1, 2, 3, 4) * 3.0');
-        expect(expression.evaluate(frameState, undefined)).toEqual(new Cartesian4(3, 6, 9, 12));
+        expect(expression.evaluate(undefined)).toEqual(new Cartesian4(3, 6, 9, 12));
 
         expression = new Expression('3.0 * vec4(1, 2, 3, 4)');
-        expect(expression.evaluate(frameState, undefined)).toEqual(new Cartesian4(3, 6, 9, 12));
+        expect(expression.evaluate(undefined)).toEqual(new Cartesian4(3, 6, 9, 12));
 
         expression = new Expression('vec2(1, 2) / vec2(2, 5)');
-        expect(expression.evaluate(frameState, undefined)).toEqual(new Cartesian2(0.5, 0.4));
+        expect(expression.evaluate(undefined)).toEqual(new Cartesian2(0.5, 0.4));
 
         expression = new Expression('vec2(1, 2) / 2.0');
-        expect(expression.evaluate(frameState, undefined)).toEqual(new Cartesian2(0.5, 1.0));
+        expect(expression.evaluate(undefined)).toEqual(new Cartesian2(0.5, 1.0));
 
         expression = new Expression('vec3(1, 2, 3) / vec3(2, 5, 3)');
-        expect(expression.evaluate(frameState, undefined)).toEqual(new Cartesian3(0.5, 0.4, 1.0));
+        expect(expression.evaluate(undefined)).toEqual(new Cartesian3(0.5, 0.4, 1.0));
 
         expression = new Expression('vec3(1, 2, 3) / 2.0');
-        expect(expression.evaluate(frameState, undefined)).toEqual(new Cartesian3(0.5, 1.0, 1.5));
+        expect(expression.evaluate(undefined)).toEqual(new Cartesian3(0.5, 1.0, 1.5));
 
         expression = new Expression('vec4(1, 2, 3, 4) / vec4(2, 5, 3, 2)');
-        expect(expression.evaluate(frameState, undefined)).toEqual(new Cartesian4(0.5, 0.4, 1.0, 2.0));
+        expect(expression.evaluate(undefined)).toEqual(new Cartesian4(0.5, 0.4, 1.0, 2.0));
 
         expression = new Expression('vec4(1, 2, 3, 4) / 2.0');
-        expect(expression.evaluate(frameState, undefined)).toEqual(new Cartesian4(0.5, 1.0, 1.5, 2.0));
+        expect(expression.evaluate(undefined)).toEqual(new Cartesian4(0.5, 1.0, 1.5, 2.0));
 
         expression = new Expression('vec2(2, 3) % vec2(3, 3)');
-        expect(expression.evaluate(frameState, undefined)).toEqual(new Cartesian2(2, 0));
+        expect(expression.evaluate(undefined)).toEqual(new Cartesian2(2, 0));
 
         expression = new Expression('vec3(2, 3, 4) % vec3(3, 3, 3)');
-        expect(expression.evaluate(frameState, undefined)).toEqual(new Cartesian3(2, 0, 1));
+        expect(expression.evaluate(undefined)).toEqual(new Cartesian3(2, 0, 1));
 
         expression = new Expression('vec4(2, 3, 4, 5) % vec4(3, 3, 3, 2)');
-        expect(expression.evaluate(frameState, undefined)).toEqual(new Cartesian4(2, 0, 1, 1));
+        expect(expression.evaluate(undefined)).toEqual(new Cartesian4(2, 0, 1, 1));
 
         expression = new Expression('vec2(1, 2) === vec2(1, 2)');
-        expect(expression.evaluate(frameState, undefined)).toEqual(true);
+        expect(expression.evaluate(undefined)).toEqual(true);
 
         expression = new Expression('vec3(1, 2, 3) === vec3(1, 2, 3)');
-        expect(expression.evaluate(frameState, undefined)).toEqual(true);
+        expect(expression.evaluate(undefined)).toEqual(true);
 
         expression = new Expression('vec4(1, 2, 3, 4) === vec4(1, 2, 3, 4)');
-        expect(expression.evaluate(frameState, undefined)).toEqual(true);
+        expect(expression.evaluate(undefined)).toEqual(true);
 
         expression = new Expression('vec2(1, 2) !== vec2(1, 2)');
-        expect(expression.evaluate(frameState, undefined)).toEqual(false);
+        expect(expression.evaluate(undefined)).toEqual(false);
 
         expression = new Expression('vec3(1, 2, 3) !== vec3(1, 2, 3)');
-        expect(expression.evaluate(frameState, undefined)).toEqual(false);
+        expect(expression.evaluate(undefined)).toEqual(false);
 
         expression = new Expression('vec4(1, 2, 3, 4) !== vec4(1, 2, 3, 4)');
-        expect(expression.evaluate(frameState, undefined)).toEqual(false);
+        expect(expression.evaluate(undefined)).toEqual(false);
     });
 
     it('evaluates color toString function', function() {
         var expression = new Expression('color("red").toString()');
-        expect(expression.evaluate(frameState, undefined)).toEqual('(1, 0, 0, 1)');
+        expect(expression.evaluate(undefined)).toEqual('(1, 0, 0, 1)');
 
         expression = new Expression('rgba(0, 0, 255, 0.5).toString()');
-        expect(expression.evaluate(frameState, undefined)).toEqual('(0, 0, 1, 0.5)');
+        expect(expression.evaluate(undefined)).toEqual('(0, 0, 1, 0.5)');
     });
 
     it('evaluates vector toString function', function() {
@@ -1422,68 +1420,68 @@ defineSuite([
         feature.addProperty('property', new Cartesian4(1, 2, 3, 4));
 
         var expression = new Expression('vec2(1, 2).toString()');
-        expect(expression.evaluate(frameState, undefined)).toEqual('(1, 2)');
+        expect(expression.evaluate(undefined)).toEqual('(1, 2)');
 
         expression = new Expression('vec3(1, 2, 3).toString()');
-        expect(expression.evaluate(frameState, undefined)).toEqual('(1, 2, 3)');
+        expect(expression.evaluate(undefined)).toEqual('(1, 2, 3)');
 
         expression = new Expression('vec4(1, 2, 3, 4).toString()');
-        expect(expression.evaluate(frameState, undefined)).toEqual('(1, 2, 3, 4)');
+        expect(expression.evaluate(undefined)).toEqual('(1, 2, 3, 4)');
 
         expression = new Expression('${property}.toString()');
-        expect(expression.evaluate(frameState, feature)).toEqual('(1, 2, 3, 4)');
+        expect(expression.evaluate(feature)).toEqual('(1, 2, 3, 4)');
     });
 
     it('evaluates isNaN function', function() {
         var expression = new Expression('isNaN()');
-        expect(expression.evaluate(frameState, undefined)).toEqual(true);
+        expect(expression.evaluate(undefined)).toEqual(true);
 
         expression = new Expression('isNaN(NaN)');
-        expect(expression.evaluate(frameState, undefined)).toEqual(true);
+        expect(expression.evaluate(undefined)).toEqual(true);
 
         expression = new Expression('isNaN(1)');
-        expect(expression.evaluate(frameState, undefined)).toEqual(false);
+        expect(expression.evaluate(undefined)).toEqual(false);
 
         expression = new Expression('isNaN(Infinity)');
-        expect(expression.evaluate(frameState, undefined)).toEqual(false);
+        expect(expression.evaluate(undefined)).toEqual(false);
 
         expression = new Expression('isNaN(null)');
-        expect(expression.evaluate(frameState, undefined)).toEqual(false);
+        expect(expression.evaluate(undefined)).toEqual(false);
 
         expression = new Expression('isNaN(true)');
-        expect(expression.evaluate(frameState, undefined)).toEqual(false);
+        expect(expression.evaluate(undefined)).toEqual(false);
 
         expression = new Expression('isNaN("hello")');
-        expect(expression.evaluate(frameState, undefined)).toEqual(true);
+        expect(expression.evaluate(undefined)).toEqual(true);
 
         expression = new Expression('isNaN(color("white"))');
-        expect(expression.evaluate(frameState, undefined)).toEqual(true);
+        expect(expression.evaluate(undefined)).toEqual(true);
     });
 
     it('evaluates isFinite function', function() {
         var expression = new Expression('isFinite()');
-        expect(expression.evaluate(frameState, undefined)).toEqual(false);
+        expect(expression.evaluate(undefined)).toEqual(false);
 
         expression = new Expression('isFinite(NaN)');
-        expect(expression.evaluate(frameState, undefined)).toEqual(false);
+        expect(expression.evaluate(undefined)).toEqual(false);
 
         expression = new Expression('isFinite(1)');
-        expect(expression.evaluate(frameState, undefined)).toEqual(true);
+        expect(expression.evaluate(undefined)).toEqual(true);
 
         expression = new Expression('isFinite(Infinity)');
-        expect(expression.evaluate(frameState, undefined)).toEqual(false);
+        expect(expression.evaluate(undefined)).toEqual(false);
 
         expression = new Expression('isFinite(null)');
-        expect(expression.evaluate(frameState, undefined)).toEqual(true);
+        expect(expression.evaluate(undefined)).toEqual(true);
 
         expression = new Expression('isFinite(true)');
-        expect(expression.evaluate(frameState, undefined)).toEqual(true);
+        expect(expression.evaluate(undefined)).toEqual(true);
 
         expression = new Expression('isFinite("hello")');
-        expect(expression.evaluate(frameState, undefined)).toEqual(false);
+        expect(expression.evaluate(undefined)).toEqual(false);
 
         expression = new Expression('isFinite(color("white"))');
-        expect(expression.evaluate(frameState, undefined)).toEqual(false);
+        expect(expression.evaluate(undefined)).toEqual(false);
     });
 
     it('evaluates isExactClass function', function() {
@@ -1491,10 +1489,10 @@ defineSuite([
         feature.setClass('door');
 
         var expression = new Expression('isExactClass("door")');
-        expect(expression.evaluate(frameState, feature)).toEqual(true);
+        expect(expression.evaluate(feature)).toEqual(true);
 
         expression = new Expression('isExactClass("roof")');
-        expect(expression.evaluate(frameState, feature)).toEqual(false);
+        expect(expression.evaluate(feature)).toEqual(false);
     });
 
     it('throws if isExactClass takes an invalid number of arguments', function() {
@@ -1514,7 +1512,7 @@ defineSuite([
         feature.setInheritedClass('building');
 
         var expression = new Expression('isClass("door") && isClass("building")');
-        expect(expression.evaluate(frameState, feature)).toEqual(true);
+        expect(expression.evaluate(feature)).toEqual(true);
     });
 
     it('throws if isClass takes an invalid number of arguments', function() {
@@ -1531,7 +1529,7 @@ defineSuite([
         var feature = new MockFeature();
         feature.setClass('door');
         var expression = new Expression('getExactClassName()');
-        expect(expression.evaluate(frameState, feature)).toEqual('door');
+        expect(expression.evaluate(feature)).toEqual('door');
     });
 
     it('throws if getExactClassName takes an invalid number of arguments', function() {
@@ -1544,25 +1542,25 @@ defineSuite([
         // Argument must be a number or vector
         var expression = new Expression('abs("-1")');
         expect(function() {
-            expression.evaluate(frameState, undefined);
+            expression.evaluate(undefined);
         }).toThrowRuntimeError();
     });
 
     it('evaluates abs function', function() {
         var expression = new Expression('abs(-1)');
-        expect(expression.evaluate(frameState, undefined)).toEqual(1);
+        expect(expression.evaluate(undefined)).toEqual(1);
 
         expression = new Expression('abs(1)');
-        expect(expression.evaluate(frameState, undefined)).toEqual(1);
+        expect(expression.evaluate(undefined)).toEqual(1);
 
         expression = new Expression('abs(vec2(-1.0, 1.0))');
-        expect(expression.evaluate(frameState, undefined)).toEqual(new Cartesian2(1.0, 1.0));
+        expect(expression.evaluate(undefined)).toEqual(new Cartesian2(1.0, 1.0));
 
         expression = new Expression('abs(vec3(-1.0, 1.0, 0.0))');
-        expect(expression.evaluate(frameState, undefined)).toEqual(new Cartesian3(1.0, 1.0, 0.0));
+        expect(expression.evaluate(undefined)).toEqual(new Cartesian3(1.0, 1.0, 0.0));
 
         expression = new Expression('abs(vec4(-1.0, 1.0, 0.0, -1.2))');
-        expect(expression.evaluate(frameState, undefined)).toEqual(new Cartesian4(1.0, 1.0, 0.0, 1.2));
+        expect(expression.evaluate(undefined)).toEqual(new Cartesian4(1.0, 1.0, 0.0, 1.2));
     });
 
     it('throws if abs function takes an invalid number of arguments', function() {
@@ -1577,16 +1575,16 @@ defineSuite([
 
     it('evaluates cos function', function() {
         var expression = new Expression('cos(0)');
-        expect(expression.evaluate(frameState, undefined)).toEqual(1.0);
+        expect(expression.evaluate(undefined)).toEqual(1.0);
 
         expression = new Expression('cos(vec2(0, Math.PI))');
-        expect(expression.evaluate(frameState, undefined)).toEqualEpsilon(new Cartesian2(1.0, -1.0), CesiumMath.EPSILON7);
+        expect(expression.evaluate(undefined)).toEqualEpsilon(new Cartesian2(1.0, -1.0), CesiumMath.EPSILON7);
 
         expression = new Expression('cos(vec3(0, Math.PI, -Math.PI))');
-        expect(expression.evaluate(frameState, undefined)).toEqualEpsilon(new Cartesian3(1.0, -1.0, -1.0), CesiumMath.EPSILON7);
+        expect(expression.evaluate(undefined)).toEqualEpsilon(new Cartesian3(1.0, -1.0, -1.0), CesiumMath.EPSILON7);
 
         expression = new Expression('cos(vec4(0, Math.PI, -Math.PI, 0))');
-        expect(expression.evaluate(frameState, undefined)).toEqualEpsilon(new Cartesian4(1.0, -1.0, -1.0, 1.0), CesiumMath.EPSILON7);
+        expect(expression.evaluate(undefined)).toEqualEpsilon(new Cartesian4(1.0, -1.0, -1.0, 1.0), CesiumMath.EPSILON7);
     });
 
     it('throws if cos function takes an invalid number of arguments', function() {
@@ -1601,16 +1599,16 @@ defineSuite([
 
     it('evaluates sin function', function() {
         var expression = new Expression('sin(0)');
-        expect(expression.evaluate(frameState, undefined)).toEqual(0);
+        expect(expression.evaluate(undefined)).toEqual(0);
 
         expression = new Expression('sin(vec2(0, Math.PI/2))');
-        expect(expression.evaluate(frameState, undefined)).toEqualEpsilon(new Cartesian2(0.0, 1.0), CesiumMath.EPSILON7);
+        expect(expression.evaluate(undefined)).toEqualEpsilon(new Cartesian2(0.0, 1.0), CesiumMath.EPSILON7);
 
         expression = new Expression('sin(vec3(0, Math.PI/2, -Math.PI/2))');
-        expect(expression.evaluate(frameState, undefined)).toEqualEpsilon(new Cartesian3(0.0, 1.0, -1.0), CesiumMath.EPSILON7);
+        expect(expression.evaluate(undefined)).toEqualEpsilon(new Cartesian3(0.0, 1.0, -1.0), CesiumMath.EPSILON7);
 
         expression = new Expression('sin(vec4(0, Math.PI/2, -Math.PI/2, 0))');
-        expect(expression.evaluate(frameState, undefined)).toEqualEpsilon(new Cartesian4(0.0, 1.0, -1.0, 0.0), CesiumMath.EPSILON7);
+        expect(expression.evaluate(undefined)).toEqualEpsilon(new Cartesian4(0.0, 1.0, -1.0, 0.0), CesiumMath.EPSILON7);
     });
 
     it('throws if sin function takes an invalid number of arguments', function() {
@@ -1625,16 +1623,16 @@ defineSuite([
 
     it('evaluates tan function', function() {
         var expression = new Expression('tan(0)');
-        expect(expression.evaluate(frameState, undefined)).toEqual(0);
+        expect(expression.evaluate(undefined)).toEqual(0);
 
         expression = new Expression('tan(vec2(0, Math.PI/4))');
-        expect(expression.evaluate(frameState, undefined)).toEqualEpsilon(new Cartesian2(0.0, 1.0), CesiumMath.EPSILON7);
+        expect(expression.evaluate(undefined)).toEqualEpsilon(new Cartesian2(0.0, 1.0), CesiumMath.EPSILON7);
 
         expression = new Expression('tan(vec3(0, Math.PI/4, Math.PI))');
-        expect(expression.evaluate(frameState, undefined)).toEqualEpsilon(new Cartesian3(0.0, 1.0, 0.0), CesiumMath.EPSILON7);
+        expect(expression.evaluate(undefined)).toEqualEpsilon(new Cartesian3(0.0, 1.0, 0.0), CesiumMath.EPSILON7);
 
         expression = new Expression('tan(vec4(0, Math.PI/4, Math.PI, -Math.PI/4))');
-        expect(expression.evaluate(frameState, undefined)).toEqualEpsilon(new Cartesian4(0.0, 1.0, 0.0, -1.0), CesiumMath.EPSILON7);
+        expect(expression.evaluate(undefined)).toEqualEpsilon(new Cartesian4(0.0, 1.0, 0.0, -1.0), CesiumMath.EPSILON7);
     });
 
     it('throws if tan function takes an invalid number of arguments', function() {
@@ -1649,16 +1647,16 @@ defineSuite([
 
     it('evaluates acos function', function() {
         var expression = new Expression('acos(1)');
-        expect(expression.evaluate(frameState, undefined)).toEqual(0);
+        expect(expression.evaluate(undefined)).toEqual(0);
 
         expression = new Expression('acos(vec2(1, 0))');
-        expect(expression.evaluate(frameState, undefined)).toEqualEpsilon(new Cartesian2(0.0, CesiumMath.PI_OVER_TWO), CesiumMath.EPSILON7);
+        expect(expression.evaluate(undefined)).toEqualEpsilon(new Cartesian2(0.0, CesiumMath.PI_OVER_TWO), CesiumMath.EPSILON7);
 
         expression = new Expression('acos(vec3(1, 0, 1))');
-        expect(expression.evaluate(frameState, undefined)).toEqualEpsilon(new Cartesian3(0.0, CesiumMath.PI_OVER_TWO, 0.0, CesiumMath.PI_OVER_TWO), CesiumMath.EPSILON7);
+        expect(expression.evaluate(undefined)).toEqualEpsilon(new Cartesian3(0.0, CesiumMath.PI_OVER_TWO, 0.0, CesiumMath.PI_OVER_TWO), CesiumMath.EPSILON7);
 
         expression = new Expression('acos(vec4(1, 0, 1, 0))');
-        expect(expression.evaluate(frameState, undefined)).toEqualEpsilon(new Cartesian4(0.0, CesiumMath.PI_OVER_TWO, 0.0, CesiumMath.PI_OVER_TWO, 0.0), CesiumMath.EPSILON7);
+        expect(expression.evaluate(undefined)).toEqualEpsilon(new Cartesian4(0.0, CesiumMath.PI_OVER_TWO, 0.0, CesiumMath.PI_OVER_TWO, 0.0), CesiumMath.EPSILON7);
     });
 
     it('throws if acos function takes an invalid number of arguments', function() {
@@ -1673,16 +1671,16 @@ defineSuite([
 
     it('evaluates asin function', function() {
         var expression = new Expression('asin(0)');
-        expect(expression.evaluate(frameState, undefined)).toEqual(0);
+        expect(expression.evaluate(undefined)).toEqual(0);
 
         expression = new Expression('asin(vec2(0, 1))');
-        expect(expression.evaluate(frameState, undefined)).toEqualEpsilon(new Cartesian2(0.0, CesiumMath.PI_OVER_TWO), CesiumMath.EPSILON7);
+        expect(expression.evaluate(undefined)).toEqualEpsilon(new Cartesian2(0.0, CesiumMath.PI_OVER_TWO), CesiumMath.EPSILON7);
 
         expression = new Expression('asin(vec3(0, 1, 0))');
-        expect(expression.evaluate(frameState, undefined)).toEqualEpsilon(new Cartesian3(0.0, CesiumMath.PI_OVER_TWO, 0.0, CesiumMath.PI_OVER_TWO), CesiumMath.EPSILON7);
+        expect(expression.evaluate(undefined)).toEqualEpsilon(new Cartesian3(0.0, CesiumMath.PI_OVER_TWO, 0.0, CesiumMath.PI_OVER_TWO), CesiumMath.EPSILON7);
 
         expression = new Expression('asin(vec4(0, 1, 0, 1))');
-        expect(expression.evaluate(frameState, undefined)).toEqualEpsilon(new Cartesian4(0.0, CesiumMath.PI_OVER_TWO, 0.0, CesiumMath.PI_OVER_TWO, 0.0), CesiumMath.EPSILON7);
+        expect(expression.evaluate(undefined)).toEqualEpsilon(new Cartesian4(0.0, CesiumMath.PI_OVER_TWO, 0.0, CesiumMath.PI_OVER_TWO, 0.0), CesiumMath.EPSILON7);
     });
 
     it('throws if asin function takes an invalid number of arguments', function() {
@@ -1697,16 +1695,16 @@ defineSuite([
 
     it('evaluates atan function', function() {
         var expression = new Expression('atan(0)');
-        expect(expression.evaluate(frameState, undefined)).toEqual(0);
+        expect(expression.evaluate(undefined)).toEqual(0);
 
         expression = new Expression('atan(vec2(0, 1))');
-        expect(expression.evaluate(frameState, undefined)).toEqualEpsilon(new Cartesian2(0.0, CesiumMath.PI_OVER_FOUR), CesiumMath.EPSILON7);
+        expect(expression.evaluate(undefined)).toEqualEpsilon(new Cartesian2(0.0, CesiumMath.PI_OVER_FOUR), CesiumMath.EPSILON7);
 
         expression = new Expression('atan(vec3(0, 1, 0))');
-        expect(expression.evaluate(frameState, undefined)).toEqualEpsilon(new Cartesian3(0.0, CesiumMath.PI_OVER_FOUR, 0.0, CesiumMath.PI_OVER_FOUR), CesiumMath.EPSILON7);
+        expect(expression.evaluate(undefined)).toEqualEpsilon(new Cartesian3(0.0, CesiumMath.PI_OVER_FOUR, 0.0, CesiumMath.PI_OVER_FOUR), CesiumMath.EPSILON7);
 
         expression = new Expression('atan(vec4(0, 1, 0, 1))');
-        expect(expression.evaluate(frameState, undefined)).toEqualEpsilon(new Cartesian4(0.0, CesiumMath.PI_OVER_FOUR, 0.0, CesiumMath.PI_OVER_FOUR, 0.0), CesiumMath.EPSILON7);
+        expect(expression.evaluate(undefined)).toEqualEpsilon(new Cartesian4(0.0, CesiumMath.PI_OVER_FOUR, 0.0, CesiumMath.PI_OVER_FOUR, 0.0), CesiumMath.EPSILON7);
     });
 
     it('throws if atan function takes an invalid number of arguments', function() {
@@ -1721,16 +1719,16 @@ defineSuite([
 
     it('evaluates radians function', function() {
         var expression = new Expression('radians(180)');
-        expect(expression.evaluate(frameState, undefined)).toEqualEpsilon(Math.PI, CesiumMath.EPSILON10);
+        expect(expression.evaluate(undefined)).toEqualEpsilon(Math.PI, CesiumMath.EPSILON10);
 
         expression = new Expression('radians(vec2(180, 90))');
-        expect(expression.evaluate(frameState, undefined)).toEqualEpsilon(new Cartesian2(Math.PI, CesiumMath.PI_OVER_TWO), CesiumMath.EPSILON7);
+        expect(expression.evaluate(undefined)).toEqualEpsilon(new Cartesian2(Math.PI, CesiumMath.PI_OVER_TWO), CesiumMath.EPSILON7);
 
         expression = new Expression('radians(vec3(180, 90, 180))');
-        expect(expression.evaluate(frameState, undefined)).toEqualEpsilon(new Cartesian3(Math.PI, CesiumMath.PI_OVER_TWO, Math.PI), CesiumMath.EPSILON7);
+        expect(expression.evaluate(undefined)).toEqualEpsilon(new Cartesian3(Math.PI, CesiumMath.PI_OVER_TWO, Math.PI), CesiumMath.EPSILON7);
 
         expression = new Expression('radians(vec4(180, 90, 180, 90))');
-        expect(expression.evaluate(frameState, undefined)).toEqualEpsilon(new Cartesian4(Math.PI, CesiumMath.PI_OVER_TWO, Math.PI, CesiumMath.PI_OVER_TWO), CesiumMath.EPSILON7);
+        expect(expression.evaluate(undefined)).toEqualEpsilon(new Cartesian4(Math.PI, CesiumMath.PI_OVER_TWO, Math.PI, CesiumMath.PI_OVER_TWO), CesiumMath.EPSILON7);
     });
 
     it('throws if radians function takes an invalid number of arguments', function() {
@@ -1745,16 +1743,16 @@ defineSuite([
 
     it('evaluates degrees function', function() {
         var expression = new Expression('degrees(2 * Math.PI)');
-        expect(expression.evaluate(frameState, undefined)).toEqualEpsilon(360, CesiumMath.EPSILON10);
+        expect(expression.evaluate(undefined)).toEqualEpsilon(360, CesiumMath.EPSILON10);
 
         expression = new Expression('degrees(vec2(2 * Math.PI, Math.PI))');
-        expect(expression.evaluate(frameState, undefined)).toEqualEpsilon(new Cartesian2(360, 180), CesiumMath.EPSILON7);
+        expect(expression.evaluate(undefined)).toEqualEpsilon(new Cartesian2(360, 180), CesiumMath.EPSILON7);
 
         expression = new Expression('degrees(vec3(2 * Math.PI, Math.PI, 2 * Math.PI))');
-        expect(expression.evaluate(frameState, undefined)).toEqualEpsilon(new Cartesian3(360, 180, 360), CesiumMath.EPSILON7);
+        expect(expression.evaluate(undefined)).toEqualEpsilon(new Cartesian3(360, 180, 360), CesiumMath.EPSILON7);
 
         expression = new Expression('degrees(vec4(2 * Math.PI, Math.PI, 2 * Math.PI, Math.PI))');
-        expect(expression.evaluate(frameState, undefined)).toEqualEpsilon(new Cartesian4(360, 180, 360, 180), CesiumMath.EPSILON7);
+        expect(expression.evaluate(undefined)).toEqualEpsilon(new Cartesian4(360, 180, 360, 180), CesiumMath.EPSILON7);
     });
 
     it('throws if degrees function takes an invalid number of arguments', function() {
@@ -1769,22 +1767,22 @@ defineSuite([
 
     it('evaluates sqrt function', function() {
         var expression = new Expression('sqrt(1.0)');
-        expect(expression.evaluate(frameState, undefined)).toEqual(1.0);
+        expect(expression.evaluate(undefined)).toEqual(1.0);
 
         expression = new Expression('sqrt(4.0)');
-        expect(expression.evaluate(frameState, undefined)).toEqual(2.0);
+        expect(expression.evaluate(undefined)).toEqual(2.0);
 
         expression = new Expression('sqrt(-1.0)');
-        expect(expression.evaluate(frameState, undefined)).toEqual(NaN);
+        expect(expression.evaluate(undefined)).toEqual(NaN);
 
         expression = new Expression('sqrt(vec2(1.0, 4.0))');
-        expect(expression.evaluate(frameState, undefined)).toEqual(new Cartesian2(1.0, 2.0));
+        expect(expression.evaluate(undefined)).toEqual(new Cartesian2(1.0, 2.0));
 
         expression = new Expression('sqrt(vec3(1.0, 4.0, 9.0))');
-        expect(expression.evaluate(frameState, undefined)).toEqual(new Cartesian3(1.0, 2.0, 3.0));
+        expect(expression.evaluate(undefined)).toEqual(new Cartesian3(1.0, 2.0, 3.0));
 
         expression = new Expression('sqrt(vec4(1.0, 4.0, 9.0, 16.0))');
-        expect(expression.evaluate(frameState, undefined)).toEqual(new Cartesian4(1.0, 2.0, 3.0, 4.0));
+        expect(expression.evaluate(undefined)).toEqual(new Cartesian4(1.0, 2.0, 3.0, 4.0));
     });
 
     it('throws if sqrt function takes an invalid number of arguments', function() {
@@ -1799,22 +1797,22 @@ defineSuite([
 
     it('evaluates sign function', function() {
         var expression = new Expression('sign(5.0)');
-        expect(expression.evaluate(frameState, undefined)).toEqual(1.0);
+        expect(expression.evaluate(undefined)).toEqual(1.0);
 
         expression = new Expression('sign(0.0)');
-        expect(expression.evaluate(frameState, undefined)).toEqual(0.0);
+        expect(expression.evaluate(undefined)).toEqual(0.0);
 
         expression = new Expression('sign(-5.0)');
-        expect(expression.evaluate(frameState, undefined)).toEqual(-1.0);
+        expect(expression.evaluate(undefined)).toEqual(-1.0);
 
         expression = new Expression('sign(vec2(5.0, -5.0))');
-        expect(expression.evaluate(frameState, undefined)).toEqual(new Cartesian2(1.0, -1.0));
+        expect(expression.evaluate(undefined)).toEqual(new Cartesian2(1.0, -1.0));
 
         expression = new Expression('sign(vec3(5.0, -5.0, 0.0))');
-        expect(expression.evaluate(frameState, undefined)).toEqual(new Cartesian3(1.0, -1.0, 0.0));
+        expect(expression.evaluate(undefined)).toEqual(new Cartesian3(1.0, -1.0, 0.0));
 
         expression = new Expression('sign(vec4(5.0, -5.0, 0.0, 1.0))');
-        expect(expression.evaluate(frameState, undefined)).toEqual(new Cartesian4(1.0, -1.0, 0.0, 1.0));
+        expect(expression.evaluate(undefined)).toEqual(new Cartesian4(1.0, -1.0, 0.0, 1.0));
     });
 
     it('throws if sign function takes an invalid number of arguments', function() {
@@ -1829,22 +1827,22 @@ defineSuite([
 
     it('evaluates floor function', function() {
         var expression = new Expression('floor(5.5)');
-        expect(expression.evaluate(frameState, undefined)).toEqual(5.0);
+        expect(expression.evaluate(undefined)).toEqual(5.0);
 
         expression = new Expression('floor(0.0)');
-        expect(expression.evaluate(frameState, undefined)).toEqual(0.0);
+        expect(expression.evaluate(undefined)).toEqual(0.0);
 
         expression = new Expression('floor(-1.2)');
-        expect(expression.evaluate(frameState, undefined)).toEqual(-2.0);
+        expect(expression.evaluate(undefined)).toEqual(-2.0);
 
         expression = new Expression('floor(vec2(5.5, -1.2))');
-        expect(expression.evaluate(frameState, undefined)).toEqual(new Cartesian2(5.0, -2.0));
+        expect(expression.evaluate(undefined)).toEqual(new Cartesian2(5.0, -2.0));
 
         expression = new Expression('floor(vec3(5.5, -1.2, 0.0))');
-        expect(expression.evaluate(frameState, undefined)).toEqual(new Cartesian3(5.0, -2.0, 0.0));
+        expect(expression.evaluate(undefined)).toEqual(new Cartesian3(5.0, -2.0, 0.0));
 
         expression = new Expression('floor(vec4(5.5, -1.2, 0.0, -2.9))');
-        expect(expression.evaluate(frameState, undefined)).toEqual(new Cartesian4(5.0, -2.0, 0.0, -3.0));
+        expect(expression.evaluate(undefined)).toEqual(new Cartesian4(5.0, -2.0, 0.0, -3.0));
     });
 
     it('throws if floor function takes an invalid number of arguments', function() {
@@ -1859,22 +1857,22 @@ defineSuite([
 
     it('evaluates ceil function', function() {
         var expression = new Expression('ceil(5.5)');
-        expect(expression.evaluate(frameState, undefined)).toEqual(6.0);
+        expect(expression.evaluate(undefined)).toEqual(6.0);
 
         expression = new Expression('ceil(0.0)');
-        expect(expression.evaluate(frameState, undefined)).toEqual(0.0);
+        expect(expression.evaluate(undefined)).toEqual(0.0);
 
         expression = new Expression('ceil(-1.2)');
-        expect(expression.evaluate(frameState, undefined)).toEqual(-1.0);
+        expect(expression.evaluate(undefined)).toEqual(-1.0);
 
         expression = new Expression('ceil(vec2(5.5, -1.2))');
-        expect(expression.evaluate(frameState, undefined)).toEqual(new Cartesian2(6.0, -1.0));
+        expect(expression.evaluate(undefined)).toEqual(new Cartesian2(6.0, -1.0));
 
         expression = new Expression('ceil(vec3(5.5, -1.2, 0.0))');
-        expect(expression.evaluate(frameState, undefined)).toEqual(new Cartesian3(6.0, -1.0, 0.0));
+        expect(expression.evaluate(undefined)).toEqual(new Cartesian3(6.0, -1.0, 0.0));
 
         expression = new Expression('ceil(vec4(5.5, -1.2, 0.0, -2.9))');
-        expect(expression.evaluate(frameState, undefined)).toEqual(new Cartesian4(6.0, -1.0, 0.0, -2.0));
+        expect(expression.evaluate(undefined)).toEqual(new Cartesian4(6.0, -1.0, 0.0, -2.0));
     });
 
     it('throws if ceil function takes an invalid number of arguments', function() {
@@ -1889,22 +1887,22 @@ defineSuite([
 
     it('evaluates round function', function() {
         var expression = new Expression('round(5.5)');
-        expect(expression.evaluate(frameState, undefined)).toEqual(6);
+        expect(expression.evaluate(undefined)).toEqual(6);
 
         expression = new Expression('round(0.0)');
-        expect(expression.evaluate(frameState, undefined)).toEqual(0);
+        expect(expression.evaluate(undefined)).toEqual(0);
 
         expression = new Expression('round(1.2)');
-        expect(expression.evaluate(frameState, undefined)).toEqual(1);
+        expect(expression.evaluate(undefined)).toEqual(1);
 
         expression = new Expression('round(vec2(5.5, -1.2))');
-        expect(expression.evaluate(frameState, undefined)).toEqual(new Cartesian2(6.0, -1.0));
+        expect(expression.evaluate(undefined)).toEqual(new Cartesian2(6.0, -1.0));
 
         expression = new Expression('round(vec3(5.5, -1.2, 0.0))');
-        expect(expression.evaluate(frameState, undefined)).toEqual(new Cartesian3(6.0, -1.0, 0.0));
+        expect(expression.evaluate(undefined)).toEqual(new Cartesian3(6.0, -1.0, 0.0));
 
         expression = new Expression('round(vec4(5.5, -1.2, 0.0, -2.9))');
-        expect(expression.evaluate(frameState, undefined)).toEqual(new Cartesian4(6.0, -1.0, 0.0, -3.0));
+        expect(expression.evaluate(undefined)).toEqual(new Cartesian4(6.0, -1.0, 0.0, -3.0));
     });
 
     it('throws if round function takes an invalid number of arguments', function() {
@@ -1919,19 +1917,19 @@ defineSuite([
 
     it('evaluates exp function', function() {
         var expression = new Expression('exp(1.0)');
-        expect(expression.evaluate(frameState, undefined)).toEqualEpsilon(Math.E, CesiumMath.EPSILON10);
+        expect(expression.evaluate(undefined)).toEqualEpsilon(Math.E, CesiumMath.EPSILON10);
 
         expression = new Expression('exp(0.0)');
-        expect(expression.evaluate(frameState, undefined)).toEqualEpsilon(1.0, CesiumMath.EPSILON10);
+        expect(expression.evaluate(undefined)).toEqualEpsilon(1.0, CesiumMath.EPSILON10);
 
         expression = new Expression('exp(vec2(1.0, 0.0))');
-        expect(expression.evaluate(frameState, undefined)).toEqualEpsilon(new Cartesian2(Math.E, 1.0), CesiumMath.EPSILON10);
+        expect(expression.evaluate(undefined)).toEqualEpsilon(new Cartesian2(Math.E, 1.0), CesiumMath.EPSILON10);
 
         expression = new Expression('exp(vec3(1.0, 0.0, 1.0))');
-        expect(expression.evaluate(frameState, undefined)).toEqualEpsilon(new Cartesian3(Math.E, 1.0, Math.E), CesiumMath.EPSILON10);
+        expect(expression.evaluate(undefined)).toEqualEpsilon(new Cartesian3(Math.E, 1.0, Math.E), CesiumMath.EPSILON10);
 
         expression = new Expression('exp(vec4(1.0, 0.0, 1.0, 0.0))');
-        expect(expression.evaluate(frameState, undefined)).toEqualEpsilon(new Cartesian4(Math.E, 1.0, Math.E, 1.0), CesiumMath.EPSILON10);
+        expect(expression.evaluate(undefined)).toEqualEpsilon(new Cartesian4(Math.E, 1.0, Math.E, 1.0), CesiumMath.EPSILON10);
     });
 
     it('throws if exp function takes an invalid number of arguments', function() {
@@ -1946,22 +1944,22 @@ defineSuite([
 
     it('evaluates exp2 function', function() {
         var expression = new Expression('exp2(1.0)');
-        expect(expression.evaluate(frameState, undefined)).toEqual(2.0);
+        expect(expression.evaluate(undefined)).toEqual(2.0);
 
         expression = new Expression('exp2(0.0)');
-        expect(expression.evaluate(frameState, undefined)).toEqual(1.0);
+        expect(expression.evaluate(undefined)).toEqual(1.0);
 
         expression = new Expression('exp2(2.0)');
-        expect(expression.evaluate(frameState, undefined)).toEqual(4.0);
+        expect(expression.evaluate(undefined)).toEqual(4.0);
 
         expression = new Expression('exp2(vec2(1.0, 0.0))');
-        expect(expression.evaluate(frameState, undefined)).toEqual(new Cartesian2(2.0, 1.0));
+        expect(expression.evaluate(undefined)).toEqual(new Cartesian2(2.0, 1.0));
 
         expression = new Expression('exp2(vec3(1.0, 0.0, 2.0))');
-        expect(expression.evaluate(frameState, undefined)).toEqual(new Cartesian3(2.0, 1.0, 4.0));
+        expect(expression.evaluate(undefined)).toEqual(new Cartesian3(2.0, 1.0, 4.0));
 
         expression = new Expression('exp2(vec4(1.0, 0.0, 2.0, 3.0))');
-        expect(expression.evaluate(frameState, undefined)).toEqual(new Cartesian4(2.0, 1.0, 4.0, 8.0));
+        expect(expression.evaluate(undefined)).toEqual(new Cartesian4(2.0, 1.0, 4.0, 8.0));
     });
 
     it('throws if exp2 function takes an invalid number of arguments', function() {
@@ -1976,19 +1974,19 @@ defineSuite([
 
     it('evaluates log function', function() {
         var expression = new Expression('log(1.0)');
-        expect(expression.evaluate(frameState, undefined)).toEqual(0.0);
+        expect(expression.evaluate(undefined)).toEqual(0.0);
 
         expression = new Expression('log(10.0)');
-        expect(expression.evaluate(frameState, undefined)).toEqualEpsilon(2.302585092994046, CesiumMath.EPSILON7);
+        expect(expression.evaluate(undefined)).toEqualEpsilon(2.302585092994046, CesiumMath.EPSILON7);
 
         expression = new Expression('log(vec2(1.0, Math.E))');
-        expect(expression.evaluate(frameState, undefined)).toEqual(new Cartesian2(0.0, 1.0));
+        expect(expression.evaluate(undefined)).toEqual(new Cartesian2(0.0, 1.0));
 
         expression = new Expression('log(vec3(1.0, Math.E, 1.0))');
-        expect(expression.evaluate(frameState, undefined)).toEqual(new Cartesian3(0.0, 1.0, 0.0));
+        expect(expression.evaluate(undefined)).toEqual(new Cartesian3(0.0, 1.0, 0.0));
 
         expression = new Expression('log(vec4(1.0, Math.E, 1.0, Math.E))');
-        expect(expression.evaluate(frameState, undefined)).toEqual(new Cartesian4(0.0, 1.0, 0.0, 1.0));
+        expect(expression.evaluate(undefined)).toEqual(new Cartesian4(0.0, 1.0, 0.0, 1.0));
     });
 
     it('throws if log function takes an invalid number of arguments', function() {
@@ -2003,22 +2001,22 @@ defineSuite([
 
     it('evaluates log2 function', function() {
         var expression = new Expression('log2(1.0)');
-        expect(expression.evaluate(frameState, undefined)).toEqual(0.0);
+        expect(expression.evaluate(undefined)).toEqual(0.0);
 
         expression = new Expression('log2(2.0)');
-        expect(expression.evaluate(frameState, undefined)).toEqual(1.0);
+        expect(expression.evaluate(undefined)).toEqual(1.0);
 
         expression = new Expression('log2(4.0)');
-        expect(expression.evaluate(frameState, undefined)).toEqual(2.0);
+        expect(expression.evaluate(undefined)).toEqual(2.0);
 
         expression = new Expression('log2(vec2(1.0, 2.0))');
-        expect(expression.evaluate(frameState, undefined)).toEqual(new Cartesian2(0.0, 1.0));
+        expect(expression.evaluate(undefined)).toEqual(new Cartesian2(0.0, 1.0));
 
         expression = new Expression('log2(vec3(1.0, 2.0, 4.0))');
-        expect(expression.evaluate(frameState, undefined)).toEqual(new Cartesian3(0.0, 1.0, 2.0));
+        expect(expression.evaluate(undefined)).toEqual(new Cartesian3(0.0, 1.0, 2.0));
 
         expression = new Expression('log2(vec4(1.0, 2.0, 4.0, 8.0))');
-        expect(expression.evaluate(frameState, undefined)).toEqual(new Cartesian4(0.0, 1.0, 2.0, 3.0));
+        expect(expression.evaluate(undefined)).toEqual(new Cartesian4(0.0, 1.0, 2.0, 3.0));
     });
 
     it('throws if log2 function takes an invalid number of arguments', function() {
@@ -2033,22 +2031,22 @@ defineSuite([
 
     it('evaluates fract function', function() {
         var expression = new Expression('fract(1.0)');
-        expect(expression.evaluate(frameState, undefined)).toEqual(0.0);
+        expect(expression.evaluate(undefined)).toEqual(0.0);
 
         expression = new Expression('fract(2.25)');
-        expect(expression.evaluate(frameState, undefined)).toEqual(0.25);
+        expect(expression.evaluate(undefined)).toEqual(0.25);
 
         expression = new Expression('fract(-2.25)');
-        expect(expression.evaluate(frameState, undefined)).toEqual(0.75);
+        expect(expression.evaluate(undefined)).toEqual(0.75);
 
         expression = new Expression('fract(vec2(1.0, 2.25))');
-        expect(expression.evaluate(frameState, undefined)).toEqual(new Cartesian2(0.0, 0.25));
+        expect(expression.evaluate(undefined)).toEqual(new Cartesian2(0.0, 0.25));
 
         expression = new Expression('fract(vec3(1.0, 2.25, -2.25))');
-        expect(expression.evaluate(frameState, undefined)).toEqual(new Cartesian3(0.0, 0.25, 0.75));
+        expect(expression.evaluate(undefined)).toEqual(new Cartesian3(0.0, 0.25, 0.75));
 
         expression = new Expression('fract(vec4(1.0, 2.25, -2.25, 1.0))');
-        expect(expression.evaluate(frameState, undefined)).toEqual(new Cartesian4(0.0, 0.25, 0.75, 0.0));
+        expect(expression.evaluate(undefined)).toEqual(new Cartesian4(0.0, 0.25, 0.75, 0.0));
     });
 
     it('throws if fract function takes an invalid number of arguments', function() {
@@ -2063,16 +2061,16 @@ defineSuite([
 
     it('evaluates length function', function() {
         var expression = new Expression('length(-3.0)');
-        expect(expression.evaluate(frameState, undefined)).toEqual(3.0);
+        expect(expression.evaluate(undefined)).toEqual(3.0);
 
         expression = new Expression('length(vec2(-3.0, 4.0))');
-        expect(expression.evaluate(frameState, undefined)).toEqual(5.0);
+        expect(expression.evaluate(undefined)).toEqual(5.0);
 
         expression = new Expression('length(vec3(2.0, 3.0, 6.0))');
-        expect(expression.evaluate(frameState, undefined)).toEqual(7.0);
+        expect(expression.evaluate(undefined)).toEqual(7.0);
 
         expression = new Expression('length(vec4(2.0, 4.0, 7.0, 10.0))');
-        expect(expression.evaluate(frameState, undefined)).toEqual(13.0);
+        expect(expression.evaluate(undefined)).toEqual(13.0);
     });
 
     it('throws if length function takes an invalid number of arguments', function() {
@@ -2087,18 +2085,18 @@ defineSuite([
 
     it('evaluates normalize function', function() {
         var expression = new Expression('normalize(5.0)');
-        expect(expression.evaluate(frameState, undefined)).toEqual(1.0);
+        expect(expression.evaluate(undefined)).toEqual(1.0);
 
         expression = new Expression('normalize(vec2(3.0, 4.0))');
-        expect(expression.evaluate(frameState, undefined)).toEqual(new Cartesian2(0.6, 0.8));
+        expect(expression.evaluate(undefined)).toEqual(new Cartesian2(0.6, 0.8));
 
         expression = new Expression('normalize(vec3(2.0, 3.0, -4.0))');
         var length = Math.sqrt(2 * 2 + 3 * 3 + 4 * 4);
-        expect(expression.evaluate(frameState, undefined)).toEqualEpsilon(new Cartesian3(2.0 / length, 3.0 / length, -4.0 / length), CesiumMath.EPSILON10);
+        expect(expression.evaluate(undefined)).toEqualEpsilon(new Cartesian3(2.0 / length, 3.0 / length, -4.0 / length), CesiumMath.EPSILON10);
 
         expression = new Expression('normalize(vec4(-2.0, 3.0, -4.0, 5.0))');
         length = Math.sqrt(2 * 2 + 3 * 3 + 4 * 4 + 5 * 5);
-        expect(expression.evaluate(frameState, undefined)).toEqual(new Cartesian4(-2.0 / length, 3.0 / length, -4.0 / length, 5.0/length), CesiumMath.EPSILON10);
+        expect(expression.evaluate(undefined)).toEqual(new Cartesian4(-2.0 / length, 3.0 / length, -4.0 / length, 5.0/length), CesiumMath.EPSILON10);
     });
 
     it('throws if normalize function takes an invalid number of arguments', function() {
@@ -2113,25 +2111,25 @@ defineSuite([
 
     it('evaluates clamp function', function() {
         var expression = new Expression('clamp(50.0, 0.0, 100.0)');
-        expect(expression.evaluate(frameState, undefined)).toEqual(50.0);
+        expect(expression.evaluate(undefined)).toEqual(50.0);
 
         expression = new Expression('clamp(50.0, 0.0, 25.0)');
-        expect(expression.evaluate(frameState, undefined)).toEqual(25.0);
+        expect(expression.evaluate(undefined)).toEqual(25.0);
 
         expression = new Expression('clamp(50.0, 75.0, 100.0)');
-        expect(expression.evaluate(frameState, undefined)).toEqual(75.0);
+        expect(expression.evaluate(undefined)).toEqual(75.0);
 
         expression = new Expression('clamp(vec2(50.0,50.0), vec2(0.0,75.0), 100.0)');
-        expect(expression.evaluate(frameState, undefined)).toEqual(new Cartesian2(50.0, 75.0));
+        expect(expression.evaluate(undefined)).toEqual(new Cartesian2(50.0, 75.0));
 
         expression = new Expression('clamp(vec2(50.0,50.0), vec2(0.0,75.0), vec2(25.0,100.0))');
-        expect(expression.evaluate(frameState, undefined)).toEqual(new Cartesian2(25.0, 75.0));
+        expect(expression.evaluate(undefined)).toEqual(new Cartesian2(25.0, 75.0));
 
         expression = new Expression('clamp(vec3(50.0, 50.0, 50.0), vec3(0.0, 0.0, 75.0), vec3(100.0, 25.0, 100.0))');
-        expect(expression.evaluate(frameState, undefined)).toEqual(new Cartesian3(50.0, 25.0, 75.0));
+        expect(expression.evaluate(undefined)).toEqual(new Cartesian3(50.0, 25.0, 75.0));
 
         expression = new Expression('clamp(vec4(50.0, 50.0, 50.0, 100.0), vec4(0.0, 0.0, 75.0, 75.0), vec4(100.0, 25.0, 100.0, 85.0))');
-        expect(expression.evaluate(frameState, undefined)).toEqual(new Cartesian4(50.0, 25.0, 75.0, 85.0));
+        expect(expression.evaluate(undefined)).toEqual(new Cartesian4(50.0, 25.0, 75.0, 85.0));
     });
 
     it('throws if clamp function takes an invalid number of arguments', function() {
@@ -2155,51 +2153,51 @@ defineSuite([
     it('throws if clamp function takes mismatching types', function() {
         var expression = new Expression('clamp(0.0,vec2(0,1),0.0)');
         expect(function() {
-            expression.evaluate(frameState, undefined);
+            expression.evaluate(undefined);
         }).toThrowRuntimeError();
 
         expression = new Expression('clamp(vec2(0,1),vec3(0,1,2),0.0)');
         expect(function() {
-            expression.evaluate(frameState, undefined);
+            expression.evaluate(undefined);
         }).toThrowRuntimeError();
 
         expression = new Expression('clamp(vec2(0,1),vec2(0,1), vec3(1,2,3))');
         expect(function() {
-            expression.evaluate(frameState, undefined);
+            expression.evaluate(undefined);
         }).toThrowRuntimeError();
     });
 
     it('evaluates mix function', function() {
         var expression = new Expression('mix(0.0, 2.0, 0.5)');
-        expect(expression.evaluate(frameState, undefined)).toEqual(1.0);
+        expect(expression.evaluate(undefined)).toEqual(1.0);
 
         expression = new Expression('mix(vec2(0.0,1.0), vec2(2.0,3.0), 0.5)');
-        expect(expression.evaluate(frameState, undefined)).toEqual(new Cartesian2(1.0, 2.0));
+        expect(expression.evaluate(undefined)).toEqual(new Cartesian2(1.0, 2.0));
 
         expression = new Expression('mix(vec2(0.0,1.0), vec2(2.0,3.0), vec2(0.5,4.0))');
-        expect(expression.evaluate(frameState, undefined)).toEqual(new Cartesian2(1.0, 9.0));
+        expect(expression.evaluate(undefined)).toEqual(new Cartesian2(1.0, 9.0));
 
         expression = new Expression('mix(vec3(0.0,1.0,2.0), vec3(2.0,3.0,4.0), vec3(0.5,4.0,5.0))');
-        expect(expression.evaluate(frameState, undefined)).toEqual(new Cartesian3(1.0, 9.0, 12.0));
+        expect(expression.evaluate(undefined)).toEqual(new Cartesian3(1.0, 9.0, 12.0));
 
         expression = new Expression('mix(vec4(0.0,1.0,2.0,1.5), vec4(2.0,3.0,4.0,2.5), vec4(0.5,4.0,5.0,3.5))');
-        expect(expression.evaluate(frameState, undefined)).toEqual(new Cartesian4(1.0, 9.0, 12.0, 5.0));
+        expect(expression.evaluate(undefined)).toEqual(new Cartesian4(1.0, 9.0, 12.0, 5.0));
     });
 
     it('throws if mix function takes mismatching types', function() {
         var expression = new Expression('mix(0.0,vec2(0,1),0.0)');
         expect(function() {
-            expression.evaluate(frameState, undefined);
+            expression.evaluate(undefined);
         }).toThrowRuntimeError();
 
         expression = new Expression('mix(vec2(0,1),vec3(0,1,2),0.0)');
         expect(function() {
-            expression.evaluate(frameState, undefined);
+            expression.evaluate(undefined);
         }).toThrowRuntimeError();
 
         expression = new Expression('mix(vec2(0,1),vec2(0,1), vec3(1,2,3))');
         expect(function() {
-            expression.evaluate(frameState, undefined);
+            expression.evaluate(undefined);
         }).toThrowRuntimeError();
     });
 
@@ -2223,21 +2221,21 @@ defineSuite([
 
     it('evaluates atan2 function', function() {
         var expression = new Expression('atan2(0,1)');
-        expect(expression.evaluate(frameState, undefined)).toEqualEpsilon(0.0, CesiumMath.EPSILON10);
+        expect(expression.evaluate(undefined)).toEqualEpsilon(0.0, CesiumMath.EPSILON10);
 
         expression = new Expression('atan2(1,0)');
-        expect(expression.evaluate(frameState, undefined)).toEqualEpsilon(0.5 * Math.PI, CesiumMath.EPSILON10);
+        expect(expression.evaluate(undefined)).toEqualEpsilon(0.5 * Math.PI, CesiumMath.EPSILON10);
 
         expression = new Expression('atan2(vec2(0,1),vec2(1,0))');
-        expect(expression.evaluate(frameState, undefined))
+        expect(expression.evaluate(undefined))
             .toEqualEpsilon(new Cartesian2(0.0, 0.5 * Math.PI), CesiumMath.EPSILON10);
 
         expression = new Expression('atan2(vec3(0,1,0.5),vec3(1,0,0.5))');
-        expect(expression.evaluate(frameState, undefined))
+        expect(expression.evaluate(undefined))
             .toEqualEpsilon(new Cartesian3(0.0, 0.5 * Math.PI, 0.25 * Math.PI), CesiumMath.EPSILON10);
 
         expression = new Expression('atan2(vec4(0,1,0.5,1),vec4(1,0,0.5,0))');
-        expect(expression.evaluate(frameState, undefined))
+        expect(expression.evaluate(undefined))
             .toEqualEpsilon(new Cartesian4(0.0, 0.5 * Math.PI, 0.25 * Math.PI, 0.5 * Math.PI), CesiumMath.EPSILON10);
     });
 
@@ -2254,35 +2252,35 @@ defineSuite([
     it('throws if atan2 function takes mismatching types', function() {
         var expression = new Expression('atan2(0.0,vec2(0,1))');
         expect(function() {
-            expression.evaluate(frameState, undefined);
+            expression.evaluate(undefined);
         }).toThrowRuntimeError();
 
         expression = new Expression('atan2(vec2(0,1),0.0)');
         expect(function() {
-            expression.evaluate(frameState, undefined);
+            expression.evaluate(undefined);
         }).toThrowRuntimeError();
 
         expression = new Expression('atan2(vec2(0,1),vec3(0,1,2))');
         expect(function() {
-            expression.evaluate(frameState, undefined);
+            expression.evaluate(undefined);
         }).toThrowRuntimeError();
     });
 
     it('evaluates pow function', function() {
         var expression = new Expression('pow(5,0)');
-        expect(expression.evaluate(frameState, undefined)).toEqual(1.0);
+        expect(expression.evaluate(undefined)).toEqual(1.0);
 
         expression = new Expression('pow(4,2)');
-        expect(expression.evaluate(frameState, undefined)).toEqual(16.0);
+        expect(expression.evaluate(undefined)).toEqual(16.0);
 
         expression = new Expression('pow(vec2(5,4),vec2(0,2))');
-        expect(expression.evaluate(frameState, undefined)).toEqual(new Cartesian2(1.0, 16.0));
+        expect(expression.evaluate(undefined)).toEqual(new Cartesian2(1.0, 16.0));
 
         expression = new Expression('pow(vec3(5,4,3),vec3(0,2,3))');
-        expect(expression.evaluate(frameState, undefined)).toEqual(new Cartesian3(1.0, 16.0, 27.0));
+        expect(expression.evaluate(undefined)).toEqual(new Cartesian3(1.0, 16.0, 27.0));
 
         expression = new Expression('pow(vec4(5,4,3,2),vec4(0,2,3,5))');
-        expect(expression.evaluate(frameState, undefined)).toEqual(new Cartesian4(1.0, 16.0, 27.0, 32.0));
+        expect(expression.evaluate(undefined)).toEqual(new Cartesian4(1.0, 16.0, 27.0, 32.0));
     });
 
     it('throws if pow function takes an invalid number of arguments', function() {
@@ -2298,38 +2296,38 @@ defineSuite([
     it('throws if pow function takes mismatching types', function() {
         var expression = new Expression('pow(0.0, vec2(0,1))');
         expect(function() {
-            expression.evaluate(frameState, undefined);
+            expression.evaluate(undefined);
         }).toThrowRuntimeError();
 
         expression = new Expression('pow(vec2(0,1),0.0)');
         expect(function() {
-            expression.evaluate(frameState, undefined);
+            expression.evaluate(undefined);
         }).toThrowRuntimeError();
 
         expression = new Expression('pow(vec2(0,1),vec3(0,1,2))');
         expect(function() {
-            expression.evaluate(frameState, undefined);
+            expression.evaluate(undefined);
         }).toThrowRuntimeError();
     });
 
     it('evaluates min function', function() {
         var expression = new Expression('min(0,1)');
-        expect(expression.evaluate(frameState, undefined)).toEqual(0.0);
+        expect(expression.evaluate(undefined)).toEqual(0.0);
 
         expression = new Expression('min(-1,0)');
-        expect(expression.evaluate(frameState, undefined)).toEqual(-1.0);
+        expect(expression.evaluate(undefined)).toEqual(-1.0);
 
         expression = new Expression('min(vec2(-1,1),0)');
-        expect(expression.evaluate(frameState, undefined)).toEqual(new Cartesian2(-1.0, 0));
+        expect(expression.evaluate(undefined)).toEqual(new Cartesian2(-1.0, 0));
 
         expression = new Expression('min(vec2(-1,2),vec2(0,1))');
-        expect(expression.evaluate(frameState, undefined)).toEqual(new Cartesian2(-1.0, 1.0));
+        expect(expression.evaluate(undefined)).toEqual(new Cartesian2(-1.0, 1.0));
 
         expression = new Expression('min(vec3(-1,2,1),vec3(0,1,2))');
-        expect(expression.evaluate(frameState, undefined)).toEqual(new Cartesian3(-1.0, 1.0, 1.0));
+        expect(expression.evaluate(undefined)).toEqual(new Cartesian3(-1.0, 1.0, 1.0));
 
         expression = new Expression('min(vec4(-1,2,1,4),vec4(0,1,2,3))');
-        expect(expression.evaluate(frameState, undefined)).toEqual(new Cartesian4(-1.0, 1.0, 1.0, 3.0));
+        expect(expression.evaluate(undefined)).toEqual(new Cartesian4(-1.0, 1.0, 1.0, 3.0));
     });
 
     it('throws if min function takes an invalid number of arguments', function() {
@@ -2345,33 +2343,33 @@ defineSuite([
     it('throws if min function takes mismatching types', function() {
         var expression = new Expression('min(0.0, vec2(0,1))');
         expect(function() {
-            expression.evaluate(frameState, undefined);
+            expression.evaluate(undefined);
         }).toThrowRuntimeError();
 
         expression = new Expression('min(vec2(0,1),vec3(0,1,2))');
         expect(function() {
-            expression.evaluate(frameState, undefined);
+            expression.evaluate(undefined);
         }).toThrowRuntimeError();
     });
 
     it('evaluates max function', function() {
         var expression = new Expression('max(0,1)');
-        expect(expression.evaluate(frameState, undefined)).toEqual(1.0);
+        expect(expression.evaluate(undefined)).toEqual(1.0);
 
         expression = new Expression('max(-1,0)');
-        expect(expression.evaluate(frameState, undefined)).toEqual(0.0);
+        expect(expression.evaluate(undefined)).toEqual(0.0);
 
         expression = new Expression('max(vec2(-1,1),0)');
-        expect(expression.evaluate(frameState, undefined)).toEqual(new Cartesian2(0, 1.0));
+        expect(expression.evaluate(undefined)).toEqual(new Cartesian2(0, 1.0));
 
         expression = new Expression('max(vec2(-1,2),vec2(0,1))');
-        expect(expression.evaluate(frameState, undefined)).toEqual(new Cartesian2(0, 2.0));
+        expect(expression.evaluate(undefined)).toEqual(new Cartesian2(0, 2.0));
 
         expression = new Expression('max(vec3(-1,2,1),vec3(0,1,2))');
-        expect(expression.evaluate(frameState, undefined)).toEqual(new Cartesian3(0, 2.0, 2.0));
+        expect(expression.evaluate(undefined)).toEqual(new Cartesian3(0, 2.0, 2.0));
 
         expression = new Expression('max(vec4(-1,2,1,4),vec4(0,1,2,3))');
-        expect(expression.evaluate(frameState, undefined)).toEqual(new Cartesian4(0, 2.0, 2.0, 4.0));
+        expect(expression.evaluate(undefined)).toEqual(new Cartesian4(0, 2.0, 2.0, 4.0));
     });
 
     it('throws if max function takes an invalid number of arguments', function() {
@@ -2387,27 +2385,27 @@ defineSuite([
     it('throws if max function takes mismatching types', function() {
         var expression = new Expression('max(0.0, vec2(0,1))');
         expect(function() {
-            expression.evaluate(frameState, undefined);
+            expression.evaluate(undefined);
         }).toThrowRuntimeError();
 
         expression = new Expression('max(vec2(0,1),vec3(0,1,2))');
         expect(function() {
-            expression.evaluate(frameState, undefined);
+            expression.evaluate(undefined);
         }).toThrowRuntimeError();
     });
 
     it('evaluates the distance function', function() {
         var expression = new Expression('distance(0, 1)');
-        expect(expression.evaluate(frameState, undefined)).toEqual(1.0);
+        expect(expression.evaluate(undefined)).toEqual(1.0);
 
         expression = new Expression('distance(vec2(1.0, 0.0), vec2(0.0, 0.0))');
-        expect(expression.evaluate(frameState, undefined)).toEqual(1.0);
+        expect(expression.evaluate(undefined)).toEqual(1.0);
 
         expression = new Expression('distance(vec3(3.0, 2.0, 1.0), vec3(1.0, 0.0, 0.0))');
-        expect(expression.evaluate(frameState, undefined)).toEqual(3.0);
+        expect(expression.evaluate(undefined)).toEqual(3.0);
 
         expression = new Expression('distance(vec4(5.0, 5.0, 5.0, 5.0), vec4(0.0, 0.0, 0.0, 0.0))');
-        expect(expression.evaluate(frameState, undefined)).toEqual(10.0);
+        expect(expression.evaluate(undefined)).toEqual(10.0);
     });
 
     it('throws if distance function takes an invalid number of arguments', function() {
@@ -2422,26 +2420,26 @@ defineSuite([
 
     it('throws if distance function takes mismatching types of arguments', function() {
         expect(function() {
-            return new Expression('distance(1, vec2(3.0, 2.0)').evaluate(frameState, undefined);
+            return new Expression('distance(1, vec2(3.0, 2.0)').evaluate(undefined);
         }).toThrowRuntimeError();
 
         expect(function() {
-            return new Expression('distance(vec4(5.0, 2.0, 3.0, 1.0), vec3(4.0, 4.0, 4.0))').evaluate(frameState, undefined);
+            return new Expression('distance(vec4(5.0, 2.0, 3.0, 1.0), vec3(4.0, 4.0, 4.0))').evaluate(undefined);
         }).toThrowRuntimeError();
     });
 
     it('evaluates the dot function', function() {
         var expression = new Expression('dot(1, 2)');
-        expect(expression.evaluate(frameState, undefined)).toEqual(2.0);
+        expect(expression.evaluate(undefined)).toEqual(2.0);
 
         expression = new Expression('dot(vec2(1.0, 1.0), vec2(2.0, 2.0))');
-        expect(expression.evaluate(frameState, undefined)).toEqual(4.0);
+        expect(expression.evaluate(undefined)).toEqual(4.0);
 
         expression = new Expression('dot(vec3(1.0, 2.0, 3.0), vec3(2.0, 2.0, 1.0))');
-        expect(expression.evaluate(frameState, undefined)).toEqual(9.0);
+        expect(expression.evaluate(undefined)).toEqual(9.0);
 
         expression = new Expression('dot(vec4(5.0, 5.0, 2.0, 3.0), vec4(1.0, 2.0, 1.0, 1.0))');
-        expect(expression.evaluate(frameState, undefined)).toEqual(20.0);
+        expect(expression.evaluate(undefined)).toEqual(20.0);
     });
 
     it('throws if dot function takes an invalid number of arguments', function() {
@@ -2456,23 +2454,23 @@ defineSuite([
 
     it('throws if dot function takes mismatching types of arguments', function() {
         expect(function() {
-            return new Expression('dot(1, vec2(3.0, 2.0)').evaluate(frameState, undefined);
+            return new Expression('dot(1, vec2(3.0, 2.0)').evaluate(undefined);
         }).toThrowRuntimeError();
 
         expect(function() {
-            return new Expression('dot(vec4(5.0, 2.0, 3.0, 1.0), vec3(4.0, 4.0, 4.0))').evaluate(frameState, undefined);
+            return new Expression('dot(vec4(5.0, 2.0, 3.0, 1.0), vec3(4.0, 4.0, 4.0))').evaluate(undefined);
         }).toThrowRuntimeError();
     });
 
     it('evaluates the cross function', function() {
         var expression = new Expression('cross(vec3(1.0, 1.0, 1.0), vec3(2.0, 2.0, 2.0))');
-        expect(expression.evaluate(frameState, undefined)).toEqual(new Cartesian3(0.0, 0.0, 0.0));
+        expect(expression.evaluate(undefined)).toEqual(new Cartesian3(0.0, 0.0, 0.0));
 
         expression = new Expression('cross(vec3(-1.0, -1.0, -1.0), vec3(0.0, -2.0, -5.0))');
-        expect(expression.evaluate(frameState, undefined)).toEqual(new Cartesian3(3.0, -5.0, 2.0));
+        expect(expression.evaluate(undefined)).toEqual(new Cartesian3(3.0, -5.0, 2.0));
 
         expression = new Expression('cross(vec3(5.0, -2.0, 1.0), vec3(-2.0, -6.0, -8.0))');
-        expect(expression.evaluate(frameState, undefined)).toEqual(new Cartesian3(22.0, 38.0, -34.0));
+        expect(expression.evaluate(undefined)).toEqual(new Cartesian3(22.0, 38.0, -34.0));
     });
 
     it('throws if cross function takes an invalid number of arguments', function() {
@@ -2487,23 +2485,23 @@ defineSuite([
 
     it('throws if cross function does not take vec3 arguments', function() {
         expect(function() {
-            return new Expression('cross(vec2(1.0, 2.0), vec2(3.0, 2.0)').evaluate(frameState, undefined);
+            return new Expression('cross(vec2(1.0, 2.0), vec2(3.0, 2.0)').evaluate(undefined);
         }).toThrowRuntimeError();
 
         expect(function() {
-            return new Expression('cross(vec4(5.0, 2.0, 3.0, 1.0), vec3(4.0, 4.0, 4.0))').evaluate(frameState, undefined);
+            return new Expression('cross(vec4(5.0, 2.0, 3.0, 1.0), vec3(4.0, 4.0, 4.0))').evaluate(undefined);
         }).toThrowRuntimeError();
     });
 
     it('evaluates ternary conditional', function() {
         var expression = new Expression('true ? "first" : "second"');
-        expect(expression.evaluate(frameState, undefined)).toEqual('first');
+        expect(expression.evaluate(undefined)).toEqual('first');
 
         expression = new Expression('false ? "first" : "second"');
-        expect(expression.evaluate(frameState, undefined)).toEqual('second');
+        expect(expression.evaluate(undefined)).toEqual('second');
 
         expression = new Expression('(!(1 + 2 > 3)) ? (2 > 1 ? 1 + 1 : 0) : (2 > 1 ? -1 + -1 : 0)');
-        expect(expression.evaluate(frameState, undefined)).toEqual(2);
+        expect(expression.evaluate(undefined)).toEqual(2);
     });
 
     it('evaluates member expression with dot', function() {
@@ -2526,36 +2524,36 @@ defineSuite([
         });
 
         var expression = new Expression('${vector.x}');
-        expect(expression.evaluate(frameState, feature)).toEqual(1.0);
+        expect(expression.evaluate(feature)).toEqual(1.0);
 
         expression = new Expression('${vector.z}');
-        expect(expression.evaluate(frameState, feature)).toEqual(0.0);
+        expect(expression.evaluate(feature)).toEqual(0.0);
 
         expression = new Expression('${height.z}');
-        expect(expression.evaluate(frameState, feature)).toEqual(undefined);
+        expect(expression.evaluate(feature)).toEqual(undefined);
 
         expression = new Expression('${undefined.z}');
-        expect(expression.evaluate(frameState, feature)).toEqual(undefined);
+        expect(expression.evaluate(feature)).toEqual(undefined);
 
         expression = new Expression('${feature}');
-        expect(expression.evaluate(frameState, feature)).toEqual({
+        expect(expression.evaluate(feature)).toEqual({
             vector : Cartesian4.UNIT_Z
         });
 
         expression = new Expression('${feature.vector}');
-        expect(expression.evaluate(frameState, feature)).toEqual(Cartesian4.UNIT_X);
+        expect(expression.evaluate(feature)).toEqual(Cartesian4.UNIT_X);
 
         expression = new Expression('${feature.feature.vector}');
-        expect(expression.evaluate(frameState, feature)).toEqual(Cartesian4.UNIT_Z);
+        expect(expression.evaluate(feature)).toEqual(Cartesian4.UNIT_Z);
 
         expression = new Expression('${feature.vector.x}');
-        expect(expression.evaluate(frameState, feature)).toEqual(1.0);
+        expect(expression.evaluate(feature)).toEqual(1.0);
 
         expression = new Expression('${address.street}');
-        expect(expression.evaluate(frameState, feature)).toEqual('Example Street');
+        expect(expression.evaluate(feature)).toEqual('Example Street');
 
         expression = new Expression('${address.city}');
-        expect(expression.evaluate(frameState, feature)).toEqual('Example City');
+        expect(expression.evaluate(feature)).toEqual('Example City');
     });
 
     it('evaluates member expression with brackets', function() {
@@ -2579,52 +2577,52 @@ defineSuite([
         });
 
         var expression = new Expression('${vector["x"]}');
-        expect(expression.evaluate(frameState, feature)).toEqual(1.0);
+        expect(expression.evaluate(feature)).toEqual(1.0);
 
         expression = new Expression('${vector["z"]}');
-        expect(expression.evaluate(frameState, feature)).toEqual(0.0);
+        expect(expression.evaluate(feature)).toEqual(0.0);
 
         expression = new Expression('${height["z"]}');
-        expect(expression.evaluate(frameState, feature)).toEqual(undefined);
+        expect(expression.evaluate(feature)).toEqual(undefined);
 
         expression = new Expression('${undefined["z"]}');
-        expect(expression.evaluate(frameState, feature)).toEqual(undefined);
+        expect(expression.evaluate(feature)).toEqual(undefined);
 
         expression = new Expression('${feature["vector"]}');
-        expect(expression.evaluate(frameState, feature)).toEqual(Cartesian4.UNIT_X);
+        expect(expression.evaluate(feature)).toEqual(Cartesian4.UNIT_X);
 
         expression = new Expression('${feature.vector["x"]}');
-        expect(expression.evaluate(frameState, feature)).toEqual(1.0);
+        expect(expression.evaluate(feature)).toEqual(1.0);
 
         expression = new Expression('${feature["vector"].x}');
-        expect(expression.evaluate(frameState, feature)).toEqual(1.0);
+        expect(expression.evaluate(feature)).toEqual(1.0);
 
         expression = new Expression('${feature["vector.x"]}');
-        expect(expression.evaluate(frameState, feature)).toEqual('something else');
+        expect(expression.evaluate(feature)).toEqual('something else');
 
         expression = new Expression('${feature.feature["vector"]}');
-        expect(expression.evaluate(frameState, feature)).toEqual(Cartesian4.UNIT_Z);
+        expect(expression.evaluate(feature)).toEqual(Cartesian4.UNIT_Z);
 
         expression = new Expression('${feature["feature.vector"]}');
-        expect(expression.evaluate(frameState, feature)).toEqual(Cartesian4.UNIT_Y);
+        expect(expression.evaluate(feature)).toEqual(Cartesian4.UNIT_Y);
 
         expression = new Expression('${address.street}');
-        expect(expression.evaluate(frameState, feature)).toEqual('Example Street');
+        expect(expression.evaluate(feature)).toEqual('Example Street');
 
         expression = new Expression('${feature.address.street}');
-        expect(expression.evaluate(frameState, feature)).toEqual('Example Street');
+        expect(expression.evaluate(feature)).toEqual('Example Street');
 
         expression = new Expression('${feature["address"].street}');
-        expect(expression.evaluate(frameState, feature)).toEqual('Example Street');
+        expect(expression.evaluate(feature)).toEqual('Example Street');
 
         expression = new Expression('${feature["address.street"]}');
-        expect(expression.evaluate(frameState, feature)).toEqual('Other Street');
+        expect(expression.evaluate(feature)).toEqual('Other Street');
 
         expression = new Expression('${address["street"]}');
-        expect(expression.evaluate(frameState, feature)).toEqual('Example Street');
+        expect(expression.evaluate(feature)).toEqual('Example Street');
 
         expression = new Expression('${address["city"]}');
-        expect(expression.evaluate(frameState, feature)).toEqual('Example City');
+        expect(expression.evaluate(feature)).toEqual('Example City');
     });
 
     it('member expressions throw without variable notation', function() {
@@ -2654,12 +2652,12 @@ defineSuite([
         });
 
         var expression = new Expression('${feature}');
-        expect(expression.evaluate(frameState, feature)).toEqual({
+        expect(expression.evaluate(feature)).toEqual({
             vector : Cartesian4.UNIT_X
         });
 
         expression = new Expression('${feature} === ${feature.feature}');
-        expect(expression.evaluate(frameState, feature)).toEqual(true);
+        expect(expression.evaluate(feature)).toEqual(true);
     });
 
     it('constructs regex', function() {
@@ -2667,44 +2665,44 @@ defineSuite([
         feature.addProperty('pattern', '[abc]');
 
         var expression = new Expression('regExp("a")');
-        expect(expression.evaluate(frameState, undefined)).toEqual(/a/);
+        expect(expression.evaluate(undefined)).toEqual(/a/);
         expect(expression._runtimeAst._type).toEqual(ExpressionNodeType.LITERAL_REGEX);
 
         expression = new Expression('regExp("\\w")');
-        expect(expression.evaluate(frameState, undefined)).toEqual(/\w/);
+        expect(expression.evaluate(undefined)).toEqual(/\w/);
         expect(expression._runtimeAst._type).toEqual(ExpressionNodeType.LITERAL_REGEX);
 
         expression = new Expression('regExp(1 + 1)');
-        expect(expression.evaluate(frameState, undefined)).toEqual(/2/);
+        expect(expression.evaluate(undefined)).toEqual(/2/);
         expect(expression._runtimeAst._type).toEqual(ExpressionNodeType.REGEX);
 
         expression = new Expression('regExp(true)');
-        expect(expression.evaluate(frameState, undefined)).toEqual(/true/);
+        expect(expression.evaluate(undefined)).toEqual(/true/);
         expect(expression._runtimeAst._type).toEqual(ExpressionNodeType.LITERAL_REGEX);
 
         expression = new Expression('regExp()');
-        expect(expression.evaluate(frameState, undefined)).toEqual(/(?:)/);
+        expect(expression.evaluate(undefined)).toEqual(/(?:)/);
         expect(expression._runtimeAst._type).toEqual(ExpressionNodeType.LITERAL_REGEX);
 
         expression = new Expression('regExp(${pattern})');
-        expect(expression.evaluate(frameState, feature)).toEqual(/[abc]/);
+        expect(expression.evaluate(feature)).toEqual(/[abc]/);
         expect(expression._runtimeAst._type).toEqual(ExpressionNodeType.REGEX);
     });
 
     it ('constructs regex with flags', function() {
         var expression = new Expression('regExp("a", "i")');
-        expect(expression.evaluate(frameState, undefined)).toEqual(/a/i);
+        expect(expression.evaluate(undefined)).toEqual(/a/i);
         expect(expression._runtimeAst._type).toEqual(ExpressionNodeType.LITERAL_REGEX);
 
         expression = new Expression('regExp("a", "m" + "g")');
-        expect(expression.evaluate(frameState, undefined)).toEqual(/a/mg);
+        expect(expression.evaluate(undefined)).toEqual(/a/mg);
         expect(expression._runtimeAst._type).toEqual(ExpressionNodeType.REGEX);
     });
 
     it('does not throw SyntaxError if regex constructor has invalid pattern', function() {
         var expression = new Expression('regExp("(?<=\\s)" + ".")');
         expect(function() {
-            expression.evaluate(frameState, undefined);
+            expression.evaluate(undefined);
         }).not.toThrowSyntaxError();
 
         expect(function() {
@@ -2715,7 +2713,7 @@ defineSuite([
     it('throws if regex constructor has invalid flags', function() {
         var expression = new Expression('regExp("a" + "b", "q")');
         expect(function() {
-            expression.evaluate(frameState, undefined);
+            expression.evaluate(undefined);
         }).toThrowRuntimeError();
 
         expect(function() {
@@ -2728,30 +2726,30 @@ defineSuite([
         feature.addProperty('property', 'abc');
 
         var expression = new Expression('regExp("a").test("abc")');
-        expect(expression.evaluate(frameState, undefined)).toEqual(true);
+        expect(expression.evaluate(undefined)).toEqual(true);
 
         expression = new Expression('regExp("a").test("bcd")');
-        expect(expression.evaluate(frameState, undefined)).toEqual(false);
+        expect(expression.evaluate(undefined)).toEqual(false);
 
         expression = new Expression('regExp("quick\\s(brown).+?(jumps)", "ig").test("The Quick Brown Fox Jumps Over The Lazy Dog")');
-        expect(expression.evaluate(frameState, undefined)).toEqual(true);
+        expect(expression.evaluate(undefined)).toEqual(true);
 
         expression = new Expression('regExp("a").test()');
-        expect(expression.evaluate(frameState, undefined)).toEqual(false);
+        expect(expression.evaluate(undefined)).toEqual(false);
 
         expression = new Expression('regExp(${property}).test(${property})');
-        expect(expression.evaluate(frameState, feature)).toEqual(true);
+        expect(expression.evaluate(feature)).toEqual(true);
     });
 
     it('throws if regex test function has invalid arguments', function() {
         var expression = new Expression('regExp("1").test(1)');
         expect(function() {
-            expression.evaluate(frameState, undefined);
+            expression.evaluate(undefined);
         }).toThrowRuntimeError();
 
         expression = new Expression('regExp("a").test(regExp("b"))');
         expect(function() {
-            expression.evaluate(frameState, undefined);
+            expression.evaluate(undefined);
         }).toThrowRuntimeError();
     });
 
@@ -2761,33 +2759,33 @@ defineSuite([
         feature.addProperty('Name', 'Building 1');
 
         var expression = new Expression('regExp("a(.)", "i").exec("Abc")');
-        expect(expression.evaluate(frameState, undefined)).toEqual('b');
+        expect(expression.evaluate(undefined)).toEqual('b');
 
         expression = new Expression('regExp("a(.)").exec("qbc")');
-        expect(expression.evaluate(frameState, undefined)).toEqual(null);
+        expect(expression.evaluate(undefined)).toEqual(null);
 
         expression = new Expression('regExp("a(.)").exec()');
-        expect(expression.evaluate(frameState, undefined)).toEqual(null);
+        expect(expression.evaluate(undefined)).toEqual(null);
 
         expression = new Expression('regExp("quick\\s(b.*n).+?(jumps)", "ig").exec("The Quick Brown Fox Jumps Over The Lazy Dog")');
-        expect(expression.evaluate(frameState, undefined)).toEqual('Brown');
+        expect(expression.evaluate(undefined)).toEqual('Brown');
 
         expression = new Expression('regExp("(" + ${property} + ")").exec(${property})');
-        expect(expression.evaluate(frameState, feature)).toEqual('abc');
+        expect(expression.evaluate(feature)).toEqual('abc');
 
         expression = new Expression('regExp("Building\\s(\\d)").exec(${Name})');
-        expect(expression.evaluate(frameState, feature)).toEqual('1');
+        expect(expression.evaluate(feature)).toEqual('1');
     });
 
     it('throws if regex exec function has invalid arguments', function() {
         var expression = new Expression('regExp("1").exec(1)');
         expect(function() {
-            expression.evaluate(frameState, undefined);
+            expression.evaluate(undefined);
         }).toThrowRuntimeError();
 
         expression = new Expression('regExp("a").exec(regExp("b"))');
         expect(function() {
-            expression.evaluate(frameState, undefined);
+            expression.evaluate(undefined);
         }).toThrowRuntimeError();
     });
 
@@ -2796,22 +2794,22 @@ defineSuite([
         feature.addProperty('property', 'abc');
 
         var expression = new Expression('regExp("a") =~ "abc"');
-        expect(expression.evaluate(frameState, undefined)).toEqual(true);
+        expect(expression.evaluate(undefined)).toEqual(true);
 
         expression = new Expression('"abc" =~ regExp("a")');
-        expect(expression.evaluate(frameState, undefined)).toEqual(true);
+        expect(expression.evaluate(undefined)).toEqual(true);
 
         expression = new Expression('regExp("a") =~ "bcd"');
-        expect(expression.evaluate(frameState, undefined)).toEqual(false);
+        expect(expression.evaluate(undefined)).toEqual(false);
 
         expression = new Expression('"bcd" =~ regExp("a")');
-        expect(expression.evaluate(frameState, undefined)).toEqual(false);
+        expect(expression.evaluate(undefined)).toEqual(false);
 
         expression = new Expression('regExp("quick\\s(brown).+?(jumps)", "ig") =~ "The Quick Brown Fox Jumps Over The Lazy Dog"');
-        expect(expression.evaluate(frameState, undefined)).toEqual(true);
+        expect(expression.evaluate(undefined)).toEqual(true);
 
         expression = new Expression('regExp(${property}) =~ ${property}');
-        expect(expression.evaluate(frameState, feature)).toEqual(true);
+        expect(expression.evaluate(feature)).toEqual(true);
     });
 
     it('throws if regex match operator has invalid arguments', function() {
@@ -2820,17 +2818,17 @@ defineSuite([
 
         var expression = new Expression('regExp("a") =~ 1');
         expect(function() {
-            expression.evaluate(frameState, undefined);
+            expression.evaluate(undefined);
         }).toThrowRuntimeError();
 
         expression = new Expression('1 =~ regExp("a")');
         expect(function() {
-            expression.evaluate(frameState, undefined);
+            expression.evaluate(undefined);
         }).toThrowRuntimeError();
 
         expression = new Expression('1 =~ 1');
         expect(function() {
-            expression.evaluate(frameState, undefined);
+            expression.evaluate(undefined);
         }).toThrowRuntimeError();
     });
 
@@ -2839,38 +2837,38 @@ defineSuite([
         feature.addProperty('property', 'abc');
 
         var expression = new Expression('regExp("a") !~ "abc"');
-        expect(expression.evaluate(frameState, undefined)).toEqual(false);
+        expect(expression.evaluate(undefined)).toEqual(false);
 
         expression = new Expression('"abc" !~ regExp("a")');
-        expect(expression.evaluate(frameState, undefined)).toEqual(false);
+        expect(expression.evaluate(undefined)).toEqual(false);
 
         expression = new Expression('regExp("a") !~ "bcd"');
-        expect(expression.evaluate(frameState, undefined)).toEqual(true);
+        expect(expression.evaluate(undefined)).toEqual(true);
 
         expression = new Expression('"bcd" !~ regExp("a")');
-        expect(expression.evaluate(frameState, undefined)).toEqual(true);
+        expect(expression.evaluate(undefined)).toEqual(true);
 
         expression = new Expression('regExp("quick\\s(brown).+?(jumps)", "ig") !~ "The Quick Brown Fox Jumps Over The Lazy Dog"');
-        expect(expression.evaluate(frameState, undefined)).toEqual(false);
+        expect(expression.evaluate(undefined)).toEqual(false);
 
         expression = new Expression('regExp(${property}) !~ ${property}');
-        expect(expression.evaluate(frameState, feature)).toEqual(false);
+        expect(expression.evaluate(feature)).toEqual(false);
     });
 
     it('throws if regex not match operator has invalid arguments', function() {
         var expression = new Expression('regExp("a") !~ 1');
         expect(function() {
-            expression.evaluate(frameState, undefined);
+            expression.evaluate(undefined);
         }).toThrowRuntimeError();
 
         expression = new Expression('1 !~ regExp("a")');
         expect(function() {
-            expression.evaluate(frameState, undefined);
+            expression.evaluate(undefined);
         }).toThrowRuntimeError();
 
         expression = new Expression('1 !~ 1');
         expect(function() {
-            expression.evaluate(frameState, undefined);
+            expression.evaluate(undefined);
         }).toThrowRuntimeError();
     });
 
@@ -2889,13 +2887,13 @@ defineSuite([
         feature.addProperty('property', 'abc');
 
         var expression = new Expression('regExp().toString()');
-        expect(expression.evaluate(frameState, undefined)).toEqual('/(?:)/');
+        expect(expression.evaluate(undefined)).toEqual('/(?:)/');
 
         expression = new Expression('regExp("\\d\\s\\d", "ig").toString()');
-        expect(expression.evaluate(frameState, undefined)).toEqual('/\\d\\s\\d/gi');
+        expect(expression.evaluate(undefined)).toEqual('/\\d\\s\\d/gi');
 
         expression = new Expression('regExp(${property}).toString()');
-        expect(expression.evaluate(frameState, feature)).toEqual('/abc/');
+        expect(expression.evaluate(feature)).toEqual('/abc/');
     });
 
     it('throws when using toString on other type', function() {
@@ -2904,7 +2902,7 @@ defineSuite([
 
         var expression = new Expression('${property}.toString()');
         expect(function() {
-            return expression.evaluate(frameState, feature);
+            return expression.evaluate(feature);
         }).toThrowRuntimeError();
     });
 
@@ -2925,36 +2923,36 @@ defineSuite([
         });
 
         var expression = new Expression('[1, 2, 3]');
-        expect(expression.evaluate(frameState, undefined)).toEqual([1, 2, 3]);
+        expect(expression.evaluate(undefined)).toEqual([1, 2, 3]);
 
         expression = new Expression('[1+2, "hello", 2 < 3, color("blue"), ${property}]');
-        expect(expression.evaluate(frameState, feature)).toEqual([3, 'hello', true, Cartesian4.fromColor(Color.BLUE), 'value']);
+        expect(expression.evaluate(feature)).toEqual([3, 'hello', true, Cartesian4.fromColor(Color.BLUE), 'value']);
 
         expression = new Expression('${array[1]}');
-        expect(expression.evaluate(frameState, feature)).toEqual(Cartesian4.UNIT_Y);
+        expect(expression.evaluate(feature)).toEqual(Cartesian4.UNIT_Y);
 
         expression = new Expression('${complicatedArray[1].subproperty}');
-        expect(expression.evaluate(frameState, feature)).toEqual(Cartesian4.UNIT_Z);
+        expect(expression.evaluate(feature)).toEqual(Cartesian4.UNIT_Z);
 
         expression = new Expression('${complicatedArray[0]["anotherproperty"]}');
-        expect(expression.evaluate(frameState, feature)).toEqual(Cartesian4.UNIT_Y);
+        expect(expression.evaluate(feature)).toEqual(Cartesian4.UNIT_Y);
 
         expression = new Expression('${temperatures["scale"]}');
-        expect(expression.evaluate(frameState, feature)).toEqual('fahrenheit');
+        expect(expression.evaluate(feature)).toEqual('fahrenheit');
 
         expression = new Expression('${temperatures.values[0]}');
-        expect(expression.evaluate(frameState, feature)).toEqual(70);
+        expect(expression.evaluate(feature)).toEqual(70);
 
         expression = new Expression('${temperatures["values"][0]}');
-        expect(expression.evaluate(frameState, feature)).toEqual(70);
+        expect(expression.evaluate(feature)).toEqual(70);
     });
 
     it('evaluates tiles3d_tileset_time expression', function() {
         var feature = new MockFeature();
         var expression = new Expression('${tiles3d_tileset_time}');
-        expect(expression.evaluate(frameState, feature)).toEqual(0.0);
+        expect(expression.evaluate(feature)).toEqual(0.0);
         feature.content.tileset.timeSinceLoad = 1.0;
-        expect(expression.evaluate(frameState, feature)).toEqual(1.0);
+        expect(expression.evaluate(feature)).toEqual(1.0);
     });
 
     it('gets shader function', function() {

--- a/Specs/Scene/StyleExpressionSpec.js
+++ b/Specs/Scene/StyleExpressionSpec.js
@@ -4,8 +4,6 @@ defineSuite([
         StyleExpression) {
     'use strict';
 
-    var frameState = {};
-
     function MockFeature() {
     }
 
@@ -18,11 +16,11 @@ defineSuite([
         var feature = new MockFeature();
 
         expect(function() {
-            return expression.evaluate(frameState, feature);
+            return expression.evaluate(feature);
         }).toThrowDeveloperError();
 
         expect(function() {
-            return expression.evaluateColor(frameState, feature);
+            return expression.evaluateColor(feature);
         }).toThrowDeveloperError();
     });
 });

--- a/Specs/Scene/Vector3DTilePointsSpec.js
+++ b/Specs/Scene/Vector3DTilePointsSpec.js
@@ -154,7 +154,7 @@ defineSuite([
         return loadPoints(points).then(function() {
             var features = [];
             points.createFeatures(mockTileset, features);
-            points.applyStyle(scene.frameState, undefined, features);
+            points.applyStyle(undefined, features);
 
             scene.camera.lookAt(Cartesian3.fromDegrees(0.0, 0.0, 10.0), new Cartesian3(0.0, 0.0, 50.0));
             expect(scene).toRender([255, 255, 255, 255]);
@@ -188,7 +188,7 @@ defineSuite([
         return loadPoints(points).then(function() {
             var features = [];
             points.createFeatures(mockTileset, features);
-            points.applyStyle(scene.frameState, style, features);
+            points.applyStyle(style, features);
 
             for (var i = 0; i < cartoPositions.length; ++i) {
                 var position = ellipsoid.cartographicToCartesian(cartoPositions[i]);
@@ -224,7 +224,7 @@ defineSuite([
 
             var features = [];
             points.createFeatures(mockTileset, features);
-            points.applyStyle(scene.frameState, undefined, features);
+            points.applyStyle(undefined, features);
 
             var getFeature = mockTileset.getFeature;
             mockTileset.getFeature = function(index) {
@@ -297,7 +297,7 @@ defineSuite([
         return loadPoints(points).then(function() {
             var features = [];
             points.createFeatures(mockTileset, features);
-            points.applyStyle(scene.frameState, style, features);
+            points.applyStyle(style, features);
 
             var i;
             for (i = 0; i < features.length; ++i) {
@@ -367,7 +367,7 @@ defineSuite([
         return loadPoints(points).then(function() {
             var features = [];
             points.createFeatures(mockTileset, features);
-            points.applyStyle(scene.frameState, style, features);
+            points.applyStyle(style, features);
 
             var collection = points._billboardCollection;
             expect(collection.length).toEqual(1);
@@ -413,7 +413,7 @@ defineSuite([
         return loadPoints(points).then(function() {
             var features = [];
             points.createFeatures(mockTileset, features);
-            points.applyStyle(scene.frameState, style, features);
+            points.applyStyle(style, features);
             points.applyDebugSettings(true, Color.YELLOW);
 
             var i;


### PR DESCRIPTION
This addresses issue #6874 and removes mentions of frameState in evaluate and evaluateColor. This helps keep frameState private.

However, frameState still appears in the [documentation](https://cesiumjs.org/Cesium/Build/Documentation/ImageryLayer.html) for ImageryLayer.js. In the constructor, some of the parameters give the user the option of taking in a function that has the signature `function(frameState, layer, x, y, level)`. I'm not sure if frameState is needed here, and I can't find where the source code evaluates these functions. 