### PR TITLE
Remove import.meta.url usage

### DIFF
--- a/Apps/CesiumViewer/CesiumViewer.js
+++ b/Apps/CesiumViewer/CesiumViewer.js
@@ -1,3 +1,5 @@
+window.CESIUM_BASE_URL = '../../Source/';
+
 import {
     Cartesian3,
     createWorldTerrain,

--- a/Apps/Sandcastle/load-cesium-es6.js
+++ b/Apps/Sandcastle/load-cesium-es6.js
@@ -1,5 +1,6 @@
 // This file loads the unbuilt ES6 version of Cesium
 // into the global scope during local developmnet
+window.CESIUM_BASE_URL = "../../../Source/";
 import * as Cesium from "../../Source/Cesium.js";
 window.Cesium = Cesium;
 

--- a/Source/Core/buildModuleUrl.js
+++ b/Source/Core/buildModuleUrl.js
@@ -1,12 +1,11 @@
 import defined from './defined.js';
 import DeveloperError from './DeveloperError.js';
-import FeatureDetection from './FeatureDetection.js';
 import getAbsoluteUri from './getAbsoluteUri.js';
 import Resource from './Resource.js';
 
     /*global CESIUM_BASE_URL*/
 
-    var cesiumScriptRegex = /((?:.*\/)|^)cesium[\w-]*\.js(?:\W|$)/i;
+    var cesiumScriptRegex = /((?:.*\/)|^)Cesium\.js$/;
     function getBaseUrlFromCesiumScript() {
         var scripts = document.getElementsByTagName('script');
         for ( var i = 0, len = scripts.length; i < len; ++i) {
@@ -47,14 +46,8 @@ import Resource from './Resource.js';
             baseUrlString = CESIUM_BASE_URL;
         } else if (typeof define === 'object' && defined(define.amd) && !define.amd.toUrlUndefined && defined(require.toUrl)) {
             baseUrlString = getAbsoluteUri('..', buildModuleUrl('Core/buildModuleUrl.js'));
-        } else if (!FeatureDetection.isInternetExplorer() && /\/buildModuleUrl\.js$/.test(import.meta.url)) {
-            baseUrlString = getAbsoluteUri('..', import.meta.url);
         } else {
             baseUrlString = getBaseUrlFromCesiumScript();
-        }
-
-        if (baseUrlString === '') {
-            baseUrlString = '.';
         }
 
         //>>includeStart('debug', pragmas.debug);

--- a/Specs/Core/buildModuleUrlSpec.js
+++ b/Specs/Core/buildModuleUrlSpec.js
@@ -18,7 +18,6 @@ describe('Core/buildModuleUrl', function() {
         var r = buildModuleUrl._cesiumScriptRegex;
 
         expect(r.exec('Cesium.js')[1]).toEqual('');
-        expect(r.exec('assets/foo/Cesium-b16.js')[1]).toEqual('assets/foo/');
         expect(r.exec('assets/foo/Cesium.js')[1]).toEqual('assets/foo/');
         expect(r.exec('http://example.invalid/Cesium/assets/foo/Cesium.js')[1]).toEqual('http://example.invalid/Cesium/assets/foo/');
 

--- a/Specs/SpecRunner.html
+++ b/Specs/SpecRunner.html
@@ -27,6 +27,7 @@
             document.write('<script src="../Build/Specs/spec-main.js"><\/script>');
             document.write('<script src="../Build/Specs/Specs.js"><\/script>');
         } else {
+            window.CESIUM_BASE_URL = '../Source/';
             document.write('<script type="module" src="spec-main.js"><\/script>');
         }
     </script>

--- a/Specs/karma-main.js
+++ b/Specs/karma-main.js
@@ -15,5 +15,11 @@ if (__karma__.config.args) {
     release = __karma__.config.args[4];
 }
 
+if (release) {
+    window.CESIUM_BASE_URL = 'base/Build/Cesium';
+} else {
+    window.CESIUM_BASE_URL = 'base/Source';
+}
+
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 30000;
 customizeJasmine(jasmine.getEnv(), included, excluded, webglValidation, webglStub, release);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1394,6 +1394,7 @@ function buildCesiumViewer() {
         var stream = mergeStream(
             gulp.src('Build/Apps/CesiumViewer/CesiumViewer.js')
                 .pipe(gulpInsert.prepend(copyrightHeader))
+                .pipe(gulpReplace('../../Source', '.'))
                 .pipe(gulp.dest(cesiumViewerOutputDirectory)),
 
             gulp.src('Apps/CesiumViewer/CesiumViewer.css')


### PR DESCRIPTION
`import.meta.url` is only at stage 3 of the standards track and tools like webpack and babel do not have good support. Not all browsers do either.  I ran into problems just trying to update the cesium-webpack-example and Edge won't even part JS code with import.meta.url in it.

This PR removes import.meta.url usage and just does a little extra work so that all of our developer setups properly set CESIUM_BASE_URL. Most ES6 development setups would require setting CESIUM_BASE_URL anyway, so this doesn't change much of anything for our end users.

Folks using combined versions of Cesium.js are unaffected.

I also tightened up our regex for `getBaseUrlFromCesiumScript` because Cesium.js is always named Cesium.js if it is available, which wasn't the case years ago when this code was written.  This should prevent accidental detection of the wrong script, for example `CesiumViewer.js` would get selected as a false positive.  This type of check is only valid for non-ES6 module usage anyway, since there is no `script` tag inserter for individual ES6 modules.

Fixes #8251 You can now load Cesium Viewer unbuilt in Edge (but it takes forever).  But the real reason for this is improving compatibility with the current tooling ecosystem.