### PR TITLE
Make primitives/entities not cull when below ellipsoid but above terrain

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,8 @@ Change Log
 ### 1.65.0 - 2019-01-02
 
 ##### Fixes :wrench:
-* Fix Geocoder auto-complete suggestions when hosted inside Web Components. [#8425](https://github.com/AnalyticalGraphicsInc/cesium/pull/8425)
+* Fixed Geocoder auto-complete suggestions when hosted inside Web Components. [#8425](https://github.com/AnalyticalGraphicsInc/cesium/pull/8425)
+* Fixed primitive culling when below the ellipsoid but above terrain. [#8398](https://github.com/AnalyticalGraphicsInc/cesium/pull/8398)
 
 ### 1.64.0 - 2019-12-02
 

--- a/Source/Scene/FrameState.js
+++ b/Source/Scene/FrameState.js
@@ -391,6 +391,14 @@ import SceneMode from './SceneMode.js';
          * @type {Cesium3DTilePassState}
          */
         this.tilesetPassState = undefined;
+
+        /**
+         * The minimum terrain height out of all rendered terrain tiles. Used to improve culling for objects underneath the ellipsoid but above terrain.
+         *
+         * @type {Number}
+         * @default 0.0
+         */
+        this.minimumTerrainHeight = 0.0;
     }
 
     /**

--- a/Source/Scene/GlobeSurfaceTileProvider.js
+++ b/Source/Scene/GlobeSurfaceTileProvider.js
@@ -420,7 +420,10 @@ import TileSelectionResult from './TileSelectionResult.js';
             }
 
             for (var tileIndex = 0, tileLength = tilesToRender.length; tileIndex < tileLength; ++tileIndex) {
-                addDrawCommandsForTile(this, tilesToRender[tileIndex], frameState);
+                var tile = tilesToRender[tileIndex];
+                var tileBoundingRegion = tile.data.tileBoundingRegion;
+                addDrawCommandsForTile(this, tile, frameState);
+                frameState.minimumTerrainHeight = Math.min(frameState.minimumTerrainHeight, tileBoundingRegion.minimumHeight);
             }
         }
     };

--- a/Source/Scene/Scene.js
+++ b/Source/Scene/Scene.js
@@ -1711,7 +1711,8 @@ import View from './View.js';
         var globe = scene.globe;
         if (scene._mode === SceneMode.SCENE3D && defined(globe) && globe.show) {
             var ellipsoid = globe.ellipsoid;
-            scratchOccluderBoundingSphere.radius = ellipsoid.minimumRadius;
+            var minimumTerrainHeight = scene.frameState.minimumTerrainHeight;
+            scratchOccluderBoundingSphere.radius = ellipsoid.minimumRadius + minimumTerrainHeight;
             scratchOccluder = Occluder.fromBoundingSphere(scratchOccluderBoundingSphere, scene.camera.positionWC, scratchOccluder);
             return scratchOccluder;
         }
@@ -1754,6 +1755,7 @@ import View from './View.js';
         frameState.cullingVolume = camera.frustum.computeCullingVolume(camera.positionWC, camera.directionWC, camera.upWC);
         frameState.occluder = getOccluder(this);
         frameState.terrainExaggeration = this._terrainExaggeration;
+        frameState.minimumTerrainHeight = 0.0;
         frameState.minimumDisableDepthTestDistance = this._minimumDisableDepthTestDistance;
         frameState.invertClassification = this.invertClassification;
         frameState.useLogDepth = this._logDepthBuffer && !(this.camera.frustum instanceof OrthographicFrustum || this.camera.frustum instanceof OrthographicOffCenterFrustum);


### PR DESCRIPTION
The current system culls entities/primitives when they are below the minimum radius of the earth, ~6356752 meters. In practice there are not many points on earth that are below this, except maybe https://en.wikipedia.org/wiki/Bentley_Subglacial_Trench which cesium world terrain doesn't accurately map. But with terrain exaggeration enabled or some other configuration, this becomes a problem. The proposed fix is to keep track of the minimum rendered terrain tile height and offset the scene's occluder radius by it. This information could also assist in choosing a better distance for the depth plane: https://github.com/AnalyticalGraphicsInc/cesium/pull/8203.

In this [Sandcastle](http://localhost:8080/Apps/Sandcastle/index.html#c=dVRtb5swEP4rVr6USMwxhEBo02pblqnVOi1qq+1LpMmBS2rV2Mg26dKp/30HJAvpi78Ad88999yL2XBDNgIewZBzouCRTMGKqqA/G5t3kjWfU60cFwrMiU/+LhTB48AYNM2N3ogczOk+MDPAHfzSRuZ3LcTr+0chsz98vQbDndDqlMSMsoV67p8t1EK1SqjNQAFd6TUFxZcSctS24tLCa1DGC6SiFlyt2NuJy8E6oZoM5LRb1pQbh29cDb1RMBoxGgzHoyAep0k89EkUp2ychjQcJmE8jqMITeE4jVhCk5ilURqH8b4YbQRgU16nuASeC7WeC5fd32gpPSxwGMZpFIZBGDIWYsbYJx8YTViSJlEQspgNx2GMRoQyFkTRMBmjrFEasyAe9Q/twWHdc5XLl9O6xa6Dui15BrMNyrpsQd6LViGBrZl2HHXXrlRZuU9ZXYa3qlT7UugNFEjT3w+7TtyQYNou59nB3Q4C/d25nNXeA6bQlYW5tqLp2jnZ56HlztbhM3yLiN141+DmInu44VvviKPfCSgR0OFuZaylXgKtXR4S+q21bWYT19aCEjAMLOV5vl+h+uxl4YC77P4BAVKK0mqRI6QTWB+DayDe3b6A4ax90n30/WOCAu+REVyS/3drqqU29Gb25QB8bl+bBXn239uHu20J9Hr29e739Ppq+q0G9/zexLqthIuW4aMoSm0cqYz0KB04KEqJAuxgWWUP4Ghmm9WZDPZBk1xsiMjPF70X/4hFj2SSW4ueVSXlrXiCRe9iMkD8UZjUzUX5sQEj+baG3AcX162RUjoZ4OfrKKe1XHJMcmxtfy3fQVVv5nrSuvhcOaeVfdNvOZYLbyB2z38), left click to spawn red dots. In master, the dots do not appear. In this PR, they do.

This is a draft PR because there are a few unknowns:
- Do we want to include 3D tiles when calculating this minimum distance?
- Instead of limiting the offset to 0, what if it could offset upwards when all terrain heights are above 0. Any hidden downsides to this?
- What should happen to entities if the globe is missing tiles?