### PR TITLE
Add karma plugin to report longest running tests

### DIFF
--- a/Specs/karma.conf.js
+++ b/Specs/karma.conf.js
@@ -46,7 +46,8 @@ module.exports = function(config) {
         // test results reporter to use
         // possible values: 'dots', 'progress'
         // available reporters: https://npmjs.org/browse/keyword/karma-reporter
-        reporters : ['spec'],
+        reporters : ['spec', 'longest'],
+        longestSpecsToReport : 10,
 
         // web server port
         port : 9876,

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "karma-firefox-launcher": "^1.0.0",
     "karma-ie-launcher": "^1.0.0",
     "karma-jasmine": "^1.1.0",
+    "karma-longest-reporter": "^1.1.0",
     "karma-requirejs": "^1.1.0",
     "karma-safari-launcher": "^1.0.0",
     "karma-spec-reporter": "^0.0.32",


### PR DESCRIPTION
This adds [karma-longest-reporter](https://www.npmjs.com/package/karma-longest-reporter) so it'll be easy to tell every time we run the tests which tests are taking the longest. It's currently configured to show the top 10 longest running tests. 

Sample output:

```
4.592 secs: Core/VideoSynchronizer Syncs time when looping
4.041 secs: Scene/ShadowMap model casts shadow onto globe
2.971 secs: Scene/ShadowMap globe casts shadow onto globe
2.642 secs: Scene/Vector3DTileContent renders with different classification types
2.639 secs: Scene/GroundPrimitive setting per instance attribute throws when value is undefined
2.387 secs: Scene/GroundPrimitive getGeometryInstanceAttributes throws without id
2.273 secs: Scene/createTileMapServiceImageryProvider supports no slash at the endof the URL
2.268 secs: Scene/GroundPrimitive update throws when one batched instance color is undefined
2.189 secs: Scene/Vector3DTileContent renders polylines
2.107 secs: DataSources/GeometryVisualizer Creates and removes static color open geometry
```

So right now you'll have to look in the Travis logs to see it I think but this is a step towards integrating it with concierge and having it tell you if there's any tests that are taking super long on a new PR. Even without that, being able to see which tests take the longest in general is pretty useful I think. 

@mramato what do you think? Is it fine to enable this by default? 