### PR TITLE
Fix translucency with HDR

### DIFF
--- a/Source/Shaders/Builtin/Functions/gammaCorrect.glsl
+++ b/Source/Shaders/Builtin/Functions/gammaCorrect.glsl
@@ -17,7 +17,6 @@ vec3 czm_gammaCorrect(vec3 color) {
 vec4 czm_gammaCorrect(vec4 color) {
 #ifdef HDR
     color.rgb = pow(color.rgb, vec3(czm_gamma));
-    color.a = pow(color.a, 1.0 / czm_gamma);
 #endif
     return color;
 }


### PR DESCRIPTION
Do not gamma correct alpha. Fixes #7363.

There was an attempt to make colors match more closely to rendering without HDR, but there is no gamma correction during that pass. With this change, colors will be brighter, but should also be more correct. Also, translucency will be closer to the behavior in 1.51. 