### PR TITLE
Update deprecated Travis command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,10 @@ sudo: false
 addons:
   chrome: stable
   firefox: latest
+services:
+  - xvfb
 before_script:
   - export DISPLAY=:99.0
-  - sh -e /etc/init.d/xvfb start
 script:
   - npm --silent run deploy-set-version -- --buildVersion $TRAVIS_BRANCH.$TRAVIS_BUILD_NUMBER
   - npm --silent run deploy-status -- --status pending --message 'Waiting for build'


### PR DESCRIPTION
We recently started seeing Travis CI failures in a private repo with:

```
The command "sh -e /etc/init.d/xvfb start" failed and exited with 127 during .
```

This is because Travis has updated the API for starting this service (see [this official blog post](https://blog.travis-ci.com/2019-04-15-xenial-default-build-environment) and [this post explaining the breaking change](https://benlimmer.com/2019/01/14/travis-ci-xvfb/)). The update seems to be on a rolling basis, so I figured we'd update the config here since it will likely eventually break.