### PR TITLE
Update Viewer on preUpdate instead of clock tick

### DIFF
--- a/Source/Scene/Scene.js
+++ b/Source/Scene/Scene.js
@@ -3249,6 +3249,10 @@ define([
         var us = context.uniformState;
         var frameState = this._frameState;
 
+        // Update with previous frame's time, assuming that render is called before picking.
+        this._preUpdate.raiseEvent(this, frameState.time);
+        this._postUpdate.raiseEvent(this, frameState.time);
+
         var view = this._defaultView;
         this._view = view;
 

--- a/Source/Widgets/Viewer/Viewer.js
+++ b/Source/Widgets/Viewer/Viewer.js
@@ -457,7 +457,7 @@ Either specify options.terrainProvider instead or set options.baseLayerPicker to
 
         var eventHelper = new EventHelper();
 
-        eventHelper.add(clock.onTick, Viewer.prototype._onTick, this);
+        eventHelper.add(scene.preUpdate, Viewer.prototype._onUpdate, this);
         eventHelper.add(scene.morphStart, Viewer.prototype._clearTrackedObject, this);
 
         // Selection Indicator
@@ -1586,9 +1586,7 @@ Either specify options.terrainProvider instead or set options.baseLayerPicker to
     /**
      * @private
      */
-    Viewer.prototype._onTick = function(clock) {
-        var time = clock.currentTime;
-
+    Viewer.prototype._onUpdate = function(scene, time) {
         var isUpdated = this._dataSourceDisplay.update(time);
         if (this._allowDataSourcesToSuspendAnimation) {
             this._clockViewModel.canAnimate = isUpdated;

--- a/Source/Widgets/Viewer/Viewer.js
+++ b/Source/Widgets/Viewer/Viewer.js
@@ -457,7 +457,7 @@ Either specify options.terrainProvider instead or set options.baseLayerPicker to
 
         var eventHelper = new EventHelper();
 
-        eventHelper.add(scene.preUpdate, Viewer.prototype._onUpdate, this);
+        eventHelper.add(scene.preUpdate, Viewer.prototype._onPreUpdate, this);
         eventHelper.add(scene.morphStart, Viewer.prototype._clearTrackedObject, this);
 
         // Selection Indicator
@@ -1586,7 +1586,7 @@ Either specify options.terrainProvider instead or set options.baseLayerPicker to
     /**
      * @private
      */
-    Viewer.prototype._onUpdate = function(scene, time) {
+    Viewer.prototype._onPreUpdate = function(scene, time) {
         var isUpdated = this._dataSourceDisplay.update(time);
         if (this._allowDataSourcesToSuspendAnimation) {
             this._clockViewModel.canAnimate = isUpdated;

--- a/Specs/Widgets/Viewer/ViewerSpec.js
+++ b/Specs/Widgets/Viewer/ViewerSpec.js
@@ -973,7 +973,7 @@ defineSuite([
 
         viewer.selectedEntity = entity;
 
-        viewer.scene.render();
+        viewer.render();
         expect(viewModel.showInfo).toBe(true);
         expect(viewModel.titleText).toEqual(entity.id);
         expect(viewModel.description).toEqual('');
@@ -981,14 +981,14 @@ defineSuite([
         entity.name = 'Yes, this is name.';
         entity.description = 'tubelcane';
 
-        viewer.scene.render();
+        viewer.render();
         expect(viewModel.showInfo).toBe(true);
         expect(viewModel.titleText).toEqual(entity.name);
         expect(viewModel.description).toEqual(entity.description.getValue());
 
         viewer.selectedEntity = undefined;
 
-        viewer.scene.render();
+        viewer.render();
         expect(viewModel.showInfo).toBe(false);
         expect(viewModel.titleText).toEqual('');
         expect(viewModel.description).toEqual('');

--- a/Specs/Widgets/Viewer/ViewerSpec.js
+++ b/Specs/Widgets/Viewer/ViewerSpec.js
@@ -973,7 +973,7 @@ defineSuite([
 
         viewer.selectedEntity = entity;
 
-        viewer.clock.tick();
+        viewer.scene.render();
         expect(viewModel.showInfo).toBe(true);
         expect(viewModel.titleText).toEqual(entity.id);
         expect(viewModel.description).toEqual('');
@@ -981,14 +981,14 @@ defineSuite([
         entity.name = 'Yes, this is name.';
         entity.description = 'tubelcane';
 
-        viewer.clock.tick();
+        viewer.scene.render();
         expect(viewModel.showInfo).toBe(true);
         expect(viewModel.titleText).toEqual(entity.name);
         expect(viewModel.description).toEqual(entity.description.getValue());
 
         viewer.selectedEntity = undefined;
 
-        viewer.clock.tick();
+        viewer.scene.render();
         expect(viewModel.showInfo).toBe(false);
         expect(viewModel.titleText).toEqual('');
         expect(viewModel.description).toEqual('');


### PR DESCRIPTION
This changes the viewer to be updated on preUpdate rather than clock tick from this idea in [#7204](https://github.com/AnalyticalGraphicsInc/cesium/issues/7024#issuecomment-420105908).

This allows entity changes to be reflected in the pick pass.

I'm a little hesitant about making a core change like this but it seems mostly safe as `clock.tick()` and `scene.render()` are called right after another in [CesiumWidget](https://github.com/AnalyticalGraphicsInc/cesium/blob/master/Source/Widgets/CesiumWidget/CesiumWidget.js#L691-L694).

[this branch](http://cesium-dev.s3-website-us-east-1.amazonaws.com/cesium/update-entities/Apps/Sandcastle/index.html#c=dVLBitswEP0V4UtsSOWku6etN7Trhm5ooNCkPRmKIk8SUVkykuyQLfn3jiw72XXpHIQ0894b6Y1aZkgr4ASGPBIFJ5KDFU1Ff3a5eMK7Y66VY0KBmSQfCtUix3JQgJTApd0RS6G4kw0spRS11aK8gUA54QRYysoy/lMogqFYBeSBTJ6QQmDgTKahWmuLDK0ehmvlzDjcMXVH90ZXn+FgAGz8bj6/p7MpuZ/59W7mg86SXuUqi436tj4MK4XA1KtX3+Tj973IlNx2Y2EfFXNgBJPkdkcttaFP6x/LgLoU6pIEb4IPL1pXWx2PXEmu9h2ZKuV4IBuOL1WbmnFYtsh5DqBBhTOkdho9m1pwK1U37hP3Dsb7RoVNpVuoUCAZvHgzLWqP+oSd90xaP1AP8HeqBf8N5Wjg1GevgnSYVtLzuFZWS6BSH+LA95XL9H9P2p5roN9XX563v/L1Kv/q0dE0yqw7S1gEzY+iqrVxpDEypjR1UNUSJ2DTXYMNHOW2MyFLB1JWipaI8rGIRl+5iAiXzFqs7BspN+IFimiRpYh/Q5Ma/4k6fGvBSHb2kON8sQ5JSmmW4vFfltNa7ph5pfgX) vs. [master](https://cesiumjs.org/Cesium/Build/Apps/Sandcastle/#c=dVLBitswEP0V4UtsSOWku6etN7Trhm5ooNCkPRmKIk8SUVkykuyQLfn3jiw72XXpHIQ0894b6Y1aZkgr4ASGPBIFJ5KDFU1Ff3a5eMK7Y66VY0KBmSQfCtUix3JQgJTApd0RS6G4kw0spRS11aK8gUA54QRYysoy/lMogqFYBeSBTJ6QQmDgTKahWmuLDK0ehmvlzDjcMXVH90ZXn+FgAGz8bj6/p7MpuZ/59W7mg86SXuUqi436tj4MK4XA1KtX3+Tj973IlNx2Y2EfFXNgBJPkdkcttaFP6x/LgLoU6pIEb4IPL1pXWx2PXEmu9h2ZKuV4IBuOL1WbmnFYtsh5DqBBhTOkdho9m1pwK1U37hP3Dsb7RoVNpVuoUCAZvHgzLWqP+oSd90xaP1AP8HeqBf8N5Wjg1GevgnSYVtLzuFZWS6BSH+LA95XL9H9P2p5roN9XX563v/L1Kv/q0dE0yqw7S1gEzY+iqrVxpDEypjR1UNUSJ2DTXYMNHOW2MyFLB1JWipaI8rGIRl+5iAiXzFqs7BspN+IFimiRpYh/Q5Ma/4k6fGvBSHb2kON8sQ5JSmmW4vFfltNa7ph5pfgX)

