### PR TITLE
Update globe depth fix for invert classification

### DIFF
--- a/Source/Scene/Scene.js
+++ b/Source/Scene/Scene.js
@@ -2334,6 +2334,10 @@ define([
                     executeCommand(commands[j], scene, context, passState);
                 }
 
+                if (defined(globeDepth) && environmentState.useGlobeDepthFramebuffer) {
+                    globeDepth.executeUpdateDepth(context, passState, clearGlobeDepth);
+                }
+
                 // Set stencil
                 us.updatePass(Pass.CESIUM_3D_TILE_CLASSIFICATION_IGNORE_SHOW);
                 commands = frustumCommands.commands[Pass.CESIUM_3D_TILE_CLASSIFICATION_IGNORE_SHOW];
@@ -2354,10 +2358,6 @@ define([
                 // Clear stencil set by the classification for the next classification pass
                 if (length > 0 && context.stencilBuffer) {
                     clearClassificationStencil.execute(context, passState);
-                }
-
-                if (defined(globeDepth) && environmentState.useGlobeDepthFramebuffer) {
-                    globeDepth.executeUpdateDepth(context, passState, clearGlobeDepth);
                 }
 
                 // Draw style over classification.


### PR DESCRIPTION
This fixes updating the globe depth when the depth texture is from invert classification. This is needed if `CESIUM_3D_TILE_CLASSIFICATION_IGNORE_SHOW` commands reference `czm_globeDepthTexture`, which they didn't previously but now do in ion sdk.