### PR TITLE
Update BingMapsStyle to match imagery provided by Bing Maps

### DIFF
--- a/Source/Scene/BingMapsStyle.js
+++ b/Source/Scene/BingMapsStyle.js
@@ -21,7 +21,7 @@ define([
         AERIAL : 'Aerial',
 
         /**
-         * Aerial imagery with a road overlay.
+         * Aerial imagery with a road overlay, using the legacy static tile service.
          *
          * @type {String}
          * @constant
@@ -29,12 +29,28 @@ define([
         AERIAL_WITH_LABELS : 'AerialWithLabels',
 
         /**
-         * Roads without additional imagery.
+         * Aerial imagery with a road overlay, using the dynamic tile service.
+         *
+         * @type {String}
+         * @constant
+         */
+        AERIAL_WITH_LABELS_ON_DEMAND : 'AerialWithLabelsOnDemand',
+
+        /**
+         * Roads without additional imagery, using the legacy static tile service.
          *
          * @type {String}
          * @constant
          */
         ROAD : 'Road',
+
+        /**
+         * Roads without additional imagery, using the dynamic tile service.
+         *
+         * @type {String}
+         * @constant
+         */
+        ROAD_ON_DEMAND : 'RoadOnDemand',
 
         /**
          * A dark version of the road maps.


### PR DESCRIPTION
From https://docs.microsoft.com/en-us/bingmaps/rest-services/imagery/get-imagery-metadata:

> AerialWithLabels (Deprecated): Aerial imagery with a road overlay, using the legacy static tile service. This service is deprecated and current data will not be refreshed. New applications should instead use AerialWithLabelsOnDemand.

> Road (Deprecated): Roads without additional imagery, using the legacy static tile service. This service is deprecated and current data will not be refreshed. New applications should instead use RoadOnDemand.

Related: https://github.com/AnalyticalGraphicsInc/cesium/issues/7128

Not sure if there's anything else that needs to be updated, but I did a quick test and it seems to work with the new values.