### PR TITLE
Add unitTestPath to concierge settings

### DIFF
--- a/.concierge/config.json
+++ b/.concierge/config.json
@@ -1,4 +1,5 @@
 {
     "contributorsUrl": "https://api.github.com/repos/AnalyticalGraphicsInc/cesium/contents/CONTRIBUTORS.md",
+    "unitTestPath" : "Specs/",
     "maxDaysSinceUpdate": 30
 }


### PR DESCRIPTION
This will make concierge remind users when the unit tests haven't been updated. 

@ggetz 