### PR TITLE
TerrainOffsetProperty was not being cleaned up

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@ Change Log
 ##### Fixes :wrench:
 * Fixed an edge case where Cesium would provide ion access token credentials to non-ion servers if the actual asset entrypoint was being hosted by ion. [#7839](https://github.com/AnalyticalGraphicsInc/cesium/pull/7839)
 * Fixed a bug that caused Cesium to request non-existent tiles for terrain tilesets lacking tile availability, i.e. a `layer.json` file.
+* Fixed memory leak when removing entities that had a `HeightReference` of `CLAMP_TO_GROUND` or `RELATIVE_TO_GROUND`. This includes when removing a `DataSource`. 
 
 ### 1.57 - 2019-05-01
 

--- a/Source/DataSources/GeometryVisualizer.js
+++ b/Source/DataSources/GeometryVisualizer.js
@@ -364,6 +364,13 @@ define([
             subscriptions[i]();
         }
         this._subscriptions.removeAll();
+
+        var updaterSets = this._updaterSets.values;
+        length = updaterSets.length;
+        for (i = 0; i < length; i++) {
+            updaterSets[i].destroy();
+        }
+        this._updaterSets.removeAll();
         return destroyObject(this);
     };
 

--- a/Source/DataSources/GroundGeometryUpdater.js
+++ b/Source/DataSources/GroundGeometryUpdater.js
@@ -130,6 +130,20 @@ define([
     };
 
     /**
+     * Destroys and resources used by the object.  Once an object is destroyed, it should not be used.
+     *
+     * @exception {DeveloperError} This object was destroyed, i.e., destroy() was called.
+     */
+    GroundGeometryUpdater.prototype.destroy = function() {
+        if (defined(this._terrainOffsetProperty)) {
+            this._terrainOffsetProperty.destroy();
+            this._terrainOffsetProperty = undefined;
+        }
+
+        GeometryUpdater.prototype.destroy.call(this);
+    };
+
+    /**
      * @private
      */
     GroundGeometryUpdater.getGeometryHeight = function(height, heightReference) {

--- a/Specs/DataSources/GeometryVisualizerSpec.js
+++ b/Specs/DataSources/GeometryVisualizerSpec.js
@@ -516,6 +516,23 @@ defineSuite([
         expect(entityCollection.collectionChanged.numberOfListeners).toEqual(0);
     });
 
+    it('calls destroy on all updaterSets', function() {
+        var entityCollection = new EntityCollection();
+        var visualizer = new GeometryVisualizer(scene, entityCollection, scene.primitives, scene.groundPrimitives);
+
+        var destroySpy = jasmine.createSpy('destroy');
+        visualizer._updaterSets.set('test', {
+            destroy: destroySpy
+        });
+
+        expect(visualizer._updaterSets.values.length).toBe(1);
+
+        visualizer.destroy();
+
+        expect(destroySpy).toHaveBeenCalled();
+        expect(visualizer._updaterSets.values.length).toBe(0);
+    });
+
     it('Computes dynamic geometry bounding sphere.', function() {
         var entityCollection = new EntityCollection();
         var visualizer = new GeometryVisualizer(scene, entityCollection, scene.primitives, scene.groundPrimitives);

--- a/Specs/DataSources/GroundGeometryUpdaterSpec.js
+++ b/Specs/DataSources/GroundGeometryUpdaterSpec.js
@@ -115,4 +115,35 @@ defineSuite([
         result = GroundGeometryUpdater.computeGeometryOffsetAttribute(undefined, heightReference, undefined, extrudedHeightReference);
         expect(result).toBeUndefined();
     });
+
+    it('Overridden version of destroy is called', function() {
+        var options = {
+            scene: {
+                frameState: {
+                    context: {
+                        depthTexture: true
+                    }
+                }
+            },
+            entity: {},
+            geometryOptions: {},
+            geometryPropertyName: '',
+            observedPropertyNames: []
+        };
+
+        var groundGeometryUpdater = new GroundGeometryUpdater(options);
+
+        // Just make the terrain propery a dummy object with a destroy method
+        var destroySpy = jasmine.createSpy('destroy');
+        groundGeometryUpdater._terrainOffsetProperty = {
+            destroy: destroySpy
+        };
+
+        groundGeometryUpdater.destroy();
+
+        // Make sure the terrain updater is destroyed and the parent class' destroy is called
+        expect(destroySpy).toHaveBeenCalled();
+        expect(groundGeometryUpdater._terrainOffsetProperty).toBeUndefined();
+        expect(groundGeometryUpdater.isDestroyed()).toBe(true);
+    });
 });


### PR DESCRIPTION
`GroundGeometryUpdater` didn't have it's own destroy method, it's `_terrainOffsetProperty` was never getting destroyed. This would leave a bunch of listeners for `scene.terrainProviderChanged` and `scene.morphComplete`.

This change adds a `GroundGeometryUpdater.destroy` method that destroys `_terrainOffsetProperty` and then calls `GeometryUpdater.destroy` like it used to.

Added a test to make sure it's all wired up correctly.