### PR TITLE
Fix credits for request render mode

### DIFF
--- a/Source/Scene/Cesium3DTileset.js
+++ b/Source/Scene/Cesium3DTileset.js
@@ -1727,15 +1727,6 @@ define([
         cancelOutOfViewRequests(this, frameState);
         raiseLoadProgressEvent(this, frameState);
         this._cache.unloadTiles(this, unloadTile);
-
-        var statistics = this._statisticsPerPass[Cesium3DTilePass.RENDER];
-        var credits = this._credits;
-        if (defined(credits) && statistics.selected !== 0) {
-            var length = credits.length;
-            for (var i = 0; i < length; ++i) {
-                frameState.creditDisplay.addCredit(credits[i]);
-            }
-        }
     };
 
     /**
@@ -2253,6 +2244,16 @@ define([
 
         // Update pass statistics
         Cesium3DTilesetStatistics.clone(statistics, passStatistics);
+
+        if (isRender) {
+            var credits = tileset._credits;
+            if (defined(credits) && statistics.selected !== 0) {
+                var length = credits.length;
+                for (var i = 0; i < length; ++i) {
+                    frameState.creditDisplay.addCredit(credits[i]);
+                }
+            }
+        }
 
         return ready;
     }

--- a/Source/Scene/Scene.js
+++ b/Source/Scene/Scene.js
@@ -3198,12 +3198,9 @@ define([
     }
 
     function prePassesUpdate(scene) {
-        var frameState = scene._frameState;
-        frameState.creditDisplay.update();
-        frameState.creditDisplay.beginFrame();
-
         scene._jobScheduler.resetBudgets();
 
+        var frameState = scene._frameState;
         var primitives = scene.primitives;
         primitives.prePassesUpdate(frameState);
 
@@ -3212,6 +3209,7 @@ define([
         }
 
         scene._pickPositionCacheDirty = true;
+        frameState.creditDisplay.update();
     }
 
     function postPassesUpdate(scene) {
@@ -3220,7 +3218,6 @@ define([
         primitives.postPassesUpdate(frameState);
 
         RequestScheduler.update();
-        frameState.creditDisplay.endFrame();
     }
 
     var scratchBackgroundColor = new Color();
@@ -3247,6 +3244,8 @@ define([
             backgroundColor.blue = Math.pow(backgroundColor.blue, scene.gamma);
         }
         frameState.backgroundColor = backgroundColor;
+
+        frameState.creditDisplay.beginFrame();
 
         scene.fog.update(frameState);
 
@@ -3293,6 +3292,7 @@ define([
             }
         }
 
+        frameState.creditDisplay.endFrame();
         context.endFrame();
     }
 


### PR DESCRIPTION
Reverts https://github.com/AnalyticalGraphicsInc/cesium/pull/7877 because of flickering credits in request render mode. Now I remember this was the exact reason why credit updates were moved back into the render pass in https://github.com/AnalyticalGraphicsInc/cesium/commit/43c0141a55ee3f00a806fe8697095376e9fa7417.

Basically the globe only updates credits in the render pass, not its update pass, so any frames that are skipped by request render mode won't show the credits.

The fix now is to move the 3D Tiles credit update into `update` rather than `postPassesUpdate` so that 3D Tiles credits get added within the render pass.

[Sancastle](http://localhost:8080/Apps/Sandcastle/index.html#c=ZVJtc5pAEP4rjF/EGefUGDsmMZm2kNKzAToGbeMw08FjlQv3Yu4OrHby3wtBm7TdL7DPy/LcLWWirJLCDpR1bQnYWQ5oWnC0eMHsNnlpHSlMQgWodtf6FQurql5vw+QKrEtrnTAN3QZV8FSANjMQKShfpjVvVHGiefKT8oI3dEQ5OFkiNrUIizUV1Oxj8dy5ikUsyiqYoQw0mCpZExFpAgLQVlFODS1BoyRN7Wb0m+zNY+hGjd0+Jq6rUOzyJMNSzEDLQhFAayX5B12JcWqfjS/OR3/OeaqEVFehI5mDuLTasJ9mK4/QkE7x/IAHAcUai9mIOPgdzrffF870AlWip9TLaxHz3Xzke8vHpdPvL/nt7i6a8cD1Tejhswc6yH3302PAK5035Q/RnN450+2yGhbe7yg5C0riLQ74cbvC/NOB0Gla8RkZBiz97NOQ6X3o5v1g0deYsyytfH40H4TRbT+M5odg2EfhQGlXjAwZbVLnx9cvhobj4dz1ztVHqQTeOe7qYuxtV/63cfv14M+d7mujM7k7rbtBnzuxOG6r2c9BSh5J+7i3TqNC0mSgdlSDvS4EMVQKywalpOq8vWQihZYMEJObI3t1+kr10uq2JtrsGdw04HvKt1KZeqE2Qj0DfMsSA7q3KkgOBhGta9ukdzJNUlpaNL2OW//80nHLIizRumLWBWP39ABx62bSq/R/2ZhMUio2YQmKJftakg1u7hoQITTpVe3/LiMlWyXqzcTf) - this will show flickery credits in master but not this branch.