### PR TITLE
Fix clipping planes for tiles with RTC and/or no transforms

### DIFF
--- a/Apps/Sandcastle/gallery/3D Tiles Clipping Planes.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Clipping Planes.html
@@ -104,11 +104,10 @@ moveHandler.setInputAction(function(movement) {
     }
 }, Cesium.ScreenSpaceEventType.MOUSE_MOVE);
 
-var scratchPlane = new Cesium.ClippingPlane(Cesium.Cartesian3.UNIT_X, 0.0);
-function createPlaneUpdateFunction(plane, transform) {
+function createPlaneUpdateFunction(plane) {
     return function () {
         plane.distance = targetY;
-        return Cesium.Plane.transform(plane, transform, scratchPlane);
+        return plane;
     };
 }
 
@@ -116,7 +115,7 @@ var tileset;
 function loadTileset(url) {
     clippingPlanes = new Cesium.ClippingPlaneCollection({
         planes : [
-            new Cesium.ClippingPlane(new Cesium.Cartesian3(0.0, 0.0, -1.0), -100.0)
+            new Cesium.ClippingPlane(new Cesium.Cartesian3(0.0, 0.0, -1.0), 0.0)
         ],
         edgeWidth : viewModel.edgeStylingEnabled ? 1.0 : 0.0
     });
@@ -140,7 +139,7 @@ function loadTileset(url) {
                 plane : {
                     dimensions : new Cesium.Cartesian2(radius * 2.5, radius * 2.5),
                     material : Cesium.Color.WHITE.withAlpha(0.1),
-                    plane : new Cesium.CallbackProperty(createPlaneUpdateFunction(plane, tileset.modelMatrix), false),
+                    plane : new Cesium.CallbackProperty(createPlaneUpdateFunction(plane), false),
                     outline : true,
                     outlineColor : Cesium.Color.WHITE
                 }
@@ -157,7 +156,7 @@ function loadTileset(url) {
 function loadModel(url) {
     clippingPlanes = new Cesium.ClippingPlaneCollection({
         planes : [
-            new Cesium.ClippingPlane(new Cesium.Cartesian3(0.0, 0.0, -1.0), -100.0)
+            new Cesium.ClippingPlane(new Cesium.Cartesian3(0.0, 0.0, -1.0), 0.0)
         ],
         edgeWidth : viewModel.edgeStylingEnabled ? 1.0 : 0.0
     });
@@ -189,7 +188,7 @@ function loadModel(url) {
             plane : {
                 dimensions : new Cesium.Cartesian2(300.0, 300.0),
                 material : Cesium.Color.WHITE.withAlpha(0.1),
-                plane : new Cesium.CallbackProperty(createPlaneUpdateFunction(plane, Cesium.Matrix4.IDENTITY), false),
+                plane : new Cesium.CallbackProperty(createPlaneUpdateFunction(plane), false),
                 outline : true,
                 outlineColor : Cesium.Color.WHITE
             }

--- a/Apps/Sandcastle/gallery/3D Tiles Clipping Planes.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Clipping Planes.html
@@ -218,13 +218,9 @@ Cesium.knockout.getObservable(viewModel, 'currentExampleType').subscribe(functio
     if (newValue === clipObjects[0]) {
         loadTileset(bimUrl);
     } else if (newValue === clipObjects[1]) {
-        loadTileset(pointCloudUrl).then(function(tileset) {
-            tileset.clippingPlanes.modelMatrix = Cesium.Transforms.eastNorthUpToFixedFrame(tileset.boundingSphere.center);
-        });
+        loadTileset(pointCloudUrl);
     } else if (newValue === clipObjects[2]) {
-        loadTileset(instancedUrl).then(function(tileset) {
-            tileset.clippingPlanes.modelMatrix = Cesium.Transforms.eastNorthUpToFixedFrame(tileset.boundingSphere.center);
-        });
+        loadTileset(instancedUrl);
     } else {
         loadModel(modelUrl);
     }

--- a/Apps/Sandcastle/gallery/Terrain Clipping Planes.html
+++ b/Apps/Sandcastle/gallery/Terrain Clipping Planes.html
@@ -52,7 +52,7 @@ var viewer = new Cesium.Viewer('cesiumContainer', {
 });
 var globe = viewer.scene.globe;
 
-var exampleTypes = ['Cesium Man', 'St. Helens'];
+var exampleTypes = ['Cesium Man', 'St. Helens', 'Grand Canyon Isolated'];
 var viewModel = {
     exampleTypes : exampleTypes,
     currentExampleType : exampleTypes[0],
@@ -191,6 +191,27 @@ function loadStHelens() {
     });
 }
 
+function loadGrandCanyon(){
+    // Pick a position at the Grand Canyon
+    var position = Cesium.Cartographic.toCartesian(new Cesium.Cartographic.fromDegrees(-113.2665534, 36.0939345, 100));
+    var distance = 3000.0;
+    var boundingSphere = new Cesium.BoundingSphere(position, distance);
+
+    globe.clippingPlanes = new Cesium.ClippingPlaneCollection({
+        modelMatrix : Cesium.Transforms.eastNorthUpToFixedFrame(position),
+        planes : [
+            new Cesium.ClippingPlane(new Cesium.Cartesian3( 1.0,  0.0, 0.0), distance),
+            new Cesium.ClippingPlane(new Cesium.Cartesian3(-1.0,  0.0, 0.0), distance),
+            new Cesium.ClippingPlane(new Cesium.Cartesian3( 0.0,  1.0, 0.0), distance),
+            new Cesium.ClippingPlane(new Cesium.Cartesian3( 0.0, -1.0, 0.0), distance)
+        ],
+        unionClippingRegions : true
+    });
+
+    viewer.camera.viewBoundingSphere(boundingSphere, new Cesium.HeadingPitchRange(0.5, -0.5, boundingSphere.radius * 5.0));
+    viewer.camera.lookAtTransform(Cesium.Matrix4.IDENTITY);
+}
+
 Cesium.knockout.getObservable(viewModel, 'clippingPlanesEnabled').subscribe(function(value) {
     globe.clippingPlanes.enabled = value;
     clippingPlanesEnabled = value;
@@ -207,6 +228,8 @@ Cesium.knockout.getObservable(viewModel, 'currentExampleType').subscribe(functio
         loadCesiumMan();
     } else if (newValue === exampleTypes[1]) {
         loadStHelens();
+    } else if (newValue === exampleTypes[2]) {
+        loadGrandCanyon();
     }
 });
 

--- a/Apps/Sandcastle/gallery/development/Many Clipping Planes.html
+++ b/Apps/Sandcastle/gallery/development/Many Clipping Planes.html
@@ -226,9 +226,7 @@ Cesium.knockout.getObservable(viewModel, 'currentExampleType').subscribe(functio
         });
     } else if (newValue === clipObjects[3]) {
         // i3dm
-        loadTileset(instancedUrl, 100.0).then(function() {
-            tileset.clippingPlanes.modelMatrix = Cesium.Transforms.eastNorthUpToFixedFrame(tileset.boundingSphere.center);
-        });
+        loadTileset(instancedUrl, 100.0);
     } else if (newValue === clipObjects[4]) {
         // Terrain
         var position = Cesium.Cartesian3.fromRadians(-2.0872979473351286, 0.6596620013036164, 2380.0);

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,14 @@ Change Log
 
 ### 1.50 - 2018-10-01
 
+##### Breaking Changes :mega:
+* Clipping planes on tilesets now use the root tile's transform, or the root tile's bounding sphere if a transform is not defined. [#7034](https://github.com/AnalyticalGraphicsInc/cesium/pull/7034)
+    * This is to make clipping planes' coordinates always relative to the object they're attached to. So if you were positioning the clipping planes as in the example below, this is no longer necessary:
+    ```javascript
+    clippingPlanes.modelMatrix = Cesium.Transforms.eastNorthUpToFixedFrame(tileset.boundingSphere.center);
+    ```
+    * This also fixes several issues with clipping planes not using the correct transform for tilesets with children.
+
 ##### Additions :tada:
 * Added `cartographicLimitRectangle` to `Globe`. Use this to limit terrain and imagery to a specific `Rectangle` area. [#6987](https://github.com/AnalyticalGraphicsInc/cesium/pull/6987)
 

--- a/Source/Scene/Batched3DModel3DTileContent.js
+++ b/Source/Scene/Batched3DModel3DTileContent.js
@@ -465,7 +465,7 @@ define([
         // Update clipping planes
         var tilesetClippingPlanes = this._tileset.clippingPlanes;
         if (this._tile.clippingPlanesDirty && defined(tilesetClippingPlanes)) {
-            this._model._clippingPlaneOffsetMatrix = this._tileset.clippingPlaneOffsetMatrix;
+            this._model.clippingPlaneOffsetMatrix = this._tileset.clippingPlaneOffsetMatrix;
             // Dereference the clipping planes from the model if they are irrelevant.
             // Link/Dereference directly to avoid ownership checks.
             // This will also trigger synchronous shader regeneration to remove or add the clipping plane and color blending code.

--- a/Source/Scene/Batched3DModel3DTileContent.js
+++ b/Source/Scene/Batched3DModel3DTileContent.js
@@ -358,7 +358,7 @@ define([
         content._rtcCenterTransform = Matrix4.clone(Matrix4.IDENTITY);
         var rtcCenter = featureTable.getGlobalProperty('RTC_CENTER', ComponentDatatype.FLOAT, 3);
         if (defined(rtcCenter)) {
-            content._rtcCenterTransform = Matrix4.fromTranslation(Cartesian3.fromArray(rtcCenter), content._rtcCenterTransform);
+            content._rtcCenterTransform = Transforms.eastNorthUpToFixedFrame(Cartesian3.fromArray(rtcCenter), content._rtcCenterTransform);
             tile._hasRTC = true;
         }
 

--- a/Source/Scene/Batched3DModel3DTileContent.js
+++ b/Source/Scene/Batched3DModel3DTileContent.js
@@ -355,10 +355,10 @@ define([
             primitive : tileset
         };
 
-        content._rtcCenterTransform = Matrix4.clone(Matrix4.IDENTITY);
+        content._rtcCenterTransform = Matrix4.IDENTITY;
         var rtcCenter = featureTable.getGlobalProperty('RTC_CENTER', ComponentDatatype.FLOAT, 3);
         if (defined(rtcCenter)) {
-            content._rtcCenterTransform = Transforms.eastNorthUpToFixedFrame(Cartesian3.fromArray(rtcCenter), content._rtcCenterTransform);
+            content._rtcCenterTransform = Matrix4.fromTranslation(Cartesian3.fromArray(rtcCenter));
             tile._hasRTC = true;
         }
 

--- a/Source/Scene/Batched3DModel3DTileContent.js
+++ b/Source/Scene/Batched3DModel3DTileContent.js
@@ -483,6 +483,7 @@ define([
                 // If no RTC or transform for root tile, just use the bounding sphere as a fallback.
                 this._model._clippingPlaneOffsetMatrix = Transforms.eastNorthUpToFixedFrame(this._tileset.boundingSphere.center);
             }
+            this._tileset._clippingPlaneOffsetMatrix = this._model._clippingPlaneOffsetMatrix;
 
             // Dereference the clipping planes from the model if they are irrelevant.
             // Link/Dereference directly to avoid ownership checks.

--- a/Source/Scene/Batched3DModel3DTileContent.js
+++ b/Source/Scene/Batched3DModel3DTileContent.js
@@ -465,11 +465,7 @@ define([
         // Update clipping planes
         var tilesetClippingPlanes = this._tileset.clippingPlanes;
         if (this._tile.clippingPlanesDirty && defined(tilesetClippingPlanes)) {
-            if (!this._tileset.root._useBoundingSphereForClipping) {
-                this._model._clippingPlaneOffsetMatrix = this._tileset.root.computedTransform;
-            } else {
-                this._model._clippingPlaneOffsetMatrix = this._tileset.root._clippingPlaneOffsetMatrix;
-            }
+            this._model._clippingPlaneOffsetMatrix = this._tileset.clippingPlaneOffsetMatrix;
             // Dereference the clipping planes from the model if they are irrelevant.
             // Link/Dereference directly to avoid ownership checks.
             // This will also trigger synchronous shader regeneration to remove or add the clipping plane and color blending code.

--- a/Source/Scene/Batched3DModel3DTileContent.js
+++ b/Source/Scene/Batched3DModel3DTileContent.js
@@ -360,7 +360,7 @@ define([
         if (defined(rtcCenter)) {
             content._rtcCenterTransform = Matrix4.fromTranslation(Cartesian3.fromArray(rtcCenter));
         }
-        
+
         content._contentModelMatrix = Matrix4.multiply(tile.computedTransform, content._rtcCenterTransform, new Matrix4());
 
         if (!defined(tileset.classificationType)) {

--- a/Source/Scene/Batched3DModel3DTileContent.js
+++ b/Source/Scene/Batched3DModel3DTileContent.js
@@ -359,15 +359,9 @@ define([
         var rtcCenter = featureTable.getGlobalProperty('RTC_CENTER', ComponentDatatype.FLOAT, 3);
         if (defined(rtcCenter)) {
             content._rtcCenterTransform = Matrix4.fromTranslation(Cartesian3.fromArray(rtcCenter));
-            tile._hasRTC = true;
         }
-
-        // Use the boundingSphere fallback if the root tile has neither a defined transform nor an RTC property. 
-        // If the root tile hasn't loaded yet, we don't know if it has RTC, so we assume it does not.
-        tile._useBoundingSphereForClipping = !defined(tileset.root._header.transform) && !defined(tileset.root._hasRTC);
         
         content._contentModelMatrix = Matrix4.multiply(tile.computedTransform, content._rtcCenterTransform, new Matrix4());
-        tile._contentModelMatrix = content._contentModelMatrix;
 
         if (!defined(tileset.classificationType)) {
             // PERFORMANCE_IDEA: patch the shader on demand, e.g., the first time show/color changes.
@@ -471,20 +465,11 @@ define([
         // Update clipping planes
         var tilesetClippingPlanes = this._tileset.clippingPlanes;
         if (this._tile.clippingPlanesDirty && defined(tilesetClippingPlanes)) {
-            // Use the root tile's transform.
-            if (!this._tile._useBoundingSphereForClipping) {
-                if (defined(this._tileset.root._contentModelMatrix)) {
-                    this._model._clippingPlaneOffsetMatrix = this._tileset.root._contentModelMatrix;
-                } else {
-                    // If the root tile isn't loaded yet, just use its transform directly from the header.
-                    this._model._clippingPlaneOffsetMatrix = Matrix4.multiply(this._tileset.root._header.transform, this._tileset.modelMatrix, new Matrix4());
-                }
-            } else if (this._tileset.ready) {
-                // If no RTC or transform for root tile, just use the bounding sphere as a fallback.
-                this._model._clippingPlaneOffsetMatrix = Transforms.eastNorthUpToFixedFrame(this._tileset.boundingSphere.center);
+            if (!this._tileset.root._useBoundingSphereForClipping) {
+                this._model._clippingPlaneOffsetMatrix = this._tileset.root.computedTransform;
+            } else {
+                this._model._clippingPlaneOffsetMatrix = this._tileset.root._clippingPlaneOffsetMatrix;
             }
-            this._tileset._clippingPlaneOffsetMatrix = this._model._clippingPlaneOffsetMatrix;
-
             // Dereference the clipping planes from the model if they are irrelevant.
             // Link/Dereference directly to avoid ownership checks.
             // This will also trigger synchronous shader regeneration to remove or add the clipping plane and color blending code.

--- a/Source/Scene/Batched3DModel3DTileContent.js
+++ b/Source/Scene/Batched3DModel3DTileContent.js
@@ -465,6 +465,8 @@ define([
         // Update clipping planes
         var tilesetClippingPlanes = this._tileset.clippingPlanes;
         if (this._tile.clippingPlanesDirty && defined(tilesetClippingPlanes)) {
+            // Use the root tile's transform.
+            this._model._clippingPlaneOffsetMatrix = this._tileset._root.computedTransform;
             // Dereference the clipping planes from the model if they are irrelevant.
             // Link/Dereference directly to avoid ownership checks.
             // This will also trigger synchronous shader regeneration to remove or add the clipping plane and color blending code.

--- a/Source/Scene/Cesium3DTile.js
+++ b/Source/Scene/Cesium3DTile.js
@@ -1048,9 +1048,6 @@ define([
             this._viewerRequestVolume = this.createBoundingVolume(header.viewerRequestVolume, this.computedTransform, this._viewerRequestVolume);
         }
 
-        if (this._tileset._useBoundingSphereForClipping && !defined(this.parent)) {
-            this._tileset.clippingPlaneOffsetMatrix = Transforms.eastNorthUpToFixedFrame(this.boundingSphere.center);
-        }
         // Destroy the debug bounding volumes. They will be generated fresh.
         this._debugBoundingVolume = this._debugBoundingVolume && this._debugBoundingVolume.destroy();
         this._debugContentBoundingVolume = this._debugContentBoundingVolume && this._debugContentBoundingVolume.destroy();

--- a/Source/Scene/Cesium3DTile.js
+++ b/Source/Scene/Cesium3DTile.js
@@ -828,7 +828,7 @@ define([
         var clippingPlanes = tileset.clippingPlanes;
         if (defined(clippingPlanes) && clippingPlanes.enabled) {
             var tileTransform = tileset.root.computedTransform;
-            if(defined(tileset.root._clippingPlaneOffsetMatrix)) {
+            if (defined(tileset.root._clippingPlaneOffsetMatrix)) {
                 tileTransform = tileset.root._clippingPlaneOffsetMatrix;
             }
             var intersection = clippingPlanes.computeIntersectionWithBoundingVolume(boundingVolume, tileTransform);
@@ -866,7 +866,7 @@ define([
         var clippingPlanes = tileset.clippingPlanes;
         if (defined(clippingPlanes) && clippingPlanes.enabled) {
             var tileTransform = tileset.root.computedTransform;
-            if(defined(tileset.root._clippingPlaneOffsetMatrix)) {
+            if (defined(tileset.root._clippingPlaneOffsetMatrix)) {
                 tileTransform = tileset.root._clippingPlaneOffsetMatrix;
             }
             var intersection = clippingPlanes.computeIntersectionWithBoundingVolume(boundingVolume, tileTransform);

--- a/Source/Scene/Cesium3DTile.js
+++ b/Source/Scene/Cesium3DTile.js
@@ -817,8 +817,9 @@ define([
     Cesium3DTile.prototype.visibility = function(frameState, parentVisibilityPlaneMask) {
         var cullingVolume = frameState.cullingVolume;
         var boundingVolume = getBoundingVolume(this, frameState);
+        return CullingVolume.MASK_INSIDE;
 
-        var tileset = this._tileset;
+        var tileset = this._tileset; // eslint-disable-line no-unreachable
         var clippingPlanes = tileset.clippingPlanes;
         if (defined(clippingPlanes) && clippingPlanes.enabled) {
             var tileTransform = tileset.root.computedTransform;

--- a/Source/Scene/Cesium3DTile.js
+++ b/Source/Scene/Cesium3DTile.js
@@ -307,7 +307,7 @@ define([
          *
          * @private
          */
-        this.clippingPlanesDirty = true;
+        this.clippingPlanesDirty = false;
 
         // Members that are updated every frame for tree traversal and rendering optimizations:
         this._distanceToCamera = 0;
@@ -335,7 +335,7 @@ define([
         this._isClipped = true;
         this._clippingPlanesState = 0; // encapsulates (_isClipped, clippingPlanes.enabled) and number/function
         this._useBoundingSphereForClipping = false;
-        // If this is the root tile, and it doesn't have a defined transform, fall back to bounding sphere. 
+        // If this is the root tile, and it doesn't have a defined transform, fall back to bounding sphere.
         if (!defined(this.parent) && !defined(this._header.transform)) {
             this._clippingPlaneOffsetMatrix = Transforms.eastNorthUpToFixedFrame(this.boundingSphere.center);
             this._useBoundingSphereForClipping = true;
@@ -826,7 +826,6 @@ define([
 
         var tileset = this._tileset;
         var clippingPlanes = tileset.clippingPlanes;
-        // Don't run the clipping plane visibility check until the content has at least been initialized.
         if (defined(clippingPlanes) && clippingPlanes.enabled) {
             var tileTransform = tileset.root.computedTransform;
             if(defined(tileset.root._clippingPlaneOffsetMatrix)) {
@@ -1067,7 +1066,6 @@ define([
         if (this._useBoundingSphereForClipping) {
             this._clippingPlaneOffsetMatrix = Transforms.eastNorthUpToFixedFrame(this.boundingSphere.center);
         }
-
         // Destroy the debug bounding volumes. They will be generated fresh.
         this._debugBoundingVolume = this._debugBoundingVolume && this._debugBoundingVolume.destroy();
         this._debugContentBoundingVolume = this._debugContentBoundingVolume && this._debugContentBoundingVolume.destroy();

--- a/Source/Scene/Cesium3DTile.js
+++ b/Source/Scene/Cesium3DTile.js
@@ -334,13 +334,6 @@ define([
         this._priority = 0.0;
         this._isClipped = true;
         this._clippingPlanesState = 0; // encapsulates (_isClipped, clippingPlanes.enabled) and number/function
-        this._useBoundingSphereForClipping = false;
-        // If this is the root tile, and it doesn't have a defined transform, fall back to bounding sphere.
-        if (!defined(this.parent) && !defined(this._header.transform)) {
-            this._clippingPlaneOffsetMatrix = Transforms.eastNorthUpToFixedFrame(this.boundingSphere.center);
-            this._useBoundingSphereForClipping = true;
-        }
-
         this._debugBoundingVolume = undefined;
         this._debugContentBoundingVolume = undefined;
         this._debugViewerRequestVolume = undefined;
@@ -827,11 +820,7 @@ define([
         var tileset = this._tileset;
         var clippingPlanes = tileset.clippingPlanes;
         if (defined(clippingPlanes) && clippingPlanes.enabled) {
-            var tileTransform = tileset.root.computedTransform;
-            if (defined(tileset.root._clippingPlaneOffsetMatrix)) {
-                tileTransform = tileset.root._clippingPlaneOffsetMatrix;
-            }
-            var intersection = clippingPlanes.computeIntersectionWithBoundingVolume(boundingVolume, tileTransform);
+            var intersection = clippingPlanes.computeIntersectionWithBoundingVolume(boundingVolume, tileset.clippingPlaneOffsetMatrix);
             this._isClipped = intersection !== Intersect.INSIDE;
             if (intersection === Intersect.OUTSIDE) {
                 return CullingVolume.MASK_OUTSIDE;
@@ -865,11 +854,7 @@ define([
         var tileset = this._tileset;
         var clippingPlanes = tileset.clippingPlanes;
         if (defined(clippingPlanes) && clippingPlanes.enabled) {
-            var tileTransform = tileset.root.computedTransform;
-            if (defined(tileset.root._clippingPlaneOffsetMatrix)) {
-                tileTransform = tileset.root._clippingPlaneOffsetMatrix;
-            }
-            var intersection = clippingPlanes.computeIntersectionWithBoundingVolume(boundingVolume, tileTransform);
+            var intersection = clippingPlanes.computeIntersectionWithBoundingVolume(boundingVolume, tileset.clippingPlaneOffsetMatrix);
             this._isClipped = intersection !== Intersect.INSIDE;
             if (intersection === Intersect.OUTSIDE) {
                 return Intersect.OUTSIDE;
@@ -1063,8 +1048,8 @@ define([
             this._viewerRequestVolume = this.createBoundingVolume(header.viewerRequestVolume, this.computedTransform, this._viewerRequestVolume);
         }
 
-        if (this._useBoundingSphereForClipping) {
-            this._clippingPlaneOffsetMatrix = Transforms.eastNorthUpToFixedFrame(this.boundingSphere.center);
+        if (this._tileset._useBoundingSphereForClipping && !defined(this.parent)) {
+            this._tileset.clippingPlaneOffsetMatrix = Transforms.eastNorthUpToFixedFrame(this.boundingSphere.center);
         }
         // Destroy the debug bounding volumes. They will be generated fresh.
         this._debugBoundingVolume = this._debugBoundingVolume && this._debugBoundingVolume.destroy();

--- a/Source/Scene/Cesium3DTileset.js
+++ b/Source/Scene/Cesium3DTileset.js
@@ -702,6 +702,10 @@ define([
                 that._extensionsUsed = tilesetJson.extensionsUsed;
                 that._gltfUpAxis = gltfUpAxis;
                 that._extras = tilesetJson.extras;
+                if (!defined(tilesetJson.root.transform)) {
+                    that._useBoundingSphereForClipping = true;
+                    that.clippingPlaneOffsetMatrix = Transforms.eastNorthUpToFixedFrame(that.boundingSphere.center);
+                }
                 that._readyPromise.resolve(that);
             }).otherwise(function(error) {
                 that._readyPromise.reject(error);
@@ -1295,11 +1299,6 @@ define([
             if (this._cullWithChildrenBounds) {
                 Cesium3DTileOptimizations.checkChildrenWithinParent(tile);
             }
-        }
-
-        if (!defined(rootTile._header.transform)) {
-            this._useBoundingSphereForClipping = true;
-            this.clippingPlaneOffsetMatrix = Transforms.eastNorthUpToFixedFrame(rootTile.boundingSphere.center);
         }
 
         return rootTile;

--- a/Source/Scene/Cesium3DTileset.js
+++ b/Source/Scene/Cesium3DTileset.js
@@ -1832,6 +1832,9 @@ define([
         var clippingPlanes = this._clippingPlanes;
         if (defined(clippingPlanes) && clippingPlanes.enabled) {
             clippingPlanes.update(frameState);
+            if (this._useBoundingSphereForClipping) {
+                this.clippingPlaneOffsetMatrix = Transforms.eastNorthUpToFixedFrame(this.boundingSphere.center);
+            }
         }
 
         this._timeSinceLoad = Math.max(JulianDate.secondsDifference(frameState.time, this._loadTimestamp) * 1000, 0.0);

--- a/Source/Scene/Cesium3DTileset.js
+++ b/Source/Scene/Cesium3DTileset.js
@@ -704,7 +704,7 @@ define([
                 that._extras = tilesetJson.extras;
                 if (!defined(tilesetJson.root.transform)) {
                     that._useBoundingSphereForClipping = true;
-                    that.clippingPlaneOffsetMatrix = Transforms.eastNorthUpToFixedFrame(that.boundingSphere.center);
+                    that._clippingPlaneOffsetMatrix = Transforms.eastNorthUpToFixedFrame(that.boundingSphere.center);
                 }
                 that._readyPromise.resolve(that);
             }).otherwise(function(error) {
@@ -1125,9 +1125,6 @@ define([
                     return this._clippingPlaneOffsetMatrix;
                 }
                 return this.root.computedTransform;
-            },
-            set : function(value) {
-                this._clippingPlaneOffsetMatrix = Matrix4.clone(value, this._clippingPlaneOffsetMatrix);
             }
         },
 
@@ -1833,7 +1830,7 @@ define([
         if (defined(clippingPlanes) && clippingPlanes.enabled) {
             clippingPlanes.update(frameState);
             if (this._useBoundingSphereForClipping) {
-                this.clippingPlaneOffsetMatrix = Transforms.eastNorthUpToFixedFrame(this.boundingSphere.center);
+                this._clippingPlaneOffsetMatrix = Transforms.eastNorthUpToFixedFrame(this.boundingSphere.center);
             }
         }
 

--- a/Source/Scene/Cesium3DTileset.js
+++ b/Source/Scene/Cesium3DTileset.js
@@ -1478,7 +1478,6 @@ define([
         filterProcessingQueue(tileset);
         var tiles = tileset._processingQueue;
         var length = tiles.length;
-
         // Process tiles in the PROCESSING state so they will eventually move to the READY state.
         for (var i = 0; i < length; ++i) {
             tiles[i].process(tileset, frameState);

--- a/Source/Scene/ClippingPlaneCollection.js
+++ b/Source/Scene/ClippingPlaneCollection.js
@@ -70,7 +70,7 @@ define([
      * @param {ClippingPlane[]} [options.planes=[]] An array of {@link ClippingPlane} objects used to selectively disable rendering on the outside of each plane.
      * @param {Boolean} [options.enabled=true] Determines whether the clipping planes are active.
      * @param {Matrix4} [options.modelMatrix=Matrix4.IDENTITY] The 4x4 transformation matrix specifying an additional transform relative to the clipping planes original coordinate system.
-     * @param {Boolean} [options.unionClippingRegions=false] If true, a region will be clipped if included in any plane in the collection. Otherwise, the region to be clipped must intersect the regions defined by all planes in this collection.
+     * @param {Boolean} [options.unionClippingRegions=false] If true, a region will be clipped if it is on the outside of any plane in the collection. Otherwise, a region will only be clipped if it is on the outside of every plane.
      * @param {Color} [options.edgeColor=Color.WHITE] The color applied to highlight the edge along which an object is clipped.
      * @param {Number} [options.edgeWidth=0.0] The width, in pixels, of the highlight applied to the edge along which an object is clipped.
      *

--- a/Source/Scene/ClippingPlaneCollection.js
+++ b/Source/Scene/ClippingPlaneCollection.js
@@ -80,7 +80,7 @@ define([
      * @example
      * // This clipping plane's distance is positive, which means its normal
      * // is facing the origin. This will clip everything that is behind
-     * // the plane, which is anything with y coordinate > 5.
+     * // the plane, which is anything with y coordinate < -5.
      * var clippingPlanes = new Cesium.ClippingPlaneCollection({
      *     planes : [
      *         new Cesium.ClippingPlane(new Cesium.Cartesian3(0.0, 1.0, 0.0), 5.0)

--- a/Source/Scene/ClippingPlaneCollection.js
+++ b/Source/Scene/ClippingPlaneCollection.js
@@ -80,7 +80,7 @@ define([
      * @example
      * // This clipping plane's distance is positive, which means its normal
      * // is facing the origin. This will clip everything that is behind 
-     * // the plane, which is all pixels with y > 5.
+     * // the plane, which is anything with y coordinate > 5.
      * var clippingPlanes = new Cesium.ClippingPlaneCollection({
      *     planes : [
      *         new Cesium.ClippingPlane(new Cesium.Cartesian3(0.0, 1.0, 0.0), 5.0)
@@ -90,7 +90,7 @@ define([
      * var entity = viewer.entities.add({
      *     position : Cesium.Cartesian3.fromDegrees(-123.0744619, 44.0503706, 10000),
      *     model : {
-     *         uri : '../../../../Apps/SampleData/models/CesiumAir/Cesium_Air.glb',
+     *         uri : 'model.gltf',
      *         minimumPixelSize : 128,
      *         maximumScale : 20000,
      *         clippingPlanes : clippingPlanes

--- a/Source/Scene/ClippingPlaneCollection.js
+++ b/Source/Scene/ClippingPlaneCollection.js
@@ -587,7 +587,7 @@ define([
 
         var modelMatrix = this.modelMatrix;
         if (defined(transform)) {
-            modelMatrix = Matrix4.multiply(modelMatrix, transform, scratchMatrix);
+            modelMatrix = Matrix4.multiply(transform, modelMatrix, scratchMatrix);
         }
 
         // If the collection is not set to union the clipping regions, the volume must be outside of all planes to be

--- a/Source/Scene/ClippingPlaneCollection.js
+++ b/Source/Scene/ClippingPlaneCollection.js
@@ -199,8 +199,9 @@ define([
         },
 
         /**
-         * If true, a region will be clipped if included in any plane in the collection. Otherwise, the region
-         * to be clipped must intersect the regions defined by all planes in this collection.
+         * If true, a region will be clipped if it is on the outside of any plane in the
+         * collection. Otherwise, a region will only be clipped if it is on the
+         * outside of every plane.
          *
          * @memberof ClippingPlaneCollection.prototype
          * @type {Boolean}

--- a/Source/Scene/ClippingPlaneCollection.js
+++ b/Source/Scene/ClippingPlaneCollection.js
@@ -55,6 +55,13 @@ define([
     /**
      * Specifies a set of clipping planes. Clipping planes selectively disable rendering in a region on the
      * outside of the specified list of {@link ClippingPlane} objects for a single gltf model, 3D Tileset, or the globe.
+     * <p>
+     * In general the clipping planes' coordinates are relative to the object they're attached to, so a plane with distance set to 0 will clip 
+     * through the center of the object. 
+     * </p>
+     * <p>
+     * For 3D Tiles, the root tile's transform is used to position the clipping planes. If a transform is not defined, the root tile's {@link Cesium3DTile#boundingSphere} is used instead.
+     * </p>
      *
      * @alias ClippingPlaneCollection
      * @constructor
@@ -66,6 +73,30 @@ define([
      * @param {Boolean} [options.unionClippingRegions=false] If true, a region will be clipped if included in any plane in the collection. Otherwise, the region to be clipped must intersect the regions defined by all planes in this collection.
      * @param {Color} [options.edgeColor=Color.WHITE] The color applied to highlight the edge along which an object is clipped.
      * @param {Number} [options.edgeWidth=0.0] The width, in pixels, of the highlight applied to the edge along which an object is clipped.
+     *
+     * @demo {@link https://cesiumjs.org/Cesium/Build/Apps/Sandcastle/?src=3D%20Tiles%20Clipping%20Planes.html|Clipping 3D Tiles and glTF models.}
+     * @demo {@link https://cesiumjs.org/Cesium/Build/Apps/Sandcastle/?src=Terrain%20Clipping%20Planes.html|Clipping the Globe.}
+     *
+     * @example
+     * // This clipping plane's distance is positive, which means its normal
+     * // is facing the origin. This will clip everything that is behind 
+     * // the plane, which is all pixels with y > 5.
+     * var clippingPlanes = new Cesium.ClippingPlaneCollection({
+     *     planes : [
+     *         new Cesium.ClippingPlane(new Cesium.Cartesian3(0.0, 1.0, 0.0), 5.0)
+     *     ],
+     * });
+     * // Create an entity and attach the ClippingPlaneCollection to the model.
+     * var entity = viewer.entities.add({
+     *     position : Cesium.Cartesian3.fromDegrees(-123.0744619, 44.0503706, 10000),
+     *     model : {
+     *         uri : '../../../../Apps/SampleData/models/CesiumAir/Cesium_Air.glb',
+     *         minimumPixelSize : 128,
+     *         maximumScale : 20000,
+     *         clippingPlanes : clippingPlanes
+     *     }
+     * });
+     * viewer.zoomTo(entity);
      */
     function ClippingPlaneCollection(options) {
         options = defaultValue(options, defaultValue.EMPTY_OBJECT);

--- a/Source/Scene/ClippingPlaneCollection.js
+++ b/Source/Scene/ClippingPlaneCollection.js
@@ -56,8 +56,8 @@ define([
      * Specifies a set of clipping planes. Clipping planes selectively disable rendering in a region on the
      * outside of the specified list of {@link ClippingPlane} objects for a single gltf model, 3D Tileset, or the globe.
      * <p>
-     * In general the clipping planes' coordinates are relative to the object they're attached to, so a plane with distance set to 0 will clip 
-     * through the center of the object. 
+     * In general the clipping planes' coordinates are relative to the object they're attached to, so a plane with distance set to 0 will clip
+     * through the center of the object.
      * </p>
      * <p>
      * For 3D Tiles, the root tile's transform is used to position the clipping planes. If a transform is not defined, the root tile's {@link Cesium3DTile#boundingSphere} is used instead.
@@ -79,7 +79,7 @@ define([
      *
      * @example
      * // This clipping plane's distance is positive, which means its normal
-     * // is facing the origin. This will clip everything that is behind 
+     * // is facing the origin. This will clip everything that is behind
      * // the plane, which is anything with y coordinate > 5.
      * var clippingPlanes = new Cesium.ClippingPlaneCollection({
      *     planes : [

--- a/Source/Scene/Instanced3DModel3DTileContent.js
+++ b/Source/Scene/Instanced3DModel3DTileContent.js
@@ -419,6 +419,7 @@ define([
         content._modelInstanceCollection = new ModelInstanceCollection(collectionOptions);
         content._modelInstanceCollection._useBoundingSphereForClipping = !defined(rtcCenter) && !defined(content._tileset.root._header.transform);
 
+        content._modelInstanceCollection._rtcCenterTransform = Matrix4.IDENTITY;
         if (defined(rtcCenter)) {
             content._modelInstanceCollection._rtcCenterTransform = Matrix4.fromTranslation(Cartesian3.fromArray(rtcCenterArray));
         }

--- a/Source/Scene/Instanced3DModel3DTileContent.js
+++ b/Source/Scene/Instanced3DModel3DTileContent.js
@@ -472,6 +472,8 @@ define([
             // Update for clipping planes
             var tilesetClippingPlanes = this._tileset.clippingPlanes;
             if (this._tile.clippingPlanesDirty && defined(tilesetClippingPlanes)) {
+                // Use the root tile's transform.
+                model._clippingPlaneOffsetMatrix = this._tileset._root.computedTransform;
                 // Dereference the clipping planes from the model if they are irrelevant - saves on shading
                 // Link/Dereference directly to avoid ownership checks.
                 model._clippingPlanes = (tilesetClippingPlanes.enabled && this._tile._isClipped) ? tilesetClippingPlanes : undefined;

--- a/Source/Scene/Instanced3DModel3DTileContent.js
+++ b/Source/Scene/Instanced3DModel3DTileContent.js
@@ -417,13 +417,6 @@ define([
         }
 
         content._modelInstanceCollection = new ModelInstanceCollection(collectionOptions);
-        content._modelInstanceCollection._useBoundingSphereForClipping = !defined(rtcCenter) && !defined(content._tileset.root._header.transform);
-
-        content._modelInstanceCollection._rtcCenterTransform = Matrix4.IDENTITY;
-        if (defined(rtcCenter)) {
-            content._modelInstanceCollection._rtcCenterTransform = Transforms.eastNorthUpToFixedFrame(Cartesian3.fromArray(rtcCenterArray));
-        }
-
     }
 
     function createFeatures(content) {
@@ -474,8 +467,6 @@ define([
         this._modelInstanceCollection.debugWireframe = this._tileset.debugWireframe;
 
         var model = this._modelInstanceCollection._model;
-        var useBoundingSphereForClipping = this._modelInstanceCollection._useBoundingSphereForClipping;
-        var rtcCenterTransform = this._modelInstanceCollection._rtcCenterTransform;
 
         if (defined(model)) {
             // Update for clipping planes

--- a/Source/Scene/Instanced3DModel3DTileContent.js
+++ b/Source/Scene/Instanced3DModel3DTileContent.js
@@ -421,7 +421,7 @@ define([
 
         content._modelInstanceCollection._rtcCenterTransform = Matrix4.IDENTITY;
         if (defined(rtcCenter)) {
-            content._modelInstanceCollection._rtcCenterTransform = Matrix4.fromTranslation(Cartesian3.fromArray(rtcCenterArray));
+            content._modelInstanceCollection._rtcCenterTransform = Transforms.eastNorthUpToFixedFrame(Cartesian3.fromArray(rtcCenterArray));
         }
 
     }

--- a/Source/Scene/Instanced3DModel3DTileContent.js
+++ b/Source/Scene/Instanced3DModel3DTileContent.js
@@ -487,6 +487,7 @@ define([
                 } else if (this._tileset.ready) {
                     model._clippingPlaneOffsetMatrix = Transforms.eastNorthUpToFixedFrame(this._tileset.boundingSphere.center);
                 }
+                tileset._clippingPlaneOffsetMatrix = model._clippingPlaneOffsetMatrix;
 
                 // Dereference the clipping planes from the model if they are irrelevant - saves on shading
                 // Link/Dereference directly to avoid ownership checks.

--- a/Source/Scene/Instanced3DModel3DTileContent.js
+++ b/Source/Scene/Instanced3DModel3DTileContent.js
@@ -472,7 +472,7 @@ define([
             // Update for clipping planes
             var tilesetClippingPlanes = this._tileset.clippingPlanes;
             if (this._tile.clippingPlanesDirty && defined(tilesetClippingPlanes)) {
-                model._clippingPlaneOffsetMatrix = this._tileset.clippingPlaneOffsetMatrix;
+                model.clippingPlaneOffsetMatrix = this._tileset.clippingPlaneOffsetMatrix;
                 // Dereference the clipping planes from the model if they are irrelevant - saves on shading
                 // Link/Dereference directly to avoid ownership checks.
                 model._clippingPlanes = (tilesetClippingPlanes.enabled && this._tile._isClipped) ? tilesetClippingPlanes : undefined;

--- a/Source/Scene/Instanced3DModel3DTileContent.js
+++ b/Source/Scene/Instanced3DModel3DTileContent.js
@@ -482,13 +482,11 @@ define([
             var tilesetClippingPlanes = this._tileset.clippingPlanes;
             if (this._tile.clippingPlanesDirty && defined(tilesetClippingPlanes)) {
                 // Use the root tile's transform.
-                if (!useBoundingSphereForClipping) {
-                    model._clippingPlaneOffsetMatrix = Matrix4.multiply(rtcCenterTransform, this._tileset.root.computedTransform, new Matrix4());
+                if (!this._tileset.root._useBoundingSphereForClipping) {
+                    model._clippingPlaneOffsetMatrix = this._tileset.root.computedTransform;
                 } else if (this._tileset.ready) {
-                    model._clippingPlaneOffsetMatrix = Transforms.eastNorthUpToFixedFrame(this._tileset.boundingSphere.center);
+                    model._clippingPlaneOffsetMatrix = this._tileset.root._clippingPlaneOffsetMatrix;
                 }
-                tileset._clippingPlaneOffsetMatrix = model._clippingPlaneOffsetMatrix;
-
                 // Dereference the clipping planes from the model if they are irrelevant - saves on shading
                 // Link/Dereference directly to avoid ownership checks.
                 model._clippingPlanes = (tilesetClippingPlanes.enabled && this._tile._isClipped) ? tilesetClippingPlanes : undefined;

--- a/Source/Scene/Instanced3DModel3DTileContent.js
+++ b/Source/Scene/Instanced3DModel3DTileContent.js
@@ -472,12 +472,7 @@ define([
             // Update for clipping planes
             var tilesetClippingPlanes = this._tileset.clippingPlanes;
             if (this._tile.clippingPlanesDirty && defined(tilesetClippingPlanes)) {
-                // Use the root tile's transform.
-                if (!this._tileset.root._useBoundingSphereForClipping) {
-                    model._clippingPlaneOffsetMatrix = this._tileset.root.computedTransform;
-                } else if (this._tileset.ready) {
-                    model._clippingPlaneOffsetMatrix = this._tileset.root._clippingPlaneOffsetMatrix;
-                }
+                model._clippingPlaneOffsetMatrix = this._tileset.clippingPlaneOffsetMatrix;
                 // Dereference the clipping planes from the model if they are irrelevant - saves on shading
                 // Link/Dereference directly to avoid ownership checks.
                 model._clippingPlanes = (tilesetClippingPlanes.enabled && this._tile._isClipped) ? tilesetClippingPlanes : undefined;

--- a/Source/Scene/Model.js
+++ b/Source/Scene/Model.js
@@ -539,7 +539,7 @@ define([
         this.clippingPlanes = options.clippingPlanes;
         // Used for checking if shaders need to be regenerated due to clipping plane changes.
         this._clippingPlanesState = 0;
-        // If defined, it's used to position the clipping planes instead of the modelMatrix.
+        // If defined, use this matrix to position the clipping planes instead of the modelMatrix.
         // This is so that when models are part of a tileset they all get clipped relative
         // to the root tile.
         this._clippingPlaneOffsetMatrix = undefined;
@@ -598,7 +598,7 @@ define([
         this.opaquePass = defaultValue(options.opaquePass, Pass.OPAQUE);
 
         this._computedModelMatrix = new Matrix4(); // Derived from modelMatrix and scale
-        this._modelViewMatrix = Matrix4.clone(Matrix4.IDENTITY); // Derived from modelMatrix, scale, and the current view matrix
+        this._clippingPlaneModelViewMatrix = Matrix4.clone(Matrix4.IDENTITY); // Derived from modelMatrix, scale, and the current view matrix
         this._initialRadius = undefined;           // Radius without model's scale property, model-matrix scale, animations, or skins
         this._boundingSphere = undefined;
         this._scaledBoundingSphere = new BoundingSphere();
@@ -3013,7 +3013,7 @@ define([
             if (!defined(clippingPlanes)) {
                 return Matrix4.IDENTITY;
             }
-            return Matrix4.multiply(model._modelViewMatrix, clippingPlanes.modelMatrix, scratchClippingPlaneMatrix);
+            return Matrix4.multiply(model._clippingPlaneModelViewMatrix, clippingPlanes.modelMatrix, scratchClippingPlaneMatrix);
         };
     }
 
@@ -4430,11 +4430,8 @@ define([
             var clippingPlanes = this._clippingPlanes;
             var currentClippingPlanesState = 0;
             if (defined(clippingPlanes) && clippingPlanes.enabled) {
-                if (!defined(this._clippingPlaneOffsetMatrix)) {
-                    Matrix4.multiply(context.uniformState.view3D, modelMatrix, this._modelViewMatrix);
-                } else {
-                    Matrix4.multiply(context.uniformState.view3D, this._clippingPlaneOffsetMatrix, this._modelViewMatrix);
-                }
+                var clippingPlaneOffsetMatrix = defaultValue(this._clippingPlaneOffsetMatrix, modelMatrix);
+                Matrix4.multiply(context.uniformState.view3D, clippingPlaneOffsetMatrix, this._modelViewMatrix);
                 currentClippingPlanesState = clippingPlanes.clippingPlanesState;
             }
 

--- a/Source/Scene/Model.js
+++ b/Source/Scene/Model.js
@@ -539,6 +539,9 @@ define([
         this.clippingPlanes = options.clippingPlanes;
         // Used for checking if shaders need to be regenerated due to clipping plane changes.
         this._clippingPlanesState = 0;
+        // If defined, it's used to position the clipping planes instead of the modelMatrix.
+        // Used for RTC coordinates or if this model is part of a tileset.
+        this._clippingPlaneOffsetMatrix = Matrix4.IDENTITY;
 
         /**
          * This property is for debugging only; it is not for production use nor is it optimized.
@@ -4426,7 +4429,12 @@ define([
             var clippingPlanes = this._clippingPlanes;
             var currentClippingPlanesState = 0;
             if (defined(clippingPlanes) && clippingPlanes.enabled) {
-                Matrix4.multiply(context.uniformState.view3D, modelMatrix, this._modelViewMatrix);
+                if (Matrix4.equals(this._clippingPlaneOffsetMatrix, Matrix4.IDENTITY)) {
+                    Matrix4.multiply(context.uniformState.view3D, modelMatrix, this._modelViewMatrix);
+                } else {
+                    Matrix4.multiply(context.uniformState.view3D, this._clippingPlaneOffsetMatrix, this._modelViewMatrix);
+                }
+
                 currentClippingPlanesState = clippingPlanes.clippingPlanesState;
             }
 

--- a/Source/Scene/Model.js
+++ b/Source/Scene/Model.js
@@ -540,7 +540,8 @@ define([
         // Used for checking if shaders need to be regenerated due to clipping plane changes.
         this._clippingPlanesState = 0;
         // If defined, it's used to position the clipping planes instead of the modelMatrix.
-        // This is so that when models are part of a tileset they all share the same matrix.
+        // This is so that when models are part of a tileset they all get clipped relative
+        // to the root tile.
         this._clippingPlaneOffsetMatrix = undefined;
 
         /**

--- a/Source/Scene/Model.js
+++ b/Source/Scene/Model.js
@@ -542,7 +542,7 @@ define([
         // If defined, use this matrix to position the clipping planes instead of the modelMatrix.
         // This is so that when models are part of a tileset they all get clipped relative
         // to the root tile.
-        this._clippingPlaneOffsetMatrix = undefined;
+        this.clippingPlaneOffsetMatrix = undefined;
 
         /**
          * This property is for debugging only; it is not for production use nor is it optimized.
@@ -4430,7 +4430,7 @@ define([
             var clippingPlanes = this._clippingPlanes;
             var currentClippingPlanesState = 0;
             if (defined(clippingPlanes) && clippingPlanes.enabled) {
-                var clippingPlaneOffsetMatrix = defaultValue(this._clippingPlaneOffsetMatrix, modelMatrix);
+                var clippingPlaneOffsetMatrix = defaultValue(this.clippingPlaneOffsetMatrix, modelMatrix);
                 Matrix4.multiply(context.uniformState.view3D, clippingPlaneOffsetMatrix, this._clippingPlaneModelViewMatrix);
                 currentClippingPlanesState = clippingPlanes.clippingPlanesState;
             }

--- a/Source/Scene/Model.js
+++ b/Source/Scene/Model.js
@@ -4431,7 +4431,7 @@ define([
             var currentClippingPlanesState = 0;
             if (defined(clippingPlanes) && clippingPlanes.enabled) {
                 var clippingPlaneOffsetMatrix = defaultValue(this._clippingPlaneOffsetMatrix, modelMatrix);
-                Matrix4.multiply(context.uniformState.view3D, clippingPlaneOffsetMatrix, this._modelViewMatrix);
+                Matrix4.multiply(context.uniformState.view3D, clippingPlaneOffsetMatrix, this._clippingPlaneModelViewMatrix);
                 currentClippingPlanesState = clippingPlanes.clippingPlanesState;
             }
 

--- a/Source/Scene/Model.js
+++ b/Source/Scene/Model.js
@@ -540,8 +540,8 @@ define([
         // Used for checking if shaders need to be regenerated due to clipping plane changes.
         this._clippingPlanesState = 0;
         // If defined, it's used to position the clipping planes instead of the modelMatrix.
-        // Used for RTC coordinates or if this model is part of a tileset.
-        this._clippingPlaneOffsetMatrix = Matrix4.IDENTITY;
+        // This is so that when models are part of a tileset they all share the same matrix.
+        this._clippingPlaneOffsetMatrix = undefined;
 
         /**
          * This property is for debugging only; it is not for production use nor is it optimized.
@@ -4429,12 +4429,11 @@ define([
             var clippingPlanes = this._clippingPlanes;
             var currentClippingPlanesState = 0;
             if (defined(clippingPlanes) && clippingPlanes.enabled) {
-                if (Matrix4.equals(this._clippingPlaneOffsetMatrix, Matrix4.IDENTITY)) {
+                if (!defined(this._clippingPlaneOffsetMatrix)) {
                     Matrix4.multiply(context.uniformState.view3D, modelMatrix, this._modelViewMatrix);
                 } else {
                     Matrix4.multiply(context.uniformState.view3D, this._clippingPlaneOffsetMatrix, this._modelViewMatrix);
                 }
-
                 currentClippingPlanesState = clippingPlanes.clippingPlanesState;
             }
 

--- a/Source/Scene/PointCloud.js
+++ b/Source/Scene/PointCloud.js
@@ -829,7 +829,8 @@ define([
                 } else {
                     Matrix4.multiply(context.uniformState.view3D, pointCloud._clippingPlaneOffsetMatrix, scratchClippingPlaneMatrix);
                 }
-                return scratchClippingPlaneMatrix;
+                
+                return Matrix4.multiply(scratchClippingPlaneMatrix, clippingPlanes.modelMatrix, scratchClippingPlaneMatrix);;
             }
         };
 

--- a/Source/Scene/PointCloud.js
+++ b/Source/Scene/PointCloud.js
@@ -829,8 +829,7 @@ define([
                 } else {
                     Matrix4.multiply(context.uniformState.view3D, pointCloud._clippingPlaneOffsetMatrix, scratchClippingPlaneMatrix);
                 }
-                
-                return Matrix4.multiply(scratchClippingPlaneMatrix, clippingPlanes.modelMatrix, scratchClippingPlaneMatrix);;
+                return Matrix4.multiply(scratchClippingPlaneMatrix, clippingPlanes.modelMatrix, scratchClippingPlaneMatrix);
             }
         };
 

--- a/Source/Scene/PointCloud.js
+++ b/Source/Scene/PointCloud.js
@@ -188,7 +188,7 @@ define([
         // If defined, use this matrix to position the clipping planes instead of the modelMatrix.
         // This is so that when point clouds are part of a tileset they all get clipped relative
         // to the root tile.
-        this._clippingPlaneOffsetMatrix = undefined;
+        this.clippingPlaneOffsetMatrix = undefined;
 
         this.attenuation = false;
         this._attenuation = false;
@@ -824,11 +824,8 @@ define([
                     return Matrix4.IDENTITY;
                 }
 
-                if (!defined(pointCloud._clippingPlaneOffsetMatrix)) {
-                    Matrix4.multiply(context.uniformState.view3D, pointCloud._modelMatrix, scratchClippingPlaneMatrix);
-                } else {
-                    Matrix4.multiply(context.uniformState.view3D, pointCloud._clippingPlaneOffsetMatrix, scratchClippingPlaneMatrix);
-                }
+                var clippingPlaneOffsetMatrix = defaultValue(pointCloud.clippingPlaneOffsetMatrix, pointCloud._modelMatrix);
+                Matrix4.multiply(context.uniformState.view3D, clippingPlaneOffsetMatrix, scratchClippingPlaneMatrix);
                 return Matrix4.multiply(scratchClippingPlaneMatrix, clippingPlanes.modelMatrix, scratchClippingPlaneMatrix);
             }
         };

--- a/Source/Scene/PointCloud.js
+++ b/Source/Scene/PointCloud.js
@@ -185,6 +185,10 @@ define([
         this.clippingPlanes = undefined;
         this.isClipped = false;
         this.clippingPlanesDirty = false;
+        // If defined, it's used to position the clipping planes instead of the modelMatrix.
+        // This is so that when point clouds are part of a tileset they all get clipped relative
+        // to the root tile.
+        this._clippingPlaneOffsetMatrix = undefined;
 
         this.attenuation = false;
         this._attenuation = false;
@@ -819,8 +823,13 @@ define([
                 if (!defined(clippingPlanes)) {
                     return Matrix4.IDENTITY;
                 }
-                var modelViewMatrix = Matrix4.multiply(context.uniformState.view3D, pointCloud._modelMatrix, scratchClippingPlaneMatrix);
-                return Matrix4.multiply(modelViewMatrix, clippingPlanes.modelMatrix, scratchClippingPlaneMatrix);
+
+                if (!defined(pointCloud._clippingPlaneOffsetMatrix)) {
+                    Matrix4.multiply(context.uniformState.view3D, pointCloud._modelMatrix, scratchClippingPlaneMatrix);
+                } else {
+                    Matrix4.multiply(context.uniformState.view3D, pointCloud._clippingPlaneOffsetMatrix, scratchClippingPlaneMatrix);
+                }
+                return scratchClippingPlaneMatrix;
             }
         };
 

--- a/Source/Scene/PointCloud.js
+++ b/Source/Scene/PointCloud.js
@@ -185,7 +185,7 @@ define([
         this.clippingPlanes = undefined;
         this.isClipped = false;
         this.clippingPlanesDirty = false;
-        // If defined, it's used to position the clipping planes instead of the modelMatrix.
+        // If defined, use this matrix to position the clipping planes instead of the modelMatrix.
         // This is so that when point clouds are part of a tileset they all get clipped relative
         // to the root tile.
         this._clippingPlaneOffsetMatrix = undefined;

--- a/Source/Scene/PointCloud3DTileContent.js
+++ b/Source/Scene/PointCloud3DTileContent.js
@@ -297,6 +297,12 @@ define([
         var styleDirty = this._styleDirty;
         this._styleDirty = false;
 
+        if (!tileset.root._useBoundingSphereForClipping) {
+            pointCloud._clippingPlaneOffsetMatrix = tileset.root.computedTransform;
+        } else {
+            pointCloud._clippingPlaneOffsetMatrix = tileset.root._clippingPlaneOffsetMatrix;
+        }
+
         pointCloud.style = defined(batchTable) ? undefined : tileset.style;
         pointCloud.styleDirty = styleDirty;
         pointCloud.modelMatrix = tile.computedTransform;

--- a/Source/Scene/PointCloud3DTileContent.js
+++ b/Source/Scene/PointCloud3DTileContent.js
@@ -297,11 +297,7 @@ define([
         var styleDirty = this._styleDirty;
         this._styleDirty = false;
 
-        if (!tileset.root._useBoundingSphereForClipping) {
-            pointCloud._clippingPlaneOffsetMatrix = tileset.root.computedTransform;
-        } else {
-            pointCloud._clippingPlaneOffsetMatrix = tileset.root._clippingPlaneOffsetMatrix;
-        }
+        pointCloud._clippingPlaneOffsetMatrix = tileset.clippingPlaneOffsetMatrix;
 
         pointCloud.style = defined(batchTable) ? undefined : tileset.style;
         pointCloud.styleDirty = styleDirty;

--- a/Source/Scene/PointCloud3DTileContent.js
+++ b/Source/Scene/PointCloud3DTileContent.js
@@ -297,7 +297,7 @@ define([
         var styleDirty = this._styleDirty;
         this._styleDirty = false;
 
-        pointCloud._clippingPlaneOffsetMatrix = tileset.clippingPlaneOffsetMatrix;
+        pointCloud.clippingPlaneOffsetMatrix = tileset.clippingPlaneOffsetMatrix;
 
         pointCloud.style = defined(batchTable) ? undefined : tileset.style;
         pointCloud.styleDirty = styleDirty;

--- a/Source/Scene/getClippingFunction.js
+++ b/Source/Scene/getClippingFunction.js
@@ -44,7 +44,7 @@ define([
             '    vec4 position = czm_windowToEyeCoordinates(fragCoord);\n' +
             '    vec3 clipNormal = vec3(0.0);\n' +
             '    vec3 clipPosition = vec3(0.0);\n' +
-            '    float clipAmount = 0.0;\n' +
+            '    float clipAmount;\n' + // For union planes, we want to get the min distance. So we set the initial value to the first plane distance in the loop below.
             '    float pixelWidth = czm_metersPerPixel(position);\n' +
             '    bool breakAndDiscard = false;\n' +
 
@@ -56,7 +56,7 @@ define([
             '        clipPosition = -clippingPlane.w * clipNormal;\n' +
 
             '        float amount = dot(clipNormal, (position.xyz - clipPosition)) / pixelWidth;\n' +
-            '        clipAmount = max(amount, clipAmount);\n' +
+            '        clipAmount = czm_branchFreeTernary(i == 0, amount, min(amount, clipAmount));\n' +
 
             '        if (amount <= 0.0)\n' +
             '        {\n' +

--- a/Specs/Cesium3DTilesTester.js
+++ b/Specs/Cesium3DTilesTester.js
@@ -132,7 +132,8 @@ define([
         var tileset = {
             _statistics : {
                 batchTableByteLength : 0
-            }
+            },
+            root : {}
         };
         var url = Resource.createIfNeeded('');
         var content = Cesium3DTileContentFactory[type](tileset, mockTile, url, arrayBuffer, 0);

--- a/Specs/Scene/Cesium3DTilesetSpec.js
+++ b/Specs/Scene/Cesium3DTilesetSpec.js
@@ -3203,22 +3203,23 @@ defineSuite([
 
     it('uses bounding sphere for clipping only if root has no transforms', function() {
         return Cesium3DTilesTester.loadTileset(scene, tilesetOfTilesetsUrl).then(function(tileset) {
-            expect(tileset.root._useBoundingSphereForClipping).toBe(true);
+            expect(tileset._useBoundingSphereForClipping).toBe(true);
 
             return Cesium3DTilesTester.loadTileset(scene, withTransformBoxUrl).then(function(tileset) {
-                expect(tileset.root._useBoundingSphereForClipping).toBe(false);
+                expect(tileset._useBoundingSphereForClipping).toBe(false);
             });
         });
     });
 
     it('correctly computes clippingPlaneOffsetMatrix', function() {
         return Cesium3DTilesTester.loadTileset(scene, tilesetOfTilesetsUrl).then(function(tileset) {
-            var offsetMatrix = tileset.root._clippingPlaneOffsetMatrix;
+            var offsetMatrix = tileset.clippingPlaneOffsetMatrix;
             var boundingSphereMatrix = Transforms.eastNorthUpToFixedFrame(tileset.root.boundingSphere.center);
             expect(Matrix4.equals(offsetMatrix,boundingSphereMatrix)).toBe(true);
 
             return Cesium3DTilesTester.loadTileset(scene, withTransformBoxUrl).then(function(tileset) {
-                expect(tileset.root._clippingPlaneOffsetMatrix).toBeUndefined();
+                offsetMatrix = tileset.clippingPlaneOffsetMatrix;
+                expect(Matrix4.equals(offsetMatrix,tileset.root.computedTransform)).toBe(true);
             });
         });
     });

--- a/Specs/Scene/Cesium3DTilesetSpec.js
+++ b/Specs/Scene/Cesium3DTilesetSpec.js
@@ -15,6 +15,7 @@ defineSuite([
         'Core/PrimitiveType',
         'Core/RequestScheduler',
         'Core/Resource',
+        'Core/Transforms',
         'Renderer/ClearCommand',
         'Renderer/ContextLimits',
         'Scene/Cesium3DTile',
@@ -46,6 +47,7 @@ defineSuite([
         PrimitiveType,
         RequestScheduler,
         Resource,
+        Transforms,
         ClearCommand,
         ContextLimits,
         Cesium3DTile,
@@ -3198,4 +3200,27 @@ defineSuite([
             expect(root._isClipped).toBe(true);
         });
     });
+
+    it('uses bounding sphere for clipping only if root has no transforms', function() {
+        return Cesium3DTilesTester.loadTileset(scene, tilesetOfTilesetsUrl).then(function(tileset) {
+            expect(tileset.root._useBoundingSphereForClipping).toBe(true);
+
+            return Cesium3DTilesTester.loadTileset(scene, withTransformBoxUrl).then(function(tileset) {
+                expect(tileset.root._useBoundingSphereForClipping).toBe(false);
+            });
+        });
+    });
+
+    it('correctly computes clippingPlaneOffsetMatrix', function() {
+        return Cesium3DTilesTester.loadTileset(scene, tilesetOfTilesetsUrl).then(function(tileset) {
+            var offsetMatrix = tileset.root._clippingPlaneOffsetMatrix;
+            var boundingSphereMatrix = Transforms.eastNorthUpToFixedFrame(tileset.root.boundingSphere.center);
+            expect(Matrix4.equals(offsetMatrix,boundingSphereMatrix)).toBe(true);
+
+            return Cesium3DTilesTester.loadTileset(scene, withTransformBoxUrl).then(function(tileset) {
+                expect(tileset.root._clippingPlaneOffsetMatrix).toBeUndefined();
+            });
+        });
+    });
+
 }, 'WebGL');

--- a/Specs/Scene/Cesium3DTilesetSpec.js
+++ b/Specs/Scene/Cesium3DTilesetSpec.js
@@ -3122,7 +3122,9 @@ defineSuite([
 
             tileset.update(scene.frameState);
 
-            var plane = new ClippingPlane(Cartesian3.UNIT_Z, 0.0);
+            var radius = 287.0736139905632;
+
+            var plane = new ClippingPlane(Cartesian3.UNIT_X, radius);
             tileset.clippingPlanes = new ClippingPlaneCollection({
                 planes : [
                     plane
@@ -3135,7 +3137,7 @@ defineSuite([
             expect(statistics.numberOfCommands).toEqual(5);
             expect(root._isClipped).toBe(false);
 
-            plane.distance = -4081630.311150717; // center
+            plane.distance = -1;
 
             tileset.update(scene.frameState);
             scene.renderForSpecs();
@@ -3143,7 +3145,7 @@ defineSuite([
             expect(statistics.numberOfCommands).toEqual(3);
             expect(root._isClipped).toBe(true);
 
-            plane.distance = -4081630.31115071 - 287.0736139905632; // center + radius
+            plane.distance = -radius;
 
             tileset.update(scene.frameState);
             scene.renderForSpecs();
@@ -3164,7 +3166,9 @@ defineSuite([
 
             tileset.update(scene.frameState);
 
-            var plane = new ClippingPlane(Cartesian3.UNIT_Z, 0.0);
+            var radius = 142.19001637409772;
+
+            var plane = new ClippingPlane(Cartesian3.UNIT_Z, radius);
             tileset.clippingPlanes = new ClippingPlaneCollection({
                 planes : [
                     plane
@@ -3177,7 +3181,7 @@ defineSuite([
             expect(statistics.numberOfCommands).toEqual(6);
             expect(root._isClipped).toBe(false);
 
-            plane.distance = -4081608.4377916814; // center
+            plane.distance = 0;
 
             tileset.update(scene.frameState);
             scene.renderForSpecs();
@@ -3185,7 +3189,7 @@ defineSuite([
             expect(statistics.numberOfCommands).toEqual(6);
             expect(root._isClipped).toBe(true);
 
-            plane.distance = -4081608.4377916814 - 142.19001637409772; // center + radius
+            plane.distance = -radius;
 
             tileset.update(scene.frameState);
             scene.renderForSpecs();

--- a/Specs/Scene/ModelSpec.js
+++ b/Specs/Scene/ModelSpec.js
@@ -2858,9 +2858,9 @@ defineSuite([
 
             model.update(scene.frameState);
             scene.renderForSpecs();
-            // When clipping planes are created, we expect two calls to texImage2D 
-            // (one for initial creation, and one for copying the data in) 
-            // because clipping planes is stored inside a texture. 
+            // When clipping planes are created, we expect two calls to texImage2D
+            // (one for initial creation, and one for copying the data in)
+            // because clipping planes is stored inside a texture.
             expect(gl.texImage2D.calls.count() - callsBeforeClipping).toEqual(2);
 
             primitives.remove(model);

--- a/Specs/Scene/ModelSpec.js
+++ b/Specs/Scene/ModelSpec.js
@@ -2848,7 +2848,7 @@ defineSuite([
             scene.renderForSpecs();
             var callsBeforeClipping = gl.texImage2D.calls.count();
 
-            expect(model._modelViewMatrix).toEqual(Matrix4.IDENTITY);
+            expect(model._clippingPlaneModelViewMatrix).toEqual(Matrix4.IDENTITY);
 
             model.clippingPlanes = new ClippingPlaneCollection({
                planes : [
@@ -2858,7 +2858,10 @@ defineSuite([
 
             model.update(scene.frameState);
             scene.renderForSpecs();
-            expect(gl.texImage2D.calls.count() - callsBeforeClipping * 2).toEqual(2);
+            // When clipping planes are created, we expect two calls to texImage2D 
+            // (one for initial creation, and one for copying the data in) 
+            // because clipping planes is stored inside a texture. 
+            expect(gl.texImage2D.calls.count() - callsBeforeClipping).toEqual(2);
 
             primitives.remove(model);
         });

--- a/Specs/Scene/PointCloud3DTileContentSpec.js
+++ b/Specs/Scene/PointCloud3DTileContentSpec.js
@@ -934,8 +934,7 @@ defineSuite([
             tileset.clippingPlanes = new ClippingPlaneCollection({
                 planes : [
                     clipPlane
-                ],
-                modelMatrix : Transforms.eastNorthUpToFixedFrame(tileset.boundingSphere.center)
+                ]
             });
 
             expect(scene).notToRender(color);


### PR DESCRIPTION
Don't merge yet. Opening for feedback. I still have to:

* [x] Write tests.
* [x] Update tileset traversal code to use the new transforms.
* [x] Remove the debug return and eslint disable from `Cesium3DTile.js`.
* [x] Compute correct clipping matrix for PointCloud3DTileContent and make sure Composite works.
* [x] Make a pass for optimization/re-using scratch matrices (feedback welcome here).
* [x] Make docs explicit about what the coordinates are relative to and how to define them for some common cases.
* [x] Make sure ClippingPlane API is consistent with Plane (in that the signed distance means the same thing).

This resolves https://github.com/AnalyticalGraphicsInc/cesium/issues/6600. I started with the solution in https://github.com/AnalyticalGraphicsInc/cesium/pull/6616 and noticed that it has some peculiar behavior: 

![clipping_city_compressed](https://user-images.githubusercontent.com/1711126/45387168-43882680-b5e3-11e8-8310-4f1366a86015.gif)

Notice how this is almost correct, except there's a narrow window in which the the whole tileset becomes visible. This is fixed when this [scratch matrix](https://github.com/AnalyticalGraphicsInc/cesium/blob/clipping-planes-child-fix/Source/Scene/Batched3DModel3DTileContent.js#L444-L460) is moved inside the function. The reason this inverse of the tile's modelMatrix was multiplied there is because the clipping plane's coordinates should be relative to just the root tile, not to each child, so when [Model.js](https://github.com/AnalyticalGraphicsInc/cesium/blob/clipping-planes-child-fix/Source/Scene/Model.js#L4470) multiplies in each tile's modelMatrix, its inverse cancels its out. 

I think a simpler way is to simply save the root tile's matrix and just use that when this model is part of a tileset. This works just like before and fixes the issue in the GIF above. 

### Tilesets with No Root Transforms 

The problem with the [other tileset in the original issue](https://github.com/AnalyticalGraphicsInc/cesium/issues/6600#issuecomment-391595559) is that the root tile had no defined transform, which required you to manually move the clipping plane so that it's relative to the tileset:

```
clippingPlanes.modelMatrix = 
 Cesium.Transforms.eastNorthUpToFixedFrame(tileset.boundingSphere.center)
```

Since the user expects the clipping plane to be relative to the tileset, this can be annoying. The proposed solution here uses the tileset's bounding sphere if no root transform is defined. 

### Tilesets with RTC Coordinates

Another problem was tilesets that are defined with RTC coordinates. The clipping plane thinks the model's coordinates are relative to the center of the earth, so it also required manually moving the clipping planes to the bounding sphere as above. The solution here applies the RTC offset when found. 

@lilleyse there are a few things I'm unsure about here:

* Would the CESIUM_RTC extension need to be handled separately? What's a good test case for this? 
* I've applied the RTC offset to i3dm and b3dm. Do we need to do this for all other tile formats?
  * Similarly for the bounding sphere fallback?

There's one dataset this doesn't work as I expect it to. On `Cesium3DTiles/Instanced/InstancedRTC` the clipping plane seems tilted:

![tilted](https://user-images.githubusercontent.com/1711126/45388245-6ec04500-b5e6-11e8-8cd2-18c7b6a49d75.png)


Even though the plane is defined as `new Cesium.ClippingPlane(new Cesium.Cartesian3(1.0, 0.0, 0.0), 0)` with no other transformation. Here's a [localhost:8080](http://localhost:8080/Apps/Sandcastle/index.html#c=rVZbb9s2FP4rgvdgabBp51JgcJxgSzqgBdakSNz2Yd4DJR3LXChSICkn7pD/vkORVKhcug6okdg69+/cSO2oSnYM7kAlp4mAu+QCNGtr8rnjpeOiIy+kMJQJUOPsZC3WwlkQXYAAUnGZAymhMdsVaPNbhZrarEApfECvRrXgrHysD7IEjoJ/1iLBzxZYtTWLZD5xtNxsNFh6LR46Ow/pVsjiVraGGEWL27T3lPXOjZQ8pzaTUhZtDcKQCszvHOzj+f59mY69SpfHU7+0afj+nImSiUo/+p8Ev1EgxgExDkvmfo7erpww9em1ii+SMSEz93fTQKFnb6mhs4HB7D0WjYoCysen69XFzIcif2spxr5CJeRtdbOVd+ey7dB+lhzTTRZdrbFsFmkwVEDL/Ucla6aBmC2IdNOKwjApUq+ShU4M2tooVjPDdqAJLcte92Sg+lXKeiWDcBKX4x3GRWgfmSm211RUkM7JfJJM5+TNJBSQ5D6Bm2YLCohCk1YnPyeHZJ7ZUA8ZkYhZ3SH4R9w4WlL1qAsptORAuKy85MSXwDWr4VSAxl796fTjlnHWNBakVUljAVUGn6g4Sg8s6rn/yvA7W4u/eudF7EE/GYhYdiE5Bwff4/a4Fv7B9xbKCr6w0mxRYEM7bm0H8QM1it0j3/t39DHZYHNXigrNaef/5TzmgzyyvkShFc8yGTJe3ETcrqtcg9rRnEO8MWO31OOM6DbXhWJ51D4ny4b7jwEv2zrHM8eL/aCxTZIyfUkvA7+3sx8FplXCqz5YiN1w2sZg5rJStNmyAn1H9Qjcrm59gdJXRhJ3wYDqxx4961ZtaAFDp67InctrHGJsRhojwOEUFTNtCZNkyMeWObbtShTFnYI/Osiwtt1R9jg4LwbD/tnz1qQO0CSkP9j1aMyy4DzUMx7d0/8a3QhNtMXfP3YO5Mtj52T9+PQF9mPnxc/GzvO/OXbdMTRYl/+X9sulDBWPDp/Xg/TlGk1GS232HM4crl9Z3Uhl7D2U4v1joMbzBkPM8ra4tXuvdUj6p3CBRqnmeNdWyu7EIlFVTtPjw0kS/ufkl2DbnWh4USC4RXLc3EfsXKoS1NQd7rHw4UlYJprWxMF3oAwrKJ9SziqxSGpWlhyeR5wa2SySw0HUIMqlMbKOpRh2OQslWpZsl7DydD168qqzHmG1qdYo2bSc37CvsB6dLWeoPzDjsrvnrhArp3ursj04+8MxCSHLGZLPrXzKqO4wWcnZu247g3LHdiUx+wbQSNlrFHHVTCA1PZjjUFiS3iMZKG2gsSQ+lviWMc3xhQbpHeUtLPwBMEk68lODGsgcd1HGj2AGUQ3cG+sXC4DUm2/5HaZz1c3vd6dzNEjnaJjOnLySUFiSH52Q89t5CBn8Cw) Sandcastle link. I'm not sure why it's rotated that way or if this is expected. 

Overall, this fixes the original issue as well as a lot of the tilesets under the `Cesium3DTiles/Instanced/` directory, many of which either had no transforms on the root tile or were using RTC coordinates.