### PR TITLE
Reduce Bing Maps transactions and ion Bing sessions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@ Change Log
 * Added syntax to delete data from existing properties via CZML. [#7818](https://github.com/AnalyticalGraphicsInc/cesium/pull/7818)
 * Added `checkerboard` material to CZML. [#7845](https://github.com/AnalyticalGraphicsInc/cesium/pull/7845)
 * `BingMapsImageryProvider` now uses `DiscardEmptyTileImagePolicy` by default to detect missing tiles as zero-length responses instead of inspecting pixel values. [#7810](https://github.com/AnalyticalGraphicsInc/cesium/pull/7810)
+* Reduce the number of Bing transactions and ion Bing sessions used when destroying and recreating the same imagery layer to 1. [#7848](https://github.com/AnalyticalGraphicsInc/cesium/pull/7848)
 
 ##### Fixes :wrench:
 * Fixed an edge case where Cesium would provide ion access token credentials to non-ion servers if the actual asset entrypoint was being hosted by ion. [#7839](https://github.com/AnalyticalGraphicsInc/cesium/pull/7839)

--- a/Source/Scene/IonImageryProvider.js
+++ b/Source/Scene/IonImageryProvider.js
@@ -161,7 +161,7 @@ define([
         // already retrieved. This exists mainly to support Bing caching to reduce
         // world imagery sessions, but provides a small boost of performance in general
         // if constantly reloading assets
-        var cacheKey = JSON.stringify(options);
+        var cacheKey = options.assetId.toString() + options.accessToken + options.server;
         var promise = IonImageryProvider._endpointCache[cacheKey];
         if (!defined(promise)) {
             promise = endpointResource.fetchJson();

--- a/Source/Scene/IonImageryProvider.js
+++ b/Source/Scene/IonImageryProvider.js
@@ -77,11 +77,10 @@ define([
     function IonImageryProvider(options) {
         options = defaultValue(options, defaultValue.EMPTY_OBJECT);
 
+        var assetId = options.assetId;
         //>>includeStart('debug', pragmas.debug);
-        Check.typeOf.number('options.assetId', options.assetId);
+        Check.typeOf.number('options.assetId', assetId);
         //>>includeEnd('debug');
-
-        var endpointResource = IonResource._createEndpointResource(options.assetId, options);
 
         /**
          * The default alpha blending value of this provider, with 0.0 representing fully transparent and
@@ -156,10 +155,23 @@ define([
         this._errorEvent = new Event();
 
         var that = this;
-        this._readyPromise = endpointResource.fetchJson()
+        var endpointResource = IonResource._createEndpointResource(assetId, options);
+
+        // A simple cache to avoid making repeated requests to ion for endpoints we've
+        // already retrieved. This exists mainly to support Bing caching to reduce
+        // world imagery sessions, but provides a small boost of performance in general
+        // if constantly reloading assets
+        var cacheKey = JSON.stringify(options);
+        var promise = IonImageryProvider._endpointCache[cacheKey];
+        if (!defined(promise)) {
+            promise = endpointResource.fetchJson();
+            IonImageryProvider._endpointCache[cacheKey] = promise;
+        }
+
+        this._readyPromise = promise
             .then(function(endpoint) {
                 if (endpoint.type !== 'IMAGERY') {
-                    return when.reject(new RuntimeError('Cesium ion asset ' + options.assetId + ' is not an imagery asset.'));
+                    return when.reject(new RuntimeError('Cesium ion asset ' + assetId + ' is not an imagery asset.'));
                 }
 
                 var imageryProvider;
@@ -484,6 +496,9 @@ define([
         //>>includeEnd('debug');
         return this._imageryProvider.pickFeatures(x, y, level, longitude, latitude);
     };
+
+    //exposed for testing
+    IonImageryProvider._endpointCache = {};
 
     return IonImageryProvider;
 });

--- a/Specs/Scene/IonImageryProviderSpec.js
+++ b/Specs/Scene/IonImageryProviderSpec.js
@@ -59,7 +59,7 @@ defineSuite([
 
     beforeEach(function() {
         RequestScheduler.clearForSpecs();
-        IonImageryProvider._endpointCache = [];
+        IonImageryProvider._endpointCache = {};
     });
 
     it('conforms to ImageryProvider interface', function() {
@@ -127,7 +127,7 @@ defineSuite([
         };
 
         var assetId = 12335;
-        var options = { assetId: assetId };
+        var options = { assetId: assetId, accessToken: 'token', server: 'http://test.invalid' };
         var endpointResource = IonResource._createEndpointResource(assetId, options);
         spyOn(IonResource, '_createEndpointResource').and.returnValue(endpointResource);
         spyOn(endpointResource, 'fetchJson').and.returnValue(when.resolve(endpointData));
@@ -139,11 +139,14 @@ defineSuite([
             .then(function() {
                 expect(provider.ready).toBe(true);
                 expect(endpointResource.fetchJson.calls.count()).toBe(1);
-                provider2 = new IonImageryProvider(options);
+
+                // Same as options but in a different order to verify cache is order independant.
+                var options2 = { accessToken: 'token', server: 'http://test.invalid', assetId: assetId };
+                provider2 = new IonImageryProvider(options2);
                 return provider2.readyPromise;
             })
             .then(function() {
-                //Since the data is caches, fetchJson is not called again.
+                //Since the data is cached, fetchJson is not called again.
                 expect(endpointResource.fetchJson.calls.count()).toBe(1);
                 expect(provider2.ready).toBe(true);
             });


### PR DESCRIPTION
This is a simple PR to try and minimize the number of Bing transactions and ion Bing sessions over the course of a page. While we can't cache Bing metadata or ion endpoints across sessions, this type of basic caching is allowed and should dramatically reduce use for certain use cases.

1. BingMapsImageryProvider now keeps a local cache of metadata for a given url/style. This means destroying and recreating instances multiple times still only uses a single transaction.

2. IonImageryProvider now caches endpoint requests. This means that creating multiple IonImageryProviders for the same Bing asset will only use a single Bing session.

While use cases like Sandcastle, which uses an iframe, won't benefit at all from this change, applications that switch base layers often or destroy/recreate the viewer as part of a SPA will see dramatic improvement.

I'm open to other ideas to help reduce Bing transactions here, but obviously we need to stay withing the ToS for both Bing Maps and ion.  If anyone has any thoughts, let me know.