### PR TITLE
 Fix Scene.mapMode2D doc

### DIFF
--- a/Source/Scene/Scene.js
+++ b/Source/Scene/Scene.js
@@ -1448,7 +1448,7 @@ define([
         /**
          * Determines if the 2D map is rotatable or can be scrolled infinitely in the horizontal direction.
          * @memberof Scene.prototype
-         * @type {Boolean}
+         * @type {MapMode2D}
          */
         mapMode2D : {
             get : function() {


### PR DESCRIPTION
I was trying to check for the Scene's map mode, and was quite aghast when this `Boolean` returned `1`, and for a moment I wondered if I had somehow fallen from the high level world of JavaScript down into a land where Booleans were just integers and memory was not garbage collected.

Turns out it was a just a typo in the docs.