### PR TITLE
improve sanity check for geodesic distance calc

### DIFF
--- a/Source/Core/EllipsoidGeodesic.js
+++ b/Source/Core/EllipsoidGeodesic.js
@@ -171,14 +171,18 @@ define([
         ellipsoidGeodesic._uSquared = uSquared;
     }
 
+    //>>includeStart('debug', pragmas.debug);
     var scratchCart1 = new Cartesian3();
     var scratchCart2 = new Cartesian3();
+    //>>includeEnd('debug');
     function computeProperties(ellipsoidGeodesic, start, end, ellipsoid) {
-        var firstCartesian = Cartesian3.normalize(ellipsoid.cartographicToCartesian(start, scratchCart2), scratchCart1);
-        var lastCartesian = Cartesian3.normalize(ellipsoid.cartographicToCartesian(end, scratchCart2), scratchCart2);
-
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.number.greaterThanOrEquals('value', Math.abs(Math.abs(Cartesian3.angleBetween(firstCartesian, lastCartesian)) - Math.PI), 0.0125);
+        var startCartesian = Cartesian3.normalize(ellipsoid.cartographicToCartesian(start, scratchCart2), scratchCart1);
+        var endCartesian = Cartesian3.normalize(ellipsoid.cartographicToCartesian(end, scratchCart2), scratchCart2);
+        var includedAngle = Math.abs(Math.abs(Cartesian3.angleBetween(startCartesian, endCartesian)) - CesiumMath.PI);
+        // maxLambda is an approximation, assuming an oblate ellipsoid, and zero latitude (equatorial; phi = 0)
+        var maxLambda = (1 - (ellipsoid.maximumRadius - ellipsoid.minimumRadius) / ellipsoid.maximumRadius) * CesiumMath.PI;
+        Check.typeOf.number.lessThanOrEquals('value', includedAngle, maxLambda);
         //>>includeEnd('debug');
 
         vincentyInverseFormula(ellipsoidGeodesic, ellipsoid.maximumRadius, ellipsoid.minimumRadius,


### PR DESCRIPTION
https://groups.google.com/forum/#!topic/cesium-dev/uTaQKBSzxCU

Based upon the discussion linked above, I think this is a small improvement to the current logic.  The commit message has the details and this description has more: https://en.wikipedia.org/wiki/Geodesics_on_an_ellipsoid#Behavior_of_geodesics

(commit message)
> guard Vincenty's inverse computation (surface distance) by the cut locus specific to the ellipsoid (assumed as oblate given min/max radii)

(Wikipedia extract; emphasis mine)
> Gauss (1828) showed that, on any surface, geodesics and geodesic circle intersect at right angles. The red line is the cut locus, the locus of points which have multiple (two in this case) shortest geodesics from A. On a sphere, the cut locus is a point. On an oblate ellipsoid (shown here), it is a segment of the circle of latitude centered on the point antipodal to A, φ = −φ₁. **The longitudinal extent of cut locus is approximately λ₁₂ ∈ [π − f π cosφ₁, π + f π cosφ₁]. If A lies on the equator, φ₁ = 0, this relation is exact and as a consequence the equator is only a shortest geodesic if |λ₁₂| ≤ (1 − f)π.** For a prolate ellipsoid, the cut locus is a segment of the anti-meridian centered on the point antipodal to A, λ₁₂ = π, and this means that meridional geodesics stop being shortest paths before the antipodal point is reached. 