### PR TITLE
floatToByte is inverse of byteToFloat

### DIFF
--- a/Source/Core/Color.js
+++ b/Source/Core/Color.js
@@ -474,7 +474,7 @@ import CesiumMath from './Math.js';
      * @returns {Number} The converted number.
      */
     Color.floatToByte = function(number) {
-        return number === 1.0 ? 255.0 : (number * 256.0) | 0;
+        return Math.round(number * 255.0);
     };
 
     /**

--- a/Specs/Core/ColorSpec.js
+++ b/Specs/Core/ColorSpec.js
@@ -76,6 +76,9 @@ describe('Core/Color', function() {
         expect(Color.floatToByte(0)).toEqual(0);
         expect(Color.floatToByte(1.0)).toEqual(255);
         expect(Color.floatToByte(127 / 255)).toEqual(127);
+        expect(Color.floatToByte(0.749)).toEqual(191);
+        expect(Color.floatToByte(0.75)).toEqual(191);
+        expect(Color.floatToByte(0.751)).toEqual(192);
     });
 
     it('fromCartesian4 returns a color with corrrect values', function(){

--- a/Specs/Core/ColorSpec.js
+++ b/Specs/Core/ColorSpec.js
@@ -60,7 +60,7 @@ describe('Core/Color', function() {
     it('toBytes works with a result parameter', function() {
         var color = new Color(0.1, 0.2, 0.3, 0.4);
         var result = [];
-        var expectedResult = [25, 51, 76, 102];
+        var expectedResult = [26, 51, 77, 102];
         var returnedResult = color.toBytes(result);
         expect(returnedResult).toBe(result);
         expect(returnedResult).toEqual(expectedResult);
@@ -154,7 +154,7 @@ describe('Core/Color', function() {
         expect(Color.BLUE.toCssColorString()).toEqual('rgb(0,0,255)');
         expect(Color.LIME.toCssColorString()).toEqual('rgb(0,255,0)');
         expect(new Color(0.0, 0.0, 0.0, 1.0).toCssColorString()).toEqual('rgb(0,0,0)');
-        expect(new Color(0.1, 0.2, 0.3, 0.4).toCssColorString()).toEqual('rgba(25,51,76,0.4)');
+        expect(new Color(0.1, 0.2, 0.3, 0.4).toCssColorString()).toEqual('rgba(26,51,77,0.4)');
     });
 
     it('fromCssColorString supports transparent', function() {


### PR DESCRIPTION
This script demonstrates the issue; change `MAX` to `255` to see the effect for the range Cesium is using currently:

`$ cat test.js`
```javascript
#!/usr/bin/env node

const MAX = 3;
const STEP = 1 / (MAX + 1);

function old(x) {
    return x === 1 ? MAX : (x * (MAX + 1)) | 0;
}
function neo(x) {
    return Math.round(x * MAX);
}

console.log(`comparing with ${STEP} step for range [0, ${MAX}]\n`);
let x = 0;
do {
    const o = old(x);
    const n = neo(x);
    if (o !== n)
        console.log(`${x}:\n    ${o} != ${n}`);
    x += STEP;
} while (x <= 1.0);
```
----
`$ ./test.js`
```
comparing with 0.25 step for range [0, 3]

0.75:
    3 != 2
```