### PR TITLE
Fix link in CONTRIBUTORS.md

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -226,5 +226,5 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to Cesiu
 * [Pascal Poulain](https://github.com/ppoulainpro)
 * [Abu Darda](https://github.com/abuDarda97)
 * [jony89](https://github.com/jony89)
-* [TJKoury] (https://github.com/tjkoury)
+* [TJKoury](https://github.com/tjkoury)
 


### PR DESCRIPTION
The last person to add their name to the file had a space between the
link text and URL. Removing the space should get the link to display properly.

I'm not sure who's best to tag here. @hpinkos, this was related to a PR you merged recently so I'm tagging you.