### PR TITLE
Return the `GroundPolylinePrimitive` when a ground polyline is picked

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,6 +25,7 @@ Change Log
 * Fixed night shading in 2D and Columbus view. [#4122](https://github.com/AnalyticalGraphicsInc/cesium/issues/4122)
 * Fixed a crash when setting show to `false` on a polyline clamped to the ground. [#6912](https://github.com/AnalyticalGraphicsInc/cesium/issues/6912)
 * Fixed crash that happened when calling `scene.pick` after setting a new terrain provider [#6918](https://github.com/AnalyticalGraphicsInc/cesium/pull/6918)
+* Fixed an issue that caused the browser to hang when using `drillPick` on a polyline clamped to the ground. [6907](https://github.com/AnalyticalGraphicsInc/cesium/issues/6907)
 
 ### 1.48 - 2018-08-01
 

--- a/Source/Scene/GroundPolylinePrimitive.js
+++ b/Source/Scene/GroundPolylinePrimitive.js
@@ -639,7 +639,8 @@ define([
                 groundInstances[i] = new GeometryInstance({
                     geometry : geometryInstance.geometry,
                     attributes : attributes,
-                    id : geometryInstance.id
+                    id : geometryInstance.id,
+                    pickPrimitive : that
                 });
             }
 

--- a/Specs/Scene/GroundPolylinePrimitiveSpec.js
+++ b/Specs/Scene/GroundPolylinePrimitiveSpec.js
@@ -688,6 +688,7 @@ defineSuite([
         verifyGroundPolylinePrimitiveRender(groundPolylinePrimitive, polylineColor);
 
         expect(scene).toPickAndCall(function(result) {
+            expect(result.primitive).toEqual(groundPolylinePrimitive);
             expect(result.id).toEqual('polyline on terrain');
         });
     });
@@ -707,6 +708,7 @@ defineSuite([
         verifyGroundPolylinePrimitiveRender(groundPolylinePrimitive, polylineColor);
 
         expect(scene).toPickAndCall(function(result) {
+            expect(result.primitive).toEqual(groundPolylinePrimitive);
             expect(result.id).toEqual('polyline on terrain');
         });
     });
@@ -726,6 +728,7 @@ defineSuite([
         verifyGroundPolylinePrimitiveRender(groundPolylinePrimitive, polylineColor);
 
         expect(scene).toPickAndCall(function(result) {
+            expect(result.primitive).toEqual(groundPolylinePrimitive);
             expect(result.id).toEqual('polyline on terrain');
         });
     });
@@ -764,6 +767,7 @@ defineSuite([
         verifyGroundPolylinePrimitiveRender(groundPolylinePrimitive, polylineColor);
 
         expect(scene).toPickAndCall(function(result) {
+            expect(result.primitive).toEqual(groundPolylinePrimitive);
             expect(result.id).toEqual('big polyline on terrain');
         });
         scene.completeMorph();


### PR DESCRIPTION
Return the correct primitive when a polyline clamped to ground is picked.

Fixes #6907. `GroundPolylinePrimitive` is built on top of `Primitive`. When the polyline was picked, the primitive returned was its `Primitive`. `drillPick` was setting this `show` to `false` and the polyline update was resetting it to `true` on the next pick. This was causing and infinite loop.