### PR TITLE
Revert #8176

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,7 +20,6 @@ Change Log
 * Fixed relative-to-center check, `depthFailAppearance` resource freeing for `Primitive` [#8044](https://github.com/AnalyticalGraphicsInc/cesium/pull/8044)
 * Reduces size of approximateTerrainHeights.json by rounding the numbers [#7959](https://github.com/AnalyticalGraphicsInc/cesium/pull/7959)
 * Fixed undefined `quadDetails` error from zooming into the map really close. [#8011](https://github.com/AnalyticalGraphicsInc/cesium/pull/8011)
-* Fixed triangulation bug in polygons using `ArcType.RHUMB`. [#8042](https://github.com/AnalyticalGraphicsInc/cesium/issues/8042)
 * Fixed a bug where extruded polygons would sometimes be missing segments. [#8035](https://github.com/AnalyticalGraphicsInc/cesium/pull/8035)
 * 3D Tiles geometric error now scales with transform. [#8182](https://github.com/AnalyticalGraphicsInc/cesium/pull/8182)
 * Fixed per-feature post processing from sometimes selecting the wrong feature. [#7929](https://github.com/AnalyticalGraphicsInc/cesium/pull/7929)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -138,7 +138,6 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute to Cesiu
    * [Brandon Barker](https://github.com/ProjectBarks)
    * [Peter Gagliardi](https://github.com/ptrgags)
    * [Ian Lilley](https://github.com/IanLilleyT)
-   * [Shehzan Mohammed](https://github.com/shehzan10)
 * [Northrop Grumman](http://www.northropgrumman.com)
    * [Joseph Stein](https://github.com/nahgrin)
 

--- a/Source/Core/PolygonGeometry.js
+++ b/Source/Core/PolygonGeometry.js
@@ -910,29 +910,6 @@ define([
         return computeRectangle(polygonHierarchy.positions, ellipsoid, arcType, granularity, result);
     };
 
-    var cartographicScratchArray = [];
-    function cartesian3ToCartographicAsCartesian2(ellipsoid) {
-        return function (positions) {
-            var numberOfPoints = positions.length;
-
-            var i;
-            if (cartographicScratchArray.length < numberOfPoints) {
-                for (i = cartographicScratchArray.length; i < numberOfPoints; i++) {
-                    cartographicScratchArray.push(new Cartographic());
-                }
-            }
-
-            var cartographicPositions = ellipsoid.cartesianArrayToCartographicArray(positions, cartographicScratchArray);
-            var result = [];
-            for (i = 0; i < numberOfPoints; i++) {
-                var cartographicPosition = cartographicPositions[i];
-                result.push(new Cartesian2(cartographicPosition.longitude, cartographicPosition.latitude));
-            }
-
-            return result;
-        };
-    }
-
     /**
      * Computes the geometric representation of a polygon, including its vertices, indices, and a bounding sphere.
      *
@@ -957,13 +934,7 @@ define([
 
         var tangentPlane = EllipsoidTangentPlane.fromPoints(outerPositions, ellipsoid);
 
-        var results;
-        if (arcType === ArcType.RHUMB) {
-            var projectionFunction = cartesian3ToCartographicAsCartesian2(ellipsoid);
-            results = PolygonGeometryLibrary.polygonsFromHierarchy(polygonHierarchy, projectionFunction, !perPositionHeight, ellipsoid);
-        } else {
-            results = PolygonGeometryLibrary.polygonsFromHierarchy(polygonHierarchy, tangentPlane.projectPointsOntoPlane.bind(tangentPlane), !perPositionHeight, ellipsoid);
-        }
+        var results = PolygonGeometryLibrary.polygonsFromHierarchy(polygonHierarchy, tangentPlane.projectPointsOntoPlane.bind(tangentPlane), !perPositionHeight, ellipsoid);
 
         var hierarchy = results.hierarchy;
         var polygons = results.polygons;


### PR DESCRIPTION
#8176 fixed most of the common cases for polygons with rhumb lines, but broke polygons that go over the north or south pole.  Reverting it until we have a full solution (see #8206)