### PR TITLE
Prevent camera from going underground during mouse navigation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,11 @@
 Change Log
 ==========
 
+### 1.66.0 - 2020-02-03
+
+##### Fixes :wrench:
+* Fixed a bug where the camera could go underground during mouse navigation. [#8504](https://github.com/AnalyticalGraphicsInc/cesium/pull/8504)
+
 ### 1.65.0 - 2020-01-06
 
 ##### Fixes :wrench:

--- a/Source/Scene/Camera.js
+++ b/Source/Scene/Camera.js
@@ -215,7 +215,6 @@ import SceneMode from './SceneMode.js';
         this._projection = projection;
         this._maxCoord = projection.project(new Cartographic(Math.PI, CesiumMath.PI_OVER_TWO));
         this._max2Dfrustum = undefined;
-        this._suspendTerrainAdjustment = false;
 
         // set default view
         rectangleCameraPosition3D(this, Camera.DEFAULT_VIEW_RECTANGLE, this.position, true);
@@ -377,76 +376,6 @@ import SceneMode from './SceneMode.js';
             camera._changed.raiseEvent(Math.max(dirPercentage, heightPercentage));
             camera._changedPosition = Cartesian3.clone(camera.positionWC, camera._changedPosition);
             camera._changedDirection = Cartesian3.clone(camera.directionWC, camera._changedDirection);
-        }
-    };
-
-    var scratchAdjustHeightTransform = new Matrix4();
-    var scratchAdjustHeightCartographic = new Cartographic();
-
-    Camera.prototype._adjustHeightForTerrain = function() {
-        var scene = this._scene;
-
-        var screenSpaceCameraController = scene.screenSpaceCameraController;
-        var enableCollisionDetection = screenSpaceCameraController.enableCollisionDetection;
-        var minimumCollisionTerrainHeight = screenSpaceCameraController.minimumCollisionTerrainHeight;
-        var minimumZoomDistance = screenSpaceCameraController.minimumZoomDistance;
-
-        if (this._suspendTerrainAdjustment || !enableCollisionDetection) {
-            return;
-        }
-
-        var mode = this._mode;
-        var globe = scene.globe;
-
-        if (!defined(globe) || mode === SceneMode.SCENE2D || mode === SceneMode.MORPHING) {
-            return;
-        }
-
-        var ellipsoid = globe.ellipsoid;
-        var projection = scene.mapProjection;
-
-        var transform;
-        var mag;
-        if (!Matrix4.equals(this.transform, Matrix4.IDENTITY)) {
-            transform = Matrix4.clone(this.transform, scratchAdjustHeightTransform);
-            mag = Cartesian3.magnitude(this.position);
-            this._setTransform(Matrix4.IDENTITY);
-        }
-
-        var cartographic = scratchAdjustHeightCartographic;
-        if (mode === SceneMode.SCENE3D) {
-            ellipsoid.cartesianToCartographic(this.position, cartographic);
-        } else {
-            projection.unproject(this.position, cartographic);
-        }
-
-        var heightUpdated = false;
-        if (cartographic.height < minimumCollisionTerrainHeight) {
-            var height = globe.getHeight(cartographic);
-            if (defined(height)) {
-                height += minimumZoomDistance;
-                if (cartographic.height < height) {
-                    cartographic.height = height;
-                    if (mode === SceneMode.SCENE3D) {
-                        ellipsoid.cartographicToCartesian(cartographic, this.position);
-                    } else {
-                        projection.project(cartographic, this.position);
-                    }
-                    heightUpdated = true;
-                }
-            }
-        }
-
-        if (defined(transform)) {
-            this._setTransform(transform);
-            if (heightUpdated) {
-                Cartesian3.normalize(this.position, this.position);
-                Cartesian3.negate(this.position, this.direction);
-                Cartesian3.multiplyByScalar(this.position, Math.max(mag, minimumZoomDistance), this.position);
-                Cartesian3.normalize(this.direction, this.direction);
-                Cartesian3.cross(this.direction, this.up, this.right);
-                Cartesian3.cross(this.right, this.direction, this.up);
-            }
         }
     };
 
@@ -976,16 +905,6 @@ import SceneMode from './SceneMode.js';
         if (this._mode === SceneMode.SCENE2D) {
             clampMove2D(this, this.position);
         }
-
-        var globe = this._scene.globe;
-        var globeFinishedUpdating = !defined(globe) || (globe._surface.tileProvider.ready && globe._surface._tileLoadQueueHigh.length === 0 && globe._surface._tileLoadQueueMedium.length === 0 && globe._surface._tileLoadQueueLow.length === 0 && globe._surface._debug.tilesWaitingForChildren === 0);
-        if (this._suspendTerrainAdjustment) {
-            this._suspendTerrainAdjustment = !globeFinishedUpdating;
-        }
-
-        if (globeFinishedUpdating) {
-            this._adjustHeightForTerrain();
-        }
     };
 
     var setTransformPosition = new Cartesian3();
@@ -1274,8 +1193,6 @@ import SceneMode from './SceneMode.js';
         scratchHpr.heading = defaultValue(orientation.heading, 0.0);
         scratchHpr.pitch = defaultValue(orientation.pitch, -CesiumMath.PI_OVER_TWO);
         scratchHpr.roll = defaultValue(orientation.roll, 0.0);
-
-        this._suspendTerrainAdjustment = true;
 
         if (mode === SceneMode.SCENE3D) {
             setView3D(this, destination, scratchHpr);

--- a/Source/Scene/Globe.js
+++ b/Source/Scene/Globe.js
@@ -618,19 +618,26 @@ import TileSelectionResult from './TileSelectionResult.js';
             return undefined;
         }
 
+        var tileWithMesh = tile;
+
         while (tile._lastSelectionResult === TileSelectionResult.REFINED) {
             tile = tileIfContainsCartographic(tile.southwestChild, cartographic) ||
                    tileIfContainsCartographic(tile.southeastChild, cartographic) ||
                    tileIfContainsCartographic(tile.northwestChild, cartographic) ||
                    tile.northeastChild;
+            if (defined(tile.data) && defined(tile.data.renderedMesh)) {
+                tileWithMesh = tile;
+            }
         }
+
+        tile = tileWithMesh;
 
         // This tile was either rendered or culled.
         // It is sometimes useful to get a height from a culled tile,
         // e.g. when we're getting a height in order to place a billboard
         // on terrain, and the camera is looking at that same billboard.
         // The culled tile must have a valid mesh, though.
-        if (!defined(tile.data) || !defined(tile.data.renderedMesh)) {
+        if (!defined(tile)) {
             // Tile was not rendered (culled).
             return undefined;
         }

--- a/Source/Scene/ScreenSpaceCameraController.js
+++ b/Source/Scene/ScreenSpaceCameraController.js
@@ -1986,6 +1986,9 @@ import TweenCollection from './TweenCollection.js';
         }
     }
 
+    var scratchPreviousPosition = new Cartesian3();
+    var scratchPreviousDirection = new Cartesian3();
+
     /**
      * @private
      */
@@ -2008,8 +2011,8 @@ import TweenCollection from './TweenCollection.js';
         this._rotateRateRangeAdjustment = radius;
 
         this._adjustedHeightForTerrain = false;
-        var previousPosition = Cartesian3.clone(camera.positionWC);
-        var previousDirection = Cartesian3.clone(camera.directionWC);
+        var previousPosition = Cartesian3.clone(camera.positionWC, scratchPreviousPosition);
+        var previousDirection = Cartesian3.clone(camera.directionWC, scratchPreviousDirection);
 
         var scene = this._scene;
         var mode = scene.mode;

--- a/Source/Scene/ScreenSpaceCameraController.js
+++ b/Source/Scene/ScreenSpaceCameraController.js
@@ -1137,7 +1137,7 @@ import TweenCollection from './TweenCollection.js';
         controller._rotateRateRangeAdjustment = radius;
 
         var originalPosition = Cartesian3.clone(camera.positionWC, rotateCVCartesian3);
-        camera._adjustHeightForTerrain();
+        adjustHeightForTerrain(controller);
 
         if (!Cartesian3.equals(camera.positionWC, originalPosition)) {
             camera._setTransform(verticalTransform);
@@ -1766,7 +1766,7 @@ import TweenCollection from './TweenCollection.js';
         controller._rotateRateRangeAdjustment = radius;
 
         var originalPosition = Cartesian3.clone(camera.positionWC, tilt3DCartesian3);
-        camera._adjustHeightForTerrain();
+        adjustHeightForTerrain(controller);
 
         if (!Cartesian3.equals(camera.positionWC, originalPosition)) {
             camera._setTransform(verticalTransform);
@@ -1918,11 +1918,77 @@ import TweenCollection from './TweenCollection.js';
         reactToInput(controller, controller.enableLook, controller.lookEventTypes, look3D);
     }
 
+    var scratchAdjustHeightTransform = new Matrix4();
+    var scratchAdjustHeightCartographic = new Cartographic();
+
+    function adjustHeightForTerrain(controller) {
+        if (!controller.enableCollisionDetection) {
+            return;
+        }
+
+        var scene = controller._scene;
+        var mode = scene.mode;
+        var globe = scene.globe;
+
+        if (!defined(globe) || mode === SceneMode.SCENE2D || mode === SceneMode.MORPHING) {
+            return;
+        }
+
+        var camera = scene.camera;
+        var ellipsoid = globe.ellipsoid;
+        var projection = scene.mapProjection;
+
+        var transform;
+        var mag;
+        if (!Matrix4.equals(camera.transform, Matrix4.IDENTITY)) {
+            transform = Matrix4.clone(camera.transform, scratchAdjustHeightTransform);
+            mag = Cartesian3.magnitude(camera.position);
+            camera._setTransform(Matrix4.IDENTITY);
+        }
+
+        var cartographic = scratchAdjustHeightCartographic;
+        if (mode === SceneMode.SCENE3D) {
+            ellipsoid.cartesianToCartographic(camera.position, cartographic);
+        } else {
+            projection.unproject(camera.position, cartographic);
+        }
+
+        var heightUpdated = false;
+        if (cartographic.height < controller._minimumCollisionTerrainHeight) {
+            var height = globe.getHeight(cartographic);
+            if (defined(height)) {
+                height += controller.minimumZoomDistance;
+                if (cartographic.height < height) {
+                    cartographic.height = height;
+                    if (mode === SceneMode.SCENE3D) {
+                        ellipsoid.cartographicToCartesian(cartographic, camera.position);
+                    } else {
+                        projection.project(cartographic, camera.position);
+                    }
+                    heightUpdated = true;
+                }
+            }
+        }
+
+        if (defined(transform)) {
+            camera._setTransform(transform);
+            if (heightUpdated) {
+                Cartesian3.normalize(camera.position, camera.position);
+                Cartesian3.negate(camera.position, camera.direction);
+                Cartesian3.multiplyByScalar(camera.position, Math.max(mag, controller.minimumZoomDistance), camera.position);
+                Cartesian3.normalize(camera.direction, camera.direction);
+                Cartesian3.cross(camera.direction, camera.up, camera.right);
+                Cartesian3.cross(camera.right, camera.direction, camera.up);
+            }
+        }
+    }
+
     /**
      * @private
      */
     ScreenSpaceCameraController.prototype.update = function() {
-        if (!Matrix4.equals(this._scene.camera.transform, Matrix4.IDENTITY)) {
+        var camera = this._scene.camera;
+        if (!Matrix4.equals(camera.transform, Matrix4.IDENTITY)) {
             this._globe = undefined;
             this._ellipsoid = Ellipsoid.UNIT_SPHERE;
         } else {
@@ -1938,6 +2004,9 @@ import TweenCollection from './TweenCollection.js';
         this._rotateFactor = 1.0 / radius;
         this._rotateRateRangeAdjustment = radius;
 
+        var previousPosition = Cartesian3.clone(camera.positionWC);
+        var previousDirection = Cartesian3.clone(camera.directionWC);
+
         var scene = this._scene;
         var mode = scene.mode;
         if (mode === SceneMode.SCENE2D) {
@@ -1948,6 +2017,11 @@ import TweenCollection from './TweenCollection.js';
         } else if (mode === SceneMode.SCENE3D) {
             this._horizontalRotationAxis = undefined;
             update3D(this);
+        }
+
+        var cameraChanged = !Cartesian3.equals(previousPosition, camera.positionWC) || !Cartesian3.equals(previousDirection, camera.directionWC);
+        if (cameraChanged) {
+            adjustHeightForTerrain(this);
         }
 
         this._aggregator.reset();

--- a/Source/Scene/ScreenSpaceCameraController.js
+++ b/Source/Scene/ScreenSpaceCameraController.js
@@ -1138,7 +1138,10 @@ import TweenCollection from './TweenCollection.js';
         controller._rotateRateRangeAdjustment = radius;
 
         var originalPosition = Cartesian3.clone(camera.positionWC, rotateCVCartesian3);
-        adjustHeightForTerrain(controller);
+
+        if (controller.enableCollisionDetection) {
+            adjustHeightForTerrain(controller);
+        }
 
         if (!Cartesian3.equals(camera.positionWC, originalPosition)) {
             camera._setTransform(verticalTransform);
@@ -1767,7 +1770,10 @@ import TweenCollection from './TweenCollection.js';
         controller._rotateRateRangeAdjustment = radius;
 
         var originalPosition = Cartesian3.clone(camera.positionWC, tilt3DCartesian3);
-        adjustHeightForTerrain(controller);
+
+        if (controller.enableCollisionDetection) {
+            adjustHeightForTerrain(controller);
+        }
 
         if (!Cartesian3.equals(camera.positionWC, originalPosition)) {
             camera._setTransform(verticalTransform);
@@ -1923,10 +1929,6 @@ import TweenCollection from './TweenCollection.js';
     var scratchAdjustHeightCartographic = new Cartographic();
 
     function adjustHeightForTerrain(controller) {
-        if (!controller.enableCollisionDetection) {
-            return;
-        }
-
         controller._adjustedHeightForTerrain = true;
 
         var scene = controller._scene;
@@ -2026,7 +2028,7 @@ import TweenCollection from './TweenCollection.js';
             update3D(this);
         }
 
-        if (!this._adjustedHeightForTerrain) {
+        if (this.enableCollisionDetection && !this._adjustedHeightForTerrain) {
             // Adjust the camera height if the camera moved at all (user input or intertia) and an action didn't already adjust the camera height
             var cameraChanged = !Cartesian3.equals(previousPosition, camera.positionWC) || !Cartesian3.equals(previousDirection, camera.directionWC);
             if (cameraChanged) {

--- a/Source/Scene/ScreenSpaceCameraController.js
+++ b/Source/Scene/ScreenSpaceCameraController.js
@@ -266,6 +266,7 @@ import TweenCollection from './TweenCollection.js';
         this._strafing = false;
         this._zoomingOnVector = false;
         this._rotatingZoom = false;
+        this._adjustedHeightForTerrain = false;
 
         var projection = scene.mapProjection;
         this._maxCoord = projection.project(new Cartographic(Math.PI, CesiumMath.PI_OVER_TWO));
@@ -1926,6 +1927,8 @@ import TweenCollection from './TweenCollection.js';
             return;
         }
 
+        controller._adjustedHeightForTerrain = true;
+
         var scene = controller._scene;
         var mode = scene.mode;
         var globe = scene.globe;
@@ -2004,6 +2007,7 @@ import TweenCollection from './TweenCollection.js';
         this._rotateFactor = 1.0 / radius;
         this._rotateRateRangeAdjustment = radius;
 
+        this._adjustedHeightForTerrain = false;
         var previousPosition = Cartesian3.clone(camera.positionWC);
         var previousDirection = Cartesian3.clone(camera.directionWC);
 
@@ -2019,9 +2023,12 @@ import TweenCollection from './TweenCollection.js';
             update3D(this);
         }
 
-        var cameraChanged = !Cartesian3.equals(previousPosition, camera.positionWC) || !Cartesian3.equals(previousDirection, camera.directionWC);
-        if (cameraChanged) {
-            adjustHeightForTerrain(this);
+        if (!this._adjustedHeightForTerrain) {
+            // Adjust the camera height if the camera moved at all (user input or intertia) and an action didn't already adjust the camera height
+            var cameraChanged = !Cartesian3.equals(previousPosition, camera.positionWC) || !Cartesian3.equals(previousDirection, camera.directionWC);
+            if (cameraChanged) {
+                adjustHeightForTerrain(this);
+            }
         }
 
         this._aggregator.reset();

--- a/Specs/Scene/ScreenSpaceCameraControllerSpec.js
+++ b/Specs/Scene/ScreenSpaceCameraControllerSpec.js
@@ -1024,18 +1024,18 @@ describe('Scene/ScreenSpaceCameraController', function() {
         moveMouse(MouseButtons.LEFT, startPosition, endPosition);
         updateController();
 
-        expect(camera.position).toEqual(position);
-        expect(camera.direction).toEqual(direction);
-        expect(camera.up).toEqual(up);
-        expect(camera.right).toEqual(right);
+        expect(camera.position).toEqualEpsilon(position, CesiumMath.EPSILON7);
+        expect(camera.direction).toEqualEpsilon(direction, CesiumMath.EPSILON7);
+        expect(camera.up).toEqualEpsilon(up, CesiumMath.EPSILON7);
+        expect(camera.right).toEqualEpsilon(right, CesiumMath.EPSILON7);
 
         controller.enableRotate = true;
         updateController();
 
-        expect(camera.position).toEqual(position);
-        expect(camera.direction).toEqual(direction);
-        expect(camera.up).toEqual(up);
-        expect(camera.right).toEqual(right);
+        expect(camera.position).toEqualEpsilon(position, CesiumMath.EPSILON7);
+        expect(camera.direction).toEqualEpsilon(direction, CesiumMath.EPSILON7);
+        expect(camera.up).toEqualEpsilon(up, CesiumMath.EPSILON7);
+        expect(camera.right).toEqualEpsilon(right, CesiumMath.EPSILON7);
     });
 
     it('can set input type to undefined', function() {
@@ -1101,12 +1101,17 @@ describe('Scene/ScreenSpaceCameraController', function() {
         updateController();
 
         camera.setView({
-            destination : Cartesian3.fromDegrees(-72.0, 40.0, 1.0)
+            destination : Cartesian3.fromDegrees(-72.0, 40.0, -10.0)
         });
+
+        // Trigger terrain adjustment with a small mouse movement
+        var startPosition = new Cartesian2(canvas.clientWidth / 2, canvas.clientHeight / 4);
+        var endPosition = new Cartesian2(canvas.clientWidth / 2, canvas.clientHeight / 2);
+        moveMouse(MouseButtons.RIGHT, startPosition, endPosition);
 
         updateController();
 
-        expect(camera.positionCartographic.height).toEqualEpsilon(controller.minimumZoomDistance, CesiumMath.EPSILON7);
+        expect(camera.positionCartographic.height).toEqualEpsilon(controller.minimumZoomDistance, CesiumMath.EPSILON5);
     });
 
     it('camera does not go below the terrain in CV', function() {
@@ -1116,8 +1121,13 @@ describe('Scene/ScreenSpaceCameraController', function() {
         updateController();
 
         camera.setView({
-            destination : Cartesian3.fromDegrees(-72.0, 40.0, 1.0)
+            destination : Cartesian3.fromDegrees(-72.0, 40.0, -10.0)
         });
+
+        // Trigger terrain adjustment with a small mouse movement
+        var startPosition = new Cartesian2(canvas.clientWidth / 2, canvas.clientHeight / 4);
+        var endPosition = new Cartesian2(canvas.clientWidth / 2, canvas.clientHeight / 2);
+        moveMouse(MouseButtons.RIGHT, startPosition, endPosition);
 
         updateController();
 
@@ -1135,6 +1145,11 @@ describe('Scene/ScreenSpaceCameraController', function() {
             destination : Cartesian3.fromDegrees(-72.0, 40.0, -10.0)
         });
 
+        // Trigger terrain adjustment with a small mouse movement
+        var startPosition = new Cartesian2(canvas.clientWidth / 2, canvas.clientHeight / 4);
+        var endPosition = new Cartesian2(canvas.clientWidth / 2, canvas.clientHeight / 2);
+        moveMouse(MouseButtons.RIGHT, startPosition, endPosition);
+
         updateController();
 
         expect(camera.positionCartographic.height).toBeLessThan(controller.minimumZoomDistance);
@@ -1151,6 +1166,11 @@ describe('Scene/ScreenSpaceCameraController', function() {
             destination : Cartesian3.fromDegrees(-72.0, 40.0, -10.0)
         });
 
+        // Trigger terrain adjustment with a small mouse movement
+        var startPosition = new Cartesian2(canvas.clientWidth / 2, canvas.clientHeight / 4);
+        var endPosition = new Cartesian2(canvas.clientWidth / 2, canvas.clientHeight / 2);
+        moveMouse(MouseButtons.RIGHT, startPosition, endPosition);
+
         updateController();
 
         expect(camera.position.z).toBeLessThan(controller.minimumZoomDistance);
@@ -1164,6 +1184,11 @@ describe('Scene/ScreenSpaceCameraController', function() {
 
         camera.lookAt(Cartesian3.fromDegrees(-72.0, 40.0, 1.0), new Cartesian3(1.0, 1.0, -10.0));
 
+        // Trigger terrain adjustment with a small mouse movement
+        var startPosition = new Cartesian2(canvas.clientWidth / 2, canvas.clientHeight / 4);
+        var endPosition = new Cartesian2(canvas.clientWidth / 2, canvas.clientHeight / 2);
+        moveMouse(MouseButtons.RIGHT, startPosition, endPosition);
+
         updateController();
 
         expect(camera.positionCartographic.height).toBeGreaterThanOrEqualTo(controller.minimumZoomDistance);
@@ -1176,6 +1201,11 @@ describe('Scene/ScreenSpaceCameraController', function() {
         updateController();
 
         camera.lookAt(Cartesian3.fromDegrees(-72.0, 40.0, 1.0), new Cartesian3(1.0, 1.0, -10.0));
+
+        // Trigger terrain adjustment with a small mouse movement
+        var startPosition = new Cartesian2(canvas.clientWidth / 2, canvas.clientHeight / 4);
+        var endPosition = new Cartesian2(canvas.clientWidth / 2, canvas.clientHeight / 2);
+        moveMouse(MouseButtons.RIGHT, startPosition, endPosition);
 
         updateController();
 


### PR DESCRIPTION
Fixes https://github.com/AnalyticalGraphicsInc/cesium/issues/5837
Fixes https://github.com/AnalyticalGraphicsInc/cesium/issues/5999 (I think)

Since https://github.com/AnalyticalGraphicsInc/cesium/pull/4105 the camera has been allowed to underground if globe tiles are loading in order to prevent unwanted shifts during camera flights or `setView` calls. However this leads to poor user experience when manually navigating around terrain and accidentally slipping underground, especially on slower internet connections where it happens much more frequently.

This PR undoes https://github.com/AnalyticalGraphicsInc/cesium/pull/4105 and moves the onus to adjust height back to `ScreenSpaceCameraController`, but only if the camera has moved during the controller's update. Camera `flyTo` and `setView` are not affected because terrain adjustment only happens when the user interacts with the camera which cannot occur during these two operations. This behavior can be confirmed in this [sandcastle](http://localhost:8080/Apps/Sandcastle/index.html#c=7ZXbbhMxEIZfZZWbplLq+HyAtEKUolYqUNEIhJQbd9dpLRxv5XVSCuLdmc0mND1cUFB7RXIRZzy//9lvxtqFTUXpGj+ffa5TqMYuJetjsVvsL4OoTM5mt7nX3345iQuQuRD8ZVP76iTVC1+5BKrortbKg/X2SrfOWuq7ExbeXd2VfVrG+ltdUft1zKB1aWtQ/JjEAj759nHFiwfqn8SfNy6lnblkwaWzQ03pokNddJnULVHjcmveX/lUrsk+2uzrCB4bFe7blGFlI+vvUEmF0BoRRrXk8B0UO5wzZRhH2hismMRcDAqmOKXEICqIFgorpbYHnU2dvINnvG9z6Gzl4/mJz+XFxzqEvkC6PVobDK7EEDMoMMIUFtJIijEThioNFUhENdFUGkIYZlisrVysxsnGZlqnGXitfN7ZnPw3jo7eHLwfH42//GZ3amNV2iYHh2xVjes6nNn0ep5zHftbx7WtlkChMdN5LNv6+9vrHj1M9BmpPjPZx9Btc5eE/wTzYT1zT4WZUcqEpkjBLzAlVAFmyrkWghOIwiMaLAAzUUy1yUhiQolUVP4d5pYeg04xMFNGtEB3CGobZySjUhmujYQgfnKsb4M/v8hFrosAc+yedpI5ZkgJwaTWyyGCUebYMIOUNNABRXU7yUwrmG5lCEQIvj1aj5pk03ZOSMbbOwGTvAOjLLhWwmgtsCAt79UkG4U1V5grsPwn5hukpuF6XP+/8TeYNgTVPK2LI4jcndneoDdq8nVwe93OKz+7rFMu5in0ERpmN7sM8C5uhmfz8qvLqGyaVjYarkWjyi8KX+1OendenpNeUQbbNLAznYdw6r+7SW9vNIT8W7L2MgCmDwuXgr1uUy7I3nEXRAiNhvD3vip3d2vjxF8).

This method also removes some pretty bad coupling between `Camera`, `ScreenSpaceCameraController`, and `Globe`. Especially lines in `Camera` like:

```js
var globeFinishedUpdating = !defined(globe) || (globe._surface.tileProvider.ready && globe._surface._tileLoadQueueHigh.length === 0 && globe._surface._tileLoadQueueMedium.length === 0 && globe._surface._tileLoadQueueLow.length === 0 && globe._surface._debug.tilesWaitingForChildren === 0);
```

@mramato @gberaudo @IanLilleyT 