### PR TITLE
Sandcastle support for Cesium ES6

### DIFF
--- a/Apps/Sandcastle/.eslintrc.json
+++ b/Apps/Sandcastle/.eslintrc.json
@@ -19,5 +19,16 @@
         "no-implicit-globals": "off",
         "no-unused-vars": ["off"],
         "quotes": "off"
-    }
+    },
+    "overrides": [
+        {
+            "files": [
+                "load-cesium-es6.js"
+            ],
+            "parserOptions": {
+                "ecmaVersion": 2015,
+                "sourceType": "module"
+            }
+        }
+    ]
 }

--- a/Apps/Sandcastle/Sandcastle-helpers.js
+++ b/Apps/Sandcastle/Sandcastle-helpers.js
@@ -11,9 +11,8 @@
            '    Sandcastle.finishedLoading();\n' +
            '}\n' +
            'if (typeof Cesium !== \'undefined\') {\n' +
+           '    startupCalled = true;\n' +
            '    startup(Cesium);\n' +
-           '} else if (typeof require === \'function\') {\n' +
-           '    require([\'Cesium\'], startup);\n' +
            '}\n';
     };
     window.decodeBase64Data = function(base64String, pako) {

--- a/Apps/Sandcastle/index.html
+++ b/Apps/Sandcastle/index.html
@@ -132,7 +132,7 @@
             </div>
         </div>
         <div id="cesiumContainer" data-dojo-type="dijit.layout.TabContainer" data-dojo-props="region: 'center'">
-            <div id="bucketPane" data-dojo-type="dijit.layout.ContentPane" data-dojo-props="title: 'Cesium ' + Cesium.VERSION">
+            <div id="bucketPane" data-dojo-type="dijit.layout.ContentPane" data-dojo-props="title: 'Cesium ' + VERSION">
                 <iframe id="bucketFrame" src="templates/bucket.html" class="fullFrame" allowfullscreen mozallowfullscreen webkitallowfullscreen></iframe>
             </div>
         </div>

--- a/Apps/Sandcastle/load-cesium-es6.js
+++ b/Apps/Sandcastle/load-cesium-es6.js
@@ -1,0 +1,10 @@
+// This file load the ES6 unbuilt version of Cesium
+// into the global scope during local developmnet
+import * as Cesium from "../../../Source/Cesium.js";
+window.Cesium = Cesium;
+
+// Since ES6 modues have no gauranteed load order,
+// onlycall startup if it's already defined but hasn't been called yet
+if (!window.startupCalled && typeof window.startup === 'function') {
+    window.startup(Cesium);
+}

--- a/Apps/Sandcastle/standalone.html
+++ b/Apps/Sandcastle/standalone.html
@@ -8,7 +8,8 @@
     <script type="text/javascript" src="Sandcastle-header.js"></script>
     <script type="text/javascript" src="Sandcastle-client.js"></script>
     <script type="text/javascript" src="ThirdParty/pako.min.js"></script>
-    <script type="text/javascript" src="../../ThirdParty/requirejs-2.1.20/require.js"></script>
+    <script type="text/javascript" src="../../Build/CesiumUnminified/Cesium.js" nomodule></script>
+    <script type="module" src="load-cesium-es6.js"></script>
     <script type="text/javascript" src="Sandcastle-helpers.js"></script>
     <style>
         .fullSize {
@@ -32,27 +33,8 @@ if (window.location.hash.indexOf('#c=') === 0) {
     window.sandcastleData = data;
 }
 
-require({
-    baseUrl : '../../../',
-    waitSeconds : 120,
-    packages: [{
-        name: 'CesiumUnminified',
-        location: '../Build/CesiumUnminified',
-        main: 'Cesium'
-    }]
-},[
-    'Source/Cesium'
-], function(
-    Cesium) {
-     'use strict';
-     if (window.Cesium === undefined) {
-        window.Cesium = Cesium;
-     }
-
-    var defined = window.Cesium.defined;
     var code;
-
-    if (defined(window.sandcastleData)) {
+    if (window.sandcastleData) {
         var base64String = window.location.hash.substr(3);
         var data = window.sandcastleData;
         var html = data.html;
@@ -73,8 +55,6 @@ require({
         document.head.appendChild(scriptElement);
         scriptElement.innerHTML = window.embedInSandcastleTemplate(code, isFirefox);
     }
-});
-
 </script>
 </body>
 </html>

--- a/Apps/Sandcastle/templates/bucket-requirejs.html
+++ b/Apps/Sandcastle/templates/bucket-requirejs.html
@@ -6,15 +6,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no">
     <title>Cesium Demo</title>
     <script type="text/javascript" src="../Sandcastle-header.js"></script>
-    <script type="text/javascript" src="../../../ThirdParty/requirejs-2.1.20/require.js"></script>
-    <script type="text/javascript">
-        if(typeof require === 'function') {
-            require.config({
-                baseUrl : '../../../Source',
-                waitSeconds : 120
-            });
-        }
-    </script>
+    <script type="text/javascript" src="../../../Build/CesiumUnminified/Cesium.js" nomodule></script>
+    <script type="module" src="../load-cesium-es6.js"></script>
 </head>
 <body class="sandcastle-loading" data-sandcastle-bucket="bucket-requirejs.html">
 <script type="text/javascript" src="../Sandcastle-client.js"></script>

--- a/Source/Core/buildModuleUrl.js
+++ b/Source/Core/buildModuleUrl.js
@@ -1,5 +1,6 @@
 import defined from './defined.js';
 import DeveloperError from './DeveloperError.js';
+import FeatureDetection from './FeatureDetection.js';
 import getAbsoluteUri from './getAbsoluteUri.js';
 import Resource from './Resource.js';
 
@@ -46,7 +47,7 @@ import Resource from './Resource.js';
             baseUrlString = CESIUM_BASE_URL;
         } else if (typeof define === 'object' && defined(define.amd) && !define.amd.toUrlUndefined && defined(require.toUrl)) {
             baseUrlString = getAbsoluteUri('..', buildModuleUrl('Core/buildModuleUrl.js'));
-        } else if (/\/buildModuleUrl\.js$/.test(import.meta.url)) {
+        } else if (!FeatureDetection.isInternetExplorer() && /\/buildModuleUrl\.js$/.test(import.meta.url)) {
             baseUrlString = getAbsoluteUri('..', import.meta.url);
         } else {
             baseUrlString = getBaseUrlFromCesiumScript();

--- a/Source/ThirdParty/knockout-3.5.0.js
+++ b/Source/ThirdParty/knockout-3.5.0.js
@@ -1,4 +1,9 @@
-var tmp = {};
+var oldValue;
+if (typeof window !== 'undefined') {
+    oldValue = window.ko;
+}
+
+(function(){
 
 /*!
  * Knockout JavaScript library v3.5.0
@@ -6,7 +11,7 @@ var tmp = {};
  * License: MIT (http://www.opensource.org/licenses/mit-license.php)
  */
 
-(function() {(function(p){var z=tmp,w=z.document,R=z.navigator,v=z.jQuery,H=z.JSON;v||"undefined"===typeof jQuery||(v=jQuery);(function(p){p(z.ko={})})(function(S,T){function K(a,c){return null===a||typeof a in W?a===c:!1}function X(b,c){var d;return function(){d||(d=a.a.setTimeout(function(){d=p;b()},c))}}function Y(b,c){var d;return function(){clearTimeout(d);
+(function() {(function(p){var z=this||(0,eval)("this"),w=z.document,R=z.navigator,v=z.jQuery,H=z.JSON;v||"undefined"===typeof jQuery||(v=jQuery);(function(p){"function"===typeof define&&define.amd?define(["exports","require"],p):"object"===typeof exports&&"object"===typeof module?p(module.exports||exports):p(z.ko={})})(function(S,T){function K(a,c){return null===a||typeof a in W?a===c:!1}function X(b,c){var d;return function(){d||(d=a.a.setTimeout(function(){d=p;b()},c))}}function Y(b,c){var d;return function(){clearTimeout(d);
 d=a.a.setTimeout(b,c)}}function Z(a,c){c&&"change"!==c?"beforeChange"===c?this.oc(a):this.bb(a,c):this.pc(a)}function aa(a,c){null!==c&&c.s&&c.s()}function ba(a,c){var d=this.pd,e=d[t];e.qa||(this.Pb&&this.kb[c]?(d.tc(c,a,this.kb[c]),this.kb[c]=null,--this.Pb):e.F[c]||d.tc(c,a,e.G?{da:a}:d.Zc(a)),a.Ka&&a.fd())}var a="undefined"!==typeof S?S:{};a.b=function(b,c){for(var d=b.split("."),e=a,f=0;f<d.length-1;f++)e=e[d[f]];e[d[d.length-1]]=c};a.J=function(a,c,d){a[c]=d};a.version="3.5.0";a.b("version",
 a.version);a.options={deferUpdates:!1,useOnlyNativeEvents:!1,foreachHidesDestroyed:!1};a.a=function(){function b(a,b){for(var c in a)f.call(a,c)&&b(c,a[c])}function c(a,b){if(b)for(var c in b)f.call(b,c)&&(a[c]=b[c]);return a}function d(a,b){a.__proto__=b;return a}function e(b,c,d,e){var k=b[c].match(n)||[];a.a.C(d.match(n),function(b){a.a.Oa(k,b,e)});b[c]=k.join(" ")}var f=Object.prototype.hasOwnProperty,g={__proto__:[]}instanceof Array,h="function"===typeof Symbol,m={},l={};m[R&&/Firefox\/2/i.test(R.userAgent)?
 "KeyboardEvent":"UIEvents"]=["keyup","keydown","keypress"];m.MouseEvents="click dblclick mousedown mouseup mousemove mouseover mouseout mouseenter mouseleave".split(" ");b(m,function(a,b){if(b.length)for(var c=0,d=b.length;c<d;c++)l[b[c]]=a});var k={propertychange:!0},q=w&&function(){for(var a=3,b=w.createElement("div"),c=b.getElementsByTagName("i");b.innerHTML="\x3c!--[if gt IE "+ ++a+"]><i></i><![endif]--\x3e",c[0];);return 4<a?a:p}(),n=/\S+/g,r;return{Ic:["authenticity_token",/^__RequestVerificationToken(_.*)?$/],
@@ -139,4 +144,14 @@ h.beforeRemove?a.na:a.removeNode);var M,O,P;try{P=e.ownerDocument.activeElement}
 !v.tmpl)return 0;try{if(0<=v.tmpl.tag.tmpl.open.toString().indexOf("__"))return 2}catch(a){}return 1}();this.renderTemplateSource=function(b,e,f,g){g=g||w;f=f||{};if(2>a)throw Error("Your version of jQuery.tmpl is too old. Please upgrade to jQuery.tmpl 1.0.0pre or later.");var h=b.data("precompiled");h||(h=b.text()||"",h=v.template(null,"{{ko_with $item.koBindingContext}}"+h+"{{/ko_with}}"),b.data("precompiled",h));b=[e.$data];e=v.extend({koBindingContext:e},f.templateOptions);e=v.tmpl(h,b,e);e.appendTo(g.createElement("div"));
 v.fragments={};return e};this.createJavaScriptEvaluatorBlock=function(a){return"{{ko_code ((function() { return "+a+" })()) }}"};this.addTemplate=function(a,b){w.write("<script type='text/html' id='"+a+"'>"+b+"\x3c/script>")};0<a&&(v.tmpl.tag.ko_code={open:"__.push($1 || '');"},v.tmpl.tag.ko_with={open:"with($1) {",close:"} "})};a.Za.prototype=new a.ca;a.Za.prototype.constructor=a.Za;var b=new a.Za;0<b.Gd&&a.ec(b);a.b("jqueryTmplTemplateEngine",a.Za)})()})})();})();
 
-export default tmp.ko;
+})();
+
+var ko;
+if (typeof window !== 'undefined') {
+    ko = window.ko;
+    window.ko = oldValue;
+} else {
+    ko = module.exports;
+}
+
+export default ko;

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1219,6 +1219,7 @@ function createGalleryList() {
     var contents = '\
 // This file is automatically rebuilt by the Cesium build process.\n\
 var hello_world_index = ' + helloWorldIndex + ';\n\
+var VERSION = ' + version + ';\n\
 var gallery_demos = [' + demoJSONs.join(', ') + '];\n\
 var has_new_gallery_demos = ' + (newDemos.length > 0 ? 'true;' : 'false;') + '\n';
 
@@ -1249,15 +1250,16 @@ var sandcastleJsHintOptions = ' + JSON.stringify(primary, null, 4) + ';\n';
 function buildSandcastle() {
     var appStream = gulp.src([
             'Apps/Sandcastle/**',
+            '!Apps/Sandcastle/load-cesium-es6.js',
             '!Apps/Sandcastle/standalone.html',
             '!Apps/Sandcastle/images/**',
             '!Apps/Sandcastle/gallery/**.jpg'
         ])
-        // Replace require Source with pre-built Cesium
-        .pipe(gulpReplace('../../../ThirdParty/requirejs-2.1.20/require.js', '../../../CesiumUnminified/Cesium.js'))
-        // Use unminified cesium instead of source
-        .pipe(gulpReplace('Source/Cesium', 'CesiumUnminified'))
+        // Remove dev-only ES6 module loading for unbuilt Cesium
+        .pipe(gulpReplace('    <script type="module" src="../load-cesium-es6.js"></script>', ''))
+        .pipe(gulpReplace('nomodule', ''))
         // Fix relative paths for new location
+        .pipe(gulpReplace('../../../Build', '../../..'))
         .pipe(gulpReplace('../../Source', '../../../Source'))
         .pipe(gulpReplace('../../ThirdParty', '../../../ThirdParty'))
         .pipe(gulpReplace('../../SampleData', '../../../../Apps/SampleData'))
@@ -1276,8 +1278,9 @@ function buildSandcastle() {
     var standaloneStream = gulp.src([
         'Apps/Sandcastle/standalone.html'
         ])
-        .pipe(gulpReplace('../../ThirdParty/requirejs-2.1.20/require.js', '../../../ThirdParty/requirejs-2.1.20/require.js'))
-        .pipe(gulpReplace('Source/Cesium', 'CesiumUnminified'))
+        .pipe(gulpReplace('    <script type="module" src="load-cesium-es6.js"></script>', ''))
+        .pipe(gulpReplace('nomodule', ''))
+        .pipe(gulpReplace('../../Build', '../..'))
         .pipe(gulp.dest('Build/Apps/Sandcastle'));
 
     return streamToPromise(mergeStream(appStream, imageStream, standaloneStream));


### PR DESCRIPTION
* Remove Cesium usage from Sandcastle proper, since it's not really needed
* Generate a VERSION propertyin the gallery index since Cesium is no longer being included.
* Remove requirejs from Sandcastle bucket
* Update bucket to use the built version of Cesium if it is available by fallbackto the ES6 version during development.
* Minor Cesium ES6 fixes found during development.

Sandcastle and all of the examples I tested run great.  This does not update the Sandcastle example HTML files themselves, which can be converted as a separate clean-up process post-merge to avoid making a messy PR.