### PR TITLE
Make computeFlyToLocationForRectangle always return a Cartographic

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@ Change Log
 
 ##### Fixes :wrench:
 * Fixed an issue where `pickPosition` would return incorrect results when called after `sampleHeight` or `clampToHeight`. [#7113](https://github.com/AnalyticalGraphicsInc/cesium/pull/7113)
+* Fixed a crash when using `BingMapsGeocoderService` [#7143](https://github.com/AnalyticalGraphicsInc/cesium/issues/7143)
 
 ### 1.50 - 2018-10-01
 

--- a/Source/Widgets/Viewer/Viewer.js
+++ b/Source/Widgets/Viewer/Viewer.js
@@ -1982,14 +1982,9 @@ Either specify options.terrainProvider instead or set options.baseLayerPicker to
         }
 
         // If zoomTarget was an ImageryLayer
-        var isCartographic = target instanceof Cartographic;
-        if (target instanceof Rectangle || isCartographic) {
-            var destination = target;
-            if (isCartographic) {
-                destination = scene.mapProjection.ellipsoid.cartographicToCartesian(destination);
-            }
+        if (target instanceof Cartographic) {
             options = {
-                destination : destination,
+                destination : scene.mapProjection.ellipsoid.cartographicToCartesian(target),
                 duration : zoomOptions.duration,
                 maximumHeight : zoomOptions.maximumHeight,
                 complete : function() {

--- a/Specs/Scene/computeFlyToLocationForRectangleSpec.js
+++ b/Specs/Scene/computeFlyToLocationForRectangleSpec.js
@@ -84,7 +84,7 @@ defineSuite([
         return sampleTest(SceneMode.COLUMBUS_VIEW);
     });
 
-    it('returns original rectangle in 2D', function() {
+    it('returns height above ellipsoid when in 2D', function() {
         var terrainProvider = new EllipsoidTerrainProvider();
         terrainProvider.availability = {};
 
@@ -93,25 +93,27 @@ defineSuite([
         scene.mode = SceneMode.SCENE2D;
 
         var rectangle = new Rectangle(0.2, 0.4, 0.6, 0.8);
-        spyOn(computeFlyToLocationForRectangle, '_sampleTerrainMostDetailed');
+        var expectedResult = scene.mapProjection.unproject(scene.camera.getRectangleCameraCoordinates(rectangle));
 
+        spyOn(computeFlyToLocationForRectangle, '_sampleTerrainMostDetailed');
         return computeFlyToLocationForRectangle(rectangle, scene)
             .then(function(result) {
-                expect(result).toBe(rectangle);
+                expect(result).toEqual(expectedResult);
                 expect(computeFlyToLocationForRectangle._sampleTerrainMostDetailed).not.toHaveBeenCalled();
             });
     });
 
-    it('returns original rectangle when terrain not available', function() {
+    it('returns height above ellipsoid when terrain not available', function() {
         scene.globe = new Globe();
         scene.terrainProvider = new EllipsoidTerrainProvider();
 
         var rectangle = new Rectangle(0.2, 0.4, 0.6, 0.8);
         spyOn(computeFlyToLocationForRectangle, '_sampleTerrainMostDetailed');
 
+        var expectedResult = scene.mapProjection.ellipsoid.cartesianToCartographic(scene.camera.getRectangleCameraCoordinates(rectangle));
         return computeFlyToLocationForRectangle(rectangle, scene)
             .then(function(result) {
-                expect(result).toBe(rectangle);
+                expect(result).toEqual(expectedResult);
                 expect(computeFlyToLocationForRectangle._sampleTerrainMostDetailed).not.toHaveBeenCalled();
             });
     });
@@ -124,21 +126,23 @@ defineSuite([
         scene.terrainProvider = terrainProvider;
 
         var rectangle = new Rectangle(0.2, 0.4, 0.6, 0.8);
+        var expectedResult = scene.mapProjection.ellipsoid.cartesianToCartographic(scene.camera.getRectangleCameraCoordinates(rectangle));
         return computeFlyToLocationForRectangle(rectangle, scene)
             .then(function(result) {
-                expect(result).toBe(rectangle);
+                expect(result).toEqual(expectedResult);
                 expect(terrainProvider.readyPromise.then).toHaveBeenCalled();
             });
     });
 
-    it('returns original rectangle when terrain undefined', function() {
+    it('returns height above ellipsoid when terrain undefined', function() {
         scene.terrainProvider = undefined;
         var rectangle = new Rectangle(0.2, 0.4, 0.6, 0.8);
         spyOn(computeFlyToLocationForRectangle, '_sampleTerrainMostDetailed');
 
+        var expectedResult = scene.mapProjection.ellipsoid.cartesianToCartographic(scene.camera.getRectangleCameraCoordinates(rectangle));
         return computeFlyToLocationForRectangle(rectangle, scene)
             .then(function(result) {
-                expect(result).toBe(rectangle);
+                expect(result).toEqual(expectedResult);
                 expect(computeFlyToLocationForRectangle._sampleTerrainMostDetailed).not.toHaveBeenCalled();
             });
     });


### PR DESCRIPTION
Not sure what I was thinking when I wrote `computeFlyToLocationForRectangle`, but this changes it so it always returns a `Cartographic`. Previously it would return a Rectangle if terrain wasn't set or didn't have `availability` which just made the calling code confusing for no reason and lead to #7143.

`computeFlyToLocationForRectangle` is private, so this isn't a breaking change.

Fixes #7143