### PR TITLE
Fix wall segments for tiny extruded geometry

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,7 @@ Change Log
 * Reduces size of approximateTerrainHeights.json by rounding the numbers [#7959](https://github.com/AnalyticalGraphicsInc/cesium/pull/7959)
 * Fixed undefined `quadDetails` error from zooming into the map really close. [#8011](https://github.com/AnalyticalGraphicsInc/cesium/pull/8011)
 * Fixed triangulation bug in polygons using `ArcType.RHUMB`. [#8042](https://github.com/AnalyticalGraphicsInc/cesium/issues/8042)
+* Fixed a bug where extruded polygons would sometimes be missing segments. [#8035](https://github.com/AnalyticalGraphicsInc/cesium/pull/8035)
 
 ### 1.61 - 2019-09-03
 

--- a/Source/Core/PolygonGeometryLibrary.js
+++ b/Source/Core/PolygonGeometryLibrary.js
@@ -591,7 +591,8 @@ define([
 
             p1 = Cartesian3.fromArray(edgePositions, UL * 3, p1Scratch);
             p2 = Cartesian3.fromArray(edgePositions, UR * 3, p2Scratch);
-            if (Cartesian3.equalsEpsilon(p1, p2, CesiumMath.EPSILON14, CesiumMath.EPSILON6)) {
+            if (Cartesian3.equalsEpsilon(p1, p2, CesiumMath.EPSILON10, CesiumMath.EPSILON10)) {
+                //skip corner
                 continue;
             }
 

--- a/Specs/Core/PolygonGeometrySpec.js
+++ b/Specs/Core/PolygonGeometrySpec.js
@@ -1039,6 +1039,44 @@ describe('Core/PolygonGeometry', function() {
         expect(geometry.attributes.normal).toBeUndefined();
     });
 
+    it('does not include indices for extruded walls that are too small', function() {
+        var positions = Cartesian3.fromDegreesArray([
+            7.757161063097392, 48.568676799636634,
+            7.753968290229146, 48.571796467099077,
+            7.755340073906587, 48.571948854067948,
+            7.756263393414589, 48.571947951609708,
+            7.756894446412183, 48.569396703043992
+        ]);
+
+        var pRhumb = PolygonGeometry.createGeometry(PolygonGeometry.fromPositions({
+            vertexFormat : VertexFormat.POSITION_ONLY,
+            positions : positions,
+            extrudedHeight: 1000,
+            closeTop: false,
+            closeBottom: false,
+            arcType: ArcType.RHUMB
+        }));
+
+        var numVertices = 20;
+        var numTriangles = 10; //5 wall segments, 2 triangles each wall
+        expect(pRhumb.attributes.position.values.length).toEqual(numVertices * 3);
+        expect(pRhumb.indices.length).toEqual(numTriangles * 3);
+
+        var pGeodesic = PolygonGeometry.createGeometry(PolygonGeometry.fromPositions({
+            vertexFormat : VertexFormat.POSITION_ONLY,
+            positions : positions,
+            extrudedHeight: 1000,
+            closeTop: false,
+            closeBottom: false,
+            arcType: ArcType.GEODESIC
+        }));
+
+        numVertices = 20;
+        numTriangles = 10;
+        expect(pGeodesic.attributes.position.values.length).toEqual(numVertices * 3);
+        expect(pGeodesic.indices.length).toEqual(numTriangles * 3);
+    });
+
     it('computing rectangle property', function() {
         var p = new PolygonGeometry({
             vertexFormat : VertexFormat.POSITION_AND_ST,


### PR DESCRIPTION
Replaces #8035

This if statement was incorrectly passing for the test case below, so I made it more robust.  It should only `continue` if the adjacent positions are the same, meaning we are at a corner of the wall and shouldn't connect those vertices.

```js
var viewer = new Cesium.Viewer('cesiumContainer', {
    imageryProvider : Cesium.createTileMapServiceImageryProvider({
        url : Cesium.buildModuleUrl('Assets/Textures/NaturalEarthII')
    })
});

var positions = Cesium.Cartesian3.fromDegreesArray([
    7.757161063097392, 48.568676799636634,
    7.753968290229146, 48.571796467099077,
    7.755340073906587, 48.571948854067948,
    7.756263393414589, 48.571947951609708,
    7.756894446412183, 48.569396703043992
]);

viewer.entities.add({
    polygon : {
        hierarchy : positions,
        extrudedHeight: 100.0,
        material : Cesium.Color.GREEN,
        outline : true,
        closeTop : false,
        closeBottom : false,
        arcType : Cesium.ArcType.RHUMB // causes missing volume
    }
});

function lookAt() {
    viewer.camera.lookAt(positions[1], new Cesium.Cartesian3(1000.0, 1000.0, 1000.0));
    viewer.camera.lookAtTransform(Cesium.Matrix4.IDENTITY);
}

Sandcastle.addToolbarButton('reset view', function() {
    lookAt();
});

lookAt();
```