### PR TITLE
Fix Octahedral sampling artifacts

### DIFF
--- a/Source/Scene/Model.js
+++ b/Source/Scene/Model.js
@@ -2925,7 +2925,7 @@ define([
 
     function createSpecularEnvironmentMapLOD(model) {
         return function() {
-            return model._specularEnvironmentMapAtlas.maximumMipmapLevel - 1;
+            return model._specularEnvironmentMapAtlas.maximumMipmapLevel;
         };
     }
 

--- a/Source/Scene/OctahedralProjectedCubeMap.js
+++ b/Source/Scene/OctahedralProjectedCubeMap.js
@@ -192,7 +192,8 @@ define([
         });
 
         // We only need up to 6 mip levels to avoid artifacts.
-        var length = this._maximumMipmapLevel = Math.min(cubeMaps.length, 6);
+        var length = Math.min(cubeMaps.length, 6);
+        this._maximumMipmapLevel = length - 1;
         var mipTextures = this._mipTextures = new Array(length);
         var originalSize = cubeMaps[0].width * 2.0;
         var uniformMap = {

--- a/Source/Scene/processPbrMaterials.js
+++ b/Source/Scene/processPbrMaterials.js
@@ -646,7 +646,7 @@ define([
             fragmentShader += '    vec3 specularContribution = F * G * D / (4.0 * NdotL * NdotV);\n';
             fragmentShader += '    vec3 color = NdotL * lightColor * (diffuseContribution + specularContribution);\n';
 
-            
+            /*
             fragmentShader += '    vec3 r = normalize(czm_inverseViewRotation * normalize(reflect(v, n)));\n';
             // Figure out if the reflection vector hits the ellipsoid
             fragmentShader += '    czm_ellipsoid ellipsoid = czm_getWgs84EllipsoidEC();\n';
@@ -686,30 +686,22 @@ define([
             fragmentShader += '    specularIrradiance = mix(specularIrradiance, belowHorizonColor, smoothstep(aroundHorizon, farBelowHorizon, reflectionDotNadir) * inverseRoughness);\n';
             fragmentShader += '    specularIrradiance = mix(specularIrradiance, nadirColor, smoothstep(farBelowHorizon, 1.0, reflectionDotNadir) * inverseRoughness);\n';
 
-            // Angle between sun and zenith
-            fragmentShader += '    float S = acos(clamp(dot(normalize(czm_inverseViewRotation * l), normalize(v_positionWC * -1.0)), 0.001, 1.0));\n'
-            // Angle between zenith and current pixel 
-            fragmentShader += '    float theta = acos(clamp(dot(normalize(czm_inverseViewRotation * n), normalize(v_positionWC * -1.0)), 0.001, 1.0));\n'
-            // Angle between sun and current pixel
-            fragmentShader += '    float gamma = acos(NdotL);\n'
-            fragmentShader += '    float luminanceAtZenith = 10.0;\n' 
-            fragmentShader += '    float luminance = luminanceAtZenith * (((0.91 + 10.0 * exp(-3.0 * gamma) + 0.45 * pow(cos(gamma), 2.0)) * (1.0 - exp(-0.32 / cos(theta)))) / (0.91 + 10.0 * exp(-3.0 * S) + 0.45 * pow(cos(S),2.0)) * (1.0 - exp(-0.32)));\n'
-
             fragmentShader += '    vec2 brdfLut = texture2D(czm_brdfLut, vec2(NdotV, 1.0 - roughness)).rg;\n';
             fragmentShader += '    vec3 IBLColor = (diffuseIrradiance * diffuseColor) + (specularIrradiance * SRGBtoLINEAR3(specularColor * brdfLut.x + brdfLut.y));\n';
-            fragmentShader += '    color += IBLColor * luminance;\n';
+            fragmentShader += '    color += IBLColor;\n';
+            */
 
             fragmentShader += '    const mat3 yUpToZUp = mat3(-1.0, 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 1.0, 0.0); \n';
             fragmentShader += '    vec3 cubeDir = normalize(czm_inverseViewRotation * n); \n';
             fragmentShader += '    cubeDir = yUpToZUp * cubeDir; \n'; // TODO
             fragmentShader += '#ifdef DIFFUSE_IBL \n';
             fragmentShader += '#ifdef SPHERICAL_HARMONICS \n';
-            fragmentShader += '    diffuseIrradiance = czm_sphericalHarmonics(cubeDir, gltf_sphericalHarmonicCoefficients); \n';
+            fragmentShader += '    vec3 diffuseIrradiance = czm_sphericalHarmonics(cubeDir, gltf_sphericalHarmonicCoefficients); \n';
             fragmentShader += '#else \n';
-            fragmentShader += '    diffuseIrradiance = textureCube(gltf_diffuseIrradiance, cubeDir).rgb;\n';
+            fragmentShader += '    vec3 diffuseIrradiance = textureCube(gltf_diffuseIrradiance, cubeDir).rgb;\n';
             fragmentShader += '#endif \n';
             fragmentShader += '#else \n';
-            fragmentShader += '    diffuseIrradiance = vec3(0.0); \n';
+            fragmentShader += '    vec3 diffuseIrradiance = vec3(0.0); \n';
             fragmentShader += '#endif \n';
             fragmentShader += '#ifdef SPECULAR_IBL \n';
             fragmentShader += '    vec2 brdfLut = texture2D(czm_brdfLut, vec2(NdotV, roughness)).rg;\n';

--- a/Source/Scene/processPbrMaterials.js
+++ b/Source/Scene/processPbrMaterials.js
@@ -646,7 +646,7 @@ define([
             fragmentShader += '    vec3 specularContribution = F * G * D / (4.0 * NdotL * NdotV);\n';
             fragmentShader += '    vec3 color = NdotL * lightColor * (diffuseContribution + specularContribution);\n';
 
-            /*
+            
             fragmentShader += '    vec3 r = normalize(czm_inverseViewRotation * normalize(reflect(v, n)));\n';
             // Figure out if the reflection vector hits the ellipsoid
             fragmentShader += '    czm_ellipsoid ellipsoid = czm_getWgs84EllipsoidEC();\n';
@@ -686,22 +686,30 @@ define([
             fragmentShader += '    specularIrradiance = mix(specularIrradiance, belowHorizonColor, smoothstep(aroundHorizon, farBelowHorizon, reflectionDotNadir) * inverseRoughness);\n';
             fragmentShader += '    specularIrradiance = mix(specularIrradiance, nadirColor, smoothstep(farBelowHorizon, 1.0, reflectionDotNadir) * inverseRoughness);\n';
 
+            // Angle between sun and zenith
+            fragmentShader += '    float S = acos(clamp(dot(normalize(czm_inverseViewRotation * l), normalize(v_positionWC * -1.0)), 0.001, 1.0));\n'
+            // Angle between zenith and current pixel 
+            fragmentShader += '    float theta = acos(clamp(dot(normalize(czm_inverseViewRotation * n), normalize(v_positionWC * -1.0)), 0.001, 1.0));\n'
+            // Angle between sun and current pixel
+            fragmentShader += '    float gamma = acos(NdotL);\n'
+            fragmentShader += '    float luminanceAtZenith = 10.0;\n' 
+            fragmentShader += '    float luminance = luminanceAtZenith * (((0.91 + 10.0 * exp(-3.0 * gamma) + 0.45 * pow(cos(gamma), 2.0)) * (1.0 - exp(-0.32 / cos(theta)))) / (0.91 + 10.0 * exp(-3.0 * S) + 0.45 * pow(cos(S),2.0)) * (1.0 - exp(-0.32)));\n'
+
             fragmentShader += '    vec2 brdfLut = texture2D(czm_brdfLut, vec2(NdotV, 1.0 - roughness)).rg;\n';
             fragmentShader += '    vec3 IBLColor = (diffuseIrradiance * diffuseColor) + (specularIrradiance * SRGBtoLINEAR3(specularColor * brdfLut.x + brdfLut.y));\n';
-            fragmentShader += '    color += IBLColor;\n';
-            */
+            fragmentShader += '    color += IBLColor * luminance;\n';
 
             fragmentShader += '    const mat3 yUpToZUp = mat3(-1.0, 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 1.0, 0.0); \n';
             fragmentShader += '    vec3 cubeDir = normalize(czm_inverseViewRotation * n); \n';
             fragmentShader += '    cubeDir = yUpToZUp * cubeDir; \n'; // TODO
             fragmentShader += '#ifdef DIFFUSE_IBL \n';
             fragmentShader += '#ifdef SPHERICAL_HARMONICS \n';
-            fragmentShader += '    vec3 diffuseIrradiance = czm_sphericalHarmonics(cubeDir, gltf_sphericalHarmonicCoefficients); \n';
+            fragmentShader += '    diffuseIrradiance = czm_sphericalHarmonics(cubeDir, gltf_sphericalHarmonicCoefficients); \n';
             fragmentShader += '#else \n';
-            fragmentShader += '    vec3 diffuseIrradiance = textureCube(gltf_diffuseIrradiance, cubeDir).rgb;\n';
+            fragmentShader += '    diffuseIrradiance = textureCube(gltf_diffuseIrradiance, cubeDir).rgb;\n';
             fragmentShader += '#endif \n';
             fragmentShader += '#else \n';
-            fragmentShader += '    vec3 diffuseIrradiance = vec3(0.0); \n';
+            fragmentShader += '    diffuseIrradiance = vec3(0.0); \n';
             fragmentShader += '#endif \n';
             fragmentShader += '#ifdef SPECULAR_IBL \n';
             fragmentShader += '    vec2 brdfLut = texture2D(czm_brdfLut, vec2(NdotV, roughness)).rg;\n';


### PR DESCRIPTION
This fixes the incorrect sampling from the octahedral map. Here's what it looks like before:

![map_broken](https://user-images.githubusercontent.com/1711126/46616620-ee0f3e80-cae8-11e8-8ec5-e733ae065d75.png)

Notice how the perfectly reflective sphere on the left is sampling more than it should (in fact it's sampling the wrong level). The last one is also incorrect, it's going 1 more level further than it should.

And after:

![map_fixed](https://user-images.githubusercontent.com/1711126/46616605-e8b1f400-cae8-11e8-9332-bfb1bdeed3de.png)

I was also trying to toggle between the original cube map with mips to compare that against the octahedral map, but I'm not sure if there's an easy way to do that. Might be a good sanity check to make @bagnell .
