### PR TITLE
Replaced console.log and RuntimeError with window.alert for sandcastles with unsupported features

### DIFF
--- a/Apps/Sandcastle/gallery/3D Tiles Interactivity.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Interactivity.html
@@ -50,7 +50,7 @@ var viewer = new Cesium.Viewer('cesiumContainer', {
 
 var scene = viewer.scene;
 if (!scene.pickPositionSupported) {
-    console.log('This browser does not support pickPosition.');
+    window.alert('This browser does not support pickPosition.');
 }
 
 scene.globe.depthTestAgainstTerrain = true;

--- a/Apps/Sandcastle/gallery/3D Tiles Point Cloud Shading.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Point Cloud Shading.html
@@ -98,7 +98,7 @@ var scene = viewer.scene;
 var viewModelTileset;
 
 if (!Cesium.PointCloudShading.isSupported(scene)) {
-    console.log('This browser does not support point cloud shading');
+    window.alert('This browser does not support point cloud shading');
 }
 
 function reset() {

--- a/Apps/Sandcastle/gallery/Ambient Occlusion.html
+++ b/Apps/Sandcastle/gallery/Ambient Occlusion.html
@@ -61,7 +61,7 @@ function startup(Cesium) {
 var viewer = new Cesium.Viewer('cesiumContainer');
 
 if (!Cesium.PostProcessStageLibrary.isAmbientOcclusionSupported(viewer.scene)) {
-    console.log('This browser does not support the ambient occlusion post process.');
+    window.alert('This browser does not support the ambient occlusion post process.');
 }
 
 // Power Plant design model provided by Bentley Systems

--- a/Apps/Sandcastle/gallery/Clamp to 3D Model.html
+++ b/Apps/Sandcastle/gallery/Clamp to 3D Model.html
@@ -39,7 +39,7 @@ var scene = viewer.scene;
 scene.globe.depthTestAgainstTerrain = true;
 
 if (!scene.sampleHeightSupported) {
-    console.log('This browser does not support sampleHeight.');
+    window.alert('This browser does not support sampleHeight.');
 }
 
 var longitude = -2.1480545852753163;

--- a/Apps/Sandcastle/gallery/Clamp to 3D Tiles.html
+++ b/Apps/Sandcastle/gallery/Clamp to 3D Tiles.html
@@ -58,7 +58,7 @@ viewer.camera.setView({
 if (scene.clampToHeightSupported) {
     tileset.initialTilesLoaded.addEventListener(start);
 } else {
-    console.log('This browser does not support clampToHeight.');
+    window.alert('This browser does not support clampToHeight.');
 }
 
 function start() {

--- a/Apps/Sandcastle/gallery/Clamp to Terrain.html
+++ b/Apps/Sandcastle/gallery/Clamp to Terrain.html
@@ -223,7 +223,7 @@ Sandcastle.addDefaultToolbarMenu([{
     onselect : function() {
 
         if (!Cesium.Entity.supportsPolylinesOnTerrain(viewer.scene)) {
-            console.log('Polylines on terrain are not supported on this platform');
+            window.alert('Polylines on terrain are not supported on this platform');
         }
 
         viewer.entities.add({

--- a/Apps/Sandcastle/gallery/Classification.html
+++ b/Apps/Sandcastle/gallery/Classification.html
@@ -184,8 +184,8 @@ function highlightTrees() {
 }
 
 function invertClassification(checked) {
-    if (!scene.invertClassificationSupported) {
-        console.log('This browser does not support invert classification');
+    if (checked && !scene.invertClassificationSupported) {
+        window.alert('This browser does not support invert classification');
     }
 
     scene.invertClassification = checked;

--- a/Apps/Sandcastle/gallery/Depth of Field.html
+++ b/Apps/Sandcastle/gallery/Depth of Field.html
@@ -94,7 +94,7 @@ for (var name in viewModel) {
 }
 
 if (!Cesium.PostProcessStageLibrary.isDepthOfFieldSupported(viewer.scene)) {
-    console.log('This browser does not support the depth of field post process.');
+    window.alert('This browser does not support the depth of field post process.');
 }
 
 var depthOfField = viewer.scene.postProcessStages.add(Cesium.PostProcessStageLibrary.createDepthOfFieldStage());

--- a/Apps/Sandcastle/gallery/Drawing on Terrain.html
+++ b/Apps/Sandcastle/gallery/Drawing on Terrain.html
@@ -43,6 +43,11 @@ var viewer = new Cesium.Viewer('cesiumContainer',  {
     infoBox : false,
     terrainProvider : Cesium.createWorldTerrain()
 });
+
+if (!viewer.scene.pickPositionSupported) {
+    window.alert('This browser does not support pickPosition.');
+}
+
 viewer.cesiumWidget.screenSpaceEventHandler.removeInputAction(Cesium.ScreenSpaceEventType.LEFT_DOUBLE_CLICK);
 function createPoint(worldPosition) {
     var point = viewer.entities.add({
@@ -82,10 +87,6 @@ var activeShape;
 var floatingPoint;
 var handler = new Cesium.ScreenSpaceEventHandler(viewer.canvas);
 handler.setInputAction(function(event) {
-    if (!Cesium.Entity.supportsPolylinesOnTerrain(viewer.scene)) {
-        console.log('This browser does not support polylines on terrain.');
-        return;
-    }
     // We use `viewer.scene.pickPosition` here instead of `viewer.camera.pickEllipsoid` so that
     // we get the correct point when mousing over terrain.
     var earthPosition = viewer.scene.pickPosition(event.position);
@@ -134,6 +135,10 @@ handler.setInputAction(function(event) {
 var options = [{
     text : 'Draw Lines',
     onselect : function() {
+        if (!Cesium.Entity.supportsPolylinesOnTerrain(viewer.scene)) {
+            window.alert('This browser does not support polylines on terrain.');
+        }
+
         terminateShape();
         drawingMode = 'line';
     }

--- a/Apps/Sandcastle/gallery/Per-Feature Post Processing.html
+++ b/Apps/Sandcastle/gallery/Per-Feature Post Processing.html
@@ -42,7 +42,7 @@ viewer.trackedEntity = viewer.entities.add({
 });
 
 if (!Cesium.PostProcessStageLibrary.isSilhouetteSupported(viewer.scene)) {
-    console.log('This browser does not support the silhouette post process.');
+    window.alert('This browser does not support the silhouette post process.');
 }
 
 var stages = viewer.scene.postProcessStages;

--- a/Apps/Sandcastle/gallery/Picking.html
+++ b/Apps/Sandcastle/gallery/Picking.html
@@ -34,7 +34,7 @@ var viewer = new Cesium.Viewer('cesiumContainer', {
 
 var scene = viewer.scene;
 if (!scene.pickPositionSupported) {
-    console.log('This browser does not support pickPosition.');
+    window.alert('This browser does not support pickPosition.');
 }
 
 var handler;

--- a/Apps/Sandcastle/gallery/Post Processing.html
+++ b/Apps/Sandcastle/gallery/Post Processing.html
@@ -81,7 +81,7 @@ for (var name in viewModel) {
 }
 
 if (!Cesium.PostProcessStageLibrary.isSilhouetteSupported(viewer.scene)) {
-    console.log('This browser does not support the silhouette post process.');
+    window.alert('This browser does not support the silhouette post process.');
 }
 
 var stages = viewer.scene.postProcessStages;

--- a/Apps/Sandcastle/gallery/Sample Height from 3D Tiles.html
+++ b/Apps/Sandcastle/gallery/Sample Height from 3D Tiles.html
@@ -34,6 +34,10 @@ var viewer = new Cesium.Viewer('cesiumContainer', {
 });
 var scene = viewer.scene;
 
+if (!scene.clampToHeightSupported) {
+    window.alert('This browser does not support clampToHeightMostDetailed.');
+}
+
 var tileset = scene.primitives.add(
     new Cesium.Cesium3DTileset({
         url: Cesium.IonResource.fromAssetId(40866)
@@ -51,10 +55,6 @@ Sandcastle.addToolbarButton('Sample heights', function() {
 });
 
 function sampleHeights() {
-    if (!scene.clampToHeightSupported) {
-        console.log('This browser does not support clampToHeightMostDetailed.');
-    }
-
     viewer.entities.removeAll();
 
     var cartesian1 = new Cesium.Cartesian3(1216390.063324395, -4736314.814479433, 4081341.9787972216);

--- a/Apps/Sandcastle/gallery/Terrain.html
+++ b/Apps/Sandcastle/gallery/Terrain.html
@@ -194,7 +194,7 @@ Sandcastle.addToolbarButton('Sample Everest Terrain at Level 9', function() {
 
 Sandcastle.addToolbarButton('Sample Most Detailed Everest Terrain', function() {
     if (!Cesium.defined(viewer.terrainProvider.availability)) {
-        console.log('sampleTerrainMostDetailed is not supported for the selected terrain provider');
+        window.alert('sampleTerrainMostDetailed is not supported for the selected terrain provider');
         return;
     }
     var terrainSamplePositions = createGrid(0.0005);

--- a/Apps/Sandcastle/gallery/Z-Indexing Geometry.html
+++ b/Apps/Sandcastle/gallery/Z-Indexing Geometry.html
@@ -86,11 +86,11 @@ viewer.entities.add({
 });
 
 if (!Cesium.Entity.supportsPolylinesOnTerrain(viewer.scene)) {
-    console.log('Polylines on terrain are not supported on this platform, Z-index will be ignored');
+    window.alert('Polylines on terrain are not supported on this platform, Z-index will be ignored');
 }
 
 if (!Cesium.Entity.supportsMaterialsforEntitiesOnTerrain(viewer.scene)) {
-    console.log('Textured materials on terrain polygons are not supported on this platform, Z-index will be ignored');
+    window.alert('Textured materials on terrain polygons are not supported on this platform, Z-index will be ignored');
 }
 
 viewer.entities.add({

--- a/Apps/Sandcastle/gallery/development/Ground Polyline Material.html
+++ b/Apps/Sandcastle/gallery/development/Ground Polyline Material.html
@@ -33,7 +33,7 @@ var viewer = new Cesium.Viewer('cesiumContainer', {
 var scene = viewer.scene;
 
 if (!Cesium.GroundPolylinePrimitive.isSupported(scene)) {
-    throw new Cesium.RuntimeError('Polylines on terrain are not supported on this platform.');
+    window.alert('Polylines on terrain are not supported on this platform.');
 }
 
 // Polyline Glow

--- a/Apps/Sandcastle/gallery/development/Ground Primitive Materials.html
+++ b/Apps/Sandcastle/gallery/development/Ground Primitive Materials.html
@@ -39,7 +39,7 @@ var viewer = new Cesium.Viewer('cesiumContainer', {
 });
 
 if (!Cesium.GroundPrimitive.supportsMaterials(viewer.scene)) {
-    throw new Cesium.RuntimeError('GroundPrimitive materials are not supported on this platform.');
+    window.alert('GroundPrimitive materials are not supported on this platform.');
 }
 
 var rectangle;

--- a/Apps/Sandcastle/gallery/development/Pick From Ray.html
+++ b/Apps/Sandcastle/gallery/development/Pick From Ray.html
@@ -34,7 +34,7 @@ var scene = viewer.scene;
 scene.globe.depthTestAgainstTerrain = true;
 
 if (!scene.pickPositionSupported) {
-    console.log('This browser does not support pickPosition or getting position from pickFromRay.');
+    window.alert('This browser does not support pickPosition or getting position from pickFromRay.');
 }
 
 var i;

--- a/Apps/Sandcastle/gallery/development/Polylines On Terrain.html
+++ b/Apps/Sandcastle/gallery/development/Polylines On Terrain.html
@@ -47,7 +47,7 @@ var viewer = new Cesium.Viewer('cesiumContainer', {
 });
 
 if (!Cesium.GroundPolylinePrimitive.isSupported(viewer.scene)) {
-    throw new Cesium.RuntimeError('Polylines on terrain are not supported on this platform.');
+    window.alert('Polylines on terrain are not supported on this platform.');
 }
 
 var polylineIds = ['polyline1', 'polyline2'];


### PR DESCRIPTION
console.log is not obvious enough and RuntimeError looks catastrophic.

This replacement creates a small popup in the browser giving a reminder that a feature is not supported. The sandcastle demo will continue execution but it probably won't be able to show off the missing feature.