### PR TITLE
Disable PointerEvents in Firefox until they work.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,7 @@ Change Log
 * Added `heightReference` to `BoxGraphics`, `CylinderGraphics` and `EllipsoidGraphics`, which can be used to clamp these entity types to terrain [#6932](https://github.com/AnalyticalGraphicsInc/cesium/pull/6932)
 
 ##### Fixes :wrench:
+* Fixed Firefox camera control issues with mouse and touch events. [#6372](https://github.com/AnalyticalGraphicsInc/cesium/issues/6372)
 * Several performance improvements and fixes to the 3D Tiles traversal code. [#6390](https://github.com/AnalyticalGraphicsInc/cesium/pull/6390)
     * Improved load performance when `skipLevelOfDetail` is false.
     * Fixed a bug that caused some skipped tiles to load when `skipLevelOfDetail` is true.

--- a/Source/Core/FeatureDetection.js
+++ b/Source/Core/FeatureDetection.js
@@ -170,7 +170,9 @@ define([
             //we still need to use it if it exists in order to support browsers
             //that rely on it, such as the Windows WebBrowser control which defines
             //PointerEvent but sets navigator.pointerEnabled to false.
-            hasPointerEvents = typeof PointerEvent !== 'undefined' && (!defined(theNavigator.pointerEnabled) || theNavigator.pointerEnabled);
+
+            //Firefox disabled because of https://github.com/AnalyticalGraphicsInc/cesium/issues/6372
+            hasPointerEvents = !isFirefox() && typeof PointerEvent !== 'undefined' && (!defined(theNavigator.pointerEnabled) || theNavigator.pointerEnabled);
         }
         return hasPointerEvents;
     }

--- a/Specs/Core/ScreenSpaceEventHandlerSpec.js
+++ b/Specs/Core/ScreenSpaceEventHandlerSpec.js
@@ -65,12 +65,6 @@ defineSuite([
 
     beforeAll(function(){
         usePointerEvents = FeatureDetection.supportsPointerEvents();
-
-        //See https://github.com/AnalyticalGraphicsInc/cesium/issues/6539
-        if (FeatureDetection.isFirefox()) {
-            usePointerEvents = false;
-            spyOn(FeatureDetection, 'supportsPointerEvents').and.returnValue(false);
-        }
     });
 
     beforeEach(function() {

--- a/Specs/Scene/CameraEventAggregatorSpec.js
+++ b/Specs/Scene/CameraEventAggregatorSpec.js
@@ -25,12 +25,6 @@ defineSuite([
 
     beforeAll(function() {
         usePointerEvents = FeatureDetection.supportsPointerEvents();
-
-        //See https://github.com/AnalyticalGraphicsInc/cesium/issues/6539
-        if (FeatureDetection.isFirefox()) {
-            usePointerEvents = false;
-            spyOn(FeatureDetection, 'supportsPointerEvents').and.returnValue(false);
-        }
         canvas = createCanvas(1024, 768);
     });
 

--- a/Specs/Scene/ScreenSpaceCameraControllerSpec.js
+++ b/Specs/Scene/ScreenSpaceCameraControllerSpec.js
@@ -81,12 +81,6 @@ defineSuite([
     }
     beforeAll(function() {
         usePointerEvents = FeatureDetection.supportsPointerEvents();
-
-        //See https://github.com/AnalyticalGraphicsInc/cesium/issues/6539
-        if (FeatureDetection.isFirefox()) {
-            usePointerEvents = false;
-            spyOn(FeatureDetection, 'supportsPointerEvents').and.returnValue(false);
-        }
         canvas = createCanvas(1024, 768);
     });
 


### PR DESCRIPTION
We previously only disabled them in tests for #6539, but #6372 indicates the problem may be more widespread.