### PR TITLE
Add colorsEqualEpsilon to ModelSpec test

### DIFF
--- a/Specs/Scene/ModelSpec.js
+++ b/Specs/Scene/ModelSpec.js
@@ -948,8 +948,9 @@ defineSuite([
 
             expect(scene).toRenderAndCall(function(rgba) {
                 expect(rgba).toEqualEpsilon([169, 3, 3, 255], 5); // Red
-                primitives.remove(m);
             });
+
+            primitives.remove(m);
         });
     });
 

--- a/Specs/Scene/ModelSpec.js
+++ b/Specs/Scene/ModelSpec.js
@@ -247,14 +247,6 @@ defineSuite([
         model.show = false;
     }
 
-    function colorsEqualEpsilon(rgba1, rgba2, epsilon) {
-        epsilon = defaultValue(epsilon, 5);
-        return Math.abs(rgba1[0] - rgba2[0]) <= epsilon &&
-                Math.abs(rgba1[1] - rgba2[1]) <= epsilon &&
-                Math.abs(rgba1[2] - rgba2[2]) <= epsilon &&
-                Math.abs(rgba1[3] - rgba2[3]) <= epsilon;
-    }
-
     it('fromGltf throws without options', function() {
         expect(function() {
             Model.fromGltf();
@@ -955,8 +947,7 @@ defineSuite([
             m.show = true;
 
             expect(scene).toRenderAndCall(function(rgba) {
-                // Expect a red color.
-                expect(colorsEqualEpsilon([169, 3, 3, 255], rgba)).toBe(true);
+                expect(rgba).toEqualEpsilon([169, 3, 3, 255], 5); // Red
                 primitives.remove(m);
             });
         });

--- a/Specs/Scene/ModelSpec.js
+++ b/Specs/Scene/ModelSpec.js
@@ -247,6 +247,14 @@ defineSuite([
         model.show = false;
     }
 
+    function colorsEqualEpsilon(rgba1, rgba2, epsilon) {
+        epsilon = defaultValue(epsilon, 5);
+        return Math.abs(rgba1[0] - rgba2[0]) <= epsilon &&
+                Math.abs(rgba1[1] - rgba2[1]) <= epsilon &&
+                Math.abs(rgba1[2] - rgba2[2]) <= epsilon &&
+                Math.abs(rgba1[3] - rgba2[3]) <= epsilon;
+    }
+
     it('fromGltf throws without options', function() {
         expect(function() {
             Model.fromGltf();
@@ -945,8 +953,12 @@ defineSuite([
         return loadModel(boxGltf2Url).then(function(m) {
             verifyRender(m);
             m.show = true;
-            expect(scene).toRender([169, 3, 3, 255]); // Red
-            primitives.remove(m);
+
+            expect(scene).toRenderAndCall(function(rgba) {
+                // Expect a red color.
+                expect(colorsEqualEpsilon([169, 3, 3, 255], rgba)).toBe(true);
+                primitives.remove(m);
+            });
         });
     });
 


### PR DESCRIPTION
This fixes the test failure in https://github.com/AnalyticalGraphicsInc/cesium/issues/7073. 

I figured it would be useful to be able to test if colors are close enough so our tests are more flexible. Feedback is welcome!

I don't think the color change is due to https://github.com/AnalyticalGraphicsInc/cesium/pull/6877 because it looks like the `scene` in the spec doesn't have a globe initialized, so I assume that means it's not rendering the atmosphere. The box itself still looks fine in CesiumJS. 