### PR TITLE
Altered matrix inversion code to behave correctly with single precision zero scaling

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,7 +9,7 @@ Change Log
 
 ##### Fixes :wrench:
 * Fixed an issue in the 3D Tiles traversal where empty tiles would be selected instead of their nearest loaded ancestors. [#7011](https://github.com/AnalyticalGraphicsInc/cesium/pull/7011)
-* Fixed an issue where scaling near zero could cause rendering to stop. [#6954](https://github.com/AnalyticalGraphicsInc/cesium/pull/6954)
+* Fixed an issue where scaling near zero with an model animation could cause rendering to stop. [#6954](https://github.com/AnalyticalGraphicsInc/cesium/pull/6954)
 * Fixed bug where credits weren't displaying correctly if more than one viewer was initialized [#6965](expect(https://github.com/AnalyticalGraphicsInc/cesium/issues/6965)
 
 ### 1.49 - 2018-09-04

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@ Change Log
 
 ##### Fixes :wrench:
 * Fixed an issue in the 3D Tiles traversal where empty tiles would be selected instead of their nearest loaded ancestors. [#7011](https://github.com/AnalyticalGraphicsInc/cesium/pull/7011)
+* Fixed an issue where scaling near zero could cause rendering to stop. [#6954](https://github.com/AnalyticalGraphicsInc/cesium/pull/6954)
 
 ### 1.49 - 2018-09-04
 

--- a/Source/Core/Math.js
+++ b/Source/Core/Math.js
@@ -161,6 +161,13 @@ define([
     CesiumMath.EPSILON20 = 0.00000000000000000001;
 
     /**
+     * 0.000000000000000000001
+     * @type {Number}
+     * @constant
+     */
+    CesiumMath.EPSILON21 = 0.000000000000000000001;
+
+    /**
      * The gravitational parameter of the Earth in meters cubed
      * per second squared as defined by the WGS84 model: 3.986004418e14
      * @type {Number}

--- a/Source/Core/Matrix4.js
+++ b/Source/Core/Matrix4.js
@@ -2211,31 +2211,6 @@ define([
         Check.typeOf.object('matrix', matrix);
         Check.typeOf.object('result', result);
         //>>includeEnd('debug');
-
-        // Special case for a zero scale matrix that can occur, for example,
-        // when a model's node has a [0, 0, 0] scale.
-        if (Matrix3.equalsEpsilon(Matrix4.getRotation(matrix, scratchInverseRotation), scratchMatrix3Zero, CesiumMath.EPSILON7) &&
-            Cartesian4.equals(Matrix4.getRow(matrix, 3, scratchBottomRow), scratchExpectedBottomRow)) {
-
-            result[0] = 0.0;
-            result[1] = 0.0;
-            result[2] = 0.0;
-            result[3] = 0.0;
-            result[4] = 0.0;
-            result[5] = 0.0;
-            result[6] = 0.0;
-            result[7] = 0.0;
-            result[8] = 0.0;
-            result[9] = 0.0;
-            result[10] = 0.0;
-            result[11] = 0.0;
-            result[12] = -matrix[12];
-            result[13] = -matrix[13];
-            result[14] = -matrix[14];
-            result[15] = 1.0;
-            return result;
-        }
-
         //
         // Ported from:
         //   ftp://download.intel.com/design/PentiumIII/sml/24504301.pdf
@@ -2308,7 +2283,31 @@ define([
         // calculate determinant
         var det = src0 * dst0 + src1 * dst1 + src2 * dst2 + src3 * dst3;
 
-        if (Math.abs(det) < CesiumMath.EPSILON20) {
+        if (Math.abs(det) < 1e-21) {
+                // Special case for a zero scale matrix that can occur, for example,
+                // when a model's node has a [0, 0, 0] scale.
+                if (Matrix3.equalsEpsilon(Matrix4.getRotation(matrix, scratchInverseRotation), scratchMatrix3Zero, CesiumMath.EPSILON7) &&
+                Cartesian4.equals(Matrix4.getRow(matrix, 3, scratchBottomRow), scratchExpectedBottomRow)) {
+
+                result[0] = 0.0;
+                result[1] = 0.0;
+                result[2] = 0.0;
+                result[3] = 0.0;
+                result[4] = 0.0;
+                result[5] = 0.0;
+                result[6] = 0.0;
+                result[7] = 0.0;
+                result[8] = 0.0;
+                result[9] = 0.0;
+                result[10] = 0.0;
+                result[11] = 0.0;
+                result[12] = -matrix[12];
+                result[13] = -matrix[13];
+                result[14] = -matrix[14];
+                result[15] = 1.0;
+                return result;
+            }
+
             throw new RuntimeError('matrix is not invertible because its determinate is zero.');
         }
 

--- a/Source/Core/Matrix4.js
+++ b/Source/Core/Matrix4.js
@@ -2283,7 +2283,7 @@ define([
         // calculate determinant
         var det = src0 * dst0 + src1 * dst1 + src2 * dst2 + src3 * dst3;
 
-        if (Math.abs(det) < 1e-21) {
+        if (Math.abs(det) < CesiumMath.EPSILON21) {
                 // Special case for a zero scale matrix that can occur, for example,
                 // when a model's node has a [0, 0, 0] scale.
                 if (Matrix3.equalsEpsilon(Matrix4.getRotation(matrix, scratchInverseRotation), scratchMatrix3Zero, CesiumMath.EPSILON7) &&

--- a/Specs/Core/Matrix4Spec.js
+++ b/Specs/Core/Matrix4Spec.js
@@ -993,6 +993,38 @@ defineSuite([
         expect(expected).toEqualEpsilon(result, CesiumMath.EPSILON20);
     });
 
+    it('inverse behaves acceptably with near single precision zero scale matrix', function() {
+        var trs = new TranslationRotationScale(new Cartesian3(0.0, 0.0, 0.0),
+        Quaternion.fromAxisAngle(Cartesian3.UNIT_X, 0.0),
+        new Cartesian3(1.0e-7, 1.0e-7, 1.1e-7));
+
+        var matrix = Matrix4.fromTranslationRotationScale(trs);
+
+        var expected = new Matrix4(1e7, 0, 0, 0,
+                                   0, 1e7, 0, 0,
+                                   0, 0, (1.0/1.1)*1e7, 0,
+                                   0, 0, 0, 1);
+
+        var result = Matrix4.inverse(matrix, new Matrix4());
+        expect(expected).toEqualEpsilon(result, CesiumMath.EPSILON15);
+    });
+
+    it('inverse behaves acceptably with single precision zero scale matrix', function() {
+        var trs = new TranslationRotationScale(new Cartesian3(0.0, 0.0, 0.0),
+        Quaternion.fromAxisAngle(Cartesian3.UNIT_X, 0.0),
+        new Cartesian3(1.8e-8, 1.2e-8, 1.2e-8));
+
+        var matrix = Matrix4.fromTranslationRotationScale(trs);
+
+        var expected = new Matrix4(0, 0, 0, -matrix[12],
+                                   0, 0, 0, -matrix[13],
+                                   0, 0, 0, -matrix[14],
+                                   0, 0, 0, 1);
+
+        var result = Matrix4.inverse(matrix, new Matrix4());
+        expect(expected).toEqualEpsilon(result, CesiumMath.EPSILON20);
+    });
+
     it('inverseTransformation works', function() {
         var matrix = new Matrix4(1, 0, 0, 10,
                                  0, 0, 1, 20,


### PR DESCRIPTION
A fix for issue #6954 . Appropriate tests have been added.