### PR TITLE
Fix IDL intersection of rhumb lines by using the correct sign of PI

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,7 @@ Change Log
 * Fixed Node.js support for the `Resource` class and any functionality using it internally.
 * Fixed an issue where some ground polygons crossing the Prime Meridian would have incorrect bounding rectangles. [#7533](https://github.com/AnalyticalGraphicsInc/cesium/pull/7533)
 * Fixed an issue where polygons on terrain using rhumb lines where being rendered incorrectly. [#7538](https://github.com/AnalyticalGraphicsInc/cesium/pulls/7538)
+* Fixed an issue with `EllipsoidRhumbLines.findIntersectionWithLongitude` when longitude was IDL. [#7551](https://github.com/AnalyticalGraphicsInc/cesium/issues/7551)
 
 ### 1.54 - 2019-02-01
 

--- a/Source/Core/EllipsoidRhumbLine.js
+++ b/Source/Core/EllipsoidRhumbLine.js
@@ -416,6 +416,10 @@ define([
 
         intersectionLongitude = CesiumMath.negativePiToPi(intersectionLongitude);
 
+        if (CesiumMath.equalsEpsilon(Math.abs(intersectionLongitude), Math.PI, CesiumMath.EPSILON14)) {
+            intersectionLongitude = Math.sign(start.longitude) * Math.PI;
+        }
+
         if (!defined(result)) {
             result = new Cartographic();
         }
@@ -454,7 +458,7 @@ define([
         } while (!CesiumMath.equalsEpsilon(newPhi, phi, CesiumMath.EPSILON12));
 
         result.longitude = intersectionLongitude;
-        result.latitude = phi;
+        result.latitude = newPhi;
         result.height = 0;
         return result;
     };

--- a/Specs/Core/EllipsoidRhumbLineSpec.js
+++ b/Specs/Core/EllipsoidRhumbLineSpec.js
@@ -547,6 +547,25 @@ defineSuite([
         expect(Cartographic.equalsEpsilon(pointUsingInterpolation, pointUsingIntersection, CesiumMath.EPSILON12)).toBe(true);
     });
 
+    it('finds correct intersection with IDL', function() {
+        var start = Cartographic.fromDegrees(170, 10);
+        var end = Cartographic.fromDegrees(-170, 23);
+
+        var rhumb = new EllipsoidRhumbLine(start, end);
+
+        var idlIntersection1 = rhumb.findIntersectionWithLongitude(-Math.PI);
+        var idlIntersection2 = rhumb.findIntersectionWithLongitude(Math.PI);
+
+        expect(Cartographic.equalsEpsilon(idlIntersection1, idlIntersection2, CesiumMath.EPSILON12)).toBe(true);
+
+        rhumb.setEndPoints(end, start);
+
+        idlIntersection1 = rhumb.findIntersectionWithLongitude(-Math.PI);
+        idlIntersection2 = rhumb.findIntersectionWithLongitude(Math.PI);
+
+        expect(Cartographic.equalsEpsilon(idlIntersection1, idlIntersection2, CesiumMath.EPSILON12)).toBe(true);
+    });
+
     it('intersection with longitude handles E-W lines', function() {
         var start = new Cartographic(fifteenDegrees, 0.0);
         var end = new Cartographic(fortyfiveDegrees, 0.0);

--- a/Specs/Core/EllipsoidRhumbLineSpec.js
+++ b/Specs/Core/EllipsoidRhumbLineSpec.js
@@ -557,6 +557,8 @@ defineSuite([
         var idlIntersection2 = rhumb.findIntersectionWithLongitude(Math.PI);
 
         expect(Cartographic.equalsEpsilon(idlIntersection1, idlIntersection2, CesiumMath.EPSILON12)).toBe(true);
+        expect(idlIntersection1.longitude).toEqualEpsilon(Math.PI, CesiumMath.EPSILON14);
+        expect(idlIntersection2.longitude).toEqualEpsilon(Math.PI, CesiumMath.EPSILON14);
 
         rhumb.setEndPoints(end, start);
 
@@ -564,6 +566,8 @@ defineSuite([
         idlIntersection2 = rhumb.findIntersectionWithLongitude(Math.PI);
 
         expect(Cartographic.equalsEpsilon(idlIntersection1, idlIntersection2, CesiumMath.EPSILON12)).toBe(true);
+        expect(idlIntersection1.longitude).toEqualEpsilon(-Math.PI, CesiumMath.EPSILON14);
+        expect(idlIntersection2.longitude).toEqualEpsilon(-Math.PI, CesiumMath.EPSILON14);
     });
 
     it('intersection with longitude handles E-W lines', function() {


### PR DESCRIPTION
Before this fix, the intersection depended on which sign of PI was being used, and as a result of rhumb lines being spirals, a non-first latitude was being returned.

Added a spec to ensure this.

@likangning93 would you do the honors?