### PR TITLE
Max tilt for Camera

### DIFF
--- a/Source/Scene/ScreenSpaceCameraController.js
+++ b/Source/Scene/ScreenSpaceCameraController.js
@@ -1426,7 +1426,15 @@ define([
 
         var deltaPhi = rotateRate * phiWindowRatio * Math.PI * 2.0;
         var deltaTheta = rotateRate * thetaWindowRatio * Math.PI;
-
+		if(defined(constrainedAxis) && defined(camera.maxTilt)) {
+			var maxTilt=camera.maxTilt/180*Math.PI;
+			var tilt = Cartesian3.dot(camera.direction,constrainedAxis);
+			tilt = Math.PI-Math.acos(tilt);
+			tilt += deltaTheta;
+			if(tilt>maxTilt){
+				deltaTheta -= tilt - maxTilt;
+			}
+		}
         if (!rotateOnlyVertical) {
             camera.rotateRight(deltaPhi);
         }


### PR DESCRIPTION
Introduced a maxTilt property for the Camera, that, if present, limits the camera's tilt. This is taken from this forum post: https://groups.google.com/forum/#!searchin/cesium-dev/max$20tilt%7Csort:date/cesium-dev/Pjrjw9asXns/I8RevSFai0UJ