### PR TITLE
Update ground primitive related tests

### DIFF
--- a/Specs/Scene/ClassificationPrimitiveSpec.js
+++ b/Specs/Scene/ClassificationPrimitiveSpec.js
@@ -120,7 +120,6 @@ describe('Scene/ClassificationPrimitive', function() {
 
     beforeEach(function() {
         scene.morphTo3D(0);
-        scene.render(); // clear any afterRender commands
 
         // wrap rectangle primitive so it gets executed during the globe pass and 3D Tiles pass to lay down depth
         globePrimitive = new MockPrimitive(reusableGlobePrimitive, Pass.GLOBE);
@@ -148,7 +147,6 @@ describe('Scene/ClassificationPrimitive', function() {
 
     afterEach(function() {
         scene.primitives.removeAll();
-        scene.groundPrimitives.removeAll();
         primitive = primitive && !primitive.isDestroyed() && primitive.destroy();
         globePrimitive = globePrimitive && !globePrimitive.isDestroyed() && globePrimitive.destroy();
         tilesetPrimitive = tilesetPrimitive && !tilesetPrimitive.isDestroyed() && tilesetPrimitive.destroy();
@@ -208,7 +206,7 @@ describe('Scene/ClassificationPrimitive', function() {
         });
 
         expect(primitive.geometryInstances).toBeDefined();
-        scene.groundPrimitives.add(primitive);
+        scene.primitives.add(primitive);
         scene.renderForSpecs();
         expect(primitive.geometryInstances).not.toBeDefined();
     });
@@ -225,7 +223,7 @@ describe('Scene/ClassificationPrimitive', function() {
         });
 
         expect(primitive.geometryInstances).toBeDefined();
-        scene.groundPrimitives.add(primitive);
+        scene.primitives.add(primitive);
         scene.renderForSpecs();
         expect(primitive.geometryInstances).toBeDefined();
     });
@@ -241,7 +239,7 @@ describe('Scene/ClassificationPrimitive', function() {
             asynchronous : false
         });
 
-        scene.groundPrimitives.add(primitive);
+        scene.primitives.add(primitive);
         scene.renderForSpecs();
 
         return primitive.readyPromise.then(function(param) {
@@ -260,11 +258,9 @@ describe('Scene/ClassificationPrimitive', function() {
             asynchronous : false
         });
 
-        var frameState = scene.frameState;
-        frameState.commandList.length = 0;
-
-        primitive.update(frameState);
-        expect(frameState.commandList.length).toEqual(0);
+        scene.primitives.add(primitive);
+        scene.renderForSpecs();
+        expect(scene.frameState.commandList.length).toEqual(0);
     });
 
     it('does not render when show is false', function() {
@@ -277,21 +273,13 @@ describe('Scene/ClassificationPrimitive', function() {
             asynchronous : false
         });
 
-        var frameState = scene.frameState;
+        scene.primitives.add(primitive);
+        scene.renderForSpecs();
+        expect(scene.frameState.commandList.length).toBeGreaterThan(0);
 
-        frameState.commandList.length = 0;
-        primitive.update(frameState);
-        expect(frameState.afterRender.length).toEqual(1);
-
-        frameState.afterRender[0]();
-        frameState.commandList.length = 0;
-        primitive.update(frameState);
-        expect(frameState.commandList.length).toBeGreaterThan(0);
-
-        frameState.commandList.length = 0;
         primitive.show = false;
-        primitive.update(frameState);
-        expect(frameState.commandList.length).toEqual(0);
+        scene.renderForSpecs();
+        expect(scene.frameState.commandList.length).toEqual(0);
     });
 
     it('becomes ready when show is false', function() {
@@ -299,7 +287,7 @@ describe('Scene/ClassificationPrimitive', function() {
             return;
         }
 
-        primitive = scene.groundPrimitives.add(new ClassificationPrimitive({
+        primitive = scene.primitives.add(new ClassificationPrimitive({
             geometryInstances : boxInstance
         }));
         primitive.show = false;
@@ -310,7 +298,7 @@ describe('Scene/ClassificationPrimitive', function() {
         });
 
         return pollToPromise(function() {
-            scene.render();
+            scene.renderForSpecs();
             return ready;
         }).then(function() {
             expect(ready).toEqual(true);
@@ -354,7 +342,7 @@ describe('Scene/ClassificationPrimitive', function() {
 
         expectRenderBlank();
 
-        scene.groundPrimitives.add(primitive);
+        scene.primitives.add(primitive);
 
         primitive.classificationType = ClassificationType.BOTH;
         globePrimitive.show = false;
@@ -511,7 +499,7 @@ describe('Scene/ClassificationPrimitive', function() {
         scene.primitives.add(tilesetPrimitive);
         expect(scene).toRender(invertedColor);
 
-        scene.groundPrimitives.add(primitive);
+        scene.primitives.add(primitive);
         expect(scene).toRender(boxColor);
 
         primitive.getGeometryInstanceAttributes('box').show = [0];
@@ -550,7 +538,7 @@ describe('Scene/ClassificationPrimitive', function() {
         scene.primitives.add(tilesetPrimitive);
         expect(scene).toRender(invertedColor);
 
-        scene.groundPrimitives.add(primitive);
+        scene.primitives.add(primitive);
         expect(scene).toRender(boxColor);
 
         primitive.getGeometryInstanceAttributes('box').show = [0];
@@ -570,7 +558,7 @@ describe('Scene/ClassificationPrimitive', function() {
             debugShowBoundingVolume : true
         });
 
-        scene.groundPrimitives.add(primitive);
+        scene.primitives.add(primitive);
         scene.camera.setView({ destination : rectangle });
         expect(scene).toRenderAndCall(function(rgba) {
             expect(rgba[1]).toBeGreaterThanOrEqualTo(0);
@@ -591,7 +579,7 @@ describe('Scene/ClassificationPrimitive', function() {
             debugShowShadowVolume : true
         });
 
-        scene.groundPrimitives.add(primitive);
+        scene.primitives.add(primitive);
         scene.camera.setView({ destination : rectangle });
         expect(scene).toRenderAndCall(function(rgba) {
             expect(rgba[1]).toBeGreaterThanOrEqualTo(0);
@@ -633,9 +621,9 @@ describe('Scene/ClassificationPrimitive', function() {
         scene.primitives.removeAll();
         scene.primitives.destroyPrimitives = true;
 
-        scene.groundPrimitives.destroyPrimitives = false;
-        scene.groundPrimitives.removeAll();
-        scene.groundPrimitives.destroyPrimitives = true;
+        scene.primitives.destroyPrimitives = false;
+        scene.primitives.removeAll();
+        scene.primitives.destroyPrimitives = true;
 
         var newColor = [255, 255, 255, 255];
         var attributes = primitive.getGeometryInstanceAttributes('box');
@@ -663,9 +651,9 @@ describe('Scene/ClassificationPrimitive', function() {
         scene.primitives.removeAll();
         scene.primitives.destroyPrimitives = true;
 
-        scene.groundPrimitives.destroyPrimitives = false;
-        scene.groundPrimitives.removeAll();
-        scene.groundPrimitives.destroyPrimitives = true;
+        scene.primitives.destroyPrimitives = false;
+        scene.primitives.removeAll();
+        scene.primitives.destroyPrimitives = true;
 
         var attributes = primitive.getGeometryInstanceAttributes('box');
         expect(attributes.show).toBeDefined();
@@ -777,13 +765,10 @@ describe('Scene/ClassificationPrimitive', function() {
             compressVertices : false
         });
 
-        var frameState = scene.frameState;
-        frameState.afterRender.length = 0;
+        scene.primitives.add(primitive);
+
         return pollToPromise(function() {
-            for (var i = 0; i < frameState.afterRender.length; ++i) {
-                frameState.afterRender[i]();
-            }
-            primitive.update(frameState);
+            scene.renderForSpecs();
             return primitive.ready;
         }).then(function() {
             return primitive.readyPromise.then(function(arg) {
@@ -811,20 +796,11 @@ describe('Scene/ClassificationPrimitive', function() {
             compressVertices : false
         });
 
-        var frameState = scene.frameState;
-        frameState.afterRender.length = 0;
-        return pollToPromise(function() {
-            for (var i = 0; i < frameState.afterRender.length; ++i) {
-                frameState.afterRender[i]();
-                return true;
-            }
-            primitive.update(frameState);
-            return false;
-        }).then(function() {
-            return primitive.readyPromise.then(function(arg) {
-                expect(arg).toBe(primitive);
-                expect(primitive.ready).toBe(true);
-            });
+        scene.primitives.add(primitive);
+        scene.renderForSpecs();
+        return primitive.readyPromise.then(function(arg) {
+            expect(arg).toBe(primitive);
+            expect(primitive.ready).toBe(true);
         });
     });
 
@@ -1026,7 +1002,7 @@ describe('Scene/ClassificationPrimitive', function() {
             expect(rgba[0]).toEqual(0);
         });
 
-        scene.groundPrimitives.add(primitive);
+        scene.primitives.add(primitive);
         expect(scene).toRender([255, 255, 0, 255]);
 
         // become incompatible
@@ -1067,13 +1043,10 @@ describe('Scene/ClassificationPrimitive', function() {
             allowPicking : false
         });
 
-        var frameState = scene.frameState;
+        scene.primitives.add(primitive);
 
         return pollToPromise(function() {
-            primitive.update(frameState);
-            for (var i = 0; i < frameState.afterRender.length; ++i) {
-                frameState.afterRender[i]();
-            }
+            scene.renderForSpecs();
             return primitive.ready;
         }).then(function() {
             var attributes = primitive.getGeometryInstanceAttributes('box');
@@ -1142,29 +1115,38 @@ describe('Scene/ClassificationPrimitive', function() {
             geometryInstances : boxInstance
         });
 
-        var frameState = scene.frameState;
+        scene.primitives.add(primitive);
 
         return pollToPromise(function() {
-            primitive.update(frameState);
-            for (var i = 0; i < frameState.afterRender.length; ++i) {
-                frameState.afterRender[i]();
-            }
+            scene.renderForSpecs();
             return primitive.ready;
         }).then(function() {
+            scene.primitives.destroyPrimitives = false;
+            scene.primitives.removeAll();
+            scene.primitives.destroyPrimitives = true;
+
             verifyClassificationPrimitiveRender(primitive, boxColor);
         });
     });
 
-    it('destroy before asynchonous pipeline is complete', function() {
+    it('destroy before asynchronous pipeline is complete', function() {
+        if (!ClassificationPrimitive.isSupported(scene)) {
+            return;
+        }
+
         primitive = new ClassificationPrimitive({
             geometryInstances : boxInstance
         });
 
-        var frameState = scene.frameState;
-        primitive.update(frameState);
+        scene.primitives.add(primitive);
 
+        scene.renderForSpecs();
         primitive.destroy();
         expect(primitive.isDestroyed()).toEqual(true);
+
+        scene.primitives.destroyPrimitives = false;
+        scene.primitives.removeAll();
+        scene.primitives.destroyPrimitives = true;
     });
 
 }, 'WebGL');

--- a/Specs/Scene/ClassificationPrimitiveSpec.js
+++ b/Specs/Scene/ClassificationPrimitiveSpec.js
@@ -1121,6 +1121,7 @@ describe('Scene/ClassificationPrimitive', function() {
             scene.renderForSpecs();
             return primitive.ready;
         }).then(function() {
+            // verifyClassificationPrimitiveRender adds the primitive, so remove it to avoid being added twice.
             scene.primitives.destroyPrimitives = false;
             scene.primitives.removeAll();
             scene.primitives.destroyPrimitives = true;
@@ -1144,6 +1145,7 @@ describe('Scene/ClassificationPrimitive', function() {
         primitive.destroy();
         expect(primitive.isDestroyed()).toEqual(true);
 
+        // The primitive has already been destroyed, so remove it from the scene so it doesn't get destroyed again.
         scene.primitives.destroyPrimitives = false;
         scene.primitives.removeAll();
         scene.primitives.destroyPrimitives = true;

--- a/Specs/Scene/GroundPolylinePrimitiveSpec.js
+++ b/Specs/Scene/GroundPolylinePrimitiveSpec.js
@@ -87,7 +87,6 @@ describe('Scene/GroundPolylinePrimitive', function() {
 
     beforeEach(function() {
         scene.morphTo3D(0);
-        scene.render(); // clear any afterRender commands
 
         var depthpolylineColorAttribute = ColorGeometryInstanceAttribute.fromColor(new Color(0.0, 0.0, 1.0, 1.0));
         depthColor = depthpolylineColorAttribute.value;
@@ -235,11 +234,9 @@ describe('Scene/GroundPolylinePrimitive', function() {
             asynchronous : false
         });
 
-        var frameState = scene.frameState;
-        frameState.commandList.length = 0;
-
-        groundPolylinePrimitive.update(frameState);
-        expect(frameState.commandList.length).toEqual(0);
+        scene.groundPrimitives.add(groundPolylinePrimitive);
+        scene.renderForSpecs();
+        expect(scene.frameState.commandList.length).toEqual(0);
     });
 
     it('does not render when show is false', function() {
@@ -252,21 +249,13 @@ describe('Scene/GroundPolylinePrimitive', function() {
             asynchronous : false
         });
 
-        var frameState = scene.frameState;
+        scene.groundPrimitives.add(groundPolylinePrimitive);
+        scene.renderForSpecs();
+        expect(scene.frameState.commandList.length).toBeGreaterThan(0);
 
-        frameState.commandList.length = 0;
-        groundPolylinePrimitive.update(frameState);
-        expect(frameState.afterRender.length).toEqual(1);
-
-        frameState.afterRender[0]();
-        frameState.commandList.length = 0;
-        groundPolylinePrimitive.update(frameState);
-        expect(frameState.commandList.length).toBeGreaterThan(0);
-
-        frameState.commandList.length = 0;
         groundPolylinePrimitive.show = false;
-        groundPolylinePrimitive.update(frameState);
-        expect(frameState.commandList.length).toEqual(0);
+        scene.renderForSpecs();
+        expect(scene.frameState.commandList.length).toEqual(0);
     });
 
     it('becomes ready when show is false', function() {
@@ -285,7 +274,7 @@ describe('Scene/GroundPolylinePrimitive', function() {
         });
 
         return pollToPromise(function() {
-            scene.render();
+            scene.renderForSpecs();
             return ready;
         }).then(function() {
             expect(ready).toEqual(true);
@@ -394,7 +383,7 @@ describe('Scene/GroundPolylinePrimitive', function() {
 
         // Morph to 2D first because 3D -> 2D/CV morph is difficult in single-pixel
         scene.morphTo2D(0);
-        scene.render();
+        scene.renderForSpecs();
 
         scene.morphToColumbusView(1);
         verifyGroundPolylinePrimitiveRender(lookPosition, groundPolylinePrimitive, polylineColor);
@@ -739,7 +728,7 @@ describe('Scene/GroundPolylinePrimitive', function() {
 
         // Morph to 2D first because 3D -> 2D/CV morph is difficult in single-pixel
         scene.morphTo2D(0);
-        scene.render();
+        scene.renderForSpecs();
 
         scene.morphToColumbusView(1);
         verifyGroundPolylinePrimitiveRender(lookPosition, groundPolylinePrimitive, polylineColor);
@@ -821,13 +810,10 @@ describe('Scene/GroundPolylinePrimitive', function() {
             appearance : new PolylineColorAppearance()
         });
 
-        var frameState = scene.frameState;
+        scene.groundPrimitives.add(groundPolylinePrimitive);
 
         return pollToPromise(function() {
-            groundPolylinePrimitive.update(frameState);
-            for (var i = 0; i < frameState.afterRender.length; ++i) {
-                frameState.afterRender[i]();
-            }
+            scene.renderForSpecs();
             return groundPolylinePrimitive.ready;
         }).then(function() {
             var attributes = groundPolylinePrimitive.getGeometryInstanceAttributes('polyline on terrain');
@@ -889,31 +875,40 @@ describe('Scene/GroundPolylinePrimitive', function() {
             appearance : new PolylineColorAppearance()
         });
 
-        var frameState = scene.frameState;
+        scene.groundPrimitives.add(groundPolylinePrimitive);
 
         return pollToPromise(function() {
-            groundPolylinePrimitive.update(frameState);
-            for (var i = 0; i < frameState.afterRender.length; ++i) {
-                frameState.afterRender[i]();
-            }
+            scene.renderForSpecs();
             return groundPolylinePrimitive.ready;
         }).then(function() {
+            scene.groundPrimitives.destroyPrimitives = false;
+            scene.groundPrimitives.removeAll();
+            scene.groundPrimitives.destroyPrimitives = true;
+
             verifyGroundPolylinePrimitiveRender(lookPosition, groundPolylinePrimitive, polylineColor);
         });
     });
 
     it('destroy before asynchronous pipeline is complete', function() {
+        if (!GroundPolylinePrimitive.isSupported(scene)) {
+            return;
+        }
+
         groundPolylinePrimitive = new GroundPolylinePrimitive({
             geometryInstances : groundPolylineInstance,
             asynchronous : true,
             appearance : new PolylineColorAppearance()
         });
 
-        var frameState = scene.frameState;
-        groundPolylinePrimitive.update(frameState);
+        scene.groundPrimitives.add(groundPolylinePrimitive);
 
+        scene.renderForSpecs();
         groundPolylinePrimitive.destroy();
         expect(groundPolylinePrimitive.isDestroyed()).toEqual(true);
+
+        scene.groundPrimitives.destroyPrimitives = false;
+        scene.groundPrimitives.removeAll();
+        scene.groundPrimitives.destroyPrimitives = true;
     });
 
     it('creating a synchronous primitive throws if initializeTerrainHeights wasn\'t called', function() {
@@ -928,9 +923,11 @@ describe('Scene/GroundPolylinePrimitive', function() {
             asynchronous : false
         });
 
+        scene.groundPrimitives.add(groundPolylinePrimitive);
+
         if (GroundPolylinePrimitive.isSupported(scene)) {
             expect(function() {
-                groundPolylinePrimitive.update(scene.frameState);
+                scene.renderForSpecs();
             }).toThrowDeveloperError();
         }
 

--- a/Specs/Scene/GroundPolylinePrimitiveSpec.js
+++ b/Specs/Scene/GroundPolylinePrimitiveSpec.js
@@ -881,6 +881,7 @@ describe('Scene/GroundPolylinePrimitive', function() {
             scene.renderForSpecs();
             return groundPolylinePrimitive.ready;
         }).then(function() {
+            // verifyGroundPolylinePrimitiveRender adds the primitive, so remove it to avoid being added twice.
             scene.groundPrimitives.destroyPrimitives = false;
             scene.groundPrimitives.removeAll();
             scene.groundPrimitives.destroyPrimitives = true;
@@ -906,6 +907,7 @@ describe('Scene/GroundPolylinePrimitive', function() {
         groundPolylinePrimitive.destroy();
         expect(groundPolylinePrimitive.isDestroyed()).toEqual(true);
 
+        // The primitive has already been destroyed, so remove it from the scene so it doesn't get destroyed again.
         scene.groundPrimitives.destroyPrimitives = false;
         scene.groundPrimitives.removeAll();
         scene.groundPrimitives.destroyPrimitives = true;

--- a/Specs/Scene/GroundPrimitiveSpec.js
+++ b/Specs/Scene/GroundPrimitiveSpec.js
@@ -1297,6 +1297,7 @@ describe('Scene/GroundPrimitive', function() {
             scene.renderForSpecs();
             return primitive.ready;
         }).then(function() {
+            // verifyGroundPrimitiveRender adds the primitive, so remove it to avoid being added twice.
             scene.groundPrimitives.destroyPrimitives = false;
             scene.groundPrimitives.removeAll();
             scene.groundPrimitives.destroyPrimitives = true;
@@ -1320,6 +1321,7 @@ describe('Scene/GroundPrimitive', function() {
         primitive.destroy();
         expect(primitive.isDestroyed()).toEqual(true);
 
+        // The primitive has already been destroyed, so remove it from the scene so it doesn't get destroyed again.
         scene.groundPrimitives.destroyPrimitives = false;
         scene.groundPrimitives.removeAll();
         scene.groundPrimitives.destroyPrimitives = true;

--- a/Specs/Scene/GroundPrimitiveSpec.js
+++ b/Specs/Scene/GroundPrimitiveSpec.js
@@ -134,7 +134,6 @@ describe('Scene/GroundPrimitive', function() {
 
     beforeEach(function() {
         scene.morphTo3D(0);
-        scene.render(); // clear any afterRender commands
 
         rectangle = Rectangle.fromDegrees(-80.0, 20.0, -70.0, 30.0);
 
@@ -270,11 +269,9 @@ describe('Scene/GroundPrimitive', function() {
             asynchronous : false
         });
 
-        var frameState = scene.frameState;
-        frameState.commandList.length = 0;
-
-        primitive.update(frameState);
-        expect(frameState.commandList.length).toEqual(0);
+        scene.groundPrimitives.add(primitive);
+        scene.renderForSpecs();
+        expect(scene.frameState.commandList.length).toEqual(0);
     });
 
     it('does not render when show is false', function() {
@@ -287,21 +284,13 @@ describe('Scene/GroundPrimitive', function() {
             asynchronous : false
         });
 
-        var frameState = scene.frameState;
+        scene.groundPrimitives.add(primitive);
+        scene.renderForSpecs();
+        expect(scene.frameState.commandList.length).toBeGreaterThan(0);
 
-        frameState.commandList.length = 0;
-        primitive.update(frameState);
-        expect(frameState.afterRender.length).toEqual(1);
-
-        frameState.afterRender[0]();
-        frameState.commandList.length = 0;
-        primitive.update(frameState);
-        expect(frameState.commandList.length).toBeGreaterThan(0);
-
-        frameState.commandList.length = 0;
         primitive.show = false;
-        primitive.update(frameState);
-        expect(frameState.commandList.length).toEqual(0);
+        scene.renderForSpecs();
+        expect(scene.frameState.commandList.length).toEqual(0);
     });
 
     it('becomes ready when show is false', function() {
@@ -321,7 +310,7 @@ describe('Scene/GroundPrimitive', function() {
         });
 
         return pollToPromise(function() {
-            scene.render();
+            scene.renderForSpecs();
             return ready;
         }).then(function() {
             expect(ready).toEqual(true);
@@ -533,7 +522,7 @@ describe('Scene/GroundPrimitive', function() {
         });
 
         function verifyLargerScene(groundPrimitive, expectedColor, destination) {
-            largeScene.render();
+            largeScene.renderForSpecs();
 
             largeScene.postProcessStages.fxaa.enabled = false;
             largeScene.camera.setView({destination : destination});
@@ -1081,13 +1070,10 @@ describe('Scene/GroundPrimitive', function() {
             compressVertices : false
         });
 
-        var frameState = scene.frameState;
-        frameState.afterRender.length = 0;
+        scene.groundPrimitives.add(primitive);
+
         return pollToPromise(function() {
-            for (var i = 0; i < frameState.afterRender.length; ++i) {
-                frameState.afterRender[i]();
-            }
-            primitive.update(frameState);
+            scene.renderForSpecs();
             return primitive.ready;
         }).then(function() {
             return primitive.readyPromise.then(function(arg) {
@@ -1115,13 +1101,10 @@ describe('Scene/GroundPrimitive', function() {
             compressVertices : false
         });
 
-        var frameState = scene.frameState;
-        frameState.afterRender.length = 0;
+        scene.groundPrimitives.add(primitive);
+
         return pollToPromise(function() {
-            for (var i = 0; i < frameState.afterRender.length; ++i) {
-                frameState.afterRender[i]();
-            }
-            primitive.update(frameState);
+            scene.renderForSpecs();
             return primitive.ready;
         }).then(function() {
             return primitive.readyPromise.then(function(arg) {
@@ -1236,13 +1219,10 @@ describe('Scene/GroundPrimitive', function() {
             allowPicking : false
         });
 
-        var frameState = scene.frameState;
+        scene.groundPrimitives.add(primitive);
 
         return pollToPromise(function() {
-            primitive.update(frameState);
-            for (var i = 0; i < frameState.afterRender.length; ++i) {
-                frameState.afterRender[i]();
-            }
+            scene.renderForSpecs();
             return primitive.ready;
         }).then(function() {
             var attributes = primitive.getGeometryInstanceAttributes('rectangle');
@@ -1311,29 +1291,38 @@ describe('Scene/GroundPrimitive', function() {
             geometryInstances : rectangleInstance
         });
 
-        var frameState = scene.frameState;
+        scene.groundPrimitives.add(primitive);
 
         return pollToPromise(function() {
-            primitive.update(frameState);
-            for (var i = 0; i < frameState.afterRender.length; ++i) {
-                frameState.afterRender[i]();
-            }
+            scene.renderForSpecs();
             return primitive.ready;
         }).then(function() {
+            scene.groundPrimitives.destroyPrimitives = false;
+            scene.groundPrimitives.removeAll();
+            scene.groundPrimitives.destroyPrimitives = true;
+
             verifyGroundPrimitiveRender(primitive, rectColor);
         });
     });
 
-    it('destroy before asynchonous pipeline is complete', function() {
+    it('destroy before asynchronous pipeline is complete', function() {
+        if (!GroundPrimitive.isSupported(scene)) {
+            return;
+        }
+
         primitive = new GroundPrimitive({
             geometryInstances : rectangleInstance
         });
 
-        var frameState = scene.frameState;
-        primitive.update(frameState);
+        scene.groundPrimitives.add(primitive);
 
+        scene.renderForSpecs();
         primitive.destroy();
         expect(primitive.isDestroyed()).toEqual(true);
+
+        scene.groundPrimitives.destroyPrimitives = false;
+        scene.groundPrimitives.removeAll();
+        scene.groundPrimitives.destroyPrimitives = true;
     });
 
     it('creating a synchronous primitive throws if initializeTerrainHeights wasn\'t called', function() {
@@ -1348,9 +1337,11 @@ describe('Scene/GroundPrimitive', function() {
             asynchronous : false
         });
 
+        scene.groundPrimitives.add(primitive);
+
         if (GroundPrimitive.isSupported(scene)) {
             expect(function() {
-                primitive.update(scene.frameState);
+                scene.renderForSpecs();
             }).toThrowDeveloperError();
         }
 

--- a/Specs/Scene/PrimitiveSpec.js
+++ b/Specs/Scene/PrimitiveSpec.js
@@ -1282,7 +1282,7 @@ describe('Scene/Primitive', function() {
         });
     });
 
-    it('destroy before asynchonous pipeline is complete', function() {
+    it('destroy before asynchronous pipeline is complete', function() {
         primitive = new Primitive({
             geometryInstances : rectangleInstance1,
             appearance : new PerInstanceColorAppearance()


### PR DESCRIPTION
Fixes https://github.com/AnalyticalGraphicsInc/cesium/issues/8500

Updated `GroundPrimitiveSpec`, `GroundPolylinePrimitiveSpec`, and `ClassificationPrimitiveSpec` to use the `scene.primitives.add`/`scene.renderForSpecs` paradigm instead of manual `primitive.update(frameState)` wherever possible. This will hopefully fix intermittent CI failures in https://github.com/AnalyticalGraphicsInc/cesium/issues/8500.

I will refresh CI multiple times to make sure it's passing consistently and then bump for review.