### PR TITLE
Fix OIT when toggling HDR.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,7 @@ Change Log
 * Fixed 3D Tiles visibility checking when running multiple passes within the same frame. [#7289](https://github.com/AnalyticalGraphicsInc/cesium/pull/7289)
 * Fixed contrast on imagery layers. [#7382](https://github.com/AnalyticalGraphicsInc/cesium/issues/7382)
 * Fixed rendering transparent background color when `highDynamicRange` is enabled. [#7427](https://github.com/AnalyticalGraphicsInc/cesium/issues/7427)
+* Fixed translucent geometry when `highDynamicRange` is toggled. [#7451](https://github.com/AnalyticalGraphicsInc/cesium/pull/7451)
 
 ### 1.52 - 2018-12-03
 

--- a/Source/Scene/OIT.js
+++ b/Source/Scene/OIT.js
@@ -89,6 +89,8 @@ define([
 
         this._useScissorTest = false;
         this._scissorRectangle = undefined;
+
+        this._useHDR = false;
     }
 
     function destroyTextures(oit) {
@@ -200,7 +202,7 @@ define([
         return supported;
     }
 
-    OIT.prototype.update = function(context, passState, framebuffer) {
+    OIT.prototype.update = function(context, passState, framebuffer, useHDR) {
         if (!this.isSupported()) {
             return;
         }
@@ -213,7 +215,7 @@ define([
         var height = this._opaqueTexture.height;
 
         var accumulationTexture = this._accumulationTexture;
-        var textureChanged = !defined(accumulationTexture) || accumulationTexture.width !== width || accumulationTexture.height !== height;
+        var textureChanged = !defined(accumulationTexture) || accumulationTexture.width !== width || accumulationTexture.height !== height || useHDR !== this._useHDR;
         if (textureChanged) {
             updateTextures(this, context, width, height);
         }
@@ -224,6 +226,8 @@ define([
                 return;
             }
         }
+
+        this._useHDR = useHDR;
 
         var that = this;
         var fs;

--- a/Source/Scene/Scene.js
+++ b/Source/Scene/Scene.js
@@ -2987,7 +2987,7 @@ define([
         var oit = view.oit;
         var useOIT = environmentState.useOIT = !picking && defined(oit) && oit.isSupported();
         if (useOIT) {
-            oit.update(context, passState, view.globeDepth.framebuffer);
+            oit.update(context, passState, view.globeDepth.framebuffer, scene._hdr);
             oit.clear(context, passState, clearColor);
             environmentState.useOIT = oit.isSupported();
         }


### PR DESCRIPTION
Fixes #7380. The OIT buffers need to be recreated when HDR is toggled.

I tried to write a test, but I couldn't get it to fail in master.