### PR TITLE
Change camera movement close to the ground

### DIFF
--- a/Source/Scene/ScreenSpaceCameraController.js
+++ b/Source/Scene/ScreenSpaceCameraController.js
@@ -1363,12 +1363,12 @@ define([
 
         if (defined(globe) && height < controller._minimumPickingTerrainHeight) {
             if (defined(mousePos)) {
-                if (Cartesian3.magnitude(camera.position) < Cartesian3.magnitude(mousePos)) {
+                //if (Cartesian3.magnitude(camera.position) < Cartesian3.magnitude(mousePos)) {
                     Cartesian3.clone(mousePos, controller._strafeStartPosition);
 
                     controller._strafing = true;
                     strafe(controller, startPosition, movement);
-                } else {
+                /*} else {
                     magnitude = Cartesian3.magnitude(mousePos);
                     radii = scratchRadii;
                     radii.x = radii.y = radii.z = magnitude;
@@ -1376,7 +1376,7 @@ define([
                     pan3D(controller, startPosition, movement, ellipsoid);
 
                     Cartesian3.clone(mousePos, controller._rotateStartPosition);
-                }
+                }*/
             } else {
                 controller._looking = true;
                 look3D(controller, startPosition, movement, up);


### PR DESCRIPTION
This isn't ready to merge. I just opened a PR so people could test and provide feedback.

When the camera is below `ScreenSpaceCameraController.minimumPickingTerrainHeight`, the camera will no longer pan when tilted. Instead it behaves as if it was looking up at terrain. By 'no longer pans', I mean in the direction the camera is looking. You can pan left to right, but to move forward you need to zoom.

A good test is the BIM Sandcastle example. You should never over shoot the model when using the mouse to interact.