### PR TITLE
Revert "Update Viewer on preUpdate instead of clock tick"

### DIFF
--- a/Source/Scene/Scene.js
+++ b/Source/Scene/Scene.js
@@ -3249,10 +3249,6 @@ define([
         var us = context.uniformState;
         var frameState = this._frameState;
 
-        // Update with previous frame's time, assuming that render is called before picking.
-        this._preUpdate.raiseEvent(this, frameState.time);
-        this._postUpdate.raiseEvent(this, frameState.time);
-
         var view = this._defaultView;
         this._view = view;
 

--- a/Source/Widgets/Viewer/Viewer.js
+++ b/Source/Widgets/Viewer/Viewer.js
@@ -457,7 +457,7 @@ Either specify options.terrainProvider instead or set options.baseLayerPicker to
 
         var eventHelper = new EventHelper();
 
-        eventHelper.add(scene.preUpdate, Viewer.prototype._onPreUpdate, this);
+        eventHelper.add(clock.onTick, Viewer.prototype._onTick, this);
         eventHelper.add(scene.morphStart, Viewer.prototype._clearTrackedObject, this);
 
         // Selection Indicator
@@ -1586,7 +1586,9 @@ Either specify options.terrainProvider instead or set options.baseLayerPicker to
     /**
      * @private
      */
-    Viewer.prototype._onPreUpdate = function(scene, time) {
+    Viewer.prototype._onTick = function(clock) {
+        var time = clock.currentTime;
+
         var isUpdated = this._dataSourceDisplay.update(time);
         if (this._allowDataSourcesToSuspendAnimation) {
             this._clockViewModel.canAnimate = isUpdated;

--- a/Specs/Widgets/Viewer/ViewerSpec.js
+++ b/Specs/Widgets/Viewer/ViewerSpec.js
@@ -973,7 +973,7 @@ defineSuite([
 
         viewer.selectedEntity = entity;
 
-        viewer.render();
+        viewer.clock.tick();
         expect(viewModel.showInfo).toBe(true);
         expect(viewModel.titleText).toEqual(entity.id);
         expect(viewModel.description).toEqual('');
@@ -981,14 +981,14 @@ defineSuite([
         entity.name = 'Yes, this is name.';
         entity.description = 'tubelcane';
 
-        viewer.render();
+        viewer.clock.tick();
         expect(viewModel.showInfo).toBe(true);
         expect(viewModel.titleText).toEqual(entity.name);
         expect(viewModel.description).toEqual(entity.description.getValue());
 
         viewer.selectedEntity = undefined;
 
-        viewer.render();
+        viewer.clock.tick();
         expect(viewModel.showInfo).toBe(false);
         expect(viewModel.titleText).toEqual('');
         expect(viewModel.description).toEqual('');


### PR DESCRIPTION
Fixes #7081

Reverts #7069 until there is a guaranteed fix for https://github.com/AnalyticalGraphicsInc/cesium/pull/6934#issuecomment-424863827, which may look like this but may not.