### PR TITLE
Fixed terrain tile availability

### DIFF
--- a/Source/Core/CesiumTerrainProvider.js
+++ b/Source/Core/CesiumTerrainProvider.js
@@ -999,11 +999,8 @@ define([
         }
 
         var availabilityLevels = layer.availabilityLevels;
-        if (level % availabilityLevels === 0) {
-            level -= availabilityLevels;
-        }
-
-        var parentLevel = ((level / availabilityLevels) | 0) * availabilityLevels;
+        var parentLevel = (level % availabilityLevels === 0) ?
+            (level - availabilityLevels) : ((level / availabilityLevels) | 0) * availabilityLevels;
         var divisor = 1 << (level - parentLevel);
         var parentX = (x / divisor) | 0;
         var parentY = (y / divisor) | 0;
@@ -1030,7 +1027,7 @@ define([
         var availabilityTilesLoaded = layer.availabilityTilesLoaded;
         var availability = layer.availability;
 
-        var tile = getAvailabilityTile(layer, x, y, level);
+        var tile = CesiumTerrainProvider._getAvailabilityTile(layer, x, y, level);
         while(defined(tile)) {
             if (availability.isTileAvailable(tile.level, tile.x, tile.y) &&
                 !availabilityTilesLoaded.isTileAvailable(tile.level, tile.x, tile.y))
@@ -1063,13 +1060,16 @@ define([
                 };
             }
 
-            tile = getAvailabilityTile(layer, tile.x, tile.y, tile.level);
+            tile = CesiumTerrainProvider._getAvailabilityTile(layer, tile.x, tile.y, tile.level);
         }
 
         return {
             result: false
         };
     }
+
+    // Used for testing
+    CesiumTerrainProvider._getAvailabilityTile = getAvailabilityTile;
 
     return CesiumTerrainProvider;
 });

--- a/Source/Core/CesiumTerrainProvider.js
+++ b/Source/Core/CesiumTerrainProvider.js
@@ -1027,7 +1027,7 @@ define([
         var availabilityTilesLoaded = layer.availabilityTilesLoaded;
         var availability = layer.availability;
 
-        var tile = CesiumTerrainProvider._getAvailabilityTile(layer, x, y, level);
+        var tile = getAvailabilityTile(layer, x, y, level);
         while(defined(tile)) {
             if (availability.isTileAvailable(tile.level, tile.x, tile.y) &&
                 !availabilityTilesLoaded.isTileAvailable(tile.level, tile.x, tile.y))
@@ -1060,7 +1060,7 @@ define([
                 };
             }
 
-            tile = CesiumTerrainProvider._getAvailabilityTile(layer, tile.x, tile.y, tile.level);
+            tile = getAvailabilityTile(layer, tile.x, tile.y, tile.level);
         }
 
         return {

--- a/Specs/Core/CesiumTerrainProviderSpec.js
+++ b/Specs/Core/CesiumTerrainProviderSpec.js
@@ -479,6 +479,64 @@ defineSuite([
         });
     });
 
+    it('The undefined availability tile is returned at level 0', function() {
+        var layer = {
+            availabilityLevels: 10
+        };
+
+        expect(CesiumTerrainProvider._getAvailabilityTile(layer, 0, 0, 0)).toBeUndefined();
+        expect(CesiumTerrainProvider._getAvailabilityTile(layer, 1, 0, 0)).toBeUndefined();
+    });
+
+    it('The correct availability tile is computed in first level', function() {
+        var layer = {
+            availabilityLevels: 10
+        };
+
+        expect(CesiumTerrainProvider._getAvailabilityTile(layer, 1, 1, 1)).toEqual({
+            level: 0,
+            x: 0,
+            y: 0
+        });
+        expect(CesiumTerrainProvider._getAvailabilityTile(layer, 4, 2, 2)).toEqual({
+            level: 0,
+            x: 1,
+            y: 0
+        });
+
+        expect(CesiumTerrainProvider._getAvailabilityTile(layer, 80, 50, 10)).toEqual({
+            level: 0,
+            x: 0,
+            y: 0
+        });
+    });
+
+    it('The correct availability tile is computed in second level', function() {
+        var layer = {
+            availabilityLevels: 10
+        };
+
+        var expected = {
+            level: 10,
+            x: 80,
+            y: 50
+        };
+
+        var xs = [expected.x, expected.x];
+        var ys = [expected.y, expected.y];
+
+        // Compute level 20 tiles by always taking SW or NE child
+        for (var i = 0; i < 10; ++i) {
+            xs[0] *= 2;
+            ys[0] *= 2;
+            xs[1] = xs[1] * 2 + 1;
+            ys[1] = ys[1] * 2 + 1;
+        }
+
+        expect(CesiumTerrainProvider._getAvailabilityTile(layer, xs[0], ys[0], 20)).toEqual(expected);
+        expect(CesiumTerrainProvider._getAvailabilityTile(layer, xs[1], ys[1], 20)).toEqual(expected);
+    });
+
     describe('requestTileGeometry', function() {
 
         it('uses multiple urls specified in layer.json', function() {


### PR DESCRIPTION
I just happened to notice this. For terrain that uses the `metadata` extension for availability, we were computing the wrong availability tile. The availability is stored every 10 levels. 

If the level was a multiple of 10, we set the `level` to `level - 10`, instead of setting `parentLevel` , so the divisor used to compute the `x` and `y` was always 1, so the tile coordinates never got modified. For example, It would say tile `(L:20, X:80, Y:50)` had the availability tile of `(L:10, X:80, Y:50)` when it should've been `(L:10, X:0, Y:0)`.

We didn't notice it because tiles would need to be in a level that was a multiple of 10, but since level 0 is always loaded the availability for level 10 was always known. The problem would occur with levels 20, 30, ... but we don't generally have terrain that goes down that far.