### PR TITLE
Make cameraMoveEvent spec more stable

### DIFF
--- a/Specs/Scene/SceneSpec.js
+++ b/Specs/Scene/SceneSpec.js
@@ -1099,9 +1099,11 @@ defineSuite([
         var spyListener = jasmine.createSpy('listener');
         s.camera.moveEnd.addEventListener(spyListener);
 
-        s.cameraEventWaitTime = 0.0;
+        s.cameraEventWaitTime = -1.0;
         s.camera.moveLeft();
+        // The first render will trigger the moveStart event.
         s.render();
+        // The second will trigger the moveEnd.
         s.render();
 
         expect(spyListener.calls.count()).toBe(1);

--- a/Specs/Scene/SceneSpec.js
+++ b/Specs/Scene/SceneSpec.js
@@ -1098,7 +1098,7 @@ defineSuite([
 
         var spyListener = jasmine.createSpy('listener');
         s.camera.moveEnd.addEventListener(spyListener);
-
+        // We use negative time here to ensure the event runs on the next frame.
         s.cameraEventWaitTime = -1.0;
         s.camera.moveLeft();
         // The first render will trigger the moveStart event.


### PR DESCRIPTION
This is the final step in resolving the commonly occurring test failures on Travis (https://github.com/AnalyticalGraphicsInc/cesium/issues/7249#issuecomment-453522264). I will bump this PR to @lilleyse once run a couple times to verify that it no longer breaks.

I figured out the reason why there were two `render()` calls in that spec, and documented it for posterity. I had to set `s.cameraEventWaitTime` to `-1.0` because View.checkForCameraUpdates does not use Scene time to check this, it uses an absolute timestamp:

https://github.com/AnalyticalGraphicsInc/cesium/blob/master/Source/Scene/View.js#L118-L138

So it's very likely that this line:

```
if (this._cameraStartFired && getTimestamp() - this._cameraMovedTime > scene.cameraEventWaitTime) {
```

Resolves to `getTimestamp() - this._cameraMovedTime` equal to 0. So even with `scene.cameraEventWaitTime = 0.0` it doesn't run. The reason why I think setting `cameraEventWaitTime ` to negative in this spec is acceptable is because we want it to occur as soon as possible on the next frame, so this will take care of this edge case. Changing this equality to `>=` should fix it as well but this seems like a safer change to make.

**Number of times successfully ran in Travis in a row**: 4