### PR TITLE
Catch and report error when IBL map fails to load

### DIFF
--- a/Source/Scene/Model.js
+++ b/Source/Scene/Model.js
@@ -4705,9 +4705,13 @@ import ShadowMode from './ShadowMode.js';
             if (defined(this._specularEnvironmentMaps)) {
                 this._specularEnvironmentMapAtlas = new OctahedralProjectedCubeMap(this._specularEnvironmentMaps);
                 var that = this;
-                this._specularEnvironmentMapAtlas.readyPromise.then(function() {
-                    that._shouldRegenerateShaders = true;
-                });
+                this._specularEnvironmentMapAtlas.readyPromise
+                    .then(function() {
+                        that._shouldRegenerateShaders = true;
+                    })
+                    .otherwise(function(error) {
+                        console.error('Error loading specularEnvironmentMaps: ' + error);
+                    });
             }
 
             // Regenerate shaders to not use an environment map. Will be set to true again if there was a new environment map and it is ready.

--- a/Source/Scene/OctahedralProjectedCubeMap.js
+++ b/Source/Scene/OctahedralProjectedCubeMap.js
@@ -233,6 +233,7 @@ import when from '../ThirdParty/when.js';
      */
     OctahedralProjectedCubeMap.prototype.update = function(frameState) {
         var context = frameState.context;
+
         if (!OctahedralProjectedCubeMap.isSupported(context)) {
             return;
         }
@@ -262,7 +263,7 @@ import when from '../ThirdParty/when.js';
             loadKTX(this._url).then(function(buffers) {
                 that._cubeMapBuffers = buffers;
                 that._loading = false;
-            });
+            }).otherwise(this._readyPromise.reject);
             this._loading = true;
         }
         if (!defined(this._cubeMapBuffers)) {

--- a/Specs/Scene/OctahedralProjectedCubeMapSpec.js
+++ b/Specs/Scene/OctahedralProjectedCubeMapSpec.js
@@ -1,4 +1,4 @@
-import { Cartesian3 } from '../../Source/Cesium.js';
+import { Cartesian3, defined } from '../../Source/Cesium.js';
 import { ComputeEngine } from '../../Source/Cesium.js';
 import { Pass } from '../../Source/Cesium.js';
 import { OctahedralProjectedCubeMap } from '../../Source/Cesium.js';
@@ -188,6 +188,31 @@ describe('Scene/OctahedralProjectedCubeMap', function() {
             projection2.destroy();
         }).always(function() {
             projection.destroy();
+        });
+    });
+
+    it('rejects when environment map fails to load.', function() {
+        if (!OctahedralProjectedCubeMap.isSupported(context)) {
+            return;
+        }
+
+        var projection = new OctahedralProjectedCubeMap('http://invalid.url');
+        var frameState = createFrameState(context);
+        var error;
+
+        projection.readyPromise
+            .then(function() {
+                fail('Should not resolve.');
+            })
+            .otherwise(function(e) {
+                error = e;
+                expect(error).toBeDefined();
+                expect(projection.ready).toEqual(false);
+            });
+
+        return pollToPromise(function() {
+            projection.update(frameState);
+            return defined(error);
         });
     });
 }, 'WebGL');


### PR DESCRIPTION
This [came up on the forum](https://groups.google.com/d/msg/cesium-dev/6C8O1faCEFc/CvcK83ZyDgAJ). If you take the `old_venetian_crossroads_2k_ibl` in this zip, and try to load it in the [IBL Sandcastle](https://sandcastle.cesium.com/index.html?src=Image-Based%20Lighting.html) it fails to load, and the only indication you get is that the models are just completely black.

[EnvironmentMap.zip](https://github.com/AnalyticalGraphicsInc/cesium/files/3746903/EnvironmentMap.zip)

I eventually realized CesiumJS was failing to load that KTX file because it had an unsupported `glInternalFormat` of `R11F_G11F_B10F`. This PR gets `OctahedralProjectedCubeMap` to reject its readyPromise when it fails to load the environment map, and gets `Model.js` to listen on that and `console.error` it out. I also added a test to make sure the promise is rejected when it tries to load an invalid URL.

This KTX file was generated from [cmgen 1.4.1](https://github.com/google/filament/releases/tag/v1.4.1), but it seems to have this unsupported format because of some recent change. I tested with [cmgen 1.2.0](https://github.com/google/filament/releases/tag/v1.2.0) and it works in CesiumJS (included in the above zip). 