### PR TITLE
Rename new math comparison functions

### DIFF
--- a/Source/Core/Math.js
+++ b/Source/Core/Math.js
@@ -588,13 +588,13 @@ define([
      * <code>absoluteEpsilon</code> of each other, they are considered equal and this function returns false.
      *
      * @param {Number} left The first number to compare.
-     * @param {Number} second The second number to compare.
+     * @param {Number} right The second number to compare.
      * @param {Number} absoluteEpsilon The absolute epsilon to use in comparison.
      * @returns {Boolean} <code>true</code> if <code>left</code> is less than <code>right</code> by more than
      *          <code>absoluteEpsilon<code>. <code>false</code> if <code>left</code> is greater or if the two
      *          values are nearly equal.
      */
-    CesiumMath.leftIsLessThanRight = function(left, right, absoluteEpsilon) {
+    CesiumMath.lessThan = function(left, right, absoluteEpsilon) {
         //>>includeStart('debug', pragmas.debug);
         if (!defined(left)) {
             throw new DeveloperError('first is required.');
@@ -614,12 +614,12 @@ define([
      * <code>absoluteEpsilon</code> of each other, they are considered equal and this function returns true.
      *
      * @param {Number} left The first number to compare.
-     * @param {Number} second The second number to compare.
+     * @param {Number} right The second number to compare.
      * @param {Number} absoluteEpsilon The absolute epsilon to use in comparison.
      * @returns {Boolean} <code>true</code> if <code>left</code> is less than <code>right</code> or if the
      *          the values are nearly equal.
      */
-    CesiumMath.leftIsLessThanOrEqualToRight = function(left, right, absoluteEpsilon) {
+    CesiumMath.lessThanOrEquals = function(left, right, absoluteEpsilon) {
         //>>includeStart('debug', pragmas.debug);
         if (!defined(left)) {
             throw new DeveloperError('first is required.');
@@ -639,13 +639,13 @@ define([
      * <code>absoluteEpsilon</code> of each other, they are considered equal and this function returns false.
      *
      * @param {Number} left The first number to compare.
-     * @param {Number} second The second number to compare.
+     * @param {Number} right The second number to compare.
      * @param {Number} absoluteEpsilon The absolute epsilon to use in comparison.
      * @returns {Boolean} <code>true</code> if <code>left</code> is greater than <code>right</code> by more than
      *          <code>absoluteEpsilon<code>. <code>false</code> if <code>left</code> is less or if the two
      *          values are nearly equal.
      */
-    CesiumMath.leftIsGreaterThanRight = function(left, right, absoluteEpsilon) {
+    CesiumMath.greaterThan = function(left, right, absoluteEpsilon) {
         //>>includeStart('debug', pragmas.debug);
         if (!defined(left)) {
             throw new DeveloperError('first is required.');
@@ -665,12 +665,12 @@ define([
      * <code>absoluteEpsilon</code> of each other, they are considered equal and this function returns true.
      *
      * @param {Number} left The first number to compare.
-     * @param {Number} second The second number to compare.
+     * @param {Number} right The second number to compare.
      * @param {Number} absoluteEpsilon The absolute epsilon to use in comparison.
      * @returns {Boolean} <code>true</code> if <code>left</code> is greater than <code>right</code> or if the
      *          the values are nearly equal.
      */
-    CesiumMath.leftIsGreaterThanOrEqualToRight = function(left, right, absoluteEpsilon) {
+    CesiumMath.greaterThanOrEquals = function(left, right, absoluteEpsilon) {
         //>>includeStart('debug', pragmas.debug);
         if (!defined(left)) {
             throw new DeveloperError('first is required.');

--- a/Source/Scene/TerrainFillMesh.js
+++ b/Source/Scene/TerrainFillMesh.js
@@ -349,14 +349,14 @@ define([
                 for (startIndex = 0; startIndex < edgeTiles.length; ++startIndex) {
                     existingTile = edgeTiles[startIndex];
                     existingRectangle = existingTile.rectangle;
-                    if (CesiumMath.leftIsGreaterThanRight(sourceRectangle.north, existingRectangle.south, epsilon)) {
+                    if (CesiumMath.greaterThan(sourceRectangle.north, existingRectangle.south, epsilon)) {
                         break;
                     }
                 }
                 for (endIndex = startIndex; endIndex < edgeTiles.length; ++endIndex) {
                     existingTile = edgeTiles[endIndex];
                     existingRectangle = existingTile.rectangle;
-                    if (CesiumMath.leftIsGreaterThanOrEqualToRight(sourceRectangle.south, existingRectangle.north, epsilon)) {
+                    if (CesiumMath.greaterThanOrEquals(sourceRectangle.south, existingRectangle.north, epsilon)) {
                         break;
                     }
                 }
@@ -367,14 +367,14 @@ define([
                 for (startIndex = 0; startIndex < edgeTiles.length; ++startIndex) {
                     existingTile = edgeTiles[startIndex];
                     existingRectangle = existingTile.rectangle;
-                    if (CesiumMath.leftIsLessThanRight(sourceRectangle.west, existingRectangle.east, epsilon)) {
+                    if (CesiumMath.lessThan(sourceRectangle.west, existingRectangle.east, epsilon)) {
                         break;
                     }
                 }
                 for (endIndex = startIndex; endIndex < edgeTiles.length; ++endIndex) {
                     existingTile = edgeTiles[endIndex];
                     existingRectangle = existingTile.rectangle;
-                    if (CesiumMath.leftIsLessThanOrEqualToRight(sourceRectangle.east, existingRectangle.west, epsilon)) {
+                    if (CesiumMath.lessThanOrEquals(sourceRectangle.east, existingRectangle.west, epsilon)) {
                         break;
                     }
                 }
@@ -385,14 +385,14 @@ define([
                 for (startIndex = 0; startIndex < edgeTiles.length; ++startIndex) {
                     existingTile = edgeTiles[startIndex];
                     existingRectangle = existingTile.rectangle;
-                    if (CesiumMath.leftIsLessThanRight(sourceRectangle.south, existingRectangle.north, epsilon)) {
+                    if (CesiumMath.lessThan(sourceRectangle.south, existingRectangle.north, epsilon)) {
                         break;
                     }
                 }
                 for (endIndex = startIndex; endIndex < edgeTiles.length; ++endIndex) {
                     existingTile = edgeTiles[endIndex];
                     existingRectangle = existingTile.rectangle;
-                    if (CesiumMath.leftIsLessThanOrEqualToRight(sourceRectangle.north, existingRectangle.south, epsilon)) {
+                    if (CesiumMath.lessThanOrEquals(sourceRectangle.north, existingRectangle.south, epsilon)) {
                         break;
                     }
                 }
@@ -403,14 +403,14 @@ define([
                 for (startIndex = 0; startIndex < edgeTiles.length; ++startIndex) {
                     existingTile = edgeTiles[startIndex];
                     existingRectangle = existingTile.rectangle;
-                    if (CesiumMath.leftIsGreaterThanRight(sourceRectangle.east, existingRectangle.west, epsilon)) {
+                    if (CesiumMath.greaterThan(sourceRectangle.east, existingRectangle.west, epsilon)) {
                         break;
                     }
                 }
                 for (endIndex = startIndex; endIndex < edgeTiles.length; ++endIndex) {
                     existingTile = edgeTiles[endIndex];
                     existingRectangle = existingTile.rectangle;
-                    if (CesiumMath.leftIsGreaterThanOrEqualToRight(sourceRectangle.west, existingRectangle.east, epsilon)) {
+                    if (CesiumMath.greaterThanOrEquals(sourceRectangle.west, existingRectangle.east, epsilon)) {
                         break;
                     }
                 }

--- a/Specs/Core/MathSpec.js
+++ b/Specs/Core/MathSpec.js
@@ -254,107 +254,107 @@ defineSuite([
         }).toThrowDeveloperError();
     });
 
-    it('leftIsLessThanRight works', function() {
-        expect(CesiumMath.leftIsLessThanRight(1.0, 2.0, 0.2)).toBe(true);
-        expect(CesiumMath.leftIsLessThanRight(2.0, 1.0, 0.2)).toBe(false);
-        expect(CesiumMath.leftIsLessThanRight(1.0, 1.0, 0.2)).toBe(false);
-        expect(CesiumMath.leftIsLessThanRight(1.0, 1.2, 0.2)).toBe(false);
-        expect(CesiumMath.leftIsLessThanRight(1.2, 1.0, 0.2)).toBe(false);
+    it('lessThan works', function() {
+        expect(CesiumMath.lessThan(1.0, 2.0, 0.2)).toBe(true);
+        expect(CesiumMath.lessThan(2.0, 1.0, 0.2)).toBe(false);
+        expect(CesiumMath.lessThan(1.0, 1.0, 0.2)).toBe(false);
+        expect(CesiumMath.lessThan(1.0, 1.2, 0.2)).toBe(false);
+        expect(CesiumMath.lessThan(1.2, 1.0, 0.2)).toBe(false);
     });
 
-    it('leftIsLessThanRight throws for undefined left', function() {
+    it('lessThan throws for undefined left', function() {
         expect(function() {
-            CesiumMath.leftIsLessThanRight(undefined, 5.0, CesiumMath.EPSILON16);
+            CesiumMath.lessThan(undefined, 5.0, CesiumMath.EPSILON16);
         }).toThrowDeveloperError();
     });
 
-    it('leftIsLessThanRight throws for undefined right', function() {
+    it('lessThan throws for undefined right', function() {
         expect(function() {
-            CesiumMath.leftIsLessThanRight(1.0, undefined, CesiumMath.EPSILON16);
+            CesiumMath.lessThan(1.0, undefined, CesiumMath.EPSILON16);
         }).toThrowDeveloperError();
     });
 
-    it('leftIsLessThanRight throws for undefined absoluteEpsilon', function() {
+    it('lessThan throws for undefined absoluteEpsilon', function() {
         expect(function() {
-            CesiumMath.leftIsLessThanRight(1.0, 5.0, undefined);
+            CesiumMath.lessThan(1.0, 5.0, undefined);
         }).toThrowDeveloperError();
     });
 
-    it('leftIsLessThanOrEqualToRight works', function() {
-        expect(CesiumMath.leftIsLessThanOrEqualToRight(1.0, 2.0, 0.2)).toBe(true);
-        expect(CesiumMath.leftIsLessThanOrEqualToRight(2.0, 1.0, 0.2)).toBe(false);
-        expect(CesiumMath.leftIsLessThanOrEqualToRight(1.0, 1.0, 0.2)).toBe(true);
-        expect(CesiumMath.leftIsLessThanOrEqualToRight(1.0, 1.2, 0.2)).toBe(true);
-        expect(CesiumMath.leftIsLessThanOrEqualToRight(1.2, 1.0, 0.2)).toBe(true);
+    it('lessThanOrEquals works', function() {
+        expect(CesiumMath.lessThanOrEquals(1.0, 2.0, 0.2)).toBe(true);
+        expect(CesiumMath.lessThanOrEquals(2.0, 1.0, 0.2)).toBe(false);
+        expect(CesiumMath.lessThanOrEquals(1.0, 1.0, 0.2)).toBe(true);
+        expect(CesiumMath.lessThanOrEquals(1.0, 1.2, 0.2)).toBe(true);
+        expect(CesiumMath.lessThanOrEquals(1.2, 1.0, 0.2)).toBe(true);
     });
 
-    it('leftIsLessThanOrEqualToRight throws for undefined left', function() {
+    it('lessThanOrEquals throws for undefined left', function() {
         expect(function() {
-            CesiumMath.leftIsLessThanOrEqualToRight(undefined, 5.0, CesiumMath.EPSILON16);
+            CesiumMath.lessThanOrEquals(undefined, 5.0, CesiumMath.EPSILON16);
         }).toThrowDeveloperError();
     });
 
-    it('leftIsLessThanOrEqualToRight throws for undefined right', function() {
+    it('lessThanOrEquals throws for undefined right', function() {
         expect(function() {
-            CesiumMath.leftIsLessThanOrEqualToRight(1.0, undefined, CesiumMath.EPSILON16);
+            CesiumMath.lessThanOrEquals(1.0, undefined, CesiumMath.EPSILON16);
         }).toThrowDeveloperError();
     });
 
-    it('leftIsLessThanOrEqualToRight throws for undefined absoluteEpsilon', function() {
+    it('lessThanOrEquals throws for undefined absoluteEpsilon', function() {
         expect(function() {
-            CesiumMath.leftIsLessThanOrEqualToRight(1.0, 5.0, undefined);
+            CesiumMath.lessThanOrEquals(1.0, 5.0, undefined);
         }).toThrowDeveloperError();
     });
 
-    it('leftIsGreaterThanRight works', function() {
-        expect(CesiumMath.leftIsGreaterThanRight(1.0, 2.0, 0.2)).toBe(false);
-        expect(CesiumMath.leftIsGreaterThanRight(2.0, 1.0, 0.2)).toBe(true);
-        expect(CesiumMath.leftIsGreaterThanRight(1.0, 1.0, 0.2)).toBe(false);
-        expect(CesiumMath.leftIsGreaterThanRight(1.0, 1.2, 0.2)).toBe(false);
-        expect(CesiumMath.leftIsGreaterThanRight(1.2, 1.0, 0.2)).toBe(false);
+    it('greaterThan works', function() {
+        expect(CesiumMath.greaterThan(1.0, 2.0, 0.2)).toBe(false);
+        expect(CesiumMath.greaterThan(2.0, 1.0, 0.2)).toBe(true);
+        expect(CesiumMath.greaterThan(1.0, 1.0, 0.2)).toBe(false);
+        expect(CesiumMath.greaterThan(1.0, 1.2, 0.2)).toBe(false);
+        expect(CesiumMath.greaterThan(1.2, 1.0, 0.2)).toBe(false);
     });
 
-    it('leftIsGreaterThanRight throws for undefined left', function() {
+    it('greaterThan throws for undefined left', function() {
         expect(function() {
-            CesiumMath.leftIsGreaterThanRight(undefined, 5.0, CesiumMath.EPSILON16);
+            CesiumMath.greaterThan(undefined, 5.0, CesiumMath.EPSILON16);
         }).toThrowDeveloperError();
     });
 
-    it('leftIsGreaterThanRight throws for undefined right', function() {
+    it('greaterThan throws for undefined right', function() {
         expect(function() {
-            CesiumMath.leftIsGreaterThanRight(1.0, undefined, CesiumMath.EPSILON16);
+            CesiumMath.greaterThan(1.0, undefined, CesiumMath.EPSILON16);
         }).toThrowDeveloperError();
     });
 
-    it('leftIsGreaterThanRight throws for undefined absoluteEpsilon', function() {
+    it('greaterThan throws for undefined absoluteEpsilon', function() {
         expect(function() {
-            CesiumMath.leftIsGreaterThanRight(1.0, 5.0, undefined);
+            CesiumMath.greaterThan(1.0, 5.0, undefined);
         }).toThrowDeveloperError();
     });
 
-    it('leftIsGreaterThanOrEqualToRight works', function() {
-        expect(CesiumMath.leftIsGreaterThanOrEqualToRight(1.0, 2.0, 0.2)).toBe(false);
-        expect(CesiumMath.leftIsGreaterThanOrEqualToRight(2.0, 1.0, 0.2)).toBe(true);
-        expect(CesiumMath.leftIsGreaterThanOrEqualToRight(1.0, 1.0, 0.2)).toBe(true);
-        expect(CesiumMath.leftIsGreaterThanOrEqualToRight(1.0, 1.2, 0.2)).toBe(true);
-        expect(CesiumMath.leftIsGreaterThanOrEqualToRight(1.2, 1.0, 0.2)).toBe(true);
+    it('greaterThanOrEquals works', function() {
+        expect(CesiumMath.greaterThanOrEquals(1.0, 2.0, 0.2)).toBe(false);
+        expect(CesiumMath.greaterThanOrEquals(2.0, 1.0, 0.2)).toBe(true);
+        expect(CesiumMath.greaterThanOrEquals(1.0, 1.0, 0.2)).toBe(true);
+        expect(CesiumMath.greaterThanOrEquals(1.0, 1.2, 0.2)).toBe(true);
+        expect(CesiumMath.greaterThanOrEquals(1.2, 1.0, 0.2)).toBe(true);
     });
 
-    it('leftIsGreaterThanOrEqualToRight throws for undefined left', function() {
+    it('greaterThanOrEquals throws for undefined left', function() {
         expect(function() {
-            CesiumMath.leftIsGreaterThanOrEqualToRight(undefined, 5.0, CesiumMath.EPSILON16);
+            CesiumMath.greaterThanOrEquals(undefined, 5.0, CesiumMath.EPSILON16);
         }).toThrowDeveloperError();
     });
 
-    it('leftIsGreaterThanOrEqualToRight throws for undefined right', function() {
+    it('greaterThanOrEquals throws for undefined right', function() {
         expect(function() {
-            CesiumMath.leftIsGreaterThanOrEqualToRight(1.0, undefined, CesiumMath.EPSILON16);
+            CesiumMath.greaterThanOrEquals(1.0, undefined, CesiumMath.EPSILON16);
         }).toThrowDeveloperError();
     });
 
-    it('leftIsGreaterThanOrEqualToRight throws for undefined absoluteEpsilon', function() {
+    it('greaterThanOrEquals throws for undefined absoluteEpsilon', function() {
         expect(function() {
-            CesiumMath.leftIsGreaterThanOrEqualToRight(1.0, 5.0, undefined);
+            CesiumMath.greaterThanOrEquals(1.0, 5.0, undefined);
         }).toThrowDeveloperError();
     });
 


### PR DESCRIPTION
`leftIsLessThanRight` -> `lessThan`
`leftIsLessThanOrEqualToRight` -> `lessThanOrEquals`
`leftIsGreaterThanRight` -> `greaterThan`
`leftIsGreaterThanOrEqualToRight` -> `greaterThanOrEquals`

- This is consistent with our comparison functions in `Check.js`
- This is consistent with how all of of our other math type functions work.  For example, we do `Cartesian3.cross(left, right, result)`, not `Cartesian3.leftCrossRight(left, right, result)`.