### PR TITLE
Don't send ion access token to non-ion servers

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,11 +1,13 @@
 Change Log
 ==========
-### 1.58 - 2019-06-01
+### 1.58 - 2019-06-03
 
 ##### Additions :tada:
 * Added support for new `BingMapsStyle` values `ROAD_ON_DEMAND` and `AERIAL_WITH_LABELS_ON_DEMAND`. The older versions of these, `ROAD` and `AERIAL_WITH_LABELS`, have been deprecated by Bing. [#7808](https://github.com/AnalyticalGraphicsInc/cesium/pull/7808)
 * Added syntax to delete data from existing properties via CZML. [#7818](https://github.com/AnalyticalGraphicsInc/cesium/pull/7818)
 * `BingMapsImageryProvider` now uses `DiscardEmptyTileImagePolicy` by default to detect missing tiles as zero-length responses instead of inspecting pixel values. [#7810](https://github.com/AnalyticalGraphicsInc/cesium/pull/7810)
+##### Fixes :wrench:
+* Fixed an edge case where Cesium would provide ion access token credentials to non-ion servers if the actual asset entrypoint was being hosted by ion. [#7839](https://github.com/AnalyticalGraphicsInc/cesium/pull/7839)
 
 ### 1.57 - 2019-05-01
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ Change Log
 * Added support for new `BingMapsStyle` values `ROAD_ON_DEMAND` and `AERIAL_WITH_LABELS_ON_DEMAND`. The older versions of these, `ROAD` and `AERIAL_WITH_LABELS`, have been deprecated by Bing. [#7808](https://github.com/AnalyticalGraphicsInc/cesium/pull/7808)
 * Added syntax to delete data from existing properties via CZML. [#7818](https://github.com/AnalyticalGraphicsInc/cesium/pull/7818)
 * `BingMapsImageryProvider` now uses `DiscardEmptyTileImagePolicy` by default to detect missing tiles as zero-length responses instead of inspecting pixel values. [#7810](https://github.com/AnalyticalGraphicsInc/cesium/pull/7810)
+
 ##### Fixes :wrench:
 * Fixed an edge case where Cesium would provide ion access token credentials to non-ion servers if the actual asset entrypoint was being hosted by ion. [#7839](https://github.com/AnalyticalGraphicsInc/cesium/pull/7839)
 

--- a/Source/Core/IonResource.js
+++ b/Source/Core/IonResource.js
@@ -7,7 +7,8 @@ define([
         './defineProperties',
         './Ion',
         './Resource',
-        './RuntimeError'
+        './RuntimeError',
+        'ThirdParty/Uri'
     ], function(
         when,
         Check,
@@ -17,7 +18,8 @@ define([
         defineProperties,
         Ion,
         Resource,
-        RuntimeError) {
+        RuntimeError,
+        Uri) {
 'use strict';
 
     /**
@@ -64,6 +66,7 @@ define([
 
         // The asset endpoint data returned from ion.
         this._ionEndpoint = endpoint;
+        this._ionEndpointDomain = isExternal ? undefined : new Uri(endpoint.url).authority;
 
         // The endpoint resource to fetch when a new token is needed
         this._ionEndpointResource = endpointResource;
@@ -180,7 +183,8 @@ define([
     };
 
     IonResource.prototype._makeRequest = function(options) {
-        if (this._isExternal) {
+        // Don't send ion access token to non-ion servers.
+        if (this._isExternal || new Uri(this.url).authority !== this._ionEndpointDomain) {
             return Resource.prototype._makeRequest.call(this, options);
         }
 

--- a/Source/Core/IonResource.js
+++ b/Source/Core/IonResource.js
@@ -1,4 +1,5 @@
 define([
+        '../ThirdParty/Uri',
         '../ThirdParty/when',
         './Check',
         './Credit',
@@ -7,9 +8,9 @@ define([
         './defineProperties',
         './Ion',
         './Resource',
-        './RuntimeError',
-        'ThirdParty/Uri'
+        './RuntimeError'
     ], function(
+        Uri,
         when,
         Check,
         Credit,
@@ -18,8 +19,7 @@ define([
         defineProperties,
         Ion,
         Resource,
-        RuntimeError,
-        Uri) {
+        RuntimeError) {
 'use strict';
 
     /**

--- a/Specs/Core/IonResourceSpec.js
+++ b/Specs/Core/IonResourceSpec.js
@@ -221,6 +221,18 @@ defineSuite([
         expect(_makeRequest.calls.argsFor(0)[0]).toBe(options);
     });
 
+    it('Calls base _makeRequest with no changes for ion assets with external urls', function() {
+        var originalOptions = {};
+        var expectedOptions = {};
+
+        var _makeRequest = spyOn(Resource.prototype, '_makeRequest');
+        var endpointResource = IonResource._createEndpointResource(assetId);
+        var resource = new IonResource(endpoint, endpointResource);
+        resource.url = 'http://test.invalid';
+        resource._makeRequest(originalOptions);
+        expect(_makeRequest).toHaveBeenCalledWith(expectedOptions);
+    });
+
     it('Calls base fetchImage with preferBlob for ion assets', function() {
         var fetchImage = spyOn(Resource.prototype, 'fetchImage');
         var endpointResource = IonResource._createEndpointResource(assetId);


### PR DESCRIPTION
@tfili can you review.  @OmarShehata this should fix the issue you uncovered.

Some ion-hosted assets can still point to additional external servers as, part of their dataset. We were still appending the ion access_token in the Accept header to these servers, which is at best pointless but at worst would cause some CORS requests to fail because the Accept header was not allowed.