### PR TITLE
Fix 8074

### DIFF
--- a/Source/Scene/Cesium3DTileset.js
+++ b/Source/Scene/Cesium3DTileset.js
@@ -2279,7 +2279,7 @@ define([
         var pass = tilesetPassState.pass;
         if ((pass === Cesium3DTilePass.PRELOAD && (!this.preloadWhenHidden || this.show)) ||
             (pass === Cesium3DTilePass.PRELOAD_FLIGHT && (!this.preloadFlightDestinations || (!this.show && !this.preloadWhenHidden))) ||
-            (pass === Cesium3DTilePass.REQUEST_RENDER_MODE_DEFER_CHECK && ((!this.cullRequestsWhileMoving && this.foveatedTimeDelay <= 0) || !this.show)) {
+            (pass === Cesium3DTilePass.REQUEST_RENDER_MODE_DEFER_CHECK && ((!this.cullRequestsWhileMoving && this.foveatedTimeDelay <= 0) || !this.show))) {
             return;
         }
 

--- a/Source/Scene/Cesium3DTileset.js
+++ b/Source/Scene/Cesium3DTileset.js
@@ -2279,7 +2279,7 @@ define([
         var pass = tilesetPassState.pass;
         if ((pass === Cesium3DTilePass.PRELOAD && (!this.preloadWhenHidden || this.show)) ||
             (pass === Cesium3DTilePass.PRELOAD_FLIGHT && (!this.preloadFlightDestinations || (!this.show && !this.preloadWhenHidden))) ||
-            (pass === Cesium3DTilePass.REQUEST_RENDER_MODE_DEFER_CHECK && !this.cullRequestsWhileMoving && this.foveatedTimeDelay <= 0)) {
+            (pass === Cesium3DTilePass.REQUEST_RENDER_MODE_DEFER_CHECK && ((!this.cullRequestsWhileMoving && this.foveatedTimeDelay <= 0) || !this.show)) {
             return;
         }
 

--- a/Source/Scene/Scene.js
+++ b/Source/Scene/Scene.js
@@ -3355,11 +3355,14 @@ define([
          * Passes update. Add any passes here
          *
          */
-        tryAndCatchError(this, updateMostDetailedRayPicks);
-        tryAndCatchError(this, updatePreloadPass);
-        tryAndCatchError(this, updatePreloadFlightPass);
-        if (!shouldRender) {
-            tryAndCatchError(this, updateRequestRenderModeDeferCheckPass);
+        if (this.primitives.show)
+        {
+            tryAndCatchError(this, updateMostDetailedRayPicks);
+            tryAndCatchError(this, updatePreloadPass);
+            tryAndCatchError(this, updatePreloadFlightPass);
+            if (!shouldRender) {
+                tryAndCatchError(this, updateRequestRenderModeDeferCheckPass);
+            }
         }
 
         this._postUpdate.raiseEvent(this, time);


### PR DESCRIPTION
An example fix for #8074.

Right now there are `.show` s on individual primitives but there's also the scene's `primitives.show`. 

This fix treats the scene's `primitive.show` like a master switch and would be the simplest fix for this.

[localhost sandcastle](http://localhost:8080/Apps/Sandcastle/index.html#c=jVVdc+o2EP0rGl6wWyr8iU0gmfam0zYz904zIdMnXhR7AU1tyZVkcp07/Peuv8AQml4/ILR7dvdodSRNp+RRvoIijxkThqSg+VaQXKaQkULJPU8hJS8V+QTCZFCRVaUN5Hot9kyRPYc69JYIeCX3GFrm9K/GZo2TZnovhWFcgBpPyLe1IPWn4J8StHkCkYL6gpVuiFElTDp3zr7yvMxb9zPP4X7HxBZBD2LDBTfVWhzsRUtAJyAA67dEaDNFV+s0PAMNBt2NnRaK59zwPWjK0tRqyw2Yt4P/63MbZ/V88StVdtPDHqR4Ai1LlQDdKJn/ohH8kFphFLh2G3LA0W54dByoApZWj4jmGqjZgbA2pUgMl8LqIHbfn24tb1Lmz7L3ToZE/8BkXGwfuUl2T3VvLIeGE/KTQ71Jv2r6IktRo1bFDhRQhSGlJj+QgDp2ze1gU4lE1CsyOpEBpaQ6Ukmk0DIDmslt51l0zccOD1o+bK3eyVds+YZlut6KFRNpwjRqp276s9xuM/hUGoO1xiuEoi4aKA49h2QHyd+QXjbkvyp18MUV8JnSLHvxflXjOh+pM92MyY8flroa3mvsmKFvfx/RdatfHNmCuWc5KPZbVuH2nhaJgk0ax0nO7XxxAhRS8ybLbYelvWUASrmC5Bx1NA1gZXHyl8XiksXKKBQPQsbf1riA9eks4BVhuGBNhZuz88OUwX9M+FbdiZ4a/YoT3OYzW3XF9lbb7MlFOak4Xj19uUsyDaHjgj+ic0QN+ZyM1TXjdUbNhVB8WKwshlVwVp3Nruc9XBrSUvXr9geuw7jbLQWmVOJsw2rF1Xq7PHYye2GqP3e/o2BbEY4Hx86+cugv1fr+/HcK2jT+LsP3KMT1/bkb473lB77neHMX769gFrr40cj1vFkczdAWuKEbhTENXC/y3Hju2d0zcSkL8f1qwHuyLhPGfuTN3NALIsefEIfG88BxwtlsHvlOTaW5UQM/cILYcQNvFsxdty//PxpwqB+GMT4IGIfZvciN6gpB4IfzeYi/kRfN4raq54WBM3O9GBc69/2+wqEbz0TQNn80GS21qTK4ayE/87yQytSvlEXpFN/nImNIZfpS4s1oaKJ1Hbac9kHLlO8JT2/Xo4tXej0iSca0Rs+mzLIVf4P16G45RfxZWCabF+jPPaiMVTVk5959bo2U0uUUp++jTCvDQcZ/AQ)