### PR TITLE
additive point size

### DIFF
--- a/Source/Scene/PointCloud3DTileContent.js
+++ b/Source/Scene/PointCloud3DTileContent.js
@@ -12,6 +12,7 @@ define([
         '../Renderer/ShaderSource',
         './Cesium3DTileBatchTable',
         './Cesium3DTileFeature',
+        './Cesium3DTileRefine',
         './PointCloud',
         './SceneMode'
     ], function(
@@ -28,6 +29,7 @@ define([
         ShaderSource,
         Cesium3DTileBatchTable,
         Cesium3DTileFeature,
+        Cesium3DTileRefine,
         PointCloud,
         SceneMode) {
     'use strict';
@@ -310,6 +312,7 @@ define([
         pointCloud.geometricError = getGeometricError(this);
         pointCloud.geometricErrorScale = defined(pointCloudShading) ? pointCloudShading.geometricErrorScale : 1.0;
         pointCloud.maximumAttenuation = (defined(pointCloudShading) && defined(pointCloudShading.maximumAttenuation)) ? pointCloudShading.maximumAttenuation : tileset.maximumScreenSpaceError;
+        pointCloud.maximumAttenuation = (defined(tile.refine) && tile.refine === Cesium3DTileRefine.ADD) ? 5.0 : pointCloud.maximumAttenuation;
 
         pointCloud.update(frameState);
     };

--- a/Source/Scene/PointCloud3DTileContent.js
+++ b/Source/Scene/PointCloud3DTileContent.js
@@ -311,8 +311,13 @@ define([
         pointCloud.attenuation = defined(pointCloudShading) ? pointCloudShading.attenuation : false;
         pointCloud.geometricError = getGeometricError(this);
         pointCloud.geometricErrorScale = defined(pointCloudShading) ? pointCloudShading.geometricErrorScale : 1.0;
-        pointCloud.maximumAttenuation = (defined(pointCloudShading) && defined(pointCloudShading.maximumAttenuation)) ? pointCloudShading.maximumAttenuation : tileset.maximumScreenSpaceError;
-        pointCloud.maximumAttenuation = (defined(tile.refine) && tile.refine === Cesium3DTileRefine.ADD) ? 5.0 : pointCloud.maximumAttenuation;
+        if (defined(pointCloudShading) && defined(pointCloudShading.maximumAttenuation)) {
+            pointCloud.maximumAttenuation = pointCloudShading.maximumAttenuation;
+        } else if (tile.refine === Cesium3DTileRefine.ADD) {
+            pointCloud.maximumAttenuation = 5.0;
+        } else {
+            pointCloud.maximumAttenuation = tileset.maximumScreenSpaceError;
+        }
 
         pointCloud.update(frameState);
     };

--- a/Specs/Scene/PointCloud3DTileContentSpec.js
+++ b/Specs/Scene/PointCloud3DTileContentSpec.js
@@ -11,6 +11,7 @@ defineSuite([
         'Core/PerspectiveFrustum',
         'Core/Transforms',
         'Renderer/Pass',
+        'Scene/Cesium3DTileRefine',
         'Scene/Cesium3DTileStyle',
         'Scene/ClippingPlane',
         'Scene/ClippingPlaneCollection',
@@ -20,8 +21,7 @@ defineSuite([
         'Specs/createCanvas',
         'Specs/createScene',
         'Specs/pollToPromise',
-        'ThirdParty/when',
-        'Scene/Cesium3DTileRefine'
+        'ThirdParty/when'
     ], function(
         PointCloud3DTileContent,
         Cartesian3,
@@ -35,6 +35,7 @@ defineSuite([
         PerspectiveFrustum,
         Transforms,
         Pass,
+        Cesium3DTileRefine,
         Cesium3DTileStyle,
         ClippingPlane,
         ClippingPlaneCollection,
@@ -44,8 +45,7 @@ defineSuite([
         createCanvas,
         createScene,
         pollToPromise,
-        when,
-        Cesium3DTileRefine) {
+        when) {
     'use strict';
 
     var scene;
@@ -519,7 +519,7 @@ defineSuite([
 
         return Cesium3DTilesTester.loadTileset(scene, pointCloudNoColorUrl).then(function(tileset) {
             tileset.pointCloudShading.eyeDomeLighting = false;
-            tileset.refine = Cesium3DTileRefine.REPLACE;
+            tileset.root.refine = Cesium3DTileRefine.REPLACE;
             postLoadCallback(scene, tileset);
             scene.destroyForSpecs();
         });

--- a/Specs/Scene/PointCloud3DTileContentSpec.js
+++ b/Specs/Scene/PointCloud3DTileContentSpec.js
@@ -20,7 +20,8 @@ defineSuite([
         'Specs/createCanvas',
         'Specs/createScene',
         'Specs/pollToPromise',
-        'ThirdParty/when'
+        'ThirdParty/when',
+        'Scene/Cesium3DTileRefine'
     ], function(
         PointCloud3DTileContent,
         Cartesian3,
@@ -43,7 +44,8 @@ defineSuite([
         createCanvas,
         createScene,
         pollToPromise,
-        when) {
+        when,
+        Cesium3DTileRefine) {
     'use strict';
 
     var scene;
@@ -517,6 +519,7 @@ defineSuite([
 
         return Cesium3DTilesTester.loadTileset(scene, pointCloudNoColorUrl).then(function(tileset) {
             tileset.pointCloudShading.eyeDomeLighting = false;
+            tileset.refine = Cesium3DTileRefine.REPLACE;
             postLoadCallback(scene, tileset);
             scene.destroyForSpecs();
         });


### PR DESCRIPTION
Constant size seems more robust than what we have now. Still see popping and thin areas when when close and child hasn't loaded but those situations can't be robustly handled unless a more involved approach is taken (screen space pass, some amount tree traversal to see if children loaded, try to maintain world space size of a point (using the typical world space size of a point when it first loads and the depth), etc)