### PR TITLE
Fix spec title descriptions

### DIFF
--- a/Specs/Renderer/AutomaticUniformSpec.js
+++ b/Specs/Renderer/AutomaticUniformSpec.js
@@ -28,7 +28,7 @@ define([
         createFrameState) {
         'use strict';
 
-describe('Core/Cartesian2', function() {
+describe('Renderer/AutomaticUniforms', function() {
 
     var context;
 

--- a/Specs/Renderer/BuiltinFunctionsSpec.js
+++ b/Specs/Renderer/BuiltinFunctionsSpec.js
@@ -16,7 +16,7 @@ define([
         createFrameState) {
         'use strict';
 
-describe('Core/BoundingRectangle', function() {
+describe('Renderer/BuiltinFunctions', function() {
 
     var context;
 

--- a/Specs/Renderer/ClearSpec.js
+++ b/Specs/Renderer/ClearSpec.js
@@ -16,7 +16,7 @@ define([
         createContext) {
         'use strict';
 
-describe('Core/BoundingRectangle', function() {
+describe('Renderer/Clear', function() {
 
     var context;
 

--- a/Specs/Renderer/DrawSpec.js
+++ b/Specs/Renderer/DrawSpec.js
@@ -36,7 +36,7 @@ define([
         createContext) {
         'use strict';
 
-describe('Core/BoundingRectangle', function() {
+describe('Renderer/Draw', function() {
 
     var context;
     var sp;

--- a/Specs/Renderer/UniformSpec.js
+++ b/Specs/Renderer/UniformSpec.js
@@ -18,7 +18,7 @@ define([
         createContext) {
         'use strict';
 
-describe('Core/Cartesian2', function() {
+describe('Renderer/Uniform', function() {
 
     var context;
 

--- a/Specs/Renderer/VertexArrayFactorySpec.js
+++ b/Specs/Renderer/VertexArrayFactorySpec.js
@@ -26,7 +26,7 @@ define([
         createContext) {
         'use strict';
 
-describe('Core/ComponentDatatype', function() {
+describe('Renderer/VertexArrayFactory', function() {
 
     var context;
     var va;

--- a/Specs/Scene/Batched3DModel3DTileContentClassificationSpec.js
+++ b/Specs/Scene/Batched3DModel3DTileContentClassificationSpec.js
@@ -42,7 +42,7 @@ define([
         createScene) {
         'use strict';
 
-describe('Core/Cartesian3', function() {
+describe('Scene/Batched3DModel3DTileContentClassification', function() {
 
     var scene;
     var modelMatrix;

--- a/Specs/Scene/Composite3DTileContentSpec.js
+++ b/Specs/Scene/Composite3DTileContentSpec.js
@@ -12,7 +12,7 @@ define([
         createScene) {
         'use strict';
 
-describe('Core/Cartesian3', function() {
+describe('Scene/Composite3DTileContent', function() {
 
     var scene;
     var centerLongitude = -1.31968;

--- a/Specs/Scene/FrustumCommandsSpec.js
+++ b/Specs/Scene/FrustumCommandsSpec.js
@@ -6,7 +6,7 @@ define([
         FrustumCommands) {
         'use strict';
 
-describe('Renderer/Pass', function() {
+describe('Scene/FrustumCommands', function() {
 
     it('constructs without arguments', function() {
         var frustum = new FrustumCommands();

--- a/Specs/Scene/GeometryRenderingSpec.js
+++ b/Specs/Scene/GeometryRenderingSpec.js
@@ -86,7 +86,7 @@ define([
         pollToPromise) {
         'use strict';
 
-describe('Core/ArcType', function() {
+describe('Scene/GeometryRenderingSpec', function() {
 
     var scene;
     var ellipsoid;

--- a/Specs/Scene/HeightmapTessellatorSpec.js
+++ b/Specs/Scene/HeightmapTessellatorSpec.js
@@ -16,7 +16,7 @@ define([
         WebMercatorProjection) {
         'use strict';
 
-describe('Core/HeightmapTessellator', function() {
+describe('Scene/HeightmapTessellator', function() {
 
     it('throws when heightmap is not provided', function() {
         expect(function() {

--- a/Specs/Scene/Instanced3DModel3DTileContentSpec.js
+++ b/Specs/Scene/Instanced3DModel3DTileContentSpec.js
@@ -22,7 +22,7 @@ define([
         createScene) {
         'use strict';
 
-describe('Core/Cartesian3', function() {
+describe('Scene/Instanced3DModel3DTileContent', function() {
 
     var scene;
     var centerLongitude = -1.31968;

--- a/Specs/Scene/MultifrustumSpec.js
+++ b/Specs/Scene/MultifrustumSpec.js
@@ -54,7 +54,7 @@ define([
         when) {
         'use strict';
 
-describe('Core/BoundingSphere', function() {
+describe('Scene/Multifrustum', function() {
 
     var scene;
     var context;

--- a/Specs/Scene/PickSpec.js
+++ b/Specs/Scene/PickSpec.js
@@ -54,7 +54,7 @@ define([
         when) {
         'use strict';
 
-describe('Core/Cartesian3', function() {
+describe('Scene/Pick', function() {
 
     // It's not easily possible to mock the most detailed pick functions
     // so don't run those tests when using the WebGL stub

--- a/Specs/Scene/PointCloudEyeDomeLightingSpec.js
+++ b/Specs/Scene/PointCloudEyeDomeLightingSpec.js
@@ -16,7 +16,7 @@ define([
         createScene) {
         'use strict';
 
-describe('Core/Cartesian3', function() {
+describe('Scene/PointCloudEyeDomeLighting', function() {
 
     var scene;
     var centerLongitude = -1.31968;

--- a/Specs/Scene/PrimitiveCullingSpec.js
+++ b/Specs/Scene/PrimitiveCullingSpec.js
@@ -46,7 +46,7 @@ define([
         createScene) {
         'use strict';
 
-describe('Core/Cartesian3', function() {
+describe('Scene/PrimitiveCulling', function() {
 
     var scene;
     var rectangle = Rectangle.fromDegrees(-100.0, 30.0, -93.0, 37.0);

--- a/Specs/Scene/Tileset3DTileContentSpec.js
+++ b/Specs/Scene/Tileset3DTileContentSpec.js
@@ -10,7 +10,7 @@ define([
         createScene) {
         'use strict';
 
-describe('Core/Cartesian3', function() {
+describe('Scene/Tileset3DTileContent', function() {
 
     var scene;
     var centerLongitude = -1.31968;


### PR DESCRIPTION
A bunch of spec files had the wrong descriptions possible due to copy-paste. Fixed as many as I could find using a few grep commands.