### PR TITLE
Fixed a few sandcastle paths that didn't work with website build

### DIFF
--- a/Apps/Sandcastle/gallery/Export KML.html
+++ b/Apps/Sandcastle/gallery/Export KML.html
@@ -40,7 +40,7 @@ var modelCzml = [{
         "cartographicDegrees" : [-77, 37, 0]
     },
     "model": {
-        "gltf" : "../../../../Apps/SampleData/models/CesiumMilkTruck/CesiumMilkTruck.glb"
+        "gltf" : "../../SampleData/models/CesiumMilkTruck/CesiumMilkTruck.glb"
     }
 }];
 
@@ -64,11 +64,11 @@ function reset() {
 
 // We fetch the resources that will be embedded in the KMZ file.
 var daeModelPromise = Cesium.Resource.fetchBlob({
-    url: '../../../../Apps/SampleData/models/CesiumMilkTruck/CesiumMilkTruck.dae'
+    url: '../../SampleData/models/CesiumMilkTruck/CesiumMilkTruck.dae'
 });
 
 var texturePromise = Cesium.Resource.fetchBlob({
-    url: '../../../../Apps/SampleData/models/CesiumMilkTruck/CesiumMilkTruck.png'
+    url: '../../SampleData/models/CesiumMilkTruck/CesiumMilkTruck.png'
 });
 
 // This callback allows us to set the URL of the model to use

--- a/Apps/Sandcastle/gallery/High Dynamic Range.html
+++ b/Apps/Sandcastle/gallery/High Dynamic Range.html
@@ -43,7 +43,7 @@ Sandcastle.addToggleButton('HDR', true, function(checked) {
     viewer.scene.highDynamicRange = checked;
 });
 
-var url = '../../../../Apps/SampleData/models/DracoCompressed/CesiumMilkTruck.gltf';
+var url = '../../SampleData/models/DracoCompressed/CesiumMilkTruck.gltf';
 var position = Cesium.Cartesian3.fromRadians(-1.9516424279517286, 0.6322397098422969, 1239.0006814631095);
 var heading = Cesium.Math.toRadians(-15.0);
 var pitch = 0;


### PR DESCRIPTION
Two sandcastle demos, High Dynamic Range and Export KML, referenced the SampleData path in a weird way that fails on the website. See [sandcastle](https://sandcastle.cesium.com/?src=High%20Dynamic%20Range.html&label=All). I changed the paths to the correct style. 

old: `../../../../Apps/SampleData/models/DracoCompressed/CesiumMilkTruck.gltf`
new: `../../SampleData/models/DracoCompressed/CesiumMilkTruck.gltf`