### PR TITLE
Billboard 2D pick fix

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,11 @@
 Change Log
 ==========
 
+### 1.59 - 2019-07-01
+
+##### Fixes :wrench:
+* Fixed a bug where billboards were not pickable when zoomed out completely in 2D View. [#7908](https://github.com/AnalyticalGraphicsInc/cesium/pull/7908)
+
 ### 1.58.1 - 2018-06-03
 _This is an npm-only release to fix a publishing issue__
 

--- a/Source/Scene/GlobeDepth.js
+++ b/Source/Scene/GlobeDepth.js
@@ -290,6 +290,8 @@ define([
             });
         }
 
+        globeDepth._copyColorCommand.renderState = globeDepth._rs;
+
         if (!defined(globeDepth._tempCopyDepthCommand)) {
             globeDepth._tempCopyDepthCommand = context.createViewportQuadCommand(PassThroughDepth, {
                 uniformMap : {


### PR DESCRIPTION
Fixes https://github.com/AnalyticalGraphicsInc/cesium/issues/7868

A small mistake in https://github.com/AnalyticalGraphicsInc/cesium/pull/7434 caused billboards not to be pickable when zoomed out in 2D view. At the zoomed out view the scene renders the globe in two sections and the viewer/scissor were not getting accounted for in `GlobeDepth`.

Note the diff around here https://github.com/AnalyticalGraphicsInc/cesium/pull/7434/files#diff-c0134c9a4ab93c317c6e68303fd7ff00R293. The line `globeDepth._copyColorCommand.renderState = globeDepth._rs;` was accidentally removed.