### PR TITLE
Fix rhumb triangulation across IDL

### DIFF
--- a/Source/Core/PolygonGeometry.js
+++ b/Source/Core/PolygonGeometry.js
@@ -27,9 +27,7 @@ define([
         './Matrix3',
         './PolygonGeometryLibrary',
         './PolygonPipeline',
-        './PolylinePipeline',
         './Quaternion',
-        './Queue',
         './Rectangle',
         './VertexFormat',
         './WindingOrder'
@@ -62,9 +60,7 @@ define([
         Matrix3,
         PolygonGeometryLibrary,
         PolygonPipeline,
-        PolylinePipeline,
         Quaternion,
-        Queue,
         Rectangle,
         VertexFormat,
         WindingOrder) {
@@ -929,7 +925,7 @@ define([
                 carto = ellipsoid.cartesianToCartographic(positions[i], scratchCarto1);
                 var lon = carto.longitude;
                 if (Math.abs(lon - lastLongitude) > CesiumMath.PI) {
-                    // assume the position crosses the IDL if the degrees change to be more than 180degrees away
+                    // assume the position crosses the IDL if the next adjacent position longitude changes to be more than 180 degrees
                     lon += CesiumMath.TWO_PI;
                 }
                 lastLongitude = lon;


### PR DESCRIPTION
Fixes #8042

This is the same fix @shehzan10 added in #8176, but attempts to account for when the polygon positions cross the IDL for the projection into 2D for triangulation.  It makes the assumption that if adjacent polygon positions are greater than 180 degrees away, it must be because that position crossed the IDL and it adds `TWO_PI` to the longitude.  I think this is a safe assumption because Cesium can't triangulate polygons that are larger than half the earth anyway.  I honestly couldn't figure out a better way to do this, but I'm open to suggestions if anyone has one.  I originally wanted to use `Rectangle.fromCartesianArray` to get the "west" edge but that doesn't handle the case where a polygon crosses both the IDL and the prime meridian.

TODO
- [ ] Fix polygons that cross poles