### PR TITLE
Appveyor CI

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,4 +1,7 @@
 image: Visual Studio 2017
+
+version: '{build}'
+
 environment:
   matrix:
     - nodejs_version: "8"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,17 @@
+image: Visual Studio 2017
+environment:
+  matrix:
+    - nodejs_version: "8"
+
+install:
+  # Get the latest stable version of Node.js
+  - ps: Install-Product node $env:nodejs_version
+  # install modules
+  - npm install
+
+test_script:
+  - npm --silent run build
+  - npm --silent run test -- --browsers IE --webgl-stub --suppressPassed
+
+# Don't actually build.
+build: off


### PR DESCRIPTION
To improve QA, we want to run the tests on IE as part of the CI process.  Since travis-ci Windows support is still far away from official (I tried it and had issues), it's easy to enable appveyor and use it instead.

Appveyor only runs tests against IE, it doesn't do anything else, such as generate binaries or perform a build.  That's still the responsibility of the travis builds.

I made it so appveyor wouldn't fail the build on error for now, since IE has failing tests that we need to address.  Once we get them happy, we can make the unit tests fail on error.

Edge simply isn't supported by Appveyor yet, we'll add it if/when it is ever supported (or re-evaluate travis for windows in the future as well)