### PR TITLE
Set pixel alignment correctly for single or double channel textures

### DIFF
--- a/Source/Core/PixelFormat.js
+++ b/Source/Core/PixelFormat.js
@@ -285,6 +285,14 @@ define([
         /**
          * @private
          */
+        alignmentInBytes : function(pixelFormat, pixelDatatype, width) {
+            var mod = PixelFormat.textureSizeInBytes(pixelFormat, pixelDatatype, width, 1) % 4;
+            return mod === 0 ? 4 : (mod === 2 ? 2 : 1);
+        },
+
+        /**
+         * @private
+         */
         createTypedArray : function(pixelFormat, pixelDatatype, width, height) {
             var constructor;
             var sizeInBytes = PixelDatatype.sizeInBytes(pixelDatatype);

--- a/Source/Renderer/CubeMap.js
+++ b/Source/Renderer/CubeMap.js
@@ -128,13 +128,19 @@ define([
         gl.bindTexture(textureTarget, texture);
 
         function createFace(target, sourceFace, preMultiplyAlpha, flipY) {
-            // TODO: gl.pixelStorei(gl._UNPACK_ALIGNMENT, 4);
             var arrayBufferView = sourceFace.arrayBufferView;
             if (!defined(arrayBufferView)) {
                 arrayBufferView = sourceFace.bufferView;
             }
 
-            if (arrayBufferView) {
+            var unpackAlignment = 4;
+            if (defined(arrayBufferView)) {
+                unpackAlignment = PixelFormat.alignmentInBytes(pixelFormat, pixelDatatype, width);
+            }
+
+            gl.pixelStorei(gl.UNPACK_ALIGNMENT, unpackAlignment);
+
+            if (defined(arrayBufferView)) {
                 gl.pixelStorei(gl.UNPACK_PREMULTIPLY_ALPHA_WEBGL, false);
                 gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, false);
 

--- a/Source/Renderer/CubeMapFace.js
+++ b/Source/Renderer/CubeMapFace.js
@@ -96,8 +96,6 @@ define([
         var target = this._textureTarget;
         var targetFace = this._targetFace;
 
-        // TODO: gl.pixelStorei(gl._UNPACK_ALIGNMENT, 4);
-
         gl.activeTexture(gl.TEXTURE0);
         gl.bindTexture(target, this._texture);
 
@@ -111,6 +109,13 @@ define([
 
         var preMultiplyAlpha = this._preMultiplyAlpha;
         var flipY = this._flipY;
+
+        var unpackAlignment = 4;
+        if (defined(arrayBufferView)) {
+            unpackAlignment = PixelFormat.alignmentInBytes(pixelFormat, pixelDatatype, width);
+        }
+
+        gl.pixelStorei(gl.UNPACK_ALIGNMENT, unpackAlignment);
 
         var uploaded = false;
         if (!this._initialized) {
@@ -144,7 +149,7 @@ define([
         }
 
         if (!uploaded) {
-            if (arrayBufferView) {
+            if (defined(arrayBufferView)) {
                 gl.pixelStorei(gl.UNPACK_PREMULTIPLY_ALPHA_WEBGL, false);
                 gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, false);
 

--- a/Source/Renderer/Texture.js
+++ b/Source/Renderer/Texture.js
@@ -192,10 +192,16 @@ define([
         var textureTarget = gl.TEXTURE_2D;
         var texture = gl.createTexture();
 
-        // TODO: gl.pixelStorei(gl._UNPACK_ALIGNMENT, 4);
-
         gl.activeTexture(gl.TEXTURE0);
         gl.bindTexture(textureTarget, texture);
+
+        var unpackAlignment = 4;
+        if (defined(source) && defined(source.arrayBufferView) && !isCompressed) {
+            unpackAlignment = PixelFormat.alignmentInBytes(pixelFormat, pixelDatatype, width);
+            console.log(unpackAlignment);
+        }
+
+        gl.pixelStorei(gl.UNPACK_ALIGNMENT, unpackAlignment);
 
         if (defined(source)) {
             if (defined(source.arrayBufferView)) {
@@ -518,8 +524,6 @@ define([
         var gl = this._context._gl;
         var target = this._textureTarget;
 
-        // TODO: gl.pixelStorei(gl._UNPACK_ALIGNMENT, 4);
-
         gl.activeTexture(gl.TEXTURE0);
         gl.bindTexture(target, this._texture);
 
@@ -534,6 +538,13 @@ define([
 
         var preMultiplyAlpha = this._preMultiplyAlpha;
         var flipY = this._flipY;
+
+        var unpackAlignment = 4;
+        if (defined(arrayBufferView)) {
+            unpackAlignment = PixelFormat.alignmentInBytes(pixelFormat, pixelDatatype, width);
+        }
+
+        gl.pixelStorei(gl.UNPACK_ALIGNMENT, unpackAlignment);
 
         var uploaded = false;
         if (!this._initialized) {
@@ -567,7 +578,7 @@ define([
         }
 
         if (!uploaded) {
-            if (arrayBufferView) {
+            if (defined(arrayBufferView)) {
                 gl.pixelStorei(gl.UNPACK_PREMULTIPLY_ALPHA_WEBGL, false);
                 gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, false);
 

--- a/Specs/Renderer/TextureSpec.js
+++ b/Specs/Renderer/TextureSpec.js
@@ -49,6 +49,9 @@ defineSuite([
     var fs =
         'uniform sampler2D u_texture;' +
         'void main() { gl_FragColor = texture2D(u_texture, vec2(0.0)); }';
+    var fsLuminanceAlpha =
+        'uniform sampler2D u_texture;' +
+        'void main() { gl_FragColor = vec4(texture2D(u_texture, vec2(0.0)).ra, 0.0, 1.0); }';
     var texture;
     var uniformMap = {
         u_texture : function() {
@@ -531,6 +534,52 @@ defineSuite([
             fragmentShader : fragmentShaderSource,
             uniformMap : um
         }).contextToRender([255, 0, 0, 255]);
+    });
+
+    it('draws the expected luminance texture color', function() {
+        var color = new Color(0.6, 0.6, 0.6, 1.0);
+        var arrayBufferView = new Uint8Array([153]);
+
+        texture = new Texture({
+            context : context,
+            pixelFormat : PixelFormat.LUMINANCE,
+            pixelDatatype : PixelDatatype.UNSIGNED_BYTE,
+            source : {
+                width : 1,
+                height : 1,
+                arrayBufferView : arrayBufferView
+            },
+            flipY : false
+        });
+
+        expect({
+            context : context,
+            fragmentShader : fs,
+            uniformMap : uniformMap
+        }).contextToRender(color.toBytes());
+    });
+
+    it('draws the expected luminance alpha texture color', function() {
+        var color = new Color(0.6, 0.8, 0.0, 1.0);
+        var arrayBufferView = new Uint8Array([153, 204]);
+
+        texture = new Texture({
+            context : context,
+            pixelFormat : PixelFormat.LUMINANCE_ALPHA,
+            pixelDatatype : PixelDatatype.UNSIGNED_BYTE,
+            source : {
+                width : 1,
+                height : 1,
+                arrayBufferView : arrayBufferView
+            },
+            flipY : false
+        });
+
+        expect({
+            context : context,
+            fragmentShader : fsLuminanceAlpha,
+            uniformMap : uniformMap
+        }).contextToRender(color.toBytes());
     });
 
     it('can be created from a typed array', function() {


### PR DESCRIPTION
The default `gl.UNPACK_ALIGNMENT` is 4 bytes but this won't work for textures with less than 4 channels that have a certain pixel width. This detects the proper alignment and sets `gl.pixelStorei(gl.UNPACK_ALIGNMENT)`.