### PR TITLE
Fix "everything passes, travis fails"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,8 +25,8 @@ script:
 
   - echo 'makeZipFile' && echo -en 'travis_fold:start:script.makeZipFile\\r'
   - npm run clean
-  - npm run makeZipFile -- --concurrency 2
-  - npm pack
+  - npm run makeZipFile -- --concurrency 1
+  - npm pack &> /dev/null
   - echo -en 'travis_fold:end:script.makeZipFile\\r'
 
   - echo 'buildApps' && echo -en 'travis_fold:start:script.buildApps\\r'

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -43,18 +43,11 @@ var travisDeployUrl = 'http://cesium-dev.s3-website-us-east-1.amazonaws.com/cesi
 //per-task variables.  We use the command line argument here to detect which task is being run.
 var taskName = process.argv[2];
 var noDevelopmentGallery = taskName === 'release' || taskName === 'makeZipFile';
-var buildingRelease = noDevelopmentGallery;
 var minifyShaders = taskName === 'minify' || taskName === 'minifyRelease' || taskName === 'release' || taskName === 'makeZipFile' || taskName === 'buildApps';
 
 var concurrency = yargs.argv.concurrency;
 if (!concurrency) {
     concurrency = os.cpus().length;
-}
-
-//Since combine and minify run in parallel already, split concurrency in half when building both.
-//This can go away when gulp 4 comes out because it allows for synchronous tasks.
-if (buildingRelease) {
-    concurrency = concurrency / 2;
 }
 
 var sourceFiles = ['Source/**/*.js',
@@ -178,14 +171,16 @@ gulp.task('cloc', ['clean'], function() {
     });
 });
 
-gulp.task('combine', ['generateStubs'], function() {
+function combine() {
     var outputDirectory = path.join('Build', 'CesiumUnminified');
     return combineJavaScript({
-        removePragmas : false,
-        optimizer : 'none',
-        outputDirectory : outputDirectory
+        removePragmas: false,
+        optimizer: 'none',
+        outputDirectory: outputDirectory
     });
-});
+}
+
+gulp.task('combine', ['generateStubs'], combine);
 
 gulp.task('combineRelease', ['generateStubs'], function() {
     var outputDirectory = path.join('Build', 'CesiumUnminified');
@@ -197,7 +192,7 @@ gulp.task('combineRelease', ['generateStubs'], function() {
 });
 
 //Builds the documentation
-gulp.task('generateDocumentation', function() {
+function generateDocumentation() {
     var envPathSeperator = os.platform() === 'win32' ? ';' : ':';
 
     return new Promise(function(resolve, reject) {
@@ -216,7 +211,8 @@ gulp.task('generateDocumentation', function() {
             return streamToPromise(stream).then(resolve);
         });
     });
-});
+}
+gulp.task('generateDocumentation', generateDocumentation);
 
 gulp.task('instrumentForCoverage', ['build'], function(done) {
     var jscoveragePath = path.join('Tools', 'jscoverage-0.5.1', 'jscoverage.exe');
@@ -286,13 +282,15 @@ gulp.task('minify', ['generateStubs'], function() {
     });
 });
 
-gulp.task('minifyRelease', ['generateStubs'], function() {
+function minifyRelease() {
     return combineJavaScript({
-        removePragmas : true,
-        optimizer : 'uglify2',
-        outputDirectory : path.join('Build', 'Cesium')
+        removePragmas: true,
+        optimizer: 'uglify2',
+        outputDirectory: path.join('Build', 'Cesium')
     });
-});
+}
+
+gulp.task('minifyRelease', ['generateStubs'], minifyRelease);
 
 function isTravisPullRequest() {
     return process.env.TRAVIS_PULL_REQUEST !== undefined && process.env.TRAVIS_PULL_REQUEST !== 'false';
@@ -592,7 +590,11 @@ function setStatus(state, targetUrl, description, context) {
      });
 }
 
-gulp.task('release', ['combine', 'minifyRelease', 'generateDocumentation']);
+gulp.task('release', ['generateStubs'], function() {
+    return combine()
+        .then(minifyRelease)
+        .then(generateDocumentation);
+});
 
 gulp.task('test', function(done) {
     var argv = yargs.argv;
@@ -1215,7 +1217,7 @@ function buildSandcastle() {
         })
         .pipe(gulp.dest('Build/Apps/Sandcastle'));
 
-    return eventStream.merge(appStream, imageStream);
+    return streamToPromise(eventStream.merge(appStream, imageStream));
 }
 
 function buildCesiumViewer() {


### PR DESCRIPTION
1. `buildSandcastle` is returning a stream that is passed to Promise.join. That means the promise resolves before the stream is finished. Instead it should be returning a promise created from the stream.

2. `npm pack` may be screwed with travis' console leading to random failures, redirect it's output to /dev/null to see if it addresses our random build failures

3. requirejs was occasionally being killed by travis for using too much memory, reduce concurrency during the build process to prevent this from happening.