### PR TITLE
SSE Independent from Resolution Density & Cesium Renders at Screen Res

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,7 +13,6 @@ Change Log
 * Disabled HDR by default to improve visual quality in most standard use cases. Set `viewer.scene.highDynamicRange = true` to re-enable. [#7966](https://github.com/AnalyticalGraphicsInc/cesium/issues/7966)
 * Fixed a bug that causes hidden point primitives to still appear on some operating systems. [#8043](https://github.com/AnalyticalGraphicsInc/cesium/issues/8043)
 * Fixed issue where KTX or CRN files would not be properly identified. [#7979](https://github.com/AnalyticalGraphicsInc/cesium/issues/7979) 
-* Fixed loading Cesium 3DTiles at different resolutions. [#8082](https://github.com/AnalyticalGraphicsInc/cesium/issues/8082)
 
 ### 1.60 - 2019-08-01
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,7 +5,7 @@ Change Log
 
 ##### Additions :tada:
 * Added optional `index` parameter to `PrimitiveCollection.add`. [#8041](https://github.com/AnalyticalGraphicsInc/cesium/pull/8041)
-* Updated to render at the browser max resolution. Set `viewer.resolutionScale = 1.0 / window.devicePixelRatio` to render at lower pixel density. [#8082](https://github.com/AnalyticalGraphicsInc/cesium/issues/8082)  
+* Cesium now renders at native device resolution by default instead of CSS pixel resolution, to go back to the old behavior, `viewer.resolutionScale = 1.0 / window.devicePixelRatio`. [#8082](https://github.com/AnalyticalGraphicsInc/cesium/issues/8082)  
 
 ##### Fixes :wrench:
 * Fixed a crash when a glTF model used `KHR_texture_transform` without a sampler defined. [#7916](https://github.com/AnalyticalGraphicsInc/cesium/issues/7916)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@ Change Log
 
 ##### Additions :tada:
 * Added optional `index` parameter to `PrimitiveCollection.add`. [#8041](https://github.com/AnalyticalGraphicsInc/cesium/pull/8041)
+* Updated to render at the browser max resolution. Set `viewer.resolutionScale = 1.0 / window.devicePixelRatio` to render at lower pixel density. [#8082](https://github.com/AnalyticalGraphicsInc/cesium/issues/8082)  
 
 ##### Fixes :wrench:
 * Fixed a crash when a glTF model used `KHR_texture_transform` without a sampler defined. [#7916](https://github.com/AnalyticalGraphicsInc/cesium/issues/7916)
@@ -12,6 +13,7 @@ Change Log
 * Disabled HDR by default to improve visual quality in most standard use cases. Set `viewer.scene.highDynamicRange = true` to re-enable. [#7966](https://github.com/AnalyticalGraphicsInc/cesium/issues/7966)
 * Fixed a bug that causes hidden point primitives to still appear on some operating systems. [#8043](https://github.com/AnalyticalGraphicsInc/cesium/issues/8043)
 * Fixed issue where KTX or CRN files would not be properly identified. [#7979](https://github.com/AnalyticalGraphicsInc/cesium/issues/7979) 
+* Fixed loading Cesium 3DTiles at different resolutions. [#8082](https://github.com/AnalyticalGraphicsInc/cesium/issues/8082)
 
 ### 1.60 - 2019-08-01
 

--- a/Source/Scene/Cesium3DTile.js
+++ b/Source/Scene/Cesium3DTile.js
@@ -731,7 +731,7 @@ define([
                 error -= dynamicError;
             }
         }
-        
+
         error /= frameState.screenSpaceErrorPixelRatio;
 
         return error;

--- a/Source/Scene/Cesium3DTile.js
+++ b/Source/Scene/Cesium3DTile.js
@@ -732,7 +732,7 @@ define([
             }
         }
 
-        error /= frameState.screenSpaceErrorPixelRatio;
+        error /= frameState.pixelRatio;
 
         return error;
     };

--- a/Source/Scene/Cesium3DTile.js
+++ b/Source/Scene/Cesium3DTile.js
@@ -731,6 +731,9 @@ define([
                 error -= dynamicError;
             }
         }
+        
+        error /= frameState.screenSpaceErrorPixelRatio;
+
         return error;
     };
 

--- a/Source/Scene/FrameState.js
+++ b/Source/Scene/FrameState.js
@@ -157,7 +157,7 @@ define([
         this.maximumScreenSpaceError = undefined;
 
         /** The factor at which all Screen Space Error is scaled. This factor accounts for a difference in screen
-         * density with resolution scaling to decouple SSE from effective resolution.  
+         * density with resolution scaling to decouple SSE from effective resolution.
          *
          * @type {Number}
          * @default 1.0

--- a/Source/Scene/FrameState.js
+++ b/Source/Scene/FrameState.js
@@ -156,6 +156,14 @@ define([
          */
         this.maximumScreenSpaceError = undefined;
 
+        /** The factor at which all Screen Space Error is scaled. This factor accounts for a difference in screen
+         * density with resolution scaling to decouple SSE from effective resolution.  
+         *
+         * @type {Number}
+         * @default 1.0
+         */
+        this.screenSpaceErrorPixelRatio = 1.0;
+
         this.passes = {
             /**
              * <code>true</code> if the primitive should update for a render pass, <code>false</code> otherwise.

--- a/Source/Scene/FrameState.js
+++ b/Source/Scene/FrameState.js
@@ -158,7 +158,7 @@ define([
 
         /**
          * Ratio between a pixel and a density-independent pixel. Provides a standard unity of
-         * measure for real pixel measurements appropriate to a particular device. 
+         * measure for real pixel measurements appropriate to a particular device.
          *
          * @type {Number}
          * @default 1.0

--- a/Source/Scene/FrameState.js
+++ b/Source/Scene/FrameState.js
@@ -156,9 +156,10 @@ define([
          */
         this.maximumScreenSpaceError = undefined;
 
-        /** The factor at which all Screen Space Error is scaled. This factor accounts for a difference in screen
-         * density with resolution scaling to decouple SSE from effective resolution.
-         *
+        /**
+         * The factor at which all Screen Space Error is scaled. This accounts for a difference in screen
+         * density to decouple SSE from effective resolution.
+         * 
          * @type {Number}
          * @default 1.0
          */

--- a/Source/Scene/FrameState.js
+++ b/Source/Scene/FrameState.js
@@ -157,13 +157,13 @@ define([
         this.maximumScreenSpaceError = undefined;
 
         /**
-         * The factor at which all Screen Space Error is scaled. This accounts for a difference in screen
-         * density to decouple SSE from effective resolution.
+         * Ratio between a pixel and a density-independent pixel. Provides a standard unity of
+         * measure for real pixel measurements appropriate to a particular device. 
          *
          * @type {Number}
          * @default 1.0
          */
-        this.screenSpaceErrorPixelRatio = 1.0;
+        this.pixelRatio = 1.0;
 
         this.passes = {
             /**

--- a/Source/Scene/FrameState.js
+++ b/Source/Scene/FrameState.js
@@ -159,7 +159,7 @@ define([
         /**
          * The factor at which all Screen Space Error is scaled. This accounts for a difference in screen
          * density to decouple SSE from effective resolution.
-         * 
+         *
          * @type {Number}
          * @default 1.0
          */

--- a/Source/Scene/QuadtreePrimitive.js
+++ b/Source/Scene/QuadtreePrimitive.js
@@ -997,7 +997,9 @@ define([
             error -= CesiumMath.fog(distance, frameState.fog.density) * frameState.fog.sse;
         }
 
-        return error /= frameState.screenSpaceErrorPixelRatio;
+        error /= frameState.screenSpaceErrorPixelRatio;
+
+        return error;
     }
 
     function screenSpaceError2D(primitive, frameState, tile) {

--- a/Source/Scene/QuadtreePrimitive.js
+++ b/Source/Scene/QuadtreePrimitive.js
@@ -997,7 +997,7 @@ define([
             error = error - CesiumMath.fog(distance, frameState.fog.density) * frameState.fog.sse;
         }
 
-        return error;
+        return error * frameState.screenSpaceErrorPixelRatio;
     }
 
     function screenSpaceError2D(primitive, frameState, tile) {
@@ -1019,7 +1019,7 @@ define([
             error = error - CesiumMath.fog(tile._distance, frameState.fog.density) * frameState.fog.sse;
         }
 
-        return error;
+        return error * frameState.screenSpaceErrorPixelRatio;
     }
 
     function addTileToRenderList(primitive, tile) {

--- a/Source/Scene/QuadtreePrimitive.js
+++ b/Source/Scene/QuadtreePrimitive.js
@@ -997,7 +997,7 @@ define([
             error -= CesiumMath.fog(distance, frameState.fog.density) * frameState.fog.sse;
         }
 
-        error /= frameState.screenSpaceErrorPixelRatio;
+        error /= frameState.pixelRatio;
 
         return error;
     }
@@ -1021,7 +1021,7 @@ define([
             error -= CesiumMath.fog(tile._distance, frameState.fog.density) * frameState.fog.sse;
         }
 
-        error /= frameState.screenSpaceErrorPixelRatio;
+        error /= frameState.pixelRatio;
 
         return error;
     }

--- a/Source/Scene/QuadtreePrimitive.js
+++ b/Source/Scene/QuadtreePrimitive.js
@@ -997,7 +997,7 @@ define([
             error = error - CesiumMath.fog(distance, frameState.fog.density) * frameState.fog.sse;
         }
 
-        return error * frameState.screenSpaceErrorPixelRatio;
+        return error / frameState.screenSpaceErrorPixelRatio;
     }
 
     function screenSpaceError2D(primitive, frameState, tile) {
@@ -1019,7 +1019,7 @@ define([
             error = error - CesiumMath.fog(tile._distance, frameState.fog.density) * frameState.fog.sse;
         }
 
-        return error * frameState.screenSpaceErrorPixelRatio;
+        return error / frameState.screenSpaceErrorPixelRatio;
     }
 
     function addTileToRenderList(primitive, tile) {

--- a/Source/Scene/QuadtreePrimitive.js
+++ b/Source/Scene/QuadtreePrimitive.js
@@ -994,10 +994,10 @@ define([
         var error = (maxGeometricError * height) / (distance * sseDenominator);
 
         if (frameState.fog.enabled) {
-            error = error - CesiumMath.fog(distance, frameState.fog.density) * frameState.fog.sse;
+            error -= CesiumMath.fog(distance, frameState.fog.density) * frameState.fog.sse;
         }
 
-        return error / frameState.screenSpaceErrorPixelRatio;
+        return error /= frameState.screenSpaceErrorPixelRatio;
     }
 
     function screenSpaceError2D(primitive, frameState, tile) {
@@ -1016,10 +1016,12 @@ define([
         var error = maxGeometricError / pixelSize;
 
         if (frameState.fog.enabled && frameState.mode !== SceneMode.SCENE2D) {
-            error = error - CesiumMath.fog(tile._distance, frameState.fog.density) * frameState.fog.sse;
+            error -= CesiumMath.fog(tile._distance, frameState.fog.density) * frameState.fog.sse;
         }
 
-        return error / frameState.screenSpaceErrorPixelRatio;
+        error /= frameState.screenSpaceErrorPixelRatio;
+
+        return error;
     }
 
     function addTileToRenderList(primitive, tile) {

--- a/Source/Scene/Scene.js
+++ b/Source/Scene/Scene.js
@@ -646,7 +646,7 @@ define([
         /**
          * The factor at which all Screen Space Error is scaled. This accounts for a difference in screen
          * density to decouple SSE from effective resolution.
-         *
+         * 
          * @type {Number}
          * @default 1.0
          * @private

--- a/Source/Scene/Scene.js
+++ b/Source/Scene/Scene.js
@@ -1593,7 +1593,7 @@ define([
 
         /**
          * Ratio between a pixel and a density-independent pixel. Provides a standard unity of
-         * measure for real pixel measurements appropriate to a particular device. 
+         * measure for real pixel measurements appropriate to a particular device.
          *
          * @memberof Scene.prototype
          * @type {Number}
@@ -1608,7 +1608,6 @@ define([
                 this._frameState.pixelRatio = value;
             }
         },
-
 
         /**
          * @private

--- a/Source/Scene/Scene.js
+++ b/Source/Scene/Scene.js
@@ -646,7 +646,7 @@ define([
         /**
          * The factor at which all Screen Space Error is scaled. This accounts for a difference in screen
          * density to decouple SSE from effective resolution.
-         * 
+         *
          * @type {Number}
          * @default 1.0
          * @private

--- a/Source/Scene/Scene.js
+++ b/Source/Scene/Scene.js
@@ -644,14 +644,14 @@ define([
         this.cameraEventWaitTime = 500.0;
 
         /**
-         * The factor at which all Screen Space Error is scaled. This accounts for a difference in screen
-         * density to decouple SSE from effective resolution.
+         * Ratio between a pixel and a density-independent pixel. Provides a standard unity of
+         * measure for real pixel measurements appropriate to a particular device. 
          *
          * @type {Number}
          * @default 1.0
          * @private
          */
-        this.screenSpaceErrorPixelRatio = 1.0;
+        this.pixelRatio = 1.0;
 
         /**
          * Blends the atmosphere to geometry far from the camera for horizon views. Allows for additional
@@ -1815,7 +1815,7 @@ define([
             frameState.maximumScreenSpaceError = 2;
         }
 
-        frameState.screenSpaceErrorPixelRatio = scene.screenSpaceErrorPixelRatio;
+        frameState.pixelRatio = scene.pixelRatio;
 
         clearPasses(frameState.passes);
 

--- a/Source/Scene/Scene.js
+++ b/Source/Scene/Scene.js
@@ -644,6 +644,16 @@ define([
         this.cameraEventWaitTime = 500.0;
 
         /**
+         * The factor at which all Screen Space Error is scaled. This accounts for a difference in screen
+         * density to decouple SSE from effective resolution.
+         * 
+         * @type {Number}
+         * @default 1.0
+         * @private
+         */
+        this.screenSpaceErrorPixelRatio = 1.0;
+
+        /**
          * Blends the atmosphere to geometry far from the camera for horizon views. Allows for additional
          * performance improvements by rendering less geometry and dispatching less terrain requests.
          * @type {Fog}
@@ -1804,6 +1814,8 @@ define([
         } else {
             frameState.maximumScreenSpaceError = 2;
         }
+
+        frameState.screenSpaceErrorPixelRatio = scene.screenSpaceErrorPixelRatio;
 
         clearPasses(frameState.passes);
 

--- a/Source/Scene/Scene.js
+++ b/Source/Scene/Scene.js
@@ -644,16 +644,6 @@ define([
         this.cameraEventWaitTime = 500.0;
 
         /**
-         * Ratio between a pixel and a density-independent pixel. Provides a standard unity of
-         * measure for real pixel measurements appropriate to a particular device. 
-         *
-         * @type {Number}
-         * @default 1.0
-         * @private
-         */
-        this.pixelRatio = 1.0;
-
-        /**
          * Blends the atmosphere to geometry far from the camera for horizon views. Allows for additional
          * performance improvements by rendering less geometry and dispatching less terrain requests.
          * @type {Fog}
@@ -1602,6 +1592,25 @@ define([
         },
 
         /**
+         * Ratio between a pixel and a density-independent pixel. Provides a standard unity of
+         * measure for real pixel measurements appropriate to a particular device. 
+         *
+         * @memberof Scene.prototype
+         * @type {Number}
+         * @default 1.0
+         * @private
+         */
+        pixelRatio: {
+            get: function() {
+                return this._frameState.pixelRatio;
+            },
+            set: function(value) {
+                this._frameState.pixelRatio = value;
+            }
+        },
+
+
+        /**
          * @private
          */
         opaqueFrustumNearOffset : {
@@ -1814,8 +1823,6 @@ define([
         } else {
             frameState.maximumScreenSpaceError = 2;
         }
-
-        frameState.pixelRatio = scene.pixelRatio;
 
         clearPasses(frameState.passes);
 

--- a/Source/Widgets/CesiumWidget/CesiumWidget.js
+++ b/Source/Widgets/CesiumWidget/CesiumWidget.js
@@ -99,7 +99,7 @@ define([
         var devicePixelRatio = window.devicePixelRatio;
         var resolutionScale = widget._resolutionScale * devicePixelRatio;
         if (defined(widget._scene)) {
-            widget._scene.screenSpaceErrorPixelRatio = resolutionScale;
+            widget._scene.pixelRatio = resolutionScale;
         }
 
         return resolutionScale;

--- a/Source/Widgets/CesiumWidget/CesiumWidget.js
+++ b/Source/Widgets/CesiumWidget/CesiumWidget.js
@@ -113,7 +113,7 @@ define([
 
         widget._canRender = width !== 0 && height !== 0;
         widget._lastDevicePixelRatio = devicePixelRatio;
-        widget._scene.resolutionScaledScreenSpaceError = resolutionScale;
+        widget._scene.screenSpaceErrorPixelRatio = resolutionScale;
     }
 
     function configureCameraFrustum(widget) {
@@ -251,8 +251,6 @@ define([
         this._forceResize = false;
         this._clock = defined(options.clock) ? options.clock : new Clock();
 
-        configureCanvasSize(this);
-
         try {
             var scene = new Scene({
                 canvas : canvas,
@@ -272,6 +270,7 @@ define([
 
             scene.camera.constrainedAxis = Cartesian3.UNIT_Z;
 
+            configureCanvasSize(this);
             configureCameraFrustum(this);
 
             var ellipsoid = defaultValue(scene.mapProjection.ellipsoid, Ellipsoid.WGS84);

--- a/Source/Widgets/CesiumWidget/CesiumWidget.js
+++ b/Source/Widgets/CesiumWidget/CesiumWidget.js
@@ -99,10 +99,8 @@ define([
         var canvas = widget._canvas;
         var width = canvas.clientWidth;
         var height = canvas.clientHeight;
-        var resolutionScale = widget._resolutionScale;
-        if (!widget._supportsImageRenderingPixelated) {
-            resolutionScale *= defaultValue(window.devicePixelRatio, 1.0);
-        }
+        var devicePixelRatio = window.devicePixelRatio;
+        var resolutionScale = widget._resolutionScale * devicePixelRatio;
 
         widget._canvasWidth = width;
         widget._canvasHeight = height;
@@ -114,6 +112,8 @@ define([
         canvas.height = height;
 
         widget._canRender = width !== 0 && height !== 0;
+        widget._lastDevicePixelRatio = devicePixelRatio;
+        widget._scene.resolutionScaledScreenSpaceError = resolutionScale;
     }
 
     function configureCameraFrustum(widget) {
@@ -240,6 +240,7 @@ define([
         this._canvas = canvas;
         this._canvasWidth = 0;
         this._canvasHeight = 0;
+        this._lastDevicePixelRatio = 0;
         this._creditViewport = creditViewport;
         this._creditContainer = creditContainer;
         this._innerCreditContainer = innerCreditContainer;
@@ -562,8 +563,8 @@ define([
                     throw new DeveloperError('resolutionScale must be greater than 0.');
                 }
                 //>>includeEnd('debug');
+                this._forceResize = this._resolutionScale !== value;
                 this._resolutionScale = value;
-                this._forceResize = true;
             }
         }
     });
@@ -672,7 +673,7 @@ define([
         var canvas = this._canvas;
         var width = canvas.clientWidth;
         var height = canvas.clientHeight;
-        if (!this._forceResize && this._canvasWidth === width && this._canvasHeight === height) {
+        if (!this._forceResize && this._canvasWidth === width && this._canvasHeight === height && this._lastDevicePixelRatio === window.devicePixelRatio) {
             return;
         }
         this._forceResize = false;

--- a/Source/Widgets/CesiumWidget/CesiumWidget.js
+++ b/Source/Widgets/CesiumWidget/CesiumWidget.js
@@ -121,7 +121,7 @@ define([
         canvas.height = height;
 
         widget._canRender = width !== 0 && height !== 0;
-        widget._lastDevicePixelRatio = devicePixelRatio;
+        widget._lastDevicePixelRatio = window.devicePixelRatio;
     }
 
     function configureCameraFrustum(widget) {
@@ -572,8 +572,8 @@ define([
                     throw new DeveloperError('resolutionScale must be greater than 0.');
                 }
                 //>>includeEnd('debug');
-                this._forceResize = true;
                 this._resolutionScale = value;
+                this._forceResize = true;
             }
         }
     });

--- a/Source/Widgets/CesiumWidget/CesiumWidget.js
+++ b/Source/Widgets/CesiumWidget/CesiumWidget.js
@@ -95,12 +95,21 @@ define([
         requestAnimationFrame(render);
     }
 
+    function configureSceneResolution(widget) {
+        var devicePixelRatio = window.devicePixelRatio;
+        var resolutionScale = widget._resolutionScale * devicePixelRatio;
+        if (defined(widget._scene)) {
+            widget._scene.screenSpaceErrorPixelRatio = resolutionScale;
+        }
+
+        return resolutionScale;
+    }
+
     function configureCanvasSize(widget) {
         var canvas = widget._canvas;
         var width = canvas.clientWidth;
         var height = canvas.clientHeight;
-        var devicePixelRatio = window.devicePixelRatio;
-        var resolutionScale = widget._resolutionScale * devicePixelRatio;
+        var resolutionScale = configureSceneResolution(widget);
 
         widget._canvasWidth = width;
         widget._canvasHeight = height;
@@ -113,7 +122,6 @@ define([
 
         widget._canRender = width !== 0 && height !== 0;
         widget._lastDevicePixelRatio = devicePixelRatio;
-        widget._scene.screenSpaceErrorPixelRatio = resolutionScale;
     }
 
     function configureCameraFrustum(widget) {
@@ -251,6 +259,8 @@ define([
         this._forceResize = false;
         this._clock = defined(options.clock) ? options.clock : new Clock();
 
+        configureCanvasSize(this);
+
         try {
             var scene = new Scene({
                 canvas : canvas,
@@ -270,7 +280,7 @@ define([
 
             scene.camera.constrainedAxis = Cartesian3.UNIT_Z;
 
-            configureCanvasSize(this);
+            configureSceneResolution(this);
             configureCameraFrustum(this);
 
             var ellipsoid = defaultValue(scene.mapProjection.ellipsoid, Ellipsoid.WGS84);
@@ -562,7 +572,7 @@ define([
                     throw new DeveloperError('resolutionScale must be greater than 0.');
                 }
                 //>>includeEnd('debug');
-                this._forceResize = this._resolutionScale !== value;
+                this._forceResize = true;
                 this._resolutionScale = value;
             }
         }

--- a/Source/Widgets/Viewer/Viewer.js
+++ b/Source/Widgets/Viewer/Viewer.js
@@ -709,7 +709,6 @@ Either specify options.terrainProvider instead or set options.baseLayerPicker to
         this._needTrackedEntityUpdate = false;
         this._selectedEntity = undefined;
         this._clockTrackedDataSource = undefined;
-        this._forceResize = false;
         this._zoomIsFlight = false;
         this._zoomTarget = undefined;
         this._zoomPromise = undefined;
@@ -1195,7 +1194,6 @@ Either specify options.terrainProvider instead or set options.baseLayerPicker to
             },
             set : function(value) {
                 this._cesiumWidget.resolutionScale = value;
-                this._forceResize = true;
             }
         },
 
@@ -1359,12 +1357,12 @@ Either specify options.terrainProvider instead or set options.baseLayerPicker to
         var animationExists = defined(this._animation);
         var timelineExists = defined(this._timeline);
 
-        if (!this._forceResize && width === this._lastWidth && height === this._lastHeight) {
+        cesiumWidget.resize();
+
+        if (width === this._lastWidth && height === this._lastHeight) {
             return;
         }
 
-        cesiumWidget.resize();
-        this._forceResize = false;
         var panelMaxHeight = height - 125;
         var baseLayerPickerDropDown = this._baseLayerPickerDropDown;
 

--- a/Specs/Scene/Cesium3DTilesetSpec.js
+++ b/Specs/Scene/Cesium3DTilesetSpec.js
@@ -2235,7 +2235,7 @@ defineSuite([
             };
             expect(renderOptions).toRenderAndCall(function(rgba) {
                 sourceRed = rgba[0];
-                sourceGreen = rgba[1]
+                sourceGreen = rgba[1];
             });
 
             expect(renderOptions).toRenderAndCall(function(rgba) {
@@ -2318,8 +2318,6 @@ defineSuite([
             expect(renderOptions).toRenderAndCall(function(rgba) {
                 mixRed = rgba[0];
                 mixGreen = rgba[1];
-                console.log(rgba);
-                debugger;
                 expect(rgba[0]).toBeGreaterThan(replaceRed);
                 expect(rgba[0]).toBeLessThan(sourceRed);
                 expect(rgba[1]).toBeGreaterThan(sourceGreen);

--- a/Specs/Scene/Cesium3DTilesetSpec.js
+++ b/Specs/Scene/Cesium3DTilesetSpec.js
@@ -2228,12 +2228,14 @@ defineSuite([
 
             // Check that the feature is red
             var sourceRed;
+            var sourceGreen;
             var renderOptions = {
                 scene : scene,
                 time : new JulianDate(2457522.154792)
             };
             expect(renderOptions).toRenderAndCall(function(rgba) {
                 sourceRed = rgba[0];
+                sourceGreen = rgba[1]
             });
 
             expect(renderOptions).toRenderAndCall(function(rgba) {
@@ -2316,9 +2318,11 @@ defineSuite([
             expect(renderOptions).toRenderAndCall(function(rgba) {
                 mixRed = rgba[0];
                 mixGreen = rgba[1];
+                console.log(rgba);
+                debugger;
                 expect(rgba[0]).toBeGreaterThan(replaceRed);
                 expect(rgba[0]).toBeLessThan(sourceRed);
-                expect(rgba[1]).toBeGreaterThan(50);
+                expect(rgba[1]).toBeGreaterThan(sourceGreen);
                 expect(rgba[1]).toBeLessThan(replaceGreen);
                 expect(rgba[2]).toBeLessThan(25);
                 expect(rgba[3]).toEqual(255);

--- a/Specs/Scene/QuadtreePrimitiveSpec.js
+++ b/Specs/Scene/QuadtreePrimitiveSpec.js
@@ -84,7 +84,7 @@ defineSuite([
                 commandList: [],
                 cullingVolume: jasmine.createSpyObj('CullingVolume', ['computeVisibility']),
                 afterRender: [],
-                screenSpaceErrorPixelRatio: 1.0
+                pixelRatio: 1.0
             };
 
             frameState.cullingVolume.computeVisibility.and.returnValue(Intersect.INTERSECTING);

--- a/Specs/Scene/QuadtreePrimitiveSpec.js
+++ b/Specs/Scene/QuadtreePrimitiveSpec.js
@@ -83,7 +83,8 @@ defineSuite([
                 mode: SceneMode.SCENE3D,
                 commandList: [],
                 cullingVolume: jasmine.createSpyObj('CullingVolume', ['computeVisibility']),
-                afterRender: []
+                afterRender: [],
+                screenSpaceErrorPixelRatio: 1.0
             };
 
             frameState.cullingVolume.computeVisibility.and.returnValue(Intersect.INTERSECTING);

--- a/Specs/customizeJasmine.js
+++ b/Specs/customizeJasmine.js
@@ -9,7 +9,7 @@ define([
     'use strict';
 
     return function (env, includedCategory, excludedCategory, webglValidation, webglStub, release) {
-        // set this for uniform test resolution across devices 
+        // set this for uniform test resolution across devices
         window.devicePixelRatio = 1;
 
         function defineSuite(deps, name, suite, categories, focus) {

--- a/Specs/customizeJasmine.js
+++ b/Specs/customizeJasmine.js
@@ -9,6 +9,9 @@ define([
     'use strict';
 
     return function (env, includedCategory, excludedCategory, webglValidation, webglStub, release) {
+        // set this for uniform test resolution across devices 
+        window.devicePixelRatio = 1;
+
         function defineSuite(deps, name, suite, categories, focus) {
             /*global define,describe,fdescribe*/
             if (typeof suite === 'object' || typeof suite === 'string') {

--- a/Specs/spec-main.js
+++ b/Specs/spec-main.js
@@ -15,6 +15,9 @@
 (function() {
     'use strict';
 
+    // set this for uniform test resolution across devices 
+    window.devicePixelRatio = 1;
+
     function getQueryParameter(name) {
         var match = new RegExp('[?&]' + name + '=([^&]*)').exec(window.location.search);
         return match && decodeURIComponent(match[1].replace(/\+/g, ' '));

--- a/Specs/spec-main.js
+++ b/Specs/spec-main.js
@@ -15,7 +15,7 @@
 (function() {
     'use strict';
 
-    // set this for uniform test resolution across devices 
+    // set this for uniform test resolution across devices
     window.devicePixelRatio = 1;
 
     function getQueryParameter(name) {


### PR DESCRIPTION
Please see: https://github.com/AnalyticalGraphicsInc/cesium/issues/8082

### Changes
- **SSE is independent from resolution density** - Created a resolution constant within `Scene` and `FrameState` that is used to either upscale or downscale SSE values. I took the approach of dividing the SSE value by the constant opposed to scaling up the max sse value. 
- **Resolution scaled by the devices pixel ratio** - Just scales the resolutionScale by the window device pixel ratio.
- **Removed Force Update in `Viewer`** - There used to be a `_forceResize` attribute in Viewer that was used to make the canvas resize when the window size changed. However, this was only called when the `resolutionScale` function was called which calls the the  `resolutionScale` function of the `cesiumWidget`. Basically `resolutionScale` is a proxy to a class that already has a force update function and so that logic should be handled solely in the class it proxies the call.   