### PR TITLE
Fixes for Geocoder when hosted via web components

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,11 @@
 Change Log
 ==========
 
+### 1.65.0 - 2019-01-02
+
+##### Fixes :wrench:
+* Fix Geocoder auto-complete suggestions when hosted inside Web Components. [#8425](https://github.com/AnalyticalGraphicsInc/cesium/pull/8425)
+
 ### 1.64.0 - 2019-12-02
 
 ##### Fixes :wrench:


### PR DESCRIPTION
The Geocoder suggestion box does not currently work if hosted inside of a web component. I tracked it down to the use of `container.contains(e.target)` in `_onInputBegin`. Because of the shadow DOM, this check always evaluates to false inside of web components and search suggestions are never shown.

I'm not sure it's possible to make `container.contains(e.target)` work in a web components the way we were relying on it, but the entire thing way we were handling this seemed a little convoluted to begin with so I removed the use of document pointer/mouse events and made it use standard blur/focus events instead.  As far as I can tell behavior is identical but now the code should be more portable.