### PR TITLE
Tileset mixed refinement fix

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -29,6 +29,7 @@ Change Log
 
 ##### Fixes :wrench:
 * Fixed picking for overlapping translucent primitives. [#7039](https://github.com/AnalyticalGraphicsInc/cesium/pull/7039)
+* Fixed an issue in the 3D Tiles traversal where tilesets would render with mixed level of detail if an external tileset was visible but its root tile was not. [#7099](https://github.com/AnalyticalGraphicsInc/cesium/pull/7099)
 * Fixed an issue in the 3D Tiles traversal where external tilesets would not always traverse to their root tile. [#7035](https://github.com/AnalyticalGraphicsInc/cesium/pull/7035)
 * Fixed an issue in the 3D Tiles traversal where empty tiles would be selected instead of their nearest loaded ancestors. [#7011](https://github.com/AnalyticalGraphicsInc/cesium/pull/7011)
 * Fixed an issue where scaling near zero with an model animation could cause rendering to stop. [#6954](https://github.com/AnalyticalGraphicsInc/cesium/pull/6954)

--- a/Source/Scene/Cesium3DTilesetTraversal.js
+++ b/Source/Scene/Cesium3DTilesetTraversal.js
@@ -316,7 +316,11 @@ define([
             return;
         }
 
-        if (tile.hasTilesetContent && tile.children.length > 0) {
+        var hasChildren = tile.children.length > 0;
+        if (tile.hasTilesetContent && hasChildren) {
+            // Use the root tile's visibility instead of this tile's visibility.
+            // The root tile may be culled by the children bounds optimization in which
+            // case this tile should also be culled.
             var child = tile.children[0];
             updateTileVisibility(tileset, child, frameState);
             tile._visible = child._visible;
@@ -331,7 +335,6 @@ define([
         // Optimization - if none of the tile's children are visible then this tile isn't visible
         var replace = tile.refine === Cesium3DTileRefine.REPLACE;
         var useOptimization = tile._optimChildrenWithinParent === Cesium3DTileOptimizationHint.USE_OPTIMIZATION;
-        var hasChildren = tile.children.length > 0;
         if (replace && useOptimization && hasChildren) {
             if (!anyChildrenVisible(tileset, tile, frameState)) {
                 ++tileset._statistics.numberOfTilesCulledWithChildrenUnion;

--- a/Source/Scene/Cesium3DTilesetTraversal.js
+++ b/Source/Scene/Cesium3DTilesetTraversal.js
@@ -316,6 +316,13 @@ define([
             return;
         }
 
+        if (tile.hasTilesetContent && tile.children.length > 0) {
+            var child = tile.children[0];
+            updateTileVisibility(tileset, child, frameState);
+            tile._visible = child._visible;
+            return;
+        }
+
         if (meetsScreenSpaceErrorEarly(tileset, tile, frameState)) {
             tile._visible = false;
             return;

--- a/Specs/Scene/Cesium3DTilesetSpec.js
+++ b/Specs/Scene/Cesium3DTilesetSpec.js
@@ -1216,6 +1216,23 @@ defineSuite([
             });
         });
 
+        it('does not select external tileset whose root has invisible children', function() {
+            return Cesium3DTilesTester.loadTileset(scene, tilesetOfTilesetsUrl).then(function(tileset) {
+                var center = Cartesian3.fromRadians(centerLongitude, centerLatitude, 50.0);
+                scene.camera.lookAt(center, new HeadingPitchRange(0.0, 1.57, 1.0));
+                var root = tileset.root;
+                var externalRoot = root.children[0];
+                externalRoot.refine = Cesium3DTileRefine.REPLACE;
+                scene.renderForSpecs();
+
+                expect(isSelected(tileset, root)).toBe(false);
+                expect(isSelected(tileset, externalRoot)).toBe(false);
+                expect(root._visible).toBe(false);
+                expect(externalRoot._visible).toBe(false);
+                expect(tileset.statistics.numberOfTilesCulledWithChildrenUnion).toBe(1);
+            });
+        });
+
         it('does not select visible tiles not meeting SSE with visible children', function() {
             return Cesium3DTilesTester.loadTileset(scene, tilesetReplacementWithViewerRequestVolumeUrl).then(function(tileset) {
                 var root = tileset.root;


### PR DESCRIPTION
Fixes https://github.com/AnalyticalGraphicsInc/cesium/issues/7084

The problem was a tile referencing an external tileset would pass the visibility test but it's child, the root of the external tileset, would not due to the `cullWithChildrenBounds` optimization. This is why #7084 could only be replicated in views where the root's children were all off screen. The external tileset would not refine further and would select its nearest loaded ancestor, causing the tileset to render mixed LODs.

The fix is to use the root tile's visibility in place of its parent's visibility so that the traversal never gets to the parent tile in the first place.

To do:
* [x] Test