### PR TITLE
prevent colorToAlpha from carrying over from one imagery layer to its replacement

### DIFF
--- a/Source/Scene/GlobeSurfaceTileProvider.js
+++ b/Source/Scene/GlobeSurfaceTileProvider.js
@@ -1880,6 +1880,8 @@ define([
                     colorToAlpha.y = color.green;
                     colorToAlpha.z = color.blue;
                     colorToAlpha.w = imageryLayer.colorToAlphaThreshold;
+                } else {
+                    colorToAlpha.w = -1.0;
                 }
 
                 if (defined(imagery.credits)) {

--- a/Source/Scene/GlobeSurfaceTileProvider.js
+++ b/Source/Scene/GlobeSurfaceTileProvider.js
@@ -1872,9 +1872,10 @@ define([
                     colorToAlpha = uniformMapProperties.colorsToAlpha[numberOfDayTextures] = new Cartesian4();
                 }
 
-                applyColorToAlpha = defined(imageryLayer.colorToAlpha) && imageryLayer.colorToAlphaThreshold > 0.0;
+                var hasColorToAlpha = defined(imageryLayer.colorToAlpha) && imageryLayer.colorToAlphaThreshold > 0.0;
+                applyColorToAlpha = applyColorToAlpha || hasColorToAlpha;
 
-                if (applyColorToAlpha) {
+                if (hasColorToAlpha) {
                     var color = imageryLayer.colorToAlpha;
                     colorToAlpha.x = color.red;
                     colorToAlpha.y = color.green;


### PR DESCRIPTION
https://github.com/AnalyticalGraphicsInc/cesium/pull/7727 had a funny bug where switching an imagery layer with color-to-alpha out and _not_ setting color-to-alpha on the new layer would retain the color-to-alpha settings from the previous layer.

This PR always sets the value in the color-to-alpha uniform to a value that won't cause any change, regardless of whether it's used or not.