### PR TITLE
fix bounding spheres and rectangles for projections like cassini

### DIFF
--- a/Source/Core/Rectangle.js
+++ b/Source/Core/Rectangle.js
@@ -879,14 +879,14 @@ define([
     var projectedScratch = new Cartesian3();
     /**
      * Approximates a Cartographic rectangle's extents in some map projection by projecting
-     * points along the rectangle's edges.
+     * points in a grid throughout the rectangle.
      *
      * @function
      *
      * @param {Rectangle} cartographicRectangle An input rectangle in geographic coordinates.
      * @param {MapProjection} mapProjection A MapProjection indicating a projection from geographic coordinates.
      * @param {Rectangle} [result] Rectangle on which to store the projected extents of the input.
-     * @param {Number} [steps=16] Number of points to sample along each side of the geographic Rectangle.
+     * @param {Number} [steps=8] Number of points to sample along each side of the geographic Rectangle.
      */
     Rectangle.approximateProjectedExtents = function(cartographicRectangle, mapProjection, result, steps) {
         //>>includeStart('debug', pragmas.debug);
@@ -895,7 +895,7 @@ define([
         //>>includeEnd('debug');
 
         result = defaultValue(result, new Rectangle());
-        steps = defaultValue(steps, 16);
+        steps = defaultValue(steps, 8);
 
         result.west = Number.MAX_VALUE;
         result.east = -Number.MAX_VALUE;
@@ -913,41 +913,16 @@ define([
         var unprojected = unprojectedScratch;
 
         for (var longIndex = 0; longIndex < steps; longIndex++) {
-            unprojected.longitude = geographicCorner.longitude + geographicWidthStep * longIndex;
-            unprojected.latitude = geographicCorner.latitude;
+            for (var latIndex = 0; latIndex < steps; latIndex++) {
+                unprojected.longitude = geographicCorner.longitude + geographicWidthStep * longIndex;
+                unprojected.latitude = geographicCorner.latitude + geographicHeightStep * latIndex;
 
-            mapProjection.project(unprojected, projected);
-            result.west = Math.min(result.west, projected.x);
-            result.east = Math.max(result.east, projected.x);
-            result.south = Math.min(result.south, projected.y);
-            result.north = Math.max(result.north, projected.y);
-
-            unprojected.latitude = geographicCorner.latitude + geographicHeight;
-
-            mapProjection.project(unprojected, projected);
-            result.west = Math.min(result.west, projected.x);
-            result.east = Math.max(result.east, projected.x);
-            result.south = Math.min(result.south, projected.y);
-            result.north = Math.max(result.north, projected.y);
-        }
-
-        for (var latIndex = 0; latIndex < steps; latIndex++) {
-            unprojected.latitude = geographicCorner.latitude + geographicHeightStep * latIndex;
-            unprojected.longitude = geographicCorner.longitude;
-
-            mapProjection.project(unprojected, projected);
-            result.west = Math.min(result.west, projected.x);
-            result.east = Math.max(result.east, projected.x);
-            result.south = Math.min(result.south, projected.y);
-            result.north = Math.max(result.north, projected.y);
-
-            unprojected.longitude = geographicCorner.longitude + geographicWidth;
-
-            mapProjection.project(unprojected, projected);
-            result.west = Math.min(result.west, projected.x);
-            result.east = Math.max(result.east, projected.x);
-            result.south = Math.min(result.south, projected.y);
-            result.north = Math.max(result.north, projected.y);
+                mapProjection.project(unprojected, projected);
+                result.west = Math.min(result.west, projected.x);
+                result.east = Math.max(result.east, projected.x);
+                result.south = Math.min(result.south, projected.y);
+                result.north = Math.max(result.north, projected.y);
+            }
         }
 
         return result;
@@ -956,7 +931,6 @@ define([
     var northPole = new Cartographic(0, CesiumMath.PI_OVER_TWO);
     var southPole = new Cartographic(0, -CesiumMath.PI_OVER_TWO);
     var projectedPoleScratch = new Cartographic();
-    var projectedIdlScratch = new Cartographic();
     /**
      * Approximates a projected rectangle's extents in Cartographic space by unprojecting
      * points along the Rectangle's boundary, checking the poles, and guessing whether or not
@@ -993,6 +967,9 @@ define([
         var projectedHeight = projectedRectangle.height;
         var projectedWidthStep = projectedWidth / (steps - 1);
         var projectedHeightStep = projectedHeight / (steps - 1);
+        var crossedIdl = false;
+        var lastLongitudeTop = 0.0;
+        var lastLongitudeBottom = 0.0;
 
         var projected = projectedScratch;
         var unprojected = unprojectedScratch;
@@ -1006,6 +983,11 @@ define([
             result.south = Math.min(result.south, unprojected.latitude);
             result.north = Math.max(result.north, unprojected.latitude);
 
+            if (longIndex !== 0 && !CesiumMath.equalsEpsilon(Math.abs(unprojected.longitude), CesiumMath.PI, CesiumMath.EPSILON14)) {
+                crossedIdl = crossedIdl || Math.abs(lastLongitudeTop - unprojected.longitude) > CesiumMath.PI;
+            }
+            lastLongitudeTop = unprojected.longitude;
+
             idlCrossWest = unprojected.longitude > 0.0 ? Math.min(idlCrossWest, unprojected.longitude) : idlCrossWest;
             idlCrossEast = unprojected.longitude < 0.0 ? Math.max(idlCrossEast, unprojected.longitude) : idlCrossEast;
 
@@ -1016,6 +998,11 @@ define([
             result.east = Math.max(result.east, unprojected.longitude);
             result.south = Math.min(result.south, unprojected.latitude);
             result.north = Math.max(result.north, unprojected.latitude);
+
+            if (longIndex !== 0 && !CesiumMath.equalsEpsilon(Math.abs(unprojected.longitude), CesiumMath.PI, CesiumMath.EPSILON14)) {
+                crossedIdl = crossedIdl || Math.abs(lastLongitudeBottom - unprojected.longitude) > CesiumMath.PI;
+            }
+            lastLongitudeBottom = unprojected.longitude;
 
             idlCrossWest = unprojected.longitude > 0.0 ? Math.min(idlCrossWest, unprojected.longitude) : idlCrossWest;
             idlCrossEast = unprojected.longitude < 0.0 ? Math.max(idlCrossEast, unprojected.longitude) : idlCrossEast;
@@ -1050,10 +1037,10 @@ define([
         var projectionBounds = defaultValue(mapProjection.wgs84Bounds, Rectangle.MAX_VALUE);
         var containsPole;
 
-        var proejctedNorthPole = mapProjection.project(northPole, projectedScratch);
+        var projectedNorthPole = mapProjection.project(northPole, projectedScratch);
         var projectedNorthPoleCartographic = projectedPoleScratch;
-        projectedNorthPoleCartographic.longitude = proejctedNorthPole.x;
-        projectedNorthPoleCartographic.latitude = proejctedNorthPole.y;
+        projectedNorthPoleCartographic.longitude = projectedNorthPole.x;
+        projectedNorthPoleCartographic.latitude = projectedNorthPole.y;
         if (Rectangle.contains(projectionBounds, northPole) && Rectangle.contains(projectedRectangle, projectedNorthPoleCartographic)) {
             result.north = CesiumMath.PI_OVER_TWO;
             result.west = -CesiumMath.PI;
@@ -1073,17 +1060,9 @@ define([
         }
 
         // Check if the rectangle crosses the IDL
-        if (!containsPole) {
-            unprojected.longitude = CesiumMath.PI;
-            unprojected.latitude = (result.north + result.south) * 0.5;
-            var projectedIdlCheckpoint = mapProjection.project(unprojected, projectedScratch);
-            var projectedIdlCartographic = projectedIdlScratch;
-            projectedIdlCartographic.longitude = projectedIdlCheckpoint.x;
-            projectedIdlCartographic.latitude = projectedIdlCheckpoint.y;
-            if (Rectangle.contains(projectedRectangle, projectedIdlCartographic)) {
-                result.west = idlCrossWest;
-                result.east = idlCrossEast;
-            }
+        if (!containsPole && crossedIdl) {
+            result.west = idlCrossWest;
+            result.east = idlCrossEast;
         }
 
         // Clamp


### PR DESCRIPTION
The cassini projection is like this: https://proj4.org/operations/projections/cass.html

Approximating the cassini-space bounds of a lat-long rectangle by just projecting points along the lat-long rectangle's edges won't work, so this PR uses a grid instead.

[Sandcastle](http://cesium-dev.s3-website-us-east-1.amazonaws.com/cesium/cassini/Apps/Sandcastle/index.html#c=ZVDfS8MwEP5Xjr60YyXtUBRcW8Thg7AxoWy+FEaa3jSaJiVJO6v4v5utjk3Ny30/7rtc0lENHccdakhB4g5maHhbk/VBC3x2oDMlLeUStR/CZyHBnZo2j1q9IrNcSbiB8/DeuDy5gT9uHEkZNQbGgtpNnMYOKDmA96H0Q6Hp1cX1JI4dLE+wldyatIaxVJsKt8YfhcMehqHEharQ7fBzfX6UyGw5Xy3uVvlm/XD/VMiv0dQLvcTYXmA2xG953ShtodUiICSyWDduQTRR2bI3tIQZM5oWMomOoaTiHfAqLbw/X1N4wIR7oXO2rRA5/8DCy5LI9f+KCUUrLp+XHWpB+33LyySbDyIhJIkc/Z+ySomS6rOJ3w) code for testing:
```js
var viewer = new Cesium.Viewer('cesiumContainer', {
    mapProjection :  new Cesium.Proj4Projection('+proj=cass +lat_0=0 +lon_0=0 +x_0=0 +y_0=0 +a=6371000 +b=6371000 +units=m +no_defs'),
    sceneMode : Cesium.SceneMode.COLUMBUS_VIEW
});
```