### PR TITLE
Added useBrowserRecommendedResolution property to Viewer & CesiumWidget

### DIFF
--- a/Apps/Sandcastle/gallery/Resolution Scaling.html
+++ b/Apps/Sandcastle/gallery/Resolution Scaling.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no">
-    <meta name="description" content="Set a custom resolution scale or use browser recommended resolution.">
+    <meta name="description" content="Set a custom resolution scale and/or toggle the browser's recommended resolution.">
     <meta name="cesium-sandcastle-labels" content="Showcases">
     <title>Cesium Demo</title>
     <script type="text/javascript" src="../Sandcastle-header.js"></script>
@@ -31,10 +31,10 @@
         <td><input type="checkbox" data-bind="checked: useBrowserRecommendedResolution"></td>
     </tr>
     <tr>
-        <td data-bind="style: { color: useBrowserRecommendedResolution ? 'gray' : ''}">Custom Resolution Scale</td>
+        <td>Resolution Scale</td>
         <td>
-            <input type="range" min="0.1" max="2.0" step="0.1" data-bind="value: customResolutionScale, enable: !useBrowserRecommendedResolution, valueUpdate: 'input'">
-            <input type="text" size="5" data-bind="value: customResolutionScale, enable: !useBrowserRecommendedResolution">
+            <input type="range" min="0.1" max="2.0" step="0.1" data-bind="value: resolutionScale, valueUpdate: 'input'">
+            <input type="text" size="5" data-bind="value: resolutionScale">
         </td>
     </tr>
 </tbody></table>
@@ -47,7 +47,7 @@ var viewer = new Cesium.Viewer('cesiumContainer');
 
 var viewModel = {
     useBrowserRecommendedResolution : false,
-    customResolutionScale : 0.25
+    resolutionScale : 0.25
 };
 
 Cesium.knockout.track(viewModel);
@@ -60,14 +60,12 @@ for (var name in viewModel) {
 }
 
 function update() {
-    if (viewModel.useBrowserRecommendedResolution) {
-        viewer.resolutionScale = 1.0 / window.devicePixelRatio;
-    } else {
-        var resolutionScale = Number(viewModel.customResolutionScale);
-        resolutionScale = !isNaN(resolutionScale) ? resolutionScale : 1.0;
-        resolutionScale = Cesium.Math.clamp(resolutionScale, 0.1, 2.0);
-        viewer.resolutionScale = resolutionScale;
-    }
+    viewer.useBrowserRecommendedResolution = viewModel.useBrowserRecommendedResolution;
+
+    var resolutionScale = Number(viewModel.resolutionScale);
+    resolutionScale = !isNaN(resolutionScale) ? resolutionScale : 1.0;
+    resolutionScale = Cesium.Math.clamp(resolutionScale, 0.1, 2.0);
+    viewer.resolutionScale = resolutionScale;
 }
 update();
 //Sandcastle_End

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,7 +12,7 @@ Change Log
 * Added ability to create partial ellipsoids using both the Entity API and CZML. New ellipsoid geometry properties: `innerRadii`, `minimumClock`, `maximumClock`, `minimumCone`, and `maximumCone`. This affects both `EllipsoidGeometry` and `EllipsoidOutlineGeometry`. See the updated [Sandcastle example](https://cesiumjs.org/Cesium/Apps/Sandcastle/?src=Partial%20Ellipsoids.html&label=Geometries). [#5995](https://github.com/AnalyticalGraphicsInc/cesium/pull/5995)
 * Added `TileMapResourceImageryProvider` and `OpenStreetMapImageryProvider` classes to improve API consistency: [#4812](https://github.com/AnalyticalGraphicsInc/cesium/issues/4812)
 * Added `credit` parameter to `CzmlDataSource`, `GeoJsonDataSource`, `KmlDataSource` and `Model`. [#8173](https://github.com/AnalyticalGraphicsInc/cesium/pull/8173)
-* Added `useBrowserRecommendedResolution` flag to `Viewer` and `CesiumWidget`. [8215](https://github.com/AnalyticalGraphicsInc/cesium/issues/8215)
+* Added `useBrowserRecommendedResolution` flag to `Viewer` and `CesiumWidget`. When true, Cesium renders at CSS pixel resolution instead of native device resolution. This replaces the workaround in the 1.61 change list. [8215](https://github.com/AnalyticalGraphicsInc/cesium/issues/8215)
 
 ##### Fixes :wrench:
 * `Camera.flyTo` flies to the correct location in 2D when the destination crosses the international date line [#7909](https://github.com/AnalyticalGraphicsInc/cesium/pull/7909)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@ Change Log
 * Added ability to create partial ellipsoids using both the Entity API and CZML. New ellipsoid geometry properties: `innerRadii`, `minimumClock`, `maximumClock`, `minimumCone`, and `maximumCone`. This affects both `EllipsoidGeometry` and `EllipsoidOutlineGeometry`. See the updated [Sandcastle example](https://cesiumjs.org/Cesium/Apps/Sandcastle/?src=Partial%20Ellipsoids.html&label=Geometries). [#5995](https://github.com/AnalyticalGraphicsInc/cesium/pull/5995)
 * Added `TileMapResourceImageryProvider` and `OpenStreetMapImageryProvider` classes to improve API consistency: [#4812](https://github.com/AnalyticalGraphicsInc/cesium/issues/4812)
 * Added `credit` parameter to `CzmlDataSource`, `GeoJsonDataSource`, `KmlDataSource` and `Model`. [#8173](https://github.com/AnalyticalGraphicsInc/cesium/pull/8173)
+* Added `useBrowserRecommendedResolution` flag to 'Viewer' and 'CesiumWidget'. [8215](https://github.com/AnalyticalGraphicsInc/cesium/issues/8215)
 
 ##### Fixes :wrench:
 * `Camera.flyTo` flies to the correct location in 2D when the destination crosses the international date line [#7909](https://github.com/AnalyticalGraphicsInc/cesium/pull/7909)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,7 +12,7 @@ Change Log
 * Added ability to create partial ellipsoids using both the Entity API and CZML. New ellipsoid geometry properties: `innerRadii`, `minimumClock`, `maximumClock`, `minimumCone`, and `maximumCone`. This affects both `EllipsoidGeometry` and `EllipsoidOutlineGeometry`. See the updated [Sandcastle example](https://cesiumjs.org/Cesium/Apps/Sandcastle/?src=Partial%20Ellipsoids.html&label=Geometries). [#5995](https://github.com/AnalyticalGraphicsInc/cesium/pull/5995)
 * Added `TileMapResourceImageryProvider` and `OpenStreetMapImageryProvider` classes to improve API consistency: [#4812](https://github.com/AnalyticalGraphicsInc/cesium/issues/4812)
 * Added `credit` parameter to `CzmlDataSource`, `GeoJsonDataSource`, `KmlDataSource` and `Model`. [#8173](https://github.com/AnalyticalGraphicsInc/cesium/pull/8173)
-* Added `useBrowserRecommendedResolution` flag to 'Viewer' and 'CesiumWidget'. [8215](https://github.com/AnalyticalGraphicsInc/cesium/issues/8215)
+* Added `useBrowserRecommendedResolution` flag to `Viewer` and `CesiumWidget`. [8215](https://github.com/AnalyticalGraphicsInc/cesium/issues/8215)
 
 ##### Fixes :wrench:
 * `Camera.flyTo` flies to the correct location in 2D when the destination crosses the international date line [#7909](https://github.com/AnalyticalGraphicsInc/cesium/pull/7909)

--- a/Source/Widgets/CesiumWidget/CesiumWidget.js
+++ b/Source/Widgets/CesiumWidget/CesiumWidget.js
@@ -160,6 +160,7 @@ define([
      * @param {Boolean} [options.useDefaultRenderLoop=true] True if this widget should control the render loop, false otherwise.
      * @param {Number} [options.targetFrameRate] The target frame rate when using the default render loop.
      * @param {Boolean} [options.showRenderLoopErrors=true] If true, this widget will automatically display an HTML panel to the user containing the error, if a render loop error occurs.
+     * @param {Boolean} [options.useBrowserRecommendedResolution=false] If true, ignore the browser's device pixel ratio.
      * @param {Object} [options.contextOptions] Context and WebGL creation properties corresponding to <code>options</code> passed to {@link Scene}.
      * @param {Element|String} [options.creditContainer] The DOM element or ID that will contain the {@link CreditDisplay}.  If not specified, the credits are added
      *        to the bottom of the widget itself.
@@ -243,6 +244,8 @@ define([
 
         var showRenderLoopErrors = defaultValue(options.showRenderLoopErrors, true);
 
+        var useBrowserRecommendedResolution = defaultValue(options.useBrowserRecommendedResolution, false);
+
         this._element = element;
         this._container = container;
         this._canvas = canvas;
@@ -256,7 +259,7 @@ define([
         this._renderLoopRunning = false;
         this._showRenderLoopErrors = showRenderLoopErrors;
         this._resolutionScale = 1.0;
-        this._useBrowserRecommendedResolution = false;
+        this._useBrowserRecommendedResolution = useBrowserRecommendedResolution;
         this._forceResize = false;
         this._clock = defined(options.clock) ? options.clock : new Clock();
 

--- a/Source/Widgets/CesiumWidget/CesiumWidget.js
+++ b/Source/Widgets/CesiumWidget/CesiumWidget.js
@@ -157,7 +157,7 @@ define([
      * @param {Boolean} [options.orderIndependentTranslucency=true] If true and the configuration supports it, use order independent translucency.
      * @param {MapProjection} [options.mapProjection=new GeographicProjection()] The map projection to use in 2D and Columbus View modes.
      * @param {Globe} [options.globe=new Globe(mapProjection.ellipsoid)] The globe to use in the scene.  If set to <code>false</code>, no globe will be added.
-     * @param {Boolean} [options.useDefaultRenderLoop=true] True if this widget should control the render loop, false otherwise.
+     * @param {Boolean} [options.useBrowserRecommendedResolution=false] If true, render at the browser's recommended resolution and ignore <code>window.devicePixelRatio</code>.
      * @param {Number} [options.targetFrameRate] The target frame rate when using the default render loop.
      * @param {Boolean} [options.showRenderLoopErrors=true] If true, this widget will automatically display an HTML panel to the user containing the error, if a render loop error occurs.
      * @param {Boolean} [options.useBrowserRecommendedResolution=false] If true, ignore the browser's device pixel ratio.
@@ -576,8 +576,10 @@ define([
                     throw new DeveloperError('resolutionScale must be greater than 0.');
                 }
                 //>>includeEnd('debug');
-                this._resolutionScale = value;
-                this._forceResize = true;
+                if (this._resolutionScale !== value) {
+                    this._resolutionScale = value;
+                    this._forceResize = true;
+                }
             }
         },
 
@@ -586,7 +588,7 @@ define([
         * If true, the browser's device pixel ratio is ignored and 1.0 is used instead,
         * effectively rendering based on CSS pixels instead of device pixels. This can improve
         * performance on less powerful devices that have high pixel density. When false, rendering
-        * will be in device pixels. The resolutionScale property will still take effect whether
+        * will be in device pixels. {@link CesiumWidget#resolutionScale} will still take effect whether
         * this flag is true or false.
         * @memberof CesiumWidget.prototype
         *
@@ -598,8 +600,10 @@ define([
                 return this._useBrowserRecommendedResolution;
             },
             set : function(value) {
-                this._useBrowserRecommendedResolution = value;
-                this._forceResize = true;
+                if (this._useBrowserRecommendedResolution !== value) {
+                    this._useBrowserRecommendedResolution = value;
+                    this._forceResize = true;
+                }
             }
         }
     });

--- a/Source/Widgets/CesiumWidget/CesiumWidget.js
+++ b/Source/Widgets/CesiumWidget/CesiumWidget.js
@@ -95,27 +95,27 @@ define([
         requestAnimationFrame(render);
     }
 
-    function configureSceneResolution(widget) {
-        var devicePixelRatio = window.devicePixelRatio;
-        var resolutionScale = widget._resolutionScale * devicePixelRatio;
+    function configurePixelRatio(widget) {
+        var pixelRatio = widget._useBrowserRecommendedResolution ? 1.0 : window.devicePixelRatio;
+        pixelRatio *= widget._resolutionScale;
         if (defined(widget._scene)) {
-            widget._scene.pixelRatio = resolutionScale;
+            widget._scene.pixelRatio = pixelRatio;
         }
 
-        return resolutionScale;
+        return pixelRatio;
     }
 
     function configureCanvasSize(widget) {
         var canvas = widget._canvas;
         var width = canvas.clientWidth;
         var height = canvas.clientHeight;
-        var resolutionScale = configureSceneResolution(widget);
+        var pixelRatio = configurePixelRatio(widget);
 
         widget._canvasWidth = width;
         widget._canvasHeight = height;
 
-        width *= resolutionScale;
-        height *= resolutionScale;
+        width *= pixelRatio;
+        height *= pixelRatio;
 
         canvas.width = width;
         canvas.height = height;
@@ -256,6 +256,7 @@ define([
         this._renderLoopRunning = false;
         this._showRenderLoopErrors = showRenderLoopErrors;
         this._resolutionScale = 1.0;
+        this._useBrowserRecommendedResolution = false;
         this._forceResize = false;
         this._clock = defined(options.clock) ? options.clock : new Clock();
 
@@ -280,7 +281,7 @@ define([
 
             scene.camera.constrainedAxis = Cartesian3.UNIT_Z;
 
-            configureSceneResolution(this);
+            configurePixelRatio(this);
             configureCameraFrustum(this);
 
             var ellipsoid = defaultValue(scene.mapProjection.ellipsoid, Ellipsoid.WGS84);
@@ -573,6 +574,28 @@ define([
                 }
                 //>>includeEnd('debug');
                 this._resolutionScale = value;
+                this._forceResize = true;
+            }
+        },
+
+        /**
+        * Boolean flag indicating if the browser's recommended resolution is used.
+        * If true, the browser's device pixel ratio is ignored and 1.0 is used instead,
+        * effectively rendering based on CSS pixels instead of device pixels. This can improve
+        * performance on less powerful devices that have high pixel density. When false, rendering
+        * will be in device pixels. The resolutionScale property will still take effect whether
+        * this flag is true or false.
+        * @memberof CesiumWidget.prototype
+        *
+        * @type {Boolean}
+        * @default false
+        */
+        useBrowserRecommendedResolution : {
+            get : function() {
+                return this._useBrowserRecommendedResolution;
+            },
+            set : function(value) {
+                this._useBrowserRecommendedResolution = value;
                 this._forceResize = true;
             }
         }

--- a/Source/Widgets/CesiumWidget/CesiumWidget.js
+++ b/Source/Widgets/CesiumWidget/CesiumWidget.js
@@ -157,10 +157,10 @@ define([
      * @param {Boolean} [options.orderIndependentTranslucency=true] If true and the configuration supports it, use order independent translucency.
      * @param {MapProjection} [options.mapProjection=new GeographicProjection()] The map projection to use in 2D and Columbus View modes.
      * @param {Globe} [options.globe=new Globe(mapProjection.ellipsoid)] The globe to use in the scene.  If set to <code>false</code>, no globe will be added.
+     * @param {Boolean} [options.useDefaultRenderLoop=true] True if this widget should control the render loop, false otherwise.
      * @param {Boolean} [options.useBrowserRecommendedResolution=false] If true, render at the browser's recommended resolution and ignore <code>window.devicePixelRatio</code>.
      * @param {Number} [options.targetFrameRate] The target frame rate when using the default render loop.
      * @param {Boolean} [options.showRenderLoopErrors=true] If true, this widget will automatically display an HTML panel to the user containing the error, if a render loop error occurs.
-     * @param {Boolean} [options.useBrowserRecommendedResolution=false] If true, ignore the browser's device pixel ratio.
      * @param {Object} [options.contextOptions] Context and WebGL creation properties corresponding to <code>options</code> passed to {@link Scene}.
      * @param {Element|String} [options.creditContainer] The DOM element or ID that will contain the {@link CreditDisplay}.  If not specified, the credits are added
      *        to the bottom of the widget itself.

--- a/Source/Widgets/Viewer/Viewer.js
+++ b/Source/Widgets/Viewer/Viewer.js
@@ -282,6 +282,7 @@ define([
      * @param {Boolean} [options.useDefaultRenderLoop=true] True if this widget should control the render loop, false otherwise.
      * @param {Number} [options.targetFrameRate] The target frame rate when using the default render loop.
      * @param {Boolean} [options.showRenderLoopErrors=true] If true, this widget will automatically display an HTML panel to the user containing the error, if a render loop error occurs.
+     * @param {Boolean} [options.useBrowserRecommendedResolution=false] If true, ignore the browser's device pixel ratio.
      * @param {Boolean} [options.automaticallyTrackDataSourceClocks=true] If true, this widget will automatically track the clock settings of newly added DataSources, updating if the DataSource's clock changes.  Set this to false if you want to configure the clock independently.
      * @param {Object} [options.contextOptions] Context and WebGL creation properties corresponding to <code>options</code> passed to {@link Scene}.
      * @param {SceneMode} [options.sceneMode=SceneMode.SCENE3D] The initial scene mode.
@@ -428,6 +429,7 @@ Either specify options.terrainProvider instead or set options.baseLayerPicker to
             useDefaultRenderLoop : options.useDefaultRenderLoop,
             targetFrameRate : options.targetFrameRate,
             showRenderLoopErrors : options.showRenderLoopErrors,
+            useBrowserRecommendedResolution : options.useBrowserRecommendedResolution,
             creditContainer : defined(options.creditContainer) ? options.creditContainer : bottomContainer,
             creditViewport : options.creditViewport,
             scene3DOnly : scene3DOnly,

--- a/Source/Widgets/Viewer/Viewer.js
+++ b/Source/Widgets/Viewer/Viewer.js
@@ -282,7 +282,7 @@ define([
      * @param {Boolean} [options.useDefaultRenderLoop=true] True if this widget should control the render loop, false otherwise.
      * @param {Number} [options.targetFrameRate] The target frame rate when using the default render loop.
      * @param {Boolean} [options.showRenderLoopErrors=true] If true, this widget will automatically display an HTML panel to the user containing the error, if a render loop error occurs.
-     * @param {Boolean} [options.useBrowserRecommendedResolution=false] If true, ignore the browser's device pixel ratio.
+     * @param {Boolean} [options.useBrowserRecommendedResolution=false] If true, render at the browser's recommended resolution and ignore <code>window.devicePixelRatio</code>.
      * @param {Boolean} [options.automaticallyTrackDataSourceClocks=true] If true, this widget will automatically track the clock settings of newly added DataSources, updating if the DataSource's clock changes.  Set this to false if you want to configure the clock independently.
      * @param {Object} [options.contextOptions] Context and WebGL creation properties corresponding to <code>options</code> passed to {@link Scene}.
      * @param {SceneMode} [options.sceneMode=SceneMode.SCENE3D] The initial scene mode.
@@ -1202,7 +1202,7 @@ Either specify options.terrainProvider instead or set options.baseLayerPicker to
         * If true, the browser's device pixel ratio is ignored and 1.0 is used instead,
         * effectively rendering based on CSS pixels instead of device pixels. This can improve
         * performance on less powerful devices that have high pixel density. When false, rendering
-        * will be in device pixels. The resolutionScale property will still take effect whether
+        * will be in device pixels. {@link Viewer#resolutionScale} will still take effect whether
         * this flag is true or false.
         * @memberof Viewer.prototype
         *

--- a/Source/Widgets/Viewer/Viewer.js
+++ b/Source/Widgets/Viewer/Viewer.js
@@ -1196,6 +1196,27 @@ Either specify options.terrainProvider instead or set options.baseLayerPicker to
         },
 
         /**
+        * Boolean flag indicating if the browser's recommended resolution is used.
+        * If true, the browser's device pixel ratio is ignored and 1.0 is used instead,
+        * effectively rendering based on CSS pixels instead of device pixels. This can improve
+        * performance on less powerful devices that have high pixel density. When false, rendering
+        * will be in device pixels. The resolutionScale property will still take effect whether
+        * this flag is true or false.
+        * @memberof Viewer.prototype
+        *
+        * @type {Boolean}
+        * @default false
+        */
+        useBrowserRecommendedResolution : {
+            get : function() {
+                return this._cesiumWidget.useBrowserRecommendedResolution;
+            },
+            set : function(value) {
+                this._cesiumWidget.useBrowserRecommendedResolution = value;
+            }
+        },
+
+        /**
          * Gets or sets whether or not data sources can temporarily pause
          * animation in order to avoid showing an incomplete picture to the user.
          * For example, if asynchronous primitives are being processed in the

--- a/Specs/Widgets/CesiumWidget/CesiumWidgetSpec.js
+++ b/Specs/Widgets/CesiumWidget/CesiumWidgetSpec.js
@@ -273,6 +273,14 @@ describe('Widgets/CesiumWidget/CesiumWidget', function() {
         expect(widget.resolutionScale).toBe(0.5);
     });
 
+    it('can enable useBrowserRecommendedResolution', function() {
+        widget = createCesiumWidget(container, {
+            useBrowserRecommendedResolution : true
+        });
+
+        expect(widget.useBrowserRecommendedResolution).toBe(true);
+    });
+
     it('throws if resolutionScale is less than 0', function() {
         widget = createCesiumWidget(container);
         expect(function() {

--- a/Specs/Widgets/CesiumWidget/CesiumWidgetSpec.js
+++ b/Specs/Widgets/CesiumWidget/CesiumWidgetSpec.js
@@ -281,6 +281,27 @@ describe('Widgets/CesiumWidget/CesiumWidget', function() {
         expect(widget.useBrowserRecommendedResolution).toBe(true);
     });
 
+    it('useBrowserRecommendedResolution ignores devicePixelRatio', function() {
+        var oldDevicePixelRatio = window.devicePixelRatio;
+        window.devicePixelRatio = 2.0;
+
+        widget = createCesiumWidget(container, {
+            useDefaultRenderLoop : false
+        });
+
+        widget.resolutionScale = 0.5;
+
+        widget.useBrowserRecommendedResolution = true;
+        widget.resize();
+        expect(widget.scene.pixelRatio).toEqual(0.5);
+
+        widget.useBrowserRecommendedResolution = false;
+        widget.resize();
+        expect(widget.scene.pixelRatio).toEqual(1.0);
+
+        window.devicePixelRatio = oldDevicePixelRatio;
+    });
+
     it('throws if resolutionScale is less than 0', function() {
         widget = createCesiumWidget(container);
         expect(function() {

--- a/Specs/Widgets/Viewer/ViewerSpec.js
+++ b/Specs/Widgets/Viewer/ViewerSpec.js
@@ -41,8 +41,9 @@ define([
         'Widgets/NavigationHelpButton/NavigationHelpButton',
         'Widgets/SceneModePicker/SceneModePicker',
         'Widgets/SelectionIndicator/SelectionIndicator',
-        'Widgets/Timeline/Timeline'
-    ], 'Widgets/Viewer/Viewer', function(
+        'Widgets/Timeline/Timeline',
+        'Widgets/Viewer/Viewer'
+    ], function(
         BoundingSphere,
         Cartesian3,
         CartographicGeocoderService,
@@ -88,7 +89,7 @@ define([
         Timeline) {
         'use strict';
 
-describe('Core/BoundingSphere', function() {
+describe('Widgets/Viewer/Viewer', function() {
 
     var testProvider = {
         isReady : function() {
@@ -642,6 +643,20 @@ describe('Core/BoundingSphere', function() {
         });
 
         expect(viewer.useBrowserRecommendedResolution).toBe(true);
+    });
+
+    it('useBrowserRecommendedResolution ignores devicePixelRatio', function() {
+        var oldDevicePixelRatio = window.devicePixelRatio;
+        window.devicePixelRatio = 2.0;
+
+        viewer = createViewer(container, {
+            useBrowserRecommendedResolution : true
+        });
+
+        viewer.render();
+        expect(viewer.scene.pixelRatio).toEqual(1.0);
+
+        window.devicePixelRatio = oldDevicePixelRatio;
     });
 
     it('constructor throws with undefined container', function() {

--- a/Specs/Widgets/Viewer/ViewerSpec.js
+++ b/Specs/Widgets/Viewer/ViewerSpec.js
@@ -650,10 +650,17 @@ describe('Widgets/Viewer/Viewer', function() {
         window.devicePixelRatio = 2.0;
 
         viewer = createViewer(container, {
-            useBrowserRecommendedResolution : true
+            useDefaultRenderLoop : false
         });
 
-        viewer.render();
+        viewer.resolutionScale = 0.5;
+
+        viewer.useBrowserRecommendedResolution = true;
+        viewer.resize();
+        expect(viewer.scene.pixelRatio).toEqual(0.5);
+
+        viewer.useBrowserRecommendedResolution = false;
+        viewer.resize();
         expect(viewer.scene.pixelRatio).toEqual(1.0);
 
         window.devicePixelRatio = oldDevicePixelRatio;

--- a/Specs/Widgets/Viewer/ViewerSpec.js
+++ b/Specs/Widgets/Viewer/ViewerSpec.js
@@ -636,6 +636,14 @@ describe('Core/BoundingSphere', function() {
         }).toThrowDeveloperError();
     });
 
+    it('can enable useBrowserRecommendedResolution', function() {
+        viewer = createViewer(container, {
+            useBrowserRecommendedResolution : true
+        });
+
+        expect(viewer.useBrowserRecommendedResolution).toBe(true);
+    });
+
     it('constructor throws with undefined container', function() {
         expect(function() {
             return createViewer(undefined);


### PR DESCRIPTION
Fixes #8215 

This brings back old cesium behavior to render at css pixels instead of device pixels, particularly useful for less powerful devices with high pixel density. The property is `false` by default.

`useBrowserRecommendedResolution` and `resolutionScale` are independent properties. Here's how they work (in `CesiumWidget.js`):

```    
function configurePixelRatio(widget) {
        var pixelRatio = widget._useBrowserRecommendedResolution ? 1.0 : window.devicePixelRatio;
        pixelRatio *= widget._resolutionScale;
        if (defined(widget._scene)) {
            widget._scene.pixelRatio = pixelRatio;
        }

        return pixelRatio;
}
``` 