### PR TITLE
Request render mode fix

### DIFF
--- a/Source/Scene/Camera.js
+++ b/Source/Scene/Camera.js
@@ -303,7 +303,7 @@ define([
     function updateCameraDeltas(camera) {
         if (camera._scene.requestRenderMode) {
             camera.timeSinceMoved = Number.MAX_VALUE;
-            camera.positionWCDeltaMagnitude = 0;
+            camera.positionWCDeltaMagnitude = 0.0;
         } else if (!defined(camera._oldPositionWC)) {
             camera._oldPositionWC = Cartesian3.clone(camera.positionWC, camera._oldPositionWC);
         } else {

--- a/Source/Scene/Camera.js
+++ b/Source/Scene/Camera.js
@@ -301,7 +301,10 @@ define([
     }
 
     function updateCameraDeltas(camera) {
-        if (!defined(camera._oldPositionWC)) {
+        if (camera._scene.requestRenderMode) {
+            camera.timeSinceMoved = Number.MAX_VALUE;
+            camera.positionWCDeltaMagnitude = 0;
+        } else if (!defined(camera._oldPositionWC)) {
             camera._oldPositionWC = Cartesian3.clone(camera.positionWC, camera._oldPositionWC);
         } else {
             camera.positionWCDeltaMagnitudeLastFrame = camera.positionWCDeltaMagnitude;

--- a/Source/Scene/Cesium3DTileset.js
+++ b/Source/Scene/Cesium3DTileset.js
@@ -1727,7 +1727,6 @@ define([
         cancelOutOfViewRequests(this, frameState);
         raiseLoadProgressEvent(this, frameState);
         this._cache.unloadTiles(this, unloadTile);
-        this._cache.reset();
 
         var statistics = this._statisticsPerPass[Cesium3DTilePass.RENDER];
         var credits = this._credits;
@@ -2236,6 +2235,7 @@ define([
 
         // Resets the visibility check for each pass
         ++tileset._updatedVisibilityFrame;
+        tileset._cache.reset();
 
         // Update any tracked min max values
         resetMinimumMaximum(tileset);

--- a/Source/Scene/Cesium3DTileset.js
+++ b/Source/Scene/Cesium3DTileset.js
@@ -1770,7 +1770,6 @@ define([
         if (frameState.newFrame) {
             this._cache.reset();
         }
-
     };
 
     function cancelOutOfViewRequests(tileset, frameState) {
@@ -2240,9 +2239,6 @@ define([
 
         // Resets the visibility check for each pass
         ++tileset._updatedVisibilityFrame;
-        // if (isRender) {
-        //     tileset._cache.reset();
-        // }
 
         // Update any tracked min max values
         resetMinimumMaximum(tileset);

--- a/Source/Scene/Cesium3DTileset.js
+++ b/Source/Scene/Cesium3DTileset.js
@@ -2235,7 +2235,9 @@ define([
 
         // Resets the visibility check for each pass
         ++tileset._updatedVisibilityFrame;
-        tileset._cache.reset();
+        if (isRender) {
+            tileset._cache.reset();
+        }
 
         // Update any tracked min max values
         resetMinimumMaximum(tileset);

--- a/Source/Scene/Cesium3DTileset.js
+++ b/Source/Scene/Cesium3DTileset.js
@@ -1766,6 +1766,11 @@ define([
         if (this.dynamicScreenSpaceError) {
             updateDynamicScreenSpaceError(this, frameState);
         }
+
+        if (frameState.newFrame) {
+            this._cache.reset();
+        }
+
     };
 
     function cancelOutOfViewRequests(tileset, frameState) {
@@ -2235,9 +2240,9 @@ define([
 
         // Resets the visibility check for each pass
         ++tileset._updatedVisibilityFrame;
-        if (isRender) {
-            tileset._cache.reset();
-        }
+        // if (isRender) {
+        //     tileset._cache.reset();
+        // }
 
         // Update any tracked min max values
         resetMinimumMaximum(tileset);

--- a/Source/Scene/FrameState.js
+++ b/Source/Scene/FrameState.js
@@ -93,6 +93,14 @@ define([
         this.frameNumber = 0;
 
         /**
+         * <code>true</code> if a new frame has been issued and the frame number has been updated.
+         *
+         * @type {Boolean}
+         * @default false
+         */
+        this.newFrame = false;
+
+        /**
          * The scene's current time.
          *
          * @type {JulianDate}

--- a/Source/Scene/Scene.js
+++ b/Source/Scene/Scene.js
@@ -3318,6 +3318,7 @@ define([
         this._preUpdate.raiseEvent(this, time);
 
         var frameState = this._frameState;
+        frameState.newFrame = false;
 
         if (!defined(time)) {
             time = JulianDate.now();
@@ -3339,6 +3340,7 @@ define([
 
             var frameNumber = CesiumMath.incrementWrap(frameState.frameNumber, 15000000.0, 1.0);
             updateFrameNumber(this, frameNumber, time);
+            frameState.newFrame = true;
         }
 
         tryAndCatchError(this, prePassesUpdate);

--- a/Source/Scene/Scene.js
+++ b/Source/Scene/Scene.js
@@ -3206,7 +3206,7 @@ define([
 
         scene._pickPositionCacheDirty = true;
         frameState.creditDisplay.update();
-        frameState.creditDisplay.beginFrame();
+        // frameState.creditDisplay.beginFrame();
     }
 
     function postPassesUpdate(scene) {
@@ -3215,7 +3215,7 @@ define([
         primitives.postPassesUpdate(frameState);
 
         RequestScheduler.update();
-        frameState.creditDisplay.endFrame();
+        // frameState.creditDisplay.endFrame();
     }
 
     var scratchBackgroundColor = new Color();
@@ -3242,6 +3242,8 @@ define([
             backgroundColor.blue = Math.pow(backgroundColor.blue, scene.gamma);
         }
         frameState.backgroundColor = backgroundColor;
+
+        frameState.creditDisplay.beginFrame();
 
         scene.fog.update(frameState);
 
@@ -3288,6 +3290,7 @@ define([
             }
         }
 
+        frameState.creditDisplay.endFrame();
         context.endFrame();
     }
 

--- a/Source/Scene/Scene.js
+++ b/Source/Scene/Scene.js
@@ -3206,7 +3206,6 @@ define([
 
         scene._pickPositionCacheDirty = true;
         frameState.creditDisplay.update();
-        // frameState.creditDisplay.beginFrame();
     }
 
     function postPassesUpdate(scene) {
@@ -3215,7 +3214,6 @@ define([
         primitives.postPassesUpdate(frameState);
 
         RequestScheduler.update();
-        // frameState.creditDisplay.endFrame();
     }
 
     var scratchBackgroundColor = new Color();


### PR DESCRIPTION
Fixes https://github.com/AnalyticalGraphicsInc/cesium/issues/7786

The cache thrashing issues were related to cache.reset() getting called at the wrong time. 
For the requestRenderMode, render traversals stop happening when camera stops moving and there are no more tiles to request/process. When render traversals stop, tiles in the view won't get touched (what moves a tile after the cache sentinel to keep it from getting destroyed) and if cache resets happen outside of render traversals, it's going to start blowing stuff away.

To make sure this doesn't happen it would be best to check if there's a new frame in the prePassesUpdate before doing a reset. Another way of doing it is doing if (shouldRender) { tileset._cache.reset() } at the top of tileset::update but this will cause previous passes touched tiles to get evicted:
untouched | previous passes touched | sentinel | final pass touched.

Also, there were interactions with requestRenderMode and the movement based culling code. I tried to make it work but the existing code setup doesn't support a clean way of doing it. Right now I'm setting the camera delta related members to some neutral values to disable the features if requestRenderMode .

Though this is intended as a temporary fix since the point of requestRenderMode is energy efficiency and we want to keep these features enabled with this mode. The real fix I think involves moving those switches to a more global object like scene/etc. Having them (cull requests while camera moving, deferred time delay) per tileset is part of what makes the fix too ugly.

Tested all previous performance sandcastles with the mode on and off. Tested other interactions of this mode with different pass types like PRELOAD by using preload when hidden.