### PR TITLE
Fixed "Scene/Model renders with lightColor" test

### DIFF
--- a/Specs/Scene/ModelSpec.js
+++ b/Specs/Scene/ModelSpec.js
@@ -3112,16 +3112,20 @@ describe('Scene/Model', function() {
             };
 
             expect(sceneArgs).toRenderAndCall(function(rgba) {
-                expect(rgba).not.toEqual([0, 0, 0, 255]);
-                model.imageBasedLightingFactor = new Cartesian2(0.0, 0.0);
-                expect(sceneArgs).toRenderAndCall(function(rgba2) {
-                    expect(rgba2).not.toEqual(rgba);
-                    model.lightColor = new Cartesian3(5.0, 5.0, 5.0);
-                    expect(sceneArgs).notToRender(rgba2);
-
-                    primitives.remove(model);
-                });
+                expect(rgba).toEqualEpsilon([153, 6, 5, 255], 5);
             });
+
+            model.imageBasedLightingFactor = new Cartesian2(0.0, 0.0);
+            expect(sceneArgs).toRenderAndCall(function(rgba) {
+                expect(rgba).toEqualEpsilon([85, 6, 5, 255], 5);
+            });
+
+            model.lightColor = new Cartesian3(5.0, 5.0, 5.0);
+            expect(sceneArgs).toRenderAndCall(function(rgba) {
+                expect(rgba).toEqualEpsilon([164, 16, 16, 255], 5);
+            });
+
+            primitives.remove(model);
         });
     });
 

--- a/Specs/Scene/ModelSpec.js
+++ b/Specs/Scene/ModelSpec.js
@@ -3105,13 +3105,19 @@ describe('Scene/Model', function() {
         return loadModel(boxPbrUrl).then(function(model) {
             model.show = true;
             model.zoomTo();
-            expect(scene).toRenderAndCall(function(rgba) {
+
+            var sceneArgs = {
+                scene : scene,
+                time : JulianDate.fromDate(new Date('January 1, 2014 23:00:00 UTC'))
+            };
+
+            expect(sceneArgs).toRenderAndCall(function(rgba) {
                 expect(rgba).not.toEqual([0, 0, 0, 255]);
                 model.imageBasedLightingFactor = new Cartesian2(0.0, 0.0);
-                expect(scene).toRenderAndCall(function(rgba2) {
+                expect(sceneArgs).toRenderAndCall(function(rgba2) {
                     expect(rgba2).not.toEqual(rgba);
                     model.lightColor = new Cartesian3(5.0, 5.0, 5.0);
-                    expect(scene).notToRender(rgba2);
+                    expect(sceneArgs).notToRender(rgba2);
 
                     primitives.remove(model);
                 });


### PR DESCRIPTION
Fixes #8127  

As guessed by @OmarShehata in https://github.com/AnalyticalGraphicsInc/cesium/issues/8127, this test is affected by the current time at which it is run. So I hardcoded a time that works.
