### PR TITLE
OIT and log depth slowness fix

### DIFF
--- a/Source/Scene/OIT.js
+++ b/Source/Scene/OIT.js
@@ -537,6 +537,7 @@ define([
         var j;
 
         var context = scene.context;
+        var useLogDepth = scene.frameState.useLogDepth;
         var framebuffer = passState.framebuffer;
         var length = commands.length;
 
@@ -552,14 +553,14 @@ define([
 
         for (j = 0; j < length; ++j) {
             command = commands[j];
-            command = defined(command.derivedCommands.logDepth) ? command.derivedCommands.logDepth.command : command;
+            command = useLogDepth ? command.derivedCommands.logDepth.command : command;
             derivedCommand = (lightShadowsEnabled && command.receiveShadows) ? command.derivedCommands.oit.shadows.translucentCommand : command.derivedCommands.oit.translucentCommand;
             executeFunction(derivedCommand, scene, context, passState, debugFramebuffer);
         }
 
         if (defined(invertClassification)) {
             command = invertClassification.unclassifiedCommand;
-            command = defined(command.derivedCommands.logDepth) ? command.derivedCommands.logDepth.command : command;
+            command = useLogDepth ? command.derivedCommands.logDepth.command : command;
             derivedCommand = (lightShadowsEnabled && command.receiveShadows) ? command.derivedCommands.oit.shadows.translucentCommand : command.derivedCommands.oit.translucentCommand;
             executeFunction(derivedCommand, scene, context, passState, debugFramebuffer);
         }
@@ -568,14 +569,14 @@ define([
 
         for (j = 0; j < length; ++j) {
             command = commands[j];
-            command = defined(command.derivedCommands.logDepth) ? command.derivedCommands.logDepth.command : command;
+            command = useLogDepth ? command.derivedCommands.logDepth.command : command;
             derivedCommand = (lightShadowsEnabled && command.receiveShadows) ? command.derivedCommands.oit.shadows.alphaCommand : command.derivedCommands.oit.alphaCommand;
             executeFunction(derivedCommand, scene, context, passState, debugFramebuffer);
         }
 
         if (defined(invertClassification)) {
             command = invertClassification.unclassifiedCommand;
-            command = defined(command.derivedCommands.logDepth) ? command.derivedCommands.logDepth.command : command;
+            command = useLogDepth ? command.derivedCommands.logDepth.command : command;
             derivedCommand = (lightShadowsEnabled && command.receiveShadows) ? command.derivedCommands.oit.shadows.alphaCommand : command.derivedCommands.oit.alphaCommand;
             executeFunction(derivedCommand, scene, context, passState, debugFramebuffer);
         }
@@ -585,6 +586,7 @@ define([
 
     function executeTranslucentCommandsSortedMRT(oit, scene, executeFunction, passState, commands, invertClassification) {
         var context = scene.context;
+        var useLogDepth = scene.frameState.useLogDepth;
         var framebuffer = passState.framebuffer;
         var length = commands.length;
 
@@ -601,14 +603,14 @@ define([
 
         for (var j = 0; j < length; ++j) {
             command = commands[j];
-            command = defined(command.derivedCommands.logDepth) ? command.derivedCommands.logDepth.command : command;
+            command = useLogDepth ? command.derivedCommands.logDepth.command : command;
             derivedCommand = (lightShadowsEnabled && command.receiveShadows) ? command.derivedCommands.oit.shadows.translucentCommand : command.derivedCommands.oit.translucentCommand;
             executeFunction(derivedCommand, scene, context, passState, debugFramebuffer);
         }
 
         if (defined(invertClassification)) {
             command = invertClassification.unclassifiedCommand;
-            command = defined(command.derivedCommands.logDepth) ? command.derivedCommands.logDepth.command : command;
+            command = useLogDepth ? command.derivedCommands.logDepth.command : command;
             derivedCommand = (lightShadowsEnabled && command.receiveShadows) ? command.derivedCommands.oit.shadows.translucentCommand : command.derivedCommands.oit.translucentCommand;
             executeFunction(derivedCommand, scene, context, passState, debugFramebuffer);
         }

--- a/Source/Scene/OIT.js
+++ b/Source/Scene/OIT.js
@@ -560,7 +560,6 @@ define([
 
         if (defined(invertClassification)) {
             command = invertClassification.unclassifiedCommand;
-            command = useLogDepth ? command.derivedCommands.logDepth.command : command;
             derivedCommand = (lightShadowsEnabled && command.receiveShadows) ? command.derivedCommands.oit.shadows.translucentCommand : command.derivedCommands.oit.translucentCommand;
             executeFunction(derivedCommand, scene, context, passState, debugFramebuffer);
         }
@@ -576,7 +575,6 @@ define([
 
         if (defined(invertClassification)) {
             command = invertClassification.unclassifiedCommand;
-            command = useLogDepth ? command.derivedCommands.logDepth.command : command;
             derivedCommand = (lightShadowsEnabled && command.receiveShadows) ? command.derivedCommands.oit.shadows.alphaCommand : command.derivedCommands.oit.alphaCommand;
             executeFunction(derivedCommand, scene, context, passState, debugFramebuffer);
         }
@@ -610,7 +608,6 @@ define([
 
         if (defined(invertClassification)) {
             command = invertClassification.unclassifiedCommand;
-            command = useLogDepth ? command.derivedCommands.logDepth.command : command;
             derivedCommand = (lightShadowsEnabled && command.receiveShadows) ? command.derivedCommands.oit.shadows.translucentCommand : command.derivedCommands.oit.translucentCommand;
             executeFunction(derivedCommand, scene, context, passState, debugFramebuffer);
         }


### PR DESCRIPTION
Fixes #7018 

OIT was checking if log depth was enabled by checking if the derived command exists. Now it checks if `frameState.useLogDepth` is true which is more reliable.

This worked before because the log depth command was set to undefined if log depth was off ([`fb63af`](https://github.com/AnalyticalGraphicsInc/cesium/commit/4633ea6b10132066e222a73a1e6a3fd639c8071e#diff-fb63af82386df4a707d9fcfb196c35fcL1530)). This was changed to make it more efficient to call the pick from ray functions which if called often will constantly change the log depth state, where it's better to keep the log depth commands around.

@bagnell probably best for you to review since it's a follow up to https://github.com/AnalyticalGraphicsInc/cesium/pull/6957