### PR TITLE
Fix lighting on Mac/Intel

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@ Change Log
 * Fixed `OrientedBoundingBox.fromRectangle` for rectangles with width greater than 180 degrees. [#8475](https://github.com/AnalyticalGraphicsInc/cesium/pull/8475)
 * Fixed globe picking so that it returns the closest intersecting triangle instead of the first intersecting triangle. [#8390](https://github.com/AnalyticalGraphicsInc/cesium/pull/8390)
 * Fixed horizon culling issues with large root tiles. [#8487](https://github.com/AnalyticalGraphicsInc/cesium/pull/8487)
+* Fixed a lighting bug affecting Macs with Intel integrated graphics where glTF 2.0 PBR models with double sided materials would have flipped normals. [#8494](https://github.com/AnalyticalGraphicsInc/cesium/pull/8494)
 
 ##### Additions :tada:
 * Added `Globe.backFaceCulling` to support viewing terrain from below the surface. [#8470](https://github.com/AnalyticalGraphicsInc/cesium/pull/8470)

--- a/Source/Scene/processModelMaterialsCommon.js
+++ b/Source/Scene/processModelMaterialsCommon.js
@@ -543,6 +543,7 @@ import ModelUtility from './ModelUtility.js';
         if (hasNormals) {
             fragmentShader += '  vec3 normal = normalize(v_normal);\n';
             if (khrMaterialsCommon.doubleSided) {
+                // !gl_FrontFacing doesn't work as expected on Mac/Intel so use the more verbose form instead. See https://github.com/AnalyticalGraphicsInc/cesium/pull/8494.
                 fragmentShader += '  if (gl_FrontFacing == false)\n';
                 fragmentShader += '  {\n';
                 fragmentShader += '    normal = -normal;\n';

--- a/Source/Scene/processPbrMaterials.js
+++ b/Source/Scene/processPbrMaterials.js
@@ -602,6 +602,7 @@ import ModelUtility from './ModelUtility.js';
                 fragmentShader += '    vec3 n = ng;\n';
             }
             if (material.doubleSided) {
+                // !gl_FrontFacing doesn't work as expected on Mac/Intel so use the more verbose form instead. See https://github.com/AnalyticalGraphicsInc/cesium/pull/8494.
                 fragmentShader += '    if (gl_FrontFacing == false)\n';
                 fragmentShader += '    {\n';
                 fragmentShader += '        n = -n;\n';

--- a/Source/Scene/processPbrMaterials.js
+++ b/Source/Scene/processPbrMaterials.js
@@ -602,7 +602,7 @@ import ModelUtility from './ModelUtility.js';
                 fragmentShader += '    vec3 n = ng;\n';
             }
             if (material.doubleSided) {
-                fragmentShader += '    if (!gl_FrontFacing)\n';
+                fragmentShader += '    if (gl_FrontFacing == false)\n';
                 fragmentShader += '    {\n';
                 fragmentShader += '        n = -n;\n';
                 fragmentShader += '    }\n';


### PR DESCRIPTION
There's a bug on Macs with Intel integrated graphics where `!gl_FrontFacing` is not equivalent to `gl_FrontFacing == false` and this causes the glTF PBR shader to flip normals incorrectly and have the wrong lighting.

I discovered the fix thanks to https://makc3d.wordpress.com/2015/09/17/alternative-to-gl_frontfacing/ which goes into other approaches in case `gl_FrontFacing == false` doesn't work. We can explore those later if needed.

[Local sandcastle](http://localhost:8080/Apps/Sandcastle/index.html#c=ZVP/T+IwHP1XGn5hJF7Z8OA8D82RIVh0EGWimCWX0hUsdO1sO75d/N+vY6DifbIl/fTz3tvra1atgq7CwgCfapYlvSHAhFCtgZFgIzMFmBQAa02NjkSBgUgKGNMpzrhp7cChXFABLkCZbnovky5hA9ZDD1vk9RnSSNzXiY8aaJE+jfzeT2hBr3F3kYOSfsh5v3tVG2/c+jicubfh3apfG5tBG3nB0K0HCaoHtd68357V7ctu/V76bMUGwxUjtf6SdEdbNE8nKOlsSf6xJJ4j7updXxu5ZIMaj9vxdtC+Wj9ZDn7suGgu1/2QnAbz4HsQzrzpHVwn3s3zOm6FHVK79gOPdV6/6dBrpC66fxC9P4s5PWs9XcfBD1T+FYlILLECS0ZXVNljC7raxwdHuz2nTHatL4XBTFBVrryzUiUTpqmlfaR5T7WNmlA4tcNWHjaKncbpmedVIgFsQfNChTPNBDH5fThqT6iAvwUgr1ydCsPMxooX5uCuZ1RDHMfOJ2xeqdQslzs/OPGxMnaFxenOSJvOFKXacU+AfTzXrZwcCyQypvwcfJHNK1PsHBxMHo/fPtq3PJV394VhozBZ0PjqcI7iQHvc2yEOafNQKxvjp0yoUlIdBUKk0JJTyOVsP33XsYvSSampzYbTy2LzN0tSqYz1zh0Iq4YmKcc2j+oks44MJFrntGb1QGrGbAlYfBGVvtx2VAKE23/GTqYZ50O2pVHpslm1+CMalzhmYjZYUsXxJoe8eJe3xSaEsFm17f8sIyWfYPVJ8R8)

**Broken lighting**
<img width="684" alt="Screen Shot 2019-12-24 at 8 44 09 PM" src="https://user-images.githubusercontent.com/915398/71428442-ccb75580-268e-11ea-9a5e-9844ce89b416.png">
**Fixed**
<img width="660" alt="Screen Shot 2019-12-24 at 8 44 33 PM" src="https://user-images.githubusercontent.com/915398/71428441-cc1ebf00-268e-11ea-9bf3-2ddf76e8c211.png">
