### PR TITLE
Add doc for IBL example

### DIFF
--- a/Apps/Sandcastle/gallery/Image-Based Lighting.html
+++ b/Apps/Sandcastle/gallery/Image-Based Lighting.html
@@ -32,6 +32,16 @@ var viewer = new Cesium.Viewer('cesiumContainer');
 var environmentMapURL = '../../SampleData/EnvironmentMap/kiara_6_afternoon_2k_ibl.ktx';
 var modelURL = '../../SampleData/models/Spheres/MetalRoughSpheres.glb';
 
+// CesiumJS supports image-based lighting through the glTF extension `EXT_lights_image_based`.
+// Until more tools can support this extension, the environment map can be set by manually
+// defining model.sphericalHarmonicCoefficients and model.specularEnvironmentMaps. 
+// The spherical harmonic coefficients define the diffuse irradiance color,
+// and the specular environment map is the specular color.
+// This environment map was processed using Google's Filament project.
+// 1 - Download the Filament release (https://github.com/google/filament/releases).
+// 2 - Run `cmgen --type=ktx --deploy=/path/to/output /path/to/image.hd`.
+// 3 - Take the generated coefficients and the KTX file and load them in CesiumJS as shown below.
+
 var L00  = new Cesium.Cartesian3( 0.170455150831422,  0.163151083190219,  0.196966760289763);
 var L1_1 = new Cesium.Cartesian3(-0.066550267689383, -0.022088055746048,  0.078835009246127);
 var L10  = new Cesium.Cartesian3( 0.038364097478591,  0.045714300098753,  0.063498904606215);

--- a/Source/Scene/Model.js
+++ b/Source/Scene/Model.js
@@ -1160,6 +1160,7 @@ define([
          *
          * @memberof Model.prototype
          *
+         * @demo {@link https://cesiumjs.org/Cesium/Apps/Sandcastle/index.html?src=Image-Based Lighting.html|Sandcastle Image Based Lighting Demo}
          * @type {Number}
          * @default 1.0
          */
@@ -1189,7 +1190,7 @@ define([
          *
          * @type {Cartesian3[]}
          * @default undefined
-         *
+         * @demo {@link https://cesiumjs.org/Cesium/Apps/Sandcastle/index.html?src=Image-Based Lighting.html|Sandcastle Image Based Lighting Demo}
          * @see {@link https://graphics.stanford.edu/papers/envmap/envmap.pdf|An Efficient Representation for Irradiance Environment Maps}
          */
         sphericalHarmonicCoefficients : {
@@ -1211,7 +1212,7 @@ define([
          * A URL to a KTX file that contains a cube map of the specular lighting and the convoluted specular mipmaps.
          *
          * @memberof Model.prototype
-         *
+         * @demo {@link https://cesiumjs.org/Cesium/Apps/Sandcastle/index.html?src=Image-Based Lighting.html|Sandcastle Image Based Lighting Demo}
          * @type {String}
          * @default undefined
          */

--- a/Source/Scene/Model.js
+++ b/Source/Scene/Model.js
@@ -1182,7 +1182,7 @@ define([
          * will be used.
          * <p>
          * There are nine <code>Cartesian3</code> coefficients.
-         * The order of the coefficients is: L<sub>00</sub>, L<sub>1-1</sub>, L<sub>10</sub>, L<sub>11</sub>, L<sub>2-2</sub>, L<sub>2-1</sub>, L<sub>20</sub>, L<sub>21<sub>, L<sub>22</sub>
+         * The order of the coefficients is: L<sub>00</sub>, L<sub>1-1</sub>, L<sub>10</sub>, L<sub>11</sub>, L<sub>2-2</sub>, L<sub>2-1</sub>, L<sub>20</sub>, L<sub>21</sub>, L<sub>22</sub>
          * </p>
          *
          * @memberof Model.prototype


### PR DESCRIPTION
This fixes a typo for the IBL doc, adds a link to the Sandcastle in the doc, and explains how to generate the processed KTX and coefficients in the Sandcastle.

The way this feature is _supposed_ to be used is that a user just loads in a glTF that has this information embedded in, and CesiumJS automatically initializes this values. I believe the only tool that can currently do this is Adobe's Dimension CC 2.0, so this Sandcastle shows you how to load it in manually. 

I considered having this is a tutorial but I think it's not a very easy-to-use workflow and will change once the tooling for this extension matures. 

@bagnell 