### PR TITLE
Check if cartographic is defined in clipping plane setup

### DIFF
--- a/Source/Scene/Cesium3DTileset.js
+++ b/Source/Scene/Cesium3DTileset.js
@@ -750,8 +750,8 @@ define([
                 // we want to apply an ENU orientation as our best guess of orientation.
                 // Otherwise, we assume it gets its position/orientation completely from the
                 // root tile transform and the tileset's model matrix
-                var heightAboveEllipsoid = that._ellipsoid.cartesianToCartographic(clippingPlanesOrigin).height;
-                if (heightAboveEllipsoid > ApproximateTerrainHeights._defaultMinTerrainHeight) {
+                var originCartographic = that._ellipsoid.cartesianToCartographic(clippingPlanesOrigin);
+                if (defined(originCartographic) && (originCartographic.height > ApproximateTerrainHeights._defaultMinTerrainHeight)) {
                     that._initialClippingPlanesOriginMatrix = Transforms.eastNorthUpToFixedFrame(clippingPlanesOrigin);
                 }
                 that._clippingPlanesOriginMatrix = Matrix4.clone(that._initialClippingPlanesOriginMatrix);


### PR DESCRIPTION
Follow up to https://github.com/AnalyticalGraphicsInc/cesium/pull/7182. A tileset with a bounding sphere center exactly at (0, 0, 0) would cause a crash in the clipping planes setup.

Anyone could review this, but maybe @hpinkos?