### PR TITLE
Terrain back face culling option

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,11 @@
 Change Log
 ==========
 
+### 1.66.0 - 2019-02-03
+
+##### Additions :tada:
+* Added `Globe.backFaceCulling` to support viewing terrain from below the surface.
+
 ### 1.65.0 - 2019-01-02
 
 ##### Fixes :wrench:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,11 +1,6 @@
 Change Log
 ==========
 
-### 1.66.0 - 2019-02-03
-
-##### Additions :tada:
-* Added `Globe.backFaceCulling` to support viewing terrain from below the surface.
-
 ### 1.65.0 - 2019-01-02
 
 ##### Fixes :wrench:
@@ -13,6 +8,9 @@ Change Log
 * Fixed terrain tile culling problems when under ellipsoid. [#8397](https://github.com/AnalyticalGraphicsInc/cesium/pull/8397)
 * Fixed primitive culling when below the ellipsoid but above terrain. [#8398](https://github.com/AnalyticalGraphicsInc/cesium/pull/8398)
 * Improved the translucency calculation for the Water material type. [#8455](https://github.com/AnalyticalGraphicsInc/cesium/pull/8455)
+
+##### Additions :tada:
+* Added `Globe.backFaceCulling` to support viewing terrain from below the surface.
 
 ### 1.64.0 - 2019-12-02
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,7 +10,7 @@ Change Log
 * Improved the translucency calculation for the Water material type. [#8455](https://github.com/AnalyticalGraphicsInc/cesium/pull/8455)
 
 ##### Additions :tada:
-* Added `Globe.backFaceCulling` to support viewing terrain from below the surface.
+* Added `Globe.backFaceCulling` to support viewing terrain from below the surface. [#8470](https://github.com/AnalyticalGraphicsInc/cesium/pull/8470)
 
 ### 1.64.0 - 2019-12-02
 

--- a/Source/Scene/Globe.js
+++ b/Source/Scene/Globe.js
@@ -250,6 +250,14 @@ import TileSelectionResult from './TileSelectionResult.js';
          */
         this.atmosphereBrightnessShift = 0.0;
 
+        /**
+         * Whether to cull back-facing terrain. Set this to false when viewing terrain from below the surface.
+         *
+         * @type {Boolean}
+         * @default true
+         */
+        this.backFaceCulling = true;
+
         this._oceanNormalMap = undefined;
         this._zoomedOutOceanSpecularIntensity = undefined;
     }
@@ -739,7 +747,7 @@ import TileSelectionResult from './TileSelectionResult.js';
             tileProvider.saturationShift = this.atmosphereSaturationShift;
             tileProvider.brightnessShift = this.atmosphereBrightnessShift;
             tileProvider.fillHighlightColor = this.fillHighlightColor;
-
+            tileProvider.backFaceCulling = this.backFaceCulling;
             surface.beginFrame(frameState);
         }
     };

--- a/Source/Scene/GlobeSurfaceTileProvider.js
+++ b/Source/Scene/GlobeSurfaceTileProvider.js
@@ -4,6 +4,7 @@ import Cartesian2 from '../Core/Cartesian2.js';
 import Cartesian3 from '../Core/Cartesian3.js';
 import Cartesian4 from '../Core/Cartesian4.js';
 import Cartographic from '../Core/Cartographic.js';
+import clone from '../Core/clone.js';
 import Color from '../Core/Color.js';
 import ColorGeometryInstanceAttribute from '../Core/ColorGeometryInstanceAttribute.js';
 import combine from '../Core/combine.js';
@@ -100,6 +101,8 @@ import TileSelectionResult from './TileSelectionResult.js';
         this.saturationShift = 0.0;
         this.brightnessShift = 0.0;
 
+        this.backFaceCulling = true;
+
         this._quadtree = undefined;
         this._terrainProvider = options.terrainProvider;
         this._imageryLayers = options.imageryLayers;
@@ -107,6 +110,8 @@ import TileSelectionResult from './TileSelectionResult.js';
 
         this._renderState = undefined;
         this._blendRenderState = undefined;
+        this._disableCullingRenderState = undefined;
+        this._disableCullingBlendRenderState = undefined;
 
         this._errorEvent = new Event();
 
@@ -403,6 +408,16 @@ import TileSelectionResult from './TileSelectionResult.js';
                 },
                 blending : BlendingState.ALPHA_BLEND
             });
+        }
+
+        if (!this.backFaceCulling && !defined(this._disableCullingRenderState)) {
+            var rs = clone(this._renderState, true);
+            rs.cull.enabled = false;
+            this._disableCullingRenderState = RenderState.fromCache(rs);
+
+            rs = clone(this._blendRenderState, true);
+            rs.cull.enabled = false;
+            this._disableCullingBlendRenderState = RenderState.fromCache(rs);
         }
 
         // If this frame has a mix of loaded and fill tiles, we need to propagate
@@ -1652,8 +1667,8 @@ import TileSelectionResult from './TileSelectionResult.js';
         var imageryIndex = 0;
         var imageryLen = tileImageryCollection.length;
 
-        var firstPassRenderState = tileProvider._renderState;
-        var otherPassesRenderState = tileProvider._blendRenderState;
+        var firstPassRenderState = tileProvider.backFaceCulling ? tileProvider._renderState : tileProvider._disableCullingRenderState;
+        var otherPassesRenderState = tileProvider.backFaceCulling ? tileProvider._blendRenderState : tileProvider._disableCullingBlendRenderState;
         var renderState = firstPassRenderState;
 
         var initialColor = tileProvider._firstPassInitialColor;

--- a/Specs/Scene/GlobeSpec.js
+++ b/Specs/Scene/GlobeSpec.js
@@ -259,4 +259,19 @@ describe('Scene/Globe', function() {
             });
         });
     });
+
+    it('applies back face culling', function() {
+        scene.camera.setView({ destination : new Rectangle(0.0001, 0.0001, 0.0025, 0.0025) });
+
+        return updateUntilDone(globe).then(function() {
+            globe.backFaceCulling = true;
+            scene.render();
+            var command = scene.frameState.commandList[0];
+            expect(command.renderState.cull.enabled).toBe(true);
+            globe.backFaceCulling = false;
+            scene.render();
+            command = scene.frameState.commandList[0];
+            expect(command.renderState.cull.enabled).toBe(false);
+        });
+    });
 }, 'WebGL');


### PR DESCRIPTION
Fixes https://github.com/AnalyticalGraphicsInc/cesium/issues/7266

Adds `globe.backFaceCulling` to support viewing terrain from below the surface. There will be a follow up PR for disabling skirts, a few other PRs after that for camera controls, and then ultimately an "Underground" Sandcastle example.

[Local sandcastle](http://localhost:8080/Apps/Sandcastle/index.html#c=dVRdbxoxEPwrLi8BiZj7voOQqA1pVaQkjRqUqBIv5m4BC2NT20dCo/z37p0hJZDeE+uZXa9nZ1kzTdYcnkCTcyLhiQzA8HJJH+qz5klehwMlLeMS9EmbvIwlwc+C1nh0p9WaF5jd22XmGpiFR6VFMXKc5jal+jT8LsHYR6ToG2YWPWJ1Ce0jwgNoC8+3Si+ZMI7kOK+tsXxtnY3lWK6xd5ODBGzdvYHW4ZmDcrYEzRCrD6kLt9hMqAm8QXVUl3SxWWwu1TM1c/WEnCl2UKFbrJT/ARabL3apzGoOGj6mTNWMgmQTAcVxOuoG8n7FchjUnVaaayUEvsrlDDDghit5BRZyiz/2itRP2BKv+WxuuZwhXOnmtNrTZysFNWCrMe/GU6DsXLK6cG/fCwOGszCcybB5GiVJkEQRzQI/SbvdqNsmURgGceJTL06DIA29tE1OozjyspD6fpj6oednYdLazlhpDmim41u+Ayuw6Ttu8/lPfGrTo34S+KkXdJMszNIgTmOsjKdBmHZDL4v9KM6i2MvaJKFBECTduJskUeAlYba7DWQx0kyaKRrpn0VvmNX8OaLDq6+3o+Ho15uj7pkscmasAMqKYqSUmDB9WVqrZPPkkuUL1DsHkpc4CTnDZZiWsp5Es7XbCzeICXK/VaN0TJzEpw+Bs3dmFmwD2hy4mfIlm4HeXNfg1r8TgXVumMZpI93lVS0PHXe3lc09fYdKHqIvhBk0wbDokTDzA9ytqpe92pSJ1bxaIY/GB8hEVy6TYKp+A+rVj2i0G31jNwIunBif+XKltCWlFk1KOxaWK4GbbzqTMl+Apbkx1Y39zi6pX/A14cX5uHHwxzNukFxgt4hMUbp7/gfGjYt+B/nv0oSqXfRjDRpVqShz/+LaHVJK+x0Mj7Osm/Rexb8)

![culling-enabled](https://user-images.githubusercontent.com/915398/71044288-484d5b80-20ff-11ea-8442-e2b5c465b5ce.jpg)
![culling-disabled](https://user-images.githubusercontent.com/915398/71044287-484d5b80-20ff-11ea-8f77-54379ab1e68f.jpg)
