### PR TITLE
Conform to current XHR spec for overrideMimeType

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -30,6 +30,7 @@ Change Log
 * Fixed entity show issues. [#7048](https://github.com/AnalyticalGraphicsInc/cesium/issues/7048)
 * Fixed a bug where polylines on terrain covering very large portions of the globe would cull incorrectly in 3d-only scenes. [#7043](https://github.com/AnalyticalGraphicsInc/cesium/issues/7043)
 * Fixed bug causing crash on entity geometry material change [#7047](https://github.com/AnalyticalGraphicsInc/cesium/pull/7047)
+* Fixed MIME type behavior for `Resource` requests in recent versions of Edge [#7085](https://github.com/AnalyticalGraphicsInc/cesium/issues/7085).
 
 ### 1.49 - 2018-09-04
 

--- a/Source/Core/Resource.js
+++ b/Source/Core/Resource.js
@@ -1853,11 +1853,11 @@ define([
             xhr.withCredentials = true;
         }
 
+        xhr.open(method, url, true);
+
         if (defined(overrideMimeType) && defined(xhr.overrideMimeType)) {
             xhr.overrideMimeType(overrideMimeType);
         }
-
-        xhr.open(method, url, true);
 
         if (defined(headers)) {
             for (var key in headers) {


### PR DESCRIPTION
As per the updated XHR spec, you need to call open before calling `overrideMimeType`.  While they are most likely rolling back this portion of the spec, it is currently required in Edge and is harmless to keep this pay even after the spec is reverted.

Fixes #7085