### PR TITLE
8105 - Explicitly enable EXT_float_blend to silence WebGL warnings

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,7 +20,7 @@ Change Log
 
 ##### Fixes :wrench:
 * Fixed a bug where the camera could go underground during mouse navigation. [#8504](https://github.com/AnalyticalGraphicsInc/cesium/pull/8504)
-* Fixed WebGL warning message about `EXT_float_blend` being implicitly enabled
+* Fixed WebGL warning message about `EXT_float_blend` being implicitly enabled. [#8534](https://github.com/AnalyticalGraphicsInc/cesium/pull/8534)
 
 ### 1.65.0 - 2020-01-06
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,7 @@ Change Log
 
 ##### Fixes :wrench:
 * Fixed a bug where the camera could go underground during mouse navigation. [#8504](https://github.com/AnalyticalGraphicsInc/cesium/pull/8504)
+* Fixed WebGL warning message about `EXT_float_blend` being implicitly enabled
 
 ### 1.65.0 - 2020-01-06
 

--- a/Source/Renderer/Context.js
+++ b/Source/Renderer/Context.js
@@ -251,6 +251,7 @@ import VertexArray from './VertexArray.js';
         this._textureHalfFloatLinear = !!getExtension(gl, ['OES_texture_half_float_linear']);
 
         this._colorBufferFloat = !!getExtension(gl, ['EXT_color_buffer_float', 'WEBGL_color_buffer_float']);
+        this._floatBlend = !!getExtension(gl, ['EXT_float_blend']);
         this._colorBufferHalfFloat = !!getExtension(gl, ['EXT_color_buffer_half_float']);
 
         this._s3tc = !!getExtension(gl, ['WEBGL_compressed_texture_s3tc', 'MOZ_WEBGL_compressed_texture_s3tc', 'WEBKIT_WEBGL_compressed_texture_s3tc']);
@@ -497,6 +498,19 @@ import VertexArray from './VertexArray.js';
         standardDerivatives : {
             get : function() {
                 return this._standardDerivatives || this._webgl2;
+            }
+        },
+
+        /**
+         * <code>true</code> if the EXT_float_blend extension is supported. This
+         * extension enables blending with 32-bit float values.
+         * @memberof Context.prototype
+         * @type {Boolean}
+         * @see {@link https://www.khronos.org/registry/webgl/extensions/EXT_float_blend/}
+         */
+        floatBlend : {
+            get : function() {
+                return this._floatBlend;
             }
         },
 


### PR DESCRIPTION
Fixes #8105 

You can test this PR by:

1) Opening http://localhost:8080/Apps/Sandcastle/index.html?src=Billboards.html in Firefox and observing `Error: WebGL warning: drawElementsInstanced: Using format enabled by implicitly enabled extension: EXT_float_blend. For maximal portability enable it explicitly. Context.js:321:37` is printed to the console.
2) Building with this PR and verifying this message is no longer logged. 

I'm using Firefox 72.0.1 on Windows 10.0.18363.418, Couldn't reproduce warning message in Chrome 79.0.3945.117 