### PR TITLE
Imagery Provider Resource Fix

### DIFF
--- a/Source/Scene/MapboxImageryProvider.js
+++ b/Source/Scene/MapboxImageryProvider.js
@@ -61,7 +61,7 @@ define([
         //>>includeEnd('debug');
 
         var resource = Resource.createIfNeeded(defaultValue(options.url, 'https://{s}.tiles.mapbox.com/v4/'));
-        
+
         var accessToken = MapboxApi.getAccessToken(options.accessToken);
         this._mapId = mapId;
         this._accessToken = accessToken;

--- a/Source/Scene/MapboxImageryProvider.js
+++ b/Source/Scene/MapboxImageryProvider.js
@@ -60,14 +60,8 @@ define([
         }
         //>>includeEnd('debug');
 
-        var url = options.url;
-        if (!defined(url)) {
-            url = 'https://{s}.tiles.mapbox.com/v4/';
-        }
-        this._url = url;
-
-        var resource = Resource.createIfNeeded(url);
-
+        var resource = Resource.createIfNeeded(defaultValue(options.url, 'https://{s}.tiles.mapbox.com/v4/'));
+        
         var accessToken = MapboxApi.getAccessToken(options.accessToken);
         this._mapId = mapId;
         this._accessToken = accessToken;
@@ -120,7 +114,7 @@ define([
          */
         url : {
             get : function() {
-                return this._url;
+                return this._imageryProvider.url;
             }
         },
 

--- a/Source/Scene/MapboxStyleImageryProvider.js
+++ b/Source/Scene/MapboxStyleImageryProvider.js
@@ -62,13 +62,7 @@ function MapboxStyleImageryProvider(options) {
     }
     //>>includeEnd('debug');
 
-    var url = options.url;
-    if (!defined(url)) {
-        url = 'https://api.mapbox.com/styles/v1/';
-    }
-    this._url = url;
-
-    var resource = Resource.createIfNeeded(url);
+    var resource = Resource.createIfNeeded(defaultValue(options.url, 'https://api.mapbox.com/styles/v1/'));
 
     var accessToken = MapboxApi.getAccessToken(options.accessToken);
     this._styleId = styleId;
@@ -125,7 +119,7 @@ defineProperties(MapboxStyleImageryProvider.prototype, {
      */
     url : {
         get : function() {
-            return this._url;
+            return this._imageryProvider.url;
         }
     },
 

--- a/Source/Scene/createOpenStreetMapImageryProvider.js
+++ b/Source/Scene/createOpenStreetMapImageryProvider.js
@@ -1,5 +1,4 @@
 define([
-        '../Core/appendForwardSlash',
         '../Core/Credit',
         '../Core/defaultValue',
         '../Core/DeveloperError',
@@ -8,7 +7,6 @@ define([
         '../Core/WebMercatorTilingScheme',
         './UrlTemplateImageryProvider'
     ], function(
-        appendForwardSlash,
         Credit,
         defaultValue,
         DeveloperError,
@@ -61,10 +59,9 @@ define([
     function createOpenStreetMapImageryProvider(options) {
         options = defaultValue(options, {});
 
-        var url = defaultValue(options.url, 'https://a.tile.openstreetmap.org/');
-        url = appendForwardSlash(url);
-        url += '{z}/{x}/{y}.' + defaultValue(options.fileExtension, 'png');
-        var resource = Resource.createIfNeeded(url);
+        var resource = Resource.createIfNeeded(defaultValue(options.url, 'https://a.tile.openstreetmap.org/'));
+        resource.appendForwardSlash();
+        resource.url += '{z}/{x}/{y}.' + defaultValue(options.fileExtension, 'png');
 
         var tilingScheme = new WebMercatorTilingScheme({ ellipsoid : options.ellipsoid });
 

--- a/Specs/Scene/MapboxImageryProviderSpec.js
+++ b/Specs/Scene/MapboxImageryProviderSpec.js
@@ -1,6 +1,7 @@
 defineSuite([
         'Scene/MapboxImageryProvider',
         'Core/DefaultProxy',
+        'Core/MapboxApi',
         'Core/Math',
         'Core/Rectangle',
         'Core/RequestScheduler',
@@ -14,6 +15,7 @@ defineSuite([
     ], function(
         MapboxImageryProvider,
         DefaultProxy,
+        MapboxApi,
         CesiumMath,
         Rectangle,
         RequestScheduler,
@@ -137,7 +139,7 @@ defineSuite([
             mapId: 'test-id'
         });
 
-        expect(provider.url).toEqual('made/up/mapbox/server/');
+        expect(provider.url).toEqual('made/up/mapbox/server/test-id/{z}/{x}/{y}.png?access_token=' + MapboxApi.getAccessToken());
 
         return pollToPromise(function() {
             return provider.ready;

--- a/Specs/Scene/MapboxStyleImageryProviderSpec.js
+++ b/Specs/Scene/MapboxStyleImageryProviderSpec.js
@@ -1,5 +1,6 @@
 defineSuite([
         'Scene/MapboxStyleImageryProvider',
+        'Core/MapboxApi',
         'Core/Math',
         'Core/Rectangle',
         'Core/RequestScheduler',
@@ -12,6 +13,7 @@ defineSuite([
         'Specs/pollToPromise'
     ], function(
         MapboxStyleImageryProvider,
+        MapboxApi,
         CesiumMath,
         Rectangle,
         RequestScheduler,
@@ -135,7 +137,7 @@ defineSuite([
             styleId: 'test-id'
         });
 
-        expect(provider.url).toEqual('made/up/mapbox/server/');
+        expect(provider.url).toEqual('made/up/mapbox/server/mapbox/test-id/tiles/512/{z}/{x}/{y}?access_token=' + MapboxApi.getAccessToken());
 
         return pollToPromise(function() {
             return provider.ready;


### PR DESCRIPTION
This solves an issue where `createOpenStreetMapImageryProvider` would improperly handle a `Resource` object. 

I also fixed up `MapboxImageryProvider` to work in a more standardized and expected way. 

This is related to https://github.com/AnalyticalGraphicsInc/cesium/issues/4812