### PR TITLE
HeadingPitchRoll.fromQuaternion clamps pitch asin

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,8 @@ Change Log
 
 ##### Fixes :wrench:
 * Fixed the value for `BlendFunction.ONE_MINUS_CONSTANT_COLOR`. [#7624](https://github.com/AnalyticalGraphicsInc/cesium/pull/7624)
+* Fixed `HeadingPitchRoll.pitch` being `NaN` when using `.fromQuaternion` do to a rounding error
+for pitches close to +/- 90°. [#7654](https://github.com/AnalyticalGraphicsInc/cesium/pull/7654)
 
 ### 1.55 - 2019-03-01
 

--- a/Source/Core/HeadingPitchRoll.js
+++ b/Source/Core/HeadingPitchRoll.js
@@ -50,7 +50,7 @@ define([
         var numeratorHeading = 2 * (quaternion.w * quaternion.z + quaternion.x * quaternion.y);
         result.heading = -Math.atan2(numeratorHeading, denominatorHeading);
         result.roll = Math.atan2(numeratorRoll, denominatorRoll);
-        result.pitch = -Math.asin(test);
+        result.pitch = -CesiumMath.asinClamped(test);
         return result;
     };
 

--- a/Specs/Core/HeadingPitchRollSpec.js
+++ b/Specs/Core/HeadingPitchRollSpec.js
@@ -51,6 +51,12 @@ defineSuite([
         }
     });
 
+    it('it should return the correct pitch, even with a quaternion rounding error', function() {
+        var q = new Quaternion(8.801218199179452e-17, -0.7071067801637715, -8.801218315071006e-17, -0.7071067822093238);
+        var result = HeadingPitchRoll.fromQuaternion(q);
+        expect(result.pitch).toEqual(-(Math.PI / 2));
+    });
+
     it('conversion from degrees', function() {
         var testingTab = [
             [0, 0, 0],


### PR DESCRIPTION
### Issue
When evaluating a `QuaternionSpline`, it may sometimes happen, that the `pitch` value for looking straight down (-90°) is in fact larger then 1 by a rounding error of ~10^12. When using `HeadingPitchRoll.fromQuaternion`, this results in the `.pitch` value being `NaN`.

### Fix
Instead of using `Math.asin` to determine the pitch, use `CesiumMath.asinClamped`.