### PR TITLE
fix bounding volumes for hemisphere-size GroundPolylineGeometry

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,7 @@ Change Log
 * Fixed an issue in the 3D Tiles traversal where empty tiles would be selected instead of their nearest loaded ancestors. [#7011](https://github.com/AnalyticalGraphicsInc/cesium/pull/7011)
 * Fixed an issue where scaling near zero with an model animation could cause rendering to stop. [#6954](https://github.com/AnalyticalGraphicsInc/cesium/pull/6954)
 * Fixed bug where credits weren't displaying correctly if more than one viewer was initialized [#6965](expect(https://github.com/AnalyticalGraphicsInc/cesium/issues/6965)
+* Fixed a bug where polylines on terrain covering very large portions of the globe would cull incorrectly in 3d-only scenes. [#7043](https://github.com/AnalyticalGraphicsInc/cesium/issues/7043)
 
 ### 1.49 - 2018-09-04
 

--- a/Source/Core/GroundPolylineGeometry.js
+++ b/Source/Core/GroundPolylineGeometry.js
@@ -697,7 +697,6 @@ define([
     var normalNudgeScratch = new Cartesian3();
 
     var scratchBoundingSpheres = [new BoundingSphere(), new BoundingSphere()];
-    var boundingSphereCenterCartographicScratch = new Cartographic();
 
     // Winding order is reversed so each segment's volume is inside-out
     var REFERENCE_INDICES = [
@@ -1061,12 +1060,8 @@ define([
         BoundingSphere.fromVertices(topPositionsArray, Cartesian3.ZERO, 3, boundingSpheres[1]);
         var boundingSphere = BoundingSphere.fromBoundingSpheres(boundingSpheres);
 
-        // Adjust bounding sphere height and radius to cover whole volume
-        var midHeight = sumHeights / (segmentCount * 2.0);
-        var boundingSphereCenterCartographic = Cartographic.fromCartesian(boundingSphere.center, ellipsoid, boundingSphereCenterCartographicScratch);
-        boundingSphereCenterCartographic.height = midHeight;
-        boundingSphere.center = Cartographic.toCartesian(boundingSphereCenterCartographic, ellipsoid, boundingSphere.center);
-        boundingSphere.radius = Math.max(boundingSphere.radius, midHeight);
+        // Adjust bounding sphere height and radius to cover more of the volume
+        boundingSphere.radius += sumHeights / (segmentCount * 2.0);
 
         var attributes = {
             position : new GeometryAttribute({

--- a/Specs/Core/GroundPolylineGeometrySpec.js
+++ b/Specs/Core/GroundPolylineGeometrySpec.js
@@ -555,6 +555,7 @@ defineSuite([
         var pointsDistance = Cartesian3.distance(positions[0], positions[1]);
 
         expect(boundingSphere.radius > pointsDistance).toBe(true);
+        expect(boundingSphere.radius > 1000.0).toBe(true); // starting top/bottom height
     });
 
     var packedInstance = [positions.length];


### PR DESCRIPTION
Fixes https://github.com/AnalyticalGraphicsInc/cesium/issues/7043

Here's a primitive-based version of what was noted in the issue on the current release [Sandcastle](https://cesiumjs.org/Cesium/Build/Apps/Sandcastle/#c=7ZhfTxs5EMC/yooXggTGf8d2S6vrtdLppJNaiVNfSh8WsoXVLbtodwPiTv3uNzPeDUlIaNpCrw/HC8kv4/F4xp4Z+zpvs+uyuCna7EVWFzfZ66IrZ5fiPbPJ7hl/fd3UfV7WRbu7n/1zUmf4150VdWHevK2r22dZ386Kk/rz3vOT+qS+RpVXeX/xazOrp3lbFh2q/mBFCN76/cxpYYD+C6W0iQxk9DL8j54GKSlUMN4iM8LEwMwKqxXLSSFDAIVMCQ3K4q/WCA8huP1M4ycFFC6D3IgAVhoWAKU8CigjUI9VPKED7XAaLbzxACimRAQV3VqkBERwkZGxntQysjAgF1RC0doBWa/3swNHn1DKOOF8wA8HyonogkZlKghlo1IPQKeVMgylddGsdwaPjkDz0WgZVHwE6AWuygBPCUHrTQzQchqByHvl1JZsI7LSG83BCtrY+HPAYMwAXVR3cGDW3SE1Z+pB+BMucv3KtR1X7mEj9HhYjfMplCZK/3SQdqAbYQiPA7UdtqEEpX8UW7+HlLTz7RLmcp5MTR7X6kG4dlcuoSdYm9MwONViDnwIWieHkEpl1ABxv6XcBgBuhCBVGg7RUBJMw30cZtfexu/39n2EBT8O58A7F5/Ah9tnTJx2tAUTD0+shZakhgoBVgz4ChZEsEYmn2IUqGQdeIGHQNFp1gK0pIq6mWk3MkqHWzNeCJ/ftBBSTYKQao6m+szZfxsWE8OCFRPD86znLKxh9+S2XUjUgzoVg98gFnBLQvTckWDTOPiZWPgBbERuRJ5zG7FIrdNGtt7kLzN0gYmDVwDsV2uD0RLqxx5g32bdf8uW13HfU99M7u1hPL6Y8NN5itJ5tYFR5wsutWvGKTr6LGeHuoFyVF/XMkUspnNnvI9mA5OYZ6ziO5KDLyDYSupxEMUkjGHC3vrpZ/xJkAHn2NE2Or4dbECe2ndCYJJz8DpFZZZuIpGuRnjFUhKlAa9pgXuSVTAYYNkAvBXBWrRumLLO+zRXoM29PXKSbkmM7API0I0QkffWPCQFo5T+Tru2tT5NCFLrkbg4ormldpTiurNh3ApZEwmDV+kUd/R73DZe2yGHuYUvDNgxGePV42p/ZGQ8R4AcAVb/iBnvHSYQUoWx4Y3RKzx0WmFKdxTsA/zoQXOL5/BwWioC9GaACRzHWBDYNUnuHoPwLnAB0iLgViGoBTdLKGa9jmEQA0MZ98BgKgypgdbYwdB2QRPGO14UBttvrioBTXT8MWL3rS2XBo2togrcehrsJB1Tj5UgWkc6DSkAzq+AVUY6nbRKzYJRKC1TPpael8e9nBJR0UvNQQTs5CU3Wl5IgMg9RaCfbepUo5KcoDCHCJCRh0d0B5g4tyTeGZIsNaiVjIaAhY+ek5S3QkrL6tGvCtsidmHAbWzU6LGoU/E1pDS5jI4a8D1RKyewaaaPDouKTo7WuBY8guwAh3HwnGCx90bDPS/RGaEtpIeaSI6nk0uyOHMKaUTh4HjnoLCX2C2zZgpD5NBE6jUkdxhOaNA+tR3gYvg4f8gs667P67NCLT+P/lY0l0Xf3v4+/DwZXkXPB549W5Ju6Sn0XVPdVmVdjGPHMfR31XRlXzZ1hwOHQa/ztsdPeW3Ep7a5fFOct0XRvWrb/Hay+r66t3+nqmqaK9TyKa+6YgHflNP+ArkTMsHP46C879vydIaT4c8LNnUXzc3yOo6RrK781Th6smjEWVM17cJa6OvGkbw+FpksyifcdfzlGGXr88nuaTUrdvf2hiUsvzkP/n1b/1mgl8r6XVteolevi5XYLUVjLrQYjvMVU8kzH+Zb4ePCQqfF6eyc/MLRQBPfN9XsssjSm/g6weOLfNrczMU4TmNEcC3pMV7w87o4T6aOJnYin04nm9e593xnf+eo62+r4mVS+Ut5edW0fTZrq4kQh31xeVXlGOnD09nZX0UvzrqOJj06HAcdTcvrrJy+ONlZefk/2cnOqrzr8JdPs6o6Lv8uTnZeHh2i/NKwqsnJDW+vi7bKb0nkQr38I0EhxNEhfr0/qm+a6jRvFzT+Cw).

For comparison, in this branch's [Sandcastle](http://cesium-dev.s3-website-us-east-1.amazonaws.com/cesium/fixPolylineOnTerrainBoundingVolume/Apps/Sandcastle/index.html#c=7ZhfTxs5EMC/yooXggTGf8d2S6vrtdLppJNaiVNfSh8WsoXVLbtodwPiTv3uNzPeDUlIaNpCrw/HC8kv4/F4xp4Z+zpvs+uyuCna7EVWFzfZ66IrZ5fiPbPJ7hl/fd3UfV7WRbu7n/1zUmf4150VdWHevK2r22dZ386Kk/rz3vOT+qS+RpVXeX/xazOrp3lbFh2q/mBFCN76/cxpYYD+C6W0iQxk9DL8j54GKSlUMN4iM8LEwMwKqxXLSSFDAIVMCQ3K4q/WCA8huP1M4ycFFC6D3IgAVhoWAKU8CigjUI9VPKED7XAaLbzxACimRAQV3VqkBERwkZGxntQysjAgF1RC0doBWa/3swNHn1DKOOF8wA8HyonogkZlKghlo1IPQKeVMgylddGsdwaPjkDz0WgZVHwE6AWuygBPCUHrTQzQchqByHvl1JZsI7LSG83BCtrY+HPAYMwAXVR3cGDW3SE1Z+pB+BMucv3KtR1X7mEj9HhYjfMplCZK/3SQdqAbYQiPA7UdtqEEpX8UW7+HlLTz7RLmcp5MTR7X6kG4dlcuoSdYm9MwONViDnwIWieHkEpl1ABxv6XcBgBuhCBVGg7RUBJMw30cZtfexu/39n2EBT8O58A7F5/Ah9tnTJx2tAUTD0+shZakhgoBVgz4ChZEsEYmn2IUqGQdeIGHQNFp1gK0pIq6mWk3MkqHWzNeCJ/ftBBSTYKQao6m+szZfxsWE8OCFRPD86znLKxh9+S2XUjUgzoVg98gFnBLQvTckWDTOPiZWPgBbERuRJ5zG7FIrdNGtt7kLzN0gYmDVwDsV2uD0RLqxx5g32bdf8uW13HfU99M7u1hPL6Y8NN5itJ5tYFR5wsutWvGKTr6LGeHuoFyVF/XMkUspnNnvI9mA5OYZ6ziO5KDLyDYSupxEMUkjGHC3vrpZ/xJkAHn2NE2Or4dbECe2ndCYJJz8DpFZZZuIpGuRnjFUhKlAa9pgXuSVTAYYNkAvBXBWrRumLLO+zRXoM29PXKSbkmM7API0I0QkffWPCQFo5T+Tru2tT5NCFLrkbg4ormldpTiurNh3ApZEwmDV+kUd/R73DZe2yGHuYUvDNgxGePV42p/ZGQ8R4AcAVb/iBnvHSYQUoWx4Y3RKzx0WmFKdxTsA/zoQXOL5/BwWioC9GaACRzHWBDYNUnuHoPwLnAB0iLgViGoBTdLKGa9jmEQA0MZ98BgKgypgdbYwdB2QRPGO14UBttvrioBTXT8MWL3rS2XBo2togrcehrsJB1Tj5UgWkc6DSkAzq+AVUY6nbRKzYJRKC1TPpael8e9nBJR0UvNQQTs5CU3Wl5IgMg9RaCfbepUo5KcoDCHCJCRh0d0B5g4tyTeGZIsNaiVjIaAhY+ek5S3QkrL6tGvCtsidmHAbWzU6LGoU/E1pDS5jI4a8D1RKyewaaaPDouKTo7WuBY8guwAh3HwnGCx90bDPS/RGaEtpIeaSI6nk0uyOHMKaUTh4HjnoLCX2C2zZgpD5NBE6jUkdxhOaNA+tR3gYvg4f8gs667P67NCLT+P/lY0l0Xf3v4+/DwZXkXPB549W5Ju6Sn0XVPdVmVdjGPHMfR31XRlXzZ1hwOHQa/ztsdPeW3Ep7a5fFOct0XRvWrb/Hay+r66t3+nqmqaK9TyKa+6YgHflNP+ArkTMsHP46C879vydIaT4c8LNnUXzc3yOo6RrK781Th6smjEWVM17cJa6OvGkbw+FpksyifcdfzlGGXr88nuaTUrdvf2hiUsvzkP/n1b/1mgl8r6XVteolevi5XYLUVjLrQYjvMVU8kzH+Zb4ePCQqfF6eyc/MLRQBPfN9XsssjSm/g6weOLfNrczMU4TmNEcC3pMV7w87o4T6aOJnYin04nm9e593xnf+eo62+r4mVS+Ut5edW0fTZrq4kQh31xeVXlGOnD09nZX0UvzrqOJj06HAcdTcvrrJy+ONlZefk/2cnOqrzr8JdPs6o6Lv8uTnZeHh2i/NKwqsnJDW+vi7bKb0nkQr38I0EhxNEhfr0/qm+a6jRvFzT+Cw).

The problem was in how the bounding sphere was getting computed - the new method is simpler and should work for all cases. The bounding sphere doesn't necessarily cover the shadow volume for very short polylines in some places anymore, but those shadow volumes are *extremely* conservative, so in practice it shouldn't be a problem, it still covers the lines on terrain and on the ellipsoid.

Here's the spec case, roughly:
```js
var viewer = new Cesium.Viewer('cesiumContainer');

var positions = Cesium.Cartesian3.fromDegreesArray([
    -122.17580380403314, 46.19984918190237,
    -122.17581380403314, 46.19984918190237
]);

var instance = new Cesium.GeometryInstance({
    geometry : new Cesium.GroundPolylineGeometry({
        positions : positions,
        loop : true,
        width : 8.0
    })
});

var polylineOnTerrainPrimitive = new Cesium.GroundPolylinePrimitive({
    geometryInstances : [instance],
    debugShowShadowVolume : false,
    debugShowBoundingVolume : true,
});
viewer.scene.groundPrimitives.add(polylineOnTerrainPrimitive);

viewer.camera.lookAt(positions[1], new Cesium.Cartesian3(100.0, 100.0, 100.0));
viewer.camera.lookAtTransform(Cesium.Matrix4.IDENTITY);
```