### PR TITLE
Hide globe depth and pick depth options from Cesium Inspector

### DIFF
--- a/Source/Widgets/CesiumInspector/CesiumInspector.js
+++ b/Source/Widgets/CesiumInspector/CesiumInspector.js
@@ -112,15 +112,16 @@ define([
         shaderCacheDisplay.className = 'cesium-cesiumInspector-shaderCache';
         shaderCacheDisplay.setAttribute('data-bind', 'html: shaderCacheText');
         generalSection.appendChild(shaderCacheDisplay);
-/*
-        var globeDepth = createCheckBox('checked: globeDepth', 'Show globe depth');
-        generalSection.appendChild(globeDepth);
 
-        var globeDepthFrustum = document.createElement('div');
-        globeDepth.appendChild(globeDepthFrustum);
+        // https://github.com/AnalyticalGraphicsInc/cesium/issues/6763
+        // var globeDepth = createCheckBox('checked: globeDepth', 'Show globe depth');
+        // generalSection.appendChild(globeDepth);
+        //
+        // var globeDepthFrustum = document.createElement('div');
+        // globeDepth.appendChild(globeDepthFrustum);
+        //
+        // generalSection.appendChild(createCheckBox('checked: pickDepth', 'Show pick depth'));
 
-        generalSection.appendChild(createCheckBox('checked: pickDepth', 'Show pick depth'));
-*/
         var depthFrustum = document.createElement('div');
         generalSection.appendChild(depthFrustum);
 

--- a/Source/Widgets/CesiumInspector/CesiumInspector.js
+++ b/Source/Widgets/CesiumInspector/CesiumInspector.js
@@ -112,7 +112,7 @@ define([
         shaderCacheDisplay.className = 'cesium-cesiumInspector-shaderCache';
         shaderCacheDisplay.setAttribute('data-bind', 'html: shaderCacheText');
         generalSection.appendChild(shaderCacheDisplay);
-
+/*
         var globeDepth = createCheckBox('checked: globeDepth', 'Show globe depth');
         generalSection.appendChild(globeDepth);
 
@@ -120,7 +120,7 @@ define([
         globeDepth.appendChild(globeDepthFrustum);
 
         generalSection.appendChild(createCheckBox('checked: pickDepth', 'Show pick depth'));
-
+*/
         var depthFrustum = document.createElement('div');
         generalSection.appendChild(depthFrustum);
 


### PR DESCRIPTION
The `Show globe depth` and `Show pick depth` options were both broken in 1.45, likely related to the log depth changes.  This removes those options in the Cesium Inspector UI until we have a chance to fix them.

#6763