### PR TITLE
Add warning messages to Sandcastle examples when features aren't supported

### DIFF
--- a/Apps/Sandcastle/gallery/3D Tiles Point Cloud Shading.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Point Cloud Shading.html
@@ -95,6 +95,10 @@ var viewer = new Cesium.Viewer('cesiumContainer');
 var scene = viewer.scene;
 var viewModelTileset;
 
+if (!Cesium.PointCloudShading.isSupported(scene)) {
+    console.log('This browser does not support point cloud shading');
+}
+
 function reset() {
     viewer.scene.primitives.remove(viewModelTileset);
     viewModelTileset = undefined;

--- a/Apps/Sandcastle/gallery/Classification.html
+++ b/Apps/Sandcastle/gallery/Classification.html
@@ -184,6 +184,10 @@ function highlightTrees() {
 }
 
 function invertClassification(checked) {
+    if (!scene.invertClassificationSupported) {
+        console.log('This browser does not support invert classification');
+    }
+
     scene.invertClassification = checked;
     scene.invertClassificationColor = new Cesium.Color(0.25, 0.25, 0.25, 1.0);
 

--- a/Apps/Sandcastle/gallery/Drawing on Terrain.html
+++ b/Apps/Sandcastle/gallery/Drawing on Terrain.html
@@ -82,6 +82,10 @@ var activeShape;
 var floatingPoint;
 var handler = new Cesium.ScreenSpaceEventHandler(viewer.canvas);
 handler.setInputAction(function(event) {
+    if (!Cesium.Entity.supportsPolylinesOnTerrain(viewer.scene)) {
+        console.log('This browser does not support polylines on terrain.');
+        return;
+    }
     // We use `viewer.scene.pickPosition` here instead of `viewer.camera.pickEllipsoid` so that
     // we get the correct point when mousing over terrain.
     var earthPosition = viewer.scene.pickPosition(event.position);

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,11 @@
 Change Log
 ==========
 
+### 1.52 - 2018-12-03
+
+##### Additions :tada:
+* Added `Scene.invertClassificationSupported` for checking if invert classification is supported.
+
 ### 1.51 - 2018-11-01
 
 ##### Additions :tada:

--- a/Source/Scene/Scene.js
+++ b/Source/Scene/Scene.js
@@ -915,6 +915,21 @@ define([
         },
 
         /**
+         * Returns <code>true</code> if the {@link Scene#invertClassification} is supported.
+         * @memberof Scene.prototype
+         *
+         * @type {Boolean}
+         * @readonly
+         *
+         * @see Scene#invertClassification
+         */
+        invertClassificationSupported : {
+            get : function() {
+                return this._context.depthTexture;
+            }
+        },
+
+        /**
          * Gets or sets the depth-test ellipsoid.
          * @memberof Scene.prototype
          *


### PR DESCRIPTION
A few Sandcastle examples were missing warning messages when features weren't supported, and one was crashing in IE without the check.