### PR TITLE
ModelAnimationCollection doc typo

### DIFF
--- a/Source/Scene/ModelAnimationCollection.js
+++ b/Source/Scene/ModelAnimationCollection.js
@@ -98,7 +98,7 @@ define([
      * </p>
      *
      * @param {Object} options Object with the following properties:
-     * @param {String} [options.name] The glTF animation name that identifies the animation. Must be defined if <code>options.id</code> is <code>undefined</code>.
+     * @param {String} [options.name] The glTF animation name that identifies the animation. Must be defined if <code>options.index</code> is <code>undefined</code>.
      * @param {Number} [options.index] The glTF animation index that identifies the animation. Must be defined if <code>options.name</code> is <code>undefined</code>.
      * @param {JulianDate} [options.startTime] The scene time to start playing the animation.  When this is <code>undefined</code>, the animation starts at the next frame.
      * @param {Number} [options.delay=0.0] The delay, in seconds, from <code>startTime</code> to start playing.


### PR DESCRIPTION
I think this is a typo since `id` is not a property here. @lilleyse 