### PR TITLE
Make PolygonGraphics.hierarchy always produce a PolygonHierarchy.

### DIFF
--- a/Source/DataSources/PolygonGeometryUpdater.js
+++ b/Source/DataSources/PolygonGeometryUpdater.js
@@ -13,17 +13,13 @@ define([
         '../Core/DistanceDisplayConditionGeometryInstanceAttribute',
         '../Core/EllipsoidTangentPlane',
         '../Core/GeometryInstance',
-        '../Core/GeometryOffsetAttribute',
-        '../Core/isArray',
         '../Core/Iso8601',
-        '../Core/oneTimeWarning',
         '../Core/OffsetGeometryInstanceAttribute',
+        '../Core/oneTimeWarning',
         '../Core/PolygonGeometry',
-        '../Core/PolygonHierarchy',
         '../Core/PolygonOutlineGeometry',
         '../Core/Rectangle',
         '../Core/ShowGeometryInstanceAttribute',
-        '../Scene/GroundPrimitive',
         '../Scene/HeightReference',
         '../Scene/MaterialAppearance',
         '../Scene/PerInstanceColorAppearance',
@@ -47,17 +43,13 @@ define([
         DistanceDisplayConditionGeometryInstanceAttribute,
         EllipsoidTangentPlane,
         GeometryInstance,
-        GeometryOffsetAttribute,
-        isArray,
         Iso8601,
-        oneTimeWarning,
         OffsetGeometryInstanceAttribute,
+        oneTimeWarning,
         PolygonGeometry,
-        PolygonHierarchy,
         PolygonOutlineGeometry,
         Rectangle,
         ShowGeometryInstanceAttribute,
-        GroundPrimitive,
         HeightReference,
         MaterialAppearance,
         PerInstanceColorAppearance,
@@ -223,10 +215,11 @@ define([
     };
 
     PolygonGeometryUpdater.prototype._computeCenter = function(time, result) {
-        var positions = Property.getValueOrUndefined(this._entity.polygon.hierarchy, time);
-        if (defined(positions) && !isArray(positions)) {
-            positions = positions.positions;
+        var hierarchy = Property.getValueOrUndefined(this._entity.polygon.hierarchy, time);
+        if (!defined(hierarchy)) {
+            return;
         }
+        var positions = hierarchy.positions;
         if (positions.length === 0) {
             return;
         }
@@ -289,10 +282,6 @@ define([
         options.vertexFormat = isColorMaterial ? PerInstanceColorAppearance.VERTEX_FORMAT : MaterialAppearance.MaterialSupport.TEXTURED.vertexFormat;
 
         var hierarchyValue = polygon.hierarchy.getValue(Iso8601.MINIMUM_VALUE);
-        if (isArray(hierarchyValue)) {
-            hierarchyValue = new PolygonHierarchy(hierarchyValue);
-        }
-
         var heightValue = Property.getValueOrUndefined(polygon.height, Iso8601.MINIMUM_VALUE);
         var heightReferenceValue = Property.getValueOrDefault(polygon.heightReference, Iso8601.MINIMUM_VALUE, HeightReference.NONE);
         var extrudedHeightValue = Property.getValueOrUndefined(polygon.extrudedHeight, Iso8601.MINIMUM_VALUE);
@@ -364,12 +353,7 @@ define([
     DyanmicPolygonGeometryUpdater.prototype._setOptions = function(entity, polygon, time) {
         var options = this._options;
 
-        var hierarchy = Property.getValueOrUndefined(polygon.hierarchy, time);
-        if (isArray(hierarchy)) {
-            options.polygonHierarchy = new PolygonHierarchy(hierarchy);
-        } else {
-            options.polygonHierarchy = hierarchy;
-        }
+        options.polygonHierarchy = Property.getValueOrUndefined(polygon.hierarchy, time);
 
         var heightValue = Property.getValueOrUndefined(polygon.height, time);
         var heightReferenceValue = Property.getValueOrDefault(polygon.heightReference, time, HeightReference.NONE);

--- a/Source/DataSources/PolygonGraphics.js
+++ b/Source/DataSources/PolygonGraphics.js
@@ -4,6 +4,9 @@ define([
         '../Core/defineProperties',
         '../Core/DeveloperError',
         '../Core/Event',
+        '../Core/isArray',
+        '../Core/PolygonHierarchy',
+        './ConstantProperty',
         './createMaterialPropertyDescriptor',
         './createPropertyDescriptor'
     ], function(
@@ -12,9 +15,20 @@ define([
         defineProperties,
         DeveloperError,
         Event,
+        isArray,
+        PolygonHierarchy,
+        ConstantProperty,
         createMaterialPropertyDescriptor,
         createPropertyDescriptor) {
     'use strict';
+
+    function createPolygonHierarchyProperty(value) {
+        if (isArray(value)) {
+            // convert array of positions to PolygonHierarchy object
+            value = new PolygonHierarchy(value);
+        }
+        return new ConstantProperty(value);
+    }
 
     /**
      * Describes a polygon defined by an hierarchy of linear rings which make up the outer shape and any nested holes.
@@ -125,7 +139,7 @@ define([
          * @memberof PolygonGraphics.prototype
          * @type {Property}
          */
-        hierarchy : createPropertyDescriptor('hierarchy'),
+        hierarchy : createPropertyDescriptor('hierarchy', undefined, createPolygonHierarchyProperty),
 
         /**
          * Gets or sets the numeric Property specifying the constant altitude of the polygon.

--- a/Specs/DataSources/PolygonGraphicsSpec.js
+++ b/Specs/DataSources/PolygonGraphicsSpec.js
@@ -1,6 +1,7 @@
 defineSuite([
         'DataSources/PolygonGraphics',
         'Core/ArcType',
+        'Core/Cartesian3',
         'Core/Color',
         'Core/DistanceDisplayCondition',
         'Core/PolygonHierarchy',
@@ -13,6 +14,7 @@ defineSuite([
     ], function(
         PolygonGraphics,
         ArcType,
+        Cartesian3,
         Color,
         DistanceDisplayCondition,
         PolygonHierarchy,
@@ -274,5 +276,30 @@ defineSuite([
         testDefinitionChanged(property, 'classificationType', ClassificationType.TERRAIN, ClassificationType.BOTH);
         testDefinitionChanged(property, 'arcType', ArcType.GEODESIC, ArcType.RHUMB);
         testDefinitionChanged(property, 'zIndex', 54, 3);
+    });
+
+    it('converts an array of positions to a PolygonHierarchy', function() {
+        var positions = [
+            new Cartesian3(1, 2, 3),
+            new Cartesian3(4, 5, 6),
+            new Cartesian3(7, 8, 9)
+        ];
+
+        var graphics = new PolygonGraphics({
+            hierarchy: positions
+        });
+
+        expect(graphics.hierarchy).toBeInstanceOf(ConstantProperty);
+        var hierarchy = graphics.hierarchy.getValue();
+        expect(hierarchy).toBeInstanceOf(PolygonHierarchy);
+        expect(hierarchy.positions).toEqual(positions);
+
+        graphics = new PolygonGraphics();
+        graphics.hierarchy = positions;
+
+        expect(graphics.hierarchy).toBeInstanceOf(ConstantProperty);
+        hierarchy = graphics.hierarchy.getValue();
+        expect(hierarchy).toBeInstanceOf(PolygonHierarchy);
+        expect(hierarchy.positions).toEqual(positions);
     });
 });


### PR DESCRIPTION
For backwards compatibility we preserve the existing behavior of allowing an array of positions to be set.
This makes the behavior more closely match the documentation. The ability to set an array of positions
was undocumented, though some Sandcastle examples do this.

This removes the need for conversion in PolygonGeometryUpdater at the point where the data is used.

Looking through the history I believe this is the behavior intended but not completed in #2353.