### PR TITLE
Fix ImageBitmap spec on Edge

### DIFF
--- a/Specs/Core/loadImageFromTypedArraySpec.js
+++ b/Specs/Core/loadImageFromTypedArraySpec.js
@@ -8,6 +8,15 @@ defineSuite([
         when) {
     'use strict';
 
+    var supportsImageBitmapOptions;
+
+    beforeAll(function() {
+        return Resource.supportsImageBitmapOptions()
+            .then(function(result) {
+                supportsImageBitmapOptions = result;
+            });
+    });
+
     it('can load an image', function() {
         return Resource.fetchArrayBuffer('./Data/Images/Blue10x10.png').then(function(arrayBuffer) {
             var options = {
@@ -23,6 +32,10 @@ defineSuite([
     });
 
     it('flips image only when flipY is true', function() {
+        if (!supportsImageBitmapOptions) {
+            return;
+        }
+
         var options = {
             uint8Array: new Uint8Array([67, 101, 115, 105, 117, 109]), // This is an invalid PNG.
             format: 'image/png',
@@ -60,6 +73,10 @@ defineSuite([
     });
 
     it('can load an image when ImageBitmap is not supported', function() {
+        if (!supportsImageBitmapOptions) {
+            return;
+        }
+
         spyOn(Resource, 'supportsImageBitmapOptions').and.returnValue(when.resolve(false));
         spyOn(window, 'createImageBitmap').and.callThrough();
         return Resource.fetchArrayBuffer('./Data/Images/Blue10x10.png').then(function(arrayBuffer) {


### PR DESCRIPTION
The spec in `Core/loadImageFromTypedArraySpec.js` was running an `ImageBitmap` test without first checking if the browser supports ImageBitmap (specifically, it was failing when setting up the spy). This fixes https://github.com/AnalyticalGraphicsInc/cesium/issues/7894 by following the same check `Core/Resource` does. 

@hpinkos 