### PR TITLE
Fix failing PostProcessStageCollectionSpec in Firefox

### DIFF
--- a/Specs/Scene/PostProcessStageCollectionSpec.js
+++ b/Specs/Scene/PostProcessStageCollectionSpec.js
@@ -278,7 +278,9 @@ defineSuite([
 
         scene.postProcessStages.tonemapper = Tonemapper.MODIFIED_REINHARD;
 
-        expect(scene).toRender([127, 0, 0, 255]);
+        expect(scene).toRenderAndCall(function(rgba) {
+            expect(rgba).toEqualEpsilon([127, 0, 0, 255], 5);
+        });
         scene.highDynamicRange = true;
         expect(scene).toRenderAndCall(function(rgba) {
             expect(rgba).not.toEqual([0, 0, 0, 255]);


### PR DESCRIPTION
The following test is failing in master on Firefox 64:

```
Scene/PostProcessStageCollection uses modified Reinhard tonemapping
Expected to render [127,0,0,255], but actually rendered [128,0,0,255].
```

This adds an equalsEpsilon to the color check here. I'm _assuming_ this color discrepancy is harmless. @bagnell can you confirm this?