### PR TITLE
Add deprecated attribute to JSDoc type sig indicators.

### DIFF
--- a/Source/DataSources/DynamicGeometryUpdater.js
+++ b/Source/DataSources/DynamicGeometryUpdater.js
@@ -24,6 +24,7 @@ import Property from './Property.js';
      * @alias DynamicGeometryUpdater
      * @constructor
      * @private
+     * @abstract
      */
     function DynamicGeometryUpdater(geometryUpdater, primitives, orderedGroundPrimitives) {
         //>>includeStart('debug', pragmas.debug);

--- a/Source/DataSources/MaterialProperty.js
+++ b/Source/DataSources/MaterialProperty.js
@@ -10,6 +10,7 @@ import Material from '../Scene/Material.js';
      *
      * @alias MaterialProperty
      * @constructor
+     * @abstract
      *
      * @see ColorMaterialProperty
      * @see CompositeMaterialProperty

--- a/Source/DataSources/PositionProperty.js
+++ b/Source/DataSources/PositionProperty.js
@@ -13,6 +13,7 @@ import Transforms from '../Core/Transforms.js';
      *
      * @alias PositionProperty
      * @constructor
+     * @abstract
      *
      * @see CompositePositionProperty
      * @see ConstantPositionProperty

--- a/Source/DataSources/Property.js
+++ b/Source/DataSources/Property.js
@@ -9,6 +9,7 @@ import DeveloperError from '../Core/DeveloperError.js';
      *
      * @alias Property
      * @constructor
+     * @abstract
      *
      * @see CompositeProperty
      * @see ConstantProperty

--- a/Tools/jsdoc/cesium_template/publish.js
+++ b/Tools/jsdoc/cesium_template/publish.js
@@ -87,6 +87,10 @@ function addSignatureTypes(f) {
 function addAttribs(f) {
     var attribs = helper.getAttribs(f);
 
+    if (f.deprecated) {
+        attribs.push('deprecated');
+    }
+
     if (attribs.length) {
         f.attribs = attribs.map(function(attrib) {
             return '<span class="type-signature attribute-' + attrib + '">' + htmlsafe(attrib) + '</span>';

--- a/Tools/jsdoc/cesium_template/static/styles/jsdoc-default.css
+++ b/Tools/jsdoc/cesium_template/static/styles/jsdoc-default.css
@@ -576,6 +576,7 @@ dd { margin-left: 10px; }
 
 span.attribute-static,
 span.attribute-readonly,
+span.attribute-deprecated,
 span.attribute-constant {
   display: inline-block;
   border-radius: 3px;
@@ -587,6 +588,10 @@ span.attribute-constant {
   margin-bottom: 1px;
   position: relative;
   top: -1px;
+}
+
+span.attribute-deprecated {
+    background-color: #950B02 !important;
 }
 
 .description {

--- a/Tools/jsdoc/cesium_template/static/styles/jsdoc-default.css
+++ b/Tools/jsdoc/cesium_template/static/styles/jsdoc-default.css
@@ -574,6 +574,7 @@ dd { margin-left: 10px; }
     border-bottom: 1px solid #A35A00;
 }
 
+span.attribute-abstract,
 span.attribute-static,
 span.attribute-readonly,
 span.attribute-deprecated,
@@ -589,6 +590,11 @@ span.attribute-constant {
   position: relative;
   top: -1px;
 }
+
+span.attribute-abstract {
+    background-color: #fff !important;
+    border: 1px solid #888;
+    color: black;}
 
 span.attribute-deprecated {
     background-color: #950B02 !important;


### PR DESCRIPTION
Fixes #8267.

![deprecated-docs-v2](https://user-images.githubusercontent.com/1235080/66656727-8ebca080-ec0c-11e9-8e01-13eb480fbb64.png)

(And mostly for my own reference, a link to the [source for `helper.getAttribs`](https://github.com/jsdoc/jsdoc/blob/b9706918f6ae738906cab31c2deb93376d62aacb/packages/jsdoc/lib/jsdoc/util/templateHelper.js#L673).)