### PR TITLE
feat: expose getByName method for dataSourceCollection

### DIFF
--- a/Source/DataSources/DataSourceCollection.js
+++ b/Source/DataSources/DataSourceCollection.js
@@ -193,6 +193,24 @@ define([
         return this._dataSources[index];
     };
 
+    /**
+     * Gets a data source by name from the collection.
+     *
+     * @param {String} name the name to retrieve.
+     * @returns {DataSource[]} The data source at collection with the provided name.
+     */
+    DataSourceCollection.prototype.getByName = function(name) {
+        //>>includeStart('debug', pragmas.debug);
+        if (!defined(name)) {
+            throw new DeveloperError('name is required.');
+        }
+        //>>includeEnd('debug');
+
+        return this._dataSources.filter(function(dataSource) {
+            return dataSource.name === name;
+        });
+    };
+
     function getIndex(dataSources, dataSource) {
         //>>includeStart('debug', pragmas.debug);
         if (!defined(dataSource)) {

--- a/Specs/DataSources/DataSourceCollectionSpec.js
+++ b/Specs/DataSources/DataSourceCollectionSpec.js
@@ -31,6 +31,26 @@ defineSuite([
         expect(collection.contains(source)).toEqual(false);
     });
 
+    it('getByName works', function() {
+        var collection = new DataSourceCollection();
+        var source1 = new MockDataSource();
+        source1.name = 'Name1';
+        collection.add(source1);
+
+        var source2 = new MockDataSource();
+        source2.name = 'Name1';
+        collection.add(source2);
+
+        var source3 = new MockDataSource();
+        source3.name = 'Name2';
+        collection.add(source3);
+
+        var res = collection.getByName('Name1');
+        expect(res.length).toEqual(2);
+        expect(res[0].name).toEqual('Name1');
+        expect(res[1].name).toEqual('Name1');
+    });
+
     it('add and remove events work', function() {
         var source = new MockDataSource();
         var collection = new DataSourceCollection();


### PR DESCRIPTION
related issue #7837 

This PR will allow to fetch `dataSource` from `dataSourceCollection` by `name` with the new `.getByName` method.