### PR TITLE
Fix Node regression

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@ Change Log
 
 ##### Fixes :wrench:
 * Fixed an issue where models would cause a crash on load if some primitives were Draco encoded and others were not. [#7383](https://github.com/AnalyticalGraphicsInc/cesium/issues/7383)
+* Fixed Node.js support for the `Resource` class and any functionality using it internally.
 
 ### 1.54 - 2019-02-01
 

--- a/Source/Core/Resource.js
+++ b/Source/Core/Resource.js
@@ -1789,10 +1789,15 @@ define([
     }
 
     function loadWithHttpRequest(url, responseType, method, data, headers, deferred, overrideMimeType) {
+
+        // Specifically use the Node version of require to avoid conflicts with the global
+        // require defined in the built version of Cesium.
+        var nodeRequire = global.require; // eslint-disable-line
+
         // Note: only the 'json' and 'text' responseTypes transforms the loaded buffer
-        var URL = require('url').parse(url);
-        var http = URL.protocol === 'https:' ? require('https') : require('http');
-        var zlib = require('zlib');
+        var URL = nodeRequire('url').parse(url);
+        var http = URL.protocol === 'https:' ? nodeRequire('https') : nodeRequire('http');
+        var zlib = nodeRequire('zlib');
         var options = {
             protocol : URL.protocol,
             hostname : URL.hostname,


### PR DESCRIPTION
I introduced a bug in #7514 where `Resource` was broken from inside of Node.js because the built version of cesium was using a different globally defined require than Node's require. One of these days we'll have full Node testing, but this is one of the fuzzy parts of the API that we don't normally ever use via Node.

To test this, first run `minifyRelease` then run `NODE_ENV=production node` and paste the below code into the interpreter:

```
const Cesium = require('./index.js');
Cesium.IonResource.fromAssetId(1);
```

You should see `{ then: [Function: e] }` as output.  Previously it would crash with a `No url` error and callstack.
