### PR TITLE
Set time of day for Time Dynamic Sandcastle example

### DIFF
--- a/Apps/Sandcastle/gallery/Time Dynamic Wheels.html
+++ b/Apps/Sandcastle/gallery/Time Dynamic Wheels.html
@@ -27,7 +27,7 @@ var viewer = new Cesium.Viewer('cesiumContainer', {
 });
 
 //Make sure viewer is at the desired time.
-var start = Cesium.JulianDate.fromDate(new Date(2018, 11, 12));
+var start = Cesium.JulianDate.fromDate(new Date(2018, 11, 12, 15));
 var totalSeconds = 10;
 var stop = Cesium.JulianDate.addSeconds(start, totalSeconds, new Cesium.JulianDate());
 viewer.clock.startTime = start.clone();


### PR DESCRIPTION
Since we fixed the lighting so models aren't exceedingly bright, I noticed the truck in the time dynamic Sandcastle example is now pretty dark:

https://cesiumjs.org/Cesium/Apps/Sandcastle/index.html?src=Time%20Dynamic%20Wheels.html

![dark_truck](https://user-images.githubusercontent.com/1711126/66710286-2fad7780-ed43-11e9-8d5d-1a1662f10b48.png)

This is just because of the time of day. So this PR just sets it to a time when the sun is up so you can better see the spinning wheels which this Sandcastle demonstrates:

![better_truck](https://user-images.githubusercontent.com/1711126/66710288-30dea480-ed43-11e9-8d2c-e0824b477e0e.png)
