### PR TITLE
Add setter for DrawCommand.pickOnly

### DIFF
--- a/Source/Renderer/DrawCommand.js
+++ b/Source/Renderer/DrawCommand.js
@@ -479,11 +479,16 @@ define([
          * @memberof DrawCommand.prototype
          * @type {Boolean}
          * @default false
-         * @readonly
          */
         pickOnly : {
             get : function() {
                 return this._pickOnly;
+            },
+            set : function(value) {
+                if (this._pickOnly !== value) {
+                    this._pickOnly = value;
+                    this.dirty = true;
+                }
             }
         }
     });


### PR DESCRIPTION
Adds a setter for `DrawCommand.pickOnly`. Useful when creating a derived pick command.