### PR TITLE
Added pixel ratio to czm_metersPerPixel

### DIFF
--- a/Source/Shaders/BillboardCollectionVS.glsl
+++ b/Source/Shaders/BillboardCollectionVS.glsl
@@ -56,7 +56,7 @@ vec4 addScreenSpaceOffset(vec4 positionEC, vec2 imageSize, float scale, vec2 dir
 {
     // Note the halfSize cannot be computed in JavaScript because it is sent via
     // compressed vertex attributes that coerce it to an integer.
-    vec2 halfSize = imageSize * scale * czm_pixelRatio * 0.5;
+    vec2 halfSize = imageSize * scale * 0.5;
     halfSize *= ((direction * 2.0) - 1.0);
 
     vec2 originTranslate = origin * abs(halfSize);
@@ -102,7 +102,7 @@ vec4 addScreenSpaceOffset(vec4 positionEC, vec2 imageSize, float scale, vec2 dir
     }
 
     positionEC.xy += translate * mpp;
-    positionEC.xy += (pixelOffset * czm_pixelRatio) * mpp;
+    positionEC.xy += pixelOffset * mpp;
     return positionEC;
 }
 

--- a/Source/Shaders/Builtin/Functions/metersPerPixel.glsl
+++ b/Source/Shaders/Builtin/Functions/metersPerPixel.glsl
@@ -37,5 +37,5 @@ float czm_metersPerPixel(vec4 positionEC)
         pixelWidth = 2.0 * distanceToPixel * tanTheta / width;
     }
 
-    return max(pixelWidth, pixelHeight);
+    return max(pixelWidth, pixelHeight) * czm_pixelRatio;
 }

--- a/Source/Shaders/PolylineShadowVolumeMorphVS.glsl
+++ b/Source/Shaders/PolylineShadowVolumeMorphVS.glsl
@@ -103,12 +103,12 @@ void main()
 #endif // PER_INSTANCE_COLOR
 
 #ifdef WIDTH_VARYING
-    float width = czm_batchTable_width(batchId) * czm_pixelRatio;
+    float width = czm_batchTable_width(batchId);
     float halfWidth = width * 0.5;
     v_width = width;
     v_texcoordNormalizationAndHalfWidth.z = halfWidth;
 #else
-    float halfWidth = 0.5 * czm_batchTable_width(batchId) * czm_pixelRatio;
+    float halfWidth = 0.5 * czm_batchTable_width(batchId);
     v_texcoordNormalizationAndHalfWidth.z = halfWidth;
 #endif
 

--- a/Source/Shaders/PolylineShadowVolumeVS.glsl
+++ b/Source/Shaders/PolylineShadowVolumeVS.glsl
@@ -135,7 +135,7 @@ void main()
     //    { \| }
     //       o---------- polyline segment ---->
     //
-    float width = czm_batchTable_width(batchId) * czm_pixelRatio;
+    float width = czm_batchTable_width(batchId);
 #ifdef WIDTH_VARYING
     v_width = width;
 #endif


### PR DESCRIPTION
After closing https://github.com/AnalyticalGraphicsInc/cesium/issues/8113 we noticed that "Size billboard in meters" inside [this sandcastle](https://sandcastle.cesium.com/?src=Billboards.html) looked different at varying resolution scales. Turns out I missed the `czm_metersPerPixel` function which is used by billboards, clipping planes, and ground polylines. So now `czm_metersPerPixel` handles the pixel ratio multiply and these shaders no longer do their own `czm_pixelRatio` multiply.

I confirmed that polylines, billboards, and clipping planes work consistently between resolution scales