### PR TITLE
Fix model test failure

### DIFF
--- a/Specs/Scene/ModelSpec.js
+++ b/Specs/Scene/ModelSpec.js
@@ -948,8 +948,11 @@ defineSuite([
             verifyRender(m);
             m.show = true;
 
-            expect(scene).toRenderAndCall(function(rgba) {
-                expect(rgba).toEqualEpsilon([169, 3, 3, 255], 10); // Red
+            expect({
+                scene : scene,
+                time : JulianDate.fromDate(new Date('January 1, 2014 12:00:00 UTC'))
+            }).toRenderAndCall(function(rgba) {
+                expect(rgba).toEqualEpsilon([193, 17, 16, 255], 5); // Red
             });
 
             primitives.remove(m);


### PR DESCRIPTION
Fixes a test failure when running locally;

```
Scene/Model loads a glTF 2.0 model
Expected [ 180, 13, 12, 255 ] to equal epsilon [ 169, 3, 3, 255 ], 10.
Error: Expected [ 180, 13, 12, 255 ] to equal epsilon [ 169, 3, 3, 255 ], 10.
    at stack (http://localhost:8080/ThirdParty/jasmine-2.2.0/jasmine.js:1475:17)
    at buildExpectationResult (http://localhost:8080/ThirdParty/jasmine-2.2.0/jasmine.js:1445:14)
    at Spec.expectationResultFactory (http://localhost:8080/ThirdParty/jasmine-2.2.0/jasmine.js:584:18)
    at Spec.addExpectationResult (http://localhost:8080/ThirdParty/jasmine-2.2.0/jasmine.js:332:34)
    at Expectation.addExpectationResult (http://localhost:8080/ThirdParty/jasmine-2.2.0/jasmine.js:528:21)
    at Expectation.toEqualEpsilon (http://localhost:8080/ThirdParty/jasmine-2.2.0/jasmine.js:1399:12)
    at http://localhost:8080/Specs/Scene/ModelSpec.js:952:30
    at compare (http://localhost:8080/Specs/addDefaultMatchers.js:256:29)
    at Expectation.toRenderAndCall (http://localhost:8080/ThirdParty/jasmine-2.2.0/jasmine.js:1378:35)
    at http://localhost:8080/Specs/Scene/ModelSpec.js:951:27
```

This one would fail intermittently because of different sun directions at different times of day. I hard-coded a date for the test. The other tests don't seem to have this problem since most of them are either not checking the color or are using glTF 1 where the sun direction isn't accounted for.