### PR TITLE
Fix translucent picking

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@ Change Log
 * Added `OpenCageGeocoderService`, which provides geocoding via [OpenCage](https://opencagedata.com/). [#7015](https://github.com/AnalyticalGraphicsInc/cesium/pull/7015)
 
 ##### Fixes :wrench:
+* Fixed picking for overlapping translucent primitives. [#7039](https://github.com/AnalyticalGraphicsInc/cesium/pull/7039)
 * Fixed an issue in the 3D Tiles traversal where empty tiles would be selected instead of their nearest loaded ancestors. [#7011](https://github.com/AnalyticalGraphicsInc/cesium/pull/7011)
 * Fixed bug where credits weren't displaying correctly if more than one viewer was initialized [#6965](expect(https://github.com/AnalyticalGraphicsInc/cesium/issues/6965)
 

--- a/Source/Scene/DerivedCommand.js
+++ b/Source/Scene/DerivedCommand.js
@@ -289,6 +289,7 @@ define([
         if (!defined(pickState)) {
             var rs = RenderState.getState(renderState);
             rs.blending.enabled = false;
+            rs.depthMask = true;
 
             pickState = RenderState.fromCache(rs);
             cache[renderState.id] = pickState;

--- a/Source/Scene/Scene.js
+++ b/Source/Scene/Scene.js
@@ -1860,19 +1860,6 @@ define([
         }
     }
 
-    function executeTranslucentCommandsUnsorted(scene, executeFunction, passState, commands, invertClassification) {
-        var context = scene.context;
-
-        if (defined(invertClassification)) {
-            executeFunction(invertClassification.unclassifiedCommand, scene, context, passState);
-        }
-
-        var length = commands.length;
-        for (var i = 0; i < length; ++i) {
-            executeFunction(commands[i], scene, context, passState);
-        }
-    }
-
     function getDebugGlobeDepth(scene, index) {
         var globeDepths = scene._view.debugGlobeDepths;
         var globeDepth = globeDepths[index];
@@ -1974,10 +1961,8 @@ define([
                 };
             }
             executeTranslucentCommands = scene._executeOITFunction;
-        } else if (passes.render) {
-            executeTranslucentCommands = executeTranslucentCommandsSorted;
         } else {
-            executeTranslucentCommands = executeTranslucentCommandsUnsorted;
+            executeTranslucentCommands = executeTranslucentCommandsSorted;
         }
 
         var clearGlobeDepth = environmentState.clearGlobeDepth;

--- a/Source/Scene/Scene.js
+++ b/Source/Scene/Scene.js
@@ -1984,7 +1984,7 @@ define([
         } else if (passes.render) {
             executeTranslucentCommands = executeTranslucentCommandsBackToFront;
         } else {
-            executeTranslucentCommands = executeTranslucentCommandsFrontToBack
+            executeTranslucentCommands = executeTranslucentCommandsFrontToBack;
         }
 
         var clearGlobeDepth = environmentState.clearGlobeDepth;

--- a/Source/Scene/Scene.js
+++ b/Source/Scene/Scene.js
@@ -1841,14 +1841,34 @@ define([
         }
     }
 
-    function translucentCompare(a, b, position) {
+    function backToFront(a, b, position) {
         return b.boundingVolume.distanceSquaredTo(position) - a.boundingVolume.distanceSquaredTo(position);
     }
 
-    function executeTranslucentCommandsSorted(scene, executeFunction, passState, commands, invertClassification) {
+    function frontToBack(a, b, position) {
+        // When distances are equal equal favor sorting b before a. This gives render priority to commands later in the list.
+        return a.boundingVolume.distanceSquaredTo(position) - b.boundingVolume.distanceSquaredTo(position) + CesiumMath.EPSILON12;
+    }
+
+    function executeTranslucentCommandsBackToFront(scene, executeFunction, passState, commands, invertClassification) {
         var context = scene.context;
 
-        mergeSort(commands, translucentCompare, scene.camera.positionWC);
+        mergeSort(commands, backToFront, scene.camera.positionWC);
+
+        if (defined(invertClassification)) {
+            executeFunction(invertClassification.unclassifiedCommand, scene, context, passState);
+        }
+
+        var length = commands.length;
+        for (var i = 0; i < length; ++i) {
+            executeFunction(commands[i], scene, context, passState);
+        }
+    }
+
+    function executeTranslucentCommandsFrontToBack(scene, executeFunction, passState, commands, invertClassification) {
+        var context = scene.context;
+
+        mergeSort(commands, frontToBack, scene.camera.positionWC);
 
         if (defined(invertClassification)) {
             executeFunction(invertClassification.unclassifiedCommand, scene, context, passState);
@@ -1961,8 +1981,10 @@ define([
                 };
             }
             executeTranslucentCommands = scene._executeOITFunction;
+        } else if (passes.render) {
+            executeTranslucentCommands = executeTranslucentCommandsBackToFront;
         } else {
-            executeTranslucentCommands = executeTranslucentCommandsSorted;
+            executeTranslucentCommands = executeTranslucentCommandsFrontToBack
         }
 
         var clearGlobeDepth = environmentState.clearGlobeDepth;


### PR DESCRIPTION
Fixes https://github.com/AnalyticalGraphicsInc/cesium/issues/7032

This was a regression from https://github.com/AnalyticalGraphicsInc/cesium/pull/6957 at this commit https://github.com/AnalyticalGraphicsInc/cesium/pull/6957/commits/259c314ea47654309433b979339396bd72032179. That turned off translucent object sorting during the pick pass. I must have been thinking pick commands wrote depth but they currently don't.

One fix is to revert that commit, the other is to write depth for pick commands. This PR does the second. I like the second way because it makes the pick pass more accurate for overlapping primitives, and allows pick functions to get a pick id and the pick position in the same pass, which I'm trying to do to optimize the pick-from-ray functions. It does break some `PrimitiveCollection` tests where it expects primitives added at the same spot to be picked based on the order they were added. I'm not sure if this is the test being too strict or actually important behavior to preserve. @bagnell do you know?

~~Only broken in master so no CHANGES.md update needed.~~
Edit: does happen in earlier versions of Cesium. Needs CHANGES.md update.