### PR TITLE
Refactor DeviceOrientationCameraController

### DIFF
--- a/Source/Scene/DeviceOrientationCameraController.js
+++ b/Source/Scene/DeviceOrientationCameraController.js
@@ -7,7 +7,7 @@ define([
         defined,
         destroyObject,
         DeveloperError,
-        Math) {
+        CesiumMath) {
     'use strict';
 
     /**
@@ -90,9 +90,9 @@ define([
         }
 
         function updateDeviceOrientation(e) {
-            that._pitch = Math.toRadians(e.beta);
-            that._roll = Math.toRadians(e.gamma);
-            that._heading = Math.toRadians(e.alpha);
+            that._pitch = CesiumMath.toRadians(e.beta);
+            that._roll = CesiumMath.toRadians(e.gamma);
+            that._heading = CesiumMath.toRadians(e.alpha);
         }
 
         this._enableDeviceOrientation = function(enable) {
@@ -103,7 +103,7 @@ define([
                 } else if ('onmsorientationchange' in screen) {
                     msScreenOrientationChanged();
                     screen.addEventListener('MSOrientationChange', msScreenOrientationChanged, false);
-                } else if ('orientation' in window) {
+                } else if ('orientation' in window) { //Safari
                     screenOrientationChanged();
                     window.addEventListener('orientationchange', screenOrientationChanged, false);
                 }
@@ -140,8 +140,8 @@ define([
 
         this._scene.camera.setView({
             orientation: {
-                heading : Math.toRadians(this._orientationAngle + 180) - this._heading,
-                pitch : (this._flipPitchRoll ? this._roll : this._pitch) * this._invertPitchFactor - Math.toRadians(90),
+                heading : CesiumMath.toRadians(this._orientationAngle + 180) - this._heading,
+                pitch : (this._flipPitchRoll ? this._roll : this._pitch) * this._invertPitchFactor - CesiumMath.toRadians(90),
                 roll : (this._flipPitchRoll ? this._pitch : this._roll) * this._invertRollFactor
             }
         });

--- a/Source/Scene/DeviceOrientationCameraController.js
+++ b/Source/Scene/DeviceOrientationCameraController.js
@@ -97,10 +97,10 @@ define([
 
         this._enableDeviceOrientation = function(enable) {
             if (enable) {
-                if ('orientation' in screen) {
+                if ('orientation' in screen) { //current w3c standard
                     screenOrientationChanged();
                     screen.orientation.addEventListener('change', screenOrientationChanged, false);
-                } else if ('onmsorientationchange' in screen) {
+                } else if ('onmsorientationchange' in screen) { //IE11/Edge
                     msScreenOrientationChanged();
                     screen.addEventListener('MSOrientationChange', msScreenOrientationChanged, false);
                 } else if ('orientation' in window) { //Safari

--- a/Specs/DomEventSimulator.js
+++ b/Specs/DomEventSimulator.js
@@ -278,7 +278,7 @@ define([
         fireDeviceOrientation : function(element, options) {
             element.dispatchEvent(createDeviceOrientationEvent('deviceorientation', options));
         },
-        fireDeviceOrientation : function(element, options) {
+        fireDeviceOrientationAbsolute : function(element, options) {
             element.dispatchEvent(createDeviceOrientationEvent('deviceorientationabsolute', options));
         },
         fireMockEvent : function(eventHandler, event) {

--- a/Specs/DomEventSimulator.js
+++ b/Specs/DomEventSimulator.js
@@ -219,7 +219,7 @@ define([
         if (typeof event.initDeviceOrientationEvent === 'function') {
             event.initDeviceOrientationEvent(type, canBubble, cancelable, alpha, beta, gamma, absolute);
         } else {
-            event = new DeviceOrientationEvent('deviceorientation', {
+            event = new DeviceOrientationEvent(type, {
                 alpha : alpha,
                 beta : beta,
                 gamma : gamma,
@@ -277,6 +277,9 @@ define([
         },
         fireDeviceOrientation : function(element, options) {
             element.dispatchEvent(createDeviceOrientationEvent('deviceorientation', options));
+        },
+        fireDeviceOrientation : function(element, options) {
+            element.dispatchEvent(createDeviceOrientationEvent('deviceorientationabsolute', options));
         },
         fireMockEvent : function(eventHandler, event) {
             eventHandler.call(window, event);

--- a/Specs/Scene/DeviceOrientationCameraControllerSpec.js
+++ b/Specs/Scene/DeviceOrientationCameraControllerSpec.js
@@ -45,12 +45,13 @@ defineSuite([
         controller = controller && !controller.isDestroyed() && controller.destroy();
     });
 
-    function fireEvent(options) {
-        // set default orientation
-        DomEventSimulator.fireDeviceOrientation(window);
-        controller.update();
-        // update delta orientation
-        DomEventSimulator.fireDeviceOrientation(window, options);
+    function fireDeviceOrientationEvent(options) {
+        if ('ondeviceorientationabsolute' in window) {
+            DomEventSimulator.fireDeviceOrientation(window, options);
+        } else {
+            DomEventSimulator.fireDeviceOrientationAbsolute(window, options);
+        }
+
         controller.update();
     }
 
@@ -60,46 +61,110 @@ defineSuite([
         }).toThrowDeveloperError();
     });
 
-    it('rotates for alpha', function() {
+    it('Device lying flat on a horizontal surface with the top of the screen pointing North', function() {
         var position = Cartesian3.clone(camera.position);
-        var up = Cartesian3.clone(camera.up);
-
-        fireEvent({
-            alpha : 90.0
+        fireDeviceOrientationEvent({
+            alpha : 0.0,
+            beta : 0.0,
+            gamma : 0.0,
+            absolute : true
         });
 
         expect(camera.position).toEqual(position);
-        expect(camera.direction).toEqualEpsilon(Cartesian3.UNIT_Y, CesiumMath.EPSILON14);
-        expect(camera.up).toEqualEpsilon(up, CesiumMath.EPSILON14);
-        expect(camera.right).toEqualEpsilon(Cartesian3.UNIT_X, CesiumMath.EPSILON14);
+        expect(camera.heading).toEqual(CesiumMath.toRadians(180.0));
+        expect(camera.pitch).toEqual(CesiumMath.toRadians(-90.0));
+        expect(camera.roll).toEqual(0.0);
     });
 
-    it('rotates for beta', function() {
+    it('Device lying flat on a horizontal surface with the top of the screen pointing West', function() {
         var position = Cartesian3.clone(camera.position);
-        var direction = Cartesian3.clone(camera.direction);
-
-        fireEvent({
-            beta : 90.0
+        fireDeviceOrientationEvent({
+            alpha : 90.0,
+            beta : 0.0,
+            gamma : 0.0,
+            absolute : true
         });
 
         expect(camera.position).toEqual(position);
-        expect(camera.direction).toEqualEpsilon(direction, CesiumMath.EPSILON14);
-        expect(camera.up).toEqualEpsilon(Cartesian3.UNIT_Y, CesiumMath.EPSILON14);
-        expect(camera.right).toEqualEpsilon(Cartesian3.UNIT_Z, CesiumMath.EPSILON14);
+        expect(camera.heading).toEqual(CesiumMath.toRadians(90.0));
+        expect(camera.pitch).toEqual(CesiumMath.toRadians(-90.0));
+        expect(camera.roll).toEqual(0.0);
     });
 
-    it('rotates for gamma', function() {
-        var position = Cartesian3.clone(camera.position);
-        var right = Cartesian3.clone(camera.right);
 
-        fireEvent({
-            gamma : 90.0
+    it('Device lying flat on a horizontal surface with the top of the screen pointing South', function() {
+        var position = Cartesian3.clone(camera.position);
+        fireDeviceOrientationEvent({
+            alpha : 180.0,
+            beta : 0.0,
+            gamma : 0.0,
+            absolute : true
         });
 
         expect(camera.position).toEqual(position);
-        expect(camera.direction).toEqualEpsilon(Cartesian3.negate(Cartesian3.UNIT_Z, new Cartesian3()), CesiumMath.EPSILON14);
-        expect(camera.up).toEqualEpsilon(Cartesian3.UNIT_X, CesiumMath.EPSILON14);
-        expect(camera.right).toEqualEpsilon(right, CesiumMath.EPSILON14);
+        expect(camera.heading).toEqual(CesiumMath.toRadians(360.0));
+        expect(camera.pitch).toEqual(CesiumMath.toRadians(-90.0));
+        expect(camera.roll).toEqual(0.0);
+    });
+
+    it('Device lying flat on a horizontal surface with the top of the screen pointing East', function() {
+        var position = Cartesian3.clone(camera.position);
+        fireDeviceOrientationEvent({
+            alpha : 270.0,
+            beta : 0.0,
+            gamma : 0.0,
+            absolute : true
+        });
+
+        expect(camera.position).toEqual(position);
+        expect(camera.heading).toEqual(CesiumMath.toRadians(270.0));
+        expect(camera.pitch).toEqual(CesiumMath.toRadians(-90.0));
+        expect(camera.roll).toEqual(0.0);
+    });
+
+    it('Device in a vertical plane and the top of the screen pointing upwards and backside of device pointing North', function() {
+        var position = Cartesian3.clone(camera.position);
+        fireDeviceOrientationEvent({
+            alpha : 0.0,
+            beta : 90.0,
+            gamma : 0.0,
+            absolute : true
+        });
+
+        expect(camera.position).toEqual(position);
+        expect(camera.heading).toEqual(CesiumMath.toRadians(180.0));
+        expect(camera.pitch).toEqual(0.0);
+        expect(camera.roll).toEqual(CesiumMath.toRadians(360.0)); //don't know why Cesium is returning 360° instead of 0° here
+    });
+
+    it('Device in a vertical plane and the top of the screen pointing downwards and backside of device pointing North', function() {
+        var position = Cartesian3.clone(camera.position);
+        fireDeviceOrientationEvent({
+            alpha : 0.0,
+            beta : -90.0,
+            gamma : 0.0,
+            absolute : true
+        });
+
+        expect(camera.position).toEqual(position);
+        expect(camera.heading).toEqual(CesiumMath.toRadians(180.0));
+        expect(camera.pitch).toEqual(CesiumMath.toRadians(-180.0));
+        expect(camera.roll).toEqual(0.0);
+    });
+
+    it('Device lying backward flat on a horizontal surface with the top of the screen pointing North', function() {
+        var position = Cartesian3.clone(camera.position);
+        fireDeviceOrientationEvent({
+            alpha : 0.0,
+            beta : -180.0,
+            gamma : 0.0,
+            absolute : true
+        });
+
+        expect(camera.position).toEqual(position);
+        expect(camera.heading).toEqual(CesiumMath.toRadians(180.0));
+        expect(camera.pitch).toEqual(CesiumMath.toRadians(90.0));
+        expect(camera.roll).toEqual(0.0);
     });
 
     it('is destroyed', function() {

--- a/Specs/Scene/DeviceOrientationCameraControllerSpec.js
+++ b/Specs/Scene/DeviceOrientationCameraControllerSpec.js
@@ -47,9 +47,9 @@ defineSuite([
 
     function fireDeviceOrientationEvent(options) {
         if ('ondeviceorientationabsolute' in window) {
-            DomEventSimulator.fireDeviceOrientation(window, options);
-        } else {
             DomEventSimulator.fireDeviceOrientationAbsolute(window, options);
+        } else {
+            DomEventSimulator.fireDeviceOrientation(window, options);
         }
 
         controller.update();


### PR DESCRIPTION
Refactor DeviceOrientationCameraController
* it's now using more APIs to get DeviceOrientation (e.g. IE11 is now supported)
* Use camera.setView instead of calculation view by itself

I saw Cesium contains a DeviceOrientationCameraController and because or online demo is more complete with supporting this feature, I integrated our code into DeviceOrientationCameraController.

Browser Support
* IE11/Edge are supported
* Firefox seems not to support this API anymore (note sure if LTS version still contains support)
* Chrome works - but it's not possible to look at sky, because sky and earth have a gamma of 0 :grimacing: