### PR TITLE
Fixed horizon culling issues with large root tiles

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@ Change Log
 * Fixed bounding volume calculation for `GroundPrimitive`. [#4883](https://github.com/AnalyticalGraphicsInc/cesium/issues/4483)
 * Fixed `OrientedBoundingBox.fromRectangle` for rectangles with width greater than 180 degrees. [#8475](https://github.com/AnalyticalGraphicsInc/cesium/pull/8475)
 * Fixed globe picking so that it returns the closest intersecting triangle instead of the first intersecting triangle. [#8390](https://github.com/AnalyticalGraphicsInc/cesium/pull/8390)
+* Fixed horizon culling issues with large root tiles.
 
 ##### Additions :tada:
 * Added `Globe.backFaceCulling` to support viewing terrain from below the surface. [#8470](https://github.com/AnalyticalGraphicsInc/cesium/pull/8470)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,7 +11,7 @@ Change Log
 * Fixed bounding volume calculation for `GroundPrimitive`. [#4883](https://github.com/AnalyticalGraphicsInc/cesium/issues/4483)
 * Fixed `OrientedBoundingBox.fromRectangle` for rectangles with width greater than 180 degrees. [#8475](https://github.com/AnalyticalGraphicsInc/cesium/pull/8475)
 * Fixed globe picking so that it returns the closest intersecting triangle instead of the first intersecting triangle. [#8390](https://github.com/AnalyticalGraphicsInc/cesium/pull/8390)
-* Fixed horizon culling issues with large root tiles.
+* Fixed horizon culling issues with large root tiles. [#8487](https://github.com/AnalyticalGraphicsInc/cesium/pull/8487)
 
 ##### Additions :tada:
 * Added `Globe.backFaceCulling` to support viewing terrain from below the surface. [#8470](https://github.com/AnalyticalGraphicsInc/cesium/pull/8470)

--- a/Source/Core/EllipsoidalOccluder.js
+++ b/Source/Core/EllipsoidalOccluder.js
@@ -303,6 +303,10 @@ import Rectangle from './Rectangle.js';
         for (var i = 0, len = positions.length; i < len; ++i) {
             var position = positions[i];
             var candidateMagnitude = computeMagnitude(ellipsoid, position, scaledSpaceDirectionToPoint);
+            if (candidateMagnitude < 0.0) {
+                // all points should face the same direction, but this one doesn't, so return undefined
+                return undefined;
+            }
             resultMagnitude = Math.max(resultMagnitude, candidateMagnitude);
         }
 
@@ -333,6 +337,10 @@ import Rectangle from './Rectangle.js';
             positionScratch.z = vertices[i + 2] + center.z;
 
             var candidateMagnitude = computeMagnitude(ellipsoid, positionScratch, scaledSpaceDirectionToPoint);
+            if (candidateMagnitude < 0.0) {
+                // all points should face the same direction, but this one doesn't, so return undefined
+                return undefined;
+            }
             resultMagnitude = Math.max(resultMagnitude, candidateMagnitude);
         }
 

--- a/Specs/Core/EllipsoidalOccluderSpec.js
+++ b/Specs/Core/EllipsoidalOccluderSpec.js
@@ -161,6 +161,26 @@ describe('Core/EllipsoidalOccluder', function() {
             expect(result).toBeUndefined();
         });
 
+        it('returns undefined when any point is in the opposite direction of the center line', function() {
+            var ellipsoid = new Ellipsoid(1.0, 1.0, 1.0);
+            var ellipsoidalOccluder = new EllipsoidalOccluder(ellipsoid);
+            var positions = [new Cartesian3(2.0, 0.0, 0.0), new Cartesian3(-1.0, 0.0, 0.0)];
+            var directionToPoint = new Cartesian3(1.0, 0.0, 0.0);
+
+            var result = ellipsoidalOccluder.computeHorizonCullingPoint(directionToPoint, positions);
+            expect(result).toBeUndefined();
+        });
+
+        it('returns undefined when the direction is zero', function() {
+            var ellipsoid = new Ellipsoid(1.0, 1.0, 1.0);
+            var ellipsoidalOccluder = new EllipsoidalOccluder(ellipsoid);
+            var positions = [new Cartesian3(1.0, 0.0, 0.0)];
+            var directionToPoint = new Cartesian3(0.0, 0.0, 0.0);
+
+            var result = ellipsoidalOccluder.computeHorizonCullingPoint(directionToPoint, positions);
+            expect(result).toBeUndefined();
+        });
+
         it('computes a point from a single position with a grazing altitude close to zero', function() {
             var ellipsoid = new Ellipsoid(12345.0, 12345.0, 12345.0);
             var ellipsoidalOccluder = new EllipsoidalOccluder(ellipsoid);


### PR DESCRIPTION
There were some horizon culling bugs with `ArcGisTerrainProvider's` root tile which cause some child tiles to be culled or the whole screen to go black altogether. The problem is the tile was creating a horizon culling point from a set of points that were on opposite sides of the globe. This has been a bug for a while but was made worse by https://github.com/AnalyticalGraphicsInc/cesium/pull/8475. The fix was to detect these backwards points in `EllipsoidalOccluder` and throw out the entire occlusion point if one of them is backwards. In practice this only happens for very large tiles with widths greater than half the globe. `CesiumWorldTerrain` never had this problem because it has two root tiles. `ArcGisTerrainProvider` only has one root tile so it was affected. 

[Before sandcastle](https://sandcastle.cesium.com/#c=nZNta9swEMe/ismbppDK1rPcpWGjLVtgD2UNGwO/UW2lFZPlIinusrHvvnMeaJeOweY3Pp3/d7+7P1avQ6ZD/drGhQlBW38Vut42JmRnmTcP2bmJdtWiVyCZXy+sM82lM71OtvMHBeMflc/gWQV3mh3dpXQfT/Pc7NW0QcC5tRHVXZtvwzyYmPJoQm9rE/PPXXCP7elFviNANG/1rbkGoQlHlf95/KLyle9h9t6ah8NhP21y46N6czzvfIImUDjJdiOmg1VP/2zBI2jTEMXaeINq3ZqgUTRp4Oy3bmAT6zeDQ7snw5zrkCDSno5PcIlLVkrEaYFVUVI8yU6YhEgIpNTwlpJMMio5hAoVhZIlF5Sy7HiyxXTBGljnOeaN0Y31t1c21XcfO+fGGBHBMaNCEkmJkooBrBiSVOBSCUwExYWaZAVwKBZEgE4UioAS73HGN4ugfVx2oQXejvVOp2C/MTS/uHy/mC++/NWnpVsvun9yiWLJMSGIMMYw50rC4BhjSWghkCgZZUxQsAkXBDbgBFHJpFCYkf9xqeBYUcwk54wowfkAQ4yXlNPBH0woxxuTCCeYgo+klIKWSu1hzSrsSRwVOy9Gk9E0prUzs63opW3vu5CGyzFGKE+mvXcaNs5vVvVXk1Ad41A2zfdF08b2mW3OqtHBX1yNstrpGOHLcuXctf1uqtFsmoP+tzLXbVb9ADfG6fUgucOzt9skQmiaw/F5Veo6d6PDk46/AA)
<img width="359" alt="Screen Shot 2019-12-20 at 1 41 55 PM" src="https://user-images.githubusercontent.com/1328450/71283538-8a101900-232e-11ea-99f2-c8098d817016.png">
[After sandcastle (local)](http://localhost:8080/Apps/Sandcastle/index.html#c=nZNta9swEMe/ismbppDK1rPcpWGjLVtgD2UNGwO/UW2lFZPlIinusrHvvnMeaJeOweY3Pp3/d7+7P1avQ6ZD/drGhQlBW38Vut42JmRnmTcP2bmJdtWiVyCZXy+sM82lM71OtvMHBeMflc/gWQV3mh3dpXQfT/Pc7NW0QcC5tRHVXZtvwzyYmPJoQm9rE/PPXXCP7elFviNANG/1rbkGoQlHlf95/KLyle9h9t6ah8NhP21y46N6czzvfIImUDjJdiOmg1VP/2zBI2jTEMXaeINq3ZqgUTRp4Oy3bmAT6zeDQ7snw5zrkCDSno5PcIlLVkrEaYFVUVI8yU6YhEgIpNTwlpJMMio5hAoVhZIlF5Sy7HiyxXTBGljnOeaN0Y31t1c21XcfO+fGGBHBMaNCEkmJkooBrBiSVOBSCUwExYWaZAVwKBZEgE4UioAS73HGN4ugfVx2oQXejvVOp2C/MTS/uHy/mC++/NWnpVsvun9yiWLJMSGIMMYw50rC4BhjSWghkCgZZUxQsAkXBDbgBFHJpFCYkf9xqeBYUcwk54wowfkAQ4yXlNPBH0woxxuTCCeYgo+klIKWSu1hzSrsSRwVOy9Gk9E0prUzs63opW3vu5CGyzFGKE+mvXcaNs5vVvVXk1Ad41A2zfdF08b2mW3OqtHBX1yNstrpGOHLcuXctf1uqtFsmoP+tzLXbVb9ADfG6fUgucOzt9skQmiaw/F5Veo6d6PDk46/AA)
<img width="373" alt="Screen Shot 2019-12-20 at 1 42 03 PM" src="https://user-images.githubusercontent.com/1328450/71283537-8a101900-232e-11ea-9a87-588e14cd9899.png">
