### PR TITLE
Delay load google-earth-dbroot-parser

### DIFF
--- a/Source/Core/Resource.js
+++ b/Source/Core/Resource.js
@@ -10,7 +10,6 @@ define([
         './defineProperties',
         './deprecationWarning',
         './DeveloperError',
-        './FeatureDetection',
         './freezeObject',
         './getAbsoluteUri',
         './getBaseUri',
@@ -18,6 +17,7 @@ define([
         './isBlobUri',
         './isCrossOriginUrl',
         './isDataUri',
+        './loadAndExecuteScript',
         './objectToQuery',
         './queryToObject',
         './Request',
@@ -38,7 +38,6 @@ define([
         defineProperties,
         deprecationWarning,
         DeveloperError,
-        FeatureDetection,
         freezeObject,
         getAbsoluteUri,
         getBaseUri,
@@ -46,6 +45,7 @@ define([
         isBlobUri,
         isCrossOriginUrl,
         isDataUri,
+        loadAndExecuteScript,
         objectToQuery,
         queryToObject,
         Request,
@@ -1934,20 +1934,7 @@ define([
     };
 
     Resource._Implementations.loadAndExecuteScript = function(url, functionName, deferred) {
-        var script = document.createElement('script');
-        script.async = true;
-        script.src = url;
-
-        var head = document.getElementsByTagName('head')[0];
-        script.onload = function() {
-            script.onload = undefined;
-            head.removeChild(script);
-        };
-        script.onerror = function(e) {
-            deferred.reject(e);
-        };
-
-        head.appendChild(script);
+        return loadAndExecuteScript(url, functionName).otherwise(deferred.reject);
     };
 
     /**

--- a/Source/Core/loadAndExecuteScript.js
+++ b/Source/Core/loadAndExecuteScript.js
@@ -1,0 +1,32 @@
+define([
+    '../ThirdParty/when'
+], function(
+    when) {
+        'use strict';
+
+    /**
+     * @private
+     */
+    function loadAndExecuteScript(url) {
+        var deferred = when.defer();
+        var script = document.createElement('script');
+        script.async = true;
+        script.src = url;
+
+        var head = document.getElementsByTagName('head')[0];
+        script.onload = function() {
+            script.onload = undefined;
+            head.removeChild(script);
+            deferred.resolve();
+        };
+        script.onerror = function(e) {
+            deferred.reject(e);
+        };
+
+        head.appendChild(script);
+
+        return deferred.promise;
+    }
+
+    return loadAndExecuteScript;
+});

--- a/Source/ThirdParty/google-earth-dbroot-parser.js
+++ b/Source/ThirdParty/google-earth-dbroot-parser.js
@@ -1,6 +1,4 @@
-define([
-    './protobuf-minimal'
-], function(
+window.cesiumGoogleEarthDbRootParser = function(
     $protobuf) {
     /* jshint curly: false, sub: true, newcap: false, shadow: true, unused: false*/
     'use strict';
@@ -8147,4 +8145,4 @@ define([
     // End generated code
 
     return $root.keyhole.dbroot;
-});
+};

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -61,6 +61,7 @@ var sourceFiles = ['Source/**/*.js',
                    '!Source/*.js',
                    '!Source/Workers/**',
                    '!Source/ThirdParty/Workers/**',
+                   '!Source/ThirdParty/google-earth-dbroot-parser.js',
                    '!Source/ThirdParty/pako_inflate.js',
                    '!Source/ThirdParty/crunch.js',
                    'Source/Workers/createTaskProcessorWorker.js'];
@@ -891,6 +892,14 @@ function minifyCSS(outputDirectory) {
     });
 }
 
+var gulpUglify = require('gulp-uglify');
+
+function minifyModules(outputDirectory) {
+    return streamToPromise(gulp.src('Source/ThirdParty/google-earth-dbroot-parser.js')
+        .pipe(gulpUglify())
+        .pipe(gulp.dest(outputDirectory + '/ThirdParty/')));
+}
+
 function combineJavaScript(options) {
     var optimizer = options.optimizer;
     var outputDirectory = options.outputDirectory;
@@ -901,7 +910,8 @@ function combineJavaScript(options) {
 
     var promise = Promise.join(
         combineCesium(!removePragmas, optimizer, combineOutput),
-        combineWorkers(!removePragmas, optimizer, combineOutput)
+        combineWorkers(!removePragmas, optimizer, combineOutput),
+        minifyModules(outputDirectory)
     );
 
     return promise.then(function() {
@@ -1264,7 +1274,7 @@ function buildCesiumViewer() {
 
             gulp.src(['Build/Cesium/Assets/**',
                       'Build/Cesium/Workers/**',
-                      'Build/Cesium/ThirdParty/Workers/**',
+                      'Build/Cesium/ThirdParty/**',
                       'Build/Cesium/Widgets/**',
                       '!Build/Cesium/Widgets/**/*.css'],
                 {

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "gulp-rename": "^1.2.2",
     "gulp-replace": "^0.6.1",
     "gulp-tap": "^1.0.1",
+    "gulp-uglify": "^3.0.0",
     "gulp-zip": "^4.0.0",
     "jasmine-core": "^3.1.0",
     "jsdoc": "^3.4.3",


### PR DESCRIPTION
`google-earth-dbroot-parser.js` is a huge dependency (487 KB source, 202KB minified).  It's also only needed if you are using a Google Earth server.

In order to avoid bloat and paying the penalty every time Cesium is loaded, this change loads it on demand the first time it's needed.

I didn't use jsonp for this because there's no server to parse the query and wrap the code in a callback. Instead we just load the script directly into a unlikely to collide global variable. (also reset the old value if it does exist for some reason).

The file gets minified and copied to ThirdParty individually, similar to what we were already doing with the wasm file.

Also fixed a bug in buildCesiumViewer where it wasn't copying all the necessary files to its own build output.

Also extracted `loadAndExecuteScript` out of Resource.js, but had to keep a version of it in Resource.js because cleaning up test abuse of it is a much larger change best for another PR. (I'll write up an issue).

I talked this over a bit with @shunter and he agreed this is a stopgap solution at best and we either need to leverage require more directly as a module loading system within Cesium itself, or better yet just spend the time to migrate to ES6 (which we want to do but simply don't have the bandwidth for).  Until that happens, we might be able to use this approach for a few other large dependencies as well.

@likangning93 you should also be able to use `loadAndExecuteScript` in #6986, but you'll need to tweak it for Workers.

@ggetz can you review of this?  I think I covered every possible use case, but let me know if you find anything.