### PR TITLE
Remove hidden Â from Natural Earth base map.

### DIFF
--- a/Source/Widgets/BaseLayerPicker/BaseLayerPicker.js
+++ b/Source/Widgets/BaseLayerPicker/BaseLayerPicker.js
@@ -76,7 +76,7 @@ define([
      *  }));
      *
      *  imageryViewModels.push(new Cesium.ProviderViewModel({
-     *      name : 'Natural Earth\u00a0II',
+     *      name : 'Natural Earth II',
      *      iconUrl : Cesium.buildModuleUrl('Widgets/Images/ImageryProviders/naturalEarthII.png'),
      *      tooltip : 'Natural Earth II, darkened for contrast.\nhttp://www.naturalearthdata.com/',
      *      creationFunction : function() {

--- a/Source/Widgets/BaseLayerPicker/createDefaultImageryProviderViewModels.js
+++ b/Source/Widgets/BaseLayerPicker/createDefaultImageryProviderViewModels.js
@@ -221,7 +221,7 @@ area washes and organic edges over a paper texture to add warm pop to any map.\n
         }));
 
         providerViewModels.push(new ProviderViewModel({
-            name : 'Natural Earth\u00a0II',
+            name : 'Natural Earth II',
             iconUrl : buildModuleUrl('Widgets/Images/ImageryProviders/naturalEarthII.png'),
             tooltip : 'Natural Earth II, darkened for contrast.\nhttp://www.naturalearthdata.com/',
             category : 'Cesium ion',


### PR DESCRIPTION
Removes the hidden character which resolves to Â in unicode but renders as a space in most IDEs and webpages.

I realize this is a minor thing but as the character doesn't seem to operate any differently than a normal space it doesn't seem like there's a reason to keep it around and could have unintended consequences.

# Additional details
Earlier on I copied and pasted the tool tip text from the chrome inspector to use in my own custom base map selector. Which ended up causing issues on in the applications as we had some functions that tried to find a base map by name for example:
```tsx
({ name }) => name === "Natural Earth II"
```
However, the condition would always be false, because, despite looking right it would never match with the name which was actually `Natural EarthÂII`.

In the same note some JSON (specifically Java Jackson) serialization/deserialization libraries seem to handle the character poorly. Unfortunately, the team I'm working with went with the simpler fix of just removing the character and replacing it with a normal space instead of filing a issue with the Java library in question.

