### PR TITLE
Check childTileMask if provider doesn't know tile availability.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@ Change Log
 
 ##### Fixes :wrench:
 * Fixed an edge case where Cesium would provide ion access token credentials to non-ion servers if the actual asset entrypoint was being hosted by ion. [#7839](https://github.com/AnalyticalGraphicsInc/cesium/pull/7839)
+* Fixed a bug that caused Cesium to request non-existent tiles for terrain tilesets lacking tile availability, i.e. a `layer.json` file.
 
 ### 1.57 - 2019-05-01
 

--- a/Source/Scene/GlobeSurfaceTile.js
+++ b/Source/Scene/GlobeSurfaceTile.js
@@ -350,7 +350,18 @@ define([
     };
 
     function prepareNewTile(tile, terrainProvider, imageryLayerCollection) {
-        if (terrainProvider.getTileDataAvailable(tile.x, tile.y, tile.level) === false) {
+        var available = terrainProvider.getTileDataAvailable(tile.x, tile.y, tile.level);
+
+        if (!defined(available) && defined(tile.parent)) {
+            // Provider doesn't know if this tile is available. Does the parent tile know?
+            var parent = tile.parent;
+            var parentSurfaceTile = parent.data;
+            if (defined(parentSurfaceTile) && defined(parentSurfaceTile.terrainData)) {
+                available = parentSurfaceTile.terrainData.isChildAvailable(parent.x, parent.y, tile.x, tile.y);
+            }
+        }
+
+        if (available === false) {
             // This tile is not available, so mark it failed so we start upsampling right away.
             tile.data.terrainState = TerrainState.FAILED;
         }


### PR DESCRIPTION
When the terrain tileset doesn't include a layer.json file, the only way to determine tile availability is to look at the parent tile's `childTileMask`. But I neglected to do that in my terrain refactoring.

Note that the absence of a `layer.json` means we have no choice to be refine down through the tile pyramid one level at a time, so adding a `layer.json` is highly recommended for performance reasons. But at least with this PR we won't request a bunch of non-existent tiles.

Fixes #7847 

