### PR TITLE
Fix handling of CZML followSurface, which is implemented in terms of arcType.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@ Change Log
 
 ##### Additions :tada:
 * `czm_materialInput.aspect` was added as an angle in radians between 0 and 2pi (east, north, west to south).
+* Added CZML `arcType` support for `polyline` and `polygon`, which supersedes `followSurface`. `followSurface` is still supported for compatibility with existing documents. [#7582](https://github.com/AnalyticalGraphicsInc/cesium/pull/7582)
 
 ##### Fixes :wrench:
 * Fixed an issue where models would cause a crash on load if some primitives were Draco encoded and others were not. [#7383](https://github.com/AnalyticalGraphicsInc/cesium/issues/7383)
@@ -19,7 +20,7 @@ Change Log
 * Fixed model silhouette colors when rendering with high dynamic range. [#7563](https://github.com/AnalyticalGraphicsInc/cesium/pull/7563)
 * Fixed an issue with ground polylines on globes that use ellipsoids other than WGS84. [#7552](https://github.com/AnalyticalGraphicsInc/cesium/issues/7552)
 * Fixed an issue where Draco compressed models with RGB per-vertex color would not load in Cesium. [#7576](https://github.com/AnalyticalGraphicsInc/cesium/issues/7576)
-* Fixed an issue where the outline geometry for extruded Polygons didn't calculate the correct indices. [#7599](https://github.com/AnalyticalGraphicsInc/cesium/issues/7599) 
+* Fixed an issue where the outline geometry for extruded Polygons didn't calculate the correct indices. [#7599](https://github.com/AnalyticalGraphicsInc/cesium/issues/7599)
 
 ### 1.54 - 2019-02-01
 

--- a/Source/DataSources/PolylineGraphics.js
+++ b/Source/DataSources/PolylineGraphics.js
@@ -149,7 +149,6 @@ define([
          * Gets or sets the {@link ArcType} Property specifying whether the line segments should be great arcs, rhumb lines or linearly connected.
          * @memberof PolylineGraphics.prototype
          * @type {Property}
-         * @deprecated This property has been deprecated. Use {@link PolylineGraphics#arcType} instead.
          * @default ArcType.GEODESIC
          */
         arcType : createPropertyDescriptor('arcType'),


### PR DESCRIPTION
This introduces a new AdapterProperty concept in CzmlDataSource, which uses CallbackProperty to adapt a property of one type into another type, regardless of whether the property is time-varying or not.