### PR TITLE
Fix KML export with multiple images

### DIFF
--- a/Source/DataSources/exportKml.js
+++ b/Source/DataSources/exportKml.js
@@ -369,7 +369,7 @@ define([
 
             return deferred.promise
                 .then(function() {
-                    addExternalFilesToZip(writer, keys, externalFiles, index+1);
+                    return addExternalFilesToZip(writer, keys, externalFiles, index+1);
                 });
         }
 


### PR DESCRIPTION
This is the smallest PR ever. Our zip library isn't thread safe. Files must be added sequentially or else all but the first file is corrupt or missing. I just forgot a return so the promises aren't chained like they should be.

Try this and if you look in GE you need to zoom in before the icons show up. That is their behavior.

```javascript
var viewer = new Cesium.Viewer('cesiumContainer', {
    shouldAnimate : true
});

function download(filename, data) {
    var blob = new Blob([data], { type: 'application/xml' });
    if (window.navigator.msSaveOrOpenBlob) {
        window.navigator.msSaveBlob(blob, filename);
    } else {
        var elem = window.document.createElement('a');
        elem.href = window.URL.createObjectURL(blob);
        elem.download = filename;
        document.body.appendChild(elem);
        elem.click();
        document.body.removeChild(elem);
    }
}

viewer.dataSources.add(Cesium.CzmlDataSource.load('../../../../Apps/SampleData/simple.czml'))
    .then(function(ds) {
      // Call the following after the datasource is loaded
      Cesium.exportKml({
          entities: ds.entities,
          kmz: true
      })
      .then(function(result) {
        download('satellites.kmz', result.kmz);
      }); 
    });
```