### PR TITLE
Support for particle system scaling/sizing in world space

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -205,3 +205,4 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to Cesiu
 * [Rikku-x](https://github.com/Rikku-x)
 * [Adrien David](https://github.com/adridavid)
 * [Alexander Popiak](https://github.com/apopiak)
+* [Richard Becker](https://github.com/richard3d)

--- a/Source/Scene/ParticleSystem.js
+++ b/Source/Scene/ParticleSystem.js
@@ -59,6 +59,7 @@ define([
      * @param {Cartesian2} [options.imageSize=new Cartesian2(1.0, 1.0)] If set, overrides the minimumImageSize and maximumImageSize inputs that scale the particle image's dimensions in pixels.
      * @param {Cartesian2} [options.minimumImageSize] Sets the minimum bound, width by height, above which to randomly scale the particle image's dimensions in pixels.
      * @param {Cartesian2} [options.maximumImageSize] Sets the maximum bound, width by height, below which to randomly scale the particle image's dimensions in pixels.
+     * @param {Boolean} [options.sizeInMeters] Sets if the size of particles is in meters or pixels. true to size the particles in meters; otherwise, the size is in pixels.
      * @param {Number} [options.speed=1.0] If set, overrides the minimumSpeed and maximumSpeed inputs with this value.
      * @param {Number} [options.minimumSpeed] Sets the minimum bound in meters per second above which a particle's actual speed will be randomly chosen.
      * @param {Number} [options.maximumSpeed] Sets the maximum bound in meters per second below which a particle's actual speed will be randomly chosen.
@@ -136,6 +137,8 @@ define([
 
         this._minimumImageSize = Cartesian2.clone(defaultValue(options.imageSize, defaultValue(options.minimumImageSize, defaultImageSize)));
         this._maximumImageSize = Cartesian2.clone(defaultValue(options.imageSize, defaultValue(options.maximumImageSize, defaultImageSize)));
+
+        this._sizeInMeters = defaultValue(options.sizeInMeters, false);
 
         this._lifetime = defaultValue(options.lifetime, Number.MAX_VALUE);
 
@@ -453,6 +456,22 @@ define([
             }
         },
         /**
+         * Gets or sets if the particle size is in meters or pixels. true to size particles in meters; otherwise, the size is in pixels.
+         * @memberof ParticleSystem.prototype
+         * @type {Boolean}
+         * @default false
+         */
+        sizeInMeters : {
+            get : function() {
+                return this._sizeInMeters;
+            },
+            set : function(value) {
+                //>>includeStart('debug', pragmas.debug);
+                //>>includeEnd('debug');
+                this._sizeInMeters = value;
+            }
+        },
+        /**
          * How long the particle system will emit particles, in seconds.
          * @memberof ParticleSystem.prototype
          * @type {Number}
@@ -570,6 +589,7 @@ define([
         billboard.width = particle.imageSize.x;
         billboard.height = particle.imageSize.y;
         billboard.position = particle.position;
+        billboard.sizeInMeters = system.sizeInMeters;
         billboard.show = true;
 
         // Update the color


### PR DESCRIPTION
Allows particle system billboards to be sized in world space via `sizeInMeters` property that was added and cascaded to billboards during update/creation process.