### PR TITLE
Copy extension recommendations to VSCode config.

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,7 @@
+{
+    "recommendations": [
+        "dbaeumer.vscode-eslint",
+        "slevesque.shader",
+        "cesium.gltf-vscode"
+    ]
+}

--- a/Documentation/Contributors/VSCodeGuide/README.md
+++ b/Documentation/Contributors/VSCodeGuide/README.md
@@ -50,9 +50,6 @@ before they are accepted.
 * **[Shader languages support for VS Code](https://marketplace.visualstudio.com/items?itemName=slevesque.shader)**
 by slevesque -- This extension provides syntax highlighting for CesiumJS's shader code.
 
-* **[Prettify JSON](https://marketplace.visualstudio.com/items?itemName=mohsen1.prettify-json)**
- by Mohsen Azimi -- This seems generally useful.
-
 * **[glTF Extension for VS Code](https://marketplace.visualstudio.com/items?itemName=cesium.gltf-vscode)**
 by CesiumJS.org -- This extension adds features for previewing and editing 3D models in glTF files.
 


### PR DESCRIPTION
This adds a config file that causes VSCode to mark our recommended extensions as being "recommended by users of the current workspace."

Removed "Prettify JSON" as that's built-in to VSCode now.

If you're wondering if this PR is partially self-serving, the answer is yes.