### PR TITLE
Fix double globe when lighting is enabled

### DIFF
--- a/Source/Shaders/GlobeFS.glsl
+++ b/Source/Shaders/GlobeFS.glsl
@@ -376,7 +376,7 @@ void main()
     }
 
 #if defined(PER_FRAGMENT_GROUND_ATMOSPHERE) && (defined(ENABLE_DAYNIGHT_SHADING) || defined(ENABLE_VERTEX_LIGHTING))
-    float mpp = czm_metersPerPixel(vec4(0.0, 0.0, -czm_currentFrustum.x, 1.0));
+    float mpp = czm_metersPerPixel(vec4(0.0, 0.0, -czm_currentFrustum.x, 1.0)) / czm_pixelRatio;
     vec2 xy = gl_FragCoord.xy / czm_viewport.zw * 2.0 - vec2(1.0);
     xy *= czm_viewport.zw * mpp * 0.5;
 


### PR DESCRIPTION
In CesiumJS 1.63, try running:

```
var viewer = new Cesium.Viewer('cesiumContainer');
viewer.scene.globe.enableLighting = true
```

You'll get a double globe:

![image](https://user-images.githubusercontent.com/1711126/68072546-692f3c80-fd5d-11e9-8e55-3dc666f596eb.png)

You can fix this by going back to the old resolution scale behavior we had in 1.61:

```
viewer.resolutionScale = 1.0 / window.devicePixelRatio;
```

This happens because in #8318 we added a multiplication by czm_pixelRatio in metersPerPixel.glsl. This caused a second globe to render at half the size when globe lighting was enabled. This fixes it by dividing back by that value. But I'm not sure if this is the right fix. @lilleyse @IanLilleyT what do you think?

@mramato is this worth a 1.63.1 patch release?

This was reported [on the forum](https://groups.google.com/forum/#!topic/cesium-dev/Cc5JHnR9br4).