### PR TITLE
Only force camera above terrain when loading is finished.

### DIFF
--- a/Source/Scene/Camera.js
+++ b/Source/Scene/Camera.js
@@ -958,7 +958,10 @@ define([
         if (this._suspendTerrainAdjustment) {
             this._suspendTerrainAdjustment = !globeFinishedUpdating;
         }
-        this._adjustHeightForTerrain();
+
+        if (globeFinishedUpdating) {
+            this._adjustHeightForTerrain();
+        }
     };
 
     var setTransformPosition = new Cartesian3();


### PR DESCRIPTION
Fixes #6962

I'm not sure if we introduced a regression somewhere or if we just never noticed, but the desired camera behavior is that it not force the view to be above terrain if there is still terrain loading.  I also confirmed that #4075 is still fixed even with this change.