### PR TITLE
eslint-config-cesium: Allow ES6 global variables in Node.js code.

### DIFF
--- a/Tools/eslint-config-cesium/CHANGES.md
+++ b/Tools/eslint-config-cesium/CHANGES.md
@@ -1,6 +1,9 @@
 Change Log
 ==========
 
+### 6.0.1 - 2019-01-23
+* Allow ES6 global variables in Node.js code.
+
 ### 6.0.0 - 2018-05-01
 * Upgrade to eslint 5.x and it's new default rules.
 * Set ecmaVersion to 2017 for Node.js code.

--- a/Tools/eslint-config-cesium/node.js
+++ b/Tools/eslint-config-cesium/node.js
@@ -3,7 +3,8 @@
 module.exports = {
     extends: './index.js',
     env: {
-        node: true
+        node: true,
+        es6: true
     },
     parserOptions: {
         ecmaVersion: 2017

--- a/Tools/eslint-config-cesium/package.json
+++ b/Tools/eslint-config-cesium/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-cesium",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "description": "ESLint shareable configs for Cesium",
   "homepage": "http://cesiumjs.org",
   "license": "Apache-2.0",


### PR DESCRIPTION
Also bump version for release.