### PR TITLE
computeFlyToLocationForRectangle needs to wait for terrain to become …

### DIFF
--- a/Specs/Scene/computeFlyToLocationForRectangleSpec.js
+++ b/Specs/Scene/computeFlyToLocationForRectangleSpec.js
@@ -116,6 +116,21 @@ defineSuite([
             });
     });
 
+    it('waits for terrain to become ready', function() {
+        var terrainProvider = new EllipsoidTerrainProvider();
+        spyOn(terrainProvider.readyPromise, 'then').and.callThrough();
+
+        scene.globe = new Globe();
+        scene.terrainProvider = terrainProvider;
+
+        var rectangle = new Rectangle(0.2, 0.4, 0.6, 0.8);
+        return computeFlyToLocationForRectangle(rectangle, scene)
+            .then(function(result) {
+                expect(result).toBe(rectangle);
+                expect(terrainProvider.readyPromise.then).toHaveBeenCalled();
+            });
+    });
+
     it('returns original rectangle when terrain undefined', function() {
         scene.terrainProvider = undefined;
         var rectangle = new Rectangle(0.2, 0.4, 0.6, 0.8);


### PR DESCRIPTION
…ready

If you performed a geocode before the terrain became ready, it would throw an exception.

Fixes #6908.

Review this with whitespace diffing off, this PR is 99% indentation changes.

CC @lilleyse 