### PR TITLE
fix ground polyline texcoords bug for first segment on some platforms

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@ Change Log
 
 ##### Fixes :wrench:
 * `PolygonGraphics.hierarchy` now converts constant array values to a `PolygonHierarchy` when set, so code that accesses the value of the property can rely on it always being a `PolygonHierarchy`.
+* Fixed a bug with lengthwise texture coordinates in the first segment of ground polylines, as observed in some WebGL implementations such as Chrome on Linux. [#8017](https://github.com/AnalyticalGraphicsInc/cesium/issues/8017)
 
 ### 1.59 - 2019-07-01
 

--- a/Source/Core/GroundPolylineGeometry.js
+++ b/Source/Core/GroundPolylineGeometry.js
@@ -1013,7 +1013,7 @@ define([
 
                 var texcoordNormalization = texcoordNormalization3DY * topBottomSide;
                 if (texcoordNormalization === 0.0 && topBottomSide < 0.0) {
-                    texcoordNormalization = Number.POSITIVE_INFINITY;
+                    texcoordNormalization = 9.0; // some value greater than 1.0
                 }
                 rightNormalAndTextureCoordinateNormalizationY[wIndex] = texcoordNormalization;
 
@@ -1038,7 +1038,7 @@ define([
 
                     texcoordNormalization = texcoordNormalization2DY * topBottomSide;
                     if (texcoordNormalization === 0.0 && topBottomSide < 0.0) {
-                        texcoordNormalization = Number.POSITIVE_INFINITY;
+                        texcoordNormalization = 9.0; // some value greater than 1.0
                     }
                     texcoordNormalization2D[vec2Index + 1] = texcoordNormalization;
                 }


### PR DESCRIPTION
Fixes #8017.

Lengthwise texcoords for the first segment of ground polylines weren't getting computed correctly on some platforms, which manifested as buggy arrow materials on the first segment of polylines on terrain.

When packing vertex attributes to polyline volumes, we attach to each vertex a pair of floats that are used to compute each fragment's distance along the polyline as a whole from its texcoords within the segment - there's a scale term and a translation term. We also use the sign and/or magnitude of these terms to indicate in the shader whether a vertex is on the top, bottom, right, or left side of the shadow volume.

The translation term should always be in the range [0, 1) since it's a translation in texcoord space, so we say that if the value packed is negative or if it has a magnitude greater than 1.0, then the vertex is on the "bottom" of the volume. The value then needs to be remapped to [0, 1).

The "magnitude greater than 1.0" part is there because the first volume has a translation term 0.0. We were always setting it to Number.POSITIVE_INFINITY in this case as a value clearly outside the [0, 1) range, but it looks like on some platforms that can have reliability problems when remapping, so this PR brings it down to a very reasonable 9.0 instead.

Sandcastle for comparison:
* [1.59](https://cesiumjs.org/Cesium/Build/Apps/Sandcastle/#c=dZNdb5swFIb/isVNicRMWNpq6Wi0KJ2qSPuSFk2aSi9cOEmtGhsdG1I25b/PfCUm27jB9vs+x++xoWJIKg57QHJLJOzJCjQvc/qjXfMv0na6UtIwLgEvJu8TmcjKUoXS3HAltQV7aMXQ2BGTM7pFld/BDgH0EpHV/kMiiX3eRG9nNLq6eheQy2sazefTYCzMB2EW/Ie4TuRjH6MNSXUKEugOVSmzb8hzG6sCTVmW+U5H952uRC1sJ0ef/7vbZgcqB4P1WmrDpG2b3LjncX8mD5iLnhGj/Qbe5ZrndIo3p3Ew9ux5Zp6tHk3p9KQcJt34MOntrCiAYRNuHGSI8JkZQM7E8uhzw+S9atmeG/ztXW7qAvxzYahsb1jtG8cxUiIPk9EdpSwHZFQo9bI0/rHTh+gxcLOeviA/mtp2A+K+2pL/Krix7eitwtyJiPz1kq7vPn7ZrDc/G9ALvFibWsCiS/mB54VCQ0oUPqWhgbwQtjMdPpXpCxiaat1gcThAccYrwrPbxDv7KxKPpIJpbZVtKcR3/gsSbxGH1j/ChGIZl7uvFaBgdWN5jhafukVKaRza6d+UUUo8MXQq/gE)
* [deployed branch](http://cesium-dev.s3-website-us-east-1.amazonaws.com/cesium/fixGroundPolylineTexcoords/Build/Apps/Sandcastle/index.html#c=dZNdb5swFIb/isVNicRMWNpq6Wi0KJ2qSPuSFk2aSi9cOEmtGhsdG1I25b/PfCUm27jB9vs+x++xoWJIKg57QHJLJOzJCjQvc/qjXfMv0na6UtIwLgEvJu8TmcjKUoXS3HAltQV7aMXQ2BGTM7pFld/BDgH0EpHV/kMiiX3eRG9nNLq6eheQy2sazefTYCzMB2EW/Ie4TuRjH6MNSXUKEugOVSmzb8hzG6sCTVmW+U5H952uRC1sJ0ef/7vbZgcqB4P1WmrDpG2b3LjncX8mD5iLnhGj/Qbe5ZrndIo3p3Ew9ux5Zp6tHk3p9KQcJt34MOntrCiAYRNuHGSI8JkZQM7E8uhzw+S9atmeG/ztXW7qAvxzYahsb1jtG8cxUiIPk9EdpSwHZFQo9bI0/rHTh+gxcLOeviA/mtp2A+K+2pL/Krix7eitwtyJiPz1kq7vPn7ZrDc/G9ALvFibWsCiS/mB54VCQ0oUPqWhgbwQtjMdPpXpCxiaat1gcThAccYrwrPbxDv7KxKPpIJpbZVtKcR3/gsSbxGH1j/ChGIZl7uvFaBgdWN5jhafukVKaRza6d+UUUo8MXQq/gE)