### PR TITLE
PrimitiveCollection.removeAll removes guid

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -26,7 +26,7 @@ Change Log
 * Fixed image size issue when using multiple particle systems. [#7412](https://github.com/AnalyticalGraphicsInc/cesium/pull/7412)
 * Fixed Sandcastle's "Open in New Window" button not displaying imagery due to blob URI limitations. [#7250](https://github.com/AnalyticalGraphicsInc/cesium/pull/7250)
 * Fixed an issue where setting `scene.globe.cartographicLimitRectangle` to `undefined` would cause a crash. [#7477](https://github.com/AnalyticalGraphicsInc/cesium/issues/7477)
-* Fixed `PrimitiveCollection.removeAll` to no longer `contain` removed primitives.
+* Fixed `PrimitiveCollection.removeAll` to no longer `contain` removed primitives. [#7491](https://github.com/AnalyticalGraphicsInc/cesium/pull/7491)
 
 ### 1.53 - 2019-01-02
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -26,6 +26,7 @@ Change Log
 * Fixed image size issue when using multiple particle systems. [#7412](https://github.com/AnalyticalGraphicsInc/cesium/pull/7412)
 * Fixed Sandcastle's "Open in New Window" button not displaying imagery due to blob URI limitations. [#7250](https://github.com/AnalyticalGraphicsInc/cesium/pull/7250)
 * Fixed an issue where setting `scene.globe.cartographicLimitRectangle` to `undefined` would cause a crash. [#7477](https://github.com/AnalyticalGraphicsInc/cesium/issues/7477)
+* Fixed `PrimitiveCollection.removeAll` to no longer `contain` removed primitives.
 
 ### 1.53 - 2019-01-02
 

--- a/Source/Scene/PrimitiveCollection.js
+++ b/Source/Scene/PrimitiveCollection.js
@@ -181,10 +181,11 @@ define([
      * @see PrimitiveCollection#destroyPrimitives
      */
     PrimitiveCollection.prototype.removeAll = function() {
-        if (this.destroyPrimitives) {
-            var primitives = this._primitives;
-            var length = primitives.length;
-            for ( var i = 0; i < length; ++i) {
+        var primitives = this._primitives;
+        var length = primitives.length;
+        for ( var i = 0; i < length; ++i) {
+            delete primitives[i]._external._composites[this._guid];
+            if (this.destroyPrimitives) {
                 primitives[i].destroy();
             }
         }

--- a/Specs/Scene/PrimitiveCollectionSpec.js
+++ b/Specs/Scene/PrimitiveCollectionSpec.js
@@ -202,6 +202,22 @@ defineSuite([
         expect(primitives.contains(labels1)).toEqual(false);
     });
 
+    it('does not contain removed primitive', function() {
+        var labels0 = createLabels();
+        primitives.add(labels0);
+        primitives.remove(labels0);
+
+        expect(primitives.contains(labels0)).toEqual(false);
+    });
+
+    it('does not contain all removed primitives', function() {
+        var labels0 = createLabels();
+        primitives.add(labels0);
+        primitives.removeAll();
+
+        expect(primitives.contains(labels0)).toEqual(false);
+    });
+
     it('does not contain undefined', function() {
         expect(primitives.contains()).toEqual(false);
     });


### PR DESCRIPTION
`.removeAll` broke `.contains`:
```javascript
var collection = new Cesium.PrimitiveCollection();
var primitive = new Cesium.Primitive();
collection.add(primitive);
collection.removeAll();
const contained = collection.contains(primitive);
expect(contained).to.be.false // throws
```

This PR fixes this issue by removing the collection `_guid` from all its primitves on `removeAll`
