### PR TITLE
Use better example in Transforms doc

### DIFF
--- a/Source/Core/Transforms.js
+++ b/Source/Core/Transforms.js
@@ -529,8 +529,7 @@ define([
      *
      * @example
      * scene.postUpdate.addEventListener(function(scene, time) {
-     *   // By default, the camera automatically rotates with the globe.
-     *   // This example fixes the camera to its current position.
+     *   // View in ICRF. 
      *   var icrfToFixed = Cesium.Transforms.computeIcrfToFixedMatrix(time);
      *   if (Cesium.defined(icrfToFixed)) {
      *     var offset = Cesium.Cartesian3.clone(camera.position);

--- a/Source/Core/Transforms.js
+++ b/Source/Core/Transforms.js
@@ -395,7 +395,7 @@ define([
      * @returns {Matrix3} The modified result parameter or a new Matrix3 instance if none was provided.
      *
      * @example
-     * //Set the view to in the inertial frame.
+     * //Set the view to the inertial frame.
      * scene.postUpdate.addEventListener(function(scene, time) {
      *    var now = Cesium.JulianDate.now();
      *    var offset = Cesium.Matrix4.multiplyByPoint(camera.transform, camera.position, new Cesium.Cartesian3());
@@ -529,12 +529,12 @@ define([
      *
      * @example
      * scene.postUpdate.addEventListener(function(scene, time) {
+     *   // By default, the camera automatically rotates with the globe.
+     *   // This example fixes the camera to its current position.
      *   var icrfToFixed = Cesium.Transforms.computeIcrfToFixedMatrix(time);
      *   if (Cesium.defined(icrfToFixed)) {
-     *     var offset = Cesium.Matrix4.multiplyByPoint(camera.transform, camera.position, new Cesium.Cartesian3());
-     *     var transform = Cesium.Matrix4.fromRotationTranslation(icrfToFixed)
-     *     var inverseTransform = Cesium.Matrix4.inverseTransformation(transform, new Cesium.Matrix4());
-     *     Cesium.Matrix4.multiplyByPoint(inverseTransform, offset, offset);
+     *     var offset = Cesium.Cartesian3.clone(camera.position);
+     *     var transform = Cesium.Matrix4.fromRotationTranslation(icrfToFixed);
      *     camera.lookAtTransform(transform, offset);
      *   }
      * });

--- a/Source/Core/Transforms.js
+++ b/Source/Core/Transforms.js
@@ -529,7 +529,7 @@ define([
      *
      * @example
      * scene.postUpdate.addEventListener(function(scene, time) {
-     *   // View in ICRF. 
+     *   // View in ICRF.
      *   var icrfToFixed = Cesium.Transforms.computeIcrfToFixedMatrix(time);
      *   if (Cesium.defined(icrfToFixed)) {
      *     var offset = Cesium.Cartesian3.clone(camera.position);


### PR DESCRIPTION
The current example for [Transforms.computeIcrfToFixedMatrix](https://cesiumjs.org/Cesium/Build/Documentation/Transforms.html#.computeIcrfToFixedMatrix) is the only one on the page that doesn't have a comment describing what it does. 

It seems like it prevents the camera from tilting. I think we should at least describe that if that's the intended use case. Although since you can just disable tilting with a flag on the camera, I propose we use this simpler example instead:

```
scene.postUpdate.addEventListener(function(scene, time) {
  // By default, the camera automatically rotates with the globe.
  // This example fixes the camera to its current position.
  var icrfToFixed = Cesium.Transforms.computeIcrfToFixedMatrix(time);
  if (Cesium.defined(icrfToFixed)) {
    var offset = Cesium.Cartesian3.clone(camera.position);
    var transform = Cesium.Matrix4.fromRotationTranslation(icrfToFixed);
    camera.lookAtTransform(transform, offset);
  }
});
```

I don't think there's another way to do that so it's nice to have that example in the doc. 

I also wanted to use `viewer.scene` instead of `scene` so that it works if you copy paste it without having to define `scene` and `camera` but it would make it feel inconsistent unless we change all examples to do that. 