### PR TITLE
Turn off premultiply alpha for ImageBitmap

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -30,6 +30,7 @@ Change Log
 * Fixed an error where many imagery layers within a single tile would cause parts of the tile to render as black on some platforms. [#7649](https://github.com/AnalyticalGraphicsInc/cesium/issues/7649)
 * Fixed a bug that could cause terrain with a single, global root tile (e.g. that uses `WebMercatorTilingScheme`) to be culled unexpectedly in some views. [#7702](https://github.com/AnalyticalGraphicsInc/cesium/issues/7702)
 * Fixed a problem where instanced 3D models were incorrectly lit when using physically based materials. [#7775](https://github.com/AnalyticalGraphicsInc/cesium/issues/7775)
+* Fixed a bug where glTF models with certain blend modes were rendered incorrectly in browsers that support ImageBitmap. [#7795](https://github.com/AnalyticalGraphicsInc/cesium/issues/7795)
 
 ### 1.56.1 - 2019-04-02
 

--- a/Source/Core/Resource.js
+++ b/Source/Core/Resource.js
@@ -404,7 +404,8 @@ define([
         })
             .then(function(blob) {
                 return createImageBitmap(blob, {
-                    imageOrientation: 'flipY'
+                    imageOrientation: 'flipY',
+                    premultiplyAlpha: 'none'
                 });
             })
             .then(function(imageBitmap) {

--- a/Source/Core/Resource.js
+++ b/Source/Core/Resource.js
@@ -916,7 +916,10 @@ define([
                 }
                 generatedBlob = blob;
                 if (useImageBitmap) {
-                    return Resource.createImageBitmapFromBlob(blob, flipY);
+                    return Resource.createImageBitmapFromBlob(blob, {
+                        flipY: flipY,
+                        premultiplyAlpha: false
+                    });
                 }
                 var blobUrl = window.URL.createObjectURL(blob);
                 generatedBlobResource = new Resource({
@@ -1874,7 +1877,10 @@ define([
                     return;
                 }
 
-                return Resource.createImageBitmapFromBlob(blob, flipY);
+                return Resource.createImageBitmapFromBlob(blob, {
+                    flipY: flipY,
+                    premultiplyAlpha: false
+                });
             })
             .then(function(imageBitmap) {
                 if (!defined(imageBitmap)) {
@@ -1891,9 +1897,14 @@ define([
      *
      * @private
      */
-    Resource.createImageBitmapFromBlob = function(blob, flipY) {
+    Resource.createImageBitmapFromBlob = function(blob, options) {
+        Check.defined('options', options);
+        Check.typeOf.bool('options.flipY', options.flipY);
+        Check.typeOf.bool('options.premultiplyAlpha', options.premultiplyAlpha);
+
         return createImageBitmap(blob, {
-            imageOrientation: flipY ? 'flipY' : 'none'
+            imageOrientation: options.flipY ? 'flipY' : 'none',
+            premultiplyAlpha: options.premultiplyAlpha ? 'premultiply' : 'none'
         });
     };
 

--- a/Source/Core/loadImageFromTypedArray.js
+++ b/Source/Core/loadImageFromTypedArray.js
@@ -35,7 +35,10 @@ define([
         return Resource.supportsImageBitmapOptions()
             .then(function(result) {
                 if (result) {
-                    return when(Resource.createImageBitmapFromBlob(blob, flipY));
+                    return when(Resource.createImageBitmapFromBlob(blob, {
+                        flipY: flipY,
+                        premultiplyAlpha: false
+                    }));
                 }
 
                 blobUrl = window.URL.createObjectURL(blob);

--- a/Specs/Core/loadImageFromTypedArraySpec.js
+++ b/Specs/Core/loadImageFromTypedArraySpec.js
@@ -42,7 +42,8 @@ defineSuite([
                 return loadImageFromTypedArray(options)
                     .then(function() {
                         expect(window.createImageBitmap).toHaveBeenCalledWith(blob, {
-                            imageOrientation: 'flipY'
+                            imageOrientation: 'flipY',
+                            premultiplyAlpha: 'none'
                         });
 
                          window.createImageBitmap.calls.reset();
@@ -51,7 +52,8 @@ defineSuite([
                     })
                     .then(function() {
                         expect(window.createImageBitmap).toHaveBeenCalledWith(blob, {
-                            imageOrientation: 'none'
+                            imageOrientation: 'none',
+                            premultiplyAlpha: 'none'
                         });
                     });
             });


### PR DESCRIPTION
### Background

This PR fixes https://github.com/AnalyticalGraphicsInc/cesium/issues/7795 where glTF textures were incorrectly getting set as premultiplied alpha. This happened when we switched to ImageBitmap because just like with flipY, an ImageBitmap ignores the premultiply alpha setting on texture upload. You need to set this on decode, during the Resource.fetch.

The current behavior in `master` is that the ImageBitmap's premultiplyAlpha is set to `default`. This is neither on or off. From the [spec](https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html):

> If val is "default", the alpha premultiplication behavior is implementation-specific, and should be chosen according to implementation deems optimal for drawing images onto the canvas.

There is nowhere in the public API where you can control the premultiplyAlpha setting. It seems to only be set here in Texture.js:

https://github.com/AnalyticalGraphicsInc/cesium/blob/master/Source/Renderer/Texture.js#L184-L186

As far as I can tell, the only time we set `preMultiplAlpha` to true is for opaque textures, for performance reasons. 

### What this PR does

Turn off premultiply alpha by default when creating an ImageBitmap.

### What could go wrong

It might be that certain imagery renders incorrectly without premultiplied alpha. But I doubt this since it's only set to true right now for opaque textures and there's no way to turn this on from the public API.

A better option would be to leave it as `default` for opaque images and only turn it off for places we know we want it off (like glTF/3d models) but this will introduce another public API option that only applies if the browser supports ImageBitmap. And at that point I'm starting to rethink if it would have been better to create a separate `Resource.fetchImageBitmap` and have the caller figure out which one they want to call, as opposed to making `Resource.fetchImage` make all this work behind the scenes.