### PR TITLE
Fix GeoJSON Polygon Overlapping problem

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,7 @@ Change Log
 * Improved display of tile coordinates for `TileCoordinatesImageryProvider` [#8131](https://github.com/AnalyticalGraphicsInc/cesium/pull/8131)
 * Fixed relative-to-center check, `depthFailAppearance` resource freeing for `Primitive` [#8044](https://github.com/AnalyticalGraphicsInc/cesium/pull/8044)
 * Fixed undefined `quadDetails` error from zooming into the map really close. [#8011](https://github.com/AnalyticalGraphicsInc/cesium/pull/8011)
+* Fixed triangulation bug in polygons using `ArcType.RHUMB`. [#8042](https://github.com/AnalyticalGraphicsInc/cesium/issues/8042)
 
 ### 1.61 - 2019-09-03
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -136,6 +136,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to Cesiu
    * [Brandon Barker](https://github.com/ProjectBarks)
    * [Peter Gagliardi](https://github.com/ptrgags)
    * [Ian Lilley](https://github.com/IanLilleyT)
+   * [Shehzan Mohammed](https://github.com/shehzan10)
 * [Northrop Grumman](http://www.northropgrumman.com)
    * [Joseph Stein](https://github.com/nahgrin)
 


### PR DESCRIPTION
Thanks @hpinkos for the suggestion - Using the cartographic points instead of projecting to tangent plane fixed the overlap.

This was caused by the triangulation detecting that a polygon was inside rather than outside the boundary.

Fixes #8042.