### PR TITLE
Fix default value in doc for enableLighting

### DIFF
--- a/Source/Scene/Globe.js
+++ b/Source/Scene/Globe.js
@@ -175,7 +175,7 @@ define([
          * Enable lighting the globe with the sun as a light source.
          *
          * @type {Boolean}
-         * @default true
+         * @default false
          */
         this.enableLighting = false;
 


### PR DESCRIPTION
The doc currently says `Globe.enableLighting` defaults to true, when it's actually false.

https://cesiumjs.org/Cesium/Build/Documentation/Globe.html#enableLighting

This PR updates the doc to match the actual default.