### PR TITLE
Fix artifacts with Octahedral Projection

### DIFF
--- a/Apps/Sandcastle/gallery/IBL WebGL 1.html
+++ b/Apps/Sandcastle/gallery/IBL WebGL 1.html
@@ -1,3 +1,4 @@
+
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -28,72 +29,152 @@ function startup(Cesium) {
     'use strict';
 //Sandcastle_Begin
 var viewer = new Cesium.Viewer('cesiumContainer');
-    var scene = viewer.scene;
-    scene.skyBox = undefined;
-    scene.sun = undefined;
-    scene.moon = undefined;
-    scene.globe = undefined;
+var scene = viewer.scene;
+scene.skyBox = undefined;
+scene.sun = undefined;
+scene.moon = undefined;
+scene.globe = undefined;
 
-    //scene.context.throwOnWebGLError = true;
+//scene.context.throwOnWebGLError = true;
 
-    var height = 5000000.0;
-    var heading = 0.0;
-    var pitch = 0.0;
-    var roll = 0.0;
-    var hpr = new Cesium.HeadingPitchRoll(heading, pitch, roll);
+var height = 5000000.0;
+var heading = 0.0;
+var pitch = 0.0;
+var mipLevel = 0;
+var roll = 0.0;
+var hpr = new Cesium.HeadingPitchRoll(heading, pitch, roll);
 
-    var origin = Cesium.Cartesian3.fromDegrees(-123.0744619, 44.0503706, height);
-    var modelMatrix = Cesium.Transforms.headingPitchRollToFixedFrame(origin, hpr);
+var origin = Cesium.Cartesian3.fromDegrees(-123.0744619, 44.0503706, height);
+var modelMatrix = Cesium.Transforms.headingPitchRollToFixedFrame(origin, hpr);
 
-    //var diffuseEnvMapURL = '../../SampleData/models/EnvMap/rustig_koppie_envDiffuseHDR.dds';
-    //var specularEnvMapURL = '../../SampleData/models/EnvMap/rustig_koppie_envSpecularHDR.dds';
-    var diffuseEnvMapURL = '../../SampleData/models/EnvMap/gold_roomDiffuseHDR.dds';
-    var specularEnvMapURL = '../../SampleData/models/EnvMap/gold_roomSpecularHDR.dds';
-    var origEnvMapURL = '../../SampleData/models/EnvMap/gold_roomEnvHDR.dds';
-    var modelURL = '../../SampleData/models/Spheres/MetalRoughSpheres.glb';
+//var diffuseEnvMapURL = '../../SampleData/models/EnvMap/rustig_koppie_envDiffuseHDR.dds';
+//var specularEnvMapURL = '../../SampleData/models/EnvMap/rustig_koppie_envSpecularHDR.dds';
+var diffuseEnvMapURL = '../../SampleData/models/EnvMap/gold_roomDiffuseHDR.dds';
+var specularEnvMapURL = '../../SampleData/models/EnvMap/gold_roomSpecularHDR.dds';
+var origEnvMapURL = '../../SampleData/models/EnvMap/gold_roomEnvHDR.dds';
+var modelURL = '../../SampleData/models/Spheres/MetalRoughSpheres.glb';
 
-    var model = scene.primitives.add(Cesium.Model.fromGltf({
-        url : modelURL,
-        modelMatrix : modelMatrix,
-        minimumPixelSize : 128
-    }));
+var model = scene.primitives.add(Cesium.Model.fromGltf({
+    url : modelURL,
+    modelMatrix : modelMatrix,
+    minimumPixelSize : 128
+}));
 
-    model.readyPromise.then(function(model) {
-        var camera = viewer.camera;
+var tex;
 
-        // Zoom to model
-        var controller = scene.screenSpaceCameraController;
-        var r = 2.0 * Math.max(model.boundingSphere.radius, camera.frustum.near);
-        controller.minimumZoomDistance = r * 0.5;
+function createImageFromTexture(gl, texture, width, height) {
+    // Create a framebuffer backed by the texture
+    var framebuffer = gl.createFramebuffer();
+    gl.bindFramebuffer(gl.FRAMEBUFFER, framebuffer);
+    gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, texture, 0);
 
-        var center = Cesium.Matrix4.multiplyByPoint(model.modelMatrix, model.boundingSphere.center, new Cesium.Cartesian3());
-        var heading = Cesium.Math.toRadians(230.0);
-        var pitch = Cesium.Math.toRadians(-20.0);
-        camera.lookAt(center, new Cesium.HeadingPitchRange(heading, pitch, r * 2.0));
+    // Read the contents of the framebuffer
+    var data = new Uint8Array(width * height * 4);
+    gl.readPixels(0, 0, width, height, gl.RGBA, gl.UNSIGNED_BYTE, data);
 
-        loadEnvMap(diffuseEnvMapURL).then(function(cubeMap) {
-            //model.diffuseIrradiance = cubeMap;
-        });
-        loadEnvMap(specularEnvMapURL).then(function(cubeMap) {
-            //model.specularEnvironmentMap = cubeMap;
-        });
-        loadEnvMap(origEnvMapURL).then(function(octahedralMap) {
-            viewCubeMap(octahedralMap);
-        });
-    }).otherwise(function(error){
-        window.alert(error);
+    gl.deleteFramebuffer(framebuffer);
+
+    // Create a 2D canvas to store the result 
+    var canvas = document.createElement('canvas');
+    canvas.width = width;
+    canvas.height = height;
+    var context = canvas.getContext('2d');
+
+    // Copy the pixels to a 2D canvas
+    var imageData = context.createImageData(width, height);
+    imageData.data.set(data);
+    context.putImageData(imageData, 0, 0);
+
+    var img = new Image();
+    img.src = canvas.toDataURL();
+    return img;
+}
+
+model.readyPromise.then(function(model) {
+    var camera = viewer.camera;
+
+    // Zoom to model
+    var controller = scene.screenSpaceCameraController;
+    var r = 2.0 * Math.max(model.boundingSphere.radius, camera.frustum.near);
+    controller.minimumZoomDistance = r * 0.5;
+
+    var center = Cesium.Matrix4.multiplyByPoint(model.modelMatrix, model.boundingSphere.center, new Cesium.Cartesian3());
+    var heading = Cesium.Math.toRadians(230.0);
+    var pitch = Cesium.Math.toRadians(-20.0);
+    camera.lookAt(center, new Cesium.HeadingPitchRange(heading, pitch, r * 2.0));
+
+    loadEnvMap(diffuseEnvMapURL).then(function(cubeMap) {
+        //model.diffuseIrradiance = cubeMap;
     });
+    loadEnvMap(specularEnvMapURL).then(function(cubeMap) {
+        //model.specularEnvironmentMap = cubeMap;
+    });
+    loadEnvMap(origEnvMapURL).then(function(octahedralMap) {
+        viewCubeMap(octahedralMap);
+        //var img = createImageFromTexture(scene.context._gl, octahedralMap._texture, octahedralMap.width, octahedralMap.height);
+        //document.body.appendChild(img);
+        //console.log(img);
+    });
+}).otherwise(function(error){
+    window.alert(error);
+});
 
-    function loadEnvMap(url) {
-        return Cesium.Resource.fetchArrayBuffer({
-            url : url
-        }).then(function(buffer) {
-            var mipLevel = 0;
-            var dds = parseDDS(buffer, true);
-            var width = dds.mipmaps[mipLevel].width;
-            var height = dds.mipmaps[mipLevel].height;
-            var mipmapCount = dds.mipmapCount;
-            console.log(width);
+function loadEnvMap(url) {
+    return Cesium.Resource.fetchArrayBuffer({
+        url : url
+    }).then(function(buffer) {
+        var mipLevel = 0;
+        var dds = parseDDS(buffer, true);
+        var width = dds.mipmaps[mipLevel].width;
+        var height = dds.mipmaps[mipLevel].height;
+        var mipmapCount = dds.mipmapCount;
+
+        var sources = {
+            positiveX : {
+                arrayBufferView : dds.mipmaps[mipLevel].data,
+                width : width,
+                height : height
+            },
+            negativeX : {
+                arrayBufferView : dds.mipmaps[mipLevel + mipmapCount].data,
+                width : width,
+                height : height
+            },
+            positiveY : {
+                arrayBufferView : dds.mipmaps[mipLevel + 2 * mipmapCount].data,
+                width : width,
+                height : height
+            },
+            negativeY : {
+                arrayBufferView : dds.mipmaps[mipLevel + 3 * mipmapCount].data,
+                width : width,
+                height : height
+            },
+            positiveZ : {
+                arrayBufferView : dds.mipmaps[mipLevel + 4 * mipmapCount].data,
+                width : width,
+                height : height
+            },
+            negativeZ : {
+                arrayBufferView : dds.mipmaps[mipLevel + 5 * mipmapCount].data,
+                width : width,
+                height : height
+            }
+        };
+        
+        var cubeMaps = [];
+        cubeMaps.push(
+            new Cesium.CubeMap({
+                context : scene.context,
+                source : sources,
+                pixelDatatype : Cesium.PixelDatatype.FLOAT,
+            })
+        );
+
+        for (var i = 0; i < mipmapCount - 1; ++i) {
+            mipLevel = i + 1;
+            width = dds.mipmaps[mipLevel].width;
+            height = dds.mipmaps[mipLevel].height;
             var sources = {
                 positiveX : {
                     arrayBufferView : dds.mipmaps[mipLevel].data,
@@ -126,8 +207,7 @@ var viewer = new Cesium.Viewer('cesiumContainer');
                     height : height
                 }
             };
-            
-            var cubeMaps = [];
+
             cubeMaps.push(
                 new Cesium.CubeMap({
                     context : scene.context,
@@ -135,382 +215,405 @@ var viewer = new Cesium.Viewer('cesiumContainer');
                     pixelDatatype : Cesium.PixelDatatype.FLOAT,
                 })
             );
+        }
+        
+        return Cesium.packOctahedralMap(cubeMaps, scene.context);
+    });
+}
 
-            for (var i = 0; i < mipmapCount - 1; ++i) {
-                mipLevel = i + 1;
-                width = dds.mipmaps[mipLevel].width;
-                height = dds.mipmaps[mipLevel].height;
-                var sources = {
-                    positiveX : {
-                        arrayBufferView : dds.mipmaps[mipLevel].data,
-                        width : width,
-                        height : height
-                    },
-                    negativeX : {
-                        arrayBufferView : dds.mipmaps[mipLevel + mipmapCount].data,
-                        width : width,
-                        height : height
-                    },
-                    positiveY : {
-                        arrayBufferView : dds.mipmaps[mipLevel + 2 * mipmapCount].data,
-                        width : width,
-                        height : height
-                    },
-                    negativeY : {
-                        arrayBufferView : dds.mipmaps[mipLevel + 3 * mipmapCount].data,
-                        width : width,
-                        height : height
-                    },
-                    positiveZ : {
-                        arrayBufferView : dds.mipmaps[mipLevel + 4 * mipmapCount].data,
-                        width : width,
-                        height : height
-                    },
-                    negativeZ : {
-                        arrayBufferView : dds.mipmaps[mipLevel + 5 * mipmapCount].data,
-                        width : width,
-                        height : height
-                    }
-                };
+function viewCubeMap(octahedralMap, lod) {
+    lod = Cesium.defaultValue(lod, 0.0);
+    var boxGeometryInstance = new Cesium.GeometryInstance({
+        geometry : Cesium.BoxGeometry.fromDimensions({
+            vertexFormat : Cesium.VertexFormat.POSITION_NORMAL_AND_ST,
+            dimensions : new Cesium.Cartesian3(500000.0, 500000.0, 500000.0)
+        })
+    });
 
-                cubeMaps.push(
-                    new Cesium.CubeMap({
-                        context : scene.context,
-                        source : sources,
-                        pixelDatatype : Cesium.PixelDatatype.FLOAT,
-                    })
-                );
-            }
-            
-            return Cesium.packOctahedralMap(cubeMaps, scene.context);
-        });
-    }
+    var customAppearance = {};
+    customAppearance.vertexShaderSource =
+        'attribute vec3 position3DHigh;\n' +
+        'attribute vec3 position3DLow;\n' +
+        'attribute vec3 normal;\n' +
+        'attribute vec2 st;\n' +
+        'attribute float batchId;\n' +
+        '\n' +
+        'varying vec3 v_positionEC;\n' +
+        'varying vec3 v_normalEC;\n' +
+        'varying vec2 v_st;\n' +
+        '\n' +
+        'void main()\n' +
+        '{\n' +
+        '    vec4 p = czm_computePosition();\n' +
+        '    v_st = st;\n' +
+        '\n' +
+        '    v_positionEC = (czm_modelViewRelativeToEye * p).xyz;\n' +
+        '    v_normalEC = czm_normal * normal;\n' +
+        '\n' +
+        '    gl_Position = czm_modelViewProjectionRelativeToEye * p;\n' +
+        '}';
+    customAppearance.fragmentShaderSource =
+        `uniform sampler2D u_octahedralMap;
+        varying vec3 v_positionEC; 
+        varying vec3 v_normalEC; 
 
-    function viewCubeMap(octahedralMap, lod) {
-        lod = Cesium.defaultValue(lod, 0.0);
-        var boxGeometryInstance = new Cesium.GeometryInstance({
-            geometry : Cesium.BoxGeometry.fromDimensions({
-                vertexFormat : Cesium.VertexFormat.POSITION_NORMAL_AND_ST,
-                dimensions : new Cesium.Cartesian3(500000.0, 500000.0, 500000.0)
-            })
-        });
+        varying vec2 v_st; 
+        uniform float mipLevelVal;
 
-        var customAppearance = {};
-        customAppearance.vertexShaderSource =
-            'attribute vec3 position3DHigh;\n' +
-            'attribute vec3 position3DLow;\n' +
-            'attribute vec3 normal;\n' +
-            'attribute vec2 st;\n' +
-            'attribute float batchId;\n' +
-            '\n' +
-            'varying vec3 v_positionEC;\n' +
-            'varying vec3 v_normalEC;\n' +
-            '\n' +
-            'void main()\n' +
-            '{\n' +
-            '    vec4 p = czm_computePosition();\n' +
-            '\n' +
-            '    v_positionEC = (czm_modelViewRelativeToEye * p).xyz;\n' +
-            '    v_normalEC = czm_normal * normal;\n' +
-            '\n' +
-            '    gl_Position = czm_modelViewProjectionRelativeToEye * p;\n' +
-            '}';
-        customAppearance.fragmentShaderSource =
-            `uniform sampler2D u_octahedralMap;
-            varying vec3 v_positionEC; 
-            varying vec3 v_normalEC; 
+        vec2 octahedralProjection(vec3 dir) {
+            dir /= dot(vec3(1.0), abs(dir));
+            vec2 rev = abs(dir.zx) - vec2(1.0,1.0);
+            vec2 neg = vec2(dir.x < 0.0 ? rev.x : -rev.x,
+                            dir.z < 0.0 ? rev.y : -rev.y);
+            vec2 uv = dir.y < 0.0 ? neg : dir.xz; 
 
-            vec2 octahedralProjection(vec3 dir) {
-                dir /= dot(vec3(1.0), abs(dir));
-                vec2 rev = abs(dir.zx) - vec2(1.0,1.0);
-                vec2 neg = vec2(dir.x < 0.0 ? rev.x : -rev.x,
-                                dir.z < 0.0 ? rev.y : -rev.y);
-                vec2 uv = dir.y < 0.0 ? neg : dir.xz; 
+            return 0.5 * uv + vec2(0.5, 0.5);
+        }
 
-                return 0.5 * uv + vec2(0.5, 0.5);
+        void main() 
+        {
+            // This is the texture size 
+            vec2 textureSize = vec2(1538.0, 1024.0);
+            vec2 pixel = 1.0 / textureSize;
+
+            vec3 sampleDirection = normalize((czm_inverseModelView * vec4(v_positionEC, 1.0)).xyz);
+            vec2 coord = octahedralProjection(sampleDirection); 
+          
+            float mipLevel = mipLevelVal;
+
+            if (mipLevel > 0.0){
+                // Each subseqeuent mip level is half the size
+                float scale = 1.0/pow(2.0, mipLevel);
+                float offset = ((textureSize.y + 1.0) / textureSize.x);
+
+                coord.x *= offset;
+                coord *= scale;
+                
+                coord.x += offset + pixel.x;
+                
+                coord.y += (1.0 - (1.0/pow(2.0, mipLevel-1.0))) + pixel.y * (mipLevel - 1.0) * 2.0;
+                
+            } else {
+                coord.x *= (textureSize.y / textureSize.x);
             }
 
-            void main() 
-            {
-                vec3 sampleDirection = normalize((czm_inverseModelView * vec4(v_positionEC, 1.0)).xyz);
-                vec2 projected = octahedralProjection(sampleDirection);
-                float mipCount = 10.0; 
-
-                projected.x /= mipCount; 
-
-                vec3 color = texture2D(u_octahedralMap, projected).rgb;
-                gl_FragColor = vec4(color, 1.0);
-            }`;
-        customAppearance.isTranslucent = function() {
-            return false;
+            vec3 color = texture2D(u_octahedralMap, coord).rgb;
+            gl_FragColor = vec4(color, 1.0);
+        }`;
+    customAppearance.isTranslucent = function() {
+        return false;
+    };
+    customAppearance.getRenderState = function() {
+        return {
+            depthTest : {
+                enabled : true
+            }
         };
-        customAppearance.getRenderState = function() {
-            return {
-                depthTest : {
-                    enabled : true
-                }
-            };
-        };
-        customAppearance.getVertexShaderSource = function() {
-            return this.vertexShaderSource;
-        };
-        customAppearance.getFragmentShaderSource = function() {
-            return this.fragmentShaderSource;
-        };
-        customAppearance.material = {
-            update : function() {
+    };
+    customAppearance.getVertexShaderSource = function() {
+        return this.vertexShaderSource;
+    };
+    customAppearance.getFragmentShaderSource = function() {
+        return this.fragmentShaderSource;
+    };
+    customAppearance.material = {
+        update : function() {
+        },
+        _uniforms : {
+            u_octahedralMap : function() {
+                return octahedralMap;
             },
-            _uniforms : {
-                u_octahedralMap : function() {
-                    return octahedralMap;
-                }
+            mipLevelVal : function() {
+                return mipLevel
             }
-        };
-        scene.primitives.add(new Cesium.Primitive({
-            geometryInstances : boxGeometryInstance,
-            appearance : customAppearance,
-            asynchronous : false,
-            modelMatrix : modelMatrix
-        }));
+        }
+    };
+    scene.primitives.add(new Cesium.Primitive({
+        geometryInstances : boxGeometryInstance,
+        appearance : customAppearance,
+        asynchronous : false,
+        modelMatrix : modelMatrix
+    }));
+}
+
+function DrawTexture(texture){
+    var material = new Cesium.Material({
+        fabric : {
+            uniforms : {
+                image : texture,
+            },
+            components : {
+                diffuse : 'texture2D(image, materialInput.st).rgb',
+            }
+        }
+    });
+    
+    var viewportQuad = new Cesium.ViewportQuad(new Cesium.BoundingRectangle(0, 0, texture.width, texture.height), material);
+    viewer.scene.primitives.add(viewportQuad);
+}
+
+var drawn = false;
+
+scene.postRender.addEventListener(function(){
+  if(tex && !drawn) {
+    drawn = true;
+    DrawTexture(tex)
+  }
+})
+
+// Temporary code to parse DDS files for loading environment maps adapted from threejs:
+//    https://github.com/mrdoob/three.js/blob/dev/examples/js/loaders/DDSLoader.js
+function parseDDS(buffer, loadMipmaps) {
+    var dds = {mipmaps : [], width : 0, height : 0, format : null, mipmapCount : 1};
+
+    // Adapted from @toji's DDS utils
+    // https://github.com/toji/webgl-texture-utils/blob/master/texture-util/dds.js
+
+    // All values and structures referenced from:
+    // http://msdn.microsoft.com/en-us/library/bb943991.aspx/
+
+    var DDS_MAGIC = 0x20534444;
+
+    var DDSD_CAPS = 0x1,
+        DDSD_HEIGHT = 0x2,
+        DDSD_WIDTH = 0x4,
+        DDSD_PITCH = 0x8,
+        DDSD_PIXELFORMAT = 0x1000,
+        DDSD_MIPMAPCOUNT = 0x20000,
+        DDSD_LINEARSIZE = 0x80000,
+        DDSD_DEPTH = 0x800000;
+
+    var DDSCAPS_COMPLEX = 0x8,
+        DDSCAPS_MIPMAP = 0x400000,
+        DDSCAPS_TEXTURE = 0x1000;
+
+    var DDSCAPS2_CUBEMAP = 0x200,
+        DDSCAPS2_CUBEMAP_POSITIVEX = 0x400,
+        DDSCAPS2_CUBEMAP_NEGATIVEX = 0x800,
+        DDSCAPS2_CUBEMAP_POSITIVEY = 0x1000,
+        DDSCAPS2_CUBEMAP_NEGATIVEY = 0x2000,
+        DDSCAPS2_CUBEMAP_POSITIVEZ = 0x4000,
+        DDSCAPS2_CUBEMAP_NEGATIVEZ = 0x8000,
+        DDSCAPS2_VOLUME = 0x200000;
+
+    var DDPF_ALPHAPIXELS = 0x1,
+        DDPF_ALPHA = 0x2,
+        DDPF_FOURCC = 0x4,
+        DDPF_RGB = 0x40,
+        DDPF_YUV = 0x200,
+        DDPF_LUMINANCE = 0x20000;
+
+    function fourCCToInt32(value) {
+        return value.charCodeAt(0) +
+               (value.charCodeAt(1) << 8) +
+               (value.charCodeAt(2) << 16) +
+               (value.charCodeAt(3) << 24);
+
     }
 
-    // Temporary code to parse DDS files for loading environment maps adapted from threejs:
-    //    https://github.com/mrdoob/three.js/blob/dev/examples/js/loaders/DDSLoader.js
-    function parseDDS(buffer, loadMipmaps) {
-        var dds = {mipmaps : [], width : 0, height : 0, format : null, mipmapCount : 1};
+    function int32ToFourCC(value) {
+        return String.fromCharCode(
+            value & 0xff,
+            (value >> 8) & 0xff,
+            (value >> 16) & 0xff,
+            (value >> 24) & 0xff
+        );
+    }
 
-        // Adapted from @toji's DDS utils
-        // https://github.com/toji/webgl-texture-utils/blob/master/texture-util/dds.js
-
-        // All values and structures referenced from:
-        // http://msdn.microsoft.com/en-us/library/bb943991.aspx/
-
-        var DDS_MAGIC = 0x20534444;
-
-        var DDSD_CAPS = 0x1,
-            DDSD_HEIGHT = 0x2,
-            DDSD_WIDTH = 0x4,
-            DDSD_PITCH = 0x8,
-            DDSD_PIXELFORMAT = 0x1000,
-            DDSD_MIPMAPCOUNT = 0x20000,
-            DDSD_LINEARSIZE = 0x80000,
-            DDSD_DEPTH = 0x800000;
-
-        var DDSCAPS_COMPLEX = 0x8,
-            DDSCAPS_MIPMAP = 0x400000,
-            DDSCAPS_TEXTURE = 0x1000;
-
-        var DDSCAPS2_CUBEMAP = 0x200,
-            DDSCAPS2_CUBEMAP_POSITIVEX = 0x400,
-            DDSCAPS2_CUBEMAP_NEGATIVEX = 0x800,
-            DDSCAPS2_CUBEMAP_POSITIVEY = 0x1000,
-            DDSCAPS2_CUBEMAP_NEGATIVEY = 0x2000,
-            DDSCAPS2_CUBEMAP_POSITIVEZ = 0x4000,
-            DDSCAPS2_CUBEMAP_NEGATIVEZ = 0x8000,
-            DDSCAPS2_VOLUME = 0x200000;
-
-        var DDPF_ALPHAPIXELS = 0x1,
-            DDPF_ALPHA = 0x2,
-            DDPF_FOURCC = 0x4,
-            DDPF_RGB = 0x40,
-            DDPF_YUV = 0x200,
-            DDPF_LUMINANCE = 0x20000;
-
-        function fourCCToInt32(value) {
-            return value.charCodeAt(0) +
-                   (value.charCodeAt(1) << 8) +
-                   (value.charCodeAt(2) << 16) +
-                   (value.charCodeAt(3) << 24);
-
-        }
-
-        function int32ToFourCC(value) {
-            return String.fromCharCode(
-                value & 0xff,
-                (value >> 8) & 0xff,
-                (value >> 16) & 0xff,
-                (value >> 24) & 0xff
-            );
-        }
-
-        function loadARGBMip(buffer, dataOffset, width, height) {
-            var dataLength = width * height * 4;
-            //var srcBuffer = new Uint8Array(buffer, dataOffset, dataLength);
-            //var byteArray = new Uint8Array(dataLength);
-            var srcBuffer = new Float32Array(buffer, dataOffset, dataLength);
-            var byteArray = new Float32Array(dataLength);
-            var dst = 0;
-            var src = 0;
-            for (var y = 0; y < height; y++) {
-                for (var x = 0; x < width; x++) {
-                    /*
-                    var b = srcBuffer[src];
-                    src++;
-                    var g = srcBuffer[src];
-                    src++;
-                    var r = srcBuffer[src];
-                    src++;
-                    */
-                    var r = srcBuffer[src];
-                    src++;
-                    var g = srcBuffer[src];
-                    src++;
-                    var b = srcBuffer[src];
-                    src++;
-                    var a = srcBuffer[src];
-                    src++;
-                    byteArray[dst] = r;
-                    dst++;  //r
-                    byteArray[dst] = g;
-                    dst++;  //g
-                    byteArray[dst] = b;
-                    dst++;  //b
-                    byteArray[dst] = a;
-                    dst++;  //a
-                }
-            }
-            return byteArray;
-        }
-
-        var FOURCC_DXT1 = fourCCToInt32("DXT1");
-        var FOURCC_DXT3 = fourCCToInt32("DXT3");
-        var FOURCC_DXT5 = fourCCToInt32("DXT5");
-        var FOURCC_ETC1 = fourCCToInt32("ETC1");
-
-        var headerLengthInt = 31; // The header length in 32 bit ints
-
-        // Offsets into the header array
-
-        var off_magic = 0;
-
-        var off_size = 1;
-        var off_flags = 2;
-        var off_height = 3;
-        var off_width = 4;
-
-        var off_mipmapCount = 7;
-
-        var off_pfFlags = 20;
-        var off_pfFourCC = 21;
-        var off_RGBBitCount = 22;
-        var off_RBitMask = 23;
-        var off_GBitMask = 24;
-        var off_BBitMask = 25;
-        var off_ABitMask = 26;
-
-        var off_caps = 27;
-        var off_caps2 = 28;
-        var off_caps3 = 29;
-        var off_caps4 = 30;
-
-        // Parse header
-
-        var header = new Int32Array(buffer, 0, headerLengthInt);
-
-        if (header[off_magic] !== DDS_MAGIC) {
-            console.error('Invalid magic number in DDS header.');
-            return dds;
-        }
-
-        /*
-        if (!header[off_pfFlags] & DDPF_FOURCC) {
-            console.error('TUnsupported format, must contain a FourCC code.');
-            return dds;
-        }
-        */
-
-        var blockBytes;
-        var fourCC = header[off_pfFourCC];
-        var isRGBAUncompressed = false;
-
-        switch (fourCC) {
-            case FOURCC_DXT1:
-                blockBytes = 8;
-                dds.format = Cesium.PixelFormat.RGB_DXT1;
-                break;
-            case FOURCC_DXT3:
-                blockBytes = 16;
-                dds.format = Cesium.PixelFormat.RGBA_DXT3;
-                break;
-            case FOURCC_DXT5:
-                blockBytes = 16;
-                dds.format = Cesium.PixelFormat.RGBA_DXT5;
-                break;
-            case FOURCC_ETC1:
-                blockBytes = 8;
-                dds.format = Cesium.PixelFormat.RGB_ETC1;
-                break;
-            default:
-                //if (header[off_RGBBitCount] === 32
-                //    && header[off_RBitMask] & 0xff0000
-                //    && header[off_GBitMask] & 0xff00
-                //    && header[off_BBitMask] & 0xff
-                //    && header[off_ABitMask] & 0xff000000) {
-
-                    isRGBAUncompressed = true;
-                    blockBytes = 64;
-                    dds.format = Cesium.PixelFormat.RGBA;
-                //} else {
-                //    console.error('THREE.DDSLoader.parse: Unsupported FourCC code ', int32ToFourCC(fourCC));
-                //    return dds;
-                //}
-
-        }
-
-        dds.mipmapCount = 1;
-
-        if (header[off_flags] & DDSD_MIPMAPCOUNT && loadMipmaps !== false) {
-            dds.mipmapCount = Math.max(1, header[off_mipmapCount]);
-        }
-
-        var caps2 = header[off_caps2];
-        dds.isCubemap = caps2 & DDSCAPS2_CUBEMAP ? true : false;
-        if (dds.isCubemap && (
-            !(caps2 & DDSCAPS2_CUBEMAP_POSITIVEX) ||
-            !(caps2 & DDSCAPS2_CUBEMAP_NEGATIVEX) ||
-            !(caps2 & DDSCAPS2_CUBEMAP_POSITIVEY) ||
-            !(caps2 & DDSCAPS2_CUBEMAP_NEGATIVEY) ||
-            !(caps2 & DDSCAPS2_CUBEMAP_POSITIVEZ) ||
-            !(caps2 & DDSCAPS2_CUBEMAP_NEGATIVEZ)
-        )) {
-            console.error('Incomplete cubemap faces');
-            return dds;
-        }
-
-        dds.width = header[off_width];
-        dds.height = header[off_height];
-
-        var dataOffset = header[off_size] + 4;
-
-        // Extract mipmaps buffers
-
-        var faces = dds.isCubemap ? 6 : 1;
-
-        for (var face = 0; face < faces; face++) {
-            var width = dds.width;
-            var height = dds.height;
-            for (var i = 0; i < dds.mipmapCount; i++) {
-                var byteArray;
-                var dataLength;
-                if (isRGBAUncompressed) {
-                    byteArray = loadARGBMip(buffer, dataOffset, width, height);
-                    dataLength = byteArray.byteLength;
-                } else {
-                    dataLength = Math.max(4, width) / 4 * Math.max(4, height) / 4 * blockBytes;
-                    byteArray = new Uint8Array(buffer, dataOffset, dataLength);
-                }
-
-                var mipmap = {"data" : byteArray, "width" : width, "height" : height};
-                dds.mipmaps.push(mipmap);
-
-                dataOffset += dataLength;
-
-                width = Math.max(width >> 1, 1);
-                height = Math.max(height >> 1, 1);
+    function loadARGBMip(buffer, dataOffset, width, height) {
+        var dataLength = width * height * 4;
+        //var srcBuffer = new Uint8Array(buffer, dataOffset, dataLength);
+        //var byteArray = new Uint8Array(dataLength);
+        var srcBuffer = new Float32Array(buffer, dataOffset, dataLength);
+        var byteArray = new Float32Array(dataLength);
+        var dst = 0;
+        var src = 0;
+        for (var y = 0; y < height; y++) {
+            for (var x = 0; x < width; x++) {
+                /*
+                var b = srcBuffer[src];
+                src++;
+                var g = srcBuffer[src];
+                src++;
+                var r = srcBuffer[src];
+                src++;
+                */
+                var r = srcBuffer[src];
+                src++;
+                var g = srcBuffer[src];
+                src++;
+                var b = srcBuffer[src];
+                src++;
+                var a = srcBuffer[src];
+                src++;
+                byteArray[dst] = r;
+                dst++;  //r
+                byteArray[dst] = g;
+                dst++;  //g
+                byteArray[dst] = b;
+                dst++;  //b
+                byteArray[dst] = a;
+                dst++;  //a
             }
         }
+        return byteArray;
+    }
+
+    var FOURCC_DXT1 = fourCCToInt32("DXT1");
+    var FOURCC_DXT3 = fourCCToInt32("DXT3");
+    var FOURCC_DXT5 = fourCCToInt32("DXT5");
+    var FOURCC_ETC1 = fourCCToInt32("ETC1");
+
+    var headerLengthInt = 31; // The header length in 32 bit ints
+
+    // Offsets into the header array
+
+    var off_magic = 0;
+
+    var off_size = 1;
+    var off_flags = 2;
+    var off_height = 3;
+    var off_width = 4;
+
+    var off_mipmapCount = 7;
+
+    var off_pfFlags = 20;
+    var off_pfFourCC = 21;
+    var off_RGBBitCount = 22;
+    var off_RBitMask = 23;
+    var off_GBitMask = 24;
+    var off_BBitMask = 25;
+    var off_ABitMask = 26;
+
+    var off_caps = 27;
+    var off_caps2 = 28;
+    var off_caps3 = 29;
+    var off_caps4 = 30;
+
+    // Parse header
+
+    var header = new Int32Array(buffer, 0, headerLengthInt);
+
+    if (header[off_magic] !== DDS_MAGIC) {
+        console.error('Invalid magic number in DDS header.');
         return dds;
     }
+
+    /*
+    if (!header[off_pfFlags] & DDPF_FOURCC) {
+        console.error('TUnsupported format, must contain a FourCC code.');
+        return dds;
+    }
+    */
+
+    var blockBytes;
+    var fourCC = header[off_pfFourCC];
+    var isRGBAUncompressed = false;
+
+    switch (fourCC) {
+        case FOURCC_DXT1:
+            blockBytes = 8;
+            dds.format = Cesium.PixelFormat.RGB_DXT1;
+            break;
+        case FOURCC_DXT3:
+            blockBytes = 16;
+            dds.format = Cesium.PixelFormat.RGBA_DXT3;
+            break;
+        case FOURCC_DXT5:
+            blockBytes = 16;
+            dds.format = Cesium.PixelFormat.RGBA_DXT5;
+            break;
+        case FOURCC_ETC1:
+            blockBytes = 8;
+            dds.format = Cesium.PixelFormat.RGB_ETC1;
+            break;
+        default:
+            //if (header[off_RGBBitCount] === 32
+            //    && header[off_RBitMask] & 0xff0000
+            //    && header[off_GBitMask] & 0xff00
+            //    && header[off_BBitMask] & 0xff
+            //    && header[off_ABitMask] & 0xff000000) {
+
+                isRGBAUncompressed = true;
+                blockBytes = 64;
+                dds.format = Cesium.PixelFormat.RGBA;
+            //} else {
+            //    console.error('THREE.DDSLoader.parse: Unsupported FourCC code ', int32ToFourCC(fourCC));
+            //    return dds;
+            //}
+
+    }
+
+    dds.mipmapCount = 1;
+
+    if (header[off_flags] & DDSD_MIPMAPCOUNT && loadMipmaps !== false) {
+        dds.mipmapCount = Math.max(1, header[off_mipmapCount]);
+    }
+
+    var caps2 = header[off_caps2];
+    dds.isCubemap = caps2 & DDSCAPS2_CUBEMAP ? true : false;
+    if (dds.isCubemap && (
+        !(caps2 & DDSCAPS2_CUBEMAP_POSITIVEX) ||
+        !(caps2 & DDSCAPS2_CUBEMAP_NEGATIVEX) ||
+        !(caps2 & DDSCAPS2_CUBEMAP_POSITIVEY) ||
+        !(caps2 & DDSCAPS2_CUBEMAP_NEGATIVEY) ||
+        !(caps2 & DDSCAPS2_CUBEMAP_POSITIVEZ) ||
+        !(caps2 & DDSCAPS2_CUBEMAP_NEGATIVEZ)
+    )) {
+        console.error('Incomplete cubemap faces');
+        return dds;
+    }
+
+    dds.width = header[off_width];
+    dds.height = header[off_height];
+
+    var dataOffset = header[off_size] + 4;
+
+    // Extract mipmaps buffers
+
+    var faces = dds.isCubemap ? 6 : 1;
+
+    for (var face = 0; face < faces; face++) {
+        var width = dds.width;
+        var height = dds.height;
+        for (var i = 0; i < dds.mipmapCount; i++) {
+            var byteArray;
+            var dataLength;
+            if (isRGBAUncompressed) {
+                byteArray = loadARGBMip(buffer, dataOffset, width, height);
+                dataLength = byteArray.byteLength;
+            } else {
+                dataLength = Math.max(4, width) / 4 * Math.max(4, height) / 4 * blockBytes;
+                byteArray = new Uint8Array(buffer, dataOffset, dataLength);
+            }
+
+            var mipmap = {"data" : byteArray, "width" : width, "height" : height};
+            dds.mipmaps.push(mipmap);
+
+            dataOffset += dataLength;
+
+            width = Math.max(width >> 1, 1);
+            height = Math.max(height >> 1, 1);
+        }
+    }
+    return dds;
+}
+
+var handler = new Cesium.ScreenSpaceEventHandler(viewer.canvas);
+
+handler.setInputAction(function(movement) {
+    mipLevel --;
+    if(mipLevel < 0) mipLevel = 0;
+    if(mipLevel > 5) mipLevel = 5;
+}, Cesium.ScreenSpaceEventType.LEFT_DOWN);
+
+handler.setInputAction(function(movement) {
+    mipLevel ++;
+    if(mipLevel < 0) mipLevel = 0;
+    if(mipLevel > 5) mipLevel = 5;
+}, Cesium.ScreenSpaceEventType.RIGHT_DOWN);
+
+
 
 //Sandcastle_End
     Sandcastle.finishedLoading();

--- a/Source/Renderer/packOctahedralMap.js
+++ b/Source/Renderer/packOctahedralMap.js
@@ -11,7 +11,10 @@ define([
         './VertexArray',
         './DrawCommand',
         './RenderState',
-        './ShaderProgram'
+        './ShaderProgram',
+        './Sampler',
+        './TextureMinificationFilter',
+        './TextureMagnificationFilter'
     ], function(
         defined,
         DeveloperError,
@@ -25,7 +28,10 @@ define([
         VertexArray,
         DrawCommand,
         RenderState,
-        ShaderProgram) {
+        ShaderProgram,
+        Sampler,
+        TextureMinificationFilter,
+        TextureMagnificationFilter) {
     'use strict';
 
     /**
@@ -52,21 +58,6 @@ define([
             throw new DeveloperError('context is required.');
         }
         //>>includeEnd('debug');
-        var originalSize = cubeMaps[0]._size * 2;
-
-        var texture = new Texture({
-            context : context, 
-            width : originalSize * 1.5,
-            height : originalSize * 1.5,
-            pixelDataType : cubeMaps[0]._pixelDatatype,
-            pixelFormat : cubeMaps[0]._pixelFormat
-        });
-
-        var framebuffer = new Framebuffer({
-            context : context, 
-            colorTextures : [texture],
-            destroyAttachments : false
-        });
 
         var vertexArray = makeOctahedronVertexArray(context);
         var shaderProgram = ShaderProgram.fromCache({
@@ -79,25 +70,35 @@ define([
                 }
             });
 
-        var length = cubeMaps.length; 
+        // We only need up to 6 mip levels to avoid artifacts. 
+        var length = Math.min(cubeMaps.length,6); 
         var command; 
+        var uniformMap = {};
 
+        // First we project each cubemap onto a flat octahedron, and write that to a texture.
         for (var i = 0; i < length; ++i) {
             var factor = (1/Math.pow(2,i));
-            var size = originalSize * factor;
-            var xOffset = 0; 
-            var yOffset = 0;
+            var size = cubeMaps[i]._size * 2;
 
-            if (i > 0) {
-                xOffset = originalSize + 1;
-                yOffset = (1 - (1/Math.pow(2,i-1))) * originalSize + (i-1);
-            }
+            var mipTexture = new Texture({
+                context : context, 
+                width : size, 
+                height : size,
+                pixelDataType : cubeMaps[i]._pixelDatatype,
+                pixelFormat : cubeMaps[i]._pixelFormat
+            });
+
+            var mipFramebuffer = new Framebuffer({
+                context : context, 
+                colorTextures : [mipTexture],
+                destroyAttachments : false
+            });
 
             command = new DrawCommand({
                 vertexArray : vertexArray,
                 primitiveType : PrimitiveType.TRIANGLES,
                 renderState : RenderState.fromCache({
-                    viewport : new BoundingRectangle(xOffset, yOffset, size, size)
+                    viewport : new BoundingRectangle(0, 0, size, size)
                 }),
                 shaderProgram : shaderProgram,
                 uniformMap : {
@@ -105,11 +106,123 @@ define([
                         return cubeMaps[i];
                     }
                 },
-                framebuffer : framebuffer
+                framebuffer : mipFramebuffer
             });
 
             command.execute(context);
+
+            mipFramebuffer.destroy();
+
+            uniformMap['texture' + i] = (function(capturedTexture){
+                return function(){
+                    return capturedTexture
+                }
+            })(mipTexture);   
+            
+            
         }
+
+        var originalSize = cubeMaps[0]._size * 2;
+
+        var texture = new Texture({
+            context : context, 
+            width : originalSize * 1.5 + 2, // We add a 1 pixel border to avoid linear sampling artifacts.
+            height : originalSize,
+            pixelDataType : cubeMaps[0]._pixelDatatype,
+            pixelFormat : cubeMaps[0]._pixelFormat
+        });
+
+        var framebuffer = new Framebuffer({
+            context : context, 
+            colorTextures : [texture],
+            destroyAttachments : false
+        });
+
+        // Now render all those textures onto an atlas.
+        var fs = `
+            varying vec2 v_textureCoordinates;
+            uniform sampler2D texture0; 
+            uniform sampler2D texture1;
+            uniform sampler2D texture2;
+            uniform sampler2D texture3;
+            uniform sampler2D texture4;
+            uniform sampler2D texture5; 
+
+            void main()
+            {
+                vec2 uv = v_textureCoordinates;
+                vec2 textureSize = vec2(${originalSize * 1.5 + 2}.0, ${originalSize}.0);
+                vec2 pixel = 1.0 / textureSize;
+                
+                float mipLevel = 0.0;
+
+                if (uv.x - pixel.x > (textureSize.y / textureSize.x)) {
+                    mipLevel = 1.0;
+                    if (uv.y - pixel.y > 1.0 - (1.0/pow(2.0, mipLevel)) ) {
+                        mipLevel = 2.0;
+                        if (uv.y - pixel.y * 3.0 > 1.0 - (1.0/pow(2.0, mipLevel)) ) {
+                            mipLevel = 3.0;
+                            if (uv.y - pixel.y * 5.0 > 1.0 - (1.0/pow(2.0, mipLevel)) ) {
+                                mipLevel = 4.0;
+                                if (uv.y - pixel.y * 7.0 > 1.0 - (1.0/pow(2.0, mipLevel)) ) {
+                                    mipLevel = 5.0;
+                                }
+                            }
+                        }
+                    }
+                }
+
+                if (mipLevel > 0.0) {
+                    float scale = pow(2.0, mipLevel);
+
+                    uv.y -= (pixel.y * (mipLevel-1.0) * 2.0);
+                    uv.x *= ((textureSize.x - 2.0) / textureSize.y);
+
+                    uv.x -= 1.0 + pixel.x;
+                    uv.y -= (1.0 - (1.0/pow(2.0, mipLevel-1.0)));
+                    uv *= scale;
+
+                } else {
+                    uv.x *= (textureSize.x / textureSize.y);
+                }
+
+                if(mipLevel == 0.0) {
+                    gl_FragColor = texture2D(texture0, uv);
+                }
+
+                if(mipLevel == 1.0) {
+                    gl_FragColor = texture2D(texture1, uv);
+                }
+
+                if(mipLevel == 2.0) {
+                    gl_FragColor = texture2D(texture2, uv);
+                }
+
+                if(mipLevel == 3.0) {
+                    gl_FragColor = texture2D(texture3, uv);
+                }
+
+                if(mipLevel == 4.0) {
+                    gl_FragColor = texture2D(texture4, uv);
+                }
+
+                if(mipLevel == 5.0) {
+                    gl_FragColor = texture2D(texture5, uv);
+                }
+
+                
+            }
+            `;
+
+        command = context.createViewportQuadCommand(fs, {
+            framebuffer : framebuffer,
+            renderState : RenderState.fromCache({
+                viewport : new BoundingRectangle(0.0, 0.0, originalSize * 1.5 + 2, originalSize)
+            }),
+            uniformMap : uniformMap
+        });
+
+        command.execute(context);
 
         return texture;
     }
@@ -215,6 +328,7 @@ define([
 
     void main()
         {
+            
             gl_FragColor = textureCube(cubeMap, v_cubeMapCoordinates);
         }
     `;

--- a/Source/Renderer/packOctahedralMap.js
+++ b/Source/Renderer/packOctahedralMap.js
@@ -57,7 +57,7 @@ define([
         var texture = new Texture({
             context : context, 
             width : originalSize * 1.5,
-            height : originalSize,
+            height : originalSize * 1.5,
             pixelDataType : cubeMaps[0]._pixelDatatype,
             pixelFormat : cubeMaps[0]._pixelFormat
         });


### PR DESCRIPTION
@bagnell  This fixes the black artifacts I was seeing with unwrapping the octahedral projection. Notice the black lines that become more obvious at lower mips:

![unwrapping](https://user-images.githubusercontent.com/1711126/46550129-1527ff00-c8a2-11e8-92e2-543ee94cc1f9.gif)

This was happening because as you sample pixels at the edge, the linear filtering will take some of the black pixels. Pushing it 1 or half a pixel away causes seams to be visible. 

What I do now is have a border that duplicates the last pixel, so when it does do the linear interpolation it uses the correct pixel. This effectively simulates linear filtering on all the pixels but nearest/clamped on border pixels. 

The result:

![unwrapping_fixed](https://user-images.githubusercontent.com/1711126/46550125-11947800-c8a2-11e8-99b3-4f5e9514c27f.gif)

The cost is one more draw call when constructing this. The `Apps/Sandcastle/gallery/IBL WebGL 1.html` is an example of unwrapping this projection correctly. 

