### PR TITLE
Revert to jasmine 3.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "gulp-tap": "^1.0.1",
     "gulp-uglify": "^3.0.0",
     "gulp-zip": "^4.0.0",
-    "jasmine-core": "^3.1.0",
+    "jasmine-core": "3.2.0",
     "jsdoc": "^3.4.3",
     "karma": "^2.0.3",
     "karma-chrome-launcher": "^2.0.0",


### PR DESCRIPTION
The new jasmine release broke the karma-jasmine spec runner.
https://github.com/jasmine/jasmine/issues/1617

This should fix #7193