### PR TITLE
Fix framebuffer tests in Edge

### DIFF
--- a/Specs/Renderer/FramebufferSpec.js
+++ b/Specs/Renderer/FramebufferSpec.js
@@ -337,6 +337,13 @@ defineSuite([
     function renderDepthAttachment(framebuffer, texture) {
         ClearCommand.ALL.execute(context);
 
+        var framebufferClear = new ClearCommand({
+            depth : 1.0,
+            framebuffer : framebuffer
+        });
+
+        framebufferClear.execute(context);
+
         // 1 of 3.  Render green point into color attachment.
         var vs = 'attribute vec4 position; void main() { gl_PointSize = 1.0; gl_Position = position; }';
         var fs = 'void main() { gl_FragColor = vec4(0.0, 1.0, 0.0, 1.0); }';


### PR DESCRIPTION
Fixes https://github.com/AnalyticalGraphicsInc/cesium/issues/7106

These tests should pass on Edge now: http://cesium-dev.s3-website-us-east-1.amazonaws.com/cesium/clear-framebuffer-test/Specs/SpecRunner.html?spec=Renderer%2FFramebuffer