### PR TITLE
Fix the initial view in the cardboard sandcastle example

### DIFF
--- a/Apps/Sandcastle/gallery/Cardboard.html
+++ b/Apps/Sandcastle/gallery/Cardboard.html
@@ -59,7 +59,7 @@ function computeCirclularFlight(lon, lat, radius) {
         var radians = Cesium.Math.toRadians(i);
         var timeIncrement = i - startAngle;
         var time = Cesium.JulianDate.addSeconds(start, timeIncrement, new Cesium.JulianDate());
-        var position = Cesium.Cartesian3.fromDegrees(lon + (radius * 1.5 * Math.cos(radians)), lat + (radius * Math.sin(radians)), Cesium.Math.nextRandomNumber() * 500 + 1750);
+        var position = Cesium.Cartesian3.fromDegrees(lon + (radius * 1.5 * Math.cos(radians)), lat + (radius * Math.sin(radians)), Cesium.Math.nextRandomNumber() * 500 + 1800);
         property.addSample(time, position);
     }
     return property;


### PR DESCRIPTION
Fixes #6964 

This broke when we switched to use ion world terrain instead of assets.agi.com.  I'm guessing the ion world terrain is slightly higher in that area so it was trying to push the camera up, but since the camera was set to lookat the model it just put it at a weird angle.  Increasing the height of the balloon fixed the issue.