### PR TITLE
Fix Globe double render

### DIFF
--- a/Source/Scene/Globe.js
+++ b/Source/Scene/Globe.js
@@ -784,16 +784,7 @@ define([
             this._material.update(frameState.context);
         }
 
-        var surface = this._surface;
-        var pass = frameState.passes;
-
-        if (pass.render) {
-            surface.render(frameState);
-        }
-
-        if (pass.pick) {
-            surface.render(frameState);
-        }
+        this._surface.render(frameState);
     };
 
     /**


### PR DESCRIPTION
Fixes #7816.

Right now, the pick and render passes are mutually exclusive, so this doesn't cause a double render. There are plans to have multiple passes in the same render. For example, use multiple render targets where we render the color to one buffer and the pick id to another.

I removed the pass check since the QuadtreePrimitive handles the passes.