### PR TITLE
Remove 1.57 deprecation warnings

### DIFF
--- a/Source/Core/PolylineGeometry.js
+++ b/Source/Core/PolylineGeometry.js
@@ -139,10 +139,7 @@ define([
         this._colorsPerVertex = colorsPerVertex;
         this._vertexFormat = VertexFormat.clone(defaultValue(options.vertexFormat, VertexFormat.DEFAULT));
 
-        this._followSurface = defaultValue(options.followSurface, true);
         this._arcType = defaultValue(options.arcType, ArcType.GEODESIC);
-        this._followSurface = (this._arcType !== ArcType.NONE);
-
         this._granularity = defaultValue(options.granularity, CesiumMath.RADIANS_PER_DEGREE);
         this._ellipsoid = Ellipsoid.clone(defaultValue(options.ellipsoid, Ellipsoid.WGS84));
         this._workerName = 'createPolylineGeometry';

--- a/Source/Core/PolylineGeometry.js
+++ b/Source/Core/PolylineGeometry.js
@@ -7,7 +7,6 @@ define([
         './ComponentDatatype',
         './defaultValue',
         './defined',
-        './deprecationWarning',
         './DeveloperError',
         './Ellipsoid',
         './Geometry',
@@ -28,7 +27,6 @@ define([
         ComponentDatatype,
         defaultValue,
         defined,
-        deprecationWarning,
         DeveloperError,
         Ellipsoid,
         Geometry,
@@ -142,10 +140,6 @@ define([
         this._vertexFormat = VertexFormat.clone(defaultValue(options.vertexFormat, VertexFormat.DEFAULT));
 
         this._followSurface = defaultValue(options.followSurface, true);
-        if (defined(options.followSurface)) {
-            deprecationWarning('PolylineGeometry.followSurface', 'PolylineGeometry.followSurface is deprecated and will be removed in Cesium 1.57. Use PolylineGeometry.arcType instead.');
-            options.arcType = options.followSurface ? ArcType.GEODESIC : ArcType.NONE;
-        }
         this._arcType = defaultValue(options.arcType, ArcType.GEODESIC);
         this._followSurface = (this._arcType !== ArcType.NONE);
 

--- a/Source/Core/Resource.js
+++ b/Source/Core/Resource.js
@@ -8,7 +8,6 @@ define([
         './defaultValue',
         './defined',
         './defineProperties',
-        './deprecationWarning',
         './DeveloperError',
         './freezeObject',
         './FeatureDetection',
@@ -37,7 +36,6 @@ define([
         defaultValue,
         defined,
         defineProperties,
-        deprecationWarning,
         DeveloperError,
         freezeObject,
         FeatureDetection,
@@ -869,12 +867,6 @@ define([
      * @see {@link http://wiki.commonjs.org/wiki/Promises/A|CommonJS Promises/A}
      */
     Resource.prototype.fetchImage = function (options) {
-        if (typeof options === 'boolean') {
-            deprecationWarning('fetchImage-parameter-change', 'fetchImage now takes an options object in CesiumJS 1.57. Use resource.fetchImage({ preferBlob: true }) instead of resource.fetchImage(true).');
-            options = {
-                preferBlob : options
-            };
-        }
         options = defaultValue(options, defaultValue.EMPTY_OBJECT);
         var preferImageBitmap = defaultValue(options.preferImageBitmap, false);
         var preferBlob = defaultValue(options.preferBlob, false);

--- a/Source/Core/SimplePolylineGeometry.js
+++ b/Source/Core/SimplePolylineGeometry.js
@@ -127,10 +127,6 @@ define([
         this._colorsPerVertex = colorsPerVertex;
 
         this._followSurface = defaultValue(options.followSurface, true);
-        if (defined(options.followSurface)) {
-            deprecationWarning('PolylineGeometry.followSurface', 'PolylineGeometry.followSurface is deprecated and will be removed in Cesium 1.57. Use PolylineGeometry.arcType instead.');
-            options.arcType = options.followSurface ? ArcType.GEODESIC : ArcType.NONE;
-        }
         this._arcType = defaultValue(options.arcType, ArcType.GEODESIC);
         this._followSurface = this._arcType === ArcType.NONE;
 

--- a/Source/Core/SimplePolylineGeometry.js
+++ b/Source/Core/SimplePolylineGeometry.js
@@ -126,10 +126,7 @@ define([
         this._colors = colors;
         this._colorsPerVertex = colorsPerVertex;
 
-        this._followSurface = defaultValue(options.followSurface, true);
         this._arcType = defaultValue(options.arcType, ArcType.GEODESIC);
-        this._followSurface = this._arcType === ArcType.NONE;
-
         this._granularity = defaultValue(options.granularity, CesiumMath.RADIANS_PER_DEGREE);
         this._ellipsoid = defaultValue(options.ellipsoid, Ellipsoid.WGS84);
         this._workerName = 'createSimplePolylineGeometry';

--- a/Source/DataSources/PolylineGeometryUpdater.js
+++ b/Source/DataSources/PolylineGeometryUpdater.js
@@ -82,7 +82,6 @@ define([
         this.vertexFormat = undefined;
         this.positions = undefined;
         this.width = undefined;
-        this.followSurface = undefined;
         this.arcType = undefined;
         this.granularity = undefined;
     }
@@ -515,13 +514,12 @@ define([
         this._zIndex = defaultValue(zIndex, defaultZIndex);
 
         var width = polyline.width;
-        var followSurface = polyline.followSurface;
         var arcType = polyline.arcType;
         var clampToGround = polyline.clampToGround;
         var granularity = polyline.granularity;
 
         if (!positionsProperty.isConstant || !Property.isConstant(width) ||
-            !Property.isConstant(followSurface) || !Property.isConstant(arcType) || !Property.isConstant(granularity) ||
+            !Property.isConstant(arcType) || !Property.isConstant(granularity) ||
             !Property.isConstant(clampToGround) || !Property.isConstant(zIndex)) {
             if (!this._dynamic) {
                 this._dynamic = true;
@@ -551,7 +549,6 @@ define([
             geometryOptions.vertexFormat = vertexFormat;
             geometryOptions.positions = positions;
             geometryOptions.width = defined(width) ? width.getValue(Iso8601.MINIMUM_VALUE) : undefined;
-            geometryOptions.followSurface = defined(followSurface) ? followSurface.getValue(Iso8601.MINIMUM_VALUE) : undefined;
             geometryOptions.arcType = defined(arcType) ? arcType.getValue(Iso8601.MINIMUM_VALUE) : undefined;
             geometryOptions.granularity = defined(granularity) ? granularity.getValue(Iso8601.MINIMUM_VALUE) : undefined;
 
@@ -706,11 +703,7 @@ define([
             return;
         }
 
-        var followSurface = Property.getValueOrUndefined(polyline._followSurface, time);
         var arcType = ArcType.GEODESIC;
-        if (defined(followSurface)) {
-            arcType = followSurface ? ArcType.GEODESIC : ArcType.NONE;
-        }
         arcType = Property.getValueOrDefault(polyline._arcType, time, arcType);
 
         var globe = geometryUpdater._scene.globe;

--- a/Source/DataSources/PolylineGraphics.js
+++ b/Source/DataSources/PolylineGraphics.js
@@ -52,8 +52,6 @@ define([
         this._depthFailMaterialSubscription = undefined;
         this._positions = undefined;
         this._positionsSubscription = undefined;
-        this._followSurface = undefined;
-        this._followSurfaceSubscription = undefined;
         this._arcType = undefined;
         this._arcTypeSubscription = undefined;
         this._clampToGround = undefined;
@@ -136,16 +134,6 @@ define([
         width : createPropertyDescriptor('width'),
 
         /**
-         * Gets or sets the boolean Property specifying whether the line segments
-         * should be great arcs or linearly connected.
-         * @memberof PolylineGraphics.prototype
-         * @type {Property}
-         * @deprecated This property has been deprecated. Use {@link PolylineGraphics#arcType} instead.
-         * @default true
-         */
-        followSurface : createPropertyDescriptor('followSurface'),
-
-        /**
          * Gets or sets the {@link ArcType} Property specifying whether the line segments should be great arcs, rhumb lines or linearly connected.
          * @memberof PolylineGraphics.prototype
          * @type {Property}
@@ -218,7 +206,6 @@ define([
         result.depthFailMaterial = this.depthFailMaterial;
         result.positions = this.positions;
         result.width = this.width;
-        result.followSurface = this.followSurface;
         result.arcType = this.arcType;
         result.clampToGround = this.clampToGround;
         result.granularity = this.granularity;
@@ -248,7 +235,6 @@ define([
         this.depthFailMaterial = defaultValue(this.depthFailMaterial, source.depthFailMaterial);
         this.positions = defaultValue(this.positions, source.positions);
         this.width = defaultValue(this.width, source.width);
-        this.followSurface = defaultValue(this.followSurface, source.followSurface);
         this.arcType = defaultValue(this.arcType, source.arcType);
         this.clampToGround = defaultValue(this.clampToGround, source.clampToGround);
         this.granularity = defaultValue(this.granularity, source.granularity);

--- a/Specs/Core/PolylineGeometrySpec.js
+++ b/Specs/Core/PolylineGeometrySpec.js
@@ -39,24 +39,6 @@ defineSuite([
         }).toThrowDeveloperError();
     });
 
-    it('constructor converts followSurface to arcType', function() {
-        var line = new PolylineGeometry({
-            positions: [Cartesian3.ZERO, Cartesian3.UNIT_X, Cartesian3.UNIT_Y],
-            followSurface: false
-        });
-
-        expect(line._followSurface).toBe(false);
-        expect(line._arcType).toBe(ArcType.NONE);
-
-        line = new PolylineGeometry({
-            positions: [Cartesian3.ZERO, Cartesian3.UNIT_X, Cartesian3.UNIT_Y],
-            followSurface: true
-        });
-
-        expect(line._followSurface).toBe(true);
-        expect(line._arcType).toBe(ArcType.GEODESIC);
-    });
-
     it('constructor returns undefined when line width is negative', function() {
         var positions = [new Cartesian3(1.0, 0.0, 0.0), new Cartesian3(0.0, 1.0, 0.0), new Cartesian3(0.0, 0.0, 1.0)];
         var line = PolylineGeometry.createGeometry(new PolylineGeometry({

--- a/Specs/DataSources/PolylineGeometryUpdaterSpec.js
+++ b/Specs/DataSources/PolylineGeometryUpdaterSpec.js
@@ -205,17 +205,17 @@ defineSuite([
         expect(updater.isDynamic).toBe(true);
     });
 
-    it('A time-varying followSurface causes geometry to be dynamic', function() {
-        var followSurface = new TimeIntervalCollectionProperty();
-        followSurface.intervals.addInterval(new TimeInterval({
+    it('A time-varying arcType causes geometry to be dynamic', function() {
+        var arcType = new TimeIntervalCollectionProperty();
+        arcType.intervals.addInterval(new TimeInterval({
             start : new JulianDate(0, 0),
             stop : new JulianDate(10, 0),
-            data : false
+            data : ArcType.NONE
         }));
 
         var entity = createBasicPolyline();
         var updater = new PolylineGeometryUpdater(entity, scene);
-        entity.polyline.followSurface = followSurface;
+        entity.polyline.arcType = arcType;
         expect(updater.isDynamic).toBe(true);
     });
 
@@ -261,7 +261,6 @@ defineSuite([
         polyline.depthFailMaterial = options.depthFailMaterial;
 
         polyline.width = new ConstantProperty(options.width);
-        polyline.followSurface = new ConstantProperty(options.followSurface);
         polyline.granularity = new ConstantProperty(options.granularity);
         polyline.distanceDisplayCondition = options.distanceDisplayCondition;
         polyline.clampToGround = new ConstantProperty(clampToGround);
@@ -280,9 +279,6 @@ defineSuite([
             expect(geometry.width).toEqual(options.width);
         } else {
             expect(geometry._width).toEqual(options.width);
-            if (defined(options.followSurface)) {
-                expect(geometry._followSurface).toEqual(options.followSurface);
-            }
             if (defined(options.arcType)) {
                 expect(geometry._arcType).toEqual(options.arcType);
             }
@@ -311,7 +307,6 @@ defineSuite([
             show : true,
             material : new ColorMaterialProperty(Color.RED),
             width : 3,
-            followSurface : false,
             clampToGround : false,
             granularity : 1.0,
             arcType : ArcType.NONE
@@ -326,7 +321,6 @@ defineSuite([
             show : true,
             material : new ColorMaterialProperty(Color.RED),
             width : 3,
-            followSurface : false,
             clampToGround : true,
             granularity : 1.0,
             arcType : ArcType.GEODESIC
@@ -339,7 +333,6 @@ defineSuite([
             material : new ColorMaterialProperty(Color.RED),
             depthFailMaterial : new ColorMaterialProperty(Color.BLUE),
             width : 3,
-            followSurface : true,
             clampToGround : false,
             granularity : 1.0,
             arcType : ArcType.GEODESIC
@@ -363,7 +356,6 @@ defineSuite([
             show : true,
             material : new GridMaterialProperty(),
             width : 4,
-            followSurface : true,
             clampToGround : false,
             granularity : 0.5,
             arcType: ArcType.GEODESIC
@@ -378,7 +370,6 @@ defineSuite([
             show : true,
             material : new GridMaterialProperty(),
             width : 4,
-            followSurface : true,
             clampToGround : true,
             granularity : 0.5,
             arcType: ArcType.GEODESIC
@@ -391,7 +382,6 @@ defineSuite([
             material : new GridMaterialProperty(),
             depthFailMaterial : new ColorMaterialProperty(Color.BLUE),
             width : 4,
-            followSurface : true,
             clampToGround : false,
             granularity : 0.5
         });
@@ -403,7 +393,6 @@ defineSuite([
             material : new GridMaterialProperty(),
             depthFailMaterial : new GridMaterialProperty(),
             width : 4,
-            followSurface : true,
             clampToGround : false,
             granularity : 0.5
         });
@@ -414,7 +403,6 @@ defineSuite([
             show : true,
             material : new ColorMaterialProperty(Color.RED),
             width : 3,
-            followSurface : false,
             clampToGround : false,
             granularity : 1.0,
             distanceDisplayCondition : new DistanceDisplayCondition(10.0, 100.0)
@@ -429,7 +417,6 @@ defineSuite([
             show : true,
             material : new ColorMaterialProperty(Color.RED),
             width : 3,
-            followSurface : false,
             clampToGround : true,
             granularity : 1.0,
             distanceDisplayCondition : new DistanceDisplayCondition(10.0, 100.0)
@@ -500,9 +487,8 @@ defineSuite([
         polyline.width = width;
         polyline.positions = new ConstantProperty([Cartesian3.fromDegrees(0, 0, 0), Cartesian3.fromDegrees(0, 1, 0)]);
         polyline.material = new ColorMaterialProperty(Color.RED);
-        polyline.followSurface = new ConstantProperty(false);
         polyline.granularity = new ConstantProperty(0.001);
-        polyline.ArcType = new ConstantProperty(ArcType.NONE);
+        polyline.arcType = new ConstantProperty(ArcType.NONE);
 
         var updater = new PolylineGeometryUpdater(entity, scene);
 
@@ -524,7 +510,6 @@ defineSuite([
         expect(primitive.material.uniforms.color).toEqual(Color.RED);
         expect(primitive.positions.length).toEqual(2);
 
-        polyline.followSurface = new ConstantProperty(true);
         polyline.arcType = new ConstantProperty(ArcType.GEODESIC);
         dynamicUpdater.update(time3);
 
@@ -557,7 +542,6 @@ defineSuite([
         polyline.width = new ConstantProperty(1.0);
         polyline.positions = new ConstantProperty([Cartesian3.fromDegrees(0, 0, 0), Cartesian3.fromDegrees(0, 1, 0)]);
         polyline.material = new ColorMaterialProperty(Color.RED);
-        polyline.followSurface = new ConstantProperty(false);
         polyline.granularity = new ConstantProperty(0.001);
         polyline.clampToGround = clampToGround;
 
@@ -604,7 +588,6 @@ defineSuite([
         polyline.width = new ConstantProperty(1.0);
         polyline.positions = new ConstantProperty([Cartesian3.fromDegrees(0, 0, 0), Cartesian3.fromDegrees(0, 1, 0)]);
         polyline.material = new ColorMaterialProperty(Color.RED);
-        polyline.followSurface = new ConstantProperty(true);
         polyline.granularity = new ConstantProperty(0.001);
         polyline.clampToGround = new ConstantProperty(false);
         polyline.arcType = arcType;
@@ -844,28 +827,6 @@ defineSuite([
 
         expect(scene.primitives.length).toBe(0);
         expect(scene.groundPrimitives.length).toBe(0);
-    });
-
-    it('followSurface true with undefined globe does not call generateCartesianArc', function() {
-        if (!Entity.supportsPolylinesOnTerrain(scene)) {
-            return;
-        }
-
-        var entity = createBasicPolyline();
-        entity.polyline.width = createDynamicProperty(1);
-        scene.globe = undefined;
-        var updater = new PolylineGeometryUpdater(entity, scene);
-        var dynamicUpdater = updater.createDynamicUpdater(scene.primitives, scene.groundPrimitives);
-        spyOn(PolylinePipeline, 'generateCartesianArc').and.callThrough();
-        dynamicUpdater.update(time);
-        expect(PolylinePipeline.generateCartesianArc).not.toHaveBeenCalled();
-        dynamicUpdater.destroy();
-        updater.destroy();
-
-        expect(scene.primitives.length).toBe(0);
-        expect(scene.groundPrimitives.length).toBe(0);
-
-        scene.globe = new Globe();
     });
 
     it('arcType GEODESIC with undefined globe does not call generateCartesianArc', function() {

--- a/Specs/DataSources/PolylineGraphicsSpec.js
+++ b/Specs/DataSources/PolylineGraphicsSpec.js
@@ -29,7 +29,6 @@ defineSuite([
             positions : [],
             show : true,
             width : 1,
-            followSurface : false,
             clampToGround : true,
             granularity : 2,
             shadows : ShadowMode.DISABLED,
@@ -45,7 +44,6 @@ defineSuite([
         expect(polyline.positions).toBeInstanceOf(ConstantProperty);
         expect(polyline.show).toBeInstanceOf(ConstantProperty);
         expect(polyline.width).toBeInstanceOf(ConstantProperty);
-        expect(polyline.followSurface).toBeInstanceOf(ConstantProperty);
         expect(polyline.clampToGround).toBeInstanceOf(ConstantProperty);
         expect(polyline.granularity).toBeInstanceOf(ConstantProperty);
         expect(polyline.shadows).toBeInstanceOf(ConstantProperty);
@@ -59,7 +57,6 @@ defineSuite([
         expect(polyline.positions.getValue()).toEqual(options.positions);
         expect(polyline.show.getValue()).toEqual(options.show);
         expect(polyline.width.getValue()).toEqual(options.width);
-        expect(polyline.followSurface.getValue()).toEqual(options.followSurface);
         expect(polyline.clampToGround.getValue()).toEqual(options.clampToGround);
         expect(polyline.granularity.getValue()).toEqual(options.granularity);
         expect(polyline.shadows.getValue()).toEqual(options.shadows);
@@ -76,7 +73,6 @@ defineSuite([
         source.positions = new ConstantProperty();
         source.width = new ConstantProperty();
         source.show = new ConstantProperty();
-        source.followSurface = new ConstantProperty();
         source.clampToGround = new ConstantProperty();
         source.granularity = new ConstantProperty();
         source.shadows = new ConstantProperty(ShadowMode.ENABLED);
@@ -92,7 +88,6 @@ defineSuite([
         expect(target.positions).toBe(source.positions);
         expect(target.width).toBe(source.width);
         expect(target.show).toBe(source.show);
-        expect(target.followSurface).toBe(source.followSurface);
         expect(target.clampToGround).toBe(source.clampToGround);
         expect(target.granularity).toBe(source.granularity);
         expect(target.shadows).toBe(source.shadows);
@@ -109,7 +104,6 @@ defineSuite([
         source.positions = new ConstantProperty();
         source.width = new ConstantProperty();
         source.show = new ConstantProperty();
-        source.followSurface = new ConstantProperty();
         source.clampToGround = new ConstantProperty();
         source.granularity = new ConstantProperty();
         source.shadows = new ConstantProperty();
@@ -123,7 +117,6 @@ defineSuite([
         var positions = new ConstantProperty();
         var width = new ConstantProperty();
         var show = new ConstantProperty();
-        var followSurface = new ConstantProperty();
         var clampToGround = new ConstantProperty();
         var granularity = new ConstantProperty();
         var shadows = new ConstantProperty();
@@ -138,7 +131,6 @@ defineSuite([
         target.positions = positions;
         target.width = width;
         target.show = show;
-        target.followSurface = followSurface;
         target.clampToGround = clampToGround;
         target.granularity = granularity;
         target.shadows = shadows;
@@ -153,7 +145,6 @@ defineSuite([
         expect(target.positions).toBe(positions);
         expect(target.width).toBe(width);
         expect(target.show).toBe(show);
-        expect(target.followSurface).toBe(followSurface);
         expect(target.clampToGround).toBe(clampToGround);
         expect(target.granularity).toBe(granularity);
         expect(target.shadows).toBe(shadows);
@@ -170,7 +161,6 @@ defineSuite([
         source.width = new ConstantProperty();
         source.positions = new ConstantProperty();
         source.show = new ConstantProperty();
-        source.followSurface = new ConstantProperty();
         source.clampToGround = new ConstantProperty();
         source.granularity = new ConstantProperty();
         source.shadows = new ConstantProperty();
@@ -185,7 +175,6 @@ defineSuite([
         expect(result.positions).toBe(source.positions);
         expect(result.width).toBe(source.width);
         expect(result.show).toBe(source.show);
-        expect(result.followSurface).toBe(source.followSurface);
         expect(result.clampToGround).toBe(source.clampToGround);
         expect(result.granularity).toBe(source.granularity);
         expect(result.shadows).toBe(source.shadows);
@@ -209,7 +198,6 @@ defineSuite([
         testDefinitionChanged(property, 'show', true, false);
         testDefinitionChanged(property, 'positions', [], []);
         testDefinitionChanged(property, 'width', 3, 4);
-        testDefinitionChanged(property, 'followSurface', false, true);
         testDefinitionChanged(property, 'clampToGround', false, true);
         testDefinitionChanged(property, 'granularity', 2, 1);
         testDefinitionChanged(property, 'shadows', ShadowMode.ENABLED, ShadowMode.DISABLED);


### PR DESCRIPTION
This removes the deprecation warnings for fetchImage https://github.com/AnalyticalGraphicsInc/cesium/issues/7630 and followSurface https://github.com/AnalyticalGraphicsInc/cesium/issues/7504.

@tfili 