### PR TITLE
Fixed pixel size for polylines and point clouds under different resolutions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -33,6 +33,7 @@ Change Log
 * Fixed alpha equation for `BlendingState.ALPHA_BLEND` and `BlendingState.ADDITIVE_BLEND`. [#8202](https://github.com/AnalyticalGraphicsInc/cesium/pull/8202)
 * Fixed atmosphere brightness when High Dynamic Range is disabled. [#8149](https://github.com/AnalyticalGraphicsInc/cesium/issues/8149)
 * Fixed brightness levels for procedural Image Based Lighting. [#7803](https://github.com/AnalyticalGraphicsInc/cesium/issues/7803)
+* Made pixel sizes consistent for polylines and point clouds when rendering at different pixel ratios. [#8113](https://github.com/AnalyticalGraphicsInc/cesium/issues/8113)
 
 ### 1.61 - 2019-09-03
 

--- a/Source/DataSources/PolylineDashMaterialProperty.js
+++ b/Source/DataSources/PolylineDashMaterialProperty.js
@@ -29,7 +29,7 @@ define([
      * @param {Object} [options] Object with the following properties:
      * @param {Property} [options.color=Color.WHITE] A Property specifying the {@link Color} of the line.
      * @param {Property} [options.gapColor=Color.TRANSPARENT] A Property specifying the {@link Color} of the gaps in the line.
-     * @param {Property} [options.dashLength=16.0] A numeric Property specifying the length of the dash pattern in pixel.s
+     * @param {Property} [options.dashLength=16.0] A numeric Property specifying the length of the dash pattern in pixels.
      * @param {Property} [options.dashPattern=255.0] A numeric Property specifying a 16 bit pattern for the dash
      */
     function PolylineDashMaterialProperty(options) {

--- a/Source/Renderer/AutomaticUniforms.js
+++ b/Source/Renderer/AutomaticUniforms.js
@@ -1665,18 +1665,18 @@ define([
         /**
          * An automatic GLSL uniform representing the ratio of canvas coordinate space to canvas pixel space.
          *
-         * @alias czm_resolutionScale
+         * @alias czm_pixelRatio
          * @namespace
          * @glslUniform
          *
          * @example
-         * uniform float czm_resolutionScale;
+         * uniform float czm_pixelRatio;
          */
-        czm_resolutionScale : new AutomaticUniform({
+        czm_pixelRatio : new AutomaticUniform({
             size : 1,
             datatype : WebGLConstants.FLOAT,
             getValue : function(uniformState) {
-                return uniformState.resolutionScale;
+                return uniformState.pixelRatio;
             }
         }),
 

--- a/Source/Renderer/UniformState.js
+++ b/Source/Renderer/UniformState.js
@@ -158,7 +158,7 @@ define([
         this._cameraUp = new Cartesian3();
         this._frustum2DWidth = 0.0;
         this._eyeHeight2D = new Cartesian2();
-        this._resolutionScale = 1.0;
+        this._pixelRatio = 1.0;
         this._orthographicIn3D = false;
         this._backgroundColor = new Color();
 
@@ -813,9 +813,9 @@ define([
          * @memberof UniformState.prototype
          * @type {Number}
          */
-        resolutionScale : {
+        pixelRatio : {
             get : function() {
-                return this._resolutionScale;
+                return this._pixelRatio;
             }
         },
 
@@ -1118,9 +1118,7 @@ define([
     UniformState.prototype.update = function(frameState) {
         this._mode = frameState.mode;
         this._mapProjection = frameState.mapProjection;
-
-        var canvas = frameState.context._canvas;
-        this._resolutionScale = canvas.width / canvas.clientWidth;
+        this._pixelRatio = frameState.pixelRatio;
 
         var camera = frameState.camera;
         this.updateCamera(camera);

--- a/Source/Scene/FrameState.js
+++ b/Source/Scene/FrameState.js
@@ -157,7 +157,7 @@ define([
         this.maximumScreenSpaceError = undefined;
 
         /**
-         * Ratio between a pixel and a density-independent pixel. Provides a standard unity of
+         * Ratio between a pixel and a density-independent pixel. Provides a standard unit of
          * measure for real pixel measurements appropriate to a particular device.
          *
          * @type {Number}

--- a/Source/Scene/LabelCollection.js
+++ b/Source/Scene/LabelCollection.js
@@ -864,7 +864,7 @@ define([
         }
 
         var uniformState = context.uniformState;
-        var resolutionScale = uniformState.resolutionScale;
+        var resolutionScale = uniformState.pixelRatio;
         var resolutionChanged = this._resolutionScale !== resolutionScale;
         this._resolutionScale = resolutionScale;
 

--- a/Source/Scene/PointCloud.js
+++ b/Source/Scene/PointCloud.js
@@ -782,6 +782,8 @@ define([
             u_pointSizeAndTimeAndGeometricErrorAndDepthMultiplier : function() {
                 var scratch = scratchPointSizeAndTimeAndGeometricErrorAndDepthMultiplier;
                 scratch.x = pointCloud._attenuation ? pointCloud.maximumAttenuation : pointCloud._pointSize;
+                scratch.x *= frameState.pixelRatio;
+
                 scratch.y = pointCloud.time;
 
                 if (pointCloud._attenuation) {
@@ -1145,7 +1147,7 @@ define([
         }
 
         if (hasPointSizeStyle) {
-            vs += '    gl_PointSize = getPointSizeFromStyle(position, position_absolute, color, normal); \n';
+            vs += '    gl_PointSize = getPointSizeFromStyle(position, position_absolute, color, normal) * czm_pixelRatio; \n';
         } else if (attenuation) {
             vs += '    vec4 positionEC = czm_modelView * vec4(position, 1.0); \n' +
                   '    float depth = -positionEC.z; \n' +

--- a/Source/Scene/PointCloudEyeDomeLighting.js
+++ b/Source/Scene/PointCloudEyeDomeLighting.js
@@ -243,7 +243,7 @@ define([
         }
 
         this._strength = pointCloudShading.eyeDomeLightingStrength;
-        this._radius = pointCloudShading.eyeDomeLightingRadius;
+        this._radius = pointCloudShading.eyeDomeLightingRadius * frameState.pixelRatio;
 
         var dirty = createResources(this, frameState.context);
 

--- a/Source/Scene/Scene.js
+++ b/Source/Scene/Scene.js
@@ -1620,7 +1620,7 @@ define([
         },
 
         /**
-         * Ratio between a pixel and a density-independent pixel. Provides a standard unity of
+         * Ratio between a pixel and a density-independent pixel. Provides a standard unit of
          * measure for real pixel measurements appropriate to a particular device.
          *
          * @memberof Scene.prototype

--- a/Source/Shaders/BillboardCollectionVS.glsl
+++ b/Source/Shaders/BillboardCollectionVS.glsl
@@ -56,7 +56,7 @@ vec4 addScreenSpaceOffset(vec4 positionEC, vec2 imageSize, float scale, vec2 dir
 {
     // Note the halfSize cannot be computed in JavaScript because it is sent via
     // compressed vertex attributes that coerce it to an integer.
-    vec2 halfSize = imageSize * scale * czm_resolutionScale * 0.5;
+    vec2 halfSize = imageSize * scale * czm_pixelRatio * 0.5;
     halfSize *= ((direction * 2.0) - 1.0);
 
     vec2 originTranslate = origin * abs(halfSize);
@@ -102,7 +102,7 @@ vec4 addScreenSpaceOffset(vec4 positionEC, vec2 imageSize, float scale, vec2 dir
     }
 
     positionEC.xy += translate * mpp;
-    positionEC.xy += (pixelOffset * czm_resolutionScale) * mpp;
+    positionEC.xy += (pixelOffset * czm_pixelRatio) * mpp;
     return positionEC;
 }
 

--- a/Source/Shaders/Materials/ElevationContourMaterial.glsl
+++ b/Source/Shaders/Materials/ElevationContourMaterial.glsl
@@ -18,7 +18,7 @@ czm_material czm_getMaterial(czm_materialInput materialInput)
     float dF = max(dxc, dyc) * width;
     float alpha = (distanceToContour < dF) ? 1.0 : 0.0;
 #else
-    float alpha = (distanceToContour < (czm_resolutionScale * width)) ? 1.0 : 0.0;
+    float alpha = (distanceToContour < (czm_pixelRatio * width)) ? 1.0 : 0.0;
 #endif
 
     vec4 outColor = czm_gammaCorrect(vec4(color.rgb, alpha));

--- a/Source/Shaders/Materials/GridMaterial.glsl
+++ b/Source/Shaders/Materials/GridMaterial.glsl
@@ -23,7 +23,7 @@ czm_material czm_getMaterial(czm_materialInput materialInput)
 #ifdef GL_OES_standard_derivatives
     // Fuzz Factor - Controls blurriness of lines
     const float fuzz = 1.2;
-    vec2 thickness = (lineThickness * czm_resolutionScale) - 1.0;
+    vec2 thickness = (lineThickness * czm_pixelRatio) - 1.0;
 
     // From "3D Engine Design for Virtual Globes" by Cozzi and Ring, Listing 4.13.
     vec2 dx = abs(dFdx(st));

--- a/Source/Shaders/Materials/PolylineArrowMaterial.glsl
+++ b/Source/Shaders/Materials/PolylineArrowMaterial.glsl
@@ -19,9 +19,9 @@ czm_material czm_getMaterial(czm_materialInput materialInput)
     vec2 st = materialInput.st;
 
 #ifdef GL_OES_standard_derivatives
-    float base = 1.0 - abs(fwidth(st.s)) * 10.0;
+    float base = 1.0 - abs(fwidth(st.s)) * 10.0 * czm_pixelRatio;
 #else
-    float base = 0.99; // 1% of the line will be the arrow head
+    float base = 0.975; // 2.5% of the line will be the arrow head
 #endif
 
     vec2 center = vec2(1.0, 0.5);

--- a/Source/Shaders/Materials/PolylineDashMaterial.glsl
+++ b/Source/Shaders/Materials/PolylineDashMaterial.glsl
@@ -22,7 +22,7 @@ czm_material czm_getMaterial(czm_materialInput materialInput)
     vec2 pos = rotate(v_polylineAngle) * gl_FragCoord.xy;
 
     // Get the relative position within the dash from 0 to 1
-    float dashPosition = fract(pos.x / dashLength);
+    float dashPosition = fract(pos.x / (dashLength * czm_pixelRatio));
     // Figure out the mask index.
     float maskIndex = floor(dashPosition * maskLength);
     // Test the bit mask.

--- a/Source/Shaders/PointPrimitiveCollectionVS.glsl
+++ b/Source/Shaders/PointPrimitiveCollectionVS.glsl
@@ -27,7 +27,7 @@ void main()
     float totalSize = positionHighAndSize.w + outlineWidthBothSides;
     float outlinePercent = outlineWidthBothSides / totalSize;
     // Scale in response to browser-zoom.
-    totalSize *= czm_resolutionScale;
+    totalSize *= czm_pixelRatio;
     // Add padding for anti-aliasing on both sides.
     totalSize += 3.0;
 

--- a/Source/Shaders/PolylineCommon.glsl
+++ b/Source/Shaders/PolylineCommon.glsl
@@ -117,7 +117,7 @@ vec4 getPolylineWindowCoordinatesEC(vec4 positionEC, vec4 prevEC, vec4 nextEC, f
         expandWidth = clamp(expandWidth / sinAngle, 0.0, width * 2.0);
     }
 
-    vec2 offset = direction * expandDirection * expandWidth * czm_resolutionScale;
+    vec2 offset = direction * expandDirection * expandWidth * czm_pixelRatio;
     return vec4(endPointWC.xy + offset, -endPointWC.z, 1.0);
 }
 

--- a/Source/Shaders/PolylineShadowVolumeMorphVS.glsl
+++ b/Source/Shaders/PolylineShadowVolumeMorphVS.glsl
@@ -103,12 +103,12 @@ void main()
 #endif // PER_INSTANCE_COLOR
 
 #ifdef WIDTH_VARYING
-    float width = czm_batchTable_width(batchId);
+    float width = czm_batchTable_width(batchId) * czm_pixelRatio;
     float halfWidth = width * 0.5;
     v_width = width;
     v_texcoordNormalizationAndHalfWidth.z = halfWidth;
 #else
-    float halfWidth = 0.5 * czm_batchTable_width(batchId);
+    float halfWidth = 0.5 * czm_batchTable_width(batchId) * czm_pixelRatio;
     v_texcoordNormalizationAndHalfWidth.z = halfWidth;
 #endif
 

--- a/Source/Shaders/PolylineShadowVolumeVS.glsl
+++ b/Source/Shaders/PolylineShadowVolumeVS.glsl
@@ -135,7 +135,7 @@ void main()
     //    { \| }
     //       o---------- polyline segment ---->
     //
-    float width = czm_batchTable_width(batchId);
+    float width = czm_batchTable_width(batchId) * czm_pixelRatio;
 #ifdef WIDTH_VARYING
     v_width = width;
 #endif

--- a/Source/Widgets/CesiumWidget/CesiumWidget.js
+++ b/Source/Widgets/CesiumWidget/CesiumWidget.js
@@ -111,8 +111,8 @@ define([
         var height = canvas.clientHeight;
         var pixelRatio = configurePixelRatio(widget);
 
-        widget._canvasWidth = width;
-        widget._canvasHeight = height;
+        widget._canvasClientWidth = width;
+        widget._canvasClientHeight = height;
 
         width *= pixelRatio;
         height *= pixelRatio;
@@ -249,8 +249,8 @@ define([
         this._element = element;
         this._container = container;
         this._canvas = canvas;
-        this._canvasWidth = 0;
-        this._canvasHeight = 0;
+        this._canvasClientWidth = 0;
+        this._canvasClientHeight = 0;
         this._lastDevicePixelRatio = 0;
         this._creditViewport = creditViewport;
         this._creditContainer = creditContainer;
@@ -710,9 +710,7 @@ define([
      */
     CesiumWidget.prototype.resize = function() {
         var canvas = this._canvas;
-        var width = canvas.clientWidth;
-        var height = canvas.clientHeight;
-        if (!this._forceResize && this._canvasWidth === width && this._canvasHeight === height && this._lastDevicePixelRatio === window.devicePixelRatio) {
+        if (!this._forceResize && this._canvasClientWidth === canvas.clientWidth && this._canvasClientHeight === canvas.clientHeight && this._lastDevicePixelRatio === window.devicePixelRatio) {
             return;
         }
         this._forceResize = false;


### PR DESCRIPTION
This is a partial fix for #8113 

Polylines and point clouds had a number of areas that were not consistently sized between different resolutions:

- Point cloud size
- Styled point cloud size
- Point cloud eye dome lighting radius
- Polyline arrow
- Polyline dash
- Polyline shadow volume

**Point cloud**
new (low res):
<img width="1131" alt="point_lowres" src="https://user-images.githubusercontent.com/1328450/65894753-47b2ed80-e378-11e9-993e-5dea8c7b9384.png">
new (high res):
<img width="1129" alt="point_highres" src="https://user-images.githubusercontent.com/1328450/65894778-53061900-e378-11e9-98c7-e7db65b5b887.png">
cesium 1.60 (low res):
<img width="1129" alt="point_160" src="https://user-images.githubusercontent.com/1328450/65894789-57cacd00-e378-11e9-956c-f160e2bd7bd2.png">

**Polylines**
new (low res):
![poly_lowres](https://user-images.githubusercontent.com/1328450/65894800-5d281780-e378-11e9-8a9b-d5840b0856b5.png)
new (high res):
![poly_highres](https://user-images.githubusercontent.com/1328450/65894809-5ef1db00-e378-11e9-8c44-b49b328ca5bb.png)
cesium 1.60 (low res):
![poly_160](https://user-images.githubusercontent.com/1328450/65894828-6add9d00-e378-11e9-9efc-a5f6539b6a9f.png)

Further thoughts: 
- I tried to move the pixel ratio multiply outside shaders where possible, but some systems are not flexible enough for this. See `PolylineShadowVolumeMorphVS.glsl`, which "spawns" the `czm_batchTable_width` function prior to shader compilation, where there is no easy way to insert the pixel ratio multiply. `getPointSizeFromStyle` in `PointCloud.js` has the same problem.
- Polylines which use the `renderState's` `lineWidth` property still look incorrect. This is because they are rendered as GL lines which is capped to 1 pixel on many computers. Example below:

Native resolution:
<img width="721" alt="Screen Shot 2019-09-30 at 9 51 33 AM" src="https://user-images.githubusercontent.com/1328450/65892161-d2ddb480-e373-11e9-9664-74ca0edec334.png">
Browser recommended resolution:
<img width="718" alt="Screen Shot 2019-09-30 at 9 51 44 AM" src="https://user-images.githubusercontent.com/1328450/65892165-d4a77800-e373-11e9-89e2-5f78426a8140.png">







 
