### PR TITLE
Fix GEE terrain negative altitude handling

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,7 +5,7 @@ Change Log
 
 ##### Additions :tada:
 * Added optional `index` parameter to `PrimitiveCollection.add`. [#8041](https://github.com/AnalyticalGraphicsInc/cesium/pull/8041)
-* Cesium now renders at native device resolution by default instead of CSS pixel resolution, to go back to the old behavior, `viewer.resolutionScale = 1.0 / window.devicePixelRatio`. [#8082](https://github.com/AnalyticalGraphicsInc/cesium/issues/8082)  
+* Cesium now renders at native device resolution by default instead of CSS pixel resolution, to go back to the old behavior, `viewer.resolutionScale = 1.0 / window.devicePixelRatio`. [#8082](https://github.com/AnalyticalGraphicsInc/cesium/issues/8082)
 * Added `getByName` method to `DataSourceCollection` allowing to retreive `DataSource`s by their name property from the collection
 
 ##### Fixes :wrench:
@@ -14,7 +14,8 @@ Change Log
 * Fixed post-processing selection filtering to work for bloom. [#7984](https://github.com/AnalyticalGraphicsInc/cesium/issues/7984)
 * Disabled HDR by default to improve visual quality in most standard use cases. Set `viewer.scene.highDynamicRange = true` to re-enable. [#7966](https://github.com/AnalyticalGraphicsInc/cesium/issues/7966)
 * Fixed a bug that causes hidden point primitives to still appear on some operating systems. [#8043](https://github.com/AnalyticalGraphicsInc/cesium/issues/8043)
-* Fixed issue where KTX or CRN files would not be properly identified. [#7979](https://github.com/AnalyticalGraphicsInc/cesium/issues/7979) 
+* Fix negative altitude altitide handling in `GoogleEarthEnterpriseTerrainProvider`. [#8109](https://github.com/AnalyticalGraphicsInc/cesium/pull/8109)
+* Fixed issue where KTX or CRN files would not be properly identified. [#7979](https://github.com/AnalyticalGraphicsInc/cesium/issues/7979)
 * Fixed multiple globe materials making the globe darker. [#7726](https://github.com/AnalyticalGraphicsInc/cesium/issues/7726)
 
 ### 1.60 - 2019-08-01

--- a/Source/Workers/createVerticesFromGoogleEarthEnterpriseBuffer.js
+++ b/Source/Workers/createVerticesFromGoogleEarthEnterpriseBuffer.js
@@ -237,17 +237,19 @@ define([
                 scratchCartographic.longitude = longitude;
                 var latitude = originY + dv.getUint8(offset++) * stepY;
                 scratchCartographic.latitude = latitude;
-                // Height is stored in units of (1/EarthRadius) or (1/6371010.0)
-                var height = dv.getFloat32(offset, true) * 6371010.0;
+
+                var height = dv.getFloat32(offset, true);
                 offset += sizeOfFloat;
 
                 // In order to support old clients, negative altitude values are stored as
                 // height/-2^32. Old clients see the value as really close to 0 but new clients multiply
                 // by -2^32 to get the real negative altitude value.
-                if (height < negativeElevationThreshold) {
-                    height *= negativeAltitudeExponentBias;
+                if (height !== 0 && height < negativeElevationThreshold) {
+                    height *= -Math.pow(2, negativeAltitudeExponentBias);
                 }
-                height *= exaggeration;
+
+                // Height is stored in units of (1/EarthRadius) or (1/6371010.0)
+                height *= 6371010.0 * exaggeration;
 
                 scratchCartographic.height = height;
 


### PR DESCRIPTION
1. We were multiplying height by the `negativeAltitudeExponentBias` directly instead of `-2^negativeAltitudeExponentBias` which is correct in the comments, but not in the code.

2. The conversion from earth radius to meters needs to happen after the negative altitude bias is applied, otherwise the value would be incorrect.