### PR TITLE
Fix StaticGeometryMaterialBatch remove

### DIFF
--- a/Source/DataSources/StaticGeometryColorBatch.js
+++ b/Source/DataSources/StaticGeometryColorBatch.js
@@ -109,7 +109,9 @@ define([
                 this.subscriptions.remove(id);
                 this.showsUpdated.remove(id);
             }
+            return true;
         }
+        return false;
     };
 
     Batch.prototype.update = function(time) {
@@ -353,8 +355,8 @@ define([
                 if (item.updaters.length === 0) {
                     items.splice(i, 1);
                     item.destroy();
-                    return true;
                 }
+                return true;
             }
         }
         return false;

--- a/Source/DataSources/StaticGeometryPerMaterialBatch.js
+++ b/Source/DataSources/StaticGeometryPerMaterialBatch.js
@@ -104,8 +104,9 @@ define([
                 this.subscriptions.remove(id);
                 this.showsUpdated.remove(id);
             }
+            return true;
         }
-        return this.createPrimitive;
+        return false
     };
 
     var colorScratch = new Color();

--- a/Source/DataSources/StaticOutlineGeometryBatch.js
+++ b/Source/DataSources/StaticOutlineGeometryBatch.js
@@ -79,7 +79,9 @@ define([
                 this.subscriptions.remove(id);
                 this.showsUpdated.remove(id);
             }
+            return true;
         }
+        return false;
     };
 
     Batch.prototype.update = function(time) {


### PR DESCRIPTION
Fixes #7160

`StaticGeometryMaterialBatch` `Batch.remove` was returning the wrong thing, causing `StaticGeometryMaterialBatch` to think the updater was removed from a batch it wasn't removed from.

Also cleaned up remove for `StaticGeometryColorBatch` and `StaticOutlineGeometryBatch` which weren't returning anything from the remove functions.