### PR TITLE
Remove previously depreacted properties for 1.54

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ Change Log
 ##### Breaking Changes :mega:
 * Billboards with `HeightReference.CLAMP_TO_GROUND` are now clamped to both terrain and 3D Tiles. [#7434](https://github.com/AnalyticalGraphicsInc/cesium/pull/7434)
 * The default `classificationType` for `GroundPrimitive`, `CorridorGraphics`, `EllipseGraphics`, `PolygonGraphics` and `RectangleGraphics` is now `ClassificationType.BOTH`. [#7434](https://github.com/AnalyticalGraphicsInc/cesium/pull/7434)
+* The properties `ModelAnimation.speedup` and `ModelAnimationCollection.speedup` have been removed. Use `ModelAnimation.multiplier` and `ModelAnimationCollection.multiplier` respectively instead. [TODO]()
 
 ##### Deprecated :hourglass_flowing_sand:
 * `Scene.clampToHeight` now takes an optional `width` argument before the `result` argument.  The previous function definition will no longer work in 1.56. [#7287](https://github.com/AnalyticalGraphicsInc/cesium/pull/7287)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,7 +6,7 @@ Change Log
 ##### Breaking Changes :mega:
 * Billboards with `HeightReference.CLAMP_TO_GROUND` are now clamped to both terrain and 3D Tiles. [#7434](https://github.com/AnalyticalGraphicsInc/cesium/pull/7434)
 * The default `classificationType` for `GroundPrimitive`, `CorridorGraphics`, `EllipseGraphics`, `PolygonGraphics` and `RectangleGraphics` is now `ClassificationType.BOTH`. [#7434](https://github.com/AnalyticalGraphicsInc/cesium/pull/7434)
-* The properties `ModelAnimation.speedup` and `ModelAnimationCollection.speedup` have been removed. Use `ModelAnimation.multiplier` and `ModelAnimationCollection.multiplier` respectively instead. [TODO]()
+* The properties `ModelAnimation.speedup` and `ModelAnimationCollection.speedup` have been removed. Use `ModelAnimation.multiplier` and `ModelAnimationCollection.multiplier` respectively instead. [#7494](https://github.com/AnalyticalGraphicsInc/cesium/issues/7394)
 
 ##### Deprecated :hourglass_flowing_sand:
 * `Scene.clampToHeight` now takes an optional `width` argument before the `result` argument.  The previous function definition will no longer work in 1.56. [#7287](https://github.com/AnalyticalGraphicsInc/cesium/pull/7287)

--- a/Source/Scene/ModelAnimation.js
+++ b/Source/Scene/ModelAnimation.js
@@ -49,12 +49,6 @@ define([
          * @default false
          */
         this.removeOnStop = defaultValue(options.removeOnStop, false);
-
-        if (defined(options.speedup)) {
-            deprecationWarning('ModelAnimation.speedup', 'ModelAnimation.speedup is deprecated and will be removed in Cesium 1.54. Use ModelAnimation.multiplier instead.');
-            options.multiplier = options.speedup;
-        }
-
         this._multiplier = defaultValue(options.multiplier, 1.0);
         this._reverse = defaultValue(options.reverse, false);
         this._loop = defaultValue(options.loop, ModelAnimationLoop.NONE);
@@ -214,27 +208,6 @@ define([
          */
         multiplier : {
             get : function() {
-                return this._multiplier;
-            }
-        },
-
-        /**
-         * Values greater than <code>1.0</code> increase the speed that the animation is played relative
-         * to the scene clock speed; values less than <code>1.0</code> decrease the speed.  A value of
-         * <code>1.0</code> plays the animation at the speed in the glTF animation mapped to the scene
-         * clock speed.  For example, if the scene is played at 2x real-time, a two-second glTF animation
-         * will play in one second even if <code>multiplier</code> is <code>1.0</code>.
-         * @memberof ModelAnimation.prototype
-         *
-         * @type {Number}
-         * @readonly
-         * @deprecated This property has been deprecated. Use {@link ModelAnimation#multiplier} instead.
-         *
-         * @default 1.0
-         */
-        speedup : {
-            get : function() {
-                deprecationWarning('ModelAnimation.speedup', 'ModelAnimation.speedup is deprecated and will be removed in Cesium 1.54. Use ModelAnimation.multiplier instead.');
                 return this._multiplier;
             }
         },

--- a/Source/Scene/ModelAnimationCollection.js
+++ b/Source/Scene/ModelAnimationCollection.js
@@ -167,11 +167,6 @@ define([
             throw new DeveloperError('Either options.name or options.index must be defined.');
         }
 
-        if (defined(options.speedup)) {
-            deprecationWarning('options.speedup', 'options.speedup is deprecated and will be removed in Cesium 1.54. Use options.multiplier instead.');
-            options.multiplier = options.speedup;
-        }
-
         if (defined(options.multiplier) && (options.multiplier <= 0.0)) {
             throw new DeveloperError('options.multiplier must be greater than zero.');
         }
@@ -235,11 +230,6 @@ define([
         //>>includeStart('debug', pragmas.debug);
         if (!defined(this._model._runtime.animations)) {
             throw new DeveloperError('Animations are not loaded.  Wait for Model.readyPromise to resolve.');
-        }
-
-        if (defined(options.speedup)) {
-            deprecationWarning('options.speedup', 'options.speedup is deprecated and will be removed in Cesium 1.54. Use options.multiplier instead.');
-            options.multiplier = options.speedup;
         }
 
         if (defined(options.multiplier) && (options.multiplier <= 0.0)) {


### PR DESCRIPTION
Fixes https://github.com/AnalyticalGraphicsInc/cesium/issues/7394

Removes deprecated `ModelAnimation.speedup` and `ModelAnimationCollection.speedup`.