### PR TITLE
Fixed bad terrain test that fails with new CWT

### DIFF
--- a/Specs/Core/CesiumTerrainProviderSpec.js
+++ b/Specs/Core/CesiumTerrainProviderSpec.js
@@ -806,7 +806,7 @@ defineSuite([
                 var getDerivedResource = spyOn(IonResource.prototype, 'getDerivedResource').and.callThrough();
                 terrainProvider.requestTileGeometry(0, 0, 0);
                 var options = getDerivedResource.calls.argsFor(0)[0];
-                expect(options.queryParameters.extensions).toEqual('octvertexnormals-watermask');
+                expect(options.queryParameters.extensions).toEqual('octvertexnormals-watermask-metadata');
             });
         });
     });

--- a/Specs/Scene/GlobeSurfaceTileSpec.js
+++ b/Specs/Scene/GlobeSurfaceTileSpec.js
@@ -530,7 +530,7 @@ defineSuite([
             scene.destroyForSpecs();
         });
 
-        xit('gets correct results even when the mesh includes normals', function() {
+        it('gets correct results even when the mesh includes normals', function() {
             var terrainProvider = createWorldTerrain({
                 requestVertexNormals: true,
                 requestWaterMask: false
@@ -549,6 +549,10 @@ defineSuite([
                 if (!terrainProvider.ready) {
                     return false;
                 }
+
+                // We know this tile is available, so we don't need to load the level 0 and level 10
+                //  tile to compute the availability.
+                terrainProvider._availability.addAvailableTileRange(11, 3788, 1336, 3788, 1336);
 
                 GlobeSurfaceTile.processStateMachine(tile, scene.frameState, terrainProvider, imageryLayerCollection, []);
                 RequestScheduler.update();

--- a/Specs/Scene/GlobeSurfaceTileSpec.js
+++ b/Specs/Scene/GlobeSurfaceTileSpec.js
@@ -530,7 +530,7 @@ defineSuite([
             scene.destroyForSpecs();
         });
 
-        it('gets correct results even when the mesh includes normals', function() {
+        xit('gets correct results even when the mesh includes normals', function() {
             var terrainProvider = createWorldTerrain({
                 requestVertexNormals: true,
                 requestWaterMask: false


### PR DESCRIPTION
`metadata` extension is enabled by default and the new CWT has it, so we request it.