### PR TITLE
Fix VRTheWorld terrain geometry with ImageBitmap

### DIFF
--- a/Source/Core/VRTheWorldTerrainProvider.js
+++ b/Source/Core/VRTheWorldTerrainProvider.js
@@ -267,7 +267,9 @@ define([
             },
             request : request
         });
-        var promise = resource.fetchImage();
+        var promise = resource.fetchImage({
+            flipY : false
+        });
         if (!defined(promise)) {
             return undefined;
         }


### PR DESCRIPTION
This fixes https://github.com/AnalyticalGraphicsInc/cesium/issues/7697. If you go to the [terrain Sandcastle](http://localhost:8080/Apps/Sandcastle/index.html?src=Terrain.html) in master and try the VRTheWorldTerrain, you'll see incorrect terrain geometry.

It's because `VRTheWorldTerrainProvider` constructs geometry from a heightmap by reading the pixels! The fix is just to make sure `flipY: false` in the `requestTileGeometry` function.

@lilleyse 