### PR TITLE
Fixed vector tile point color test in FF, IE, Edge

### DIFF
--- a/Specs/Scene/Vector3DTilePointsSpec.js
+++ b/Specs/Scene/Vector3DTilePointsSpec.js
@@ -154,7 +154,7 @@ defineSuite([
             points.createFeatures(mockTileset, features);
             points.applyStyle(undefined, features);
 
-            scene.camera.lookAt(Cartesian3.fromDegrees(0.0, 0.0, 10.0), new Cartesian3(0.0, 0.0, 50.0));
+            scene.camera.lookAt(Cartesian3.fromDegrees(0.0, 0.0, 30.0), new Cartesian3(0.0, 0.0, 50.0));
             expect(scene).toRender([255, 255, 255, 255]);
         });
     });


### PR DESCRIPTION
Fixes https://github.com/AnalyticalGraphicsInc/cesium/issues/7105

These tests should pass now: http://cesium-dev.s3-website-us-east-1.amazonaws.com/cesium/vector-tile-point-fix/Specs/SpecRunner.html?spec=Scene%2FVector3DTileContent%20renders%20points