### PR TITLE
Possible fix for possible scene.pickFromRay bug

### DIFF
--- a/Source/Scene/Scene.js
+++ b/Source/Scene/Scene.js
@@ -2944,7 +2944,9 @@ define([
         // the function modifies scene state that should remain constant over the frame.
         var functions = scene._frameState.afterRender;
         for (var i = 0, length = functions.length; i < length; ++i) {
-            functions[i]();
+            if (functions[i]) {
+                functions[i]();
+						}
             scene.requestRender();
         }
 

--- a/Source/Scene/Scene.js
+++ b/Source/Scene/Scene.js
@@ -2944,9 +2944,7 @@ define([
         // the function modifies scene state that should remain constant over the frame.
         var functions = scene._frameState.afterRender;
         for (var i = 0, length = functions.length; i < length; ++i) {
-            if (functions[i]) {
-                functions[i]();
-						}
+            functions[i]();
             scene.requestRender();
         }
 
@@ -3691,7 +3689,6 @@ define([
 
         scene._view = scene._defaultView;
         context.endFrame();
-        callAfterRenderFunctions(scene);
 
         if (defined(object) || defined(position)) {
             return {


### PR DESCRIPTION
We encountered an error when testing `scene.pickFromRay()`.

After calling `pickFromRay()`, the function returns with results, however the scene crashes. We've not been able to reproduce the bug using an unminified version of Cesium, but the exception is `functions[i] is not a function`. Inspecting `functions[i]` shows that it is undefined sometimes.

This is a naive approach to fixing this problem, but it does appear to stop the scene from crashing. 

@lilleyse 