### PR TITLE
Fixed blank line in terrain attribution

### DIFF
--- a/Source/Core/CesiumTerrainProvider.js
+++ b/Source/Core/CesiumTerrainProvider.js
@@ -320,12 +320,14 @@ define([
                         }
                     }
 
-                    var layerJsonCredit = new Credit(attribution);
+                    if (attribution.length > 0) {
+                        var layerJsonCredit = new Credit(attribution);
 
-                    if (defined(that._tileCredits)) {
-                        that._tileCredits.push(layerJsonCredit);
-                    } else {
-                        that._tileCredits = [layerJsonCredit];
+                        if (defined(that._tileCredits)) {
+                            that._tileCredits.push(layerJsonCredit);
+                        } else {
+                            that._tileCredits = [layerJsonCredit];
+                        }
                     }
 
                     that._ready = true;

--- a/Specs/Core/CesiumTerrainProviderSpec.js
+++ b/Specs/Core/CesiumTerrainProviderSpec.js
@@ -461,6 +461,20 @@ defineSuite([
         });
     });
 
+    it('do not add blank attribution if layer.json does not have one', function() {
+        returnTileJson('Data/CesiumTerrainTileJson/WaterMask.tile.json');
+
+        var provider = new CesiumTerrainProvider({
+            url : 'made/up/url'
+        });
+
+        return pollToPromise(function() {
+            return provider.ready;
+        }).then(function() {
+            expect(provider._tileCredit).toBeUndefined();
+        });
+    });
+
     describe('requestTileGeometry', function() {
 
         it('uses multiple urls specified in layer.json', function() {


### PR DESCRIPTION
This would always insert a blank link in attribution dialog if there was no `attribution` string in `layer.json`