### PR TITLE
Fix vertex shader generation for draco-compressed RGB per-vertex color

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,7 @@ Change Log
 * Fixed an issue where polygons on terrain using rhumb lines where being rendered incorrectly. [#7538](https://github.com/AnalyticalGraphicsInc/cesium/pulls/7538)
 * Fixed an issue with `EllipsoidRhumbLines.findIntersectionWithLongitude` when longitude was IDL. [#7551](https://github.com/AnalyticalGraphicsInc/cesium/issues/7551)
 * Fixed an issue with ground polylines on globes that use ellipsoids other than WGS84. [#7552](https://github.com/AnalyticalGraphicsInc/cesium/issues/7552)
+* Fixed an issue where Draco compressed models with RGB per-vertex color would not load in Cesium. [#7576](https://github.com/AnalyticalGraphicsInc/cesium/issues/7576)
 
 ### 1.54 - 2019-02-01
 

--- a/Source/Scene/ModelUtility.js
+++ b/Source/Scene/ModelUtility.js
@@ -602,6 +602,12 @@ define([
                     }
                     shader = variableType + ' ' + decodedAttributeVarName + ';\n' + shader;
 
+                    // The gltf 2.0 COLOR_0 vertex attribute can be VEC4 or VEC3
+                    var vec3Color = size === 3 && attributeSemantic === 'COLOR_0';
+                    if (vec3Color) {
+                        shader = replaceAllButFirstInString(shader, decodedAttributeVarName, 'vec4(' + decodedAttributeVarName + ', 1.0)');
+                    }
+
                     // splice decode function into the shader
                     var decode = '';
                     if (quantization.octEncoded) {
@@ -618,9 +624,10 @@ define([
                         var decodeUniformVarNameMin = decodeUniformVarName + '_min';
                         shader = 'uniform float ' + decodeUniformVarNameNormConstant + ';\n' +
                                 'uniform ' + variableType + ' ' + decodeUniformVarNameMin + ';\n' + shader;
+                        var attributeVarAccess = vec3Color ? '.xyz' : '';
                         decode = '\n' +
                                 'void main() {\n' +
-                                '    ' + decodedAttributeVarName + ' = ' + decodeUniformVarNameMin + ' + ' + attributeVarName + ' * ' + decodeUniformVarNameNormConstant + ';\n' +
+                                '    ' + decodedAttributeVarName + ' = ' + decodeUniformVarNameMin + ' + ' + attributeVarName + attributeVarAccess + ' * ' + decodeUniformVarNameNormConstant + ';\n' +
                                 '    ' + newMain + '();\n' +
                                 '}\n';
                     }

--- a/Specs/Data/Models/DracoCompression/BoxVertexColorsDracoRGB.gltf
+++ b/Specs/Data/Models/DracoCompression/BoxVertexColorsDracoRGB.gltf
@@ -1,0 +1,213 @@
+{
+  "accessors": [
+    {
+      "componentType": 5123,
+      "count": 36,
+      "type": "SCALAR"
+    },
+    {
+      "componentType": 5126,
+      "count": 24,
+      "type": "VEC3"
+    },
+    {
+      "componentType": 5126,
+      "count": 24,
+      "type": "VEC3"
+    },
+    {
+      "componentType": 5126,
+      "count": 24,
+      "max": [
+        0.5,
+        0.5,
+        0.5
+      ],
+      "min": [
+        -0.5,
+        -0.5,
+        -0.5
+      ],
+      "type": "VEC3"
+    },
+    {
+      "componentType": 5126,
+      "count": 24,
+      "type": "VEC2"
+    }
+  ],
+  "asset": {
+    "generator": "FBX2glTF",
+    "version": "2.0"
+  },
+  "bufferViews": [
+    {
+      "buffer": 0,
+      "byteOffset": 0,
+      "byteLength": 291
+    }
+  ],
+  "buffers": [
+    {
+      "name": "BoxVertexColorsDracoRGB",
+      "byteLength": 292,
+      "uri": "data:application/octet-stream;base64,RFJBQ08CAgEBAAAACAwDCwAAA2+rFAEBEP8CNUFVBEs7K0acBPS3XVcEAAAA/wAAAgEAAQEAAQIJAwAAAgEACQMAAgIBAwkCAAMCAQEJAwABAwEBAQAJDwEIBwEgARgEAHoAggE8LscrycxCBfwIQmx3gBQoA6BlYwAAAAD/AAAAHekGMAjDNTqgF+43Iv5/PwgBAQEAAgMBQAEAoAIIAAAAAP8/AAAAAAC/AAAAvwAAAL8AAIA/DgUBAQANA5UEG20b3RYDJQkFr5XCIE4AsKoACAAApJoqAFOtAqDqVKurAlDVKgCsApDq1KkApgIMAAAAAQLAQAAAAAD/DwAAAAAAAAAAAAAAAIA/DAYDAQEBAQFAAQD/AwAA/wEAAP8CoUEKAA=="
+    }
+  ],
+  "materials": [
+    {
+      "name": "Default",
+      "pbrMetallicRoughness": {
+        "baseColorFactor": [
+          0.800000011920929,
+          0.800000011920929,
+          0.800000011920929,
+          1
+        ],
+        "metallicFactor": 0.100000001490116,
+        "roughnessFactor": 0.990000005960464
+      },
+      "emissiveFactor": [
+        0,
+        0,
+        0
+      ],
+      "alphaMode": "OPAQUE",
+      "doubleSided": false
+    }
+  ],
+  "meshes": [
+    {
+      "name": "Cube",
+      "primitives": [
+        {
+          "attributes": {
+            "COLOR_0": 1,
+            "NORMAL": 2,
+            "POSITION": 3,
+            "TEXCOORD_0": 4
+          },
+          "indices": 0,
+          "material": 0,
+          "mode": 4,
+          "extensions": {
+            "KHR_draco_mesh_compression": {
+              "bufferView": 0,
+              "attributes": {
+                "COLOR_0": 0,
+                "NORMAL": 1,
+                "POSITION": 2,
+                "TEXCOORD_0": 3
+              }
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "nodes": [
+    {
+      "children": [
+        1,
+        2,
+        3
+      ],
+      "name": "RootNode",
+      "rotation": [
+        0,
+        0,
+        0,
+        1
+      ],
+      "scale": [
+        1,
+        1,
+        1
+      ],
+      "translation": [
+        0,
+        0,
+        0
+      ]
+    },
+    {
+      "name": "Mesh",
+      "rotation": [
+        0,
+        0,
+        0,
+        1
+      ],
+      "scale": [
+        1,
+        1,
+        1
+      ],
+      "translation": [
+        0,
+        0,
+        0
+      ]
+    },
+    {
+      "mesh": 0,
+      "name": "Cube",
+      "rotation": [
+        0,
+        0,
+        0,
+        1
+      ],
+      "scale": [
+        1,
+        1,
+        1
+      ],
+      "translation": [
+        0,
+        0,
+        0
+      ]
+    },
+    {
+      "name": "Texture Group",
+      "rotation": [
+        0,
+        0,
+        0,
+        1
+      ],
+      "scale": [
+        1,
+        1,
+        1
+      ],
+      "translation": [
+        0,
+        0,
+        0
+      ]
+    }
+  ],
+  "samplers": [
+    {
+      "wrapS": 10497,
+      "wrapT": 10497
+    }
+  ],
+  "scene": 0,
+  "scenes": [
+    {
+      "name": "Root Scene",
+      "nodes": [
+        0
+      ]
+    }
+  ],
+  "extensionsRequired": [
+    "KHR_draco_mesh_compression"
+  ],
+  "extensionsUsed": [
+    "KHR_draco_mesh_compression"
+  ]
+}

--- a/Specs/Data/Models/DracoCompression/BoxVertexColorsDracoRGBA.gltf
+++ b/Specs/Data/Models/DracoCompression/BoxVertexColorsDracoRGBA.gltf
@@ -1,0 +1,213 @@
+{
+  "accessors": [
+    {
+      "componentType": 5123,
+      "count": 36,
+      "type": "SCALAR"
+    },
+    {
+      "componentType": 5126,
+      "count": 24,
+      "type": "VEC4"
+    },
+    {
+      "componentType": 5126,
+      "count": 24,
+      "type": "VEC3"
+    },
+    {
+      "componentType": 5126,
+      "count": 24,
+      "max": [
+        0.5,
+        0.5,
+        0.5
+      ],
+      "min": [
+        -0.5,
+        -0.5,
+        -0.5
+      ],
+      "type": "VEC3"
+    },
+    {
+      "componentType": 5126,
+      "count": 24,
+      "type": "VEC2"
+    }
+  ],
+  "asset": {
+    "generator": "FBX2glTF",
+    "version": "2.0"
+  },
+  "bufferViews": [
+    {
+      "buffer": 0,
+      "byteOffset": 0,
+      "byteLength": 302
+    }
+  ],
+  "buffers": [
+    {
+      "name": "BoxVertexColorsDracoRGBA",
+      "byteLength": 304,
+      "uri": "data:application/octet-stream;base64,RFJBQ08CAgEBAAAACAwDCwAAA2+rFAEBEP8CNUFVBEs7K0acBPS3XVcEAAAA/wAAAgEAAQEAAQIJBAAAAgEACQMAAgIBAwkCAAMCAQEJAwABAwEBAQAJDwEIBwEgARgEAHoAggEM43I8UElmJhAq4CdAEGIJ3QGSIVAGEqBlYwEAAAAA/wAAAB3pBjAIwzU6oBfuN1HSJzAAAIA/CAEBAQACAwFAAQCgAggAAAAA/z8AAAAAAL8AAAC/AAAAvwAAgD8OBQEBAA0DlQQbbRvdFgMlCQWvlcIgTgCwqgAIAACkmioAU60CoOpUq6sCUNUqAKwCkOrUqQCmAgwAAAABAsBAAAAAAP8PAAAAAAAAAAAAAAAAgD8MBgMBAQEBAUABAP8DAAD/AQAA/wKhQQoAAA=="
+    }
+  ],
+  "materials": [
+    {
+      "name": "Default",
+      "pbrMetallicRoughness": {
+        "baseColorFactor": [
+          0.800000011920929,
+          0.800000011920929,
+          0.800000011920929,
+          1
+        ],
+        "metallicFactor": 0.100000001490116,
+        "roughnessFactor": 0.990000005960464
+      },
+      "emissiveFactor": [
+        0,
+        0,
+        0
+      ],
+      "alphaMode": "OPAQUE",
+      "doubleSided": false
+    }
+  ],
+  "meshes": [
+    {
+      "name": "Cube",
+      "primitives": [
+        {
+          "attributes": {
+            "COLOR_0": 1,
+            "NORMAL": 2,
+            "POSITION": 3,
+            "TEXCOORD_0": 4
+          },
+          "indices": 0,
+          "material": 0,
+          "mode": 4,
+          "extensions": {
+            "KHR_draco_mesh_compression": {
+              "bufferView": 0,
+              "attributes": {
+                "COLOR_0": 0,
+                "NORMAL": 1,
+                "POSITION": 2,
+                "TEXCOORD_0": 3
+              }
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "nodes": [
+    {
+      "children": [
+        1,
+        2,
+        3
+      ],
+      "name": "RootNode",
+      "rotation": [
+        0,
+        0,
+        0,
+        1
+      ],
+      "scale": [
+        1,
+        1,
+        1
+      ],
+      "translation": [
+        0,
+        0,
+        0
+      ]
+    },
+    {
+      "name": "Mesh",
+      "rotation": [
+        0,
+        0,
+        0,
+        1
+      ],
+      "scale": [
+        1,
+        1,
+        1
+      ],
+      "translation": [
+        0,
+        0,
+        0
+      ]
+    },
+    {
+      "mesh": 0,
+      "name": "Cube",
+      "rotation": [
+        0,
+        0,
+        0,
+        1
+      ],
+      "scale": [
+        1,
+        1,
+        1
+      ],
+      "translation": [
+        0,
+        0,
+        0
+      ]
+    },
+    {
+      "name": "Texture Group",
+      "rotation": [
+        0,
+        0,
+        0,
+        1
+      ],
+      "scale": [
+        1,
+        1,
+        1
+      ],
+      "translation": [
+        0,
+        0,
+        0
+      ]
+    }
+  ],
+  "samplers": [
+    {
+      "wrapS": 10497,
+      "wrapT": 10497
+    }
+  ],
+  "scene": 0,
+  "scenes": [
+    {
+      "name": "Root Scene",
+      "nodes": [
+        0
+      ]
+    }
+  ],
+  "extensionsRequired": [
+    "KHR_draco_mesh_compression"
+  ],
+  "extensionsUsed": [
+    "KHR_draco_mesh_compression"
+  ]
+}

--- a/Specs/Scene/ModelSpec.js
+++ b/Specs/Scene/ModelSpec.js
@@ -137,6 +137,8 @@ defineSuite([
     var dracoCompressedModelUrl = './Data/Models/DracoCompression/CesiumMilkTruck/CesiumMilkTruck.gltf';
     var dracoCompressedModelWithAnimationUrl = './Data/Models/DracoCompression/CesiumMan/CesiumMan.gltf';
     var dracoCompressedModelWithLinesUrl = './Data/Models/DracoCompression/BoxWithLines/BoxWithLines.gltf';
+    var dracoBoxVertexColorsRGBUrl = './Data/Models/DracoCompression/BoxVertexColorsDracoRGB.gltf';
+    var dracoBoxVertexColorsRGBAUrl = './Data/Models/DracoCompression/BoxVertexColorsDracoRGBA.gltf';
 
     var boxGltf2Url = './Data/Models/Box-Gltf-2/Box.gltf';
     var boxGltf2WithTechniquesUrl = './Data/Models/Box-Gltf-2-Techniques/Box.gltf';
@@ -2680,6 +2682,20 @@ defineSuite([
             expect(atrributeData['NORMAL'].quantization).toBeDefined();
             expect(atrributeData['JOINTS_0'].quantization).toBeUndefined();
 
+            primitives.remove(m);
+        });
+    });
+
+    it('loads draco compressed glTF with RGBA per-vertex color', function() {
+        return loadModel(dracoBoxVertexColorsRGBAUrl).then(function(m) {
+            verifyRender(m);
+            primitives.remove(m);
+        });
+    });
+
+    it('loads draco compressed glTF with RGB per-vertex color', function() {
+        return loadModel(dracoBoxVertexColorsRGBUrl).then(function(m) {
+            verifyRender(m);
             primitives.remove(m);
         });
     });


### PR DESCRIPTION
Fixes #7576.

Draco-compressed models with RGB per-vertex color were causing vertex-shader compilation failure because the existing per-vertex-color shader assumes RGBA (vec4) per-vertex color, but the decoding glsl injected decodes to RGB (vec3).

This PR detects when `COLOR_0` is getting decoded to `vec3` and wraps access in the vertex shader in a `vec4`.

There's also a pair of new spec models generated by running [BoxVertexColors ](https://github.com/KhronosGroup/glTF-Sample-Models/tree/master/2.0/BoxVertexColors) and a modified variant with vec3 vertex color through `gltf-pipeline` for Draco compression.

I tried using draco-compressed versions of the ["Vertex Color Test"](https://github.com/KhronosGroup/glTF-Sample-Models/tree/master/2.0/VertexColorTest) model, but the `checkVertexColors` test function wouldn't produce the same results, I suspect because of compression artifacts making a difference when rendering at 1x1.