### PR TITLE
Update tile statistics immediately after failure

### DIFF
--- a/Source/Scene/Cesium3DTile.js
+++ b/Source/Scene/Cesium3DTile.js
@@ -776,8 +776,13 @@ import TileOrientedBoundingBox from './TileOrientedBoundingBox.js';
         }
     }
 
-    function getContentFailedFunction(tile) {
+    function getContentFailedFunction(tile, tileset) {
         return function(error) {
+            if (tile._contentState === Cesium3DTileContentState.PROCESSING) {
+                --tileset.statistics.numberOfTilesProcessing;
+            } else {
+                --tileset.statistics.numberOfPendingRequests;
+            }
             tile._contentState = Cesium3DTileContentState.FAILED;
             tile._contentReadyPromise.reject(error);
             tile._contentReadyToProcessPromise.reject(error);
@@ -841,7 +846,7 @@ import TileOrientedBoundingBox from './TileOrientedBoundingBox.js';
             this.expireDate = undefined;
         }
 
-        var contentFailedFunction = getContentFailedFunction(this);
+        var contentFailedFunction = getContentFailedFunction(this, tileset);
         promise.then(function(arrayBuffer) {
             if (that.isDestroyed()) {
                 // Tile is unloaded before the content finishes loading

--- a/Source/Scene/Cesium3DTileset.js
+++ b/Source/Scene/Cesium3DTileset.js
@@ -1756,14 +1756,6 @@ import TileOrientedBoundingBox from './TileOrientedBoundingBox.js';
 
     function handleTileFailure(tileset, tile) {
         return function(error) {
-            if (tileset._processingQueue.indexOf(tile) >= 0) {
-                // Failed during processing
-                --tileset._statistics.numberOfTilesProcessing;
-            } else {
-                // Failed when making request
-                --tileset._statistics.numberOfPendingRequests;
-            }
-
             var url = tile._contentResource.url;
             var message = defined(error.message) ? error.message : error.toString();
             if (tileset.tileFailed.numberOfListeners > 0) {


### PR DESCRIPTION
CC https://github.com/AnalyticalGraphicsInc/cesium/pull/8525#issuecomment-573757923

This doesn't fix a current bug but it fixes a potential bug if promises handling is no longer synchronous once https://github.com/AnalyticalGraphicsInc/cesium/pull/8525 is merged.

The tile failure handler in `Cesium3DTileset` only knows that a tile's state is FAILED and doesn't know whether to decrement the `numberOfTilesProcessing` or `numberOfPendingRequests` statistic. The previous code determined the right statistic by checking if the tile was in the processing queue. This was safe at the time because the failure handler got called before the processing queue got cleared the next update. But with https://github.com/AnalyticalGraphicsInc/cesium/pull/8525 there's no guarantee of that so it's safer to update the statistics in a different way.

The change itself is pretty simple, similar logic but moved into `Cesium3DTile` and now less fragile.