### PR TITLE
Speed up GroundPrimitive tests

### DIFF
--- a/Specs/Scene/GroundPrimitiveSpec.js
+++ b/Specs/Scene/GroundPrimitiveSpec.js
@@ -64,15 +64,10 @@ defineSuite([
     var rectangleInstance;
     var primitive;
     var depthPrimitive;
-    var largeScene;
     var reusablePrimitive;
-    var largeSceneReusablePrimitive;
 
     beforeAll(function() {
         scene = createScene();
-        largeScene = createScene({
-            canvas : createCanvas(2, 2)
-        });
 
         scene.postProcessStages.fxaa.enabled = false;
 
@@ -101,32 +96,12 @@ defineSuite([
                 }),
                 asynchronous : false
             });
-
-            largeSceneReusablePrimitive = new Primitive({
-                geometryInstances : new GeometryInstance({
-                    geometry : new RectangleGeometry({
-                        ellipsoid : ellipsoid,
-                        rectangle : bigRectangle
-                    }),
-                    id : 'depth rectangle',
-                    attributes : {
-                        color : depthColorAttribute
-                    }
-                }),
-                appearance : new PerInstanceColorAppearance({
-                    translucent : false,
-                    flat : true
-                }),
-                asynchronous : false
-            });
         });
     });
 
     afterAll(function() {
         reusablePrimitive.destroy();
         scene.destroyForSpecs();
-        largeScene.destroyForSpecs();
-
         // Leave ground primitive uninitialized
         ApproximateTerrainHeights._initPromise = undefined;
         ApproximateTerrainHeights._terrainHeights = undefined;
@@ -181,7 +156,6 @@ defineSuite([
 
     afterEach(function() {
         scene.groundPrimitives.removeAll();
-        largeScene.groundPrimitives.removeAll();
         primitive = primitive && !primitive.isDestroyed() && primitive.destroy();
         depthPrimitive = depthPrimitive && !depthPrimitive.isDestroyed() && depthPrimitive.destroy();
     });
@@ -333,9 +307,9 @@ defineSuite([
 
         primitive = scene.groundPrimitives.add(new GroundPrimitive({
             geometryInstances : rectangleInstance,
-            asynchronous : false
+            asynchronous : false,
+            show : false
         }));
-        primitive.show = false;
 
         var ready = false;
         primitive.readyPromise.then(function() {
@@ -494,6 +468,43 @@ defineSuite([
 
     describe('larger scene', function() {
         // Screen space techniques may produce unexpected results with 1x1 canvasses
+        var largeScene;
+        var largeSceneReusablePrimitive;
+        beforeAll(function() {
+            largeScene = createScene({
+                canvas : createCanvas(2, 2)
+            });
+
+            var depthColorAttribute = ColorGeometryInstanceAttribute.fromColor(new Color(0.0, 0.0, 1.0, 1.0));
+            depthColor = depthColorAttribute.value;
+            var bigRectangle = Rectangle.fromDegrees(-180 + CesiumMath.EPSILON4, -90 + CesiumMath.EPSILON4, 180 - CesiumMath.EPSILON4, 90 - CesiumMath.EPSILON4);
+
+            largeSceneReusablePrimitive = new Primitive({
+                geometryInstances : new GeometryInstance({
+                    geometry : new RectangleGeometry({
+                        ellipsoid : ellipsoid,
+                        rectangle : bigRectangle
+                    }),
+                    id : 'depth rectangle',
+                    attributes : {
+                        color : depthColorAttribute
+                    }
+                }),
+                appearance : new PerInstanceColorAppearance({
+                    translucent : false,
+                    flat : true
+                }),
+                asynchronous : false
+            });
+        });
+        afterAll(function() {
+            largeSceneReusablePrimitive.destroy();
+            largeScene.destroyForSpecs();
+        });
+        afterEach(function(){
+            largeScene.groundPrimitives.removeAll();
+        });
+
         function verifyLargerScene(groundPrimitive, expectedColor, destination) {
             largeScene.render();
 


### PR DESCRIPTION
This PR makes `GroundPrimitiveSpec` almost twice as fast (on my machine it goes from 30 sec to 17 sec). Timings before:

```
2.453 secs: Scene/GroundPrimitive becomes ready when show is false
1.109 secs: Scene/GroundPrimitive renders in 3D
0.785 secs: Scene/GroundPrimitive larger scene renders small GeometryInstances with texture classifying terrain
0.784 secs: Scene/GroundPrimitive larger scene renders batched instances
0.783 secs: Scene/GroundPrimitive picking in 2D
0.762 secs: Scene/GroundPrimitive renders in Columbus view when scene3DOnly is false
0.759 secs: Scene/GroundPrimitive renders GroundPrimitives with planar texture coordinates across the IDL in 3D
0.711 secs: Scene/GroundPrimitive larger scene update throws with texture and ClassificationType that is not TERRAIN
0.705 secs: Scene/GroundPrimitive picking in 3D
0.679 secs: Scene/GroundPrimitive renders with invert classification and an opaque color

Chrome 70.0.3538 (Windows 10 0.0.0): Executed 48 of 10412 (skipped 10364) SUCCESS (30.552 secs / 21.259 secs)
```

After:

```
1.466 secs: Scene/GroundPrimitive internally invalid asynchronous geometry resolves promise and sets ready
1.013 secs: Scene/GroundPrimitive renders in 3D
0.853 secs: Scene/GroundPrimitive larger scene renders batched instances
0.271 secs: Scene/GroundPrimitive releases geometry instances when releaseGeometryInstances is true
0.259 secs: Scene/GroundPrimitive larger scene renders small GeometryInstances with texture classifying terrain
0.223 secs: Scene/GroundPrimitive renders with invert classification and an opaque color
0.215 secs: Scene/GroundPrimitive renders with distance display condition per instance attribute
0.202 secs: Scene/GroundPrimitive renders in 2D when scene3DOnly is false
0.193 secs: Scene/GroundPrimitive larger scene renders large GeometryInstances with texture classifying terrain
0.184 secs: Scene/GroundPrimitive picking without depth texture

Chrome 70.0.3538 (Windows 10 0.0.0): Executed 48 of 10412 (skipped 10364) SUCCESS (17.27 secs / 7.772 secs)
```

I did this by:

* Setting async to false on `becomes ready when show is false` which was one of the slowest ones.
* Instead of recreating the large scene on `beforeEach` I made it on `beforeAll`
* I cached MockGlobePrimitive, since it was spending a lot of time on each test just creating that huge geometry. 
  * I couldn't figure out how to use one primitive for both scenes, even though it's the same primitive. So now it creates 2 global reusable primitives.
* I also did some misc cleanup, like there was one test that was recreating the MockGlobePrimitive for some reason. 

@likangning93 do you want to review? 