### PR TITLE
Fix banding at lower mips

### DIFF
--- a/Source/Shaders/Builtin/Functions/sampleOctahedralProjection.glsl
+++ b/Source/Shaders/Builtin/Functions/sampleOctahedralProjection.glsl
@@ -24,8 +24,6 @@ vec3 czm_sampleOctahedralProjectionWithFiltering(sampler2D projectedMap, vec2 te
 
         coord.x += offset + pixel.x;
         coord.y += (1.0 - (1.0 / pow(2.0, lod - 1.0))) + pixel.y * (lod - 1.0) * 2.0;
-
-        pixel *= scale;
     }
     else
     {


### PR DESCRIPTION
I was erroneously scaling the texel size, which meant at lower mips it was doing bilinear filtering all within the same texel. 

This should fix the banding you saw @bagnell .