### PR TITLE
Add Trilinear Filtering to Octahedral Maps

### DIFF
--- a/Apps/Sandcastle/gallery/Hello World.html
+++ b/Apps/Sandcastle/gallery/Hello World.html
@@ -119,12 +119,12 @@ function startup(Cesium) {
                     width : width,
                     height : height
                 },
-                positiveY : {
+                negativeY : {
                     arrayBufferView : dds.mipmaps[mipLevel + 2 * mipmapCount].data,
                     width : width,
                     height : height
                 },
-                negativeY : {
+                positiveY : {
                     arrayBufferView : dds.mipmaps[mipLevel + 3 * mipmapCount].data,
                     width : width,
                     height : height
@@ -166,12 +166,12 @@ function startup(Cesium) {
                         width : width,
                         height : height
                     },
-                    positiveY : {
+                    negativeY : {
                         arrayBufferView : dds.mipmaps[mipLevel + 2 * mipmapCount].data,
                         width : width,
                         height : height
                     },
-                    negativeY : {
+                    positiveY : {
                         arrayBufferView : dds.mipmaps[mipLevel + 3 * mipmapCount].data,
                         width : width,
                         height : height

--- a/Source/Renderer/ShaderSource.js
+++ b/Source/Renderer/ShaderSource.js
@@ -248,6 +248,11 @@ define([
             result += '#define OUTPUT_DECLARATION\n\n';
         }
 
+        // Define a constant for the OES_texture_float_linear extension since WebGL does not.
+        if (context.textureFloatLinear) {
+            result += '#define OES_texture_float_linear\n\n';
+        }
+
         // append built-ins
         if (shaderSource.includeBuiltIns) {
             result += getBuiltinsAndAutomaticUniforms(combinedSources);

--- a/Source/Scene/OctahedralProjectedCubeMap.js
+++ b/Source/Scene/OctahedralProjectedCubeMap.js
@@ -80,9 +80,9 @@ define([
 
     // These vertices are based on figure 1 from "Octahedron Environment Maps".
     var v1 = new Cartesian3(1.0, 0.0, 0.0);
-    var v2 = new Cartesian3(0.0, 0.0, -1.0);
+    var v2 = new Cartesian3(0.0, 0.0, 1.0);
     var v3 = new Cartesian3(-1.0, 0.0, 0.0);
-    var v4 = new Cartesian3(0.0, 0.0, 1.0);
+    var v4 = new Cartesian3(0.0, 0.0, -1.0);
     var v5 = new Cartesian3(0.0, 1.0, 0.0);
     var v6 = new Cartesian3(0.0, -1.0, 0.0);
 

--- a/Source/Scene/processPbrMaterials.js
+++ b/Source/Scene/processPbrMaterials.js
@@ -709,7 +709,7 @@ define([
             fragmentShader += '#endif \n';
             fragmentShader += '#ifdef SPECULAR_IBL \n';
             fragmentShader += '    vec2 brdfLut = texture2D(czm_brdfLut, vec2(NdotV, roughness)).rg;\n';
-            fragmentShader += '    vec3 specularIBL = czm_sampleOctahedralProjection(gltf_specularMap, gltf_specularMapSize, cubeDir,  roughness * gltf_maxSpecularLOD);\n';
+            fragmentShader += '    vec3 specularIBL = czm_sampleOctahedralProjection(gltf_specularMap, gltf_specularMapSize, cubeDir,  roughness * gltf_maxSpecularLOD, gltf_maxSpecularLOD);\n';
             fragmentShader += '    specularIBL *= F * brdfLut.x + brdfLut.y;\n';
             fragmentShader += '#else \n';
             fragmentShader += '    vec3 specularIBL = vec3(0.0); \n';

--- a/Source/Shaders/Builtin/Functions/sampleOctahedralProjection.glsl
+++ b/Source/Shaders/Builtin/Functions/sampleOctahedralProjection.glsl
@@ -1,4 +1,56 @@
 /**
+ * Samples the 4 neighboring pixels and return the weighted average. 
+ * 
+ * @private
+ */
+vec3 czm_sampleOctahedralProjectionWithFiltering(sampler2D projectedMap, vec2 textureSize, vec3 direction, float lod)
+{
+    direction /= dot(vec3(1.0), abs(direction));
+    vec2 rev = abs(direction.zx) - vec2(1.0);
+    vec2 neg = vec2(direction.x < 0.0 ? rev.x : -rev.x,
+                    direction.z < 0.0 ? rev.y : -rev.y);
+    vec2 uv = direction.y < 0.0 ? neg : direction.xz;
+    vec2 coord = 0.5 * uv + vec2(0.5);
+    vec2 pixel = 1.0 / textureSize;
+
+    if (lod > 0.0)
+    {
+        // Each subseqeuent mip level is half the size
+        float scale = 1.0 / pow(2.0, lod);
+        float offset = ((textureSize.y + 1.0) / textureSize.x);
+
+        coord.x *= offset;
+        coord *= scale;
+
+        coord.x += offset + pixel.x;
+        coord.y += (1.0 - (1.0 / pow(2.0, lod - 1.0))) + pixel.y * (lod - 1.0) * 2.0;
+
+        pixel *= scale;
+    }
+    else
+    {
+        coord.x *= (textureSize.y / textureSize.x);
+    }
+
+    // Do bilinear filtering
+    vec3 color1 = texture2D(projectedMap, coord + vec2(0.0, pixel.y)).rgb;
+    vec3 color2 = texture2D(projectedMap, coord + vec2(pixel.x, 0.0)).rgb;
+    vec3 color3 = texture2D(projectedMap, coord + pixel).rgb;
+    vec3 color4 = texture2D(projectedMap, coord).rgb;
+
+    vec2 texturePosition = coord * textureSize;
+
+    float fu = fract(texturePosition.x);
+    float fv = fract(texturePosition.y);
+
+    vec3 average1 = mix(color4, color2, fu);
+    vec3 average2 = mix(color1, color3, fu);
+
+    return mix(average1, average2, fv);
+}
+
+
+/**
  * Samples from a cube map that has been projected using an octahedral projection from the given direction.
  *
  * @name czm_sampleOctahedralProjection
@@ -8,35 +60,15 @@
  * @param {vec2} textureSize The width and height dimensions in pixels of the projected map.
  * @param {vec3} direction The normalized direction used to sample the cube map.
  * @param {float} lod The level of detail to sample.
+ * @param {float} maxLod The maximum level of detail.
  * @returns {vec3} The color of the cube map at the direction.
  */
-vec3 czm_sampleOctahedralProjection(sampler2D projectedMap, vec2 textureSize, vec3 direction, float lod) {
-    direction /= dot(vec3(1.0), abs(direction));
-    vec2 rev = abs(direction.zx) - vec2(1.0);
-    vec2 neg = vec2(direction.x < 0.0 ? rev.x : -rev.x,
-                    direction.z < 0.0 ? rev.y : -rev.y);
-    vec2 uv = direction.y < 0.0 ? neg : direction.xz;
-    vec2 coord = 0.5 * uv + vec2(0.5);
+vec3 czm_sampleOctahedralProjection(sampler2D projectedMap, vec2 textureSize, vec3 direction, float lod, float maxLod) {
+    float currentLod = floor(lod + 0.5);
+    float nextLod = min(currentLod + 1.0, maxLod);
 
-    lod = floor(lod + 0.5);
+    vec3 colorCurrentLod = czm_sampleOctahedralProjectionWithFiltering(projectedMap, textureSize, direction, currentLod); 
+    vec3 colorNextLod = czm_sampleOctahedralProjectionWithFiltering(projectedMap, textureSize, direction, nextLod); 
 
-    if (lod > 0.0)
-    {
-        // Each subseqeuent mip level is half the size
-        float scale = 1.0 / pow(2.0, lod);
-        float offset = ((textureSize.y + 1.0) / textureSize.x);
-        vec2 pixel = 1.0 / textureSize;
-
-        coord.x *= offset;
-        coord *= scale;
-
-        coord.x += offset + pixel.x;
-        coord.y += (1.0 - (1.0 / pow(2.0, lod - 1.0))) + pixel.y * (lod - 1.0) * 2.0;
-    }
-    else
-    {
-        coord.x *= (textureSize.y / textureSize.x);
-    }
-
-    return texture2D(projectedMap, coord).rgb;
+    return mix(colorNextLod, colorCurrentLod, nextLod - lod); 
 }

--- a/Source/Shaders/Builtin/Functions/sampleOctahedralProjection.glsl
+++ b/Source/Shaders/Builtin/Functions/sampleOctahedralProjection.glsl
@@ -33,20 +33,24 @@ vec3 czm_sampleOctahedralProjectionWithFiltering(sampler2D projectedMap, vec2 te
     }
 
     // Do bilinear filtering
-    vec3 color1 = texture2D(projectedMap, coord + vec2(0.0, pixel.y)).rgb;
-    vec3 color2 = texture2D(projectedMap, coord + vec2(pixel.x, 0.0)).rgb;
-    vec3 color3 = texture2D(projectedMap, coord + pixel).rgb;
-    vec3 color4 = texture2D(projectedMap, coord).rgb;
+    #ifndef OES_texture_float_linear
+        vec3 color1 = texture2D(projectedMap, coord + vec2(0.0, pixel.y)).rgb;
+        vec3 color2 = texture2D(projectedMap, coord + vec2(pixel.x, 0.0)).rgb;
+        vec3 color3 = texture2D(projectedMap, coord + pixel).rgb;
+        vec3 color4 = texture2D(projectedMap, coord).rgb;
 
-    vec2 texturePosition = coord * textureSize;
+        vec2 texturePosition = coord * textureSize;
 
-    float fu = fract(texturePosition.x);
-    float fv = fract(texturePosition.y);
+        float fu = fract(texturePosition.x);
+        float fv = fract(texturePosition.y);
 
-    vec3 average1 = mix(color4, color2, fu);
-    vec3 average2 = mix(color1, color3, fu);
+        vec3 average1 = mix(color4, color2, fu);
+        vec3 average2 = mix(color1, color3, fu);
 
-    return mix(average1, average2, fv);
+        return mix(average1, average2, fv);
+    #else 
+        return texture2D(projectedMap, coord).rgb;
+    #endif
 }
 
 

--- a/Source/Shaders/Builtin/Functions/sampleOctahedralProjection.glsl
+++ b/Source/Shaders/Builtin/Functions/sampleOctahedralProjection.glsl
@@ -18,7 +18,7 @@ vec3 czm_sampleOctahedralProjection(sampler2D projectedMap, vec2 textureSize, ve
     vec2 uv = direction.y < 0.0 ? neg : direction.xz;
     vec2 coord = 0.5 * uv + vec2(0.5);
 
-    lod = floor(lod);
+    lod = floor(lod + 0.5);
 
     if (lod > 0.0)
     {


### PR DESCRIPTION
@bagnell the good news is the octahedral specular map in WebGL 1 and the original cube map in WebGL 2 now look identical* ! 

\* _Identical for lower mips, small differences in higher mips_. 

I noticed the Z axis was reversed in the projection. And I also need to swap the positiveY with the negativeY faces when constructing the cube maps, I'm not sure why exactly (but I updated the gallery/Hello World example to reflect that).

Finally, I added trilinear filtering. Note that it they do look identical even without the trilinear filtering, but without it any values in between the current ones in the sphere will pop/be discrete as opposed to be a gradual change. 