### PR TITLE
Apply styles to photogrammetry

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@ Change Log
     * Added `Scene.clampToHeightMostDetailed`, an asynchronous version of `Scene.clampToHeight` that uses the maximum level of detail for 3D Tiles.
 * Added `Scene.invertClassificationSupported` for checking if invert classification is supported.
 * Added `computeLineSegmentLineSegmentIntersection` to `Intersections2D`. [#7228](https://github.com/AnalyticalGraphicsInc/Cesium/pull/7228)
+* Added the ability to apply styles to 3D Tilesets that don't contain features. [#7255](https://github.com/AnalyticalGraphicsInc/Cesium/pull/7255)
 
 ##### Fixes :wrench:
 * Fixed issue causing polyline to look wavy depending on the position of the camera [#7209](https://github.com/AnalyticalGraphicsInc/cesium/pull/7209)

--- a/Source/Scene/Batched3DModel3DTileContent.js
+++ b/Source/Scene/Batched3DModel3DTileContent.js
@@ -446,8 +446,17 @@ define([
         }
     };
 
+    var scratchColor = new Color();
+
     Batched3DModel3DTileContent.prototype.applyStyle = function(style) {
-        this._batchTable.applyStyle(style);
+        if (this.featuresLength === 0) {
+            var hasColorStyle = defined(style) && defined(style.color);
+            var hasShowStyle = defined(style) && defined(style.show);
+            this._model.color = hasColorStyle ? style.color.evaluateColor(undefined, scratchColor) : Color.WHITE;
+            this._model.show = hasShowStyle ? style.show.evaluate(undefined) : true;
+        } else {
+            this._batchTable.applyStyle(style);
+        }
     };
 
     Batched3DModel3DTileContent.prototype.update = function(tileset, frameState) {

--- a/Source/Scene/Cesium3DTileBatchTable.js
+++ b/Source/Scene/Cesium3DTileBatchTable.js
@@ -547,7 +547,7 @@ define([
     Cesium3DTileBatchTable.prototype.applyStyle = function(style) {
         if (!defined(style)) {
             this.setAllColor(DEFAULT_COLOR_VALUE);
-            this.setAllShow(true);
+            this.setAllShow(DEFAULT_SHOW_VALUE);
             return;
         }
 

--- a/Source/Scene/Expression.js
+++ b/Source/Scene/Expression.js
@@ -824,7 +824,7 @@ define([
             } else if (node._value === 'isClass') {
                 node.evaluate = node._evaluateIsClass;
             } else if (node._value === 'getExactClassName') {
-                node.evaluate = node._evaluategetExactClassName;
+                node.evaluate = node._evaluateGetExactClassName;
             } else if (node._value === 'Boolean') {
                 node.evaluate = node._evaluateBooleanConversion;
             } else if (node._value === 'Number') {
@@ -900,6 +900,9 @@ define([
     }
 
     function evaluateTilesetTime(feature) {
+        if (!defined(feature)) {
+            return 0.0;
+        }
         return feature.content.tileset.timeSinceLoad;
     }
 
@@ -928,6 +931,13 @@ define([
             var test = this._test.evaluate(feature);
             return evaluate(call, left, right, test);
         };
+    }
+
+    function getFeatureProperty(feature, name) {
+        // Returns undefined if the feature is not defined or the property name is not defined for that feature
+        if (defined(feature)) {
+            return feature.getProperty(name);
+        }
     }
 
     Node.prototype._evaluateLiteral = function() {
@@ -1046,7 +1056,7 @@ define([
         while (match !== null) {
             var placeholder = match[0];
             var variableName = match[1];
-            var property = feature.getProperty(variableName);
+            var property = getFeatureProperty(feature, variableName);
             if (!defined(property)) {
                 property = '';
             }
@@ -1058,7 +1068,7 @@ define([
 
     Node.prototype._evaluateVariable = function(feature) {
         // evaluates to undefined if the property name is not defined for that feature
-        return feature.getProperty(this._value);
+        return getFeatureProperty(feature, this._value);
     };
 
     function checkFeature (ast) {
@@ -1068,7 +1078,7 @@ define([
     // PERFORMANCE_IDEA: Determine if parent property needs to be computed before runtime
     Node.prototype._evaluateMemberDot = function(feature) {
         if (checkFeature(this._left)) {
-            return feature.getProperty(this._right.evaluate(feature));
+            return getFeatureProperty(feature, this._right.evaluate(feature));
         }
         var property = this._left.evaluate(feature);
         if (!defined(property)) {
@@ -1093,7 +1103,7 @@ define([
 
     Node.prototype._evaluateMemberBrackets = function(feature) {
         if (checkFeature(this._left)) {
-            return feature.getProperty(this._right.evaluate(feature));
+            return getFeatureProperty(feature, this._right.evaluate(feature));
         }
         var property = this._left.evaluate(feature);
         if (!defined(property)) {
@@ -1388,15 +1398,23 @@ define([
     };
 
     Node.prototype._evaluateIsExactClass = function(feature) {
-        return feature.isExactClass(this._left.evaluate(feature));
+        if (defined(feature)) {
+            return feature.isExactClass(this._left.evaluate(feature));
+        }
+        return false;
     };
 
     Node.prototype._evaluateIsClass = function(feature) {
-        return feature.isClass(this._left.evaluate(feature));
+        if (defined(feature)) {
+            return feature.isClass(this._left.evaluate(feature));
+        }
+        return false;
     };
 
-    Node.prototype._evaluategetExactClassName = function(feature) {
-        return feature.getExactClassName();
+    Node.prototype._evaluateGetExactClassName = function(feature) {
+        if (defined(feature)) {
+            return feature.getExactClassName();
+        }
     };
 
     Node.prototype._evaluateBooleanConversion = function(feature) {

--- a/Specs/Scene/Cesium3DTilesetSpec.js
+++ b/Specs/Scene/Cesium3DTilesetSpec.js
@@ -1973,6 +1973,18 @@ defineSuite([
         });
     });
 
+    it('applies show style to a tileset without features', function() {
+        return Cesium3DTilesTester.loadTileset(scene, noBatchIdsUrl).then(function(tileset) {
+            var hideStyle = new Cesium3DTileStyle({show : 'false'});
+            tileset.style = hideStyle;
+            expect(tileset.style).toBe(hideStyle);
+            expect(scene).toRender([0, 0, 0, 255]);
+
+            tileset.style = new Cesium3DTileStyle({show : 'true'});
+            expect(scene).notToRender([0, 0, 0, 255]);
+        });
+    });
+
     it('applies style with complex show expression to a tileset', function() {
         return Cesium3DTilesTester.loadTileset(scene, withBatchTableUrl).then(function(tileset) {
             // Each feature in the b3dm file has an id property from 0 to 9
@@ -2041,6 +2053,12 @@ defineSuite([
 
     it('applies color style to a tileset with translucent and opaque tiles', function() {
         return Cesium3DTilesTester.loadTileset(scene, translucentOpaqueMixUrl).then(function(tileset) {
+            expectColorStyle(tileset);
+        });
+    });
+
+    it('applies color style to tileset without features', function() {
+        return Cesium3DTilesTester.loadTileset(scene, noBatchIdsUrl).then(function(tileset) {
             expectColorStyle(tileset);
         });
     });

--- a/Specs/Scene/ExpressionSpec.js
+++ b/Specs/Scene/ExpressionSpec.js
@@ -126,6 +126,30 @@ defineSuite([
         }).toThrowRuntimeError();
     });
 
+    it('evaluates variable to undefined if feature is undefined', function() {
+        var expression = new Expression('${height}');
+        expect(expression.evaluate(undefined)).toBeUndefined();
+
+        expression = new Expression('${vector.x}');
+        expect(expression.evaluate(undefined)).toBeUndefined();
+
+        expression = new Expression('${feature}');
+        expect(expression.evaluate(undefined)).toBeUndefined();
+
+        expression = new Expression('${feature.vector}');
+        expect(expression.evaluate(undefined)).toBeUndefined();
+
+        expression = new Expression('${vector["x"]}');
+        expect(expression.evaluate(undefined)).toBeUndefined();
+
+        expression = new Expression('${feature["vector"]}');
+        expect(expression.evaluate(undefined)).toBeUndefined();
+
+        // Evaluating inside a string is an exception. "" is returned instead of "undefined"
+        expression = new Expression('\'${height}\'');
+        expect(expression.evaluate(undefined)).toBe('');
+    });
+
     it('evaluates with defines', function() {
         var defines = {
             halfHeight: '${Height}/2'
@@ -1493,6 +1517,8 @@ defineSuite([
 
         expression = new Expression('isExactClass("roof")');
         expect(expression.evaluate(feature)).toEqual(false);
+
+        expect(expression.evaluate(undefined)).toEqual(false);
     });
 
     it('throws if isExactClass takes an invalid number of arguments', function() {
@@ -1513,6 +1539,8 @@ defineSuite([
 
         var expression = new Expression('isClass("door") && isClass("building")');
         expect(expression.evaluate(feature)).toEqual(true);
+
+        expect(expression.evaluate(undefined)).toEqual(false);
     });
 
     it('throws if isClass takes an invalid number of arguments', function() {
@@ -1530,6 +1558,7 @@ defineSuite([
         feature.setClass('door');
         var expression = new Expression('getExactClassName()');
         expect(expression.evaluate(feature)).toEqual('door');
+        expect(expression.evaluate(undefined)).toBeUndefined();
     });
 
     it('throws if getExactClassName takes an invalid number of arguments', function() {
@@ -2953,6 +2982,7 @@ defineSuite([
         expect(expression.evaluate(feature)).toEqual(0.0);
         feature.content.tileset.timeSinceLoad = 1.0;
         expect(expression.evaluate(feature)).toEqual(1.0);
+        expect(expression.evaluate(undefined)).toEqual(0.0);
     });
 
     it('gets shader function', function() {


### PR DESCRIPTION
Fixes https://github.com/AnalyticalGraphicsInc/cesium/issues/7149

Styles now work for tilesets that don't have features. All property expressions (e.g. `${Height}`) evaluate to undefined.

@OmarShehata can you review?

```js
tileset.style = new Cesium.Cesium3DTileStyle({
    color : 'rgba(255, 0, 0, 0.5)'
});
```
![style](https://user-images.githubusercontent.com/915398/48308871-30d69300-e53b-11e8-9cdd-e6a032604516.PNG)

