### PR TITLE
Fix viewer.zoomTo and viewer.flyTo imagery when using terrain.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@ Change Log
 
 ##### Fixes :wrench:
 * The Geocoder widget now takes terrain altitude into account when calculating its final destination.
+* The Viewer widget now takes terrain altitude into account when zooming or flying to imagery layers.
 * Fixed bug that caused a new `ClippingPlaneCollection` to be created every frame when used with a model entity [#6872](https://github.com/AnalyticalGraphicsInc/cesium/pull/6872)
 
 ### 1.48 - 2018-08-01

--- a/Source/Scene/computeFlyToLocationForRectangle.js
+++ b/Source/Scene/computeFlyToLocationForRectangle.js
@@ -26,7 +26,7 @@ define([
         var terrainProvider = scene.terrainProvider;
         var availability = defined(terrainProvider) ? terrainProvider.availability : undefined;
 
-        if (!defined(availability)) {
+        if (!defined(availability) || scene.mode === SceneMode.SCENE2D) {
             return when.resolve(rectangle);
         }
 

--- a/Source/Scene/computeFlyToLocationForRectangle.js
+++ b/Source/Scene/computeFlyToLocationForRectangle.js
@@ -1,0 +1,68 @@
+define([
+    '../Core/defined',
+    '../Core/Rectangle',
+    '../Core/sampleTerrainMostDetailed',
+    './SceneMode',
+    '../ThirdParty/when'
+], function(
+    defined,
+    Rectangle,
+    sampleTerrainMostDetailed,
+    SceneMode,
+    when) {
+'use strict';
+
+    /**
+     * Computes the final camera location to view a rectangle adjusted for terrain.
+     *
+     * @param {Rectangle} rectangle The rectangle being zoomed to.
+     * @param {Scene} scene The scene being used.
+     *
+     * @returns {Cartographic|Rectangle} The location to place the camera or the original rectangle if terrain does not have availability.
+     *
+     * @private
+     */
+    function computeFlyToLocationForRectangle(rectangle, scene) {
+        var terrainProvider = scene.terrainProvider;
+        var availability = defined(terrainProvider) ? terrainProvider.availability : undefined;
+
+        if (!defined(availability)) {
+            return when.resolve(rectangle);
+        }
+
+        var cartographics = [
+            Rectangle.center(rectangle),
+            Rectangle.southeast(rectangle),
+            Rectangle.southwest(rectangle),
+            Rectangle.northeast(rectangle),
+            Rectangle.northwest(rectangle)
+        ];
+
+        return computeFlyToLocationForRectangle._sampleTerrainMostDetailed(terrainProvider, cartographics)
+            .then(function(positionsOnTerrain) {
+                var maxHeight = positionsOnTerrain.reduce(function(currentMax, item) {
+                    return Math.max(item.height, currentMax);
+                }, -Number.MAX_VALUE);
+
+                var finalPosition;
+
+                var camera = scene.camera;
+                var mapProjection = scene.mapProjection;
+                var ellipsoid = mapProjection.ellipsoid;
+                var tmp = camera.getRectangleCameraCoordinates(rectangle);
+                if (scene.mode === SceneMode.SCENE3D) {
+                    finalPosition = ellipsoid.cartesianToCartographic(tmp);
+                } else {
+                    finalPosition = mapProjection.unproject(tmp);
+                }
+
+                finalPosition.height += maxHeight;
+                return finalPosition;
+            });
+    }
+
+    //Exposed for testing.
+    computeFlyToLocationForRectangle._sampleTerrainMostDetailed = sampleTerrainMostDetailed;
+
+    return computeFlyToLocationForRectangle;
+});

--- a/Specs/Scene/computeFlyToLocationForRectangleSpec.js
+++ b/Specs/Scene/computeFlyToLocationForRectangleSpec.js
@@ -1,4 +1,4 @@
-defineSuite([
+fdefineSuite([
         'Scene/computeFlyToLocationForRectangle',
         'Core/EllipsoidTerrainProvider',
         'Core/Rectangle',
@@ -64,11 +64,10 @@ defineSuite([
         var expectedResult;
         if (sceneMode === SceneMode.SCENE3D) {
             expectedResult = scene.mapProjection.ellipsoid.cartesianToCartographic(scene.camera.getRectangleCameraCoordinates(rectangle));
-            expectedResult.height += maxHeight;
         } else {
             expectedResult = scene.mapProjection.unproject(scene.camera.getRectangleCameraCoordinates(rectangle));
-            expectedResult.height += maxHeight;
         }
+        expectedResult.height += maxHeight;
 
         return computeFlyToLocationForRectangle(rectangle, scene)
             .then(function(result) {
@@ -78,15 +77,29 @@ defineSuite([
     }
 
     it('samples terrain and returns expected result in 3D', function() {
-        return sampleTest(SceneMode.SCENE2D);
-    });
-
-    it('samples terrain and returns expected result in 2D', function() {
         return sampleTest(SceneMode.SCENE3D);
     });
 
     it('samples terrain and returns expected result in CV', function() {
         return sampleTest(SceneMode.COLUMBUS_VIEW);
+    });
+
+    it('returns original rectangle in 2D', function() {
+        var terrainProvider = new EllipsoidTerrainProvider();
+        terrainProvider.availability = {};
+
+        scene.globe = new Globe();
+        scene.terrainProvider = terrainProvider;
+        scene.mode = SceneMode.SCENE2D;
+
+        var rectangle = new Rectangle(0.2, 0.4, 0.6, 0.8);
+        spyOn(computeFlyToLocationForRectangle, '_sampleTerrainMostDetailed');
+
+        return computeFlyToLocationForRectangle(rectangle, scene)
+            .then(function(result) {
+                expect(result).toBe(rectangle);
+                expect(computeFlyToLocationForRectangle._sampleTerrainMostDetailed).not.toHaveBeenCalled();
+            });
     });
 
     it('returns original rectangle when terrain not available', function() {

--- a/Specs/Scene/computeFlyToLocationForRectangleSpec.js
+++ b/Specs/Scene/computeFlyToLocationForRectangleSpec.js
@@ -1,4 +1,4 @@
-fdefineSuite([
+defineSuite([
         'Scene/computeFlyToLocationForRectangle',
         'Core/EllipsoidTerrainProvider',
         'Core/Rectangle',

--- a/Specs/Scene/computeFlyToLocationForRectangleSpec.js
+++ b/Specs/Scene/computeFlyToLocationForRectangleSpec.js
@@ -1,0 +1,117 @@
+defineSuite([
+        'Scene/computeFlyToLocationForRectangle',
+        'Core/EllipsoidTerrainProvider',
+        'Core/Rectangle',
+        'Scene/Globe',
+        'Scene/SceneMode',
+        'Specs/createScene',
+        'ThirdParty/when'
+    ], function(
+        computeFlyToLocationForRectangle,
+        EllipsoidTerrainProvider,
+        Rectangle,
+        Globe,
+        SceneMode,
+        createScene,
+        when) {
+    'use strict';
+
+    var scene;
+
+    beforeEach(function() {
+        scene = createScene();
+    });
+
+    afterEach(function() {
+        scene.destroyForSpecs();
+    });
+
+    function sampleTest(sceneMode){
+        //Pretend we have terrain with availability.
+        var terrainProvider = new EllipsoidTerrainProvider();
+        terrainProvider.availability = {};
+
+        scene.globe = new Globe();
+        scene.terrainProvider = terrainProvider;
+        scene.mode = sceneMode;
+
+        var rectangle = new Rectangle(0.2, 0.4, 0.6, 0.8);
+        var cartographics = [
+            Rectangle.center(rectangle),
+            Rectangle.southeast(rectangle),
+            Rectangle.southwest(rectangle),
+            Rectangle.northeast(rectangle),
+            Rectangle.northwest(rectangle)
+        ];
+
+        // Mock sampleTerrainMostDetailed with same positions but with heights.
+        var maxHeight = 1234;
+        var sampledResults = [
+            Rectangle.center(rectangle),
+            Rectangle.southeast(rectangle),
+            Rectangle.southwest(rectangle),
+            Rectangle.northeast(rectangle),
+            Rectangle.northwest(rectangle)
+        ];
+        sampledResults[0].height = 145;
+        sampledResults[1].height = 1211;
+        sampledResults[2].height = -123;
+        sampledResults[3].height = maxHeight;
+
+        spyOn(computeFlyToLocationForRectangle, '_sampleTerrainMostDetailed').and.returnValue(when.resolve(sampledResults));
+
+        // Basically do the computation ourselves with our known values;
+        var expectedResult;
+        if (sceneMode === SceneMode.SCENE3D) {
+            expectedResult = scene.mapProjection.ellipsoid.cartesianToCartographic(scene.camera.getRectangleCameraCoordinates(rectangle));
+            expectedResult.height += maxHeight;
+        } else {
+            expectedResult = scene.mapProjection.unproject(scene.camera.getRectangleCameraCoordinates(rectangle));
+            expectedResult.height += maxHeight;
+        }
+
+        return computeFlyToLocationForRectangle(rectangle, scene)
+            .then(function(result) {
+                expect(result).toEqual(expectedResult);
+                expect(computeFlyToLocationForRectangle._sampleTerrainMostDetailed).toHaveBeenCalledWith(terrainProvider, cartographics);
+            });
+    }
+
+    it('samples terrain and returns expected result in 3D', function() {
+        return sampleTest(SceneMode.SCENE2D);
+    });
+
+    it('samples terrain and returns expected result in 2D', function() {
+        return sampleTest(SceneMode.SCENE3D);
+    });
+
+    it('samples terrain and returns expected result in CV', function() {
+        return sampleTest(SceneMode.COLUMBUS_VIEW);
+    });
+
+    it('returns original rectangle when terrain not available', function() {
+        scene.globe = new Globe();
+        scene.terrainProvider = new EllipsoidTerrainProvider();
+
+        var rectangle = new Rectangle(0.2, 0.4, 0.6, 0.8);
+        spyOn(computeFlyToLocationForRectangle, '_sampleTerrainMostDetailed');
+
+        return computeFlyToLocationForRectangle(rectangle, scene)
+            .then(function(result) {
+                expect(result).toBe(rectangle);
+                expect(computeFlyToLocationForRectangle._sampleTerrainMostDetailed).not.toHaveBeenCalled();
+            });
+    });
+
+    it('returns original rectangle when terrain undefined', function() {
+        scene.terrainProvider = undefined;
+        var rectangle = new Rectangle(0.2, 0.4, 0.6, 0.8);
+        spyOn(computeFlyToLocationForRectangle, '_sampleTerrainMostDetailed');
+
+        return computeFlyToLocationForRectangle(rectangle, scene)
+            .then(function(result) {
+                expect(result).toBe(rectangle);
+                expect(computeFlyToLocationForRectangle._sampleTerrainMostDetailed).not.toHaveBeenCalled();
+            });
+    });
+});


### PR DESCRIPTION
Realized Viewer had the same problem as Geocoder when zooming to imagery extents. This PR mostly moves code around.

1. Pull `computeFlyToLocationForRectangle` out of Geocoder and make it a standalone private function. Add tests for it too (can't believe you guys let me get away with no tests in my other PR) :open_mouth: .
2. Have Viewer call the function when zooming or flying to terrain.

Part of #5942