### PR TITLE
Update `Cartesian2|3|4.normalize` to accept Zero vector.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,11 @@
 Change Log
 ==========
 
+### 1.6x - 2019-xx-xx
+
+##### Additions :tada:
+* Update `Cartesian2|Cartesian3|Cartesian4.normalize` to accept Zero vector. [#xxxx](https://github.com/AnalyticalGraphicsInc/cesium/pull/xxxx)
+
 ### 1.62 - 2019-10-01
 
 ##### Deprecated :hourglass_flowing_sand:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@ Change Log
 ### 1.6x - 2019-xx-xx
 
 ##### Additions :tada:
-* Update `Cartesian2|Cartesian3|Cartesian4.normalize` to accept Zero vector. [#xxxx](https://github.com/AnalyticalGraphicsInc/cesium/pull/xxxx)
+* Update `Cartesian2|Cartesian3|Cartesian4.normalize` to accept Zero vector. [#8273](https://github.com/AnalyticalGraphicsInc/cesium/pull/8273)
 
 ### 1.62 - 2019-10-01
 

--- a/Source/Core/Cartesian2.js
+++ b/Source/Core/Cartesian2.js
@@ -369,8 +369,13 @@ import CesiumMath from './Math.js';
 
         var magnitude = Cartesian2.magnitude(cartesian);
 
-        result.x = cartesian.x / magnitude;
-        result.y = cartesian.y / magnitude;
+        if (magnitude >0 ) {
+            result.x = cartesian.x / magnitude;
+            result.y = cartesian.y / magnitude;
+        } else {
+            result.x = 0.0;
+            result.y = 0.0;
+        }
 
         //>>includeStart('debug', pragmas.debug);
         if (isNaN(result.x) || isNaN(result.y)) {

--- a/Source/Core/Cartesian3.js
+++ b/Source/Core/Cartesian3.js
@@ -403,9 +403,15 @@ import CesiumMath from './Math.js';
 
         var magnitude = Cartesian3.magnitude(cartesian);
 
-        result.x = cartesian.x / magnitude;
-        result.y = cartesian.y / magnitude;
-        result.z = cartesian.z / magnitude;
+        if (magnitude >0 ) {
+            result.x = cartesian.x / magnitude;
+            result.y = cartesian.y / magnitude;
+            result.z = cartesian.z / magnitude;
+        } else {
+            result.x = 0.0;
+            result.y = 0.0;
+            result.z = 0.0;
+        }
 
         //>>includeStart('debug', pragmas.debug);
         if (isNaN(result.x) || isNaN(result.y) || isNaN(result.z)) {

--- a/Source/Core/Cartesian4.js
+++ b/Source/Core/Cartesian4.js
@@ -406,10 +406,17 @@ import CesiumMath from './Math.js';
 
         var magnitude = Cartesian4.magnitude(cartesian);
 
-        result.x = cartesian.x / magnitude;
-        result.y = cartesian.y / magnitude;
-        result.z = cartesian.z / magnitude;
-        result.w = cartesian.w / magnitude;
+        if (magnitude >0 ) {
+            result.x = cartesian.x / magnitude;
+            result.y = cartesian.y / magnitude;
+            result.z = cartesian.z / magnitude;
+            result.w = cartesian.w / magnitude;
+        } else {
+            result.x = 0.0;
+            result.y = 0.0;
+            result.z = 0.0;
+            result.w = 0.0;
+        }
 
         //>>includeStart('debug', pragmas.debug);
         if (isNaN(result.x) || isNaN(result.y) || isNaN(result.z) || isNaN(result.w)) {

--- a/Specs/Core/Cartesian2Spec.js
+++ b/Specs/Core/Cartesian2Spec.js
@@ -297,7 +297,6 @@ describe('Core/Cartesian2', function() {
         expect(cartesian).toEqual(expectedResult);
     });
 
-
     it('multiplyComponents works with a result parameter', function() {
         var left = new Cartesian2(2.0, 3.0);
         var right = new Cartesian2(4.0, 5.0);

--- a/Specs/Core/Cartesian2Spec.js
+++ b/Specs/Core/Cartesian2Spec.js
@@ -297,11 +297,6 @@ describe('Core/Cartesian2', function() {
         expect(cartesian).toEqual(expectedResult);
     });
 
-    it('normalize throws with zero vector', function() {
-        expect(function() {
-            Cartesian2.normalize(Cartesian2.ZERO, new Cartesian2());
-        }).toThrowDeveloperError();
-    });
 
     it('multiplyComponents works with a result parameter', function() {
         var left = new Cartesian2(2.0, 3.0);

--- a/Specs/Core/Cartesian3Spec.js
+++ b/Specs/Core/Cartesian3Spec.js
@@ -367,11 +367,6 @@ describe('Core/Cartesian3', function() {
         expect(cartesian).toEqual(expectedResult);
     });
 
-    it('normalize throws with zero vector', function() {
-        expect(function() {
-            Cartesian3.normalize(Cartesian3.ZERO, new Cartesian3());
-        }).toThrowDeveloperError();
-    });
 
     it('multiplyComponents works with a result parameter', function() {
         var left = new Cartesian3(2.0, 3.0, 6.0);

--- a/Specs/Core/Cartesian3Spec.js
+++ b/Specs/Core/Cartesian3Spec.js
@@ -367,7 +367,6 @@ describe('Core/Cartesian3', function() {
         expect(cartesian).toEqual(expectedResult);
     });
 
-
     it('multiplyComponents works with a result parameter', function() {
         var left = new Cartesian3(2.0, 3.0, 6.0);
         var right = new Cartesian3(4.0, 5.0, 7.0);

--- a/Specs/Core/Cartesian4Spec.js
+++ b/Specs/Core/Cartesian4Spec.js
@@ -432,11 +432,6 @@ describe('Core/Cartesian4', function() {
         expect(cartesian).toEqual(expectedResult);
     });
 
-    it('normalize throws with zero vector', function() {
-        expect(function() {
-            Cartesian4.normalize(Cartesian4.ZERO, new Cartesian4());
-        }).toThrowDeveloperError();
-    });
 
     it('multiplyComponents works with a result parameter', function() {
         var left = new Cartesian4(2.0, 3.0, 6.0, 8.0);

--- a/Specs/Core/Cartesian4Spec.js
+++ b/Specs/Core/Cartesian4Spec.js
@@ -432,7 +432,6 @@ describe('Core/Cartesian4', function() {
         expect(cartesian).toEqual(expectedResult);
     });
 
-
     it('multiplyComponents works with a result parameter', function() {
         var left = new Cartesian4(2.0, 3.0, 6.0, 8.0);
         var right = new Cartesian4(4.0, 5.0, 7.0, 9.0);


### PR DESCRIPTION
Existing code generates an error when a zero vector is normalized.
This update removes the restriction by providing back a zero vector.