### PR TITLE
Add rollup plugin to strip pragmas

### DIFF
--- a/Tools/rollup-plugin-strip-pragma.js
+++ b/Tools/rollup-plugin-strip-pragma.js
@@ -1,0 +1,89 @@
+'use strict';
+/**
+ * Inspired from rollup-plugin-replace https://github.com/rollup/rollup-plugin-replace/blob/master/src/index.js
+ * and
+ * strip-pragma-loader https://github.com/AnalyticalGraphicsInc/strip-pragma-loader/blob/master/index.js
+ *
+ * Usage:
+ *
+ * const rollup = require('rollup');
+ * const rollupStripPragma = require('./rollup-plugin-strip-pragma');
+ * const bundle = await rollup.rollup({
+ *     input: .....,
+ *     plugins: [
+ *         rollupStripPragma({
+ *             include: '*', // optional
+ *             pragmas: [ 'debug', .... ]
+ *         })
+ *     ]
+ * });
+ */
+const MagicString = require('magic-string');
+const { createFilter } = require('rollup-pluginutils');
+
+function escapeCharacters(token) {
+    return token.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, '\\$&');
+}
+
+function constructRegex(pragma) {
+    const prefix = 'include';
+    pragma = escapeCharacters(pragma);
+
+    const s = '[\\t ]*\\/\\/>>\\s?' +
+        prefix +
+        'Start\\s?\\(\\s?(["\'])' +
+        pragma +
+        '\\1\\s?,\\s?pragmas\\.' +
+        pragma +
+        '\\s?\\)\\s?;?' +
+
+        // multiline code block
+        '[\\s\\S]*?' +
+
+        // end comment
+        '[\\t ]*\\/\\/>>\\s?' +
+        prefix +
+        'End\\s?\\(\\s?(["\'])' +
+        pragma +
+        '\\2\\s?\\)\\s?;?\\s?[\\t]*\\n?';
+
+    return new RegExp(s, 'gm');
+}
+
+function stripPragma(options = {}) {
+    const filter = createFilter(options.include, options.exclude);
+    const patterns = options.pragmas.map(pragma => constructRegex(pragma));
+
+    return {
+        name: 'replace',
+
+        // code: The contents of the file
+        // id: the file path
+        transform(code, id) {
+            // Filters out includes and excluded files
+            if (!filter(id)) {
+                return null;
+            }
+
+            const magicString = new MagicString(code);
+
+            let match;
+            let start;
+            let end;
+
+            for (let i = 0; i < patterns.length; i++) {
+                const pattern = patterns[i];
+                while ((match = pattern.exec(code))) {
+                    start = match.index;
+                    end = start + match[0].length;
+                    magicString.overwrite(start, end, '');
+                }
+            }
+
+            const result = { code: magicString.toString() };
+            return result;
+        }
+    };
+}
+
+module.exports = stripPragma;

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -32,6 +32,8 @@ var AWS = require('aws-sdk');
 var mime = require('mime');
 var rollup = require('rollup');
 
+var rollupStripPragma = require('./Tools/rollup-plugin-strip-pragma');
+
 var packageJson = require('./package.json');
 var version = packageJson.version;
 if (/\.0$/.test(version)) {
@@ -121,8 +123,13 @@ function createWorkers() {
         '!Source/Workers/transferTypedArrayTest.js'
     ]);
     return rollup.rollup({
-        input: workers
-    }).then(bundle => {
+        input: workers,
+        plugins: [
+            rollupStripPragma({
+                pragmas: [ 'debug' ]
+            })
+        ]
+    }).then(function(bundle) {
         return bundle.write({
             dir: 'Source/Workers/Build',
             format: 'amd'

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "karma-requirejs": "^1.1.0",
     "karma-safari-launcher": "^1.0.0",
     "karma-spec-reporter": "^0.0.32",
+    "magic-string": "^0.25.3",
     "merge-stream": "^2.0.0",
     "mime": "^2.0.3",
     "mkdirp": "^0.5.1",
@@ -72,6 +73,7 @@
     "request": "^2.79.0",
     "rimraf": "^2.6.1",
     "rollup": "^1.21.4",
+    "rollup-pluginutils": "^2.8.2",
     "stream-to-promise": "^2.2.0",
     "yargs": "^14.0.0"
   },


### PR DESCRIPTION
Add a rollup plugin that removes pragmas from files.

The plugin takes include/exclude files as input along with an array of pragmas to remove, then removes them.

@mramato 