### PR TITLE
Credit support for 3D Tiles tileset.json

### DIFF
--- a/Source/Scene/Cesium3DTileset.js
+++ b/Source/Scene/Cesium3DTileset.js
@@ -799,7 +799,8 @@ define([
                         that._credits = credits;
                     }
                     for (var i = 0; i < extraCredits.length; i++) {
-                        credits.push(new Credit(extraCredits[i]));
+                        var credit = extraCredits[i];
+                        credits.push(new Credit(credit.html, credit.showOnScreen));
                     }
                 }
 

--- a/Source/Scene/Cesium3DTileset.js
+++ b/Source/Scene/Cesium3DTileset.js
@@ -783,14 +783,15 @@ define([
             .then(function(tilesetJson) {
                 that._root = that.loadTileset(resource, tilesetJson);
                 var gltfUpAxis = defined(tilesetJson.asset.gltfUpAxis) ? Axis.fromName(tilesetJson.asset.gltfUpAxis) : Axis.Y;
-                that._asset = tilesetJson.asset;
+                var asset = tilesetJson.asset;
+                that._asset = asset;
                 that._properties = tilesetJson.properties;
                 that._geometricError = tilesetJson.geometricError;
                 that._extensionsUsed = tilesetJson.extensionsUsed;
                 that._gltfUpAxis = gltfUpAxis;
+                that._extras = tilesetJson.extras;
 
-                var extras =  tilesetJson.extras;
-
+                var extras = asset.extras;
                 if (defined(extras) && defined(extras.cesium) && defined(extras.cesium.credits)) {
                     var extraCredits = extras.cesium.credits;
                     var credits = that._credits;
@@ -803,8 +804,6 @@ define([
                         credits.push(new Credit(credit.html, credit.showOnScreen));
                     }
                 }
-
-                that._extras = extras;
 
                 // Save the original, untransformed bounding volume position so we can apply
                 // the tile transform and model matrix at run time

--- a/Source/Scene/Cesium3DTileset.js
+++ b/Source/Scene/Cesium3DTileset.js
@@ -4,6 +4,7 @@ define([
         '../Core/Cartesian3',
         '../Core/Cartographic',
         '../Core/Check',
+        '../Core/Credit',
         '../Core/defaultValue',
         '../Core/defined',
         '../Core/defineProperties',
@@ -49,6 +50,7 @@ define([
         Cartesian3,
         Cartographic,
         Check,
+        Credit,
         defaultValue,
         defined,
         defineProperties,
@@ -192,6 +194,7 @@ define([
         this._timeSinceLoad = 0.0;
         this._updatedVisibilityFrame = 0;
         this._extras = undefined;
+        this._credits = undefined;
 
         this._cullWithChildrenBounds = defaultValue(options.cullWithChildrenBounds, true);
         this._allTilesAdditive = true;
@@ -755,7 +758,6 @@ define([
          * @default false
          */
         this.debugShowUrl = defaultValue(options.debugShowUrl, false);
-        this._credits = undefined;
 
         var that = this;
         var resource;
@@ -786,7 +788,23 @@ define([
                 that._geometricError = tilesetJson.geometricError;
                 that._extensionsUsed = tilesetJson.extensionsUsed;
                 that._gltfUpAxis = gltfUpAxis;
-                that._extras = tilesetJson.extras;
+
+                var extras =  tilesetJson.extras;
+
+                if (defined(extras) && defined(extras.cesium) && defined(extras.cesium.credits)) {
+                    var extraCredits = extras.cesium.credits;
+                    var credits = that._credits;
+                    if (!defined(credits)) {
+                        credits = [];
+                        that._credits = credits;
+                    }
+                    for (var i = 0; i < extraCredits.length; i++) {
+                        credits.push(new Credit(extraCredits[i]));
+                    }
+                }
+
+                that._extras = extras;
+
                 // Save the original, untransformed bounding volume position so we can apply
                 // the tile transform and model matrix at run time
                 var boundingVolume = that._root.createBoundingVolume(tilesetJson.root.boundingVolume, Matrix4.IDENTITY);


### PR DESCRIPTION
Allows credits to be defined as part of tileset.json under `extras.cesium.credits`

Here's an example of what that might look like:

```
{
  "asset": {
    "extras": {
      "cesium": {
        "credits": [
          { 
            "html": "this is my credit", 
            "showOnScreen": false 
          }, { 
            "html": "<span>this one uses html</span>", 
            "showOnScreen": true 
          }
        ]
      }
    }
  }
  ...
}
```
cc @mramato 