### PR TITLE
Fix Undefined Min/Max Height in Inspector

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ Change Log
 ##### Fixes :wrench:
 * Fixed a bug that caused missing segments for ground polylines with coplanar points over large distances and problems with polylines containing duplicate points. [#7885](https://github.com/AnalyticalGraphicsInc/cesium//pull/7885)
 * Fixed a bug where billboards were not pickable when zoomed out completely in 2D View. [#7908](https://github.com/AnalyticalGraphicsInc/cesium/pull/7908)
+* Fixed a bug in the inspector where the min/max height values of a picked tile were undefined. [#7904](https://github.com/AnalyticalGraphicsInc/cesium/pull/7904)
 
 ### 1.58.1 - 2018-06-03
 _This is an npm-only release to fix a publishing issue_

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -208,3 +208,4 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to Cesiu
 * [Alexander Popiak](https://github.com/apopiak)
 * [Trubie Turner](https://github.com/flexei)
 * [Merijn Wijngaard](https://github.com/mwijngaard)
+* [Dennis Adams](https://github.com/dennisadams)

--- a/Source/Scene/Globe.js
+++ b/Source/Scene/Globe.js
@@ -675,7 +675,11 @@ define([
         if (!defined(rayOrigin)) {
             // intersection point is outside the ellipsoid, try other value
             // minimum height (-11500.0) for the terrain set, need to get this information from the terrain provider
-            var magnitude = Math.min(defaultValue(tile.data.minimumHeight, 0.0), -11500.0);
+            var minimumHeight;
+            if (defined(tile.data.tileBoundingRegion)) {
+                minimumHeight = tile.data.tileBoundingRegion.minimumHeight;
+            }
+            var magnitude = Math.min(defaultValue(minimumHeight, 0.0), -11500.0);
 
             // multiply by the *positive* value of the magnitude
             var vectorToMinimumPoint = Cartesian3.multiplyByScalar(surfaceNormal, Math.abs(magnitude) + 1, scratchGetHeightIntersection);

--- a/Source/Scene/QuadtreePrimitive.js
+++ b/Source/Scene/QuadtreePrimitive.js
@@ -1131,7 +1131,11 @@ define([
                         if (!defined(rayOrigin)) {
                             // intersection point is outside the ellipsoid, try other value
                             // minimum height (-11500.0) for the terrain set, need to get this information from the terrain provider
-                            var magnitude = Math.min(defaultValue(tile.data.minimumHeight, 0.0),-11500.0);
+                            var minimumHeight;
+                            if (defined(tile.data.tileBoundingRegion)) {
+                                minimumHeight = tile.data.tileBoundingRegion.minimumHeight;
+                            }
+                            var magnitude = Math.min(defaultValue(minimumHeight, 0.0), -11500.0);
 
                             // multiply by the *positive* value of the magnitude
                             var vectorToMinimumPoint = Cartesian3.multiplyByScalar(surfaceNormal, Math.abs(magnitude) + 1, scratchPosition);

--- a/Source/Widgets/CesiumInspector/CesiumInspectorViewModel.js
+++ b/Source/Widgets/CesiumInspector/CesiumInspectorViewModel.js
@@ -883,8 +883,8 @@ define([
                         this.tileText += '<br>SW corner: ' + newTile.rectangle.west + ', ' + newTile.rectangle.south;
                         this.tileText += '<br>NE corner: ' + newTile.rectangle.east + ', ' + newTile.rectangle.north;
                         var data = newTile.data;
-                        if (defined(data)) {
-                            this.tileText += '<br>Min: ' + data.minimumHeight + ' Max: ' + data.maximumHeight;
+                        if (defined(data) && defined(data.tileBoundingRegion)) {
+                            this.tileText += '<br>Min: ' + data.tileBoundingRegion.minimumHeight + ' Max: ' + data.tileBoundingRegion.maximumHeight;
                         } else {
                             this.tileText += '<br>(Tile is not loaded)';
                         }


### PR DESCRIPTION
Fixes #7672.
Following the terrain overhaul (#7061), the min/max height properties have moved from the `QuadtreeTile`'s `data` to `data.tileBoundingRegion` and not all places were updated.
This PR updates the cesium inspector and also a couple of other places: `Globe`'s `getHeight` and `QuadtreePrimitive`'s `updateHeights` which share the relevant code.
Hope I haven't missed any others.