### PR TITLE
Fixed edge detection shader for different resolution scales

### DIFF
--- a/Source/Shaders/PostProcessStages/EdgeDetection.glsl
+++ b/Source/Shaders/PostProcessStages/EdgeDetection.glsl
@@ -16,8 +16,8 @@ void main(void)
     scalars[1] = 10.0;
     scalars[2] = 3.0;
 
-    float padx = 1.0 / czm_viewport.z;
-    float pady = 1.0 / czm_viewport.w;
+    float padx = czm_pixelRatio / czm_viewport.z;
+    float pady = czm_pixelRatio / czm_viewport.w;
 
 #ifdef CZM_SELECTED_FEATURE
     bool selected = false;


### PR DESCRIPTION
Just another #8113 fix, this time for the edge detection shader. Before it was sampling fixed pixels away from the source pixel, now it incorporates pixel ratio into it.

Note: The shader quality degrades at lower resolutions because each pixel takes up so much space that the shader might sample from inside its own pixel, resulting in smaller depth differences. Not a big deal because most users will not be bringing the resolution down to 0.1X.

A more robust solution would be enlarge the silhouette as the resolution gets lower. I didn't think it was worth going down this rabbit hole.

Native resolution:
<img width="387" alt="Screen Shot 2019-10-02 at 4 33 04 PM" src="https://user-images.githubusercontent.com/1328450/66079951-1e8a8c80-e533-11e9-9b23-f2c79d16f4d2.png">
0.25X native
<img width="384" alt="Screen Shot 2019-10-02 at 4 33 16 PM" src="https://user-images.githubusercontent.com/1328450/66079956-20545000-e533-11e9-8c30-f3f6ce2035b0.png">
0.1X native
<img width="369" alt="Screen Shot 2019-10-02 at 4 33 57 PM" src="https://user-images.githubusercontent.com/1328450/66079961-21857d00-e533-11e9-8b50-f97c7e1bda02.png">
