### PR TITLE
Altered Model's cacheKey to use a GUID.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -36,6 +36,7 @@ Change Log
 * Fixed crash that happened when calling `scene.pick` after setting a new terrain provider [#6918](https://github.com/AnalyticalGraphicsInc/cesium/pull/6918)
 * Fixed an issue that caused the browser to hang when using `drillPick` on a polyline clamped to the ground. [6907](https://github.com/AnalyticalGraphicsInc/cesium/issues/6907)
 * Fixed an issue where color wasn't updated propertly for polylines clamped to ground [#6927](https://github.com/AnalyticalGraphicsInc/cesium/pull/6927)
+* Fixed an excessive memory use bug that occurred when a data URI was used to specify a glTF model. [#6928](https://github.com/AnalyticalGraphicsInc/cesium/issues/6928)
 
 ### 1.48 - 2018-08-01
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -49,6 +49,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to Cesiu
    * [Josh Lawrence](https://github.com/loshjawrence)
    * [Omar Shehata](https://github.com/OmarShehata)
    * [Matt Petry](https://github.com/MattPetry)
+   * [Michael Squires](https://github.com/mksquires)
 * [NICTA](http://www.nicta.com.au/)
    * [Chris Cooper](https://github.com/chris-cooper)
    * [Kevin Ring](https://github.com/kring)

--- a/Source/Scene/Model.js
+++ b/Source/Scene/Model.js
@@ -1213,9 +1213,9 @@ define([
 
         // If no cache key is provided, use a GUID.
         // Check using a URI to GUID dictionary that we have not already added this model.
-        var cacheKey = defaultValue(options.cacheKey, defaultValue(uriToGuid[getAbsoluteUri(modelResource.url)], createGuid()));
-        var guidFromUri = uriToGuid[getAbsoluteUri(modelResource.url)];
-        if(!defined(guidFromUri)){
+        var cacheKey = defaultValue(options.cacheKey, uriToGuid[getAbsoluteUri(modelResource.url)]);
+        if (!defined(cacheKey)) {
+            cacheKey = createGuid();
             uriToGuid[getAbsoluteUri(modelResource.url)] = cacheKey;
         }
 

--- a/Source/Scene/Model.js
+++ b/Source/Scene/Model.js
@@ -7,6 +7,7 @@ define([
         '../Core/clone',
         '../Core/Color',
         '../Core/combine',
+        '../Core/createGuid',
         '../Core/defaultValue',
         '../Core/defined',
         '../Core/defineProperties',
@@ -85,6 +86,7 @@ define([
         clone,
         Color,
         combine,
+        createGuid,
         defaultValue,
         defined,
         defineProperties,
@@ -221,7 +223,7 @@ define([
     };
 
     var gltfCache = {};
-
+    var uriToGuid = {};
     ///////////////////////////////////////////////////////////////////////////
 
     /**
@@ -1209,9 +1211,14 @@ define([
         var basePath = defaultValue(options.basePath, modelResource.clone());
         var resource = Resource.createIfNeeded(basePath);
 
-        // If no cache key is provided, use the absolute URL, since two URLs with
-        // different relative paths could point to the same model.
-        var cacheKey = defaultValue(options.cacheKey, getAbsoluteUri(modelResource.url));
+        // If no cache key is provided, use a GUID.
+        // Check using a URI to GUID dictionary that we have not already added this model.
+        var cacheKey = defaultValue(options.cacheKey, defaultValue(uriToGuid[getAbsoluteUri(modelResource.url)], createGuid()));
+        var guidFromUri = uriToGuid[getAbsoluteUri(modelResource.url)];
+        if(!defined(guidFromUri)){
+            uriToGuid[getAbsoluteUri(modelResource.url)] = cacheKey;
+        }
+
         if (defined(options.basePath) && !defined(options.cacheKey)) {
             cacheKey += resource.url;
         }

--- a/Specs/Scene/ModelSpec.js
+++ b/Specs/Scene/ModelSpec.js
@@ -265,7 +265,7 @@ defineSuite([
         expect(texturedBoxModel.ready).toEqual(true);
         expect(texturedBoxModel.asynchronous).toEqual(true);
         expect(texturedBoxModel.releaseGltfJson).toEqual(false);
-        expect(texturedBoxModel.cacheKey).toEndWith('Data/Models/Box-Textured/CesiumTexturedBoxTest.gltf');
+        expect(texturedBoxModel.cacheKey).not.toContain('Data/Models/Box-Textured/CesiumTexturedBoxTest.gltf');
         expect(texturedBoxModel.debugShowBoundingVolume).toEqual(false);
         expect(texturedBoxModel.debugWireframe).toEqual(false);
         expect(texturedBoxModel.distanceDisplayCondition).toBeUndefined();

--- a/Specs/Scene/ModelSpec.js
+++ b/Specs/Scene/ModelSpec.js
@@ -265,6 +265,7 @@ defineSuite([
         expect(texturedBoxModel.ready).toEqual(true);
         expect(texturedBoxModel.asynchronous).toEqual(true);
         expect(texturedBoxModel.releaseGltfJson).toEqual(false);
+        expect(texturedBoxModel.cacheKey).toBeDefined();
         expect(texturedBoxModel.cacheKey).not.toContain('Data/Models/Box-Textured/CesiumTexturedBoxTest.gltf');
         expect(texturedBoxModel.debugShowBoundingVolume).toEqual(false);
         expect(texturedBoxModel.debugWireframe).toEqual(false);


### PR DESCRIPTION
This change list remedies the bug referenced in #6928. The system now uses a GUID in place of the URI as the model's cache key when no explicit cache key has been supplied. This technique alleviates memory use when a large data URI is input.