### PR TITLE
Added support for large Rectangles in OrientedBoundingBox.fromRectangle

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,8 @@ Change Log
 * Fixed terrain tile culling problems when under ellipsoid. [#8397](https://github.com/AnalyticalGraphicsInc/cesium/pull/8397)
 * Fixed primitive culling when below the ellipsoid but above terrain. [#8398](https://github.com/AnalyticalGraphicsInc/cesium/pull/8398)
 * Improved the translucency calculation for the Water material type. [#8455](https://github.com/AnalyticalGraphicsInc/cesium/pull/8455)
+* Fixed bounding volume calculation for GroundPrimitive. [#4883](https://github.com/AnalyticalGraphicsInc/cesium/issues/4483)
+* Fixed OrientedBoundingBox.fromRectangle for rectangles with width greater than 180 degrees. [#8475](https://github.com/AnalyticalGraphicsInc/cesium/pull/8475)
 
 ### 1.64.0 - 2019-12-02
 

--- a/Source/Core/CesiumTerrainProvider.js
+++ b/Source/Core/CesiumTerrainProvider.js
@@ -12,7 +12,6 @@ import GeographicTilingScheme from './GeographicTilingScheme.js';
 import getStringFromTypedArray from './getStringFromTypedArray.js';
 import HeightmapTerrainData from './HeightmapTerrainData.js';
 import IndexDatatype from './IndexDatatype.js';
-import CesiumMath from './Math.js';
 import OrientedBoundingBox from './OrientedBoundingBox.js';
 import QuantizedMeshTerrainData from './QuantizedMeshTerrainData.js';
 import Request from './Request.js';
@@ -549,19 +548,13 @@ import TileProviderError from './TileProviderError.js';
 
         var skirtHeight = provider.getLevelMaximumGeometricError(level) * 5.0;
 
+        // The skirt is not included in the OBB computation. If this ever
+        // causes any rendering artifacts (cracks), they are expected to be
+        // minor and in the corners of the screen. It's possible that this
+        // might need to be changed - just change to `minimumHeight - skirtHeight`
+        // A similar change might also be needed in `upsampleQuantizedTerrainMesh.js`.
         var rectangle = provider._tilingScheme.tileXYToRectangle(x, y, level);
-        var orientedBoundingBox;
-        if (rectangle.width < CesiumMath.PI_OVER_TWO + CesiumMath.EPSILON5) {
-            // Here, rectangle.width < pi/2, and rectangle.height < pi
-            // (though it would still work with rectangle.width up to pi)
-
-            // The skirt is not included in the OBB computation. If this ever
-            // causes any rendering artifacts (cracks), they are expected to be
-            // minor and in the corners of the screen. It's possible that this
-            // might need to be changed - just change to `minimumHeight - skirtHeight`
-            // A similar change might also be needed in `upsampleQuantizedTerrainMesh.js`.
-            orientedBoundingBox = OrientedBoundingBox.fromRectangle(rectangle, minimumHeight, maximumHeight, provider._tilingScheme.ellipsoid);
-        }
+        var orientedBoundingBox = OrientedBoundingBox.fromRectangle(rectangle, minimumHeight, maximumHeight, provider._tilingScheme.ellipsoid);
 
         return new QuantizedMeshTerrainData({
             center : center,

--- a/Source/Core/HeightmapTessellator.js
+++ b/Source/Core/HeightmapTessellator.js
@@ -387,9 +387,7 @@ import WebMercatorProjection from './WebMercatorProjection.js';
 
         var boundingSphere3D = BoundingSphere.fromPoints(positions);
         var orientedBoundingBox;
-        if (defined(rectangle) && rectangle.width < CesiumMath.PI_OVER_TWO + CesiumMath.EPSILON5) {
-            // Here, rectangle.width < pi/2, and rectangle.height < pi
-            // (though it would still work with rectangle.width up to pi)
+        if (defined(rectangle)) {
             orientedBoundingBox = OrientedBoundingBox.fromRectangle(rectangle, minimumHeight, maximumHeight, ellipsoid);
         }
 

--- a/Source/Core/OrientedBoundingBox.js
+++ b/Source/Core/OrientedBoundingBox.js
@@ -392,7 +392,7 @@ import Rectangle from './Rectangle.js';
         // This results in a better fit than the obb approach for smaller rectangles, which orients with the rectangle's center normal.
         var planeOrigin = Cartesian3.fromRadians(centerLongitude, latitudeNearestToEquator, maximumHeight, ellipsoid, scratchPlaneOrigin);
         planeOrigin.z = 0.0; // center the plane on the equator to simpify plane normal calculation
-        var isPole = planeOrigin.x < CesiumMath.EPSILON10 && planeOrigin.y < CesiumMath.EPSILON10;
+        var isPole = Math.abs(planeOrigin.x) < CesiumMath.EPSILON10 && Math.abs(planeOrigin.y) < CesiumMath.EPSILON10;
         var planeNormal = !isPole ? Cartesian3.normalize(planeOrigin, scratchPlaneNormal) : Cartesian3.UNIT_X;
         var planeYAxis = Cartesian3.UNIT_Z;
         var planeXAxis = Cartesian3.cross(planeNormal, planeYAxis, scratchPlaneXAxis);

--- a/Source/Core/OrientedBoundingBox.js
+++ b/Source/Core/OrientedBoundingBox.js
@@ -386,7 +386,7 @@ import Rectangle from './Rectangle.js';
         var fullyAboveEquator = rectangle.south > 0.0;
         var fullyBelowEquator = rectangle.north < 0.0;
         var latitudeNearestToEquator = fullyAboveEquator ? rectangle.south : (fullyBelowEquator ? rectangle.north : 0.0);
-        var centerLongitude = 0.5 * (rectangle.west + rectangle.east);
+        var centerLongitude = Rectangle.center(rectangle, scratchRectangleCenterCartographic).longitude;
 
         // Plane is located at the rectangle's center longitude and the rectangle's latitude that is closest to the equator. It rotates around the Z axis.
         // This results in a better fit than the obb approach for smaller rectangles, which orients with the rectangle's center normal.

--- a/Source/Core/OrientedBoundingBox.js
+++ b/Source/Core/OrientedBoundingBox.js
@@ -231,7 +231,7 @@ import Rectangle from './Rectangle.js';
 
     var scratchOffset = new Cartesian3();
     var scratchScale = new Cartesian3();
-    function fromTangentPlaneExtents(tangentPlane, minimumX, maximumX, minimumY, maximumY, minimumZ, maximumZ, result) {
+    function fromPlaneExtents(planeOrigin, planeXAxis, planeYAxis, planeZAxis, minimumX, maximumX, minimumY, maximumY, minimumZ, maximumZ, result) {
         //>>includeStart('debug', pragmas.debug);
         if (!defined(minimumX) ||
             !defined(maximumX) ||
@@ -248,9 +248,9 @@ import Rectangle from './Rectangle.js';
         }
 
         var halfAxes = result.halfAxes;
-        Matrix3.setColumn(halfAxes, 0, tangentPlane.xAxis, halfAxes);
-        Matrix3.setColumn(halfAxes, 1, tangentPlane.yAxis, halfAxes);
-        Matrix3.setColumn(halfAxes, 2, tangentPlane.zAxis, halfAxes);
+        Matrix3.setColumn(halfAxes, 0, planeXAxis, halfAxes);
+        Matrix3.setColumn(halfAxes, 1, planeYAxis, halfAxes);
+        Matrix3.setColumn(halfAxes, 2, planeZAxis, halfAxes);
 
         var centerOffset = scratchOffset;
         centerOffset.x = (minimumX + maximumX) / 2.0;
@@ -264,7 +264,7 @@ import Rectangle from './Rectangle.js';
 
         var center = result.center;
         centerOffset = Matrix3.multiplyByVector(halfAxes, centerOffset, centerOffset);
-        Cartesian3.add(tangentPlane.origin, centerOffset, center);
+        Cartesian3.add(planeOrigin, centerOffset, center);
         Matrix3.multiplyByScale(halfAxes, scale, halfAxes);
 
         return result;
@@ -272,9 +272,32 @@ import Rectangle from './Rectangle.js';
 
     var scratchRectangleCenterCartographic = new Cartographic();
     var scratchRectangleCenter = new Cartesian3();
-    var perimeterCartographicScratch = [new Cartographic(), new Cartographic(), new Cartographic(), new Cartographic(), new Cartographic(), new Cartographic(), new Cartographic(), new Cartographic()];
-    var perimeterCartesianScratch = [new Cartesian3(), new Cartesian3(), new Cartesian3(), new Cartesian3(), new Cartesian3(), new Cartesian3(), new Cartesian3(), new Cartesian3()];
-    var perimeterProjectedScratch = [new Cartesian2(), new Cartesian2(), new Cartesian2(), new Cartesian2(), new Cartesian2(), new Cartesian2(), new Cartesian2(), new Cartesian2()];
+    var scratchPerimeterCartographicNC = new Cartographic();
+    var scratchPerimeterCartographicNW = new Cartographic();
+    var scratchPerimeterCartographicCW = new Cartographic();
+    var scratchPerimeterCartographicSW = new Cartographic();
+    var scratchPerimeterCartographicSC = new Cartographic();
+    var scratchPerimeterCartesianNC = new Cartesian3();
+    var scratchPerimeterCartesianNW = new Cartesian3();
+    var scratchPerimeterCartesianCW = new Cartesian3();
+    var scratchPerimeterCartesianSW = new Cartesian3();
+    var scratchPerimeterCartesianSC = new Cartesian3();
+    var scratchPerimeterProjectedNC = new Cartesian2();
+    var scratchPerimeterProjectedNW = new Cartesian2();
+    var scratchPerimeterProjectedCW = new Cartesian2();
+    var scratchPerimeterProjectedSW = new Cartesian2();
+    var scratchPerimeterProjectedSC = new Cartesian2();
+
+    var scratchPlaneOrigin = new Cartesian3();
+    var scratchPlaneNormal = new Cartesian3();
+    var scratchPlaneXAxis = new Cartesian3();
+    var scratchHorizonCartesian = new Cartesian3();
+    var scratchHorizonProjected = new Cartesian2();
+    var scratchMaxY = new Cartesian3();
+    var scratchMinY = new Cartesian3();
+    var scratchZ = new Cartesian3();
+    var scratchPlane = new Plane(Cartesian3.UNIT_X, 0.0);
+
     /**
      * Computes an OrientedBoundingBox that bounds a {@link Rectangle} on the surface of an {@link Ellipsoid}.
      * There are no guarantees about the orientation of the bounding box.
@@ -310,59 +333,86 @@ import Rectangle from './Rectangle.js';
         maximumHeight = defaultValue(maximumHeight, 0.0);
         ellipsoid = defaultValue(ellipsoid, Ellipsoid.WGS84);
 
-        // The bounding box will be aligned with the tangent plane at the center of the rectangle.
-        var tangentPointCartographic = Rectangle.center(rectangle, scratchRectangleCenterCartographic);
-        var tangentPoint = ellipsoid.cartographicToCartesian(tangentPointCartographic, scratchRectangleCenter);
-        var tangentPlane = new EllipsoidTangentPlane(tangentPoint, ellipsoid);
-        var plane = tangentPlane.plane;
+        var minX, maxX, minY, maxY, minZ, maxZ, plane;
 
-        // Corner arrangement:
-        //          N/+y
-        //      [0] [1] [2]
-        // W/-x [7]     [3] E/+x
-        //      [6] [5] [4]
-        //          S/-y
-        // "C" refers to the central lat/long, which by default aligns with the tangent point (above).
-        // If the rectangle spans the equator, CW and CE are instead aligned with the equator.
-        var perimeterNW = perimeterCartographicScratch[0];
-        var perimeterNC = perimeterCartographicScratch[1];
-        var perimeterNE = perimeterCartographicScratch[2];
-        var perimeterCE = perimeterCartographicScratch[3];
-        var perimeterSE = perimeterCartographicScratch[4];
-        var perimeterSC = perimeterCartographicScratch[5];
-        var perimeterSW = perimeterCartographicScratch[6];
-        var perimeterCW = perimeterCartographicScratch[7];
+        if (rectangle.width <= CesiumMath.PI) {
+            // The bounding box will be aligned with the tangent plane at the center of the rectangle.
+            var tangentPointCartographic = Rectangle.center(rectangle, scratchRectangleCenterCartographic);
+            var tangentPoint = ellipsoid.cartographicToCartesian(tangentPointCartographic, scratchRectangleCenter);
+            var tangentPlane = new EllipsoidTangentPlane(tangentPoint, ellipsoid);
+            plane = tangentPlane.plane;
 
-        var lonCenter = tangentPointCartographic.longitude;
-        var latCenter = (rectangle.south < 0.0 && rectangle.north > 0.0) ? 0.0 : tangentPointCartographic.latitude;
-        perimeterSW.latitude = perimeterSC.latitude = perimeterSE.latitude = rectangle.south;
-        perimeterCW.latitude = perimeterCE.latitude = latCenter;
-        perimeterNW.latitude = perimeterNC.latitude = perimeterNE.latitude = rectangle.north;
-        perimeterSW.longitude = perimeterCW.longitude = perimeterNW.longitude = rectangle.west;
-        perimeterSC.longitude = perimeterNC.longitude = lonCenter;
-        perimeterSE.longitude = perimeterCE.longitude = perimeterNE.longitude = rectangle.east;
+            // If the rectangle spans the equator, CW is instead aligned with the equator (because it sticks out the farthest at the equator).
+            var lonCenter = tangentPointCartographic.longitude;
+            var latCenter = (rectangle.south < 0.0 && rectangle.north > 0.0) ? 0.0 : tangentPointCartographic.latitude;
 
-        // Compute XY extents using the rectangle at maximum height
-        perimeterNE.height = perimeterNC.height = perimeterNW.height = perimeterCW.height = perimeterSW.height = perimeterSC.height = perimeterSE.height = perimeterCE.height = maximumHeight;
+            // Compute XY extents using the rectangle at maximum height
+            var perimeterCartographicNC = Cartographic.fromRadians(lonCenter, rectangle.north, maximumHeight, scratchPerimeterCartographicNC);
+            var perimeterCartographicNW = Cartographic.fromRadians(rectangle.west, rectangle.north, maximumHeight, scratchPerimeterCartographicNW);
+            var perimeterCartographicCW = Cartographic.fromRadians(rectangle.west, latCenter, maximumHeight, scratchPerimeterCartographicCW);
+            var perimeterCartographicSW = Cartographic.fromRadians(rectangle.west, rectangle.south, maximumHeight, scratchPerimeterCartographicSW);
+            var perimeterCartographicSC = Cartographic.fromRadians(lonCenter, rectangle.south, maximumHeight, scratchPerimeterCartographicSC);
 
-        ellipsoid.cartographicArrayToCartesianArray(perimeterCartographicScratch, perimeterCartesianScratch);
-        tangentPlane.projectPointsToNearestOnPlane(perimeterCartesianScratch, perimeterProjectedScratch);
-        // See the `perimeterXX` definitions above for what these are
-        var minX = Math.min(perimeterProjectedScratch[6].x, perimeterProjectedScratch[7].x, perimeterProjectedScratch[0].x);
-        var maxX = Math.max(perimeterProjectedScratch[2].x, perimeterProjectedScratch[3].x, perimeterProjectedScratch[4].x);
-        var minY = Math.min(perimeterProjectedScratch[4].y, perimeterProjectedScratch[5].y, perimeterProjectedScratch[6].y);
-        var maxY = Math.max(perimeterProjectedScratch[0].y, perimeterProjectedScratch[1].y, perimeterProjectedScratch[2].y);
+            var perimeterCartesianNC = ellipsoid.cartographicToCartesian(perimeterCartographicNC, scratchPerimeterCartesianNC);
+            var perimeterCartesianNW = ellipsoid.cartographicToCartesian(perimeterCartographicNW, scratchPerimeterCartesianNW);
+            var perimeterCartesianCW = ellipsoid.cartographicToCartesian(perimeterCartographicCW, scratchPerimeterCartesianCW);
+            var perimeterCartesianSW = ellipsoid.cartographicToCartesian(perimeterCartographicSW, scratchPerimeterCartesianSW);
+            var perimeterCartesianSC = ellipsoid.cartographicToCartesian(perimeterCartographicSC, scratchPerimeterCartesianSC);
 
-        // Compute minimum Z using the rectangle at minimum height
-        perimeterNE.height = perimeterNW.height = perimeterSE.height = perimeterSW.height = minimumHeight;
-        ellipsoid.cartographicArrayToCartesianArray(perimeterCartographicScratch, perimeterCartesianScratch);
-        var minZ = Math.min(Plane.getPointDistance(plane, perimeterCartesianScratch[0]),
-                            Plane.getPointDistance(plane, perimeterCartesianScratch[2]),
-                            Plane.getPointDistance(plane, perimeterCartesianScratch[4]),
-                            Plane.getPointDistance(plane, perimeterCartesianScratch[6]));
-        var maxZ = maximumHeight;  // Since the tangent plane touches the surface at height = 0, this is okay
+            var perimeterProjectedNC = tangentPlane.projectPointToNearestOnPlane(perimeterCartesianNC, scratchPerimeterProjectedNC);
+            var perimeterProjectedNW = tangentPlane.projectPointToNearestOnPlane(perimeterCartesianNW, scratchPerimeterProjectedNW);
+            var perimeterProjectedCW = tangentPlane.projectPointToNearestOnPlane(perimeterCartesianCW, scratchPerimeterProjectedCW);
+            var perimeterProjectedSW = tangentPlane.projectPointToNearestOnPlane(perimeterCartesianSW, scratchPerimeterProjectedSW);
+            var perimeterProjectedSC = tangentPlane.projectPointToNearestOnPlane(perimeterCartesianSC, scratchPerimeterProjectedSC);
 
-        return fromTangentPlaneExtents(tangentPlane, minX, maxX, minY, maxY, minZ, maxZ, result);
+            minX = Math.min(perimeterProjectedNW.x, perimeterProjectedCW.x, perimeterProjectedSW.x);
+            maxX = -minX; // symmetrical
+
+            maxY = Math.max(perimeterProjectedNW.y, perimeterProjectedNC.y);
+            minY = Math.min(perimeterProjectedSW.y, perimeterProjectedSC.y);
+
+            // Compute minimum Z using the rectangle at minimum height, since it will be deeper than the maximum height
+            perimeterCartographicNW.height = perimeterCartographicSW.height = minimumHeight;
+            perimeterCartesianNW = ellipsoid.cartographicToCartesian(perimeterCartographicNW, scratchPerimeterCartesianNW);
+            perimeterCartesianSW = ellipsoid.cartographicToCartesian(perimeterCartographicSW, scratchPerimeterCartesianSW);
+
+            minZ = Math.min(Plane.getPointDistance(plane, perimeterCartesianNW), Plane.getPointDistance(plane, perimeterCartesianSW));
+            maxZ = maximumHeight;  // Since the tangent plane touches the surface at height = 0, this is okay
+
+            return fromPlaneExtents(tangentPlane.origin, tangentPlane.xAxis, tangentPlane.yAxis, tangentPlane.zAxis, minX, maxX, minY, maxY, minZ, maxZ, result);
+        }
+
+        // Handle the case where rectangle width is greater than PI (wraps around more than half the ellipsoid).
+        var fullyAboveEquator = rectangle.south > 0.0;
+        var fullyBelowEquator = rectangle.north < 0.0;
+        var latitudeNearestToEquator = fullyAboveEquator ? rectangle.south : (fullyBelowEquator ? rectangle.north : 0.0);
+        var centerLongitude = 0.5 * (rectangle.west + rectangle.east);
+
+        // Plane is located at the rectangle's center longitude and the rectangle's latitude that is closest to the equator. It rotates around the Z axis.
+        // This results in a better fit than the obb approach for smaller rectangles, which orients with the rectangle's center normal.
+        var planeOrigin = Cartesian3.fromRadians(centerLongitude, latitudeNearestToEquator, maximumHeight, ellipsoid, scratchPlaneOrigin);
+        planeOrigin.z = 0.0; // center the plane on the equator to simpify plane normal calculation
+        var isPole = planeOrigin.x < CesiumMath.EPSILON10 && planeOrigin.y < CesiumMath.EPSILON10;
+        var planeNormal = !isPole ? Cartesian3.normalize(planeOrigin, scratchPlaneNormal) : Cartesian3.UNIT_X;
+        var planeYAxis = Cartesian3.UNIT_Z;
+        var planeXAxis = Cartesian3.cross(planeNormal, planeYAxis, scratchPlaneXAxis);
+        plane = Plane.fromPointNormal(planeOrigin, planeNormal, scratchPlane);
+
+        // Get the horizon point relative to the center. This will be the farthest extent in the plane's X dimension.
+        var horizonCartesian = Cartesian3.fromRadians(centerLongitude + CesiumMath.PI_OVER_TWO, latitudeNearestToEquator, maximumHeight, ellipsoid, scratchHorizonCartesian);
+        maxX = Cartesian3.dot(Plane.projectPointOntoPlane(plane, horizonCartesian, scratchHorizonProjected), planeXAxis);
+        minX = -maxX; // symmetrical
+
+        // Get the min and max Y, using the height that will give the largest extent
+        maxY = Cartesian3.fromRadians(0.0, rectangle.north, fullyBelowEquator ? minimumHeight : maximumHeight, ellipsoid, scratchMaxY).z;
+        minY = Cartesian3.fromRadians(0.0, rectangle.south, fullyAboveEquator ? minimumHeight : maximumHeight, ellipsoid, scratchMinY).z;
+
+        var farZ = Cartesian3.fromRadians(rectangle.east, latitudeNearestToEquator, maximumHeight, ellipsoid, scratchZ);
+        minZ = Plane.getPointDistance(plane, farZ);
+        maxZ = 0.0; // plane origin starts at maxZ already
+
+        // min and max are local to the plane axes
+        return fromPlaneExtents(planeOrigin, planeXAxis, planeYAxis, planeNormal, minX, maxX, minY, maxY, minZ, maxZ, result);
     };
 
     /**

--- a/Source/Scene/GlobeSurfaceTileProvider.js
+++ b/Source/Scene/GlobeSurfaceTileProvider.js
@@ -855,7 +855,7 @@ import TileSelectionResult from './TileSelectionResult.js';
             surfaceTile.boundingVolumeSourceTile = heightSource;
 
             var rectangle = tile.rectangle;
-            if (defined(rectangle) && rectangle.width < CesiumMath.PI_OVER_TWO + CesiumMath.EPSILON5) {
+            if (defined(rectangle)) {
                 surfaceTile.orientedBoundingBox = OrientedBoundingBox.fromRectangle(
                     tile.rectangle,
                     tileBoundingRegion.minimumHeight,

--- a/Source/Scene/GroundPrimitive.js
+++ b/Source/Scene/GroundPrimitive.js
@@ -448,7 +448,7 @@ import ShadowVolumeAppearance from './ShadowVolumeAppearance.js';
         var ellipsoid = frameState.mapProjection.ellipsoid;
         var rectangle = getRectangle(frameState, geometry);
 
-        var obb = OrientedBoundingBox.fromRectangle(rectangle, groundPrimitive._maxHeight, groundPrimitive._minHeight, ellipsoid);
+        var obb = OrientedBoundingBox.fromRectangle(rectangle, groundPrimitive._minHeight, groundPrimitive._maxHeight, ellipsoid);
         groundPrimitive._boundingVolumes.push(obb);
 
         if (!frameState.scene3DOnly) {

--- a/Source/Scene/GroundPrimitive.js
+++ b/Source/Scene/GroundPrimitive.js
@@ -10,7 +10,6 @@ import destroyObject from '../Core/destroyObject.js';
 import DeveloperError from '../Core/DeveloperError.js';
 import GeometryInstance from '../Core/GeometryInstance.js';
 import isArray from '../Core/isArray.js';
-import CesiumMath from '../Core/Math.js';
 import OrientedBoundingBox from '../Core/OrientedBoundingBox.js';
 import Rectangle from '../Core/Rectangle.js';
 import when from '../ThirdParty/when.js';
@@ -449,15 +448,8 @@ import ShadowVolumeAppearance from './ShadowVolumeAppearance.js';
         var ellipsoid = frameState.mapProjection.ellipsoid;
         var rectangle = getRectangle(frameState, geometry);
 
-        // Use an oriented bounding box by default, but switch to a bounding sphere if bounding box creation would fail.
-        if (rectangle.width < CesiumMath.PI) {
-            var obb = OrientedBoundingBox.fromRectangle(rectangle, groundPrimitive._maxHeight, groundPrimitive._minHeight, ellipsoid);
-            groundPrimitive._boundingVolumes.push(obb);
-        } else {
-            var highPositions = geometry.attributes.position3DHigh.values;
-            var lowPositions = geometry.attributes.position3DLow.values;
-            groundPrimitive._boundingVolumes.push(BoundingSphere.fromEncodedCartesianVertices(highPositions, lowPositions));
-        }
+        var obb = OrientedBoundingBox.fromRectangle(rectangle, groundPrimitive._maxHeight, groundPrimitive._minHeight, ellipsoid);
+        groundPrimitive._boundingVolumes.push(obb);
 
         if (!frameState.scene3DOnly) {
             var projection = frameState.mapProjection;

--- a/Source/WorkersES6/createVerticesFromGoogleEarthEnterpriseBuffer.js
+++ b/Source/WorkersES6/createVerticesFromGoogleEarthEnterpriseBuffer.js
@@ -365,9 +365,7 @@ import createTaskProcessorWorker from './createTaskProcessorWorker.js';
 
         var boundingSphere3D = BoundingSphere.fromPoints(positions);
         var orientedBoundingBox;
-        if (defined(rectangle) && rectangle.width < CesiumMath.PI_OVER_TWO + CesiumMath.EPSILON5) {
-            // Here, rectangle.width < pi/2, and rectangle.height < pi
-            // (though it would still work with rectangle.width up to pi)
+        if (defined(rectangle)) {
             orientedBoundingBox = OrientedBoundingBox.fromRectangle(rectangle, minHeight, maxHeight, ellipsoid);
         }
 

--- a/Source/WorkersES6/createVerticesFromQuantizedTerrainMesh.js
+++ b/Source/WorkersES6/createVerticesFromQuantizedTerrainMesh.js
@@ -11,6 +11,7 @@ import IndexDatatype from '../Core/IndexDatatype.js';
 import CesiumMath from '../Core/Math.js';
 import Matrix4 from '../Core/Matrix4.js';
 import OrientedBoundingBox from '../Core/OrientedBoundingBox.js';
+import Rectangle from '../Core/Rectangle.js';
 import TerrainEncoding from '../Core/TerrainEncoding.js';
 import Transforms from '../Core/Transforms.js';
 import WebMercatorProjection from '../Core/WebMercatorProjection.js';
@@ -35,7 +36,7 @@ import createTaskProcessorWorker from './createTaskProcessorWorker.js';
                               parameters.southIndices.length + parameters.northIndices.length;
         var includeWebMercatorT = parameters.includeWebMercatorT;
 
-        var rectangle = parameters.rectangle;
+        var rectangle = Rectangle.clone(parameters.rectangle);
         var west = rectangle.west;
         var south = rectangle.south;
         var east = rectangle.east;

--- a/Source/WorkersES6/upsampleQuantizedTerrainMesh.js
+++ b/Source/WorkersES6/upsampleQuantizedTerrainMesh.js
@@ -10,6 +10,7 @@ import IndexDatatype from '../Core/IndexDatatype.js';
 import Intersections2D from '../Core/Intersections2D.js';
 import CesiumMath from '../Core/Math.js';
 import OrientedBoundingBox from '../Core/OrientedBoundingBox.js';
+import Rectangle from '../Core/Rectangle.js';
 import TerrainEncoding from '../Core/TerrainEncoding.js';
 import createTaskProcessorWorker from './createTaskProcessorWorker.js';
 
@@ -206,7 +207,7 @@ import createTaskProcessorWorker from './createTaskProcessorWorker.js';
         cartesianVertices.length = 0;
 
         var ellipsoid = Ellipsoid.clone(parameters.ellipsoid);
-        var rectangle = parameters.childRectangle;
+        var rectangle = Rectangle.clone(parameters.childRectangle);
 
         var north = rectangle.north;
         var south = rectangle.south;

--- a/Specs/Core/OrientedBoundingBoxSpec.js
+++ b/Specs/Core/OrientedBoundingBoxSpec.js
@@ -236,6 +236,8 @@ describe('Core/OrientedBoundingBox', function() {
         var d45 = CesiumMath.PI_OVER_FOUR;
         var onePlusSqrtHalfDivTwo = (1.0 + Math.SQRT1_2) / 2.0;
         var oneMinusOnePlusSqrtHalfDivTwo = 1.0 - onePlusSqrtHalfDivTwo;
+        var sqrtTwoMinusOneDivFour = (Math.SQRT2 - 1.0) / 4.0;
+        var sqrtTwoPlusOneDivFour = (Math.SQRT2 + 1.0) / 4.0;
         var box;
 
         // Entire ellipsoid
@@ -252,6 +254,11 @@ describe('Core/OrientedBoundingBox', function() {
         box = OrientedBoundingBox.fromRectangle(new Rectangle(-d135, -d45, d135, d45), 0, 0, Ellipsoid.UNIT_SPHERE);
         expect(box.center).toEqualEpsilon(new Cartesian3(oneMinusOnePlusSqrtHalfDivTwo, 0, 0), CesiumMath.EPSILON15);
         expect(box.halfAxes).toEqualEpsilon(new Matrix3(0, 0, onePlusSqrtHalfDivTwo, 1, 0, 0, 0, Math.SQRT1_2, 0), CesiumMath.EPSILON15);
+
+        // 3/4s of longitude centered at IDL, 1/2 of latitude centered at equator
+        box = OrientedBoundingBox.fromRectangle(new Rectangle(d180, -d45, d90, d45), 0, 0, Ellipsoid.UNIT_SPHERE);
+        expect(box.center).toEqualEpsilon(new Cartesian3(sqrtTwoMinusOneDivFour, -sqrtTwoMinusOneDivFour, 0), CesiumMath.EPSILON15);
+        expect(box.halfAxes).toEqualEpsilon(new Matrix3(Math.SQRT1_2, 0, sqrtTwoPlusOneDivFour, Math.SQRT1_2, 0, -sqrtTwoPlusOneDivFour, 0, Math.SQRT1_2, 0.0), CesiumMath.EPSILON15);
 
         // Full longitude, 1/2 of latitude centered at equator
         box = OrientedBoundingBox.fromRectangle(new Rectangle(-d180, -d45, d180, d45), 0, 0, Ellipsoid.UNIT_SPHERE);

--- a/Specs/Core/OrientedBoundingBoxSpec.js
+++ b/Specs/Core/OrientedBoundingBoxSpec.js
@@ -226,6 +226,67 @@ describe('Core/OrientedBoundingBox', function() {
         box = OrientedBoundingBox.fromRectangle(new Rectangle(-d90, -d90, d90, d90), -1.0, 0.0, Ellipsoid.UNIT_SPHERE);
         expect(box.center).toEqualEpsilon(new Cartesian3(0.5, 0.0, 0.0), CesiumMath.EPSILON15);
         expect(box.halfAxes).toEqualEpsilon(new Matrix3(0, 0, 0.5, 1, 0, 0, 0, 1, 0), CesiumMath.EPSILON15);
+
+    });
+
+    it('fromRectangle for rectangles that span over half the ellipsoid', function() {
+        var d90 = CesiumMath.PI_OVER_TWO;
+        var d180 = CesiumMath.PI;
+        var d135 = (3/4) * CesiumMath.PI;
+        var d45 = CesiumMath.PI_OVER_FOUR;
+        var onePlusSqrtHalfDivTwo = (1.0 + Math.SQRT1_2) / 2.0;
+        var oneMinusOnePlusSqrtHalfDivTwo = 1.0 - onePlusSqrtHalfDivTwo;
+        var box;
+
+        // Entire ellipsoid
+        box = OrientedBoundingBox.fromRectangle(new Rectangle(-d180, -d90, d180, d90), 0, 0, Ellipsoid.UNIT_SPHERE);
+        expect(box.center).toEqualEpsilon(new Cartesian3(0, 0, 0), CesiumMath.EPSILON15);
+        expect(box.halfAxes).toEqualEpsilon(new Matrix3(0, 0, 1, 1, 0, 0, 0, 1, 0), CesiumMath.EPSILON15);
+
+        // 3/4s of longitude, full latitude
+        box = OrientedBoundingBox.fromRectangle(new Rectangle(-d135, -d90, d135, d90), 0, 0, Ellipsoid.UNIT_SPHERE);
+        expect(box.center).toEqualEpsilon(new Cartesian3(oneMinusOnePlusSqrtHalfDivTwo, 0, 0), CesiumMath.EPSILON15);
+        expect(box.halfAxes).toEqualEpsilon(new Matrix3(0, 0, onePlusSqrtHalfDivTwo, 1, 0, 0, 0, 1, 0), CesiumMath.EPSILON15);
+
+        // 3/4s of longitude, 1/2 of latitude centered at equator
+        box = OrientedBoundingBox.fromRectangle(new Rectangle(-d135, -d45, d135, d45), 0, 0, Ellipsoid.UNIT_SPHERE);
+        expect(box.center).toEqualEpsilon(new Cartesian3(oneMinusOnePlusSqrtHalfDivTwo, 0, 0), CesiumMath.EPSILON15);
+        expect(box.halfAxes).toEqualEpsilon(new Matrix3(0, 0, onePlusSqrtHalfDivTwo, 1, 0, 0, 0, Math.SQRT1_2, 0), CesiumMath.EPSILON15);
+
+        // Full longitude, 1/2 of latitude centered at equator
+        box = OrientedBoundingBox.fromRectangle(new Rectangle(-d180, -d45, d180, d45), 0, 0, Ellipsoid.UNIT_SPHERE);
+        expect(box.center).toEqualEpsilon(new Cartesian3(0, 0, 0), CesiumMath.EPSILON15);
+        expect(box.halfAxes).toEqualEpsilon(new Matrix3(0, 0, 1, 1, 0, 0, 0, Math.SQRT1_2, 0), CesiumMath.EPSILON15);
+
+        // Full longitude, 1/4 of latitude starting from north pole
+        box = OrientedBoundingBox.fromRectangle(new Rectangle(-d180, d45, d180, d90), 0, 0, Ellipsoid.UNIT_SPHERE);
+        expect(box.center).toEqualEpsilon(new Cartesian3(0, 0, onePlusSqrtHalfDivTwo), CesiumMath.EPSILON15);
+        expect(box.halfAxes).toEqualEpsilon(new Matrix3(0, 0, Math.SQRT1_2, Math.SQRT1_2, 0, 0, 0, oneMinusOnePlusSqrtHalfDivTwo, 0), CesiumMath.EPSILON15);
+
+        // Full longitude, 1/4 of latitude starting from south pole
+        box = OrientedBoundingBox.fromRectangle(new Rectangle(-d180, -d90, d180, -d45), 0, 0, Ellipsoid.UNIT_SPHERE);
+        expect(box.center).toEqualEpsilon(new Cartesian3(0, 0, -onePlusSqrtHalfDivTwo), CesiumMath.EPSILON15);
+        expect(box.halfAxes).toEqualEpsilon(new Matrix3(0, 0, Math.SQRT1_2, Math.SQRT1_2, 0, 0, 0, oneMinusOnePlusSqrtHalfDivTwo, 0), CesiumMath.EPSILON15);
+
+        // Cmpletely on north pole
+        box = OrientedBoundingBox.fromRectangle(new Rectangle(-d180, d90, d180, d90), 0, 0, Ellipsoid.UNIT_SPHERE);
+        expect(box.center).toEqualEpsilon(new Cartesian3(0, 0, 1), CesiumMath.EPSILON15);
+        expect(box.halfAxes).toEqualEpsilon(new Matrix3(0, 0, 0, 0, 0, 0, 0, 0, 0), CesiumMath.EPSILON15);
+
+        // Completely on north pole 2
+        box = OrientedBoundingBox.fromRectangle(new Rectangle(-d135, d90, d135, d90), 0, 0, Ellipsoid.UNIT_SPHERE);
+        expect(box.center).toEqualEpsilon(new Cartesian3(0, 0, 1), CesiumMath.EPSILON15);
+        expect(box.halfAxes).toEqualEpsilon(new Matrix3(0, 0, 0, 0, 0, 0, 0, 0, 0), CesiumMath.EPSILON15);
+
+        // Completely on south pole
+        box = OrientedBoundingBox.fromRectangle(new Rectangle(-d180, -d90, d180, -d90), 0, 0, Ellipsoid.UNIT_SPHERE);
+        expect(box.center).toEqualEpsilon(new Cartesian3(0, 0, -1), CesiumMath.EPSILON15);
+        expect(box.halfAxes).toEqualEpsilon(new Matrix3(0, 0, 0, 0, 0, 0, 0, 0, 0), CesiumMath.EPSILON15);
+
+        // Completely on south pole 2
+        box = OrientedBoundingBox.fromRectangle(new Rectangle(-d135, -d90, d135, -d90), 0, 0, Ellipsoid.UNIT_SPHERE);
+        expect(box.center).toEqualEpsilon(new Cartesian3(0, 0, -1), CesiumMath.EPSILON15);
+        expect(box.halfAxes).toEqualEpsilon(new Matrix3(0, 0, 0, 0, 0, 0, 0, 0, 0), CesiumMath.EPSILON15);
     });
 
     it('fromRectangle for interesting, degenerate, and edge-case rectangles', function() {

--- a/Specs/Core/OrientedBoundingBoxSpec.js
+++ b/Specs/Core/OrientedBoundingBoxSpec.js
@@ -232,7 +232,7 @@ describe('Core/OrientedBoundingBox', function() {
     it('fromRectangle for rectangles that span over half the ellipsoid', function() {
         var d90 = CesiumMath.PI_OVER_TWO;
         var d180 = CesiumMath.PI;
-        var d135 = (3/4) * CesiumMath.PI;
+        var d135 = (3.0 / 4.0) * CesiumMath.PI;
         var d45 = CesiumMath.PI_OVER_FOUR;
         var onePlusSqrtHalfDivTwo = (1.0 + Math.SQRT1_2) / 2.0;
         var oneMinusOnePlusSqrtHalfDivTwo = 1.0 - onePlusSqrtHalfDivTwo;


### PR DESCRIPTION
There have been reports of 3D tiles that use `TileBoundingRegion` disappearing when viewing from a horizon angle. This is because the root tile generates a broken `OrientedBoundingBox` when the `Rectangle`'s width is greater than half the ellipsoid. The terrain system doesn't have this problem because it handles this edge case and generates a `BoundingSphere` instead.

In this PR `OrientedBoundingBox.fromRectangle` has been made to work with larger rectangles. The approach is different than small rectangles which orient the OBB around the rectangle's center normal. I tried doing it this way for large rectangles but it produced very poorly fitted, albeit correct OBBs. The final approach ignores the latitude when calculating the OBBs orientation.

With this fix, all of the special case code is gone. I did a good amount of testing but this change impacts a lot of core systems so more eyes on it the better.

Fixes #4483

[Sandcastle](http://localhost:8080/Apps/Sandcastle/index.html#c=tVdfb+M2DP8qXh+uzs51k3QH7HJpsbbr7Qr0H9ruuocCg2IzqVBbDiQ5TTr0u4+ULVu2212yw/khkSiSIn+kKGrBpLfg8ATS2/cEPHnHoHiehl8Nzd+OzPQ4E5pxAXK79+leLFBGRSAARQrZ0ExxqVgk4nkWQ4IM/9wLD78nUNobeTuDvX7YDwoaMEN779JUlusHYhzWNJFJQ3tPtHvxYvYp7XwUWfSIMqGWLHr0q52tnTrLkgkj5+IsylMQOpyBPkmAhker09jfLlmMa22tbD5PVkdcxFzMVK09sHpJZppJz6e9BEvB46J2v2e951OvFg4fmLp8Elcym4PUK5/EehUrfW0r0OLLiQK5YJMEXCuMaKjyiYokn4Cfz2Om4RoizcQsAbKO9L0gaITZNBeR5pnwWnx+tbsbznAueco1X4AKJaTZAg6TxLc6S35024R237vI0wlmTO0m0S038Zlwv8JHdJevSIFXGM2Cy1kkxiucZsHl1JDOTdrYaBSi42KzBvjESmeBGD7VZLuXEXDo1tpyhxLuJkLSAo18ZWwr7MOpzNLfYSYBlE+QBYXKwOAVeJUrtbqUC57m6RfgswdC9EOfvrDv+JuyZYNl0O/ySIgrK06FwkEEzSLwB2QpaLmyq74D06xcw3PpSFQKragrQl8NxageB02eBR4LWH7OZMqoPpSqr0BaO46zJJOH8zkwSdPw68n17clff3++vD4/vG0pg6WWeQxxCcWoCU2L+aFiciGueV56jgDTGg9drkGNvJaXERlYWW7MbWN5aKVNAhgW3wGyIAywBnp95+dDr+dYU6ZbnR2dc8vi2NV6ZVdei6S1TJnQdHPDdb3Cvhn+t2PUzoMoyRTEKI3RARdg61O3zmSTSX1+LiXHAg7xUZab4nyULQ2QdU2rs6sZzaCZAd19cFX1653OGQZquUdFGH3KU+GjIVjDk+nhEhQGJXAROGaYu4ozsef33AJESgfrKx2srXS4vtLh2kr7ZyBQ7zDsez93+cOUzQTXeKp8w9zxcxPpQcehTaSHvUZVr2z/aX+fjoz37l1tUYs2dGiNC6AC4QIrUI2uY4Og0pTw59L/b8LaAGdNrYONtA7X1DpcW2tEx4v6JsqhYlJBbXlijl2UwoZCNe8NR6+NSFDFIajQ73UUTrKlucCLTG4qLWi/+M06UgUqXAY1vnYytJPCARy9Jb1ypVeu9KqSXr0p/exKP7vSz5X0c0u636ztA2pt7dqryFzmOsEe3F4kdbSPOmtFU1FFp118nbiNnIlbhv/DgM17hVa/0PWlBU3q5MColRTtGFSXsNe5haub2Nv8Knb5w7svp7cnvabylzfR+l+X8FsXcRf2NgDffRXTN01Mq0WXcdBdlSBikDca3wyvo0wf2XjHY/NSw1A9hHjr+kNK7QKQ8tY9TDjDm//Mcve62l5aSLstD9Ype1cXr5rOUwZjsRVsjZVeJXBQcP7G0zm20V4uEz8Md6lVR39B7U7y6BF0GClFYuNdKzSO+cLj8f79Vuv9e7+FnQtTClemeZLcYF293zoY7yJ/QyzJGHUll9jKJmxFLA+Dg7OCGIbheBenXanyUYnsSNX02DsY60kWr0o/xloe1FiMdXxwhw+G8S4OmuQxF/Nce3o1B1SLUZ+hmdQG4Wxn8GufJmyJk2KsNMxpgkMEk+1M8MGL8wVLchh5xaPETP40YI+8baN/27hebY5D+aahJ+zHG1o8mL7T0Bt6fG1q6cfa0I/ftrN8332noRf0MPyxhpq35waG4p/JVvw3yUsUTO5/AQ)

Examples:
<img width="434" alt="Screen Shot 2019-12-18 at 5 46 45 PM" src="https://user-images.githubusercontent.com/1328450/71131653-4d73de80-21c3-11ea-96c4-2b6dee148972.png">
<img width="445" alt="Screen Shot 2019-12-18 at 5 45 45 PM" src="https://user-images.githubusercontent.com/1328450/71131654-4d73de80-21c3-11ea-846a-e4cd62c92bb0.png">
<img width="481" alt="Screen Shot 2019-12-18 at 5 45 33 PM" src="https://user-images.githubusercontent.com/1328450/71131655-4d73de80-21c3-11ea-866e-a47325ef9afa.png">
<img width="546" alt="Screen Shot 2019-12-18 at 5 44 46 PM" src="https://user-images.githubusercontent.com/1328450/71131656-4d73de80-21c3-11ea-8efb-feb2a3a0ec47.png">

3D tile before (incorrectly culled):
<img width="607" alt="Screen Shot 2019-12-18 at 5 53 26 PM" src="https://user-images.githubusercontent.com/1328450/71131651-4d73de80-21c3-11ea-9b0f-5b9adc75e263.png">
3D tile after:
<img width="704" alt="Screen Shot 2019-12-18 at 5 51 35 PM" src="https://user-images.githubusercontent.com/1328450/71131652-4d73de80-21c3-11ea-9c25-66d35dee5648.png">

@loshjawrence 
@lilleyse 
@jasonbeverage 


