### PR TITLE
Request render mode full fix

### DIFF
--- a/Source/Scene/Camera.js
+++ b/Source/Scene/Camera.js
@@ -301,10 +301,7 @@ define([
     }
 
     function updateCameraDeltas(camera) {
-        if (camera._scene.requestRenderMode) {
-            camera.timeSinceMoved = Number.MAX_VALUE;
-            camera.positionWCDeltaMagnitude = 0.0;
-        } else if (!defined(camera._oldPositionWC)) {
+        if (!defined(camera._oldPositionWC)) {
             camera._oldPositionWC = Cartesian3.clone(camera.positionWC, camera._oldPositionWC);
         } else {
             camera.positionWCDeltaMagnitudeLastFrame = camera.positionWCDeltaMagnitude;

--- a/Source/Scene/Cesium3DTilePass.js
+++ b/Source/Scene/Cesium3DTilePass.js
@@ -21,9 +21,10 @@ define([
         SHADOW : 2,
         PRELOAD : 3,
         PRELOAD_FLIGHT : 4,
-        MOST_DETAILED_PRELOAD : 5,
-        MOST_DETAILED_PICK : 6,
-        NUMBER_OF_PASSES : 7
+        REQUEST_RENDER_MODE_DEFER_CHECK : 5,
+        MOST_DETAILED_PRELOAD : 6,
+        MOST_DETAILED_PICK : 7,
+        NUMBER_OF_PASSES : 8
     };
 
     var passOptions = new Array(Cesium3DTilePass.NUMBER_OF_PASSES);
@@ -57,6 +58,13 @@ define([
     });
 
     passOptions[Cesium3DTilePass.PRELOAD_FLIGHT] = freezeObject({
+        traversal : Cesium3DTilesetTraversal,
+        isRender : false,
+        requestTiles : true,
+        ignoreCommands : true
+    });
+
+    passOptions[Cesium3DTilePass.REQUEST_RENDER_MODE_DEFER_CHECK] = freezeObject({
         traversal : Cesium3DTilesetTraversal,
         isRender : false,
         requestTiles : true,

--- a/Source/Scene/Cesium3DTileset.js
+++ b/Source/Scene/Cesium3DTileset.js
@@ -2275,7 +2275,8 @@ define([
 
         var pass = tilesetPassState.pass;
         if ((pass === Cesium3DTilePass.PRELOAD && (!this.preloadWhenHidden || this.show)) ||
-            (pass === Cesium3DTilePass.PRELOAD_FLIGHT & (!this.preloadFlightDestinations || !this.show))) {
+            (pass === Cesium3DTilePass.PRELOAD_FLIGHT && (!this.preloadFlightDestinations || !this.show)) ||
+            (pass === Cesium3DTilePass.REQUEST_RENDER_MODE_DEFER_CHECK && !this.cullRequestsWhileMoving && this.foveatedTimeDelay <= 0)) {
             return;
         }
 

--- a/Source/Scene/Cesium3DTileset.js
+++ b/Source/Scene/Cesium3DTileset.js
@@ -2275,7 +2275,7 @@ define([
 
         var pass = tilesetPassState.pass;
         if ((pass === Cesium3DTilePass.PRELOAD && (!this.preloadWhenHidden || this.show)) ||
-            (pass === Cesium3DTilePass.PRELOAD_FLIGHT && (!this.preloadFlightDestinations || !this.show)) ||
+            (pass === Cesium3DTilePass.PRELOAD_FLIGHT && (!this.preloadFlightDestinations || (!this.show && !this.preloadWhenHidden))) ||
             (pass === Cesium3DTilePass.REQUEST_RENDER_MODE_DEFER_CHECK && !this.cullRequestsWhileMoving && this.foveatedTimeDelay <= 0)) {
             return;
         }

--- a/Source/Scene/Scene.js
+++ b/Source/Scene/Scene.js
@@ -1727,6 +1727,10 @@ define([
         pass : Cesium3DTilePass.PRELOAD_FLIGHT
     });
 
+    var requestRenderModeDeferCheckPassState = new Cesium3DTilePassState({
+        pass : Cesium3DTilePass.REQUEST_RENDER_MODE_DEFER_CHECK
+    });
+
     var scratchOccluderBoundingSphere = new BoundingSphere();
     var scratchOccluder;
 
@@ -3354,6 +3358,9 @@ define([
         tryAndCatchError(this, updateMostDetailedRayPicks);
         tryAndCatchError(this, updatePreloadPass);
         tryAndCatchError(this, updatePreloadFlightPass);
+        if (!shouldRender) {
+            tryAndCatchError(this, updateRequestRenderModeDeferCheckPass);
+        }
 
         this._postUpdate.raiseEvent(this, time);
 
@@ -3895,6 +3902,18 @@ define([
 
         var primitives = scene.primitives;
         primitives.updateForPass(frameState, preloadFlightTilesetPassState);
+    }
+
+    function updateRequestRenderModeDeferCheckPass(scene) {
+        // Check if any ignored requests are ready to go (to wake rendering up again)
+        var frameState = scene._frameState;
+        var camera = frameState.camera;
+
+        requestRenderModeDeferCheckPassState.camera = camera;
+        requestRenderModeDeferCheckPassState.cullingVolume = frameState.cullingVolume;
+
+        var primitives = scene.primitives;
+        primitives.updateForPass(frameState, requestRenderModeDeferCheckPassState);
     }
 
     var scratchRight = new Cartesian3();

--- a/Source/Scene/Scene.js
+++ b/Source/Scene/Scene.js
@@ -3906,10 +3906,7 @@ define([
 
     function updateRequestRenderModeDeferCheckPass(scene) {
         // Check if any ignored requests are ready to go (to wake rendering up again)
-        var frameState = scene._frameState;
-
-        var primitives = scene.primitives;
-        primitives.updateForPass(frameState, requestRenderModeDeferCheckPassState);
+        scene.primitives.updateForPass(scene._frameState, requestRenderModeDeferCheckPassState);
     }
 
     var scratchRight = new Cartesian3();

--- a/Source/Scene/Scene.js
+++ b/Source/Scene/Scene.js
@@ -3909,9 +3909,6 @@ define([
         var frameState = scene._frameState;
         var camera = frameState.camera;
 
-        requestRenderModeDeferCheckPassState.camera = camera;
-        requestRenderModeDeferCheckPassState.cullingVolume = frameState.cullingVolume;
-
         var primitives = scene.primitives;
         primitives.updateForPass(frameState, requestRenderModeDeferCheckPassState);
     }

--- a/Source/Scene/Scene.js
+++ b/Source/Scene/Scene.js
@@ -3907,7 +3907,6 @@ define([
     function updateRequestRenderModeDeferCheckPass(scene) {
         // Check if any ignored requests are ready to go (to wake rendering up again)
         var frameState = scene._frameState;
-        var camera = frameState.camera;
 
         var primitives = scene.primitives;
         primitives.updateForPass(frameState, requestRenderModeDeferCheckPassState);


### PR DESCRIPTION
This fix for https://github.com/AnalyticalGraphicsInc/cesium/issues/7789 enables the more advanced request culling features to work with request render mode.



It adds a pass that preforms a traversal when no longer rendering to see if any formerly deferred requests are a ready to be issued (which will lead to events that cause render mode to wake up). Something like this is probably the cleanest solution since it won't care about per tileset differences in their culling settings and should just work if any new types of request deferral are introduced in the future.

Previous sandcastles that we've used to check this bug are sufficient but should set the tileset option foveatedTimeDelay to something higher than the scene resolve time.