### PR TITLE
Fix typo in Scene docs.

### DIFF
--- a/Source/Scene/Scene.js
+++ b/Source/Scene/Scene.js
@@ -602,7 +602,7 @@ define([
          *          return;
          *      }
          *      viewer.scene.render();
-         *      var worldPosition = viewer.scene.pickPosition(movement.position));
+         *      var worldPosition = viewer.scene.pickPosition(movement.position);
          * }, Cesium.ScreenSpaceEventType.LEFT_CLICK);
          *
          * @type {Boolean}


### PR DESCRIPTION
This fixes the typo in the code example for [Scene.pickTranslucentDepth](https://cesiumjs.org/Cesium/Build/Documentation/Scene.html#pickTranslucentDepth).