### PR TITLE
Re-enable Chrome for travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ script:
   - npm --silent run deploy-s3 -- -b cesium-dev -d cesium/$TRAVIS_BRANCH --confirm -c 'no-cache'
   - npm --silent run deploy-status -- --status success --message Deployed
 
-  - npm --silent run test -- --browsers FirefoxHeadless --failTaskOnError --webgl-stub --release --suppressPassed
+  - npm --silent run test -- --browsers ChromeCI --failTaskOnError --webgl-stub --release --suppressPassed
 
 # Various Node.js smoke-screen tests
   - node -e "const Cesium = require('./');"

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "jasmine-core": "^3.3.0",
     "jsdoc": "^3.4.3",
     "karma": "^4.0.0",
-    "karma-chrome-launcher": "^3.0.0",
+    "karma-chrome-launcher": "^3.1.0",
     "karma-detect-browsers": "^2.2.3",
     "karma-edge-launcher": "^0.4.2",
     "karma-firefox-launcher": "^1.0.0",


### PR DESCRIPTION
Looks like the Chrome bug (or karma issue?) that prevented them from running is now fixed!