### PR TITLE
Ignore rollup eval warnings in third-party code

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -109,6 +109,14 @@ var filesToConvertES6 = ['Source/**/*.js',
                          '!Specs/TestWorkers/**'
                         ];
 
+function rollupWarning(message) {
+    // Ignore eval warnings in third-party code we don't have control over
+    if (message.code === 'EVAL' && /(protobuf-minimal|crunch)\.js$/.test(message.loc.file)) {
+        return;
+    }
+    console.log(message);
+}
+
 function createWorkers() {
     rimraf.sync('Build/createWorkers');
 
@@ -126,7 +134,8 @@ function createWorkers() {
 
     return rollup.rollup({
         input: workers,
-        plugins: [rollupPluginBanner.default('This file is automatically rebuilt by the Cesium build process.')]
+        plugins: [rollupPluginBanner.default('This file is automatically rebuilt by the Cesium build process.')],
+        onwarn: rollupWarning
     }).then(function(bundle) {
         return bundle.write({
             dir: 'Build/createWorkers',
@@ -176,7 +185,8 @@ gulp.task('build-specs', function buildSpecs() {
     var promise = Promise.join(
         rollup.rollup({
             input: 'Specs/SpecList.js',
-            plugins: [externalCesium]
+            plugins: [externalCesium],
+            onwarn: rollupWarning
         }).then(function(bundle) {
             return bundle.write({
                 file: 'Build/Specs/Specs.js',
@@ -195,7 +205,8 @@ gulp.task('build-specs', function buildSpecs() {
         }).then(function(){
             return rollup.rollup({
                 input: 'Specs/karma-main.js',
-                plugins: [removePragmas, externalCesium]
+                plugins: [removePragmas, externalCesium],
+                onwarn: rollupWarning
             }).then(function(bundle) {
                 return bundle.write({
                     file: 'Build/Specs/karma-main.js',
@@ -1003,7 +1014,8 @@ function combineCesium(debug, optimizer, combineOutput) {
 
     return rollup.rollup({
         input: 'Source/Cesium.js',
-        plugins: plugins
+        plugins: plugins,
+        onwarn: rollupWarning
     }).then(function(bundle) {
         return bundle.write({
             format: 'umd',
@@ -1053,7 +1065,8 @@ function combineWorkers(debug, optimizer, combineOutput) {
 
             return rollup.rollup({
                 input: files,
-                plugins: plugins
+                plugins: plugins,
+                onwarn: rollupWarning
             }).then(function(bundle) {
                 return bundle.write({
                     dir: path.join(combineOutput, 'Workers'),
@@ -1389,7 +1402,8 @@ function buildCesiumViewer() {
                     pragmas: ['debug']
                 }),
                 rollupPluginUglify.uglify()
-            ]
+            ],
+            onwarn: rollupWarning
         }).then(function(bundle) {
             return bundle.write({
                 file: 'Build/Apps/CesiumViewer/CesiumViewer.js',

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -31,7 +31,6 @@ var yargs = require('yargs');
 var AWS = require('aws-sdk');
 var mime = require('mime');
 var rollup = require('rollup');
-var rollupPluginBanner = require('rollup-plugin-banner');
 var rollupPluginStripPragma = require('rollup-plugin-strip-pragma');
 var rollupPluginExternalGlobals = require('rollup-plugin-external-globals');
 var rollupPluginUglify = require('rollup-plugin-uglify');
@@ -134,11 +133,11 @@ function createWorkers() {
 
     return rollup.rollup({
         input: workers,
-        plugins: [rollupPluginBanner.default('This file is automatically rebuilt by the Cesium build process.')],
         onwarn: rollupWarning
     }).then(function(bundle) {
         return bundle.write({
             dir: 'Build/createWorkers',
+            banner: '/* This file is automatically rebuilt by the Cesium build process. */',
             format: 'amd'
         });
     }).then(function(){

--- a/package.json
+++ b/package.json
@@ -72,7 +72,6 @@
     "request": "^2.79.0",
     "rimraf": "^3.0.0",
     "rollup": "^1.21.4",
-    "rollup-plugin-banner": "^0.2.1",
     "rollup-plugin-external-globals": "^0.4.0",
     "rollup-plugin-strip-pragma": "^1.0.0",
     "rollup-plugin-uglify": "^6.0.3",


### PR DESCRIPTION
roll-up likes to yell about eval since there are cases where its usage can cause problems, none of which seems to be triggered in Cesium.

This just listens to the two known warnings produced by rollup and ignores them, letting any other warnings apss through.