### PR TITLE
Update tutorial links in index.release.html

### DIFF
--- a/index.release.html
+++ b/index.release.html
@@ -102,7 +102,7 @@
                 <td>Follow project news, developer tips, and posts about Cesium's innovative technology</td>
             </tr>
             <tr>
-                <td><a href="https://cesiumjs.org/tutorials.html">Tutorials</a></td>
+                <td><a href="https://cesium.com/docs/">Tutorials</a></td>
                 <td>Step-by-step guides for learning to use CesiumJS</td>
             </tr>
             <tr>
@@ -132,7 +132,7 @@
     if (window.location.protocol === 'file:') {
         document.body.innerHTML = '';
         document.write('<p><b>This file must be hosted in a web server.</br>');
-        document.write('See our <a href="https://cesiumjs.org/tutorials/Cesium-Workshop/#setup">Cesium Workshop</a> ');
+        document.write('See our <a href="https://cesium.com/docs/tutorials/cesium-workshop/#setup">Cesium Workshop</a> ');
         document.write('tutorial for a step-by-step guide.</b></p>');
     }
 </script>


### PR DESCRIPTION
While doing the release I noticed some links were outdated, since the tutorials have moved from cesiumjs.org to cesium.com. This PR updates them. 

@mramato 