### PR TITLE
Translucent geometry fix

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,7 @@ Change Log
 ##### Fixes :wrench:
 * Fixed issue causing polyline to look wavy depending on the position of the camera [#7209](https://github.com/AnalyticalGraphicsInc/cesium/pull/7209)
 * Fixed an issue where polylines intersecting the near plane would cause blinking. [#6955](https://github.com/AnalyticalGraphicsInc/cesium/pull/6955)
+* Fixed translucency issues for dynamic geometry entities. [#7364](https://github.com/AnalyticalGraphicsInc/cesium/issues/7364)
 
 ### 1.51 - 2018-11-01
 

--- a/Source/DataSources/DynamicGeometryUpdater.js
+++ b/Source/DataSources/DynamicGeometryUpdater.js
@@ -107,7 +107,7 @@ define([
             if (isColorAppearance) {
                 appearance = new PerInstanceColorAppearance({
                     closed: closed,
-                    flat : !(onTerrain && geometryUpdater._supportsMaterialsforEntitiesOnTerrain)
+                    flat : onTerrain && !geometryUpdater._supportsMaterialsforEntitiesOnTerrain
                 });
             } else {
                 var material = MaterialProperty.getValue(time, fillMaterialProperty, this._material);


### PR DESCRIPTION
Fixes #7364

The fix in #7212 wasn't the correct logic and was making all dynamic geometry not on terrain `flat: true`
Double checked and #7103 is still fixed