### PR TITLE
Removed Tile URI Workaround

### DIFF
--- a/Source/Scene/Cesium3DTile.js
+++ b/Source/Scene/Cesium3DTile.js
@@ -200,10 +200,6 @@ define([
                 contentHeaderUri = contentHeader.url;
             }
 
-            if (tileset._brokenUrlWorkaround && contentHeaderUri.length > 0 && (contentHeaderUri[0] === '/')) {
-                contentHeaderUri = contentHeader.uri = contentHeaderUri.substring(1);
-            }
-
             hasEmptyContent = false;
             contentState = Cesium3DTileContentState.UNLOADED;
             contentResource = baseResource.getDerivedResource({

--- a/Source/Scene/Cesium3DTileset.js
+++ b/Source/Scene/Cesium3DTileset.js
@@ -54,7 +54,6 @@ define([
         DoublyLinkedList,
         Ellipsoid,
         Event,
-        getMagic,
         JulianDate,
         ManagedArray,
         CesiumMath,

--- a/Source/Scene/Cesium3DTileset.js
+++ b/Source/Scene/Cesium3DTileset.js
@@ -12,7 +12,6 @@ define([
         '../Core/DoublyLinkedList',
         '../Core/Ellipsoid',
         '../Core/Event',
-        '../Core/getMagic',
         '../Core/JulianDate',
         '../Core/ManagedArray',
         '../Core/Math',

--- a/Source/Scene/Cesium3DTileset.js
+++ b/Source/Scene/Cesium3DTileset.js
@@ -666,12 +666,6 @@ define([
          * @default false
          */
         this.debugShowUrl = defaultValue(options.debugShowUrl, false);
-
-        // A bunch of tilesets were generated that have a leading / in front of all URLs in the tileset JSON file. If the tiles aren't
-        //  at the root of the domain they will not load anymore. If we find a b3dm file with a leading slash, we test load a tile.
-        //  If it succeeds we continue on. If it fails, we set this to true so we know to strip the slash when loading tiles.
-        this._brokenUrlWorkaround = false;
-
         this._credits = undefined;
 
         var that = this;
@@ -696,13 +690,6 @@ define([
                 return Cesium3DTileset.loadJson(resource);
             })
             .then(function(tilesetJson) {
-                return detectBrokenUrlWorkaround(that, resource, tilesetJson);
-            })
-            .then(function(tilesetJson) {
-                if (that._brokenUrlWorkaround) {
-                    deprecationWarning('Cesium3DTileset.leadingSlash', 'Having a leading slash in a tile URL that is actually relative to the tileset JSON file is deprecated.');
-                }
-
                 that._root = that.loadTileset(resource, tilesetJson);
                 var gltfUpAxis = defined(tilesetJson.asset.gltfUpAxis) ? Axis.fromName(tilesetJson.asset.gltfUpAxis) : Axis.Y;
                 that._asset = tilesetJson.asset;
@@ -714,60 +701,6 @@ define([
             }).otherwise(function(error) {
                 that._readyPromise.reject(error);
             });
-    }
-
-    function detectBrokenUrlWorkaround(tileset, resource, tilesetJson) {
-        var testUrl = findBrokenUrl(tilesetJson.root);
-
-        // If it's an empty string, we are good to load the tileset.
-        if (!defined(testUrl) || (testUrl.length === 0)) {
-            return tilesetJson;
-        }
-
-        var testResource = resource.getDerivedResource({
-            url : testUrl
-        });
-
-        return testResource.fetchArrayBuffer()
-            .then(function(buffer) {
-                var uint8Array = new Uint8Array(buffer);
-                var magic = getMagic(uint8Array);
-
-                // If its not a b3dm file, then use workaround
-                // This accounts for servers that return an error page with a 200 status code
-                tileset._brokenUrlWorkaround = (magic !== 'b3dm');
-
-                return tilesetJson;
-            })
-            .otherwise(function() {
-                // Tile failed to load, so use the workaround
-                tileset._brokenUrlWorkaround = true;
-                return tilesetJson;
-            });
-    }
-
-    var brokenUrlRegex = /^\/.+\.b3dm$/;
-
-    function findBrokenUrl(node) {
-        var content = node.content;
-        if (defined(content) && defined(content.url)) {
-            if (brokenUrlRegex.test(content.url)) {
-                return content.url;
-            }
-
-            return '';
-        }
-
-        var children = node.children;
-        if (defined(children)) {
-            var count = children.length;
-            for (var i = 0; i < count; ++i) {
-                var result = findBrokenUrl(children[i]);
-                if (defined(result)) {
-                    return result;
-                }
-            }
-        }
     }
 
     defineProperties(Cesium3DTileset.prototype, {


### PR DESCRIPTION
Fixes https://github.com/AnalyticalGraphicsInc/cesium/issues/6868. 

I confirmed that this hasn't broken any tests, and the "3D Tiles Photogrammetry Classification" example in Sandcastle works with no errors. 

@lilleyse can you review?