### PR TITLE
Fix KTX/CRN Tiles 

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,7 +7,8 @@ Change Log
 * Added optional `index` parameter to `PrimitiveCollection.add`. [#8041](https://github.com/AnalyticalGraphicsInc/cesium/pull/8041)
 
 ##### Fixes :wrench:
-Disabled HDR by default to improve visual quality in most standard use cases. Set `viewer.scene.highDynamicRange = true` to re-enable it. [#7966](https://github.com/AnalyticalGraphicsInc/cesium/issues/7966)
+* Disabled HDR by default to improve visual quality in most standard use cases. Set `viewer.scene.highDynamicRange = true` to re-enable. [#7966](https://github.com/AnalyticalGraphicsInc/cesium/issues/7966)
+* Fixed issue where KTX or CRN files would not be properly identified. [#7979](https://github.com/AnalyticalGraphicsInc/cesium/issues/7979) 
 
 ### 1.60 - 2019-08-01
 

--- a/Source/Scene/ImageryProvider.js
+++ b/Source/Scene/ImageryProvider.js
@@ -340,11 +340,11 @@ define([
 
         var resource = Resource.createIfNeeded(url);
 
-        if (ktxRegex.test(resource)) {
+        if (ktxRegex.test(resource.url)) {
             return loadKTX(resource);
-        } else if (crnRegex.test(resource)) {
+        } else if (crnRegex.test(resource.url)) {
             return loadCRN(resource);
-        } else if (defined(imageryProvider.tileDiscardPolicy)) {
+        } else if (defined(imageryProvider) && defined(imageryProvider.tileDiscardPolicy)) {
             return resource.fetchImage({
                 preferBlob : true,
                 preferImageBitmap : true,

--- a/Source/Scene/Material.js
+++ b/Source/Scene/Material.js
@@ -813,9 +813,9 @@ define([
                     var resource = isResource ? uniformValue : Resource.createIfNeeded(uniformValue);
 
                     var promise;
-                    if (ktxRegex.test(uniformValue)) {
+                    if (ktxRegex.test(resource.url)) {
                         promise = loadKTX(resource);
-                    } else if (crnRegex.test(uniformValue)) {
+                    } else if (crnRegex.test(resource.url)) {
                         promise = loadCRN(resource);
                     } else {
                         promise = resource.fetchImage();

--- a/Source/Scene/SingleTileImageryProvider.js
+++ b/Source/Scene/SingleTileImageryProvider.js
@@ -1,4 +1,5 @@
 define([
+        './ImageryProvider',
         '../Core/Credit',
         '../Core/defaultValue',
         '../Core/defined',
@@ -12,6 +13,7 @@ define([
         '../Core/TileProviderError',
         '../ThirdParty/when'
     ], function(
+        ImageryProvider,
         Credit,
         defaultValue,
         defined,
@@ -109,7 +111,10 @@ define([
         }
 
         function doRequest() {
-            resource.fetchImage().then(success).otherwise(failure);
+            ImageryProvider
+                .loadImage(null, resource)
+                .then(success)
+                .otherwise(failure);
         }
 
         doRequest();


### PR DESCRIPTION
The `loadImage` function would test against the Resource file and not the actual URL. This also fixes SingleImageTilesets to load KTX/CRN files as well.

For testing try out this [sandcastle](http://localhost:8080/Apps/Sandcastle/index.html#c=tVPRbtowFP2VKC9ABTZU6thaikah2pCyrSJo3UMkZJxLsOrYke0E2NR/nx2TFVrtYQ/zQxTfe47vOdfXFVFBxWAHKrgNBOyCKWhW5uh7HWu3aL2dSmEIE6Ba3eBXIgK7WE4yUIcHJSuWWvZ1w6QKiIFHqXg695j2keKWNgcOL+C5FKfI2GXR5H4xn0Srx/ny8yqa3N1Hsec/d7r+Z000ROQA6oHRp7r2hnANiXju3CQiEZU1xV1eW1PeHdIUBKCj6pqsz7EDi/UkRNJGUGOv7QufNChmIuOwZBxeQ0/clopbcS2EcF1Y40hmcvZjOUBPZt9qXCXCy8YXf8Rc/j8xW2MKfY1xxsy2XCMqczwRhB8Mo4R/UqTYMqrngmJ/9ViRHc6JNqBwXADVeEYMwV9kClzjO7nvLWFvSgVpb7r4iuv6/X5/0KOqFHRrx0GcGb3Azurfvf2Lqzft9cSV6/JKVqBsGVSIrHWcGwXUEHfmywAumhDaKJnPIFMAut0bXqF+N7h87769d8N68wENrzpuxjo3YTcc1ZM89gd/ZHkhlXGC2laNgbzg9hFovC7tgBpEtXZXPMINaZSyKmDpbRK+emBJGFBOtLaZTcl5zH5CEo5H2OLPaFyS1LbnmzfpINvBOPJBhNAI2+1blpGSr4k6OfE3). I was unable to find a working CRN file but if someone wants to test that before merging that would be fantastic!

In reference to: https://github.com/AnalyticalGraphicsInc/cesium/issues/7979