### PR TITLE
Fix IE test regressions

### DIFF
--- a/Specs/Scene/ModelSpec.js
+++ b/Specs/Scene/ModelSpec.js
@@ -947,7 +947,7 @@ defineSuite([
             m.show = true;
 
             expect(scene).toRenderAndCall(function(rgba) {
-                expect(rgba).toEqualEpsilon([169, 3, 3, 255], 5); // Red
+                expect(rgba).toEqualEpsilon([169, 3, 3, 255], 10); // Red
             });
 
             primitives.remove(m);
@@ -2292,22 +2292,22 @@ defineSuite([
         // Red
         scene.camera.moveLeft(0.5);
         expect(scene).toRenderAndCall(function(rgba) {
-            expect(rgba[0]).toBeGreaterThan(10);
-            expect(rgba[1]).toBeLessThan(10);
-            expect(rgba[2]).toBeLessThan(10);
+            expect(rgba[0]).toBeGreaterThan(20);
+            expect(rgba[1]).toBeLessThan(20);
+            expect(rgba[2]).toBeLessThan(20);
         });
         // Green
         scene.camera.moveRight(0.5);
         expect(scene).toRenderAndCall(function(rgba) {
-            expect(rgba[0]).toBeLessThan(10);
+            expect(rgba[0]).toBeLessThan(20);
             expect(rgba[1]).toBeGreaterThan(20);
-            expect(rgba[2]).toBeLessThan(10);
+            expect(rgba[2]).toBeLessThan(20);
         });
         // Blue
         scene.camera.moveRight(0.5);
         expect(scene).toRenderAndCall(function(rgba) {
-            expect(rgba[0]).toBeLessThan(10);
-            expect(rgba[1]).toBeLessThan(10);
+            expect(rgba[0]).toBeLessThan(20);
+            expect(rgba[1]).toBeLessThan(20);
             expect(rgba[2]).toBeGreaterThan(20);
         });
     }
@@ -2347,9 +2347,9 @@ defineSuite([
             model.zoomTo();
             expect(scene).toRenderAndCall(function(rgba) {
                 // Emissive texture is red
-                expect(rgba[0]).toBeGreaterThan(10);
-                expect(rgba[1]).toBeLessThan(10);
-                expect(rgba[2]).toBeLessThan(10);
+                expect(rgba[0]).toBeGreaterThan(20);
+                expect(rgba[1]).toBeLessThan(20);
+                expect(rgba[2]).toBeLessThan(20);
             });
 
             primitives.remove(model);

--- a/Specs/Scene/PickSpec.js
+++ b/Specs/Scene/PickSpec.js
@@ -300,7 +300,7 @@ defineSuite([
                 rectangle : Rectangle.fromDegrees(-50.0, -50.0, 50.0, 50.0),
                 granularity : CesiumMath.toRadians(20.0),
                 vertexFormat : EllipsoidSurfaceAppearance.VERTEX_FORMAT,
-                height : 1.0
+                height : 20.0
             });
 
             var instance1 = new GeometryInstance({
@@ -387,7 +387,7 @@ defineSuite([
                 rectangle : Rectangle.fromDegrees(-50.0, -50.0, 50.0, 50.0),
                 granularity : CesiumMath.toRadians(20.0),
                 vertexFormat : EllipsoidSurfaceAppearance.VERTEX_FORMAT,
-                height : 1.0
+                height : 20.0
             });
 
             var instance1 = new GeometryInstance({
@@ -467,6 +467,9 @@ defineSuite([
         });
 
         it('picks the globe', function() {
+            if (!scene.context.depthTexture) {
+                return;
+            }
             return createGlobe().then(function() {
                 expect(scene).toPickFromRayAndCall(function(result) {
                     expect(result.object).toBeUndefined();


### PR DESCRIPTION
Fixes

```
Scene/Pick drillPick can drill pick batched Primitives with show attribute
Scene/Pick drillPick can drill pick batched Primitives without show attribute
Scene/Pick pickFromRay picks the globe
```

in https://github.com/AnalyticalGraphicsInc/cesium/issues/2860#issuecomment-426016048

The first two failed because IE doesn't use log depth and the depth buffer didn't have enough precision for the 1 meter spacing. The third failed because IE doesn't support depth textures which needed to be checked before running that test.

The model fixes are for test failures in the ion sdk.