### PR TITLE
Fix depth plane clipping

### DIFF
--- a/Source/Scene/DepthPlane.js
+++ b/Source/Scene/DepthPlane.js
@@ -1,4 +1,5 @@
 define([
+        '../Core/ApproximateTerrainHeights',
         '../Core/BoundingSphere',
         '../Core/Cartesian3',
         '../Core/ComponentDatatype',
@@ -18,6 +19,7 @@ define([
         '../Shaders/DepthPlaneVS',
         './SceneMode'
     ], function(
+        ApproximateTerrainHeights,
         BoundingSphere,
         Cartesian3,
         ComponentDatatype,
@@ -51,14 +53,22 @@ define([
     }
 
     var depthQuadScratch = FeatureDetection.supportsTypedArrays() ? new Float32Array(12) : [];
+    var scratchRadii = new Cartesian3();
     var scratchCartesian1 = new Cartesian3();
     var scratchCartesian2 = new Cartesian3();
     var scratchCartesian3 = new Cartesian3();
     var scratchCartesian4 = new Cartesian3();
 
     function computeDepthQuad(ellipsoid, frameState) {
-        var radii = ellipsoid.radii;
+        var radii = Cartesian3.clone(ellipsoid.radii, scratchRadii);
         var p = frameState.camera.positionWC;
+
+        // This effectively pushes the depth plane farther from the camera so that the depth plane does not render
+        // above primitives in the scene.
+        var radiusOffset = -ApproximateTerrainHeights._defaultMinTerrainHeight;
+        radii.x -= radiusOffset;
+        radii.y -= radiusOffset;
+        radii.z -= radiusOffset;
 
         // Find the corresponding position in the scaled space of the ellipsoid.
         var q = Cartesian3.multiplyComponents(ellipsoid.oneOverRadii, p, scratchCartesian1);


### PR DESCRIPTION
Fixes https://github.com/AnalyticalGraphicsInc/cesium/issues/7879. Merge https://github.com/AnalyticalGraphicsInc/cesium/pull/8207 first.

Pushes the depth plane farther from the camera so that the depth plane does not render above primitives in the scene.

This is a lot like existing code that used to push the depth plane below classification primitives to avoid rendering artifacts. https://github.com/AnalyticalGraphicsInc/cesium/commit/1fda8c0ce8a95e13df150bd686fbfc957823908f

Don't merge until https://github.com/AnalyticalGraphicsInc/cesium/issues/8179 is fixed, otherwise `pickPosition` will be extremely wrong when `scene.depthTestAgainstTerrain` is false.