### PR TITLE
Don't apply tonemapping for unlit material

### DIFF
--- a/Source/Scene/processPbrMaterials.js
+++ b/Source/Scene/processPbrMaterials.js
@@ -846,7 +846,10 @@ define([
         }
 
         // Final color
-        fragmentShader += '    color = LINEARtoSRGB(color);\n';
+        if (!isUnlit) {
+            fragmentShader += '    color = LINEARtoSRGB(color);\n';
+        }
+
         if (defined(alphaMode)) {
             if (alphaMode === 'MASK') {
                 fragmentShader += '    if (baseColorWithAlpha.a < u_alphaCutoff) {\n';

--- a/Source/Scene/processPbrMaterials.js
+++ b/Source/Scene/processPbrMaterials.js
@@ -535,10 +535,20 @@ define([
             '}\n\n';
 
         fragmentShader +=
+            'vec3 applyTonemapping(vec3 linearIn) \n' +
+            '{\n' +
+            '#ifndef HDR \n' +
+            '    return czm_acesTonemapping(linearIn);\n' +
+            '#else \n' +
+            '    return linearIn;\n' +
+            '#endif \n' +
+            '}\n\n';
+
+        fragmentShader +=
             'vec3 LINEARtoSRGB(vec3 linearIn) \n' +
             '{\n' +
             '#ifndef HDR \n' +
-            '    return pow(czm_acesTonemapping(linearIn), vec3(1.0/2.2));\n' +
+            '    return pow(linearIn, vec3(1.0/2.2));\n' +
             '#else \n' +
             '    return linearIn;\n' +
             '#endif \n' +
@@ -845,10 +855,11 @@ define([
             }
         }
 
-        // Final color
         if (!isUnlit) {
-            fragmentShader += '    color = LINEARtoSRGB(color);\n';
+            fragmentShader += '    color = applyTonemapping(color);\n';
         }
+
+        fragmentShader += '    color = LINEARtoSRGB(color);\n';
 
         if (defined(alphaMode)) {
             if (alphaMode === 'MASK') {

--- a/Specs/Scene/ModelSpec.js
+++ b/Specs/Scene/ModelSpec.js
@@ -1026,7 +1026,7 @@ defineSuite([
                 scene : scene,
                 time : JulianDate.fromDate(new Date('January 1, 2014 12:00:00 UTC'))
             }).toRenderAndCall(function(rgba) {
-                expect(rgba).toEqualEpsilon([193, 17, 16, 255], 5); // Red
+                expect(rgba).toEqualEpsilon([174, 6, 5, 255], 5); // Red
             });
 
             primitives.remove(m);


### PR DESCRIPTION
This PR skips the `LINEARtoSRGB` if the material is unlit. This seemed like a simpler approach than changing the `LINEARtoSRGB` function to be a no-op for unlit materials. @lilleyse let me know if you agree with this approach.

This also fixes the 2nd failing unit test (from https://github.com/AnalyticalGraphicsInc/cesium/issues/8127) by just updating the color. 

You can test that this correctly renders an unlit material with:

```
var viewer = new Cesium.Viewer('cesiumContainer', {
    infoBox : false,
    selectionIndicator : false,
    shadows : true,
    shouldAnimate : true
});

//viewer.scene.highDynamicRange = true;

function createModel(url, height) {
    viewer.entities.removeAll();

    var position = Cesium.Cartesian3.fromDegrees(-123.0744619, 44.0503706, height);
    var heading = Cesium.Math.toRadians(135);
    var pitch = 0;
    var roll = 0;
    var hpr = new Cesium.HeadingPitchRoll(heading, pitch, roll);
    var orientation = Cesium.Transforms.headingPitchRollQuaternion(position, hpr);

    var entity = viewer.entities.add({
        name : url,
        position : position,
        orientation : orientation,
        model : {
            uri : url,
            minimumPixelSize : 128,
            maximumScale : 20000
        }
    });
    viewer.trackedEntity = entity;
}

createModel('../../../Specs/Data/Models/PBR/BoxUnlit/BoxUnlit.gltf', 5000.0);
```

I used the browser's color picker to verify it is indeed the green base color.