### PR TITLE
fixed an Error where the AnchorlineColor reused the given color

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,7 @@ Change Log
 * Fixed `HeadingPitchRoll.pitch` being `NaN` when using `.fromQuaternion` do to a rounding error
 for pitches close to +/- 90°. [#7654](https://github.com/AnalyticalGraphicsInc/cesium/pull/7654)
 * Fixed an error in `Resource` when used with template replacements using numeric keys. [#7668](https://github.com/AnalyticalGraphicsInc/cesium/pull/7668)
+* Fixed an error in `Cesium3DTilePointFeature` where `anchorLineColor` used the same color Instance instead of cloning the color [#7686](https://github.com/AnalyticalGraphicsInc/cesium/pull/7686)
 
 ### 1.55 - 2019-03-01
 

--- a/Source/Scene/Cesium3DTilePointFeature.js
+++ b/Source/Scene/Cesium3DTilePointFeature.js
@@ -463,7 +463,7 @@ define([
                 return this._polyline.material.uniforms.color;
             },
             set : function(value) {
-                this._polyline.material.uniforms.color = value;
+                this._polyline.material.uniforms.color = Color.clone(value, this._polyline.material.uniforms.color);
             }
         },
 


### PR DESCRIPTION
AnchorLineColor in the Vector3DTilePoints  is using a scratchColor to set the Color to the Cesium3DTilePointFeature. This only works when the function clones the Color, otherwise all colors take the value of the last feature.
https://github.com/AnalyticalGraphicsInc/cesium/blob/master/Source/Scene/Vector3DTilePoints.js#L425