### PR TITLE
Turn off log depth for large globe tiles

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,9 @@ Change Log
 ##### Additions :tada:
 * Added support for new `BingMapsStyle` values `ROAD_ON_DEMAND` and `AERIAL_WITH_LABELS_ON_DEMAND`. The older versions of these, `ROAD` and `AERIAL_WITH_LABELS`, have been deprecated by Bing. [#7808](https://github.com/AnalyticalGraphicsInc/cesium/pull/7808)
 
+##### Fixes :wrench:
+* Fixed an issue where globe tiles were incorrectly clipped, which led to the atmosphere being visible through the Earth when the ground first loads. #[7822](https://github.com/AnalyticalGraphicsInc/cesium/pull/7822)
+
 ### 1.57 - 2019-05-01
 
 ##### Additions :tada:

--- a/Source/Scene/GlobeSurfaceShaderSet.js
+++ b/Source/Scene/GlobeSurfaceShaderSet.js
@@ -92,6 +92,7 @@ define([
         var colorCorrect = options.colorCorrect;
         var highlightFillTile = options.highlightFillTile;
         var colorToAlpha = options.colorToAlpha;
+        var isReadyForAtmosphere = options.isReadyForAtmosphere;
 
         var quantization = 0;
         var quantizationDefine = '';
@@ -106,7 +107,7 @@ define([
 
         var vertexLogDepth = 0;
         var vertexLogDepthDefine = '';
-        if (!defined(surfaceTile.vertexArray) || !defined(surfaceTile.terrainData) || surfaceTile.terrainData._createdByUpsampling) {
+        if (!defined(surfaceTile.vertexArray) || !defined(surfaceTile.terrainData) || surfaceTile.terrainData._createdByUpsampling || !isReadyForAtmosphere) {
             vertexLogDepth = 1;
             vertexLogDepthDefine = 'DISABLE_GL_POSITION_LOG_DEPTH';
         }

--- a/Source/Scene/GlobeSurfaceShaderSet.js
+++ b/Source/Scene/GlobeSurfaceShaderSet.js
@@ -109,7 +109,7 @@ define([
         var vertexLogDepthDefine = '';
         if (!defined(surfaceTile.vertexArray) || !defined(surfaceTile.terrainData) || surfaceTile.terrainData._createdByUpsampling || disableLogarithmicDepth === true) {
             vertexLogDepth = 1;
-            vertexLogDepthDefine = 'DISABLE_GL_POSITION_LOG_DEPTH';
+            vertexLogDepthDefine = 'ENABLE_GL_POSITION_LOG_DEPTH_AT_HEIGHT';
         }
 
         var cartographicLimitRectangleFlag = 0;

--- a/Source/Scene/GlobeSurfaceShaderSet.js
+++ b/Source/Scene/GlobeSurfaceShaderSet.js
@@ -92,7 +92,7 @@ define([
         var colorCorrect = options.colorCorrect;
         var highlightFillTile = options.highlightFillTile;
         var colorToAlpha = options.colorToAlpha;
-        var isReadyForAtmosphere = options.isReadyForAtmosphere;
+        var disableLogarithmicDepth = options.disableLogarithmicDepth;
 
         var quantization = 0;
         var quantizationDefine = '';
@@ -107,7 +107,7 @@ define([
 
         var vertexLogDepth = 0;
         var vertexLogDepthDefine = '';
-        if (!defined(surfaceTile.vertexArray) || !defined(surfaceTile.terrainData) || surfaceTile.terrainData._createdByUpsampling || !isReadyForAtmosphere) {
+        if (!defined(surfaceTile.vertexArray) || !defined(surfaceTile.terrainData) || surfaceTile.terrainData._createdByUpsampling || disableLogarithmicDepth === true) {
             vertexLogDepth = 1;
             vertexLogDepthDefine = 'DISABLE_GL_POSITION_LOG_DEPTH';
         }

--- a/Source/Scene/GlobeSurfaceTileProvider.js
+++ b/Source/Scene/GlobeSurfaceTileProvider.js
@@ -1943,6 +1943,7 @@ define([
             surfaceShaderSetOptions.colorCorrect = colorCorrect;
             surfaceShaderSetOptions.highlightFillTile = highlightFillTile;
             surfaceShaderSetOptions.colorToAlpha = applyColorToAlpha;
+            surfaceShaderSetOptions.isReadyForAtmosphere = frameState.isReadyForAtmosphere;
 
             command.shaderProgram = tileProvider._surfaceShaderSet.getShaderProgram(surfaceShaderSetOptions);
             command.castShadows = castShadows;

--- a/Source/Scene/GlobeSurfaceTileProvider.js
+++ b/Source/Scene/GlobeSurfaceTileProvider.js
@@ -156,6 +156,14 @@ define([
         this.saturationShift = 0.0;
         this.brightnessShift = 0.0;
 
+        /**
+         * Determines whether logarithmic depth should be used in this frame.
+         * @type {Boolean}
+         * @default undefined
+         * @private
+         */
+        this.disableLogarithmicDepth = undefined;
+
         this._quadtree = undefined;
         this._terrainProvider = options.terrainProvider;
         this._imageryLayers = options.imageryLayers;
@@ -1692,6 +1700,7 @@ define([
         surfaceShaderSetOptions.hasVertexNormals = hasVertexNormals;
         surfaceShaderSetOptions.useWebMercatorProjection = useWebMercatorProjection;
         surfaceShaderSetOptions.clippedByBoundaries = surfaceTile.clippedByBoundaries;
+        surfaceShaderSetOptions.disableLogarithmicDepth = tileProvider.disableLogarithmicDepth;
 
         var tileImageryCollection = surfaceTile.imagery;
         var imageryIndex = 0;
@@ -1943,7 +1952,6 @@ define([
             surfaceShaderSetOptions.colorCorrect = colorCorrect;
             surfaceShaderSetOptions.highlightFillTile = highlightFillTile;
             surfaceShaderSetOptions.colorToAlpha = applyColorToAlpha;
-            surfaceShaderSetOptions.isReadyForAtmosphere = frameState.isReadyForAtmosphere;
 
             command.shaderProgram = tileProvider._surfaceShaderSet.getShaderProgram(surfaceShaderSetOptions);
             command.castShadows = castShadows;

--- a/Source/Scene/QuadtreePrimitive.js
+++ b/Source/Scene/QuadtreePrimitive.js
@@ -330,6 +330,11 @@ define([
         if (defined(this._tileProvider.update)) {
             this._tileProvider.update(frameState);
         }
+
+        // Force log depth off if there's not enough tiles
+        // and we're close to the surface. This is because large
+        // geometry will be incorrectly clipped with log depth.
+        this._tileProvider.disableLogarithmicDepth = this._tilesToRender.length < 40;
     };
 
     function clearTileLoadQueue(primitive) {

--- a/Source/Scene/QuadtreePrimitive.js
+++ b/Source/Scene/QuadtreePrimitive.js
@@ -334,7 +334,12 @@ define([
         // Force log depth off if there's not enough tiles
         // and we're close to the surface. This is because large
         // geometry will be incorrectly clipped with log depth.
-        this._tileProvider.disableLogarithmicDepth = this._tilesToRender.length < 40;
+        var camera = frameState.camera;
+        var maxHeight = 2000;
+        var factor = 1.0 - CesiumMath.clamp(camera.positionCartographic.height / maxHeight, 0.0, 1.0);
+        // A maximum of 10 tiles is chosen empirically. See https://github.com/AnalyticalGraphicsInc/cesium/pull/7822
+        var minimumEstimatedTilesRequired = CesiumMath.lerp(0, 10, factor);
+        this._tileProvider.disableLogarithmicDepth = this._tilesToRender.length < minimumEstimatedTilesRequired;
     };
 
     function clearTileLoadQueue(primitive) {

--- a/Source/Scene/QuadtreePrimitive.js
+++ b/Source/Scene/QuadtreePrimitive.js
@@ -116,6 +116,7 @@ define([
         this._tileToUpdateHeights = [];
         this._lastTileIndex = 0;
         this._updateHeightsTimeSlice = 2.0;
+        this._isReadyForLogarithmicDepth = false;
 
         // If a culled tile contains _cameraPositionCartographic or _cameraReferenceFrameOriginCartographic, it will be marked
         // TileSelectionResult.CULLED_BUT_NEEDED and added to the list of tiles to update heights,
@@ -337,9 +338,16 @@ define([
         var camera = frameState.camera;
         var maxHeight = 2000;
         var factor = 1.0 - CesiumMath.clamp(camera.positionCartographic.height / maxHeight, 0.0, 1.0);
-        // A maximum of 10 tiles is chosen empirically. See https://github.com/AnalyticalGraphicsInc/cesium/pull/7822
-        var minimumEstimatedTilesRequired = CesiumMath.lerp(0, 10, factor);
-        this._tileProvider.disableLogarithmicDepth = this._tilesToRender.length < minimumEstimatedTilesRequired;
+        // A maximum of 20 tiles is chosen empirically. See https://github.com/AnalyticalGraphicsInc/cesium/pull/7822
+        var minimumEstimatedTilesRequired = CesiumMath.lerp(0, 20, factor);
+ 
+        if (this._tilesToRender.length === 0) {
+            this._isReadyForLogarithmicDepth = false;
+        } else if (this._tilesToRender.length >= minimumEstimatedTilesRequired) {
+            this._isReadyForLogarithmicDepth = true;
+        }
+
+        this._tileProvider.disableLogarithmicDepth = !this._isReadyForLogarithmicDepth;
     };
 
     function clearTileLoadQueue(primitive) {

--- a/Source/Scene/QuadtreePrimitive.js
+++ b/Source/Scene/QuadtreePrimitive.js
@@ -340,7 +340,7 @@ define([
         var factor = 1.0 - CesiumMath.clamp(camera.positionCartographic.height / maxHeight, 0.0, 1.0);
         // A maximum of 20 tiles is chosen empirically. See https://github.com/AnalyticalGraphicsInc/cesium/pull/7822
         var minimumEstimatedTilesRequired = CesiumMath.lerp(0, 20, factor);
- 
+
         if (this._tilesToRender.length === 0) {
             this._isReadyForLogarithmicDepth = false;
         } else if (this._tilesToRender.length >= minimumEstimatedTilesRequired) {

--- a/Source/Scene/Scene.js
+++ b/Source/Scene/Scene.js
@@ -2858,6 +2858,7 @@ define([
             if (defined(skyAtmosphere) && defined(globe)) {
                 skyAtmosphere.setDynamicAtmosphereColor(globe.enableLighting);
                 environmentState.isReadyForAtmosphere = environmentState.isReadyForAtmosphere || globe._surface._tilesToRender.length > 0;
+                frameState.isReadyForAtmosphere = environmentState.frameState;
             }
             environmentState.skyAtmosphereCommand = defined(skyAtmosphere) ? skyAtmosphere.update(frameState) : undefined;
             environmentState.skyBoxCommand = defined(scene.skyBox) ? scene.skyBox.update(frameState, scene._hdr) : undefined;

--- a/Source/Scene/Scene.js
+++ b/Source/Scene/Scene.js
@@ -2858,7 +2858,6 @@ define([
             if (defined(skyAtmosphere) && defined(globe)) {
                 skyAtmosphere.setDynamicAtmosphereColor(globe.enableLighting);
                 environmentState.isReadyForAtmosphere = environmentState.isReadyForAtmosphere || globe._surface._tilesToRender.length > 0;
-                frameState.isReadyForAtmosphere = environmentState.frameState;
             }
             environmentState.skyAtmosphereCommand = defined(skyAtmosphere) ? skyAtmosphere.update(frameState) : undefined;
             environmentState.skyBoxCommand = defined(scene.skyBox) ? scene.skyBox.update(frameState, scene._hdr) : undefined;


### PR DESCRIPTION
This fixes https://github.com/AnalyticalGraphicsInc/cesium/issues/7189 in the same way we fixed it for ClassificationPrimitives in https://github.com/AnalyticalGraphicsInc/cesium/pull/6465.

In master:

![](https://user-images.githubusercontent.com/1711126/47519804-66516000-d85c-11e8-8307-b36d8215521a.gif)

In this branch:

![](https://user-images.githubusercontent.com/1711126/47519816-70735e80-d85c-11e8-8a63-4415becac34f.gif)

_These gifs are copied from that issue, but this is indeed what I see in this branch._

This is just from opening the [3D Tiles BIM](https://cesiumjs.org/Cesium/Build/Apps/Sandcastle/?src=3D%20Tiles%20BIM.html) Sandcastle with no modification.

I noticed there was already a condition for ~disabling log depth~ pushing depth writing to the fragment shader in `GlobeSurfaceShaderSet`. I added one more check, to use the `isReadyForAtmosphere` boolean, which is computed in Scene.js and is true only when enough globe tiles have loaded to cover the screen and the atmosphere renders.

Code is NOT final. I threw the `isReadyForAtmosphere` in FrameState so I can pass it to GlobeSurfaceShaderSet, but I wanted to get feedback on whether this was a good approach first. @bagnell can you take a look?

Todo:

* [x] Update changes
* [x] Cleanup code, we probably don't want this `isReadyForAtmosphere` on frameState.
* [x] Test this with the EXT_frag_depth extension disabled.