### PR TITLE
Do not include approimateTerrainHeightsPrecise in built Cesium

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1025,7 +1025,7 @@ function combineJavaScript(options) {
 
         promises.push(streamToPromise(stream));
 
-        var everythingElse = ['Source/**', '!**/*.js', '!**/*.glsl'];
+        var everythingElse = ['Source/**', '!**/*.js', '!**/*.glsl', '!Source/Assets/approximateTerrainHeightsPrecise.json'];
 
         if (optimizer === 'uglify2') {
             promises.push(minifyCSS(outputDirectory));


### PR DESCRIPTION
While reviewing https://github.com/AnalyticalGraphicsInc/cesium/pull/8224 I noticed we were including `approimateTerrainHeightsPrecise.json` into the `Build` folder. This is not a big deal because it doesn't actually get included, it just adds half a megabyte to the zip file. 