### PR TITLE
Multiple globe materials makes the globe darker

### DIFF
--- a/.slackbot.yml
+++ b/.slackbot.yml
@@ -1,11 +1,11 @@
 releaseSchedule:
-  ggetz: 2/1/2019
-  hpinkos: 3/1/2019
-  lilleyse: 4/1/2019
-  tfili: 5/1/2019
-  dbagnell: 6/3/2019
-  tfili: 7/1/2019
-  tfili: 8/1/2019
+  OmarShehata: 9/2/2019
+  mramato: 10/1/2019
+  hpinkos: 11/1/2019
+  lilleyse: 12/1/2019
+  ggetz: 1/2/2020
+  likangning93: 2/3/2020
+  tfili: 3/2/2020
 
 greetings:
   - Happy Friday everyone!

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,7 +7,8 @@ Change Log
 * Added optional `index` parameter to `PrimitiveCollection.add`. [#8041](https://github.com/AnalyticalGraphicsInc/cesium/pull/8041)
 
 ##### Fixes :wrench:
-Disabled HDR by default to improve visual quality in most standard use cases. Set `viewer.scene.highDynamicRange = true` to re-enable it. [#7966](https://github.com/AnalyticalGraphicsInc/cesium/issues/7966)
+* Disabled HDR by default to improve visual quality in most standard use cases. Set `viewer.scene.highDynamicRange = true` to re-enable. [#7966](https://github.com/AnalyticalGraphicsInc/cesium/issues/7966)
+* Fixed multiple globe materials making the globe darker. [#7726](https://github.com/AnalyticalGraphicsInc/cesium/issues/7726)
 
 ### 1.60 - 2019-08-01
 

--- a/Source/Scene/Material.js
+++ b/Source/Scene/Material.js
@@ -691,9 +691,12 @@ define([
     }
 
     function isMaterialFused(shaderComponent, material) {
-        for ( var subMaterialId in material._template.materials) {
-            if (shaderComponent.indexOf(subMaterialId) > -1) {
-                return true;
+        var materials = material._template.materials;
+        for (var subMaterialId in materials) {
+            if (materials.hasOwnProperty(subMaterialId)) {
+                if (shaderComponent.indexOf(subMaterialId) > -1) {
+                    return true;
+                }
             }
         }
 
@@ -717,7 +720,6 @@ define([
                             var isFusion = isMultiMaterial && isMaterialFused(components[component], material);
                             var componentSource = isFusion ? components[component] : 'czm_gammaCorrect(' + components[component]  + ')';
                             material.shaderSource += 'material.' + component + ' = ' + componentSource + '; \n';
-                            material.shaderSource += '; \n';
                         } else if (component === 'alpha') {
                             material.shaderSource += 'material.alpha = ' + components.alpha + '; \n';
                         } else {

--- a/Source/Scene/Material.js
+++ b/Source/Scene/Material.js
@@ -691,9 +691,8 @@ define([
     }
 
     function isMaterialFused(shaderComponent, material) {
-        var matchCount = 0;
         for ( var subMaterialId in material._template.materials) {
-            if (shaderComponent.indexOf(subMaterialId) > -1 && ++matchCount === 1) {
+            if (shaderComponent.indexOf(subMaterialId) > -1) {
                 return true;
             }
         }

--- a/Source/Scene/Material.js
+++ b/Source/Scene/Material.js
@@ -693,7 +693,7 @@ define([
     function isMaterialFused(shaderComponent, material) {
         var matchCount = 0;
         for ( var subMaterialId in material._template.materials) {
-            if (shaderComponent.indexOf(subMaterialId) > -1 && ++matchCount === 2) {
+            if (shaderComponent.indexOf(subMaterialId) > -1 && ++matchCount === 1) {
                 return true;
             }
         }
@@ -711,7 +711,7 @@ define([
             material.shaderSource += 'czm_material czm_getMaterial(czm_materialInput materialInput)\n{\n';
             material.shaderSource += 'czm_material material = czm_getDefaultMaterial(materialInput);\n';
             if (defined(components)) {
-                var isMultiMaterial = Object.keys(material._template.materials).length > 1;
+                var isMultiMaterial = Object.keys(material._template.materials).length > 0;
                 for ( var component in components) {
                     if (components.hasOwnProperty(component)) {
                         if (component === 'diffuse' || component === 'emission') {

--- a/Source/Scene/Material.js
+++ b/Source/Scene/Material.js
@@ -703,9 +703,9 @@ define([
                 for ( var component in components) {
                     if (components.hasOwnProperty(component)) {
                         if (component === 'diffuse' || component === 'emission') {
-                            material.shaderSource += 'material.' + component + ' = czm_gammaCorrect(' + components[component] + '); \n';
+                            material.shaderSource += 'material.' + component + ' = ' + components[component] + '; \n';
                         } else if (component === 'alpha') {
-                            material.shaderSource += 'material.alpha = czm_gammaCorrect(vec4(vec3(0.0), ' + components.alpha + ')).a; \n';
+                            material.shaderSource += 'material.alpha = ' + components.alpha + '; \n';
                         } else {
                             material.shaderSource += 'material.' + component + ' = ' + components[component] + ';\n';
                         }

--- a/Source/Scene/Material.js
+++ b/Source/Scene/Material.js
@@ -693,6 +693,7 @@ define([
     // Create the czm_getMaterial method body using source or components.
     function createMethodDefinition(material) {
         var components = material._template.components;
+        var isMultiMaterial = material._template.materials.length > 0;
         var source = material._template.source;
         if (defined(source)) {
             material.shaderSource += source + '\n';
@@ -703,7 +704,13 @@ define([
                 for ( var component in components) {
                     if (components.hasOwnProperty(component)) {
                         if (component === 'diffuse' || component === 'emission') {
-                            material.shaderSource += 'material.' + component + ' = ' + components[component] + '; \n';
+                            material.shaderSource += 'material.' + component + ' = ';
+                            if (isMultiMaterial) {
+                                material.shaderSource += components[component];
+                            } else {
+                                material.shaderSource += 'czm_gammaCorrect(' + components[component]  + ')';
+                            }
+                            material.shaderSource += '; \n';
                         } else if (component === 'alpha') {
                             material.shaderSource += 'material.alpha = ' + components.alpha + '; \n';
                         } else {


### PR DESCRIPTION
### Fixes
- Found bug where gamma was being correct on alpha, which had no impact
- Fix that only adjusts gamma once

### Notes: 
While the gamma is adjusted per each material type I would like to make it so that it is adjusted on the final RGB values.


### Screenshots:
<h4><p align="center">Before</p></h4>

|  <img width="400" alt="image" src="https://user-images.githubusercontent.com/4194371/63107005-16aa6500-bf52-11e9-99c8-730c2e610e2e.png"> |  <img width="400" alt="image" src="https://user-images.githubusercontent.com/4194371/63107035-2e81e900-bf52-11e9-803f-3899b69078f6.png"> |
|---|---|

<h4><p align="center">After</p></h4>

|  <img width="400" alt="image" src="https://user-images.githubusercontent.com/4194371/63106884-d3e88d00-bf51-11e9-8b00-5e844768ef6e.png"> | <img width="400" alt="image" src="https://user-images.githubusercontent.com/4194371/63106926-e5ca3000-bf51-11e9-84ea-167820681bd1.png"> |
|---|---|

<h4><p align="center">After with HDR</p></h4>

| <img width="400" alt="image" src="https://user-images.githubusercontent.com/4194371/63109060-4e1b1080-bf56-11e9-8601-e43ad680e68c.png"> | <img width="400" alt="image" src="https://user-images.githubusercontent.com/4194371/63109081-583d0f00-bf56-11e9-946c-fac6ad7b6af7.png"> |
|---|---|


In reference to: https://github.com/AnalyticalGraphicsInc/cesium/issues/7726
