### PR TITLE
fix dynamic entities on terrain when depth textures are not supported

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,6 +25,7 @@ Change Log
 * Fixed clipping plane crash when adding a plane to an empty collection. [#7168](https://github.com/AnalyticalGraphicsInc/cesium/pull/7168)
 * Fixed texture coordinate calculation for polygon entities with `perPositionHeight` [#7188](https://github.com/AnalyticalGraphicsInc/cesium/pull/7188)
 * Fixed middle mouse button locked glitch [#7137](https://github.com/AnalyticalGraphicsInc/cesium/pull/7137)
+* Fixed an issue where dynamic Entities on terrain would cause a crash in platforms that do not support depth textures such as Internet Explorer [#7103](https://github.com/AnalyticalGraphicsInc/cesium/issues/7103)
 
 ### 1.50 - 2018-10-01
 

--- a/Source/DataSources/DynamicGeometryUpdater.js
+++ b/Source/DataSources/DynamicGeometryUpdater.js
@@ -106,7 +106,8 @@ define([
             var closed = geometryUpdater._getIsClosed(options);
             if (isColorAppearance) {
                 appearance = new PerInstanceColorAppearance({
-                    closed: closed
+                    closed: closed,
+                    flat : !(onTerrain && geometryUpdater._supportsMaterialsforEntitiesOnTerrain)
                 });
             } else {
                 var material = MaterialProperty.getValue(time, fillMaterialProperty, this._material);


### PR DESCRIPTION
Fixes #7103

What was happening was that `DynamicGeometryUpdater` was creating a `GroundPrimitive` with a "lit" `PerInstanceColor`. This produces shaders using materials-on-polygons-on-terrain, which won't work on platforms without depth texture support.