### PR TITLE
Generate documentation in watch mode

### DIFF
--- a/Documentation/Contributors/DocumentationGuide/README.md
+++ b/Documentation/Contributors/DocumentationGuide/README.md
@@ -1,6 +1,6 @@
 # Documentation Guide
 
-CesiumJS's reference documentation is one of the most popular sections of the CesiumJS website, and a critical resource for developers.  
+CesiumJS's reference documentation is one of the most popular sections of the CesiumJS website, and a critical resource for developers.
 
 This guide describes best practices for writing reference doc.
 
@@ -33,6 +33,8 @@ The reference doc is written in JavaScript code comments using [JSDoc3](http://u
 npm run generateDocumentation
 ```
 This creates a `Build/Documentation` directory with the built HTML files.
+
+>Alternatively, you can build documentation in watch mode `npm run generateDocumentation-watch` and have it generated automatically when source files change.
 
 There is a link to the doc from CesiumJS's main `index.html` when running
 ```
@@ -442,7 +444,7 @@ DESCRIPTION.
 @see TYPE#INSTANCE_MEMBER
 @see TYPE.STATIC_MEMBER
 
-@example 
+@example
 
 [@private]
 ```
@@ -463,7 +465,7 @@ DESCRIPTION.
 @see TYPE#INSTANCE_MEMBER
 @see TYPE.STATIC_MEMBER
 
-@example 
+@example
 
 [@private]
 ```
@@ -484,7 +486,7 @@ DESCRIPTION.
 @see TYPE#INSTANCE_MEMBER
 @see TYPE.STATIC_MEMBER
 
-@example 
+@example
 
 [@private]
 ```
@@ -507,7 +509,7 @@ DESCRIPTION.
 @see TYPE#INSTANCE_MEMBER
 @see TYPE.STATIC_MEMBER
 
-@example 
+@example
 
 [@private]
 ```

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -284,19 +284,6 @@ gulp.task('generateDocumentation-watch', function() {
     });
 });
 
-gulp.task('instrumentForCoverage', gulp.series('build', function(done) {
-    var jscoveragePath = path.join('Tools', 'jscoverage-0.5.1', 'jscoverage.exe');
-    var cmdLine = jscoveragePath + ' Source Instrumented --no-instrument=./ThirdParty';
-    child_process.exec(cmdLine, function(error, stdout, stderr) {
-        if (error) {
-            console.log(stderr);
-            return done(error);
-        }
-        console.log(stdout);
-        done();
-    });
-}));
-
 gulp.task('release', gulp.series('generateStubs', combine, minifyRelease, generateDocumentation));
 
 gulp.task('makeZipFile', gulp.series('release', function() {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -278,7 +278,7 @@ function generateDocumentation() {
 gulp.task('generateDocumentation', generateDocumentation);
 
 gulp.task('generateDocumentation-watch', function() {
-    return generateDocumentation().done(() => {
+    return generateDocumentation().done(function() {
         console.log('Listening for changes in documentation...');
         return gulp.watch(sourceFiles, gulp.series('generateDocumentation'));
     });

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -277,6 +277,23 @@ function generateDocumentation() {
 }
 gulp.task('generateDocumentation', generateDocumentation);
 
+gulp.task('generateDocumentation-watch', function() {
+    return gulp.watch(sourceFiles, gulp.series('generateDocumentation'));
+});
+
+gulp.task('instrumentForCoverage', gulp.series('build', function(done) {
+    var jscoveragePath = path.join('Tools', 'jscoverage-0.5.1', 'jscoverage.exe');
+    var cmdLine = jscoveragePath + ' Source Instrumented --no-instrument=./ThirdParty';
+    child_process.exec(cmdLine, function(error, stdout, stderr) {
+        if (error) {
+            console.log(stderr);
+            return done(error);
+        }
+        console.log(stdout);
+        done();
+    });
+}));
+
 gulp.task('release', gulp.series('generateStubs', combine, minifyRelease, generateDocumentation));
 
 gulp.task('makeZipFile', gulp.series('release', function() {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -278,7 +278,10 @@ function generateDocumentation() {
 gulp.task('generateDocumentation', generateDocumentation);
 
 gulp.task('generateDocumentation-watch', function() {
-    return gulp.watch(sourceFiles, gulp.series('generateDocumentation'));
+    return generateDocumentation().done(() => {
+        console.log('Listening for changes in documentation...');
+        return gulp.watch(sourceFiles, gulp.series('generateDocumentation'));
+    });
 });
 
 gulp.task('instrumentForCoverage', gulp.series('build', function(done) {

--- a/package.json
+++ b/package.json
@@ -88,7 +88,6 @@
     "requirejs": "gulp requirejs",
     "generateDocumentation": "gulp generateDocumentation",
     "generateDocumentation-watch": "gulp generateDocumentation-watch",
-    "instrumentForCoverage": "gulp instrumentForCoverage",
     "eslint": "eslint \"./**/*.js\" \"./**/*.html\" --cache --quiet",
     "makeZipFile": "gulp makeZipFile",
     "minify": "gulp minify",

--- a/package.json
+++ b/package.json
@@ -87,6 +87,8 @@
     "coverage": "gulp coverage",
     "requirejs": "gulp requirejs",
     "generateDocumentation": "gulp generateDocumentation",
+    "generateDocumentation-watch": "gulp generateDocumentation-watch",
+    "instrumentForCoverage": "gulp instrumentForCoverage",
     "eslint": "eslint \"./**/*.js\" \"./**/*.html\" --cache --quiet",
     "makeZipFile": "gulp makeZipFile",
     "minify": "gulp minify",


### PR DESCRIPTION
Fixes #7500 

1. Create a task `generateDocumentation-watch` to keep `generateDocumentation` task running.
2. Align `build-watch` task with gulp version 4.
3. Update readme file of Documentation Guide .
4. Add script entry for `generateDocumentation-watch` in the `package.json` file