### PR TITLE
Better rhumbline polygon subdivision

### DIFF
--- a/Specs/Core/PolygonGeometrySpec.js
+++ b/Specs/Core/PolygonGeometrySpec.js
@@ -206,8 +206,25 @@ describe('Core/PolygonGeometry', function() {
             arcType : ArcType.RHUMB
         }));
 
-        expect(p.attributes.position.values.length).toEqual(15 * 3); // 8 around edge + 7 in the middle
-        expect(p.indices.length).toEqual(20 * 3); //5 squares * 4 triangles per square
+        expect(p.attributes.position.values.length).toEqual(13 * 3); // 8 around edge + 5 in the middle
+        expect(p.indices.length).toEqual(16 * 3); //5 squares * 4 triangles per square
+    });
+
+    it('create geometry creates with rhumb lines around pole', function() {
+        var p = PolygonGeometry.createGeometry(PolygonGeometry.fromPositions({
+            vertexFormat : VertexFormat.POSITION_ONLY,
+            positions : Cartesian3.fromDegreesArray([
+                180, -89,
+                -90, -89,
+                0, -89,
+                90, -89
+            ]),
+            granularity : CesiumMath.RADIANS_PER_DEGREE,
+            arcType : ArcType.RHUMB
+        }));
+
+        expect(p.attributes.position.values.length).toEqual(17 * 3);
+        expect(p.indices.length).toEqual(24 * 3);
     });
 
     it('create geometry throws if arcType is STRAIGHT', function() {


### PR DESCRIPTION
Fixes #8032

Instead of using rhumblines to find the midpoints of every triangle in a polygon mesh as it subdivides, it only uses rhumblines to subdivide the edges and uses the shortest distance between to points to subdivide the inner triangles.  This results in way fewer triangles per rhumbline polygon, especially towards the poles.