### PR TITLE
Fix Model specularEnvironmentMaps bug

### DIFF
--- a/Source/Scene/Model.js
+++ b/Source/Scene/Model.js
@@ -1235,7 +1235,7 @@ define([
                 return this._specularEnvironmentMaps;
             },
             set : function(value) {
-                this._shouldUpdateSpecularMapAtlas = value !== this._specularEnvironmentMaps;
+                this._shouldUpdateSpecularMapAtlas = this._shouldUpdateSpecularMapAtlas || value !== this._specularEnvironmentMaps;
                 this._specularEnvironmentMaps = value;
             }
         }


### PR DESCRIPTION
Fixes #7684

If `specularEnvironmentMaps` is set twice to the same value before `Model.update` is called, then the `specularEnvironmentMapAtlas` is not updated properly