### PR TITLE
More concise concierge message

### DIFF
--- a/.concierge/templates/pullRequestOpened.hbs
+++ b/.concierge/templates/pullRequestOpened.hbs
@@ -37,11 +37,8 @@ Thanks for the pull request @{{ userName }}!
     * Make sure you've [updated tests](https://github.com/AnalyticalGraphicsInc/cesium/tree/master/Documentation/Contributors/TestingGuide) to reflect your changes, added tests for any new code, and ran the code coverage tool.
 {{/if}}
 
-<details>
-<summary>Reviewer reminders.</summary>
-<br>
-- Does Cesium Viewer work? <br>
-- Does it work in 2D/CV? <br>
-- Does it work (or fail gracefully) in IE11? <br>
-<br>
-</details>
+Reviewers, don't forget to make sure that:
+
+- [ ] Cesium Viewer works.
+- [ ] Works in 2D/CV.
+- [ ] Works (or fails gracefully) in IE11.

--- a/.concierge/templates/pullRequestOpened.hbs
+++ b/.concierge/templates/pullRequestOpened.hbs
@@ -37,8 +37,11 @@ Thanks for the pull request @{{ userName }}!
     * Make sure you've [updated tests](https://github.com/AnalyticalGraphicsInc/cesium/tree/master/Documentation/Contributors/TestingGuide) to reflect your changes, added tests for any new code, and ran the code coverage tool.
 {{/if}}
 
-Reviewers, don't forget to make sure that:
-
-- [ ] Cesium Viewer works.
-- [ ] Works in 2D/CV.
-- [ ] Works (or fails gracefully) in IE11.
+<details>
+<summary>Reviewer reminders.</summary>
+<br>
+- Does Cesium Viewer work? <br>
+- Does it work in 2D/CV? <br>
+- Does it work (or fail gracefully) in IE11? <br>
+<br>
+</details>

--- a/.concierge/templates/signature.hbs
+++ b/.concierge/templates/signature.hbs
@@ -1,6 +1,1 @@
 
----
-
-__I am a bot who helps you make Cesium awesome! [Contributions to my configuration are welcome.](https://github.com/AnalyticalGraphicsInc/cesium/tree/master/.concierge)__
-
-:earth_africa: :earth_americas: :earth_asia:


### PR DESCRIPTION
This makes concierge slightly more concise by moving the reviewer checklist to a collapsed dropdown and removing the signature. I think the signature was nice to have but since concierge's bio now has a link to its repo, its settings information are just 2 clicks away for those that are curious. It's otherwise just noise on every post.

The only issue is you can't have checkboxes inside of these dropdowns on GitHub. I think it's worth compromising because then all the info concierge posts will be pertaining to the user who opened the PR, and those reminders are I think where most of its value is.

@ggetz 

[Before](https://github.com/AnalyticalGraphicsInc/cesium/pull/7465#issuecomment-451698351)
[After](https://github.com/AnalyticalGraphicsInc/cesium/pull/7465#issuecomment-451698423)