### PR TITLE
Fix intermittent debugColorizeTiles test failures

### DIFF
--- a/Specs/Cesium3DTilesTester.js
+++ b/Specs/Cesium3DTilesTester.js
@@ -3,6 +3,7 @@ define([
         'Core/Color',
         'Core/defaultValue',
         'Core/defined',
+        'Core/JulianDate',
         'Core/Resource',
         'Scene/Cesium3DTileContentFactory',
         'Scene/Cesium3DTileset',
@@ -13,6 +14,7 @@ define([
         Color,
         defaultValue,
         defined,
+        JulianDate,
         Resource,
         Cesium3DTileContentFactory,
         Cesium3DTileset,
@@ -46,11 +48,17 @@ define([
         return string + whitespace;
     }
 
+    var time = new JulianDate(2457522.0);
+
     Cesium3DTilesTester.expectRender = function(scene, tileset, callback) {
+        var renderOptions = {
+            scene : scene,
+            time : time
+        };
         tileset.show = false;
-        expect(scene).toRender([0, 0, 0, 255]);
+        expect(renderOptions).toRender([0, 0, 0, 255]);
         tileset.show = true;
-        expect(scene).toRenderAndCall(function(rgba) {
+        expect(renderOptions).toRenderAndCall(function(rgba) {
             expect(rgba).not.toEqual([0, 0, 0, 255]);
             if (defined(callback)) {
                 callback(rgba);
@@ -59,10 +67,14 @@ define([
     };
 
     Cesium3DTilesTester.expectRenderBlank = function(scene, tileset) {
+        var renderOptions = {
+            scene : scene,
+            time : time
+        };
         tileset.show = false;
-        expect(scene).toRender([0, 0, 0, 255]);
+        expect(renderOptions).toRender([0, 0, 0, 255]);
         tileset.show = true;
-        expect(scene).toRender([0, 0, 0, 255]);
+        expect(renderOptions).toRender([0, 0, 0, 255]);
     };
 
     Cesium3DTilesTester.expectRenderTileset = function(scene, tileset) {


### PR DESCRIPTION
Some 3D Tiles tests would fail based on the time of day because of sun direction and how that interacts with shading. The tests that were failing were related to debug colorize tiles where debug color was the same as the non-debug color (pure white), probably due to a specular highlight or something that blows out the color. The fix is to force a certain time of day when rendering 3D Tiles in the tests.

@tfili 