### PR TITLE
WebP cleanup

### DIFF
--- a/Source/Core/FeatureDetection.js
+++ b/Source/Core/FeatureDetection.js
@@ -203,33 +203,43 @@ define([
         return supportsImageRenderingPixelated() ? imageRenderingValueResult : undefined;
     }
 
-    var supportsWebpPromise;
-    function supportsWebp() {
+    var supportsWebPResult;
+    var supportsWebPPromise;
+    function supportsWebP() {
         // From https://developers.google.com/speed/webp/faq#how_can_i_detect_browser_support_for_webp
-        if (defined(supportsWebpPromise)) {
-            return supportsWebpPromise.promise;
+        if (defined(supportsWebPPromise)) {
+            return supportsWebPPromise.promise;
         }
 
-        supportsWebpPromise = when.defer();
+        supportsWebPPromise = when.defer();
         if (isEdge()) {
             // Edge's WebP support with WebGL is incomplete.
             // See bug report: https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/19221241/
-            supportsWebpPromise.resolve(false);
+            supportsWebPResult = false;
+            supportsWebPPromise.resolve(supportsWebPResult);
         }
 
         var image = new Image();
         image.onload = function () {
-            var success = (image.width > 0) && (image.height > 0);
-            supportsWebpPromise.resolve(success);
+            supportsWebPResult = (image.width > 0) && (image.height > 0);
+            supportsWebPPromise.resolve(supportsWebPResult);
         };
 
         image.onerror = function () {
-            supportsWebpPromise.resolve(false);
+            supportsWebPResult = false;
+            supportsWebPPromise.resolve(supportsWebPResult);
         };
 
         image.src = 'data:image/webp;base64,UklGRiIAAABXRUJQVlA4IBYAAAAwAQCdASoBAAEADsD+JaQAA3AAAAAA';
 
-        return supportsWebpPromise.promise;
+        return supportsWebPPromise.promise;
+    }
+
+    function supportsWebPSync() {
+        if (!defined(supportsWebPPromise)) {
+            supportsWebP();
+        }
+        return supportsWebPResult;
     }
 
     var typedArrayTypes = [];
@@ -268,7 +278,8 @@ define([
         hardwareConcurrency : defaultValue(theNavigator.hardwareConcurrency, 3),
         supportsPointerEvents : supportsPointerEvents,
         supportsImageRenderingPixelated: supportsImageRenderingPixelated,
-        supportsWebp: supportsWebp,
+        supportsWebP: supportsWebP,
+        supportsWebPSync: supportsWebPSync,
         imageRenderingValue: imageRenderingValue,
         typedArrayTypes: typedArrayTypes
     };

--- a/Source/Scene/ClassificationModel.js
+++ b/Source/Scene/ClassificationModel.js
@@ -261,14 +261,6 @@ define([
         this._rtcCenterEye = undefined; // in eye coordinates
         this._rtcCenter3D = undefined;  // in world coordinates
         this._rtcCenter2D = undefined;  // in projected world coordinates
-
-        this._supportsWebp = undefined;
-
-        var that = this;
-        FeatureDetection.supportsWebp()
-            .then(function(result) {
-                that._supportsWebp = result;
-            });
     }
 
     defineProperties(ClassificationModel.prototype, {
@@ -966,7 +958,8 @@ define([
             return;
         }
 
-        if (!defined(this._supportsWebp)) {
+        var supportsWebP = FeatureDetection.supportsWebPSync();
+        if (!defined(supportsWebP)) {
             return;
         }
 
@@ -1003,7 +996,7 @@ define([
             // Transition from LOADING -> LOADED once resources are downloaded and created.
             // Textures may continue to stream in while in the LOADED state.
             if (loadResources.pendingBufferLoads === 0) {
-                ModelUtility.checkSupportedExtensions(this.extensionsRequired, this._supportsWebp);
+                ModelUtility.checkSupportedExtensions(this.extensionsRequired, supportsWebP);
 
                 addBuffersToLoadResources(this);
                 parseBufferViews(this);

--- a/Source/Scene/Model.js
+++ b/Source/Scene/Model.js
@@ -686,13 +686,6 @@ define([
         this._useDefaultSpecularMaps = false;
 
         this._shouldRegenerateShaders = false;
-        this._supportsWebp = undefined;
-
-        var that = this;
-        FeatureDetection.supportsWebp()
-            .then(function(result) {
-                that._supportsWebp = result;
-            });
     }
 
     defineProperties(Model.prototype, {
@@ -1653,14 +1646,14 @@ define([
     var ktxRegex = /(^data:image\/ktx)|(\.ktx$)/i;
     var crnRegex = /(^data:image\/crn)|(\.crn$)/i;
 
-    function parseTextures(model, context) {
+    function parseTextures(model, context, supportsWebP) {
         var gltf = model.gltf;
         var images = gltf.images;
         var uri;
         ForEach.texture(gltf, function(texture, id) {
             var imageId = texture.source;
 
-            if (defined(texture.extensions) && defined(texture.extensions.EXT_texture_webp) && model._supportsWebp) {
+            if (defined(texture.extensions) && defined(texture.extensions.EXT_texture_webp) && supportsWebP) {
                 imageId = texture.extensions.EXT_texture_webp.source;
             }
 
@@ -4308,7 +4301,8 @@ define([
             return;
         }
 
-        if (!defined(this._supportsWebp)) {
+        var supportsWebP = FeatureDetection.supportsWebPSync();
+        if (!defined(supportsWebP)) {
             return;
         }
 
@@ -4386,7 +4380,7 @@ define([
                 if (!loadResources.initialized) {
                     frameState.brdfLutGenerator.update(frameState);
 
-                    ModelUtility.checkSupportedExtensions(this.extensionsRequired, this._supportsWebp);
+                    ModelUtility.checkSupportedExtensions(this.extensionsRequired, supportsWebP);
                     ModelUtility.updateForwardAxis(this);
 
                     // glTF pipeline updates, not needed if loading from cache
@@ -4423,7 +4417,7 @@ define([
                         parseBufferViews(this);
                         parseShaders(this);
                         parsePrograms(this);
-                        parseTextures(this, context);
+                        parseTextures(this, context, supportsWebP);
                     }
                     parseMaterials(this);
                     parseMeshes(this);

--- a/Specs/Core/FeatureDetectionSpec.js
+++ b/Specs/Core/FeatureDetectionSpec.js
@@ -117,9 +117,10 @@ defineSuite([
     });
 
     it('detects WebP support', function() {
-        return FeatureDetection.supportsWebp()
-            .then(function(supportsWebp) {
-                expect(typeof supportsWebp).toEqual('boolean');
+        return FeatureDetection.supportsWebP()
+            .then(function(supportsWebP) {
+                expect(typeof supportsWebP).toEqual('boolean');
+                expect(FeatureDetection.supportsWebPSync()).toEqual(supportsWebP);
             });
     });
 });

--- a/Specs/Scene/ModelSpec.js
+++ b/Specs/Scene/ModelSpec.js
@@ -977,7 +977,7 @@ defineSuite([
     });
 
     it('Throws for EXT_texture_webp if browser does not support WebP', function() {
-        spyOn(FeatureDetection, 'supportsWebp').and.returnValue(when.resolve(false));
+        spyOn(FeatureDetection, 'supportsWebP').and.returnValue(when.resolve(false));
         return Resource.fetchJson(texturedBoxWebpUrl).then(function(gltf) {
             gltf.extensionsRequired = ['EXT_texture_webp'];
             var model = primitives.add(new Model({

--- a/Specs/Scene/ModelSpec.js
+++ b/Specs/Scene/ModelSpec.js
@@ -977,7 +977,7 @@ defineSuite([
     });
 
     it('Throws for EXT_texture_webp if browser does not support WebP', function() {
-        spyOn(FeatureDetection, 'supportsWebP').and.returnValue(when.resolve(false));
+        spyOn(FeatureDetection, 'supportsWebPSync').and.returnValue(false);
         return Resource.fetchJson(texturedBoxWebpUrl).then(function(gltf) {
             gltf.extensionsRequired = ['EXT_texture_webp'];
             var model = primitives.add(new Model({


### PR DESCRIPTION
Sorry @OmarShehata, didn't notice this until after @lilleyse merged the PR.  Please do an initial review and then bump to @lilleyse for merge.

1. Rename `Webp`-> `WebP` as per our naming convention.
2. Add `FeatureDetection.supportsWebPSync` which returns true, false or undefined (if not known yet).  If it's not known, it kicks off a background promise to make it known in the future.
3. Simplify checks in Model.js and ClassificationModel.js, using supportsWebPSync.

