### PR TITLE
Clarify license for mouse gesture icons

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -932,7 +932,8 @@ http://raphaeljs.com/license.html
 
 ### Mouse and gesture vector icons made by Freepik from Flaticon.com
 
-http://www.flaticon.com/authors/freepik
+Creative Commons Attribution 3.0
+https://web.archive.org/web/20140419110558/http://www.flaticon.com/terms-of-use
 
 ### Maki icon set from Mapbox
 


### PR DESCRIPTION
We received a question regarding licensing of flaticon.com icons that were introduced way back in 2014 with #1621.

Turns out that website changed dramatically and the link no longer points to the same place it used to. I updated the MD to specficially state these files are CC BY 3.0 and included a web archive link instead of the current website.