### PR TITLE
Fix polygons using rhumb lines across IDL

### DIFF
--- a/Specs/Core/PolygonGeometrySpec.js
+++ b/Specs/Core/PolygonGeometrySpec.js
@@ -202,8 +202,8 @@ defineSuite([
             arcType : ArcType.RHUMB
         }));
 
-        expect(p.attributes.position.values.length).toEqual(13 * 3); // 8 around edge + 5 in the middle
-        expect(p.indices.length).toEqual(16 * 3); //4 squares * 4 triangles per square
+        expect(p.attributes.position.values.length).toEqual(15 * 3); // 8 around edge + 7 in the middle
+        expect(p.indices.length).toEqual(20 * 3); //5 squares * 4 triangles per square
     });
 
     it('create geometry throws if arcType is STRAIGHT', function() {

--- a/Specs/Core/PolygonPipelineSpec.js
+++ b/Specs/Core/PolygonPipelineSpec.js
@@ -265,7 +265,20 @@ defineSuite([
         var indices = [0, 1, 2];
         var subdivision = PolygonPipeline.computeRhumbLineSubdivision(Ellipsoid.WGS84, positions, indices,  0.5 * CesiumMath.RADIANS_PER_DEGREE);
 
-        expect(subdivision.attributes.position.values.length).toEqual(30); // 10 vertices
-        expect(subdivision.indices.length).toEqual(27); // 9 triangles
+        expect(subdivision.attributes.position.values.length).toEqual(36); // 12 vertices
+        expect(subdivision.indices.length).toEqual(36); // 12 triangles
+    });
+
+    it('computeRhumbLineSubdivision with subdivisions across the IDL', function() {
+        var positions = Cartesian3.fromDegreesArray([
+                        178, 0,
+                        -178, 0,
+                        -178, 1
+                        ]);
+        var indices = [0, 1, 2];
+        var subdivision = PolygonPipeline.computeRhumbLineSubdivision(Ellipsoid.WGS84, positions, indices,  0.5 * CesiumMath.RADIANS_PER_DEGREE);
+
+        expect(subdivision.attributes.position.values.length).toEqual(180); // 60 vertices
+        expect(subdivision.indices.length).toEqual(252); // 84 triangles
     });
 });


### PR DESCRIPTION
Polygons with rhumb lines weren't being correctly rendered across the IDL because of subdivision. This has now been fixed.

Doesn't affect Polylines, PolygonOutlineGeometry etc.

I added a spec for the IDL test case. The change in computation also required updating the existing spec for the function.

Sandcastle to test:

```
var viewer = new Cesium.Viewer('cesiumContainer');

var purplePolygonUsingRhumbLines = viewer.entities.add({
    name : 'Purple polygon using rhumb lines with outline',
    polygon : {
        hierarchy : Cesium.Cartesian3.fromDegreesArray([-170.0, 45.0,
                                                        170.0, 45.0,
                                                        170.0, 55.0,
                                                        -170.0, 55.0]),
        extrudedHeight: 50000,
        material : Cesium.Color.PURPLE,
        outline : true,
        outlineColor : Cesium.Color.MAGENTA,
        arcType : Cesium.ArcType.RHUMB
    }
});

var degrees = [
    170, 50,
   -170, 50,
   -170, 40,
    175, 40,
    175, 30,
   -170, 30,
   -170, 20,
    170, 20
];

viewer.entities.add({
    name : 'rhumb',
    polygon : {
        hierarchy : Cesium.Cartesian3.fromDegreesArray(degrees),
        arcType : Cesium.ArcType.RHUMB,
        material : Cesium.Color.BLUE.withAlpha(0.5),
        height: 0
    }
});

viewer.zoomTo(viewer.entities);
```

@likangning93 Can you review? Thanks for letting me know of this.