### PR TITLE
Use ES6 modules under Node versions that support them.

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,9 @@
     "url": "https://github.com/AnalyticalGraphicsInc/cesium/issues",
     "email": "cesium-dev@googlegroups.com"
   },
+  "main": "index.js",
+  "module": "Source/Cesium.js",
+  "type": "module",
   "dependencies": {
     "esm": "^3.2.25"
   },


### PR DESCRIPTION
When running in a version of Node that supports ES6, this will now load the ES6 version of Cesium instead of the transpiled modules or modules loaded via ESM. It does it by setting the module type and entry points in package.json.

There are 3 use cases this allows:

1. Roll-up and other tools that support resolving front-end dependencies via node_modules can now make use of Cesium. `import { defined, JulianDate } from 'cesium';` can now be used in such systems instead of specifying the relative path to Source/Cesium.js This makes it easier to write reusable components that rely on Cesium.

2. Since we are using Cesium ES6, node bundlers can perform treeshaking and eliminate unused code, basically allow for building combined minified node code with tools like roll-up.

3. Requiring in individual modules, such as `cesium/Source/Core/Cartesian3.js` is now possible in situations where pulling the primary entry point is not desired.

The one downside of this change is that ES6 versions of Node will no longer automatically pull in the combined/minimized version of Cesium.js, though its still technically possible to do via manual esm usage. This may (or may not) impact performance under node in certain situations but ultimately a build process is properly the preferred method for optimizing node applications.

@TJKoury let me know if this is what you had in mind.