### PR TITLE
Fixed Hidden Point Primitive Bug

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,9 @@ Change Log
 ##### Additions :tada:
 * Added optional `index` parameter to `PrimitiveCollection.add`. [#8041](https://github.com/AnalyticalGraphicsInc/cesium/pull/8041)
 
+##### Fixes :wrench:
+* Fixed a bug that causes hidden point primitives to still appear on some operating systems. [#8043](https://github.com/AnalyticalGraphicsInc/cesium/issues/8043)
+
 ### 1.60 - 2019-08-01
 
 ##### Additions :tada:

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -132,7 +132,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to Cesiu
    * [Hannah Pinkos](https://github.com/hpinkos)
    * [Kangning Li](https://github.com/likangning93)
    * [Sean Lilley](https://github.com/lilleyse)
-   
+   * [Brandon Barker](https://github.com/ProjectBarks)
 
 ## [Individual CLA](Documentation/Contributors/CLAs/individual-contributor-license-agreement-v1.0.pdf)
 * [Victor Berchet](https://github.com/vicb)
@@ -222,4 +222,3 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to Cesiu
 * [Dennis Adams](https://github.com/dennisadams)
 * [Hai Zhou](https://github.com/verybigzhouhai)
 * [Pascal Poulain](https://github.com/ppoulainpro)
-* [Brandon Barker](https://github.com/ProjectBarks)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -222,3 +222,4 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to Cesiu
 * [Dennis Adams](https://github.com/dennisadams)
 * [Hai Zhou](https://github.com/verybigzhouhai)
 * [Pascal Poulain](https://github.com/ppoulainpro)
+* [Brandon Barker](https://github.com/ProjectBarks)

--- a/Source/Shaders/PointPrimitiveCollectionVS.glsl
+++ b/Source/Shaders/PointPrimitiveCollectionVS.glsl
@@ -91,7 +91,6 @@ void main()
 
     vec4 p = czm_translateRelativeToEye(positionHigh, positionLow);
     vec4 positionEC = czm_modelViewRelativeToEye * p;
-    positionEC.xyz *= show;
 
     ///////////////////////////////////////////////////////////////////////////
 
@@ -173,7 +172,8 @@ void main()
 
     v_innerPercent = 1.0 - outlinePercent;
     v_pixelDistance = 2.0 / totalSize;
-    gl_PointSize = totalSize;
+    gl_PointSize = totalSize * show;
+    gl_Position *= show;
 
     v_pickColor = pickColor;
 }

--- a/Source/Shaders/PointPrimitiveCollectionVS.glsl
+++ b/Source/Shaders/PointPrimitiveCollectionVS.glsl
@@ -167,9 +167,9 @@ void main()
 #endif
 
     v_color = color;
-    v_color.a *= translucency;
+    v_color.a *= translucency * show;
     v_outlineColor = outlineColor;
-    v_outlineColor.a *= translucency;
+    v_outlineColor.a *= translucency * show;
 
     v_innerPercent = 1.0 - outlinePercent;
     v_pixelDistance = 2.0 / totalSize;


### PR DESCRIPTION
create an entity with point graphics and change its show property to false it doesn't hide, instead, it positions itself in the center of the screen while still being visible.

this issue only occurs when I'm in a Ubuntu environment

Fixed by changing translucency in addition to point location when showing

This is in response to https://github.com/AnalyticalGraphicsInc/cesium/issues/8043