### PR TITLE
Fix crash when morphing from 2D to 3D is cancelled.

### DIFF
--- a/Source/Scene/SceneTransitioner.js
+++ b/Source/Scene/SceneTransitioner.js
@@ -285,6 +285,7 @@ define([
 
             var completeMorph = function() {
                 transitioner._morphCancelled = true;
+                transitioner._scene.camera.cancelFlight();
                 completeMorphFunction(transitioner);
             };
             transitioner._completeMorph = completeMorph;


### PR DESCRIPTION
Fixes #6929.

A better way to reproduce this consistently is to:
1. Switch to 2D
2. Zoom in a bit.
3. Switch to 3D.
4. Cancel the morph by clicking the canvas.