### PR TITLE
Fix tests in #6805

### DIFF
--- a/Specs/Scene/ModelSpec.js
+++ b/Specs/Scene/ModelSpec.js
@@ -2739,6 +2739,8 @@ defineSuite([
             model.zoomTo();
 
             scene.renderForSpecs();
+
+            primitives.remove(model);
         });
     });
 
@@ -2748,6 +2750,8 @@ defineSuite([
             model.zoomTo();
 
             scene.renderForSpecs();
+
+            primitives.remove(model);
         });
     });
 
@@ -2757,6 +2761,8 @@ defineSuite([
             model.zoomTo();
 
             scene.renderForSpecs();
+
+            primitives.remove(model);
         });
     });
 

--- a/Specs/Scene/ModelSpec.js
+++ b/Specs/Scene/ModelSpec.js
@@ -187,9 +187,8 @@ defineSuite([
 
     function addZoomTo(model) {
         model.zoomTo = function(zoom) {
-            if (!defined(zoom)) {
-                zoom = 4.0;
-            }
+            zoom = defaultValue(zoom, 4.0);
+
             var camera = scene.camera;
             var center = Matrix4.multiplyByPoint(model.modelMatrix, model.boundingSphere.center, new Cartesian3());
             var r = zoom * Math.max(model.boundingSphere.radius, camera.frustum.near);

--- a/Specs/Scene/ModelSpec.js
+++ b/Specs/Scene/ModelSpec.js
@@ -2738,7 +2738,7 @@ defineSuite([
     it('renders with the KHR_materials_pbrSpecularGlossiness extension', function() {
         return loadModel(boomBoxPbrSpecularGlossinessUrl).then(function(model) {
             model.show = false;
-            model.zoomTo(2);
+            model.zoomTo(2.0);
 
             var originalColor;
             expect(scene).toRenderAndCall(function(rgba) {
@@ -2758,7 +2758,7 @@ defineSuite([
     it('renders with the KHR_materials_pbrSpecularGlossiness extension with defaults', function() {
         return loadModel(boomBoxPbrSpecularGlossinessDefaultsUrl).then(function(model) {
             model.show = false;
-            model.zoomTo(2);
+            model.zoomTo(2.0);
 
             var originalColor;
             expect(scene).toRenderAndCall(function(rgba) {
@@ -2778,7 +2778,7 @@ defineSuite([
     it('renders with the KHR_materials_pbrSpecularGlossiness extension when no textures are found', function() {
         return loadModel(boomBoxPbrSpecularGlossinessNoTextureUrl).then(function(model) {
             model.show = false;
-            model.zoomTo(2);
+            model.zoomTo(2.0);
 
             var originalColor;
             expect(scene).toRenderAndCall(function(rgba) {

--- a/Specs/Scene/ModelSpec.js
+++ b/Specs/Scene/ModelSpec.js
@@ -186,10 +186,13 @@ defineSuite([
     });
 
     function addZoomTo(model) {
-        model.zoomTo = function() {
+        model.zoomTo = function(zoom) {
+            if (!defined(zoom)) {
+                zoom = 4.0;
+            }
             var camera = scene.camera;
             var center = Matrix4.multiplyByPoint(model.modelMatrix, model.boundingSphere.center, new Cartesian3());
-            var r = 4.0 * Math.max(model.boundingSphere.radius, camera.frustum.near);
+            var r = zoom * Math.max(model.boundingSphere.radius, camera.frustum.near);
             camera.lookAt(center, new HeadingPitchRange(0.0, 0.0, r));
         };
     }
@@ -2735,10 +2738,19 @@ defineSuite([
 
     it('renders with the KHR_materials_pbrSpecularGlossiness extension', function() {
         return loadModel(boomBoxPbrSpecularGlossinessUrl).then(function(model) {
-            model.show = true;
-            model.zoomTo();
+            model.show = false;
+            model.zoomTo(2);
 
-            scene.renderForSpecs();
+            var originalColor;
+            expect(scene).toRenderAndCall(function(rgba) {
+                originalColor = rgba;
+            });
+
+            model.show = true;
+
+            expect(scene).toRenderAndCall(function(rgba) {
+                expect(rgba).not.toEqual(originalColor);
+            });
 
             primitives.remove(model);
         });
@@ -2746,10 +2758,19 @@ defineSuite([
 
     it('renders with the KHR_materials_pbrSpecularGlossiness extension with defaults', function() {
         return loadModel(boomBoxPbrSpecularGlossinessDefaultsUrl).then(function(model) {
-            model.show = true;
-            model.zoomTo();
+            model.show = false;
+            model.zoomTo(2);
 
-            scene.renderForSpecs();
+            var originalColor;
+            expect(scene).toRenderAndCall(function(rgba) {
+                originalColor = rgba;
+            });
+
+            model.show = true;
+
+            expect(scene).toRenderAndCall(function(rgba) {
+                expect(rgba).not.toEqual(originalColor);
+            });
 
             primitives.remove(model);
         });
@@ -2757,10 +2778,19 @@ defineSuite([
 
     it('renders with the KHR_materials_pbrSpecularGlossiness extension when no textures are found', function() {
         return loadModel(boomBoxPbrSpecularGlossinessNoTextureUrl).then(function(model) {
-            model.show = true;
-            model.zoomTo();
+            model.show = false;
+            model.zoomTo(2);
 
-            scene.renderForSpecs();
+            var originalColor;
+            expect(scene).toRenderAndCall(function(rgba) {
+                originalColor = rgba;
+            });
+
+            model.show = true;
+
+            expect(scene).toRenderAndCall(function(rgba) {
+                expect(rgba).not.toEqual(originalColor);
+            });
 
             primitives.remove(model);
         });


### PR DESCRIPTION
This fixes the failing tests from https://github.com/AnalyticalGraphicsInc/cesium/pull/6805#discussion_r218568248. 

@ggetz let me know how this looks. The new expectation is just that the rendered model looks different than before rendering. If it can load those 3 models without crashing it should at least guarantee that the spec gloss code still works when textures are provided vs just a base color etc.