### PR TITLE
Remove assets.agi.com deprecation notice

### DIFF
--- a/Source/Core/CesiumTerrainProvider.js
+++ b/Source/Core/CesiumTerrainProvider.js
@@ -9,7 +9,6 @@ define([
         './defaultValue',
         './defined',
         './defineProperties',
-        './deprecationWarning',
         './DeveloperError',
         './Event',
         './GeographicTilingScheme',
@@ -37,7 +36,6 @@ define([
         defaultValue,
         defined,
         defineProperties,
-        deprecationWarning,
         DeveloperError,
         Event,
         GeographicTilingScheme,
@@ -177,19 +175,8 @@ define([
                     url: 'layer.json'
                 });
 
-                var uri = new Uri(layerJsonResource.url);
-                if (uri.authority === 'assets.agi.com') {
-                    var deprecationText = 'STK World Terrain at assets.agi.com was shut down on October 1, 2018.';
-                    var deprecationLinkText = 'Check out the new high-resolution Cesium World Terrain for migration instructions.';
-                    var deprecationLink = 'https://cesium.com/blog/2018/03/01/introducing-cesium-world-terrain/';
-                    that._tileCredits = [
-                        new Credit('<span><b>' + deprecationText + '</b></span> <a href="' + deprecationLink + '">' + deprecationLinkText + '</a>', true)
-                    ];
-                    deprecationWarning('assets.agi.com', deprecationText + ' ' + deprecationLinkText + ' ' + deprecationLink);
-                } else {
-                    // ion resources have a credits property we can use for additional attribution.
-                    that._tileCredits = resource.credits;
-                }
+                // ion resources have a credits property we can use for additional attribution.
+                that._tileCredits = resource.credits;
 
                 requestLayerJson();
             })


### PR DESCRIPTION
Fixes #6279

@mramato #6279 was marked `remove in 1.53`.  Do you think we want to remove this warning for the upcoming release or push it back a little while longer?