### PR TITLE
Don't use requirejs with minified Cesium.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,8 +28,9 @@ script:
 
   - npm --silent run test -- --browsers FirefoxHeadless --failTaskOnError --webgl-stub --release --suppressPassed
 
+# Various Node.js smoke-screen tests
+  - node -e "const Cesium = require('./');"
   - NODE_ENV=development node index.js
-
   - NODE_ENV=production node index.js
 
   - npm --silent run cloc

--- a/Source/ThirdParty/NoSleep.js
+++ b/Source/ThirdParty/NoSleep.js
@@ -1,8 +1,8 @@
 /*! NoSleep.js v0.7.0 - git.io/vfn01 - Rich Tibbett - MIT license */
 (function webpackUniversalModuleDefinition(root, factory) {
-	if(typeof exports === 'object' && typeof module === 'object')
+	/* if(typeof exports === 'object' && typeof module === 'object')
 		module.exports = factory();
-	else if(typeof define === 'function' && define.amd)
+	else */ if(typeof define === 'function' && define.amd)
 		define([], factory);
 	else if(typeof exports === 'object')
 		exports["NoSleep"] = factory();

--- a/Source/ThirdParty/purify.js
+++ b/Source/ThirdParty/purify.js
@@ -1,5 +1,5 @@
 (function (global, factory) {
-	typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory() :
+	// typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory() :
 	typeof define === 'function' && define.amd ? define(factory) :
 	(global.DOMPurify = factory());
 }(this, (function () { 'use strict';

--- a/Source/main.js
+++ b/Source/main.js
@@ -6,13 +6,13 @@ require([
     ], function(
         Cesium) {
     'use strict';
-    /*global self,global*/
+    /*global self,module*/
     if (typeof window !== 'undefined') {
         window.Cesium = Cesium;
     } else if (typeof self !== 'undefined') {
         self.Cesium = Cesium;
-    } else if (typeof global !== 'undefined') {
-        global.Cesium = Cesium;
+    } else if(typeof module !== 'undefined') {
+        module.exports = Cesium;
     } else {
         console.log('Unable to load Cesium.');
     }

--- a/index.js
+++ b/index.js
@@ -2,36 +2,20 @@
 'use strict';
 
 var path = require('path');
-var requirejs = require('requirejs');
 
-//In explicit development mode, use un-optimized requirejs modules for improved error checking.
-if (process.env.NODE_ENV === 'development') {
-    requirejs.config({
-        paths: {
-            'Cesium': path.join(__dirname, 'Source')
-        },
-        nodeRequire: require
-    });
-    module.exports = requirejs('Cesium/Cesium');
+// If not explicitly in development mode, use the combined/minified/optimized version of Cesium
+if (process.env.NODE_ENV !== 'development') {
+    module.exports = require(path.join(__dirname, 'Build/Cesium/Cesium'));
     return;
 }
 
-//In all other cases, use minified Cesium for performance.
+// Otherwise, use un-optimized requirejs modules for improved error checking.
+var requirejs = require('requirejs');
 requirejs.config({
     paths: {
-        'Cesium': path.join(__dirname, 'Build/Cesium/Cesium')
+        'Cesium': path.join(__dirname, 'Source')
     },
     nodeRequire: require
 });
 
-const hadCesiumProperty = global.hasOwnProperty('Cesium');
-const oldCesium = global.Cesium;
-
-requirejs('Cesium');
-module.exports = global.Cesium;
-
-if (hadCesiumProperty) {
-    global.Cesium = oldCesium;
-} else {
-    delete global.Cesium;
-}
+module.exports = requirejs('Cesium/Cesium');


### PR DESCRIPTION
@lilleyse this will fix the oddness you were seeing yesterday.

While the improvements in #7514 worked, they were a little more convoluted than they had to be and also caused some weird edge cases where loading Cesium in eval'd Node.js code didn't work.

This change avoids using requirejs entirely when loading minified Cesium in Node and adds a smokescreen test to travis that fails in master. This also avoids the odd global workaround I had to put in place previously.

I did have to modify the UMD headers for NoSleep.js and purify.js because their preference is to look for Node.js first and not use AMD if it's found, this was the root cause of the failures we were seeing in eval'd code.  The smokescreen test I added will fail again if the problem were reintroduced.

So overall, this make Cesium a little more node-friendly and just makes things cleaner from our end.