### PR TITLE
Fix typo in docs

### DIFF
--- a/Source/Widgets/Viewer/Viewer.js
+++ b/Source/Widgets/Viewer/Viewer.js
@@ -1285,7 +1285,7 @@ Either specify options.terrainProvider instead or set options.baseLayerPicker to
             }
         },
         /**
-         * Gets the event that is raised when the selected entity chages
+         * Gets the event that is raised when the selected entity changes.
          * @memberof Viewer.prototype
          * @type {Event}
          * @readonly
@@ -1296,7 +1296,7 @@ Either specify options.terrainProvider instead or set options.baseLayerPicker to
             }
         },
         /**
-         * Gets the event that is raised when the tracked entity chages
+         * Gets the event that is raised when the tracked entity changes.
          * @memberof Viewer.prototype
          * @type {Event}
          * @readonly


### PR DESCRIPTION
In https://cesiumjs.org/Cesium/Build/Documentation/Viewer.html?classFilter=Viewer#selectedEntityChanged

changed:

> Gets the event that is raised when the selected entity chages

to:

> Gets the event that is raised when the selected entity changes.