### PR TITLE
KHR_texture_transform shouldn't emulate sampler repeat options

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@ Change Log
 
 ##### Fixes :wrench:
 Disabled HDR by default to improve visual quality in most standard use cases. Set `viewer.scene.highDynamicRange = true` to re-enable it. [#7966](https://github.com/AnalyticalGraphicsInc/cesium/issues/7966)
+* Fixed a crash when a glTF model used `KHR_texture_transform` without a sampler defined. [#7916](https://github.com/AnalyticalGraphicsInc/cesium/issues/7916)
 
 ### 1.60 - 2019-08-01
 

--- a/Source/Scene/processPbrMaterials.js
+++ b/Source/Scene/processPbrMaterials.js
@@ -90,14 +90,8 @@ define([
     function addTextureCoordinates(gltf, textureName, generatedMaterialValues, defaultTexCoord, result) {
         var texCoord;
         if (defined(generatedMaterialValues[textureName + 'Offset'])) {
-            var textureIndex = generatedMaterialValues[textureName].index;
-            var sampler = gltf.samplers[gltf.textures[textureIndex].sampler];
-
-            var repeatS = sampler.wrapS === WebGLConstants.REPEAT ? 'true' : 'false';
-            var repeatT = sampler.wrapT === WebGLConstants.REPEAT ? 'true' : 'false';
-
             texCoord = textureName + 'Coord';
-            result.fragmentShaderMain += '    vec2 ' + texCoord + ' = computeTexCoord(' + defaultTexCoord + ', ' + textureName + 'Offset, ' + textureName + 'Rotation, ' + textureName + 'Scale, ' + repeatS + ', ' + repeatT + ');\n';
+            result.fragmentShaderMain += '    vec2 ' + texCoord + ' = computeTexCoord(' + defaultTexCoord + ', ' + textureName + 'Offset, ' + textureName + 'Rotation, ' + textureName + 'Scale);\n';
         } else {
             texCoord = defaultTexCoord;
         }
@@ -551,7 +545,7 @@ define([
             '}\n\n';
 
         fragmentShader +=
-            'vec2 computeTexCoord(vec2 texCoords, vec2 offset, float rotation, vec2 scale, bool repeatS, bool repeatT) \n' +
+            'vec2 computeTexCoord(vec2 texCoords, vec2 offset, float rotation, vec2 scale) \n' +
             '{\n' +
             '    rotation = -rotation; \n' +
             '    mat3 transform = mat3(\n' +
@@ -559,8 +553,6 @@ define([
             '       -sin(rotation) * scale.y, cos(rotation) * scale.y, 0.0, \n' +
             '        offset.x, offset.y, 1.0); \n' +
             '    vec2 transformedTexCoords = (transform * vec3(fract(texCoords), 1.0)).xy; \n' +
-            '    transformedTexCoords.x = repeatS ? fract(transformedTexCoords.x) : clamp(transformedTexCoords.x, 0.0, 1.0); \n' +
-            '    transformedTexCoords.y = repeatT ? fract(transformedTexCoords.y) : clamp(transformedTexCoords.y, 0.0, 1.0); \n' +
             '    return transformedTexCoords; \n' +
             '}\n\n';
 


### PR DESCRIPTION
The KHR_texture_transform extension was looking at texture repeat options and trying to factor them into the transformed texture.  This is not needed, as WebGL will do the correct thing with sampler repeat options regardless of whether the coordinates have been transformed or not.

Fixes #7916

Alternative solution to #8065