### PR TITLE
Create standalone Sandcastle mode

### DIFF
--- a/Apps/Sandcastle/CesiumSandcastle.js
+++ b/Apps/Sandcastle/CesiumSandcastle.js
@@ -931,7 +931,7 @@ require({
         return location.protocol + '//' + location.host + location.pathname;
     }
 
-    registry.byId('buttonShareDrop').on('click', function() {
+    function makeCompressedBase64String() {
         var code = jsEditor.getValue();
         var html = htmlEditor.getValue();
 
@@ -942,6 +942,12 @@ require({
         jsonString = jsonString.substr(2, jsonString.length - 4);
         var base64String = btoa(pako.deflate(jsonString, { raw: true, to: 'string', level: 9 }));
         base64String = base64String.replace(/\=+$/, ''); // remove padding
+
+        return base64String;
+    }
+
+    registry.byId('buttonShareDrop').on('click', function() {
+        var base64String = makeCompressedBase64String();
 
         var shareUrlBox = document.getElementById('shareUrl');
         shareUrlBox.value = getBaseUrl() + '#c=' + base64String;
@@ -1022,25 +1028,10 @@ require({
     });
 
     registry.byId('buttonNewWindow').on('click', function() {
-        var baseHref = window.location.href;
+        var data = makeCompressedBase64String();
+        var url = '/Apps/Sandcastle/Standalone/?c=' + data;
 
-        //Handle case where demo is in a sub-directory.
-        var searchLen = window.location.search.length;
-        if (searchLen > 0) {
-            baseHref = baseHref.substring(0, baseHref.length - searchLen);
-        }
-
-        var pos = baseHref.lastIndexOf('/');
-        baseHref = baseHref.substring(0, pos) + '/gallery/';
-
-        var html = getDemoHtml();
-        html = html.replace('<head>', '<head>\n    <base href="' + baseHref + '">');
-        var htmlBlob = new Blob([html], {
-            'type' : 'text/html;charset=utf-8',
-            'endings' : 'native'
-        });
-        var htmlBlobURL = URL.createObjectURL(htmlBlob);
-        window.open(htmlBlobURL, '_blank');
+        window.open(url, '_blank');
         window.focus();
     });
 

--- a/Apps/Sandcastle/views/SandcastleStandalone.liquid
+++ b/Apps/Sandcastle/views/SandcastleStandalone.liquid
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no">
+    <meta name="description" content="Create 3D models using glTF.">
+    <meta name="cesium-sandcastle-labels" content="Tutorials,Showcases">
+    <title>Cesium Demo</title>
+    <script type="text/javascript" src="../Sandcastle-header.js"></script>
+    <script type="text/javascript" src="../../../ThirdParty/requirejs-2.1.20/require.js"></script>
+    <script type="text/javascript">
+        if(typeof require === 'function') {
+            require.config({
+                baseUrl : '../../../Source',
+                waitSeconds : 120
+            });
+        }
+    </script>
+</head>
+<body class="sandcastle-loading" data-sandcastle-bucket="bucket-requirejs.html">
+<style>
+    @import url(../templates/bucket.css);
+</style>
+{{html}}
+<script id="cesium_sandcastle_script">
+function startup(Cesium) {
+    'use strict';
+//Sandcastle_Begin
+{{code}}
+//Sandcastle_End
+    Sandcastle.finishedLoading();
+}
+if (typeof Cesium !== 'undefined') {
+    startup(Cesium);
+} else if (typeof require === 'function') {
+    require(['Cesium'], startup);
+}
+</script>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -30,6 +30,9 @@
     "email": "cesium-dev@googlegroups.com"
   },
   "dependencies": {
+    "atob": "^2.1.2",
+    "liquidjs": "^6.0.0",
+    "pako": "^1.0.6",
     "requirejs": "^2.3.2"
   },
   "devDependencies": {


### PR DESCRIPTION
Right now, if you click "Open in New Window" in Sandcastle it will requests from ion will fail, and you'll just see a blue sphere. 

This PR creates a page to render any Sandcastle example as a standalone page that opens when you click "Open in a New Window". So any Sandcastle link that looks like:

```
https://cesiumjs.org/Cesium/Build/Apps/Sandcastle/#c=ZYw7C8Iw...
```

Will now also be accessible at:

```
https://cesiumjs.org/Cesium/Build/Apps/Sandcastle/Standalone/#c=ZYw7C8Iw...
```

The other motivation to do this is to be able to show Sandcastle examples on mobile. You can easily share the second link now (or just click the open in new window button). 

The other issue is, at least on my iPhone 5s Safari, the current open in new window blob URL just loads the HTML as text and doesn't actually render. 

If there's a better way to get Sandcastle to look nice on mobile I'm happy to hear it. 

I also added a few dependencies to get this to work, but I wonder if these should be added to `devDependencies` instead?