### PR TITLE
Lower epsilon for comparison in computeWallGeometry for extruded polygons

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@ Change Log
 * Fixed an issue where models would cause a crash on load if some primitives were Draco encoded and others were not. [#7383](https://github.com/AnalyticalGraphicsInc/cesium/issues/7383)
 * Fixed Node.js support for the `Resource` class and any functionality using it internally.
 * Fixed an issue where some ground polygons crossing the Prime Meridian would have incorrect bounding rectangles. [#7533](https://github.com/AnalyticalGraphicsInc/cesium/pull/7533)
+* Fixed an issue where polygons on terrain using rhumb lines where being rendered incorrectly. [#7538](https://github.com/AnalyticalGraphicsInc/cesium/pulls/7538)
 
 ### 1.54 - 2019-02-01
 

--- a/Source/Core/PolygonGeometryLibrary.js
+++ b/Source/Core/PolygonGeometryLibrary.js
@@ -591,7 +591,7 @@ define([
 
             p1 = Cartesian3.fromArray(edgePositions, UL * 3, p1Scratch);
             p2 = Cartesian3.fromArray(edgePositions, UR * 3, p2Scratch);
-            if (Cartesian3.equalsEpsilon(p1, p2, CesiumMath.EPSILON6)) {
+            if (Cartesian3.equalsEpsilon(p1, p2, CesiumMath.EPSILON14, CesiumMath.EPSILON6)) {
                 continue;
             }
 

--- a/Source/Core/PolygonGeometryLibrary.js
+++ b/Source/Core/PolygonGeometryLibrary.js
@@ -591,7 +591,7 @@ define([
 
             p1 = Cartesian3.fromArray(edgePositions, UL * 3, p1Scratch);
             p2 = Cartesian3.fromArray(edgePositions, UR * 3, p2Scratch);
-            if (Cartesian3.equalsEpsilon(p1, p2, CesiumMath.EPSILON14)) {
+            if (Cartesian3.equalsEpsilon(p1, p2, CesiumMath.EPSILON6)) {
                 continue;
             }
 


### PR DESCRIPTION
When using ground polygons with rhumb lines, the polygon was being rendered like 
![image](https://user-images.githubusercontent.com/2288659/52150519-3c1ef380-263e-11e9-84ec-f8eaea24fd4c.png)

For a small polygon like the one in the sandcastle below, while debugging @likangning93 found that the indices for geodesic vs rhumb line polygons were not the same. Upon further digging, we found that the check to see if the points are too close was resulting in equality for geodesic, but not for rhumb line polygon (rhumb line was equal upto 1e-8).

The fix, changing the epsilon to 6 will allow this and other such equalities to pass, and in my opinion is precise enough in Cartesian coordinates.

@bagnell Can you review this since you were the original author of this code and both @likangning93 and I worked on this.

Sandcastle to reproduce:
```
var viewer = new Cesium.Viewer('cesiumContainer', {
    terrainProvider: Cesium.createWorldTerrain()
});
var scene = viewer.scene;
viewer.extend(Cesium.viewerCesiumInspectorMixin);

var handler;

var points = [
    Cesium.Cartesian3.fromRadians(-0.004009249759272205, 0.3943878335588929),
    Cesium.Cartesian3.fromRadians(-0.004163539060811744, 0.3881044459031214),
    Cesium.Cartesian3.fromRadians(0.005080091230656227, 0.3880980356196967),
    Cesium.Cartesian3.fromRadians(0.0047191879663033304, 0.3945808943589415)
];

Sandcastle.addDefaultToolbarButton('Rhumb polygon', function() {
    // Rhumb line polygon geometry
    scene.groundPrimitives.add(new Cesium.GroundPrimitive({
        geometryInstances : new Cesium.GeometryInstance({
            geometry : new Cesium.PolygonGeometry({
                polygonHierarchy: new Cesium.PolygonHierarchy(points),
                arcType : Cesium.ArcType.RHUMB
            }),
            attributes: {
                color: Cesium.ColorGeometryInstanceAttribute.fromColor(new Cesium.Color(1.0, 1.0, 0.0, 0.5))
            },
            id : 'rhumbPolygon'
        }),
        classificationType : Cesium.ClassificationType.TERRAIN,
        //debugShowBoundingVolume: true,
        //debugShowShadowVolume: true
    }));
});
Sandcastle.addToolbarButton('Geodesic polygon', function() {
    scene.groundPrimitives.add(new Cesium.GroundPrimitive({
        geometryInstances : new Cesium.GeometryInstance({
            geometry : new Cesium.PolygonGeometry({
                polygonHierarchy: new Cesium.PolygonHierarchy(points),
            }),
            attributes: {
                color: Cesium.ColorGeometryInstanceAttribute.fromColor(new Cesium.Color(1.0, 0.0, 0.0, 0.5))
            },
            id : 'geodesicPolygon'
        }),
        classificationType : Cesium.ClassificationType.TERRAIN
    }));
});

Sandcastle.reset = function() {
    scene.groundPrimitives.removeAll();
    handler = handler && handler.destroy();

    viewer.camera.lookAt(Cesium.Cartesian3.fromDegrees(0.0, 22.5), new Cesium.Cartesian3(0.0, 0.0, 200000.0));
    viewer.camera.lookAtTransform(Cesium.Matrix4.IDENTITY);
};
```