### PR TITLE
No array.fill in ie

### DIFF
--- a/Apps/Sandcastle/gallery/Labels.html
+++ b/Apps/Sandcastle/gallery/Labels.html
@@ -5,15 +5,17 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no">
     <meta name="description" content="Create and style textual labels.">
-    <meta name="cesium-sandcastle-labels" content="Showcases">
+    <meta name="cesium-sandcastle-labels" content="Showcases, Beginner">
     <title>Cesium Demo</title>
     <script type="text/javascript" src="../Sandcastle-header.js"></script>
     <script type="text/javascript" src="../../../ThirdParty/requirejs-2.1.20/require.js"></script>
     <script type="text/javascript">
-    require.config({
-        baseUrl : '../../../Source',
-        waitSeconds : 60
-    });
+        if(typeof require === 'function') {
+            require.config({
+                baseUrl : '../../../Source',
+                waitSeconds : 120
+            });
+        }
     </script>
 </head>
 <body class="sandcastle-loading" data-sandcastle-bucket="bucket-requirejs.html">

--- a/Source/Core/EllipsoidGeometry.js
+++ b/Source/Core/EllipsoidGeometry.js
@@ -317,8 +317,8 @@ define([
 
         var vertexCount = numThetas * numPhis * vertexMultiplier;
         var positions = new Float64Array(vertexCount * 3);
-        var isInner = new Array(vertexCount).fill(false);
-        var negateNormal = new Array(vertexCount).fill(false);
+        var isInner = arrayFill(new Array(vertexCount), false);
+        var negateNormal = arrayFill(new Array(vertexCount), false);
 
         // Multiply by 6 because there are two triangles per sector
         var indexCount = slicePartitions * stackPartitions * vertexMultiplier;


### PR DESCRIPTION
The cutout ellipsoid PR broke IE because IE doesn't support array.fill.  I changed these to use fillArray instead.

Also added the 'Beginner' label to the labels sandcastle example.