### PR TITLE
Revert separate primitive framebuffer

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@ Change Log
 
 ##### Fixes :wrench:
 * Fixed regression in 1.63 where ground atmosphere and labels rendered incorrectly on displays with `window.devicePixelRatio` greater than 1.0. [#8351](https://github.com/AnalyticalGraphicsInc/cesium/pull/8351)
+* Fixed regression in 1.63 where some primitives would show through the globe when log depth is disabled. [#8368](https://github.com/AnalyticalGraphicsInc/cesium/pull/8368)
 
 ### 1.63 - 2019-11-01
 

--- a/Source/Scene/Scene.js
+++ b/Source/Scene/Scene.js
@@ -2198,7 +2198,7 @@ import View from './View.js';
 
         var clearGlobeDepth = environmentState.clearGlobeDepth;
         var useDepthPlane = environmentState.useDepthPlane;
-        var separatePrimitiveFramebuffer = environmentState.separatePrimitiveFramebuffer = (numFrustums > 1) && clearGlobeDepth && environmentState.useGlobeDepthFramebuffer;
+        var separatePrimitiveFramebuffer = environmentState.separatePrimitiveFramebuffer = false;
         var clearDepth = scene._depthClearCommand;
         var clearStencil = scene._stencilClearCommand;
         var clearClassificationStencil = scene._classificationStencilClearCommand;


### PR DESCRIPTION
Fixes https://github.com/AnalyticalGraphicsInc/cesium/issues/8366 and https://github.com/AnalyticalGraphicsInc/cesium/issues/8356

Reverts https://github.com/AnalyticalGraphicsInc/cesium/pull/8205. I'm going to open a separate next-release issue to add back this fix but address the depth plane problem https://github.com/AnalyticalGraphicsInc/cesium/issues/8356#issuecomment-549629310:

> The points on the opposite side of the globe are rendered in the last frustum which is past the depth plane. The same thing happened in 1.62 but the points would get overwritten by globe commands in closer frustums.

