### PR TITLE
Fix Sandcastle CSS Race Condition

### DIFF
--- a/Apps/Sandcastle/CesiumSandcastle.js
+++ b/Apps/Sandcastle/CesiumSandcastle.js
@@ -624,13 +624,18 @@ require({
                 bucketDoc.body.appendChild(element);
             }
         };
-
-        // Create an observer instance linked to the callback function
+        // If we just add `htmlElement` to the DOM and run
+        // loadScript(), there's a chance it will inject CSS
+        // before the HTML content is fully loaded, leading to a broken page.
+        // So instead we create an observer instance to watch for when
+        // the element has been added.
+        // See https://github.com/AnalyticalGraphicsInc/cesium/issues/5265
         var observer = new MutationObserver(function (mutationsList) {
+            // See https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver
             var length = mutationsList.length;
             for (var i = 0; i < length; i++) {
                 var mutation = mutationsList[i];
-
+                // Watch for an element with the data-sandcastle-loaded attribute.
                 if (defined(mutation.target.dataset) && mutation.target.dataset.sandcastleLoaded === 'yes') {
                     loadScript();
                     observer.disconnect();

--- a/Apps/Sandcastle/CesiumSandcastle.js
+++ b/Apps/Sandcastle/CesiumSandcastle.js
@@ -578,7 +578,6 @@ require({
         // Apply user HTML to bucket.
         var htmlElement = bucketDoc.createElement('div');
         htmlElement.innerHTML = htmlEditor.getValue();
-        bucketDoc.body.appendChild(htmlElement);
 
         var onScriptTagError = function() {
             if (bucketFrame.contentDocument === bucketDoc) {
@@ -625,7 +624,25 @@ require({
                 bucketDoc.body.appendChild(element);
             }
         };
-        loadScript();
+
+        // Create an observer instance linked to the callback function
+        var observer = new MutationObserver(function(mutationsList){
+            var length = mutationsList.length;
+            for(var i = 0; i < length; i++) {
+                var mutation = mutationsList[i];
+
+                if(defined(mutation.target.dataset) && mutation.target.dataset.sandcastleLoaded === 'yes') {
+                    loadScript();
+                    observer.disconnect();
+                }
+            }
+        });
+
+        // Start observing the target node for configured mutations
+        var config = { attributes: true, childList: true, subtree: true };
+        observer.observe(bucketDoc, config);
+
+        bucketDoc.body.appendChild(htmlElement);
     }
 
     function applyBucket() {

--- a/Apps/Sandcastle/CesiumSandcastle.js
+++ b/Apps/Sandcastle/CesiumSandcastle.js
@@ -626,12 +626,12 @@ require({
         };
 
         // Create an observer instance linked to the callback function
-        var observer = new MutationObserver(function(mutationsList){
+        var observer = new MutationObserver(function (mutationsList) {
             var length = mutationsList.length;
-            for(var i = 0; i < length; i++) {
+            for (var i = 0; i < length; i++) {
                 var mutation = mutationsList[i];
 
-                if(defined(mutation.target.dataset) && mutation.target.dataset.sandcastleLoaded === 'yes') {
+                if (defined(mutation.target.dataset) && mutation.target.dataset.sandcastleLoaded === 'yes') {
                     loadScript();
                     observer.disconnect();
                 }


### PR DESCRIPTION
This fixes https://github.com/AnalyticalGraphicsInc/cesium/issues/5265.

@mramato was right, it is a race condition. You can recreate it locally by editing `Apps/Sandcastle/CesiumSandcastle.js` and changing:

```
bucketDoc.body.appendChild(htmlElement);
```

to:

```
setTimeout(function(){
  bucketDoc.body.appendChild(htmlElement);
}, 2000);
```

You might need to play around with the time delay. Too slow and it errors because the element hasn't been added yet. You want it to be between when it's added and fully loaded. 

The fix uses [MutationObserver](https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver) to detect the change, and only then loads the script. Now even with the artificial delay it never happens, so it feels a lot more robust now. [Caniuse reports 92.88%](https://caniuse.com/#feat=mutationobserver) adoption for MutationObserver. Works in IE11. 

@mramato do you want to review? 