### PR TITLE
Fix eslint errors in CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "cloc": "^2.3.3",
     "compressible": "^2.0.9",
     "compression": "^1.6.2",
-    "eslint": "^5.2.0",
+    "eslint": "5.12.1",
     "eslint-plugin-html": "^5.0.0",
     "express": "^4.15.0",
     "globby": "^8.0.1",


### PR DESCRIPTION
The latest eslint version has breaking changes. Resolves eslint errors in CI by setting eslint to exactly version `5.12.1`.