### PR TITLE
Add Transforms.fixedFrameToHeadingPitchRoll

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ Change Log
 ##### Additions :tada:
 * Shrink minified and gzipped Cesium.js by 27 KB (~3.7%) by delay loading seldom-used third-party dependencies. [#7140](https://github.com/AnalyticalGraphicsInc/cesium/pull/7140)
 * Added WMS-T (time) support in WebMapServiceImageryProvider [#2581](https://github.com/AnalyticalGraphicsInc/cesium/issues/2581)
+* Added `Transforms.fixedFrameToHeadingPitchRoll`, a helper function for extracting a `HeadingPitchRoll` from a fixed frame transform [#7164](https://github.com/AnalyticalGraphicsInc/cesium/pull/7164)
 * Added `cutoutRectangle` to `ImageryLayer`, which allows cutting out rectangular areas in imagery layers to reveal underlying imagery. [#7056](https://github.com/AnalyticalGraphicsInc/cesium/pull/7056)
 
 ##### Fixes :wrench:

--- a/Specs/Core/TransformsSpec.js
+++ b/Specs/Core/TransformsSpec.js
@@ -1121,6 +1121,23 @@ defineSuite([
         expect(actualTranslation).toEqualEpsilon(expectedTranslation, CesiumMath.EPSILON14);
     });
 
+    it('fixedFrameToHeadingPitchRoll returns heading/pitch/roll from a transform', function () {
+        var expected = new HeadingPitchRoll(0.5, 0.6, 0.7);
+
+        var transform = Transforms.eastNorthUpToFixedFrame(Cartesian3.fromDegrees(0, 0));
+        var transform2 = Matrix4.fromTranslationQuaternionRotationScale(new Cartesian3(), Quaternion.fromHeadingPitchRoll(expected), new Cartesian3(1, 1, 1));
+        transform = Matrix4.multiply(transform, transform2, transform2);
+
+        var actual = Transforms.fixedFrameToHeadingPitchRoll(transform);
+        expect(actual).toEqualEpsilon(expected, CesiumMath.EPSILON10);
+    });
+
+    it('fixedFrameToHeadingPitchRoll throws with no transform', function() {
+        expect(function() {
+            return Transforms.fixedFrameToHeadingPitchRoll();
+        }).toThrowDeveloperError();
+    });
+
     it('eastNorthUpToFixedFrame throws without an origin', function() {
         expect(function() {
             Transforms.eastNorthUpToFixedFrame(undefined, Ellipsoid.WGS84);


### PR DESCRIPTION
Adds a helper function for extracting a `HeadingPitchRoll` from a fixed frame transform.

@bagnell can you review please?