### PR TITLE
sanitize against divide-by-zero in imagery shader code

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ Change Log
 ##### Fixes :wrench:
 
 * Fixed an error where `clampToHeightMostDetailed` or `sampleHeightMostDetailed` would crash if entities were created when the promise resolved. [#7690](https://github.com/AnalyticalGraphicsInc/cesium/pull/7690)
+* Fixed an error where many imagery layers within a single tile would cause parts of the tile to render as black on some platforms. [#7649](https://github.com/AnalyticalGraphicsInc/cesium/issues/7649)
 
 ### 1.56.1 - 2019-04-02
 


### PR DESCRIPTION
Fixes #7649
Fixes #7640

GlobeFS renders imagery layers by packing as many as it can into a single draw call through shader modification, then rendering additional layers in additional draw calls.
The number of draw calls is determined by the maximum number of texture image units in the fragment shader, on iOS devices this seems to be 8 across the board.

When rendering additional layers in additional draw calls this was producing a divide-by-zero in `GlobeFS` -> `sampleAndBlend`, which apparently isn't a problem on some platforms when it's alpha'd out with a alpha zero but can be on others. I found that on Intel (Bay Trail/Ivy Bridge) + Chrome + Linux in particular, the divide-by-zero would cause problems even if the shader detected it and rewrote the color value unless the divide-by-zero was masked out using an `if` block.

So this PR adds code to sanitize against that divide-by-zero. I saw what might have been a 1 FPS performance dip on Bay Trail (~28 -> ~27 FPS at maybe 640 x 400) but that might have just been noise, and it's definitely way less of a hit than you'd get just by adding other things to the scene.

[Branch Sandcastle](http://cesium-dev.s3-website-us-east-1.amazonaws.com/cesium/fixManyImageryLayersIntel/Build/Apps/Sandcastle/index.html#c=jVPfb9owEP5XLF4IAxxgYnQloLGuUpEyrSrd+hIJOcklWHXsyDZBrOJ/3yUhQMvL/OL47vvuvvuRgmlScNiBJjMiYUfuwPBtRv9UNqcdVc87JS3jEnS7R94CSfDwjKWg949aFTxG9m3DjDQwCy9Ki3hZY5wjpTzG7gWcwUslL5Gr0ksX90/Lhb9+WT4/rP3F93t/VfMPnV79ETIDPtuDfuTRa5U7YcJAIA+daSADWWBRovQbLKqujpoIJNCj6opspjUyFCx6/cl0iMJmRx5lcaOpqdC56A7K/uh9I8wYsMv4lny+GY5QbK3lIjplIt8wzDGg4ytfqHm6sRJMqXlEBxUgUZo4pUZesqZ4eWQ4xrvb7TSDKN0qSTB3hamNrkt+y0hlGUhL7AZIooRQOy5TInCOxCrC8lzsj8weYTKucKngNtoQbkiqJDTBTvFH5BPhxxz/1akVphTwzAVcNey8FFstcIZtSt1qPsatyWtfpWqtCtCYiuYybffOHA2RZWXs8zI9NSaaaJX9gFQDGKc/GdMB6Z8qHd3gs3t69r9M3ru/0sn45O80m1cO89Dqtbxqgee1+RvPcqVtqd9B8RayXODuGzfc4l5aGhlT8jy3IXkxLwiPZ0Hrw38VtEgkcIHQk2yFWPG/ELTmnov4dzShWIwd/VX3pIRshnO/NlJKPRef1yyrlAiZvoj4Dw) for testing #7649, [vs current release](https://cesiumjs.org/Cesium/Build/Apps/Sandcastle/#c=jVPfb9owEP5XLF4IAxxgYnQloLGuUpEyrSrd+hIJOcklWHXsyDZBrOJ/3yUhQMvL/OL47vvuvvuRgmlScNiBJjMiYUfuwPBtRv9UNqcdVc87JS3jEnS7R94CSfDwjKWg949aFTxG9m3DjDQwCy9Ki3hZY5wjpTzG7gWcwUslL5Gr0ksX90/Lhb9+WT4/rP3F93t/VfMPnV79ETIDPtuDfuTRa5U7YcJAIA+daSADWWBRovQbLKqujpoIJNCj6opspjUyFCx6/cl0iMJmRx5lcaOpqdC56A7K/uh9I8wYsMv4lny+GY5QbK3lIjplIt8wzDGg4ytfqHm6sRJMqXlEBxUgUZo4pUZesqZ4eWQ4xrvb7TSDKN0qSTB3hamNrkt+y0hlGUhL7AZIooRQOy5TInCOxCrC8lzsj8weYTKucKngNtoQbkiqJDTBTvFH5BPhxxz/1akVphTwzAVcNey8FFstcIZtSt1qPsatyWtfpWqtCtCYiuYybffOHA2RZWXs8zI9NSaaaJX9gFQDGKc/GdMB6Z8qHd3gs3t69r9M3ru/0sn45O80m1cO89Dqtbxqgee1+RvPcqVtqd9B8RayXODuGzfc4l5aGhlT8jy3IXkxLwiPZ0Hrw38VtEgkcIHQk2yFWPG/ELTmnov4dzShWIwd/VX3pIRshnO/NlJKPRef1yyrlAiZvoj4Dw)

[Branch Sandcastle](http://cesium-dev.s3-website-us-east-1.amazonaws.com/cesium/fixManyImageryLayersIntel/Build/Apps/Sandcastle/index.html#c=zVrrctu6EX4VNCcTSROJlOJcZdmtYmd81HHixHJOJo0zHoiEJUQgwQCgLCXj1+iD9Hefpk/SXZAUL6JvOTnt0UwcCtjrh8UuuNCCKrLg7IIpskNCdkH2mOZx4Pxmx5oNz37dk6GhPGSq0SbfT0MCnwnV7JCumHrLvTlw98k5FZqdhpet7dNwAWJ5QKdMrSyRBumJGqc0DKQJMU6+lj4TQJhqEAljn3z63K7oLI3GkR2DoTAWIh305UVYM6yZYJ5hfs0U12M7SSeCZdPncegZLsOmtaWVWYYfxUysQmJmXDu5XQ4PfbY8Os8YdndIdzthukz1KMo125DdJpazpKKElGP5UrnbOdEaOCfDYSdBrpYmh2WnMJog/ek1NTMnoMtmN7WGdEiv9bkgKI58ahJXD7k2zaIhF8AiLxzNzAkPmIxNc+0heFVrZ71duCbbABfpdVsV7IS8qFmXm7GzfLfD7gpUeNiszjiChVMzQ5AyvB5W8Kp3sLo8/29UPRoe1wblaAPWNOrzWbK7EeAg7rB2nW4lDjYMefCgODSoLuYa9kwxJJ005xQyRBGIfNgmnDTHzUPpzQFSxyjqzfP1bVmizHbIGSYFVzfX1rsu2VMMlo1QISALMKs6y1lmRo1NDYQtaRAJBusIZDqOIqmMsxZxMmO6zEkVCxsGgAGxK6Ij5nEqHEJGpqFJJLXmkJ6IkWRGF4wEsTAcxctztCFYC2YhpjGfgBky9FibfIm1IYLPmbVVwh+VqmyTSWwIN5AymUbdAZ2jZG8GnodoHvNojJk9lY0OJ/pysz25AIEomoWGK0amQk4Am9BHj4iM6NeYpX5T33+ZrcdRZMMjjwj8NF7ycEpe00iTIVPgf6NdJoghLs6hHPmtbTQI1XqxAuRMAcu7KzuW1K+qKpREJES6URKNb5VccB/SyvcyhzVQCYj+xsyYSPdd12cLZ8GVialgVEE6CZmpKsJPQKOxWQnWr6q0o87x0XC/zHTZyvbyzX4OlXcwGpMPUgmfjI1izFi3r/EYWbgGojFTsL53d1wDH4cjhEOVN+VahgJWzfFk4CbWuIpps6ZyrW1niW1noNZdq278uN9HEQsTkXXepp56di+XSKve3kElcL+LwTPys3TfjLQ0XLBeRzvBV88PLcQ4ot2e03W6rtSB+zswHBsasJD80U5oq6ZjDXeoo7Vwzqk2YoUbxr0ABcqTQiq3bvOcA9erpYGUBQ6A0C/RtI4MDPW56dtFIlYTmaxI6uA+ODMN2zbBKLK3R15+JFsAINmnhiJdycEy3Xjo/A6E31CohFSQV5gfyGhEmkJ6VLSuhfsEzE+3COyfW+OdypjEXPhQ8GLB3ivRbAw1VDrtnrAlmAKRk5pkLRqNGq0fd+79+GBMxjPqQ0U6ZoKzcwLVlpIPr0/GrWvyzwc2AffQy7u6aEMKIgrLAWRVJ6RoFxX4PJULN8lHlfSDZiZWJkYehWKVpyAXra2LKJG+LDTq+OsYNGZzZIAqRqGC10azVAEUbyCyhx/3S8Rqw9nYEDCKL8fMjPYLUruPngdBfZVZ8iAODtmCiT7pvbhyk1ifHDJ2yAGDbTflEJBkHAMYq9pIr56MsC5DcPAE+vSoAEQpL0wN17PXFejRmwNySCdM6LtXZ0J+Yn2esxWyDcUsln9/Ovo4+TCdvH3y5tno8fBg1v2y//WR2gvl0/k4eP1kad794/n0G3930Rl2OtOLrfcH887i3SszDK4r/eSK2j98dTwaHp59GJ38enY4fPnqcEyqS1CRCok/X5TbYl3OKMSC+UekoIbjuDawtZt0GM4AAIxl5Sbizw7lVJ7tYbZv3OBo13lUSEW3cnMM2Ior3CvEVEKGLv6IY0VH8HgM8e9EYe0uVth3sCatl/84G3LOlQz22RSKjm52er0nDryebz3Hv51e9xk8v3CePWndLhrutPGOebQ3g/2gCeb3a3C6RSjcdhsqHnlWpz3CjL8KlPorvEdAaDhUz5Z/5f5O72n3xdOtpw+WO9+Xlw9WO99Xlw++7Xz/dvnArCK2gyDfZXP8ECBmtgqYUas/ESxbzwCUn4AKPv4wMnvJi5j+M4XL1vPnvcfdnxUuxb+3xedA8eteLXF6432jjWrbSVv1rgkOYSB7Uiqfw9GHXbcaSFqgvNGMy1JzpObwF8JRup31bDI568YJdmmKDTAOZ0FcBnleZSE7OzuksX7Xb5Q6RyJta5VbQ1Nmmt36Dl+581tuwl0SOFuwOvEFnEYFTc2qd3knqtC7dhAJFAL/bVc72E4U61nektxAtX6Za7FtEyqiGW0TPZMXm0BvoATSq6t8hT+JG1Y6SEmBSM+Xv1ERs2aques8KfOgKVew4FSbGBWzMssmWvV9urTn+6lhdTfapIES8X9kbXzehHOjwVrEKISjcNYxrGs0prZsdH91JCBvYa/8isZw5h0c5eF1By9EbBs204b9SxiyNwSk0+Gl8N4QaaNlM9h5qxB61ulStxLm6prLp6HrwvHStyf0/ObFSDuwf/Qa9gMLMIunjT7yfpT0ND1s/qFDHLuY6JSRUkwoBpkvvRiZ0LBXCf/L1chvNlKSBqquLimNIrFCW+CopfMWbDuT26pt2IKGowm+t2GXs8jVKG3zRsvR8UR7ik9Y3jdf78FiMzepGQSKSQhntwwKX8mog130Ql8xvUOSysljiILkRSI06Vnn1z7VELsiWOpipYvxMci5t8nDh+Uw4fZFOhO4cYO1cWXxiX9ulQTYmrJpPN8uk0ygYs8LY5frmKtBoO4SparjcwGdNFUUSGz2KFBkCahIYseyGlK+KGMBHLebBeJKEd3IhnlItEsbdAMZvA+rZvIs1RVszufWlhesrduRl0mc32vfG9juwG5C+jce4IUBnnya8GJhWBAJLNLuJPbmzDie1pk9v2QbsbC6E0iXUyWhhPaJmk5o8/GjNsn+dZ3nxUoZ4Zt6OO2Tx9GyMDyBgwFTHUV9Huvi5GVFLQ+j2JRSGFMGOwYdKvg07JOA+7DDNjV2jIz65FFJazY1kcbIoDhbVWuDHYpJUTOUiVBjA6WfPCJkH8vnAjtu62s/JwdIHmvCYPE6kGRuUOjE0c06t7ai5VVqQxmym3TY1HOjls7t1QzcLLwGPl8QOByf3qtc8Z/eI56gWsPMeSzEmH9jp/d2By7Ql9iEpLhGR8mbLZLMeruHyaDjOAMXvm5ypS4COYxaP3cHZiL9FYFNQTsTqASoWELC8Wb9rGd0L90PA1joIh3Ef598hx3VJ/cjvDoz+T0oHB7vI23b/hYgJyhcimYkgEymIdHi7w6SeLYvCKBnxrz5RC4Bm5J6HGawuXDvW5CAsyynnEcHOqJhSYRhS9MnybFuwe3tXp/8JbN1M6Nbe1tWF8rakG/JSxrWUm8S2ibSHjJ1TpofV9eTJ9bg5KgFJuOJLqcvVd/ESDtSBOVGjErIK6zHAHvAQ/jWxSe6hKcePGnDIhx0ur3KwqRmpYdT++29zbrYT0XxjfKCb9o0mMSQesLMjORbYWskm6azHi+FBRwM54XLb7yozxBKfsWRBuZ9+6sBvFnCi/mNhcru5ZtrOrD6P//818BN1O7+D+1OfkFxa7sPE/KS3f+usxseFaYC1yYBnLE5AUeS1PFf) for testing #7640, [vs current release](https://cesiumjs.org/Cesium/Build/Apps/Sandcastle/#c=zVrrctu6EX4VNCcTSROJlOJcZdmtYmd81HHixHJOJo0zHoiEJUQgwQCgLCXj1+iD9Hefpk/SXZAUL6JvOTnt0UwcCtjrh8UuuNCCKrLg7IIpskNCdkH2mOZx4Pxmx5oNz37dk6GhPGSq0SbfT0MCnwnV7JCumHrLvTlw98k5FZqdhpet7dNwAWJ5QKdMrSyRBumJGqc0DKQJMU6+lj4TQJhqEAljn3z63K7oLI3GkR2DoTAWIh305UVYM6yZYJ5hfs0U12M7SSeCZdPncegZLsOmtaWVWYYfxUysQmJmXDu5XQ4PfbY8Os8YdndIdzthukz1KMo125DdJpazpKKElGP5UrnbOdEaOCfDYSdBrpYmh2WnMJog/ek1NTMnoMtmN7WGdEiv9bkgKI58ahJXD7k2zaIhF8AiLxzNzAkPmIxNc+0heFVrZ71duCbbABfpdVsV7IS8qFmXm7GzfLfD7gpUeNiszjiChVMzQ5AyvB5W8Kp3sLo8/29UPRoe1wblaAPWNOrzWbK7EeAg7rB2nW4lDjYMefCgODSoLuYa9kwxJJ005xQyRBGIfNgmnDTHzUPpzQFSxyjqzfP1bVmizHbIGSYFVzfX1rsu2VMMlo1QISALMKs6y1lmRo1NDYQtaRAJBusIZDqOIqmMsxZxMmO6zEkVCxsGgAGxK6Ij5nEqHEJGpqFJJLXmkJ6IkWRGF4wEsTAcxctztCFYC2YhpjGfgBky9FibfIm1IYLPmbVVwh+VqmyTSWwIN5AymUbdAZ2jZG8GnodoHvNojJk9lY0OJ/pysz25AIEomoWGK0amQk4Am9BHj4iM6NeYpX5T33+ZrcdRZMMjjwj8NF7ycEpe00iTIVPgf6NdJoghLs6hHPmtbTQI1XqxAuRMAcu7KzuW1K+qKpREJES6URKNb5VccB/SyvcyhzVQCYj+xsyYSPdd12cLZ8GVialgVEE6CZmpKsJPQKOxWQnWr6q0o87x0XC/zHTZyvbyzX4OlXcwGpMPUgmfjI1izFi3r/EYWbgGojFTsL53d1wDH4cjhEOVN+VahgJWzfFk4CbWuIpps6ZyrW1niW1noNZdq278uN9HEQsTkXXepp56di+XSKve3kElcL+LwTPys3TfjLQ0XLBeRzvBV88PLcQ4ot2e03W6rtSB+zswHBsasJD80U5oq6ZjDXeoo7Vwzqk2YoUbxr0ABcqTQiq3bvOcA9erpYGUBQ6A0C/RtI4MDPW56dtFIlYTmaxI6uA+ODMN2zbBKLK3R15+JFsAINmnhiJdycEy3Xjo/A6E31CohFSQV5gfyGhEmkJ6VLSuhfsEzE+3COyfW+OdypjEXPhQ8GLB3ivRbAw1VDrtnrAlmAKRk5pkLRqNGq0fd+79+GBMxjPqQ0U6ZoKzcwLVlpIPr0/GrWvyzwc2AffQy7u6aEMKIgrLAWRVJ6RoFxX4PJULN8lHlfSDZiZWJkYehWKVpyAXra2LKJG+LDTq+OsYNGZzZIAqRqGC10azVAEUbyCyhx/3S8Rqw9nYEDCKL8fMjPYLUruPngdBfZVZ8iAODtmCiT7pvbhyk1ifHDJ2yAGDbTflEJBkHAMYq9pIr56MsC5DcPAE+vSoAEQpL0wN17PXFejRmwNySCdM6LtXZ0J+Yn2esxWyDcUsln9/Ovo4+TCdvH3y5tno8fBg1v2y//WR2gvl0/k4eP1kad794/n0G3930Rl2OtOLrfcH887i3SszDK4r/eSK2j98dTwaHp59GJ38enY4fPnqcEyqS1CRCok/X5TbYl3OKMSC+UekoIbjuDawtZt0GM4AAIxl5Sbizw7lVJ7tYbZv3OBo13lUSEW3cnMM2Ior3CvEVEKGLv6IY0VH8HgM8e9EYe0uVth3sCatl/84G3LOlQz22RSKjm52er0nDryebz3Hv51e9xk8v3CePWndLhrutPGOebQ3g/2gCeb3a3C6RSjcdhsqHnlWpz3CjL8KlPorvEdAaDhUz5Z/5f5O72n3xdOtpw+WO9+Xlw9WO99Xlw++7Xz/dvnArCK2gyDfZXP8ECBmtgqYUas/ESxbzwCUn4AKPv4wMnvJi5j+M4XL1vPnvcfdnxUuxb+3xedA8eteLXF6432jjWrbSVv1rgkOYSB7Uiqfw9GHXbcaSFqgvNGMy1JzpObwF8JRup31bDI568YJdmmKDTAOZ0FcBnleZSE7OzuksX7Xb5Q6RyJta5VbQ1Nmmt36Dl+581tuwl0SOFuwOvEFnEYFTc2qd3knqtC7dhAJFAL/bVc72E4U61nektxAtX6Za7FtEyqiGW0TPZMXm0BvoATSq6t8hT+JG1Y6SEmBSM+Xv1ERs2aques8KfOgKVew4FSbGBWzMssmWvV9urTn+6lhdTfapIES8X9kbXzehHOjwVrEKISjcNYxrGs0prZsdH91JCBvYa/8isZw5h0c5eF1By9EbBs204b9SxiyNwSk0+Gl8N4QaaNlM9h5qxB61ulStxLm6prLp6HrwvHStyf0/ObFSDuwf/Qa9gMLMIunjT7yfpT0ND1s/qFDHLuY6JSRUkwoBpkvvRiZ0LBXCf/L1chvNlKSBqquLimNIrFCW+CopfMWbDuT26pt2IKGowm+t2GXs8jVKG3zRsvR8UR7ik9Y3jdf78FiMzepGQSKSQhntwwKX8mog130Ql8xvUOSysljiILkRSI06Vnn1z7VELsiWOpipYvxMci5t8nDh+Uw4fZFOhO4cYO1cWXxiX9ulQTYmrJpPN8uk0ygYs8LY5frmKtBoO4SparjcwGdNFUUSGz2KFBkCahIYseyGlK+KGMBHLebBeJKEd3IhnlItEsbdAMZvA+rZvIs1RVszufWlhesrduRl0mc32vfG9juwG5C+jce4IUBnnya8GJhWBAJLNLuJPbmzDie1pk9v2QbsbC6E0iXUyWhhPaJmk5o8/GjNsn+dZ3nxUoZ4Zt6OO2Tx9GyMDyBgwFTHUV9Huvi5GVFLQ+j2JRSGFMGOwYdKvg07JOA+7DDNjV2jIz65FFJazY1kcbIoDhbVWuDHYpJUTOUiVBjA6WfPCJkH8vnAjtu62s/JwdIHmvCYPE6kGRuUOjE0c06t7ai5VVqQxmym3TY1HOjls7t1QzcLLwGPl8QOByf3qtc8Z/eI56gWsPMeSzEmH9jp/d2By7Ql9iEpLhGR8mbLZLMeruHyaDjOAMXvm5ypS4COYxaP3cHZiL9FYFNQTsTqASoWELC8Wb9rGd0L90PA1joIh3Ef598hx3VJ/cjvDoz+T0oHB7vI23b/hYgJyhcimYkgEymIdHi7w6SeLYvCKBnxrz5RC4Bm5J6HGawuXDvW5CAsyynnEcHOqJhSYRhS9MnybFuwe3tXp/8JbN1M6Nbe1tWF8rakG/JSxrWUm8S2ibSHjJ1TpofV9eTJ9bg5KgFJuOJLqcvVd/ESDtSBOVGjErIK6zHAHvAQ/jWxSe6hKcePGnDIhx0ur3KwqRmpYdT++29zbrYT0XxjfKCb9o0mMSQesLMjORbYWskm6azHi+FBRwM54XLb7yozxBKfsWRBuZ9+6sBvFnCi/mNhcru5ZtrOrD6P//818BN1O7+D+1OfkFxa7sPE/KS3f+usxseFaYC1yYBnLE5AUeS1PFf) - note that Ripcharts looks messy on desktop too, so focus on differences with the grid and tile coordinates