### PR TITLE
Changed require.toUrl to Cesium.buildModuleUrl

### DIFF
--- a/Apps/Sandcastle/gallery/Materials.html
+++ b/Apps/Sandcastle/gallery/Materials.html
@@ -176,7 +176,7 @@ function applyWaterMaterial(primitive, scene) {
             type : 'Water',
             uniforms : {
                 specularMap: '../images/earthspec1k.jpg',
-                normalMap: require.toUrl('Assets/Textures/waterNormals.jpg'),
+                normalMap: Cesium.buildModuleUrl('Assets/Textures/waterNormals.jpg'),
                 frequency: 10000.0,
                 animationSpeed: 0.01,
                 amplitude: 1.0

--- a/Apps/Sandcastle/gallery/development/Ground Primitive Materials.html
+++ b/Apps/Sandcastle/gallery/development/Ground Primitive Materials.html
@@ -190,7 +190,7 @@ function applyWaterMaterial(primitive, scene) {
             type : 'Water',
             uniforms : {
                 specularMap: '../images/earthspec1k.jpg',
-                normalMap: require.toUrl('Assets/Textures/waterNormals.jpg'),
+                normalMap: Cesium.buildModuleUrl('Assets/Textures/waterNormals.jpg'),
                 frequency: 10000.0,
                 animationSpeed: 0.01,
                 amplitude: 1.0


### PR DESCRIPTION
in Materials and Ground Primitive Materials (in gallery/development) sandcastle examples.