### PR TITLE
Ignore yarn.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ Thumbs.db
 npm-debug.log
 npm-debug.log.*
 package-lock.json
+yarn.lock
 
 # WebStorm user-specific
 .idea/workspace.xml


### PR DESCRIPTION
As soon as Cesium developers [ignore and don't create package-lock.json](https://github.com/AnalyticalGraphicsInc/cesium/pull/5968/commits/a8cacae67bb086698880683e03829399d4735e54) `yarn.lock` should also be ignored.