### PR TITLE
Fix WebP feature detection

### DIFF
--- a/Source/Core/FeatureDetection.js
+++ b/Source/Core/FeatureDetection.js
@@ -1,12 +1,16 @@
 define([
         './defaultValue',
         './defined',
+        './defineProperties',
+        './DeveloperError',
         './Fullscreen',
         './RuntimeError',
         '../ThirdParty/when'
     ], function(
         defaultValue,
         defined,
+        defineProperties,
+        DeveloperError,
         Fullscreen,
         RuntimeError,
         when) {
@@ -203,44 +207,54 @@ define([
         return supportsImageRenderingPixelated() ? imageRenderingValueResult : undefined;
     }
 
-    var supportsWebPResult;
-    var supportsWebPPromise;
     function supportsWebP() {
+        //>>includeStart('debug', pragmas.debug);
+        if (!supportsWebP.initialized) {
+            throw new DeveloperError('You must call FeatureDetection.supportsWebP.initialize and wait for the promise to resolve before calling FeatureDetection.supportsWebP');
+        }
+        //>>includeEnd('debug');
+        return supportsWebP._result;
+    }
+    supportsWebP._promise = undefined;
+    supportsWebP._result = undefined;
+    supportsWebP.initialize = function() {
         // From https://developers.google.com/speed/webp/faq#how_can_i_detect_browser_support_for_webp
-        if (defined(supportsWebPPromise)) {
-            return supportsWebPPromise.promise;
+        if (defined(supportsWebP._promise)) {
+            return supportsWebP._promise;
         }
 
-        supportsWebPPromise = when.defer();
+        var supportsWebPDeferred = when.defer();
+        supportsWebP._promise = supportsWebPDeferred.promise;
         if (isEdge()) {
             // Edge's WebP support with WebGL is incomplete.
             // See bug report: https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/19221241/
-            supportsWebPResult = false;
-            supportsWebPPromise.resolve(supportsWebPResult);
+            supportsWebP._result = false;
+            supportsWebPDeferred.resolve(supportsWebP._result);
+            return supportsWebPDeferred.promise;
         }
 
         var image = new Image();
         image.onload = function () {
-            supportsWebPResult = (image.width > 0) && (image.height > 0);
-            supportsWebPPromise.resolve(supportsWebPResult);
+            supportsWebP._result = (image.width > 0) && (image.height > 0);
+            supportsWebPDeferred.resolve(supportsWebP._result);
         };
 
         image.onerror = function () {
-            supportsWebPResult = false;
-            supportsWebPPromise.resolve(supportsWebPResult);
+            supportsWebP._result = false;
+            supportsWebPDeferred.resolve(supportsWebP._result);
         };
 
         image.src = 'data:image/webp;base64,UklGRiIAAABXRUJQVlA4IBYAAAAwAQCdASoBAAEADsD+JaQAA3AAAAAA';
 
-        return supportsWebPPromise.promise;
-    }
-
-    function supportsWebPSync() {
-        if (!defined(supportsWebPPromise)) {
-            supportsWebP();
+        return supportsWebPDeferred.promise;
+    };
+    defineProperties(supportsWebP, {
+        initialized: {
+            get: function() {
+                return defined(supportsWebP._result);
+            }
         }
-        return supportsWebPResult;
-    }
+    });
 
     var typedArrayTypes = [];
     if (typeof ArrayBuffer !== 'undefined') {
@@ -279,7 +293,6 @@ define([
         supportsPointerEvents : supportsPointerEvents,
         supportsImageRenderingPixelated: supportsImageRenderingPixelated,
         supportsWebP: supportsWebP,
-        supportsWebPSync: supportsWebPSync,
         imageRenderingValue: imageRenderingValue,
         typedArrayTypes: typedArrayTypes
     };

--- a/Source/Scene/ClassificationModel.js
+++ b/Source/Scene/ClassificationModel.js
@@ -958,10 +958,11 @@ define([
             return;
         }
 
-        var supportsWebP = FeatureDetection.supportsWebPSync();
-        if (!defined(supportsWebP)) {
+        if (!FeatureDetection.supportsWebP.initialized) {
+            FeatureDetection.supportsWebP.initialize();
             return;
         }
+        var supportsWebP = FeatureDetection.supportsWebP();
 
         if ((this._state === ModelState.NEEDS_LOAD) && defined(this.gltf)) {
             this._state = ModelState.LOADING;

--- a/Source/Scene/Model.js
+++ b/Source/Scene/Model.js
@@ -4303,10 +4303,11 @@ define([
             return;
         }
 
-        var supportsWebP = FeatureDetection.supportsWebPSync();
-        if (!defined(supportsWebP)) {
+        if (!FeatureDetection.supportsWebP.initialized) {
+            FeatureDetection.supportsWebP.initialize();
             return;
         }
+        var supportsWebP = FeatureDetection.supportsWebP();
 
         var context = frameState.context;
         this._defaultTexture = context.defaultTexture;

--- a/Specs/Core/FeatureDetectionSpec.js
+++ b/Specs/Core/FeatureDetectionSpec.js
@@ -116,11 +116,23 @@ defineSuite([
         }
     });
 
+    it('supportWebP throws when it has not been initialized', function() {
+        FeatureDetection.supportsWebP._promise = undefined;
+        FeatureDetection.supportsWebP._result = undefined;
+        expect(function() {
+            FeatureDetection.supportsWebP();
+        }).toThrowDeveloperError();
+    });
+
     it('detects WebP support', function() {
-        return FeatureDetection.supportsWebP()
+        FeatureDetection.supportsWebP._promise = undefined;
+        FeatureDetection.supportsWebP._result = undefined;
+
+        return FeatureDetection.supportsWebP.initialize()
             .then(function(supportsWebP) {
                 expect(typeof supportsWebP).toEqual('boolean');
-                expect(FeatureDetection.supportsWebPSync()).toEqual(supportsWebP);
+                expect(FeatureDetection.supportsWebP()).toEqual(supportsWebP);
             });
     });
+
 });

--- a/Specs/Scene/ModelSpec.js
+++ b/Specs/Scene/ModelSpec.js
@@ -174,6 +174,7 @@ defineSuite([
         modelPromises.push(loadModel(riggedFigureUrl).then(function(model) {
             riggedFigureModel = model;
         }));
+        modelPromises.push(FeatureDetection.supportsWebP.initialize());
 
         return when.all(modelPromises);
     });
@@ -980,7 +981,8 @@ defineSuite([
     });
 
     it('Throws for EXT_texture_webp if browser does not support WebP', function() {
-        spyOn(FeatureDetection, 'supportsWebPSync').and.returnValue(false);
+        var supportsWebP = FeatureDetection.supportsWebP._result;
+        FeatureDetection.supportsWebP._result = false;
         return Resource.fetchJson(texturedBoxWebpUrl).then(function(gltf) {
             gltf.extensionsRequired = ['EXT_texture_webp'];
             var model = primitives.add(new Model({
@@ -991,6 +993,7 @@ defineSuite([
                 scene.renderForSpecs();
             }).toThrowRuntimeError();
             primitives.remove(model);
+            FeatureDetection.supportsWebP._result = supportsWebP;
         });
     });
 
@@ -1206,6 +1209,9 @@ defineSuite([
     });
 
     it('renders textured box with WebP texture', function() {
+        if (!FeatureDetection.supportsWebP()) {
+            return;
+        }
         return loadModel(texturedBoxWebpUrl, {
             incrementallyLoadTextures : false
         }).then(function(m) {


### PR DESCRIPTION
The `Model` tests were broken in Edge because the `WebP` test would fail then all the test after that would fail with an unspecified error.  Looking into it further, the logic for `FeatureDetection.supportsWebP` was broken for Edge because it would incorrectly return `true` even though we were explicitly setting it to false because the function didn't return after setting it to `false` and the image check would set the value to `true` because Edge has partial WebP support.

Then I noticed the logic for `FeatureDetection.supportsWebP` was really confusing. For starters, `FeatureDetection.supportsWebPSync` wasn't actually synchronous because it didn't wait for the `supportsWebP` promise to resolve.  I re-architected it to work the same way `ApproximateTerrainHeights` works, where you're required to wait for it to be `initialized` and the promise to resolve before attempting to retrieve the value.

`FeatureDetection.supportsWebP` and `FeatureDetection.supportsWebPSync` were both private functions, so no need to mention anything in CHANGES.md.
And the WebP Edge errors were already released in 1.54 so no need to hold up the 1.55 release today waiting for this to be merged.