### PR TITLE
Fixed build-watch task

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -105,7 +105,7 @@ gulp.task('build', function(done) {
 });
 
 gulp.task('build-watch', function() {
-    return gulp.watch(buildFiles, 'build');
+    return gulp.watch(buildFiles, gulp.series('build'));
 });
 
 gulp.task('buildApps', function() {


### PR DESCRIPTION
This fixes the build-watch task with the upgraded gulp.  Without this change you get:
 Error: watching Specs/**/*.js,!Specs/SpecList.js,Source/Shaders/**/*.glsl: watch task has to be a function (optionally generated by using gulp.parallel or gulp.series)