### PR TITLE
use un-optimized requireJS modules if NODE_ENV === 'test'

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,8 +3,8 @@
 
 var path = require('path');
 
-// If not explicitly in development mode, use the combined/minified/optimized version of Cesium
-if (process.env.NODE_ENV !== 'development') {
+// If not explicitly in development or test mode, use the combined/minified/optimized version of Cesium
+if (process.env.NODE_ENV !== 'development' && process.env.NODE_ENV !== 'test') {
     module.exports = require(path.join(__dirname, 'Build/Cesium/Cesium'));
     return;
 }

--- a/index.js
+++ b/index.js
@@ -3,13 +3,13 @@
 
 var path = require('path');
 
-// If not explicitly in development or test mode, use the combined/minified/optimized version of Cesium
-if (process.env.NODE_ENV !== 'development' && process.env.NODE_ENV !== 'test') {
+// If in 'production' mode, use the combined/minified/optimized version of Cesium
+if (process.env.NODE_ENV === 'production') {
     module.exports = require(path.join(__dirname, 'Build/Cesium/Cesium'));
     return;
 }
 
-// Otherwise, use un-optimized requirejs modules for improved error checking.
+// Otherwise, use un-optimized requirejs modules for improved error checking. For example 'development' mode
 var requirejs = require('requirejs');
 requirejs.config({
     paths: {


### PR DESCRIPTION
i just updated the cesium version we are using, which unfortunatly broke our test workflow. 

To fix this we would like to load the un-optimized cesium source code if the NODE_ENV  is set to `test`, the same as 'development'



