### PR TITLE
Fix incorrect PBR lighting on instanced 3D models

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@ Change Log
 ##### Fixes :wrench:
 * Fixed an error where `clampToHeightMostDetailed` or `sampleHeightMostDetailed` would crash if entities were created when the promise resolved. [#7690](https://github.com/AnalyticalGraphicsInc/cesium/pull/7690)
 * Fixed an error where many imagery layers within a single tile would cause parts of the tile to render as black on some platforms. [#7649](https://github.com/AnalyticalGraphicsInc/cesium/issues/7649)
+* Fixed a problem where instanced 3D models were incorrectly lit when using physically based materials. [#7775](https://github.com/AnalyticalGraphicsInc/cesium/issues/7775)
 
 ### 1.56.1 - 2019-04-02
 

--- a/Source/Scene/processPbrMaterials.js
+++ b/Source/Scene/processPbrMaterials.js
@@ -336,7 +336,6 @@ define([
         vertexShader += 'attribute vec3 a_position;\n';
         if (hasNormals) {
             vertexShader += 'varying vec3 v_positionEC;\n';
-            vertexShader += 'varying vec3 v_positionWC;\n';
         }
 
         // Morph Target Weighting
@@ -375,9 +374,6 @@ define([
         } else {
             vertexShaderMain += '    vec4 position = vec4(weightedPosition, 1.0);\n';
         }
-        if (hasNormals) {
-            vertexShaderMain += '    v_positionWC = (czm_model * position).xyz;\n';
-        }
         vertexShaderMain += '    position = u_modelViewMatrix * position;\n';
         if (hasNormals) {
             vertexShaderMain += '    v_positionEC = position.xyz;\n';
@@ -399,7 +395,6 @@ define([
 
             fragmentShader += 'varying vec3 v_normal;\n';
             fragmentShader += 'varying vec3 v_positionEC;\n';
-            fragmentShader += 'varying vec3 v_positionWC;\n';
         }
 
         // Read tangents if available
@@ -582,6 +577,7 @@ define([
         // Add normal mapping to fragment shader
         if (hasNormals) {
             fragmentShader += '    vec3 ng = normalize(v_normal);\n';
+            fragmentShader += '    vec3 positionWC = vec3(czm_inverseView * vec4(v_positionEC, 1.0));';
             if (defined(generatedMaterialValues.u_normalTexture)) {
                 if (hasTangents) {
                     // Read tangents from varying
@@ -745,9 +741,9 @@ define([
             fragmentShader += '    vec3 r = normalize(czm_inverseViewRotation * normalize(reflect(v, n)));\n';
             // Figure out if the reflection vector hits the ellipsoid
             fragmentShader += '    czm_ellipsoid ellipsoid = czm_getWgs84EllipsoidEC();\n';
-            fragmentShader += '    float vertexRadius = length(v_positionWC);\n';
+            fragmentShader += '    float vertexRadius = length(positionWC);\n';
             fragmentShader += '    float horizonDotNadir = 1.0 - min(1.0, ellipsoid.radii.x / vertexRadius);\n';
-            fragmentShader += '    float reflectionDotNadir = dot(r, normalize(v_positionWC));\n';
+            fragmentShader += '    float reflectionDotNadir = dot(r, normalize(positionWC));\n';
             // Flipping the X vector is a cheap way to get the inverse of czm_temeToPseudoFixed, since that's a rotation about Z.
             fragmentShader += '    r.x = -r.x;\n';
             fragmentShader += '    r = -normalize(czm_temeToPseudoFixed * r);\n';
@@ -784,10 +780,10 @@ define([
             // Luminance model from page 40 of http://silviojemma.com/public/papers/lighting/spherical-harmonic-lighting.pdf
             fragmentShader += '#ifdef USE_SUN_LUMINANCE \n';
             // Angle between sun and zenith
-            fragmentShader += '    float LdotZenith = clamp(dot(normalize(czm_inverseViewRotation * l), normalize(v_positionWC * -1.0)), 0.001, 1.0);\n';
+            fragmentShader += '    float LdotZenith = clamp(dot(normalize(czm_inverseViewRotation * l), normalize(positionWC * -1.0)), 0.001, 1.0);\n';
             fragmentShader += '    float S = acos(LdotZenith);\n';
             // Angle between zenith and current pixel
-            fragmentShader += '    float NdotZenith = clamp(dot(normalize(czm_inverseViewRotation * n), normalize(v_positionWC * -1.0)), 0.001, 1.0);\n';
+            fragmentShader += '    float NdotZenith = clamp(dot(normalize(czm_inverseViewRotation * n), normalize(positionWC * -1.0)), 0.001, 1.0);\n';
             // Angle between sun and current pixel
             fragmentShader += '    float gamma = acos(NdotL);\n';
             fragmentShader += '    float numerator = ((0.91 + 10.0 * exp(-3.0 * gamma) + 0.45 * pow(NdotL, 2.0)) * (1.0 - exp(-0.32 / NdotZenith)));\n';


### PR DESCRIPTION
This fixes https://github.com/AnalyticalGraphicsInc/cesium/issues/7655. The problem is that instanced 3D models set up the model and modelView matrices differently, see https://github.com/AnalyticalGraphicsInc/cesium/blob/master/Source/Scene/ModelInstanceCollection.js#L277-L305. So instead of instead of using `czm_modelView` in the PBR shader, you'd want to set up and use `czm_instanced_modelView` (does that sound right @lilleyse ?)

The ModelInstanceCollection class handles this substitution in the vertex shader but doesn't make any changes to the fragment shader. One way to fix this issue would require setting up similar substitutions for the fragment shader of instanced models. 

Sean noticed that a simpler change would be to just not rely on the model matrix in the PBR shader, which solves this issue. 

Before:

![incorrect shading](https://user-images.githubusercontent.com/1711126/56626786-26074a80-6611-11e9-8bc1-002eab795008.png)

After:

![fixed_instanced](https://user-images.githubusercontent.com/1711126/56689158-7978a780-66a8-11e9-9622-38ea557aa078.png)

I can also write up an issue to figure out a long term solution to this. Since this now involves having to remember not to use any of the model matrices in these shaders since they are different from instanced vs non instanced models.

Sean has already looked at this code, @bagnell can you review this (and post any thoughts here too)? 