### PR TITLE
Fixed contour material css pixel ratio

### DIFF
--- a/Source/Shaders/Materials/ElevationContourMaterial.glsl
+++ b/Source/Shaders/Materials/ElevationContourMaterial.glsl
@@ -15,7 +15,7 @@ czm_material czm_getMaterial(czm_materialInput materialInput)
 #ifdef GL_OES_standard_derivatives
     float dxc = abs(dFdx(materialInput.height));
     float dyc = abs(dFdy(materialInput.height));
-    float dF = max(dxc, dyc) * width;
+    float dF = max(dxc, dyc) * czm_pixelRatio * width;
     float alpha = (distanceToContour < dF) ? 1.0 : 0.0;
 #else
     float alpha = (distanceToContour < (czm_pixelRatio * width)) ? 1.0 : 0.0;


### PR DESCRIPTION
Another #8113 fix, this time for contour materials, as seen in the [Globe Materials](https://cesiumjs.org/Cesium/Build/Apps/Sandcastle/index.html?src=Globe%20Materials.html&label=All) demo.

It looks like the non-`GL_OES_standard_derivatives` version of the shader was already fixed.

The following screenshots were taken with
Shading: Elevation
Enable contour lines: Checked
Spacing: 500m
Line width: 4px

New (native res)
![Screen Shot 2019-10-03 at 10 16 41 AM](https://user-images.githubusercontent.com/1328450/66135062-56dbaa80-e5c7-11e9-82a5-f51bf4cc7285.png)
New (0.25x)
![Screen Shot 2019-10-03 at 10 16 25 AM](https://user-images.githubusercontent.com/1328450/66135066-58a56e00-e5c7-11e9-8428-9060186156ea.png)
Old (0.25x)
![Screen Shot 2019-10-03 at 10 17 22 AM](https://user-images.githubusercontent.com/1328450/66135078-5b07c800-e5c7-11e9-94aa-3e51b2487b67.png)
