### PR TITLE
Don't throttle requests by server if RequestScheduler.throttleRequests is false

### DIFF
--- a/Source/Core/RequestScheduler.js
+++ b/Source/Core/RequestScheduler.js
@@ -329,7 +329,7 @@ import RequestState from './RequestState.js';
             request.serverKey = RequestScheduler.getServerKey(request.url);
         }
 
-        if (request.throttleByServer && !serverHasOpenSlots(request.serverKey)) {
+        if (RequestScheduler.throttleRequests && request.throttleByServer && !serverHasOpenSlots(request.serverKey)) {
             // Server is saturated. Try again later.
             return undefined;
         }

--- a/Specs/Core/RequestSchedulerSpec.js
+++ b/Specs/Core/RequestSchedulerSpec.js
@@ -627,7 +627,7 @@ describe('Core/RequestScheduler', function() {
         }
     });
 
-    it('throttleRequests', function() {
+    it('does not throttle requests when throttleRequests is false', function() {
         RequestScheduler.maximumRequests = 0;
 
         function requestFunction() {
@@ -646,6 +646,34 @@ describe('Core/RequestScheduler', function() {
         RequestScheduler.throttleRequests = false;
         request = new Request({
             throttle : true,
+            url : 'https://test.invalid/1',
+            requestFunction : requestFunction
+        });
+        promise = RequestScheduler.request(request);
+        expect(promise).toBeDefined();
+
+        RequestScheduler.throttleRequests = true;
+    });
+
+    it('does not throttle requests by server when throttleRequests is false', function() {
+        RequestScheduler.maximumRequestsPerServer = 0;
+
+        function requestFunction() {
+            return when.resolve();
+        }
+
+        RequestScheduler.throttleRequests = true;
+        var request = new Request({
+            throttleByServer : true,
+            url : 'https://test.invalid/1',
+            requestFunction : requestFunction
+        });
+        var promise = RequestScheduler.request(request);
+        expect(promise).toBeUndefined();
+
+        RequestScheduler.throttleRequests = false;
+        request = new Request({
+            throttleByServer : true,
             url : 'https://test.invalid/1',
             requestFunction : requestFunction
         });


### PR DESCRIPTION
Requests that are throttled by server should not be throttled if `RequestScheduler.throttleRequests` is false. Not sure if this has come up in practice since `RequestScheduler.throttleRequests` is true by default and is not visible to the public API.