### PR TITLE
Stop actually requesting full screen in unit tests

### DIFF
--- a/Source/Core/Fullscreen.js
+++ b/Source/Core/Fullscreen.js
@@ -251,5 +251,8 @@ define([
         document[_names.exitFullscreen]();
     };
 
+    //For unit tests
+    Fullscreen._names = _names;
+
     return Fullscreen;
 });

--- a/Specs/Core/FullscreenSpec.js
+++ b/Specs/Core/FullscreenSpec.js
@@ -37,10 +37,20 @@ defineSuite([
     });
 
     it('can request fullscreen', function() {
-        // we can get away with this because the request is async, allowing us to
-        // exit before it actually happens
-        Fullscreen.requestFullscreen(document.body);
-        Fullscreen.exitFullscreen();
+        if (Fullscreen.supportsFullscreen()) {
+            spyOn(document.body, Fullscreen._names.requestFullscreen);
+            spyOn(document, Fullscreen._names.exitFullscreen);
+
+            Fullscreen.requestFullscreen(document.body);
+            expect(document.body[Fullscreen._names.requestFullscreen]).toHaveBeenCalled();
+
+            Fullscreen.exitFullscreen();
+            expect(document[Fullscreen._names.exitFullscreen]).toHaveBeenCalled();
+        } else {
+            // These are no-ops if supportsFullscreen is false.
+            Fullscreen.requestFullscreen(document.body);
+            Fullscreen.exitFullscreen();
+        }
     });
 
     if (!FeatureDetection.isInternetExplorer()) {


### PR DESCRIPTION
Uses a jasmine spy to avoid actually making the browser go full screen. The test was also showing a console exception the way it was written before.

Fixes #8103