### PR TITLE
Gamma correction fix for polylines

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ Change Log
 ##### Fixes :wrench:
 * Fixed a bug that caused missing segments for ground polylines with coplanar points over large distances and problems with polylines containing duplicate points. [#7885](https://github.com/AnalyticalGraphicsInc/cesium//pull/7885)
 * Fixed a bug where billboards were not pickable when zoomed out completely in 2D View. [#7908](https://github.com/AnalyticalGraphicsInc/cesium/pull/7908)
+* Fixed polyline colors when `scene.highDynamicRange` is enabled. [#7924](https://github.com/AnalyticalGraphicsInc/cesium/pull/7924)
 
 ### 1.58.1 - 2018-06-03
 _This is an npm-only release to fix a publishing issue_

--- a/Source/Shaders/Appearances/PerInstanceFlatColorAppearanceFS.glsl
+++ b/Source/Shaders/Appearances/PerInstanceFlatColorAppearanceFS.glsl
@@ -2,5 +2,5 @@ varying vec4 v_color;
 
 void main()
 {
-    gl_FragColor = v_color;
+    gl_FragColor = czm_gammaCorrect(v_color);
 }

--- a/Source/Shaders/PolylineShadowVolumeFS.glsl
+++ b/Source/Shaders/PolylineShadowVolumeFS.glsl
@@ -65,7 +65,7 @@ void main(void)
     distanceFromEnd = czm_planeDistance(alignedPlaneNormal, -dot(alignedPlaneNormal, v_endEcAndStartEcX.xyz), eyeCoordinate.xyz);
 
 #ifdef PER_INSTANCE_COLOR
-    gl_FragColor = v_color;
+    gl_FragColor = czm_gammaCorrect(v_color);
 #else // PER_INSTANCE_COLOR
     // Clamp - distance to aligned planes may be negative due to mitering,
     // so fragment texture coordinate might be out-of-bounds.

--- a/Source/Shaders/PolylineShadowVolumeMorphFS.glsl
+++ b/Source/Shaders/PolylineShadowVolumeMorphFS.glsl
@@ -20,7 +20,7 @@ void main(void)
     eyeCoordinate /= eyeCoordinate.w;
 
 #ifdef PER_INSTANCE_COLOR
-    gl_FragColor = v_color;
+    gl_FragColor = czm_gammaCorrect(v_color);
 #else // PER_INSTANCE_COLOR
     // Use distances for planes aligned with segment to prevent skew in dashing
     float distanceFromStart = rayPlaneDistanceUnsafe(eyeCoordinate.xyz, -v_forwardDirectionEC, v_forwardDirectionEC.xyz, v_alignedPlaneDistances.x);


### PR DESCRIPTION
Some polyline shaders were missing gamma correction.

Fixes https://github.com/AnalyticalGraphicsInc/cesium/issues/7920