### PR TITLE
Update all npm packages to latest versions.

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,10 +39,10 @@
     "cloc": "^2.3.3",
     "compressible": "^2.0.9",
     "compression": "^1.6.2",
-    "eslint": "5.12.1",
-    "eslint-plugin-html": "^5.0.0",
+    "eslint": "^5.13.0",
+    "eslint-plugin-html": "^5.0.3",
     "express": "^4.15.0",
-    "globby": "^8.0.1",
+    "globby": "^9.0.0",
     "glsl-strip-comments": "^1.0.0",
     "gulp": "^4.0.0",
     "gulp-insert": "^0.5.0",
@@ -53,7 +53,7 @@
     "gulp-zip": "^4.0.0",
     "jasmine-core": "^3.3.0",
     "jsdoc": "^3.4.3",
-    "karma": "^3.1.1",
+    "karma": "^4.0.0",
     "karma-chrome-launcher": "^2.0.0",
     "karma-detect-browsers": "^2.2.3",
     "karma-edge-launcher": "^0.4.2",
@@ -70,7 +70,7 @@
     "request": "^2.79.0",
     "rimraf": "^2.6.1",
     "stream-to-promise": "^2.2.0",
-    "yargs": "^12.0.2"
+    "yargs": "^13.2.0"
   },
   "scripts": {
     "start": "node server.js",


### PR DESCRIPTION
Closes #7536 and also updates some other packages greenkeeper recently reminded us about.