### PR TITLE
createGroundPolylineGeometry dependencies, Scene cleanup

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -35,6 +35,7 @@ Change Log
 * Fixed crash that happened when calling `scene.pick` after setting a new terrain provider [#6918](https://github.com/AnalyticalGraphicsInc/cesium/pull/6918)
 * Fixed an issue that caused the browser to hang when using `drillPick` on a polyline clamped to the ground. [6907](https://github.com/AnalyticalGraphicsInc/cesium/issues/6907)
 * Fixed an issue where color wasn't updated propertly for polylines clamped to ground [#6927](https://github.com/AnalyticalGraphicsInc/cesium/pull/6927)
+* The `createGroundPolylineGeometry` web worker no longer depends on `GroundPolylinePrimitive`, making the worker smaller and potentially avoiding a hanging build in some webpack configurations.
 
 ### 1.48 - 2018-08-01
 

--- a/Source/Core/ApproximateTerrainHeights.js
+++ b/Source/Core/ApproximateTerrainHeights.js
@@ -2,6 +2,7 @@ define([
         './buildModuleUrl',
         './defaultValue',
         './defined',
+        './defineProperties',
         './BoundingSphere',
         './Cartesian2',
         './Cartesian3',
@@ -16,6 +17,7 @@ define([
         buildModuleUrl,
         defaultValue,
         defined,
+        defineProperties,
         BoundingSphere,
         Cartesian2,
         Cartesian3,
@@ -198,6 +200,21 @@ define([
     ApproximateTerrainHeights._defaultMinTerrainHeight = -100000.0;
     ApproximateTerrainHeights._terrainHeights = undefined;
     ApproximateTerrainHeights._initPromise = undefined;
+
+    defineProperties(ApproximateTerrainHeights, {
+        /**
+         * Determines if the terrain heights are initialized and ready to use. To initialize the terrain heights,
+         * call {@link ApproximateTerrainHeights#initialize} and wait for the returned promise to resolve.
+         * @type {Boolean}
+         * @readonly
+         * @memberof ApproximateTerrainHeights
+         */
+        initialized: {
+            get: function() {
+                return defined(ApproximateTerrainHeights._terrainHeights);
+            }
+        }
+    });
 
     return ApproximateTerrainHeights;
 });

--- a/Source/DataSources/DataSourceDisplay.js
+++ b/Source/DataSources/DataSourceDisplay.js
@@ -1,4 +1,5 @@
 define([
+        '../Core/ApproximateTerrainHeights',
         '../Core/BoundingSphere',
         '../Core/Check',
         '../Core/defaultValue',
@@ -20,6 +21,7 @@ define([
         './PointVisualizer',
         './PolylineVisualizer'
     ], function(
+        ApproximateTerrainHeights,
         BoundingSphere,
         Check,
         defaultValue,
@@ -245,7 +247,7 @@ define([
         Check.defined('time', time);
         //>>includeEnd('debug');
 
-        if (!GroundPrimitive._initialized) {
+        if (!ApproximateTerrainHeights.initialized) {
             this._ready = false;
             return false;
         }

--- a/Source/Scene/GroundPolylinePrimitive.js
+++ b/Source/Scene/GroundPolylinePrimitive.js
@@ -343,9 +343,6 @@ define([
         }
     });
 
-    GroundPolylinePrimitive._initialized = false;
-    GroundPolylinePrimitive._initPromise = undefined;
-
     /**
      * Initializes the minimum and maximum terrain heights. This only needs to be called if you are creating the
      * GroundPolylinePrimitive synchronously.
@@ -353,17 +350,7 @@ define([
      * @returns {Promise} A promise that will resolve once the terrain heights have been loaded.
      */
     GroundPolylinePrimitive.initializeTerrainHeights = function() {
-        var initPromise = GroundPolylinePrimitive._initPromise;
-        if (defined(initPromise)) {
-            return initPromise;
-        }
-
-        GroundPolylinePrimitive._initPromise = ApproximateTerrainHeights.initialize()
-            .then(function() {
-                GroundPolylinePrimitive._initialized = true;
-            });
-
-        return GroundPolylinePrimitive._initPromise;
+        return ApproximateTerrainHeights.initialize();
     };
 
     function createShaderProgram(groundPolylinePrimitive, frameState, appearance) {
@@ -582,7 +569,7 @@ define([
             return;
         }
 
-        if (!GroundPolylinePrimitive._initialized) {
+        if (!ApproximateTerrainHeights.initialized) {
             //>>includeStart('debug', pragmas.debug);
             if (!this.asynchronous) {
                 throw new DeveloperError('For synchronous GroundPolylinePrimitives, you must call GroundPolylinePrimitives.initializeTerrainHeights() and wait for the returned promise to resolve.');

--- a/Source/Scene/GroundPrimitive.js
+++ b/Source/Scene/GroundPrimitive.js
@@ -614,9 +614,6 @@ define([
         }
     }
 
-    GroundPrimitive._initialized = false;
-    GroundPrimitive._initPromise = undefined;
-
     /**
      * Initializes the minimum and maximum terrain heights. This only needs to be called if you are creating the
      * GroundPrimitive synchronously.
@@ -625,17 +622,7 @@ define([
      *
      */
     GroundPrimitive.initializeTerrainHeights = function() {
-        var initPromise = GroundPrimitive._initPromise;
-        if (defined(initPromise)) {
-            return initPromise;
-        }
-
-        GroundPrimitive._initPromise = ApproximateTerrainHeights.initialize()
-            .then(function() {
-                GroundPrimitive._initialized = true;
-            });
-
-        return GroundPrimitive._initPromise;
+        return ApproximateTerrainHeights.initialize();
     };
 
     /**
@@ -655,7 +642,7 @@ define([
             return;
         }
 
-        if (!GroundPrimitive._initialized) {
+        if (!ApproximateTerrainHeights.initialized) {
             //>>includeStart('debug', pragmas.debug);
             if (!this.asynchronous) {
                 throw new DeveloperError('For synchronous GroundPrimitives, you must call GroundPrimitive.initializeTerrainHeights() and wait for the returned promise to resolve.');

--- a/Source/Scene/Scene.js
+++ b/Source/Scene/Scene.js
@@ -3950,26 +3950,22 @@ define([
         this.sun = this.sun && this.sun.destroy();
         this._sunPostProcess = this._sunPostProcess && this._sunPostProcess.destroy();
         this._depthPlane = this._depthPlane && this._depthPlane.destroy();
-        this._transitioner.destroy();
+        this._transitioner = this._transitioner && this._transitioner.destroy();
         this._debugFrustumPlanes = this._debugFrustumPlanes && this._debugFrustumPlanes.destroy();
         this._brdfLutGenerator = this._brdfLutGenerator && this._brdfLutGenerator.destroy();
+        this._globeDepth = this._globeDepth && this._globeDepth.destroy();
+        this._oit = this._oit && this._oit.destroy();
 
-        if (defined(this._globeDepth)) {
-            this._globeDepth.destroy();
-        }
         if (this._removeCreditContainer) {
             this._canvas.parentNode.removeChild(this._creditContainer);
-        }
-
-        if (defined(this._oit)) {
-            this._oit.destroy();
         }
 
         this._sceneFramebuffer = this._sceneFramebuffer && this._sceneFramebuffer.destroy();
         this.postProcessStages = this.postProcessStages && this.postProcessStages.destroy();
 
         this._context = this._context && this._context.destroy();
-        this._frameState.creditDisplay.destroy();
+        this._frameState.creditDisplay = this._frameState.creditDisplay && this._frameState.creditDisplay.destroy();
+
         if (defined(this._performanceDisplay)){
             this._performanceDisplay = this._performanceDisplay && this._performanceDisplay.destroy();
             this._performanceContainer.parentNode.removeChild(this._performanceContainer);

--- a/Source/Workers/createGroundPolylineGeometry.js
+++ b/Source/Workers/createGroundPolylineGeometry.js
@@ -1,15 +1,15 @@
 define([
+        '../Core/ApproximateTerrainHeights',
         '../Core/defined',
-        '../Core/GroundPolylineGeometry',
-        '../Scene/GroundPolylinePrimitive'
+        '../Core/GroundPolylineGeometry'
     ], function(
+        ApproximateTerrainHeights,
         defined,
-        GroundPolylineGeometry,
-        GroundPolylinePrimitive) {
+        GroundPolylineGeometry) {
     'use strict';
 
     function createGroundPolylineGeometry(groundPolylineGeometry, offset) {
-        return GroundPolylinePrimitive.initializeTerrainHeights()
+        return ApproximateTerrainHeights.initialize()
             .then(function() {
                 if (defined(offset)) {
                     groundPolylineGeometry = GroundPolylineGeometry.unpack(groundPolylineGeometry, offset);

--- a/Specs/DataSources/DataSourceDisplaySpec.js
+++ b/Specs/DataSources/DataSourceDisplaySpec.js
@@ -42,10 +42,6 @@ defineSuite([
         scene.destroyForSpecs();
 
         // Leave ground primitive uninitialized
-        GroundPrimitive._initialized = false;
-        GroundPrimitive._initPromise = undefined;
-        GroundPolylinePrimitive._initialized = false;
-        GroundPolylinePrimitive._initPromise = undefined;
         ApproximateTerrainHeights._initPromise = undefined;
         ApproximateTerrainHeights._terrainHeights = undefined;
     });
@@ -365,8 +361,6 @@ defineSuite([
     });
 
     it('verify update returns false till terrain heights are initialized', function() {
-        GroundPrimitive._initialized = false;
-        GroundPrimitive._initPromise = undefined;
         ApproximateTerrainHeights._initPromise = undefined;
         ApproximateTerrainHeights._terrainHeights = undefined;
 

--- a/Specs/Scene/GroundPolylinePrimitiveSpec.js
+++ b/Specs/Scene/GroundPolylinePrimitiveSpec.js
@@ -76,8 +76,6 @@ defineSuite([
         scene.destroyForSpecs();
 
         // Leave ground primitive uninitialized
-        GroundPolylinePrimitive._initialized = false;
-        GroundPolylinePrimitive._initPromise = undefined;
         ApproximateTerrainHeights._initPromise = undefined;
         ApproximateTerrainHeights._terrainHeights = undefined;
     });
@@ -940,9 +938,10 @@ defineSuite([
 
     it('creating a synchronous primitive throws if initializeTerrainHeights wasn\'t called', function() {
         // Make it seem like initializeTerrainHeights was never called
-        var initPromise = GroundPolylinePrimitive._initPromise;
-        GroundPolylinePrimitive._initPromise = undefined;
-        GroundPolylinePrimitive._initialized = false;
+        var initPromise = ApproximateTerrainHeights._initPromise;
+        var terrainHeights = ApproximateTerrainHeights._terrainHeights;
+        ApproximateTerrainHeights._initPromise = undefined;
+        ApproximateTerrainHeights._terrainHeights = undefined;
 
         groundPolylinePrimitive = new GroundPolylinePrimitive({
             geometryInstances : groundPolylineInstance,
@@ -956,7 +955,7 @@ defineSuite([
         }
 
         // Set back to initialized state
-        GroundPolylinePrimitive._initPromise = initPromise;
-        GroundPolylinePrimitive._initialized = true;
+        ApproximateTerrainHeights._initPromise = initPromise;
+        ApproximateTerrainHeights._terrainHeights = terrainHeights;
     });
 }, 'WebGL');

--- a/Specs/Scene/GroundPrimitiveSpec.js
+++ b/Specs/Scene/GroundPrimitiveSpec.js
@@ -77,9 +77,6 @@ defineSuite([
         scene.destroyForSpecs();
 
         // Leave ground primitive uninitialized
-        GroundPrimitive._initialized = false;
-        GroundPrimitive._initPromise = undefined;
-
         ApproximateTerrainHeights._initPromise = undefined;
         ApproximateTerrainHeights._terrainHeights = undefined;
     });
@@ -1260,9 +1257,10 @@ defineSuite([
 
     it('creating a synchronous primitive throws if initializeTerrainHeights wasn\'t called', function() {
         // Make it seem like initializeTerrainHeights was never called
-        var initPromise = GroundPrimitive._initPromise;
-        GroundPrimitive._initPromise = undefined;
-        GroundPrimitive._initialized = false;
+        var initPromise = ApproximateTerrainHeights._initPromise;
+        var terrainHeights = ApproximateTerrainHeights._terrainHeights;
+        ApproximateTerrainHeights._initPromise = undefined;
+        ApproximateTerrainHeights._terrainHeights = undefined;
 
         primitive = new GroundPrimitive({
             geometryInstances : rectangleInstance,
@@ -1276,7 +1274,7 @@ defineSuite([
         }
 
         // Set back to initialized state
-        GroundPrimitive._initPromise = initPromise;
-        GroundPrimitive._initialized = true;
+        ApproximateTerrainHeights._initPromise = initPromise;
+        ApproximateTerrainHeights._terrainHeights = terrainHeights;
     });
 }, 'WebGL');


### PR DESCRIPTION
Hopefully fairly uncontroversial stuff here from our Cesium fork:

* Remove dependency of `createGroundPolylineGeometry` on `GroundPolylinePrimitive`. It was only needed for initializing terrain heights, which was delegated to `ApproximateTerrainHeights` anyway. This change should make that web worker smaller and in my webpack configuration, at least, it avoids a dependency cycle that makes the build hang.
* Make `Scene` more consistent in how it destroys sub-objects. Random, inconsequential, but overall positive change I had kicking around.

I don't these things need to be mentioned in CHANGES.md, but let me know if you disagree.