### PR TITLE
Test code cleanup.  

### DIFF
--- a/Specs/Core/CesiumTerrainProviderSpec.js
+++ b/Specs/Core/CesiumTerrainProviderSpec.js
@@ -194,8 +194,7 @@ defineSuite([
         return pollToPromise(function() {
             return provider.ready;
         }).then(function() {
-            var tilingScheme = provider.tilingScheme;
-            expect(tilingScheme instanceof GeographicTilingScheme).toBe(true);
+            expect(provider.tilingScheme).toBeInstanceOf(GeographicTilingScheme);
         });
     });
 

--- a/Specs/Core/ColorSpec.js
+++ b/Specs/Core/ColorSpec.js
@@ -103,17 +103,17 @@ defineSuite([
 
     it('clone with no parameters returns a new identical copy.', function() {
         var v = new Color(0.1, 0.2, 0.3, 0.4);
-        var v2 = v.clone();
-        expect(v).toEqual(v2);
-        expect(v === v2).toEqual(false);
+        var clone = v.clone();
+        expect(clone).toEqual(v);
+        expect(clone).not.toBe(v);
     });
 
     it('clone with a parameter modifies the parameter.', function() {
         var v = new Color(0.1, 0.2, 0.3, 0.4);
         var v2 = new Color();
-        var v3 = v.clone(v2);
-        expect(v).toEqual(v2);
-        expect(v3 === v2).toEqual(true);
+        var clone = v.clone(v2);
+        expect(clone).toEqual(v2);
+        expect(clone).toBe(v2);
     });
 
     it('equals works', function() {

--- a/Specs/Core/EllipsoidSpec.js
+++ b/Specs/Core/EllipsoidSpec.js
@@ -411,7 +411,7 @@ defineSuite([
         };
 
         var cloned = Ellipsoid.clone(myEllipsoid);
-        expect(cloned instanceof Ellipsoid).toBe(true);
+        expect(cloned).toBeInstanceOf(Ellipsoid);
         expect(cloned).toEqual(myEllipsoid);
     });
 
@@ -460,7 +460,7 @@ defineSuite([
         var cartographic  = Cartographic.fromDegrees(35.23,33.23);
         var cartesianOnTheSurface = ellipsoid.cartographicToCartesian(cartographic);
         var returnedResult = ellipsoid.getSurfaceNormalIntersectionWithZAxis(cartesianOnTheSurface);
-        expect(returnedResult instanceof Cartesian3).toBe(true);
+        expect(returnedResult).toBeInstanceOf(Cartesian3);
     });
 
     it('getSurfaceNormalIntersectionWithZAxis works with a result parameter', function() {

--- a/Specs/Core/GoogleEarthEnterpriseTerrainProviderSpec.js
+++ b/Specs/Core/GoogleEarthEnterpriseTerrainProviderSpec.js
@@ -141,8 +141,7 @@ defineSuite([
         return pollToPromise(function() {
             return terrainProvider.ready;
         }).then(function() {
-            var tilingScheme = terrainProvider.tilingScheme;
-            expect(tilingScheme instanceof GeographicTilingScheme).toBe(true);
+            expect(terrainProvider.tilingScheme).toBeInstanceOf(GeographicTilingScheme);
         });
     });
 

--- a/Specs/Core/GroundPolylineGeometrySpec.js
+++ b/Specs/Core/GroundPolylineGeometrySpec.js
@@ -112,16 +112,16 @@ defineSuite([
 
         // Expect rightNormalAndTextureCoordinateNormalizationY and texcoordNormalization2D.y to encode if the vertex is on the bottom
         values = rightNormalAndTextureCoordinateNormalizationY.values;
-        expect(values[3] > 1.0).toBe(true);
-        expect(values[1 * 4 + 3] > 1.0).toBe(true);
-        expect(values[4 * 4 + 3] > 1.0).toBe(true);
-        expect(values[5 * 4 + 3] > 1.0).toBe(true);
+        expect(values[3]).toBeGreaterThan(1.0);
+        expect(values[1 * 4 + 3]).toBeGreaterThan(1.0);
+        expect(values[4 * 4 + 3]).toBeGreaterThan(1.0);
+        expect(values[5 * 4 + 3]).toBeGreaterThan(1.0);
 
         values = texcoordNormalization2D.values;
-        expect(values[1] > 1.0).toBe(true);
-        expect(values[1 * 2 + 1] > 1.0).toBe(true);
-        expect(values[4 * 2 + 1] > 1.0).toBe(true);
-        expect(values[5 * 2 + 1] > 1.0).toBe(true);
+        expect(values[1]).toBeGreaterThan(1.0);
+        expect(values[1 * 2 + 1]).toBeGreaterThan(1.0);
+        expect(values[4 * 2 + 1]).toBeGreaterThan(1.0);
+        expect(values[5 * 2 + 1]).toBeGreaterThan(1.0);
 
         // Line segment geometry is encoded as:
         // - start position
@@ -635,8 +635,8 @@ defineSuite([
         var boundingSphere = geometry.boundingSphere;
         var pointsDistance = Cartesian3.distance(positions[0], positions[1]);
 
-        expect(boundingSphere.radius > pointsDistance).toBe(true);
-        expect(boundingSphere.radius > 1000.0).toBe(true); // starting top/bottom height
+        expect(boundingSphere.radius).toBeGreaterThan(pointsDistance);
+        expect(boundingSphere.radius).toBeGreaterThan(1000.0); // starting top/bottom height
     });
 
     var packedInstance = [positions.length];

--- a/Specs/Core/HeapSpec.js
+++ b/Specs/Core/HeapSpec.js
@@ -68,7 +68,7 @@ defineSuite([
             pass = pass && checkHeap(heap, comparator);
         }
         expect(pass).toBe(true);
-        expect(heap.length <= heap.maximumLength).toBe(true);
+        expect(heap.length).toBeLessThanOrEqualTo(heap.maximumLength);
         // allowed one extra slot for swapping
         expect(heap.internalArray.length).toBeLessThanOrEqualTo(heap.maximumLength + 1);
     });

--- a/Specs/Core/ResourceSpec.js
+++ b/Specs/Core/ResourceSpec.js
@@ -1228,7 +1228,7 @@ defineSuite([
             }).then(function(loadedImage) {
                 expect(loadedImage.width).toEqual(1);
                 expect(loadedImage.height).toEqual(1);
-                expect(loadedImage instanceof ImageBitmap);
+                expect(loadedImage).toBeInstanceOf(ImageBitmap);
             });
         });
 
@@ -1745,7 +1745,7 @@ defineSuite([
                     }).then(function() {
                         fail('expected promise to reject');
                     }).otherwise(function(err) {
-                        expect(err instanceof RequestErrorEvent).toBe(true);
+                        expect(err).toBeInstanceOf(RequestErrorEvent);
                     });
                 });
 
@@ -1757,7 +1757,7 @@ defineSuite([
                         fail('expected promise to reject');
                     }).otherwise(function(err) {
                         expect(err).toBeDefined();
-                        expect(err instanceof Error).toBe(true);
+                        expect(err).toBeInstanceOf(Error);
                     });
                 });
             });
@@ -1844,7 +1844,7 @@ defineSuite([
 
                     fakeXHR.simulateError();
                     expect(resolvedValue).toBeUndefined();
-                    expect(rejectedError instanceof RequestErrorEvent).toBe(true);
+                    expect(rejectedError).toBeInstanceOf(RequestErrorEvent);
                 });
 
                 it('results in an HTTP status code less than 200', function() {
@@ -1867,7 +1867,7 @@ defineSuite([
 
                     fakeXHR.simulateHttpResponse(199);
                     expect(resolvedValue).toBeUndefined();
-                    expect(rejectedError instanceof RequestErrorEvent).toBe(true);
+                    expect(rejectedError).toBeInstanceOf(RequestErrorEvent);
                 });
 
                 it('resolves undefined for status code 204', function() {
@@ -2040,7 +2040,7 @@ defineSuite([
 
                     fakeXHR.simulateError(); // This fails because we only retry once
                     expect(resolvedValue).toBeUndefined();
-                    expect(rejectedError instanceof RequestErrorEvent).toBe(true);
+                    expect(rejectedError).toBeInstanceOf(RequestErrorEvent);
                 });
 
                 it('rejects after callback returns false', function() {
@@ -2069,7 +2069,7 @@ defineSuite([
 
                     fakeXHR.simulateError(); // This fails because the callback returns false
                     expect(resolvedValue).toBeUndefined();
-                    expect(rejectedError instanceof RequestErrorEvent).toBe(true);
+                    expect(rejectedError).toBeInstanceOf(RequestErrorEvent);
 
                     expect(cb.calls.count()).toEqual(1);
                     var receivedResource = cb.calls.argsFor(0)[0];

--- a/Specs/Core/SphericalSpec.js
+++ b/Specs/Core/SphericalSpec.js
@@ -50,22 +50,23 @@ defineSuite([
 
     it('Cloning with no result parameter returns a new instance.', function() {
         var v = new Spherical(1, 2, 3);
-        var w = v.clone();
-        expect(v === w).toEqual(false);
-        expect(v).toEqual(w);
+        var clone = v.clone();
+        expect(clone).not.toBe(v);
+        expect(clone).toBeInstanceOf(Spherical);
+        expect(clone).toEqual(v);
     });
 
     it('Cloning with result modifies existing instance and returns it.', function() {
         var v = new Spherical(1, 2, 3);
         var w = new NotSpherical();
         expect(NotSpherical.areEqual(v, w)).toEqual(false);
-        var q = v.clone(w);
-        expect(v === w).toEqual(false);
-        expect(q === w).toEqual(true);
+        var clone = v.clone(w);
+        expect(clone).not.toBe(v);
+        expect(clone).toBe(w);
         expect(NotSpherical.areEqual(v, w)).toEqual(true);
     });
 
-    it('Normalizing with no result parameter creates new instance and sets magntitude to 1.0', function() {
+    it('Normalizing with no result parameter creates new instance and sets magnitude to 1.0', function() {
         var v = new Spherical(0, 2, 3);
         var w = Spherical.normalize(v);
         expect(w).not.toEqual(v);
@@ -74,24 +75,24 @@ defineSuite([
         expect(w.magnitude).toEqual(1);
     });
 
-    it('Normalizing with result parameter modifies instance and sets magntitude to 1.0', function() {
+    it('Normalizing with result parameter modifies instance and sets magnitude to 1.0', function() {
         var v = new Spherical(0, 2, 3);
         var w = new NotSpherical();
         var q = Spherical.normalize(v, w);
-        expect(w).not.toEqual(v);
-        expect(w === q).toEqual(true);
-        expect(w.clock).toEqual(0);
-        expect(w.cone).toEqual(2);
-        expect(w.magnitude).toEqual(1);
+        expect(q).not.toEqual(v);
+        expect(q).toBe(w);
+        expect(q.clock).toEqual(0);
+        expect(q.cone).toEqual(2);
+        expect(q.magnitude).toEqual(1);
     });
 
-    it('Normalizing with this as result parameter modifies instance and sets magntitude to 1.0', function() {
+    it('Normalizing with this as result parameter modifies instance and sets magnitude to 1.0', function() {
         var v = new Spherical(0, 2, 3);
         var q = Spherical.normalize(v, v);
-        expect(v === q).toEqual(true);
-        expect(v.clock).toEqual(0);
-        expect(v.cone).toEqual(2);
-        expect(v.magnitude).toEqual(1);
+        expect(q).toBe(v);
+        expect(q.clock).toEqual(0);
+        expect(q.cone).toEqual(2);
+        expect(q.magnitude).toEqual(1);
     });
 
     it('equalsEpsilon returns true for expected values.', function() {

--- a/Specs/Core/VRTheWorldTerrainProviderSpec.js
+++ b/Specs/Core/VRTheWorldTerrainProviderSpec.js
@@ -256,10 +256,10 @@ defineSuite([
             return pollToPromise(function() {
                 return terrainProvider.ready;
             }).then(function() {
-                expect(terrainProvider.tilingScheme instanceof GeographicTilingScheme).toBe(true);
-                return terrainProvider.requestTileGeometry(0, 0, 0).then(function(loadedData) {
-                    expect(loadedData).toBeInstanceOf(HeightmapTerrainData);
-                });
+                expect(terrainProvider.tilingScheme).toBeInstanceOf(GeographicTilingScheme);
+                return terrainProvider.requestTileGeometry(0, 0, 0);
+            }).then(function(loadedData) {
+                expect(loadedData).toBeInstanceOf(HeightmapTerrainData);
             });
         });
 

--- a/Specs/Core/VertexFormatSpec.js
+++ b/Specs/Core/VertexFormatSpec.js
@@ -12,7 +12,7 @@ defineSuite([
             normal : true
         });
         var cloned = VertexFormat.clone(vertexFormat);
-        expect(cloned instanceof VertexFormat).toBe(true);
+        expect(cloned).toBeInstanceOf(VertexFormat);
         expect(cloned).toEqual(vertexFormat);
     });
 

--- a/Specs/Core/loadCRNSpec.js
+++ b/Specs/Core/loadCRNSpec.js
@@ -93,7 +93,7 @@ defineSuite([
 
         fakeXHR.simulateError();
         expect(resolvedValue).toBeUndefined();
-        expect(rejectedError instanceof RequestErrorEvent).toBe(true);
+        expect(rejectedError).toBeInstanceOf(RequestErrorEvent);
         expect(rejectedError.statusCode).toBeUndefined();
         expect(rejectedError.response).toBeUndefined();
     });
@@ -118,7 +118,7 @@ defineSuite([
         var error = 'some error';
         fakeXHR.simulateHttpResponse(404, error);
         expect(resolvedValue).toBeUndefined();
-        expect(rejectedError instanceof RequestErrorEvent).toBe(true);
+        expect(rejectedError).toBeInstanceOf(RequestErrorEvent);
         expect(rejectedError.statusCode).toEqual(404);
         expect(rejectedError.response).toEqual(error);
     });

--- a/Specs/Core/loadKTXSpec.js
+++ b/Specs/Core/loadKTXSpec.js
@@ -79,7 +79,7 @@ defineSuite([
 
         fakeXHR.simulateError();
         expect(resolvedValue).toBeUndefined();
-        expect(rejectedError instanceof RequestErrorEvent).toBe(true);
+        expect(rejectedError).toBeInstanceOf(RequestErrorEvent);
         expect(rejectedError.statusCode).toBeUndefined();
         expect(rejectedError.response).toBeUndefined();
     });
@@ -104,7 +104,7 @@ defineSuite([
         var error = 'some error';
         fakeXHR.simulateHttpResponse(404, error);
         expect(resolvedValue).toBeUndefined();
-        expect(rejectedError instanceof RequestErrorEvent).toBe(true);
+        expect(rejectedError).toBeInstanceOf(RequestErrorEvent);
         expect(rejectedError.statusCode).toEqual(404);
         expect(rejectedError.response).toEqual(error);
     });
@@ -259,7 +259,7 @@ defineSuite([
         });
 
         expect(resolvedValue).toBeUndefined();
-        expect(rejectedError instanceof RuntimeError).toEqual(true);
+        expect(rejectedError).toBeInstanceOf(RuntimeError);
         expect(rejectedError.message).toEqual('Invalid KTX file.');
     });
 
@@ -279,7 +279,7 @@ defineSuite([
         });
 
         expect(resolvedValue).toBeUndefined();
-        expect(rejectedError instanceof RuntimeError).toEqual(true);
+        expect(rejectedError).toBeInstanceOf(RuntimeError);
         expect(rejectedError.message).toEqual('File is the wrong endianness.');
     });
 
@@ -299,7 +299,7 @@ defineSuite([
         });
 
         expect(resolvedValue).toBeUndefined();
-        expect(rejectedError instanceof RuntimeError).toEqual(true);
+        expect(rejectedError).toBeInstanceOf(RuntimeError);
         expect(rejectedError.message).toEqual('glInternalFormat is not a valid format.');
     });
 
@@ -319,7 +319,7 @@ defineSuite([
         });
 
         expect(resolvedValue).toBeUndefined();
-        expect(rejectedError instanceof RuntimeError).toEqual(true);
+        expect(rejectedError).toBeInstanceOf(RuntimeError);
         expect(rejectedError.message).toEqual('glType must be zero when the texture is compressed.');
     });
 
@@ -339,7 +339,7 @@ defineSuite([
         });
 
         expect(resolvedValue).toBeUndefined();
-        expect(rejectedError instanceof RuntimeError).toEqual(true);
+        expect(rejectedError).toBeInstanceOf(RuntimeError);
         expect(rejectedError.message).toEqual('The type size for compressed textures must be 1.');
     });
 
@@ -359,7 +359,7 @@ defineSuite([
         });
 
         expect(resolvedValue).toBeUndefined();
-        expect(rejectedError instanceof RuntimeError).toEqual(true);
+        expect(rejectedError).toBeInstanceOf(RuntimeError);
         expect(rejectedError.message).toEqual('The base internal format must be the same as the format for uncompressed textures.');
     });
 
@@ -379,7 +379,7 @@ defineSuite([
         });
 
         expect(resolvedValue).toBeUndefined();
-        expect(rejectedError instanceof RuntimeError).toEqual(true);
+        expect(rejectedError).toBeInstanceOf(RuntimeError);
         expect(rejectedError.message).toEqual('3D textures are unsupported.');
     });
 
@@ -399,7 +399,7 @@ defineSuite([
         });
 
         expect(resolvedValue).toBeUndefined();
-        expect(rejectedError instanceof RuntimeError).toEqual(true);
+        expect(rejectedError).toBeInstanceOf(RuntimeError);
         expect(rejectedError.message).toEqual('Texture arrays are unsupported.');
     });
 

--- a/Specs/DataSources/CzmlDataSourceSpec.js
+++ b/Specs/DataSources/CzmlDataSourceSpec.js
@@ -287,11 +287,11 @@ defineSuite([
     it('process loads data on top of existing', function() {
         var dataSource = new CzmlDataSource();
         return dataSource.process(simple).then(function(dataSource) {
-            expect(dataSource.entities.values.length === 10);
+            expect(dataSource.entities.values.length).toEqual(10);
 
             return dataSource.process(vehicle, vehicleUrl);
         }).then(function(dataSource) {
-            expect(dataSource.entities.values.length === 11);
+            expect(dataSource.entities.values.length).toEqual(11);
         });
     });
 
@@ -3287,7 +3287,7 @@ defineSuite([
             var targetEntity = dataSource.entities.getById('targetId');
             var referenceObject = dataSource.entities.getById('referenceId');
 
-            expect(referenceObject.point.pixelSize instanceof ReferenceProperty).toBe(true);
+            expect(referenceObject.point.pixelSize).toBeInstanceOf(ReferenceProperty);
             expect(targetEntity.point.pixelSize.getValue(time)).toEqual(referenceObject.point.pixelSize.getValue(time));
         });
     });
@@ -3356,7 +3356,7 @@ defineSuite([
             var targetEntity = dataSource.entities.getById('targetId');
             var referenceObject = dataSource.entities.getById('referenceId');
 
-            expect(referenceObject.position instanceof ReferenceProperty).toBe(true);
+            expect(referenceObject.position).toBeInstanceOf(ReferenceProperty);
             expect(targetEntity.position.getValue(time)).toEqual(referenceObject.position.getValue(time));
         });
     });
@@ -3424,7 +3424,7 @@ defineSuite([
             var targetEntity = dataSource.entities.getById('targetId');
             var referenceObject = dataSource.entities.getById('referenceId');
 
-            expect(referenceObject.point.pixelSize instanceof ReferenceProperty).toBe(true);
+            expect(referenceObject.point.pixelSize).toBeInstanceOf(ReferenceProperty);
             expect(targetEntity.point.pixelSize.getValue(time)).toEqual(referenceObject.point.pixelSize.getValue(time));
         });
     });
@@ -3444,7 +3444,7 @@ defineSuite([
         var dataSource = new CzmlDataSource();
         return dataSource.load(makePacket(packet)).then(function(dataSource) {
             var targetEntity = dataSource.entities.getById('testObject');
-            expect(targetEntity.point.outlineWidth instanceof ReferenceProperty).toBe(true);
+            expect(targetEntity.point.outlineWidth).toBeInstanceOf(ReferenceProperty);
             expect(targetEntity.point.outlineWidth.getValue(time)).toEqual(targetEntity.point.pixelSize.getValue(time));
         });
     });

--- a/Specs/DataSources/PointVisualizerSpec.js
+++ b/Specs/DataSources/PointVisualizerSpec.js
@@ -175,7 +175,7 @@ defineSuite([
         visualizer.update(time);
 
         var pointPrimitiveCollection = entityCluster._pointCollection;
-        expect(pointPrimitiveCollection instanceof PointPrimitiveCollection).toBe(true);
+        expect(pointPrimitiveCollection).toBeInstanceOf(PointPrimitiveCollection);
         expect(pointPrimitiveCollection.length).toEqual(1);
         var pointPrimitive = pointPrimitiveCollection.get(0);
 
@@ -237,7 +237,7 @@ defineSuite([
         visualizer.update(time);
 
         var billboardCollection = entityCluster._billboardCollection;
-        expect(billboardCollection instanceof BillboardCollection).toBe(true);
+        expect(billboardCollection).toBeInstanceOf(BillboardCollection);
         expect(billboardCollection.length).toEqual(1);
         var billboard = billboardCollection.get(0);
 

--- a/Specs/DataSources/PolylineGeometryUpdaterSpec.js
+++ b/Specs/DataSources/PolylineGeometryUpdaterSpec.js
@@ -866,7 +866,7 @@ defineSuite([
         expect(updater.clampToGround).toBe(false);
 
         var instance = updater.createFillGeometryInstance(time);
-        expect(instance.geometry instanceof GroundPolylineGeometry).toBe(false);
+        expect(instance.geometry).not.toBeInstanceOf(GroundPolylineGeometry);
 
         updater.destroy();
     });

--- a/Specs/Renderer/ContextSpec.js
+++ b/Specs/Renderer/ContextSpec.js
@@ -176,8 +176,8 @@ defineSuite([
     });
 
     it('gets maximum texture filter anisotropy', function() {
-        if(context.textureFilterAnisotropic) {
-            expect(ContextLimits.maximumTextureFilterAnisotropy >= 2).toEqual(true);
+        if (context.textureFilterAnisotropic) {
+            expect(ContextLimits.maximumTextureFilterAnisotropy).toBeGreaterThanOrEqualTo(2);
         } else {
             expect(ContextLimits.maximumTextureFilterAnisotropy).toEqual(1);
         }

--- a/Specs/Scene/ArcGisMapServerImageryProviderSpec.js
+++ b/Specs/Scene/ArcGisMapServerImageryProviderSpec.js
@@ -737,10 +737,10 @@ defineSuite([
         return pollToPromise(function() {
             return provider.ready;
         }).then(function() {
-            expect(provider.rectangle.west >= -Math.PI).toBe(true);
-            expect(provider.rectangle.east <= Math.PI).toBe(true);
-            expect(provider.rectangle.south >= -WebMercatorProjection.MaximumLatitude).toBe(true);
-            expect(provider.rectangle.north <= WebMercatorProjection.MaximumLatitude).toBe(true);
+            expect(provider.rectangle.west).toBeGreaterThanOrEqualTo(-Math.PI);
+            expect(provider.rectangle.east).toBeLessThanOrEqualTo(Math.PI);
+            expect(provider.rectangle.south).toBeGreaterThanOrEqualTo(-WebMercatorProjection.MaximumLatitude);
+            expect(provider.rectangle.north).toBeLessThanOrEqualTo(WebMercatorProjection.MaximumLatitude);
         });
     });
 

--- a/Specs/Scene/CameraSpec.js
+++ b/Specs/Scene/CameraSpec.js
@@ -3024,11 +3024,11 @@ defineSuite([
     });
 
     it('switches projections', function() {
-        expect(camera.frustum instanceof PerspectiveFrustum).toEqual(true);
+        expect(camera.frustum).toBeInstanceOf(PerspectiveFrustum);
         camera.switchToOrthographicFrustum();
-        expect(camera.frustum instanceof OrthographicFrustum).toEqual(true);
+        expect(camera.frustum).toBeInstanceOf(OrthographicFrustum);
         camera.switchToPerspectiveFrustum();
-        expect(camera.frustum instanceof PerspectiveFrustum).toEqual(true);
+        expect(camera.frustum).toBeInstanceOf(PerspectiveFrustum);
     });
 
     it('does not switch projection in 2D', function() {
@@ -3048,11 +3048,11 @@ defineSuite([
         frustum.far = 60.0 * maxRadii;
         camera.frustum = frustum;
 
-        expect(camera.frustum instanceof OrthographicOffCenterFrustum).toEqual(true);
+        expect(camera.frustum).toBeInstanceOf(OrthographicOffCenterFrustum);
         camera.switchToOrthographicFrustum();
-        expect(camera.frustum instanceof OrthographicOffCenterFrustum).toEqual(true);
+        expect(camera.frustum).toBeInstanceOf(OrthographicOffCenterFrustum);
         camera.switchToPerspectiveFrustum();
-        expect(camera.frustum instanceof OrthographicOffCenterFrustum).toEqual(true);
+        expect(camera.frustum).toBeInstanceOf(OrthographicOffCenterFrustum);
     });
 
     it('normalizes WC members', function() {

--- a/Specs/Scene/Cesium3DTilesetSpec.js
+++ b/Specs/Scene/Cesium3DTilesetSpec.js
@@ -2748,7 +2748,7 @@ defineSuite([
 
             scene.renderForSpecs();
             var commandList = scene.frameState.commandList;
-            expect(commandList[0] instanceof ClearCommand).toBe(true);
+            expect(commandList[0]).toBeInstanceOf(ClearCommand);
             expect(commandList[0].stencil).toBe(0);
         });
     });
@@ -2824,7 +2824,7 @@ defineSuite([
             var length = commandList.length;
             for (var i = 0; i < length; ++i) {
                 var command = commandList[i];
-                expect(command instanceof ClearCommand).toBe(false);
+                expect(command).not.toBeInstanceOf(ClearCommand);
                 expect(command.renderState.cull.face).not.toBe(CullFace.FRONT);
             }
         });
@@ -3615,7 +3615,7 @@ defineSuite([
             }
 
             expect(allSorted).toBe(true);
-            expect(lastPriority !== requestedTilesInFlight[0]._priority).toBe(true); // Not all the same value
+            expect(lastPriority).not.toEqual(requestedTilesInFlight[0]._priority); // Not all the same value
         });
     });
 

--- a/Specs/Scene/GroundPolylinePrimitiveSpec.js
+++ b/Specs/Scene/GroundPolylinePrimitiveSpec.js
@@ -158,7 +158,7 @@ defineSuite([
     it('default constructs', function() {
         groundPolylinePrimitive = new GroundPolylinePrimitive();
         expect(groundPolylinePrimitive.geometryInstances).not.toBeDefined();
-        expect(groundPolylinePrimitive.appearance instanceof PolylineMaterialAppearance).toBe(true);
+        expect(groundPolylinePrimitive.appearance).toBeInstanceOf(PolylineMaterialAppearance);
         expect(groundPolylinePrimitive.show).toEqual(true);
         expect(groundPolylinePrimitive.interleave).toEqual(false);
         expect(groundPolylinePrimitive.releaseGeometryInstances).toEqual(true);

--- a/Specs/Widgets/ProjectionPicker/ProjectionPickerViewModelSpec.js
+++ b/Specs/Widgets/ProjectionPicker/ProjectionPickerViewModelSpec.js
@@ -64,15 +64,15 @@ defineSuite([
 
         expect(scene.mode).toEqual(SceneMode.SCENE3D);
         expect(viewModel.isOrthographicProjection).toEqual(false);
-        expect(scene.camera.frustum instanceof PerspectiveFrustum).toEqual(true);
+        expect(scene.camera.frustum).toBeInstanceOf(PerspectiveFrustum);
 
         viewModel.switchToOrthographic();
         expect(viewModel.isOrthographicProjection).toEqual(true);
-        expect(scene.camera.frustum instanceof OrthographicFrustum).toEqual(true);
+        expect(scene.camera.frustum).toBeInstanceOf(OrthographicFrustum);
 
         viewModel.switchToPerspective();
         expect(viewModel.isOrthographicProjection).toEqual(false);
-        expect(scene.camera.frustum instanceof PerspectiveFrustum).toEqual(true);
+        expect(scene.camera.frustum).toBeInstanceOf(PerspectiveFrustum);
 
         viewModel.destroy();
     });

--- a/Specs/addDefaultMatchers.js
+++ b/Specs/addDefaultMatchers.js
@@ -222,7 +222,22 @@ define([
             toBeInstanceOf : function(util, customEqualityTesters) {
                 return {
                     compare : function(actual, expectedConstructor) {
-                        return { pass : actual instanceof expectedConstructor };
+                        var result = {};
+                        if (expectedConstructor === String) {
+                            result.pass = typeof actual === 'string' || actual instanceof String;
+                        } else if (expectedConstructor === Number) {
+                            result.pass = typeof actual === 'number' || actual instanceof Number;
+                        } else if (expectedConstructor === Function) {
+                            result.pass = typeof actual === 'function' || actual instanceof Function;
+                        } else if (expectedConstructor === Object) {
+                            result.pass = actual !== null && typeof actual === 'object';
+                        } else if (expectedConstructor === Boolean) {
+                            result.pass = typeof actual === 'boolean';
+                        } else {
+                            result.pass = actual instanceof expectedConstructor;
+                        }
+                        result.message = 'Expected ' + Object.prototype.toString.call(actual) + ' to be instance of ' + expectedConstructor.name + ', but was instance of ' + (actual && actual.constructor.name);
+                        return result;
                     }
                 };
             },


### PR DESCRIPTION
Use toBeInstanceOf and other matchers instead of matching a boolean, for better failure messages.