### PR TITLE
Use relative URL for video specs

### DIFF
--- a/Specs/Core/VideoSynchronizerSpec.js
+++ b/Specs/Core/VideoSynchronizerSpec.js
@@ -24,17 +24,17 @@ defineSuite([
     function loadVideo() {
         var element = document.createElement('video');
         var source = document.createElement('source');
-        source.setAttribute('src', '/Data/Videos/big-buck-bunny-trailer-small.webm');
+        source.setAttribute('src', 'Data/Videos/big-buck-bunny-trailer-small.webm');
         source.setAttribute('type', 'video/webm');
         element.appendChild(source);
 
         source = document.createElement('source');
-        source.setAttribute('src', '/Data/Videos/big-buck-bunny-trailer-small.mp4');
+        source.setAttribute('src', 'Data/Videos/big-buck-bunny-trailer-small.mp4');
         source.setAttribute('type', 'video/mp4');
         element.appendChild(source);
 
         source = document.createElement('source');
-        source.setAttribute('src', '/Data/Videos/big-buck-bunny-trailer-small.mov');
+        source.setAttribute('src', 'Data/Videos/big-buck-bunny-trailer-small.mov');
         source.setAttribute('type', 'video/quicktime');
         element.appendChild(source);
 


### PR DESCRIPTION
These tests were passing in Travis but not locally, because the Data folder is inside `Specs/`. My bad for not running this locally. 

