### PR TITLE
 Don't show an error when buildings forks.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1138,9 +1138,9 @@ function createGalleryList() {
     // This includes newly staged local demos as well.
     var newDemos = [];
     try {
-        newDemos = child_process.execSync('git diff --name-only --diff-filter=A ' + tagVersion + ' Apps/Sandcastle/gallery/*.html').toString().trim().split('\n');
+        newDemos = child_process.execSync('git diff --name-only --diff-filter=A ' + tagVersion + ' Apps/Sandcastle/gallery/*.html', { stdio: ['pipe', 'pipe', 'ignore'] }).toString().trim().split('\n');
     } catch (e) {
-        console.log('Failed to retrieve list of new Sandcastle demos from Git.');
+        // On a Cesium fork, tags don't exist so we can't generate the list.
     }
 
     var helloWorld;


### PR DESCRIPTION
Fixes #7090

1. Eat the error output from the failing git command.

2. Don't manually log an error either, since it's never going to occur on non-forks and that was the reason it was originally there.

To test, simply run `git tag --delete 1.51 1.52` and then `npm run build`.  You'll no longer get an error (but if you do the same in master you will.

The tags will automatically come back when you run git pull again.