### PR TITLE
Fix blending states

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,6 +28,7 @@ Change Log
 * Fixed a crash for 3D Tiles that have zero volume. [#7945](https://github.com/AnalyticalGraphicsInc/cesium/pull/7945)
 * Fixed a bug where dynamic polylines did not use the given arcType. [#8191](https://github.com/AnalyticalGraphicsInc/cesium/issues/8191)
 * Fixed a bug where GlobeSurfaceTile would not render the tile until all layers completed loading causing globe to appear to hang. [#7974](https://github.com/AnalyticalGraphicsInc/cesium/issues/7974)
+* Fixed alpha equation for `BlendingState.ALPHA_BLEND` and `BlendingState.ADDITIVE_BLEND`. [#8202](https://github.com/AnalyticalGraphicsInc/cesium/pull/8202)
 
 ### 1.61 - 2019-09-03
 

--- a/Source/Scene/BlendingState.js
+++ b/Source/Scene/BlendingState.js
@@ -40,7 +40,7 @@ define([
             equationRgb : BlendEquation.ADD,
             equationAlpha : BlendEquation.ADD,
             functionSourceRgb : BlendFunction.SOURCE_ALPHA,
-            functionSourceAlpha : BlendFunction.SOURCE_ALPHA,
+            functionSourceAlpha : BlendFunction.ONE,
             functionDestinationRgb : BlendFunction.ONE_MINUS_SOURCE_ALPHA,
             functionDestinationAlpha : BlendFunction.ONE_MINUS_SOURCE_ALPHA
         }),
@@ -72,7 +72,7 @@ define([
             equationRgb : BlendEquation.ADD,
             equationAlpha : BlendEquation.ADD,
             functionSourceRgb : BlendFunction.SOURCE_ALPHA,
-            functionSourceAlpha : BlendFunction.SOURCE_ALPHA,
+            functionSourceAlpha : BlendFunction.ONE,
             functionDestinationRgb : BlendFunction.ONE,
             functionDestinationAlpha : BlendFunction.ONE
         })


### PR DESCRIPTION
The blending equation for the alpha channel was incorrect in master. It would end up doing
`srcAlpha * srcAlpha + dstAlpha * (1.0 - srcAlpha)`

After the fix the equation is `srcAlpha * 1.0 + dstAlpha * (1.0 - srcAlpha)`

Also fixed `ADDITIVE_BLEND` which had the same problem.

Noticed while working on https://github.com/AnalyticalGraphicsInc/cesium/issues/4381. I guess it never came up before because we never alpha blend a framebuffer onto another framebuffer.