### PR TITLE
Don't rewrite Bing tile URLs to https, instead just ask for https

### DIFF
--- a/Source/Scene/BingMapsImageryProvider.js
+++ b/Source/Scene/BingMapsImageryProvider.js
@@ -51,7 +51,7 @@ define([
      * @param {String} [options.key] The Bing Maps key for your application, which can be
      *        created at {@link https://www.bingmapsportal.com/}.
      *        If this parameter is not provided, {@link BingMapsApi.defaultKey} is used, which is undefined by default.
-     * @param {String} [options.tileProtocol] The protocol to use when loading tiles, e.g. 'http:' or 'https:'.
+     * @param {String} [options.tileProtocol] The protocol to use when loading tiles, e.g. 'http' or 'https'.
      *        By default, tiles are loaded using the same protocol as the page.
      * @param {BingMapsStyle} [options.mapStyle=BingMapsStyle.AERIAL] The type of Bing Maps imagery to load.
      * @param {String} [options.culture=''] The culture to use when requesting Bing Maps imagery. Not
@@ -134,11 +134,26 @@ define([
         this._ready = false;
         this._readyPromise = when.defer();
 
+        var tileProtocol = this._tileProtocol;
+
+        // For backward compatibility reasons, the tileProtocol may end with
+        // a `:`. Remove it.
+        if (defined(tileProtocol)) {
+            if (tileProtocol.length > 0 && tileProtocol[tileProtocol.length - 1] === ':') {
+                tileProtocol = tileProtocol.substr(0, tileProtocol.length - 1);
+            }
+        } else {
+            // use http if the document's protocol is http, otherwise use https
+            var documentProtocol = document.location.protocol;
+            tileProtocol = documentProtocol === 'http:' ? 'http' : 'https';
+        }
+
         var metadataResource = this._resource.getDerivedResource({
             url:'REST/v1/Imagery/Metadata/' + this._mapStyle,
             queryParameters: {
                 incl: 'ImageryProviders',
-                key: this._key
+                key: this._key,
+                uriScheme: tileProtocol
             }
         });
         var that = this;
@@ -156,15 +171,6 @@ define([
             that._maximumLevel = resource.zoomMax - 1;
             that._imageUrlSubdomains = resource.imageUrlSubdomains;
             that._imageUrlTemplate = resource.imageUrl;
-
-            var tileProtocol = that._tileProtocol;
-            if (!defined(tileProtocol)) {
-                // use the document's protocol, unless it's not http or https
-                var documentProtocol = document.location.protocol;
-                tileProtocol = /^http/.test(documentProtocol) ? documentProtocol : 'http:';
-            }
-
-            that._imageUrlTemplate = that._imageUrlTemplate.replace(/^http:/, tileProtocol);
 
             var attributionList = that._attributionList = resource.imageryProviders;
             if (!attributionList) {


### PR DESCRIPTION
For ~5 years now, we've had code in `BingMapsImageryProvider` that rewrote the tile URL from `http://` to `https://` if the page was on an https connection. This seemed kind of dodgy, but we thought it was necessary to avoid mixed content warnings.

But, it turns out that Bing Maps (now?) has a way to directly ask for an https tile URL, by adding `&uriScheme=https` to the metadata URL. And it also turns out that this is totally necessary with the new "on demand" styles added in #7808 because, if we just rewrite the URL as we were doing before, we get invalid certificate errors. Bing Maps returns an akamai.net certificate when we're connecting on a virtualearth.net domain.

So this PR switches to using the `uriScheme` mechanism. The new on-demand styles won't work on https pages without this PR (ask me how I know).