### PR TITLE
Use node 10 in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "8"
+  - "10"
 sudo: false
 addons:
   chrome: stable


### PR DESCRIPTION
I noticed this was still using Node 8.  Any reason for that?
I bumped it to Node 10, which is the current LTS version