### PR TITLE
Add missing newline to PBR shader

### DIFF
--- a/Source/Scene/processPbrMaterials.js
+++ b/Source/Scene/processPbrMaterials.js
@@ -577,7 +577,7 @@ define([
         // Add normal mapping to fragment shader
         if (hasNormals) {
             fragmentShader += '    vec3 ng = normalize(v_normal);\n';
-            fragmentShader += '    vec3 positionWC = vec3(czm_inverseView * vec4(v_positionEC, 1.0));';
+            fragmentShader += '    vec3 positionWC = vec3(czm_inverseView * vec4(v_positionEC, 1.0));\n';
             if (defined(generatedMaterialValues.u_normalTexture)) {
                 if (hasTangents) {
                     // Read tangents from varying


### PR DESCRIPTION
We somehow missed this in the https://github.com/AnalyticalGraphicsInc/cesium/pull/7776 fix. 

It worked because all the lines end in a semicolon, so you don't actually need newlines. But for the Ground Vehicle model, the produced shader was:

```
vec3 positionWC = vec3(czm_inverseView * vec4(v_positionEC, 1.0));#ifdef GL_OES_standard_derivatives
```

Which was an invalid syntax. You can confirm that this crashes by going to:

http://localhost:8080/Apps/Sandcastle/index.html?src=3D%20Models.html

And then selecting the ground vehicle. This PR fixes that.

@bagnell 