### PR TITLE
Model caching fix

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,6 +25,7 @@ Change Log
 * Added `CesiumMath.normalize` to convert a scalar value in an arbitrary range to a scalar in the range [0.0, 1.0]. [#7774](https://github.com/AnalyticalGraphicsInc/cesium/pull/7774)
 
 ##### Fixes :wrench:
+* Fixed an error when loading the same glTF model in two separate viewers. [#7688](https://github.com/AnalyticalGraphicsInc/cesium/issues/7688)
 * Fixed an error where `clampToHeightMostDetailed` or `sampleHeightMostDetailed` would crash if entities were created when the promise resolved. [#7690](https://github.com/AnalyticalGraphicsInc/cesium/pull/7690)
 * Fixed an issue with compositing merged entity availability. [#7717](https://github.com/AnalyticalGraphicsInc/cesium/issues/7717)
 * Fixed an error where many imagery layers within a single tile would cause parts of the tile to render as black on some platforms. [#7649](https://github.com/AnalyticalGraphicsInc/cesium/issues/7649)

--- a/Source/Scene/Model.js
+++ b/Source/Scene/Model.js
@@ -668,7 +668,6 @@ define([
         this._rtcCenter3D = undefined;  // in world coordinates
         this._rtcCenter2D = undefined;  // in projected world coordinates
 
-        this._keepPipelineExtras = options.keepPipelineExtras; // keep the buffers in memory for use in other applications
         this._sourceVersion = undefined;
         this._sourceKHRTechniquesWebGL = undefined;
 
@@ -4438,7 +4437,7 @@ define([
                     ModelUtility.updateForwardAxis(this);
 
                     // glTF pipeline updates, not needed if loading from cache
-                    if (!this._loadRendererResourcesFromCache) {
+                    if (!defined(this.gltf.extras.sourceVersion)) {
                         var gltf = this.gltf;
                         // Add the original version so it remains cached
                         gltf.extras.sourceVersion = ModelUtility.getAssetVersion(gltf);
@@ -4517,10 +4516,6 @@ define([
             }
 
             if (loadResources.finished()) {
-                if (!this._keepPipelineExtras) {
-                    removePipelineExtras(this.gltf);
-                }
-
                 this._loadResources = undefined;  // Clear CPU memory since WebGL resources were created.
 
                 var resources = this._rendererResources;


### PR DESCRIPTION
Fixes https://github.com/AnalyticalGraphicsInc/cesium/issues/7688

This fixes both Sandcastle examples in https://github.com/AnalyticalGraphicsInc/cesium/issues/7688 by not removing the pipeline extras since it contains buffer data which models on different contexts need to access. This does increase memory usage since now the buffer needs to stay in memory, but it's the right thing to do. It doesn't affect 3D Tiles which avoids caching altogether and releases the glTF json.

The last version that worked, 1.49, also does not remove pipeline extras.

Also includes a fix where models on different contexts would have different lighting because `gltf.extras.sourceKHRTechniquesWebGL` would be `true` for the second model and cause it to apply gamma correction unnecessarily.

The comments in https://github.com/AnalyticalGraphicsInc/cesium/issues/7688 are good and I think we need to rethink caching to make it simpler once we can get around to it.