### PR TITLE
Improve visibility check in tileset traversal

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,11 @@
 Change Log
 ==========
 
+### 1.53 - 2019-01-02
+
+##### Fixes :wrench:
+* Fixed 3D Tiles visibility checking when running multiple passes within the same frame. [#7289](https://github.com/AnalyticalGraphicsInc/cesium/pull/7289)
+
 ### 1.52 - 2018-12-03
 
 ##### Breaking Changes :mega:

--- a/Source/Scene/Cesium3DTileset.js
+++ b/Source/Scene/Cesium3DTileset.js
@@ -187,6 +187,7 @@ define([
         this._selectedTilesToStyle = [];
         this._loadTimestamp = undefined;
         this._timeSinceLoad = 0.0;
+        this._updatedVisibilityFrame = 0;
         this._extras = undefined;
 
         this._cullWithChildrenBounds = defaultValue(options.cullWithChildrenBounds, true);
@@ -1943,6 +1944,8 @@ define([
         if (isRender) {
             tileset._cache.reset();
         }
+
+        ++tileset._updatedVisibilityFrame;
 
         var ready;
 

--- a/Source/Scene/Cesium3DTilesetTraversal.js
+++ b/Source/Scene/Cesium3DTilesetTraversal.js
@@ -217,14 +217,14 @@ define([
     }
 
     function updateVisibility(tileset, tile, frameState) {
-        if (tile._updatedVisibilityFrame === frameState.frameNumber) {
+        if (tile._updatedVisibilityFrame === tileset._updatedVisibilityFrame) {
             // Return early if visibility has already been checked during the traversal.
             // The visibility may have already been checked if the cullWithChildrenBounds optimization is used.
             return;
         }
 
         tile.updateVisibility(frameState);
-        tile._updatedVisibilityFrame = frameState.frameNumber;
+        tile._updatedVisibilityFrame = tileset._updatedVisibilityFrame;
     }
 
     function anyChildrenVisible(tileset, tile, frameState) {
@@ -470,7 +470,6 @@ define([
             visitTile(tileset, tile, frameState);
             touchTile(tileset, tile, frameState);
             tile._refines = refines;
-            tile._updatedVisibilityFrame = 0; // Reset so visibility is checked during the next pass which may use a different camera
         }
     }
 


### PR DESCRIPTION
This is a better way to set `updateVisibilityFrame` in the 3D Tiles traversal code which is used to limit the number of times a tile's visibility can be computed during each traversal.

The previous way had an edge case where the visibility frame would not get reset after a previous pass within the same frame if the tile's visibility was checked but it wasn't actually visited. This can happen with the cull-with-children-bounds optimization. I only hit this by calling `pickFromRay` after a `pick`, and it only happened sometimes.

* [x] CHANGES.md