### PR TITLE
Fix night shading fade in Columbus view

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,7 +14,7 @@ Change Log
 * The Viewer widget now takes terrain altitude into account when zooming or flying to imagery layers.
 * Fixed bug that caused a new `ClippingPlaneCollection` to be created every frame when used with a model entity [#6872](https://github.com/AnalyticalGraphicsInc/cesium/pull/6872)
 * Fixed crash when rendering translucent objects when all shadow maps in the scene set `fromLightSource` to false. [#6883](https://github.com/AnalyticalGraphicsInc/cesium/pull/6883)
-* Fixed night shading in 2D. [#4122](https://github.com/AnalyticalGraphicsInc/cesium/issues/4122)
+* Fixed night shading in 2D and Columbus view. [#4122](https://github.com/AnalyticalGraphicsInc/cesium/issues/4122)
 
 ### 1.48 - 2018-08-01
 

--- a/Source/Shaders/GlobeFS.glsl
+++ b/Source/Shaders/GlobeFS.glsl
@@ -214,7 +214,19 @@ void main()
     vec4 finalColor = vec4(color.rgb * diffuseIntensity, color.a);
 #elif defined(ENABLE_DAYNIGHT_SHADING)
     float diffuseIntensity = clamp(czm_getLambertDiffuse(czm_sunDirectionEC, normalEC) * 5.0 + 0.3, 0.0, 1.0);
-    float cameraDist = czm_sceneMode != czm_sceneMode2D ? length(czm_view[3]) : max(czm_frustumPlanes.x - czm_frustumPlanes.y, czm_frustumPlanes.w - czm_frustumPlanes.z) * 0.5;
+    float cameraDist;
+    if (czm_sceneMode == czm_sceneMode2D)
+    {
+        cameraDist = max(czm_frustumPlanes.x - czm_frustumPlanes.y, czm_frustumPlanes.w - czm_frustumPlanes.z) * 0.5;
+    }
+    else if (czm_sceneMode == czm_sceneModeColumbusView)
+    {
+        cameraDist = -czm_view[3].z;
+    }
+    else
+    {
+        cameraDist = length(czm_view[3]);
+    }
     float fadeOutDist = u_lightingFadeDistance.x;
     float fadeInDist = u_lightingFadeDistance.y;
     if (czm_sceneMode != czm_sceneMode3D) {


### PR DESCRIPTION
Continuation of #6902.

This makes the night shading fade out when the camera reaches a certain altitude like in 2D/3D.