### PR TITLE
Updated AGI HQ tileset

### DIFF
--- a/Apps/Sandcastle/gallery/3D Tiles Photogrammetry Classification.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Photogrammetry Classification.html
@@ -34,7 +34,7 @@ var viewer = new Cesium.Viewer('cesiumContainer', {
 
 // A normal b3dm tileset of photogrammetry
 var tileset = new Cesium.Cesium3DTileset({
-    url: Cesium.IonResource.fromAssetId(5712)
+    url: Cesium.IonResource.fromAssetId(6074)
 });
 viewer.scene.primitives.add(tileset);
 viewer.zoomTo(tileset);

--- a/Apps/Sandcastle/gallery/3D Tiles Photogrammetry.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Photogrammetry.html
@@ -31,7 +31,7 @@ var viewer = new Cesium.Viewer('cesiumContainer', {
 });
 
 var tileset = new Cesium.Cesium3DTileset({
-    url: Cesium.IonResource.fromAssetId(5712)
+    url: Cesium.IonResource.fromAssetId(6074)
 });
 
 viewer.scene.primitives.add(tileset);

--- a/Apps/Sandcastle/gallery/Classification Types.html
+++ b/Apps/Sandcastle/gallery/Classification Types.html
@@ -32,7 +32,7 @@ var viewer = new Cesium.Viewer('cesiumContainer', {
 });
 viewer.scene.globe.depthTestAgainstTerrain = false;
 
-var tileset = new Cesium.Cesium3DTileset({ url: Cesium.IonResource.fromAssetId(5712) });
+var tileset = new Cesium.Cesium3DTileset({ url: Cesium.IonResource.fromAssetId(6074) });
 viewer.scene.primitives.add(tileset);
 
 tileset.readyPromise.then(function(){

--- a/Apps/Sandcastle/gallery/Classification.html
+++ b/Apps/Sandcastle/gallery/Classification.html
@@ -198,7 +198,7 @@ function updateAlpha(value) {
     scene.invertClassificationColor.alpha = parseFloat(value);
 }
 
-var tileset = new Cesium.Cesium3DTileset({ url: Cesium.IonResource.fromAssetId(5712) });
+var tileset = new Cesium.Cesium3DTileset({ url: Cesium.IonResource.fromAssetId(6074) });
 scene.primitives.add(tileset);
 
 var viewModel = {

--- a/Apps/Sandcastle/gallery/Scene Rendering Performance.html
+++ b/Apps/Sandcastle/gallery/Scene Rendering Performance.html
@@ -147,7 +147,7 @@ function resetScene() {
 function loadTilesetScenario() {
     resetScene();
 
-    tileset = new Cesium.Cesium3DTileset({ url: Cesium.IonResource.fromAssetId(5712) });
+    tileset = new Cesium.Cesium3DTileset({ url: Cesium.IonResource.fromAssetId(6074) });
     viewer.scene.primitives.add(tileset);
     viewer.zoomTo(tileset);
 }

--- a/Apps/Sandcastle/gallery/development/Many Clipping Planes.html
+++ b/Apps/Sandcastle/gallery/development/Many Clipping Planes.html
@@ -152,7 +152,7 @@ function updateClippingPlanes() {
 }
 
 var modelUrl = '../../SampleData/models/CesiumAir/Cesium_Air.glb';
-var agiHqUrl = Cesium.IonResource.fromAssetId(5712);
+var agiHqUrl = Cesium.IonResource.fromAssetId(6074);
 var instancedUrl = '../../SampleData/Cesium3DTiles/Instanced/InstancedOrientation/tileset.json';
 var pointCloudUrl = Cesium.IonResource.fromAssetId(5713);
 


### PR DESCRIPTION
Updated to a new version of the AGI HQ tileset where the origin of the tileset is at the bottom center. This makes it a lot easier to reposition the tileset, which there is a demo for in the ion sdk.

Doesn't alter any existing Sandcastle demos. I checked that they still work normally.