### PR TITLE
Bump Jasmine timeout to hopefully make CI more stable..

### DIFF
--- a/Specs/karma-main.js
+++ b/Specs/karma-main.js
@@ -58,15 +58,16 @@
         'Specs/customizeJasmine'
     ], function(
         customizeJasmine) {
-                    customizeJasmine(jasmine.getEnv(), included, excluded, webglValidation, webglStub, release);
+            jasmine.DEFAULT_TIMEOUT_INTERVAL = 30000;
+            customizeJasmine(jasmine.getEnv(), included, excluded, webglValidation, webglStub, release);
 
-                    var specFiles = Object.keys(__karma__.files).filter(function(file) {
-                        return /Spec\.js$/.test(file);
-                    });
+            var specFiles = Object.keys(__karma__.files).filter(function(file) {
+                return /Spec\.js$/.test(file);
+            });
 
-                    require(specFiles, function() {
-                        __karma__.start();
-                    });
-                });
+            require(specFiles, function() {
+                __karma__.start();
+            });
+        });
     });
 })();

--- a/Specs/spec-main.js
+++ b/Specs/spec-main.js
@@ -364,7 +364,7 @@
          */
         var modules = ['Specs/addDefaultMatchers', 'Specs/equalsMethodEqualityTester'].concat(specs);
         require(modules, function(addDefaultMatchers, equalsMethodEqualityTester) {
-            jasmine.DEFAULT_TIMEOUT_INTERVAL = 6000;
+            jasmine.DEFAULT_TIMEOUT_INTERVAL = 30000;
 
             htmlReporter.initialize();
 


### PR DESCRIPTION
I suspect a lot of the random CI timeouts we've been seeing are just travis being overly slow.  This removes that possibility by making the timeout 30 seconds.  This may result in some long passing tests, but that's a much better problem to have than constant random CI failures (plus the long test reporter should point them out).