### PR TITLE
Fixed selection filtering for bloom

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,9 @@ Change Log
 ##### Additions :tada:
 * Added optional `index` parameter to `PrimitiveCollection.add`. [#8041](https://github.com/AnalyticalGraphicsInc/cesium/pull/8041)
 
+##### Fixes :wrench:
+* Fixed post-processing selection filtering to work for bloom. [#7984](https://github.com/AnalyticalGraphicsInc/cesium/issues/7984)
+
 ### 1.60 - 2019-08-01
 
 ##### Additions :tada:

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -132,7 +132,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to Cesiu
    * [Hannah Pinkos](https://github.com/hpinkos)
    * [Kangning Li](https://github.com/likangning93)
    * [Sean Lilley](https://github.com/lilleyse)
-   
+   * [Brandon Barker](https://github.com/ProjectBarks)
 
 ## [Individual CLA](Documentation/Contributors/CLAs/individual-contributor-license-agreement-v1.0.pdf)
 * [Victor Berchet](https://github.com/vicb)

--- a/Source/Shaders/PostProcessStages/BloomComposite.glsl
+++ b/Source/Shaders/PostProcessStages/BloomComposite.glsl
@@ -1,12 +1,20 @@
 uniform sampler2D colorTexture;
 uniform sampler2D bloomTexture;
-uniform bool  glowOnly;
+uniform bool glowOnly;
 
 varying vec2 v_textureCoordinates;
 
 void main(void)
 {
-    vec4 bloom = texture2D(bloomTexture, v_textureCoordinates);
     vec4 color = texture2D(colorTexture, v_textureCoordinates);
+
+#ifdef CZM_SELECTED_FEATURE
+    if (czm_selected()) {
+        gl_FragColor = color;
+        return;
+    }
+#endif
+
+    vec4 bloom = texture2D(bloomTexture, v_textureCoordinates);
     gl_FragColor = glowOnly ? bloom : bloom + color;
 }


### PR DESCRIPTION
Right now you can apply certain post process effects to just one feature. The bloom shader doesn't do any check to allow you to apply it to just to the selected feature as you would expect. Bloom post-processing is fixed by adding in the proper selection checks.

This is in reference to https://github.com/AnalyticalGraphicsInc/cesium/issues/7984

I was able to test using [this sandcastle](http://localhost:8080/Apps/Sandcastle/index.html#c=vVZtb9M6FP4rph9oKhW3YwMEdBNjVLpIqzYpu/CBIuTGp63BsSPb6W7v1f77PXbcNGmLKkBQ9UNsn/Ocx895SVbMkJWAezDknCi4J1dgRZnTD2Ev6WZheaWVY0KB6fbJf1NF8GeXupT8UomcOSCviDMlTNVD7/VUTdUKUQtthRNaIW7EvGLG4RNTp3RudP4OFgbAJk9Onp7S4Yuzs+cnL/vk7IwOnw1PXwyfeygPVBqJGF1KB/hPWV5IeMccG+Sag7SDCnzCVHz6go90IWdd7x5uQZ1h2TfgY+WEWyNW3Aa/FmAp4zyJ11Is97fBmP1qo77Gq/oxnoT4uB09/a80onKuth5qQcScJI+iDLfaulujUVmbOraAazEzzKypsKmQqCo4B2lZFBrV4knkajNQ0OttgmVaWS2BSr1IundLYcnM6HuLWeQaLFHaEVtBELcEYmtgfwlHiio87Xp2D5uMWc/GbvUJMWmxQ9fGtDQwz6NrEPLILTMDWDCNm/rDpOeJbBFpiYppk1uaaalNo4T8kl6/n4wji5nE1F4q/nEpforI26Z/g0sLd0tnYRhnvga8TM/osGahdb6NHpZ1IyyZ4hIMruelykItIb2JLi3crLDHglOd2Wjd7sYUyYJKC5bBeIVl+1dl1CoOmjEMZz35Bg614N6ronSXIXKyoZDkegU5QvWa9Rv6VvheuZl9hczt1QKe1Z7YP/w2tsQmqv/5Wo+8OcxxavCkidlrRQyjxAuARCWeAseYn5r2tDAixyAr+NwI8kCw9+E4UssndmX/e7LerQugk5u/0/GXyc2Hcd0cdd4M+MsfT93m6fHjOg8crDN6nWyUOkw1hEvRJWPWYX9jodxpLWfMTECVyacYycE/DgdNNzB5gpQMCYVM0JOEku3GIYWVGkKgdZ36VgLahQ6KzWSg4+d5Q7tGb25t5gxz8LqJhXV/4HxrsStg8GgWz57CddymVat/WjfYWPnRW7+rDsi1HUC/rNSuCgel2pHzNyh1UIY9sfb1PKbUWx/4z4h0rJ6iiD9aLT+nVEtwL9Jnv+j0OyPr1hIuqoM3Ig9vWXznJ/h54gA/T/C1YgezEkeYo5kNE3k02DiNuFgRwc+nnZ1Pq2mHZJJZiyfzUspU/AvTzsVogPYtN6kZF2rhOUq29ibLk4vrapNSOhrgct/LVVOkgfg/)