### PR TITLE
Fix camera race condition for no-op flight.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@ Change Log
 
 ##### Fixes :wrench:
 * Fix Geocoder auto-complete suggestions when hosted inside Web Components. [#8425](https://github.com/AnalyticalGraphicsInc/cesium/pull/8425)
+* Fix `Camera.hasCurrentFlight` incorrectly returning true in some cases. [#8444](https://github.com/AnalyticalGraphicsInc/cesium/pull/8444)
 
 ### 1.64.0 - 2019-12-02
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,7 +5,6 @@ Change Log
 
 ##### Fixes :wrench:
 * Fix Geocoder auto-complete suggestions when hosted inside Web Components. [#8425](https://github.com/AnalyticalGraphicsInc/cesium/pull/8425)
-* Fix `Camera.hasCurrentFlight` incorrectly returning true in some cases. [#8444](https://github.com/AnalyticalGraphicsInc/cesium/pull/8444)
 
 ### 1.64.0 - 2019-12-02
 

--- a/Source/Scene/Camera.js
+++ b/Source/Scene/Camera.js
@@ -286,15 +286,15 @@ import SceneMode from './SceneMode.js';
     }
 
     /**
-     * Checks if there's a camera flight for this camera.
+     * Checks if there's a camera flight with preload for this camera.
      *
      * @returns {Boolean} Whether or not this camera has a current flight with a valid preloadFlightCamera in scene.
      *
      * @private
      *
      */
-    Camera.prototype.hasCurrentFlight = function() {
-        return defined(this._currentFlight);
+    Camera.prototype.canPreloadFlight = function() {
+        return defined(this._currentFlight) && this._mode !== SceneMode.SCENE2D;
     };
 
     Camera.prototype._updateCameraChanged = function() {

--- a/Source/Scene/Camera.js
+++ b/Source/Scene/Camera.js
@@ -294,8 +294,7 @@ import SceneMode from './SceneMode.js';
      *
      */
     Camera.prototype.hasCurrentFlight = function() {
-        // The preload flight camera defined check only here since it can be set to undefined when not 3D mode.
-        return defined(this._currentFlight) && defined(this._scene.preloadFlightCamera);
+        return defined(this._currentFlight);
     };
 
     Camera.prototype._updateCameraChanged = function() {
@@ -2892,7 +2891,16 @@ import SceneMode from './SceneMode.js';
         newOptions.easingFunction = options.easingFunction;
 
         var scene = this._scene;
-        flightTween = scene.tweens.add(CameraFlightPath.createTween(scene, newOptions));
+        var tweenOptions = CameraFlightPath.createTween(scene, newOptions);
+        // If the camera doesn't actually need to go anywhere, duration
+        // will be 0 and we can just complete the current flight.
+        if (tweenOptions.duration === 0) {
+            if (typeof tweenOptions.complete === 'function') {
+                tweenOptions.complete();
+            }
+            return;
+        }
+        flightTween = scene.tweens.add(tweenOptions);
         this._currentFlight = flightTween;
 
         // Save the final destination view information for the PRELOAD_FLIGHT pass.
@@ -2904,8 +2912,6 @@ import SceneMode from './SceneMode.js';
             preloadFlightCamera.setView({ destination: destination, orientation: orientation });
 
             this._scene.preloadFlightCullingVolume = preloadFlightCamera.frustum.computeCullingVolume(preloadFlightCamera.positionWC, preloadFlightCamera.directionWC, preloadFlightCamera.upWC);
-        } else {
-            preloadFlightCamera = undefined;
         }
     };
 

--- a/Source/Scene/Scene.js
+++ b/Source/Scene/Scene.js
@@ -3522,7 +3522,7 @@ import View from './View.js';
     function updatePreloadFlightPass(scene) {
         var frameState = scene._frameState;
         var camera = frameState.camera;
-        if (!camera.hasCurrentFlight()) {
+        if (!camera.canPreloadFlight()) {
             return;
         }
 

--- a/Specs/Scene/CameraSpec.js
+++ b/Specs/Scene/CameraSpec.js
@@ -3004,14 +3004,14 @@ describe('Scene/Camera', function() {
         expect(tweenSpy.calls.mostRecent().args[1].destination.equalsEpsilon(expectedDestination, 0.1)).toBe(true);
     });
 
-    it('hasCurrentFlight returns false for a flight that doesn\'t go anywhere', function() {
+    it('_currentFlight is not set for a flight that doesn\'t go anywhere', function() {
         var complete = jasmine.createSpy('complete');
         spyOn(CameraFlightPath, 'createTween').and.returnValue({ complete: complete, duration: 0 });
         spyOn(scene.tweens, 'add');
 
         camera.flyTo({ complete: complete, destination: Cartesian3.fromDegrees(-117.16, 32.71, 5000) });
         expect(complete).toHaveBeenCalled();
-        expect(camera.hasCurrentFlight()).toBe(false);
+        expect(camera._currentFlight).toBeUndefined();
     });
 
     it('switches projections', function() {

--- a/Specs/Scene/CameraSpec.js
+++ b/Specs/Scene/CameraSpec.js
@@ -2892,7 +2892,7 @@ describe('Scene/Camera', function() {
     });
 
     it('flyTo rectangle in 2D', function() {
-        var tweenSpy = spyOn(CameraFlightPath, 'createTween');
+        var tweenSpy = spyOn(CameraFlightPath, 'createTween').and.returnValue({});
         spyOn(scene.tweens, 'add');
 
         camera._mode = SceneMode.SCENE2D;
@@ -2919,7 +2919,7 @@ describe('Scene/Camera', function() {
     });
 
     it('flyTo rectangle in CV', function() {
-        var tweenSpy = spyOn(CameraFlightPath, 'createTween');
+        var tweenSpy = spyOn(CameraFlightPath, 'createTween').and.returnValue({});
         spyOn(scene.tweens, 'add');
 
         camera._mode = SceneMode.COLUMBUS_VIEW;
@@ -2937,7 +2937,7 @@ describe('Scene/Camera', function() {
     });
 
     it('flyTo rectangle in 3D', function() {
-        var tweenSpy = spyOn(CameraFlightPath, 'createTween');
+        var tweenSpy = spyOn(CameraFlightPath, 'createTween').and.returnValue({});
         spyOn(scene.tweens, 'add');
 
         camera._mode = SceneMode.SCENE3D;
@@ -2955,7 +2955,7 @@ describe('Scene/Camera', function() {
     });
 
     it('flyTo does not zoom closer than minimumZoomDistance', function() {
-        var tweenSpy = spyOn(CameraFlightPath, 'createTween');
+        var tweenSpy = spyOn(CameraFlightPath, 'createTween').and.returnValue({});
         spyOn(scene.tweens, 'add');
 
         scene.mode = SceneMode.SCENE3D;
@@ -2972,7 +2972,7 @@ describe('Scene/Camera', function() {
     });
 
     it('flyTo does not zoom further than maximumZoomDistance', function() {
-        var tweenSpy = spyOn(CameraFlightPath, 'createTween');
+        var tweenSpy = spyOn(CameraFlightPath, 'createTween').and.returnValue({});
         spyOn(scene.tweens, 'add');
 
         scene.mode = SceneMode.SCENE3D;
@@ -2989,7 +2989,7 @@ describe('Scene/Camera', function() {
     });
 
     it('flyTo zooms in between minimumZoomDistance and maximumZoomDistance', function() {
-        var tweenSpy = spyOn(CameraFlightPath, 'createTween');
+        var tweenSpy = spyOn(CameraFlightPath, 'createTween').and.returnValue({});
         spyOn(scene.tweens, 'add');
 
         scene.mode = SceneMode.SCENE3D;
@@ -3002,6 +3002,16 @@ describe('Scene/Camera', function() {
         camera.flyTo({destination : sourceDestination});
 
         expect(tweenSpy.calls.mostRecent().args[1].destination.equalsEpsilon(expectedDestination, 0.1)).toBe(true);
+    });
+
+    it('hasCurrentFlight returns false for a flight that doesn\'t go anywhere', function() {
+        var complete = jasmine.createSpy('complete');
+        spyOn(CameraFlightPath, 'createTween').and.returnValue({ complete: complete, duration: 0 });
+        spyOn(scene.tweens, 'add');
+
+        camera.flyTo({ complete: complete, destination: Cartesian3.fromDegrees(-117.16, 32.71, 5000) });
+        expect(complete).toHaveBeenCalled();
+        expect(camera.hasCurrentFlight()).toBe(false);
     });
 
     it('switches projections', function() {

--- a/Specs/Scene/Cesium3DTilesetSpec.js
+++ b/Specs/Scene/Cesium3DTilesetSpec.js
@@ -3642,7 +3642,7 @@ describe('Scene/Cesium3DTileset', function() {
         viewNothing();
 
         return Cesium3DTilesTester.loadTileset(scene, tilesetUniform).then(function(tileset) {
-            spyOn(Camera.prototype, 'hasCurrentFlight').and.callFake(function() {
+            spyOn(Camera.prototype, 'canPreloadFlight').and.callFake(function() {
                 return true;
             });
             scene.renderForSpecs();


### PR DESCRIPTION
If you call `camera.flyTo` with the current camera location/orientation, it becomes a no-op, but the camera._currentFlight Tween was still being set but never actually started. The end result is a zombie flight that never took place but caused `camera.hasCurrentFlight` to return true when it should return false.

Also cleaned up some superflous code since `this._scene.preloadFlightCamera` is always defined.


Here's a Sandcastle that shows the bug: https://sandcastle.cesium.com/index.html#c=5ZNBT+MwEIX/ipVLXSk4bdmClg3ViqA9sUICxCmXwZk2Fo5djSdFXcR/x2lSAUVIe2dO8cx7b+xPygZIbAw+IYlz4fBJFBhM26j7XU+O9O5YeMdgHNJo/Kt0pesdSkODBGppt3dePpdOdFVhYOOAjXfibB9XAHH8AnesluSbS1wRYpBH09lMTX+m4seJms1TMZ9MJmoyTocoTwbj4iFqv6CrGqEybvW24C9wrdjfxDa4IKen83c5Xa0N6/pL/dHxoZ68tVEerzM0X/bTqqXdleKwdC89kFtwlYbAFhVU1Z339gHoomX2To4in1Eqlq3TnU2On78twoHX/0AratSPh9i6ELBILD/iqyEULVF86R9rVjXL8bAmSZM88Nbiojf/Ns3aE4uWrFQqY2zWFiLW7KHVj8hKh9A582xvyiuzEaY6L5ODP6FMhLYQQpwsW2tvzT8sk0WeRf0Hm/U7zNcbJAvbTlJPF1d9UymVZ/H42cU9jHeJrw

Hit `fly` as soon as the scene loads (without moving the camera) and then `check` will return true even though no flight is taking place, even after you move the mouse.