### PR TITLE
Fix gzip/content-type deployment issues

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -28,7 +28,6 @@ var Karma = require('karma');
 var yargs = require('yargs');
 var AWS = require('aws-sdk');
 var mime = require('mime');
-var compressible = require('compressible');
 
 var packageJson = require('./package.json');
 var version = packageJson.version;
@@ -424,13 +423,18 @@ function deployCesium(bucketName, uploadDirectory, cacheControl, done) {
                 var mimeLookup = getMimeType(blobName);
                 var contentType = mimeLookup.type;
                 var compress = mimeLookup.compress;
-                var contentEncoding = compress || mimeLookup.isCompressed ? 'gzip' : undefined;
+                var contentEncoding = compress ? 'gzip' : undefined;
                 var etag;
 
                 totalFiles++;
 
                 return readFile(file)
                 .then(function(content) {
+                    var alreadyCompressed = (content[0] === 0x1f) && (content[1] === 0x8b);
+                    if (alreadyCompressed) {
+                        console.log('Skipping compressing already compressed file: ' + file);
+                        return content;
+                    }
                     return compress ? gzip(content) : content;
                 })
                 .then(function(content) {
@@ -547,24 +551,38 @@ function deployCesium(bucketName, uploadDirectory, cacheControl, done) {
 }
 
 function getMimeType(filename) {
-    var ext = path.extname(filename);
-    if (ext === '.bin' || ext === '.terrain') {
-        return {type : 'application/octet-stream', compress : true, isCompressed : false};
-    } else if (ext === '.md' || ext === '.glsl') {
-        return {type : 'text/plain', compress : true, isCompressed : false};
-    } else if (ext === '.czml' || ext === '.geojson' || ext === '.json') {
-        return {type : 'application/json', compress : true, isCompressed : false};
-    } else if (ext === '.js') {
-        return {type : 'application/javascript', compress : true, isCompressed : false};
-    } else if (ext === '.svg') {
-        return {type : 'image/svg+xml', compress : true, isCompressed : false};
-    } else if (ext === '.woff') {
-        return {type : 'application/font-woff', compress : false, isCompressed : false};
+    var mimeType = mime.getType(filename);
+    if (mimeType) {
+        //Compress everything except binary images and video
+        var compress = !/^(image|video)\//i.test(mimeType);
+        if (mimeType === 'image/svg+xml') {
+            compress = true;
+        }
+        return { type: mimeType, compress: compress };
     }
 
-    var mimeType = mime.getType(filename);
-    var compress = compressible(mimeType);
-    return {type : mimeType, compress : compress, isCompressed : false};
+    //Non-standard mime types not handled by mime
+    if (/\.(glsl|LICENSE|config|state)$/i.test(filename)) {
+        return { type: 'text/plain', compress: true };
+    } else if (/\.(czml|topojson)$/i.test(filename)) {
+        return { type: 'application/json', compress: true };
+    } else if (/\.crn$/i.test(filename)) {
+        return { type: 'application/octet-stream', compress: false };
+    }
+
+    // Handle dotfiles, such as .jshintrc
+    var baseName = path.basename(filename);
+    if (baseName[0] === '.' || baseName.indexOf('.') === -1) {
+        return { type: 'text/plain', compress: true };
+    }
+
+    // Everything else can be octet-stream compressed but print a warning
+    // if we introduce a type we aren't specifically handling.
+    if (!/\.(terrain|b3dm|geom|pnts|vctr|cmpt|i3dm|metadata)$/i.test(filename)) {
+        console.log('Unknown mime type for ' + filename);
+    }
+
+    return { type: 'application/octet-stream', compress: true };
 }
 
 // get all files currently in bucket asynchronously

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "aws-sdk": "^2.18.0",
     "bluebird": "^3.4.6",
     "cloc": "^2.3.3",
-    "compressible": "^2.0.9",
     "compression": "^1.6.2",
     "eslint": "^5.13.0",
     "eslint-plugin-html": "^5.0.3",


### PR DESCRIPTION
Fixes the root issue related to #7731.

1. We weren't handling already-compressed gzips when setting Content-type
2. Our `getMimeType` helper function was incorrect and also skipped a ton of files that should be compressed.
3. Remove dependency on unneeded `compressible` module.
4. Aggressively compress everything except images/video.
5. Warn if we add an already gzipped file or a new extension type that we don't account for in getMimeType.