### PR TITLE
Fix webgl errors when rendering over 64k billboards

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,7 @@ We’ve consolidated all of our website content from cesiumjs.org and cesium.com
 * Fixed a bug where `scene.sampleHeightMostDetailed` and `scene.clampToHeightMostDetailed` would not resolve in request render mode. [#8281](https://github.com/AnalyticalGraphicsInc/cesium/issues/8281)
 * Fixed seam artifacts when log depth is disabled, `scene.globe.depthTestAgainstTerrain` is false, and primitives are under the globe. [#8205](https://github.com/AnalyticalGraphicsInc/cesium/pull/8205)
 * Fix dynamic ellipsoids using `innerRadii`, `minimumClock`, `maximumClock`, `minimumCone` or `maximumCone`. [#8277](https://github.com/AnalyticalGraphicsInc/cesium/pull/8277)
+* Fixed rendering billboard collections containing more than 65536 billboards. [#8325](https://github.com/AnalyticalGraphicsInc/cesium/pull/8325)
 
 ##### Deprecated :hourglass_flowing_sand:
 * `OrthographicFrustum.getPixelDimensions`, `OrthographicOffCenterFrustum.getPixelDimensions`, `PerspectiveFrustum.getPixelDimensions`, and `PerspectiveOffCenterFrustum.getPixelDimensions` now take a `pixelRatio` argument before the `result` argument. The previous function definition will no longer work in 1.65. [#8237](https://github.com/AnalyticalGraphicsInc/cesium/pull/8237)

--- a/Source/Renderer/VertexArrayFacade.js
+++ b/Source/Renderer/VertexArrayFacade.js
@@ -304,12 +304,13 @@ import VertexArray from './VertexArray.js';
             destroyVA(this);
             var va = this.va = [];
 
-            var numberOfVertexArrays = defined(indexBuffer) ? Math.ceil(this._size / (CesiumMath.SIXTY_FOUR_KILOBYTES - 1)) : 1;
+            var chunkSize = CesiumMath.SIXTY_FOUR_KILOBYTES - 4; // The 65535 index is reserved for primitive restart. Reserve the last 4 indices so that billboard quads are not broken up.
+            var numberOfVertexArrays = (defined(indexBuffer) && !this._instanced) ? Math.ceil(this._size / chunkSize) : 1;
             for ( var k = 0; k < numberOfVertexArrays; ++k) {
                 var attributes = [];
                 for (i = 0, length = allBuffers.length; i < length; ++i) {
                     buffer = allBuffers[i];
-                    var offset = k * (buffer.vertexSizeInBytes * (CesiumMath.SIXTY_FOUR_KILOBYTES - 1));
+                    var offset = k * (buffer.vertexSizeInBytes * chunkSize);
                     VertexArrayFacade._appendAttributes(attributes, buffer, offset, this._instanced);
                 }
 
@@ -321,7 +322,7 @@ import VertexArray from './VertexArray.js';
                         attributes : attributes,
                         indexBuffer : indexBuffer
                     }),
-                    indicesCount : 1.5 * ((k !== (numberOfVertexArrays - 1)) ? (CesiumMath.SIXTY_FOUR_KILOBYTES - 1) : (this._size % (CesiumMath.SIXTY_FOUR_KILOBYTES - 1)))
+                    indicesCount : 1.5 * ((k !== (numberOfVertexArrays - 1)) ? chunkSize : (this._size % chunkSize))
                 // TODO: not hardcode 1.5, this assumes 6 indices per 4 vertices (as for Billboard quads).
                 });
             }


### PR DESCRIPTION
Fixes https://github.com/AnalyticalGraphicsInc/cesium/issues/8315

Two separate bugs:
* When instancing is enabled - `VertexArrayFacade` breaks up vertex arrays where the number of vertices is greater than the ushort limit of 65536. This breaking up step shouldn't happen when doing instancing.
* When instancing is disabled - https://github.com/AnalyticalGraphicsInc/cesium/commit/9100963f00481df05bc5c68431e7154cb941c3dd broke non-instanced billboard rendering because the vertex array was no longer aligned to every 4 vertices.

Cesium should now be able to render large amounts of billboards without WebGL errors or artifacts whether the browser supports `ANGLE_instanced_arrays` or not.