### PR TITLE
fix vector tile byte offset alignment

### DIFF
--- a/Source/Scene/Vector3DTileContent.js
+++ b/Source/Scene/Vector3DTileContent.js
@@ -360,7 +360,7 @@ define([
 
         var batchIds = getBatchIds(featureTableJson, featureTableBinary);
 
-        byteOffset += byteOffset % 4;
+        byteOffset += (4 - (byteOffset % 4)) % 4;
 
         if (numberOfPolygons > 0) {
             var indices = new Uint32Array(arrayBuffer, byteOffset, indicesByteLength / sizeOfUint32);


### PR DESCRIPTION
fix byte offset alignment error.  if byteoffset%4 is 1, should add 3, not add 1.