### PR TITLE
Update AGI tileset

### DIFF
--- a/Apps/Sandcastle/gallery/3D Tiles Photogrammetry Classification.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Photogrammetry Classification.html
@@ -34,7 +34,7 @@ var viewer = new Cesium.Viewer('cesiumContainer', {
 
 // A normal b3dm tileset of photogrammetry
 var tileset = new Cesium.Cesium3DTileset({
-    url: Cesium.IonResource.fromAssetId(6074)
+    url: Cesium.IonResource.fromAssetId(40866)
 });
 viewer.scene.primitives.add(tileset);
 viewer.zoomTo(tileset);

--- a/Apps/Sandcastle/gallery/3D Tiles Photogrammetry.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Photogrammetry.html
@@ -32,7 +32,7 @@ var viewer = new Cesium.Viewer('cesiumContainer', {
 });
 
 var tileset = new Cesium.Cesium3DTileset({
-    url: Cesium.IonResource.fromAssetId(6074)
+    url: Cesium.IonResource.fromAssetId(40866)
 });
 
 viewer.scene.primitives.add(tileset);

--- a/Apps/Sandcastle/gallery/Clamp to 3D Tiles.html
+++ b/Apps/Sandcastle/gallery/Clamp to 3D Tiles.html
@@ -45,7 +45,7 @@ viewer.dataSources.add(dataSourcePromise).then(function(dataSource) {
 
 var tileset = scene.primitives.add(
     new Cesium.Cesium3DTileset({
-        url: Cesium.IonResource.fromAssetId(6074)
+        url: Cesium.IonResource.fromAssetId(40866)
     })
 );
 

--- a/Apps/Sandcastle/gallery/Classification Types.html
+++ b/Apps/Sandcastle/gallery/Classification Types.html
@@ -31,7 +31,7 @@ var viewer = new Cesium.Viewer('cesiumContainer', {
     terrainProvider: Cesium.createWorldTerrain()
 });
 
-var tileset = new Cesium.Cesium3DTileset({ url: Cesium.IonResource.fromAssetId(6074) });
+var tileset = new Cesium.Cesium3DTileset({ url: Cesium.IonResource.fromAssetId(40866) });
 viewer.scene.primitives.add(tileset);
 
 tileset.readyPromise.then(function(){

--- a/Apps/Sandcastle/gallery/Classification.html
+++ b/Apps/Sandcastle/gallery/Classification.html
@@ -202,7 +202,7 @@ function updateAlpha(value) {
     scene.invertClassificationColor.alpha = parseFloat(value);
 }
 
-var tileset = new Cesium.Cesium3DTileset({ url: Cesium.IonResource.fromAssetId(6074) });
+var tileset = new Cesium.Cesium3DTileset({ url: Cesium.IonResource.fromAssetId(40866) });
 scene.primitives.add(tileset);
 
 var viewModel = {

--- a/Apps/Sandcastle/gallery/Polylines on 3D Tiles.html
+++ b/Apps/Sandcastle/gallery/Polylines on 3D Tiles.html
@@ -59,7 +59,7 @@ var pipes = viewer.entities.add({
 
 var building = viewer.scene.primitives.add(
     new Cesium.Cesium3DTileset({
-        url: Cesium.IonResource.fromAssetId(6074)
+        url: Cesium.IonResource.fromAssetId(40866)
     })
 );
 var route = viewer.entities.add({

--- a/Apps/Sandcastle/gallery/Sample Height from 3D Tiles.html
+++ b/Apps/Sandcastle/gallery/Sample Height from 3D Tiles.html
@@ -36,7 +36,7 @@ var scene = viewer.scene;
 
 var tileset = scene.primitives.add(
     new Cesium.Cesium3DTileset({
-        url: Cesium.IonResource.fromAssetId(6074)
+        url: Cesium.IonResource.fromAssetId(40866)
     })
 );
 

--- a/Apps/Sandcastle/gallery/Scene Rendering Performance.html
+++ b/Apps/Sandcastle/gallery/Scene Rendering Performance.html
@@ -147,7 +147,7 @@ function resetScene() {
 function loadTilesetScenario() {
     resetScene();
 
-    tileset = new Cesium.Cesium3DTileset({ url: Cesium.IonResource.fromAssetId(6074) });
+    tileset = new Cesium.Cesium3DTileset({ url: Cesium.IonResource.fromAssetId(40866) });
     viewer.scene.primitives.add(tileset);
     viewer.zoomTo(tileset);
 }

--- a/Apps/Sandcastle/gallery/development/Many Clipping Planes.html
+++ b/Apps/Sandcastle/gallery/development/Many Clipping Planes.html
@@ -152,7 +152,7 @@ function updateClippingPlanes() {
 }
 
 var modelUrl = '../../SampleData/models/CesiumAir/Cesium_Air.glb';
-var agiHqUrl = Cesium.IonResource.fromAssetId(6074);
+var agiHqUrl = Cesium.IonResource.fromAssetId(40866);
 var instancedUrl = '../../SampleData/Cesium3DTiles/Instanced/InstancedOrientation/tileset.json';
 var pointCloudUrl = Cesium.IonResource.fromAssetId(5713);
 


### PR DESCRIPTION
The tileset now uses [KHR_materials_unlit](https://github.com/KhronosGroup/glTF/tree/master/extensions/2.0/Khronos/KHR_materials_unlit) and will not get tonemapped anymore when HDR is disabled.

CC https://github.com/AnalyticalGraphicsInc/cesium/pull/8128