### PR TITLE
Fix debugColorizeTiles test

### DIFF
--- a/Specs/Scene/Cesium3DTilesetSpec.js
+++ b/Specs/Scene/Cesium3DTilesetSpec.js
@@ -1430,6 +1430,7 @@ defineSuite([
     });
 
     function checkDebugColorizeTiles(url) {
+        CesiumMath.setRandomNumberSeed(0);
         return Cesium3DTilesTester.loadTileset(scene, url).then(function(tileset) {
             // Get initial color
             var color;

--- a/Specs/Scene/PointCloud3DTileContentSpec.js
+++ b/Specs/Scene/PointCloud3DTileContentSpec.js
@@ -334,6 +334,7 @@ defineSuite([
     });
 
     it('renders with debug color', function() {
+        CesiumMath.setRandomNumberSeed(0);
         return Cesium3DTilesTester.loadTileset(scene, pointCloudRGBUrl).then(function(tileset) {
             var color;
             expect(scene).toRenderAndCall(function(rgba) {


### PR DESCRIPTION
Fixes #7201 

Sets the random number seed before running any tests that set `debugColorizeTiles` so that a random color won't accidentally be white.

http://cesium-dev.s3-website-us-east-1.amazonaws.com/cesium/clear-framebuffer-test/Specs/SpecRunner.html?spec=Renderer%2FFramebuffer