### PR TITLE
fix PolygonOutlineGeometry indices range

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,7 @@ Change Log
 * Fixed model silhouette colors when rendering with high dynamic range. [#7563](https://github.com/AnalyticalGraphicsInc/cesium/pull/7563)
 * Fixed an issue with ground polylines on globes that use ellipsoids other than WGS84. [#7552](https://github.com/AnalyticalGraphicsInc/cesium/issues/7552)
 * Fixed an issue where Draco compressed models with RGB per-vertex color would not load in Cesium. [#7576](https://github.com/AnalyticalGraphicsInc/cesium/issues/7576)
+* Fixed an issue where the outline geometry for extruded Polygons didn't calculate the correct indices. [#7599](https://github.com/AnalyticalGraphicsInc/cesium/issues/7599) 
 
 ### 1.54 - 2019-02-01
 

--- a/Source/Core/PolygonOutlineGeometry.js
+++ b/Source/Core/PolygonOutlineGeometry.js
@@ -197,7 +197,7 @@ define([
         var cornersLength = corners.length;
 
         var indicesSize = ((length * 2) + cornersLength) * 2;
-        var indices = IndexDatatype.createTypedArray(length, indicesSize);
+        var indices = IndexDatatype.createTypedArray(length + cornersLength, indicesSize);
 
         index = 0;
         for (i = 0; i < length; ++i) {


### PR DESCRIPTION
fixes https://github.com/AnalyticalGraphicsInc/cesium/issues/7599

It may be possible that the same problem also exists in other OutlineGeometry functions, like: https://github.com/AnalyticalGraphicsInc/cesium/blob/master/Source/Core/EllipseOutlineGeometry.js#L116

Unfortunately i don't have the time at the moment to check all the other geometries