### PR TITLE
Add DrawCommand.occlude to control whether a command is occluded

### DIFF
--- a/Source/Renderer/DrawCommand.js
+++ b/Source/Renderer/DrawCommand.js
@@ -21,6 +21,7 @@ define([
         this._boundingVolume = options.boundingVolume;
         this._orientedBoundingBox = options.orientedBoundingBox;
         this._cull = defaultValue(options.cull, true);
+        this._occlude = defaultValue(options.occlude, true);
         this._modelMatrix = options.modelMatrix;
         this._primitiveType = defaultValue(options.primitiveType, PrimitiveType.TRIANGLES);
         this._vertexArray = options.vertexArray;
@@ -115,6 +116,26 @@ define([
             set : function(value) {
                 if (this._cull !== value) {
                     this._cull = value;
+                    this.dirty = true;
+                }
+            }
+        },
+
+        /**
+         * When <code>true</code>, the horizon culls the command based on its {@link DrawCommand#boundingVolume}.
+         * {@link DrawCommand#cull} must also be <code>true</code> in order for the command to be culled.
+         *
+         * @memberof DrawCommand.prototype
+         * @type {Boolean}
+         * @default true
+         */
+        occlude : {
+            get : function() {
+                return this._occlude;
+            },
+            set : function(value) {
+                if (this._occlude !== value) {
+                    this._occlude = value;
                     this.dirty = true;
                 }
             }
@@ -502,6 +523,7 @@ define([
         result._boundingVolume = command._boundingVolume;
         result._orientedBoundingBox = command._orientedBoundingBox;
         result._cull = command._cull;
+        result._occlude = command._occlude;
         result._modelMatrix = command._modelMatrix;
         result._primitiveType = command._primitiveType;
         result._vertexArray = command._vertexArray;

--- a/Source/Scene/Scene.js
+++ b/Source/Scene/Scene.js
@@ -1759,7 +1759,7 @@ define([
                 ((!defined(command.boundingVolume)) ||
                  !command.cull ||
                  ((cullingVolume.computeVisibility(command.boundingVolume) !== Intersect.OUTSIDE) &&
-                  (!defined(occluder) || !command.boundingVolume.isOccluded(occluder)))));
+                  (!defined(occluder) || !command.occlude || !command.boundingVolume.isOccluded(occluder)))));
     };
 
     function getAttributeLocations(shaderProgram) {

--- a/Specs/Renderer/DrawCommandSpec.js
+++ b/Specs/Renderer/DrawCommandSpec.js
@@ -1,10 +1,10 @@
 defineSuite([
-        'Core/PrimitiveType',
         'Renderer/DrawCommand',
+        'Core/PrimitiveType',
         'Renderer/Pass'
     ], function(
-        PrimitiveType,
         DrawCommand,
+        PrimitiveType,
         Pass) {
     'use strict';
 
@@ -12,6 +12,7 @@ defineSuite([
         var c = new DrawCommand();
         expect(c.boundingVolume).toBeUndefined();
         expect(c.cull).toEqual(true);
+        expect(c.occlude).toEqual(true);
         expect(c.modelMatrix).toBeUndefined();
         expect(c.primitiveType).toEqual(PrimitiveType.TRIANGLES);
         expect(c.vertexArray).toBeUndefined();
@@ -43,6 +44,7 @@ defineSuite([
         var c = new DrawCommand({
             boundingVolume : boundingVolume,
             cull : false,
+            occlude : false,
             modelMatrix :  modelMatrix,
             primitiveType : primitiveType,
             vertexArray : vertexArray,
@@ -61,6 +63,7 @@ defineSuite([
 
         expect(c.boundingVolume).toBe(boundingVolume);
         expect(c.cull).toEqual(false);
+        expect(c.occlude).toEqual(false);
         expect(c.modelMatrix).toBe(modelMatrix);
         expect(c.primitiveType).toEqual(primitiveType);
         expect(c.vertexArray).toBe(vertexArray);
@@ -81,6 +84,7 @@ defineSuite([
         var c = new DrawCommand({
             boundingVolume : {},
             cull : false,
+            occlude : false,
             modelMatrix :  {},
             primitiveType : PrimitiveType.TRIANGLE_FAN,
             vertexArray : {},
@@ -101,6 +105,7 @@ defineSuite([
 
         expect(clone.boundingVolume).toBe(c.boundingVolume);
         expect(clone.cull).toEqual(c.cull);
+        expect(clone.occlude).toEqual(c.occlude);
         expect(clone.modelMatrix).toBe(c.modelMatrix);
         expect(clone.primitiveType).toEqual(c.primitiveType);
         expect(clone.vertexArray).toBe(c.vertexArray);
@@ -121,6 +126,7 @@ defineSuite([
         var c = new DrawCommand({
             boundingVolume : {},
             cull : false,
+            occlude : false,
             modelMatrix :  {},
             primitiveType : PrimitiveType.TRIANGLE_FAN,
             vertexArray : {},
@@ -143,6 +149,7 @@ defineSuite([
         expect(result).toBe(clone);
         expect(clone.boundingVolume).toBe(c.boundingVolume);
         expect(clone.cull).toEqual(c.cull);
+        expect(clone.occlude).toEqual(c.occlude);
         expect(clone.modelMatrix).toBe(c.modelMatrix);
         expect(clone.primitiveType).toEqual(c.primitiveType);
         expect(clone.vertexArray).toBe(c.vertexArray);

--- a/Specs/Renderer/DrawCommandSpec.js
+++ b/Specs/Renderer/DrawCommandSpec.js
@@ -11,6 +11,7 @@ defineSuite([
     it('constructs', function() {
         var c = new DrawCommand();
         expect(c.boundingVolume).toBeUndefined();
+        expect(c.orientedBoundingBox).toBeUndefined();
         expect(c.cull).toEqual(true);
         expect(c.occlude).toEqual(true);
         expect(c.modelMatrix).toBeUndefined();
@@ -27,10 +28,16 @@ defineSuite([
         expect(c.executeInClosestFrustum).toEqual(false);
         expect(c.owner).toBeUndefined();
         expect(c.debugShowBoundingVolume).toEqual(false);
+        expect(c.debugOverlappingFrustums).toEqual(0);
+        expect(c.castShadows).toEqual(false);
+        expect(c.receiveShadows).toEqual(false);
+        expect(c.pickId).toBeUndefined();
+        expect(c.pickOnly).toBe(false);
     });
 
     it('constructs with options', function() {
         var boundingVolume = {};
+        var orientedBoundingBox = {};
         var modelMatrix = {};
         var primitiveType = PrimitiveType.TRIANGLE_FAN;
         var vertexArray = {};
@@ -40,9 +47,11 @@ defineSuite([
         var framebuffer = {};
         var pass = Pass.TRANSLUCENT;
         var owner = {};
+        var pickId = {};
 
         var c = new DrawCommand({
             boundingVolume : boundingVolume,
+            orientedBoundingBox : orientedBoundingBox,
             cull : false,
             occlude : false,
             modelMatrix :  modelMatrix,
@@ -58,10 +67,15 @@ defineSuite([
             pass : pass,
             executeInClosestFrustum : true,
             owner : owner,
-            debugShowBoundingVolume : true
+            debugShowBoundingVolume : true,
+            castShadows : true,
+            receiveShadows : true,
+            pickId : pickId,
+            pickOnly : true
         });
 
         expect(c.boundingVolume).toBe(boundingVolume);
+        expect(c.orientedBoundingBox).toBe(orientedBoundingBox);
         expect(c.cull).toEqual(false);
         expect(c.occlude).toEqual(false);
         expect(c.modelMatrix).toBe(modelMatrix);
@@ -78,11 +92,17 @@ defineSuite([
         expect(c.executeInClosestFrustum).toEqual(true);
         expect(c.owner).toBe(owner);
         expect(c.debugShowBoundingVolume).toEqual(true);
+        expect(c.debugOverlappingFrustums).toEqual(0);
+        expect(c.castShadows).toEqual(true);
+        expect(c.receiveShadows).toEqual(true);
+        expect(c.pickId).toBe(pickId);
+        expect(c.pickOnly).toEqual(true);
     });
 
     it('shallow clones', function() {
         var c = new DrawCommand({
             boundingVolume : {},
+            orientedBoundingBox : {},
             cull : false,
             occlude : false,
             modelMatrix :  {},
@@ -98,12 +118,17 @@ defineSuite([
             pass : Pass.TRANSLUCENT,
             executeInClosestFrustum : true,
             owner : {},
-            debugShowBoundingVolume : true
+            debugShowBoundingVolume : true,
+            castShadows : true,
+            receiveShadows : true,
+            pickId : {},
+            pickOnly : true
         });
 
         var clone = DrawCommand.shallowClone(c);
 
         expect(clone.boundingVolume).toBe(c.boundingVolume);
+        expect(clone.orientedBoundingBox).toBe(c.orientedBoundingBox);
         expect(clone.cull).toEqual(c.cull);
         expect(clone.occlude).toEqual(c.occlude);
         expect(clone.modelMatrix).toBe(c.modelMatrix);
@@ -120,11 +145,17 @@ defineSuite([
         expect(clone.executeInClosestFrustum).toEqual(c.executeInClosestFrustum);
         expect(clone.owner).toBe(c.owner);
         expect(clone.debugShowBoundingVolume).toEqual(c.debugShowBoundingVolume);
+        expect(clone.debugOverlappingFrustums).toEqual(c.debugOverlappingFrustums);
+        expect(clone.castShadows).toEqual(c.castShadows);
+        expect(clone.receiveShadows).toEqual(c.receiveShadows);
+        expect(clone.pickId).toBe(c.pickId);
+        expect(clone.pickOnly).toBe(c.pickOnly);
     });
 
     it('shallow clones with result', function() {
         var c = new DrawCommand({
             boundingVolume : {},
+            orientedBoundingBox : {},
             cull : false,
             occlude : false,
             modelMatrix :  {},
@@ -140,7 +171,11 @@ defineSuite([
             pass : Pass.TRANSLUCENT,
             executeInClosestFrustum : true,
             owner : {},
-            debugShowBoundingVolume : true
+            debugShowBoundingVolume : true,
+            castShadows : true,
+            receiveShadows : true,
+            pickId : {},
+            pickOnly : true
         });
 
         var result = new DrawCommand();
@@ -148,6 +183,7 @@ defineSuite([
 
         expect(result).toBe(clone);
         expect(clone.boundingVolume).toBe(c.boundingVolume);
+        expect(clone.orientedBoundingBox).toBe(c.orientedBoundingBox);
         expect(clone.cull).toEqual(c.cull);
         expect(clone.occlude).toEqual(c.occlude);
         expect(clone.modelMatrix).toBe(c.modelMatrix);
@@ -164,6 +200,11 @@ defineSuite([
         expect(clone.executeInClosestFrustum).toEqual(c.executeInClosestFrustum);
         expect(clone.owner).toBe(c.owner);
         expect(clone.debugShowBoundingVolume).toEqual(c.debugShowBoundingVolume);
+        expect(clone.debugOverlappingFrustums).toEqual(c.debugOverlappingFrustums);
+        expect(clone.castShadows).toEqual(c.castShadows);
+        expect(clone.receiveShadows).toEqual(c.receiveShadows);
+        expect(clone.pickId).toBe(c.pickId);
+        expect(clone.pickOnly).toBe(c.pickOnly);
     });
 
     it('shallow clone returns undefined', function() {

--- a/Specs/Scene/SceneSpec.js
+++ b/Specs/Scene/SceneSpec.js
@@ -1726,4 +1726,25 @@ defineSuite([
         scene.destroyForSpecs();
     });
 
+    it('does not occlude if DrawCommand.occlude is false', function() {
+        var scene = createScene();
+        scene.globe = new Globe(Ellipsoid.WGS84);
+
+        var rectangle = Rectangle.fromDegrees(-100.0, 30.0, -90.0, 40.0);
+        var rectanglePrimitive = createRectangle(rectangle, 10);
+        scene.primitives.add(rectanglePrimitive);
+
+        scene.renderForSpecs();
+        rectanglePrimitive._colorCommands[0].occlude = false;
+
+        scene.camera.setView({
+            destination: new Cartesian3(-5754647.167415793, 14907694.100240812, -483807.2406259497),
+            orientation: new HeadingPitchRoll(6.283185307179586, -1.5698869547885104, 0.0)
+        });
+        scene.renderForSpecs();
+        expect(getFrustumCommandsLength(scene)).toBe(1);
+
+        scene.destroyForSpecs();
+    });
+
 }, 'WebGL');


### PR DESCRIPTION
Previously `DrawCommand.cull` controlled both frustum and horizon culling, this adds `DrawCommand.occlude` for more control over whether horizon culling gets applies. `DrawCommand.cull` must also be true in order in order for `DrawCommand.occlude` to take effect.