### PR TITLE
Fix open in new window in shared examples

### DIFF
--- a/Apps/Sandcastle/CesiumSandcastle.js
+++ b/Apps/Sandcastle/CesiumSandcastle.js
@@ -103,9 +103,6 @@ require({
         ClipboardJS,
         pako) {
     'use strict';
-
-    window.pako = pako; // For Sandcastle-helpers.
-
     // attach clipboard handling to our Copy button
     var clipboardjs = new ClipboardJS('.copyButton');
 
@@ -742,7 +739,7 @@ require({
                 applyLoadedDemo(code, html);
             } else if (window.location.hash.indexOf('#c=') === 0) {
                 var base64String = window.location.hash.substr(3);
-                var data = decodeBase64Data(base64String);
+                var data = decodeBase64Data(base64String, pako);
                 code = data.code;
                 html = data.html;
 
@@ -1008,11 +1005,7 @@ require({
     registry.byId('buttonNewWindow').on('click', function() {
         //Handle case where demo is in a sub-directory by modifying
         //the demo's HTML to add a base href.
-        var baseHref = window.location.href;
-        var searchLen = window.location.search.length;
-        if (searchLen > 0) {
-            baseHref = baseHref.substring(0, baseHref.length - searchLen);
-        }
+        var baseHref = getBaseUrl();
         var pos = baseHref.lastIndexOf('/');
         baseHref = baseHref.substring(0, pos) + '/gallery/';
 

--- a/Apps/Sandcastle/Sandcastle-helpers.js
+++ b/Apps/Sandcastle/Sandcastle-helpers.js
@@ -1,6 +1,5 @@
 (function() {
     'use strict';
-    var pako = window.pako;
 
      window.embedInSandcastleTemplate = function(code, addExtraLine) {
         return 'function startup(Cesium) {\n' +
@@ -17,7 +16,7 @@
            '    require([\'Cesium\'], startup);\n' +
            '}\n';
     };
-    window.decodeBase64Data = function(base64String) {
+    window.decodeBase64Data = function(base64String, pako) {
         // data stored in the hash as:
         // Base64 encoded, raw DEFLATE compressed JSON array where index 0 is code, index 1 is html
         // restore padding

--- a/Apps/Sandcastle/standalone.html
+++ b/Apps/Sandcastle/standalone.html
@@ -16,7 +16,7 @@
 /*global pako */
 if (window.location.hash.indexOf('#c=') === 0) {
     var base64String = window.location.hash.substr(3);
-    var data = window.decodeBase64Data(base64String);
+    var data = window.decodeBase64Data(base64String, pako);
     //Handle case where demo is in a sub-directory by modifying
     //the HTML to add a base href.
     document.head.innerHTML = document.head.innerHTML + '<base href="' + data.baseHref + '" />';
@@ -39,9 +39,6 @@ require({
      if (window.Cesium === undefined) {
         window.Cesium = Cesium;
      }
-
-    // The helper functions script needs this.
-    window.pako = pako;
 
     var defined = window.Cesium.defined;
     var code;


### PR DESCRIPTION
This is a straightforward fix for https://github.com/AnalyticalGraphicsInc/cesium/issues/7466. The two problems were:

* URLs with `#c=...` did not load anymore in regular Sandcastle. 
  * The fix is instead of providing access to pako on `window.pako` it just passes the library to the helper script directly, since it's loaded differently in the standalone mode than in the regular mode.
* Opening a new window on a URL loaded with with `#c=...` failed to load, because the baseHref was stripping search strings, but not query parameters. 