### PR TITLE
Fixed "Scene/GroundPolylinePrimitive adds width instance attribute"

### DIFF
--- a/Specs/Scene/GroundPolylinePrimitiveSpec.js
+++ b/Specs/Scene/GroundPolylinePrimitiveSpec.js
@@ -63,6 +63,7 @@ describe('Scene/GroundPolylinePrimitive', function() {
     ]);
 
     var lookPosition = Cartesian3.fromDegrees(0.02, 0.0);
+    var lookPositionOffset = Cartesian3.fromDegrees(0.02, 0.0001);
 
     beforeAll(function() {
         scene = createScene();
@@ -332,7 +333,7 @@ describe('Scene/GroundPolylinePrimitive', function() {
         expect(frameState.commandList.length).toEqual(0);
     });
 
-    function verifyGroundPolylinePrimitiveRender(primitive, color) {
+    function verifyGroundPolylinePrimitiveRender(lookPosition, primitive, color) {
         scene.camera.lookAt(lookPosition, Cartesian3.UNIT_Z);
 
         scene.groundPrimitives.add(depthRectanglePrimitive);
@@ -356,7 +357,7 @@ describe('Scene/GroundPolylinePrimitive', function() {
             appearance : new PolylineColorAppearance()
         });
 
-        verifyGroundPolylinePrimitiveRender(groundPolylinePrimitive, polylineColor);
+        verifyGroundPolylinePrimitiveRender(lookPosition, groundPolylinePrimitive, polylineColor);
     });
 
     it('renders in Columbus view when scene3DOnly is false', function() {
@@ -371,7 +372,7 @@ describe('Scene/GroundPolylinePrimitive', function() {
         });
 
         scene.morphToColumbusView(0);
-        verifyGroundPolylinePrimitiveRender(groundPolylinePrimitive, polylineColor);
+        verifyGroundPolylinePrimitiveRender(lookPosition, groundPolylinePrimitive, polylineColor);
     });
 
     it('renders in 2D when scene3DOnly is false', function() {
@@ -386,7 +387,7 @@ describe('Scene/GroundPolylinePrimitive', function() {
         });
 
         scene.morphTo2D(0);
-        verifyGroundPolylinePrimitiveRender(groundPolylinePrimitive, polylineColor);
+        verifyGroundPolylinePrimitiveRender(lookPosition, groundPolylinePrimitive, polylineColor);
     });
 
     it('renders during morph when scene3DOnly is false', function() {
@@ -419,7 +420,7 @@ describe('Scene/GroundPolylinePrimitive', function() {
         scene.render();
 
         scene.morphToColumbusView(1);
-        verifyGroundPolylinePrimitiveRender(groundPolylinePrimitive, polylineColor);
+        verifyGroundPolylinePrimitiveRender(lookPosition, groundPolylinePrimitive, polylineColor);
         scene.completeMorph();
     });
 
@@ -462,7 +463,7 @@ describe('Scene/GroundPolylinePrimitive', function() {
             appearance : new PolylineColorAppearance()
         });
 
-        verifyGroundPolylinePrimitiveRender(groundPolylinePrimitive, [192, 192, 255, 255]);
+        verifyGroundPolylinePrimitiveRender(lookPosition, groundPolylinePrimitive, [192, 192, 255, 255]);
     });
 
     it('renders bounding volume with debugShowBoundingVolume', function() {
@@ -522,7 +523,7 @@ describe('Scene/GroundPolylinePrimitive', function() {
             appearance : new PolylineColorAppearance()
         });
 
-        verifyGroundPolylinePrimitiveRender(groundPolylinePrimitive, polylineColor);
+        verifyGroundPolylinePrimitiveRender(lookPosition, groundPolylinePrimitive, polylineColor);
 
         var attributes = groundPolylinePrimitive.getGeometryInstanceAttributes('polyline on terrain');
         expect(attributes.color).toBeDefined();
@@ -539,7 +540,7 @@ describe('Scene/GroundPolylinePrimitive', function() {
             appearance : new PolylineColorAppearance()
         });
 
-        verifyGroundPolylinePrimitiveRender(groundPolylinePrimitive, polylineColor);
+        verifyGroundPolylinePrimitiveRender(lookPosition, groundPolylinePrimitive, polylineColor);
 
         // Remove so it can be re-added, but don't destroy.
         scene.groundPrimitives.destroyPrimitives = false;
@@ -551,7 +552,7 @@ describe('Scene/GroundPolylinePrimitive', function() {
         expect(attributes.color).toBeDefined();
         attributes.color = newColor;
 
-        verifyGroundPolylinePrimitiveRender(groundPolylinePrimitive, newColor);
+        verifyGroundPolylinePrimitiveRender(lookPosition, groundPolylinePrimitive, newColor);
     });
 
     it('adds width instance attribute', function() {
@@ -565,7 +566,7 @@ describe('Scene/GroundPolylinePrimitive', function() {
             appearance : new PolylineColorAppearance()
         });
 
-        verifyGroundPolylinePrimitiveRender(groundPolylinePrimitive, polylineColor);
+        verifyGroundPolylinePrimitiveRender(lookPositionOffset, groundPolylinePrimitive, polylineColor);
 
         scene.groundPrimitives.destroyPrimitives = false;
         scene.groundPrimitives.removeAll();
@@ -575,7 +576,7 @@ describe('Scene/GroundPolylinePrimitive', function() {
         expect(attributes.width).toBeDefined();
         attributes.width = [0];
 
-        verifyGroundPolylinePrimitiveRender(groundPolylinePrimitive, depthColor);
+        verifyGroundPolylinePrimitiveRender(lookPositionOffset, groundPolylinePrimitive, depthColor);
     });
 
     it('modify show instance attribute', function() {
@@ -591,7 +592,7 @@ describe('Scene/GroundPolylinePrimitive', function() {
             appearance : new PolylineColorAppearance()
         });
 
-        verifyGroundPolylinePrimitiveRender(groundPolylinePrimitive, polylineColor);
+        verifyGroundPolylinePrimitiveRender(lookPosition, groundPolylinePrimitive, polylineColor);
 
         scene.groundPrimitives.destroyPrimitives = false;
         scene.groundPrimitives.removeAll();
@@ -601,7 +602,7 @@ describe('Scene/GroundPolylinePrimitive', function() {
         expect(attributes.show).toBeDefined();
         attributes.show = [0];
 
-        verifyGroundPolylinePrimitiveRender(groundPolylinePrimitive, depthColor);
+        verifyGroundPolylinePrimitiveRender(lookPosition, groundPolylinePrimitive, depthColor);
     });
 
     it('renders with distance display condition per instance attribute', function() {
@@ -667,7 +668,7 @@ describe('Scene/GroundPolylinePrimitive', function() {
             appearance : new PolylineColorAppearance()
         });
 
-        verifyGroundPolylinePrimitiveRender(groundPolylinePrimitive, polylineColor);
+        verifyGroundPolylinePrimitiveRender(lookPosition, groundPolylinePrimitive, polylineColor);
 
         var attributes = groundPolylinePrimitive.getGeometryInstanceAttributes('polyline on terrain');
         var attributes2 = groundPolylinePrimitive.getGeometryInstanceAttributes('polyline on terrain');
@@ -685,7 +686,7 @@ describe('Scene/GroundPolylinePrimitive', function() {
             appearance : new PolylineColorAppearance()
         });
 
-        verifyGroundPolylinePrimitiveRender(groundPolylinePrimitive, polylineColor);
+        verifyGroundPolylinePrimitiveRender(lookPosition, groundPolylinePrimitive, polylineColor);
 
         expect(scene).toPickAndCall(function(result) {
             expect(result.primitive).toEqual(groundPolylinePrimitive);
@@ -705,7 +706,7 @@ describe('Scene/GroundPolylinePrimitive', function() {
         });
 
         scene.morphTo2D(0);
-        verifyGroundPolylinePrimitiveRender(groundPolylinePrimitive, polylineColor);
+        verifyGroundPolylinePrimitiveRender(lookPosition, groundPolylinePrimitive, polylineColor);
 
         expect(scene).toPickAndCall(function(result) {
             expect(result.primitive).toEqual(groundPolylinePrimitive);
@@ -725,7 +726,7 @@ describe('Scene/GroundPolylinePrimitive', function() {
         });
 
         scene.morphToColumbusView(0);
-        verifyGroundPolylinePrimitiveRender(groundPolylinePrimitive, polylineColor);
+        verifyGroundPolylinePrimitiveRender(lookPosition, groundPolylinePrimitive, polylineColor);
 
         expect(scene).toPickAndCall(function(result) {
             expect(result.primitive).toEqual(groundPolylinePrimitive);
@@ -764,7 +765,7 @@ describe('Scene/GroundPolylinePrimitive', function() {
         scene.render();
 
         scene.morphToColumbusView(1);
-        verifyGroundPolylinePrimitiveRender(groundPolylinePrimitive, polylineColor);
+        verifyGroundPolylinePrimitiveRender(lookPosition, groundPolylinePrimitive, polylineColor);
 
         expect(scene).toPickAndCall(function(result) {
             expect(result.primitive).toEqual(groundPolylinePrimitive);
@@ -785,7 +786,7 @@ describe('Scene/GroundPolylinePrimitive', function() {
             appearance : new PolylineColorAppearance()
         });
 
-        verifyGroundPolylinePrimitiveRender(groundPolylinePrimitive, polylineColor);
+        verifyGroundPolylinePrimitiveRender(lookPosition, groundPolylinePrimitive, polylineColor);
 
         expect(scene).toPickAndCall(function(result) {
             expect(result.id).toEqual('depth rectangle');
@@ -807,7 +808,7 @@ describe('Scene/GroundPolylinePrimitive', function() {
         });
 
         expect(function() {
-            verifyGroundPolylinePrimitiveRender(groundPolylinePrimitive, polylineColor);
+            verifyGroundPolylinePrimitiveRender(lookPosition, groundPolylinePrimitive, polylineColor);
         }).toThrowDeveloperError();
     });
 
@@ -822,7 +823,7 @@ describe('Scene/GroundPolylinePrimitive', function() {
             appearance : new PolylineColorAppearance()
         });
 
-        verifyGroundPolylinePrimitiveRender(groundPolylinePrimitive, polylineColor);
+        verifyGroundPolylinePrimitiveRender(lookPosition, groundPolylinePrimitive, polylineColor);
 
         var attributes = groundPolylinePrimitive.getGeometryInstanceAttributes('polyline on terrain');
 
@@ -870,7 +871,7 @@ describe('Scene/GroundPolylinePrimitive', function() {
             appearance : new PolylineColorAppearance()
         });
 
-        verifyGroundPolylinePrimitiveRender(groundPolylinePrimitive, polylineColor);
+        verifyGroundPolylinePrimitiveRender(lookPosition, groundPolylinePrimitive, polylineColor);
 
         expect(function() {
             groundPolylinePrimitive.getGeometryInstanceAttributes();
@@ -920,7 +921,7 @@ describe('Scene/GroundPolylinePrimitive', function() {
             }
             return groundPolylinePrimitive.ready;
         }).then(function() {
-            verifyGroundPolylinePrimitiveRender(groundPolylinePrimitive, polylineColor);
+            verifyGroundPolylinePrimitiveRender(lookPosition, groundPolylinePrimitive, polylineColor);
         });
     });
 


### PR DESCRIPTION
This test failed on mac when rendering a 0 width ground polyline, likely due to a small gpu/driver discrepancy that left a tiny sliver on the screen. So now this test uses an offset look position that a width 1 polyline is inside but a width 0 one is not.
