### PR TITLE
Cache the font information

### DIFF
--- a/Source/Scene/Label.js
+++ b/Source/Scene/Label.js
@@ -17,6 +17,7 @@ import SDFSettings from './SDFSettings.js';
 import VerticalOrigin from './VerticalOrigin.js';
 
     var fontInfoCache = {};
+    var fontInfoCacheMaxSize = 256;
 
     var textTypes = freezeObject({
         LTR : 0,
@@ -62,7 +63,9 @@ import VerticalOrigin from './VerticalOrigin.js';
             };
 
             document.body.removeChild(div);
-            fontInfoCache[label._font] = fontInfo;
+            if (Object.keys(fontInfoCache).length < fontInfoCacheMaxSize) {
+                fontInfoCache[label._font] = fontInfo;
+            }
         }
         label._fontFamily = fontInfo.family;
         label._fontSize = fontInfo.size;

--- a/Source/Scene/Label.js
+++ b/Source/Scene/Label.js
@@ -17,6 +17,7 @@ import SDFSettings from './SDFSettings.js';
 import VerticalOrigin from './VerticalOrigin.js';
 
     var fontInfoCache = {};
+    var fontInfoCacheLength = 0;
     var fontInfoCacheMaxSize = 256;
 
     var textTypes = freezeObject({
@@ -63,8 +64,9 @@ import VerticalOrigin from './VerticalOrigin.js';
             };
 
             document.body.removeChild(div);
-            if (Object.keys(fontInfoCache).length < fontInfoCacheMaxSize) {
+            if (fontInfoCacheLength < fontInfoCacheMaxSize) {
                 fontInfoCache[label._font] = fontInfo;
+                fontInfoCacheLength++;
             }
         }
         label._fontFamily = fontInfo.family;

--- a/Source/Scene/Label.js
+++ b/Source/Scene/Label.js
@@ -16,6 +16,8 @@ import LabelStyle from './LabelStyle.js';
 import SDFSettings from './SDFSettings.js';
 import VerticalOrigin from './VerticalOrigin.js';
 
+    var fontInfoCache = {};
+
     var textTypes = freezeObject({
         LTR : 0,
         RTL : 1,
@@ -44,18 +46,28 @@ import VerticalOrigin from './VerticalOrigin.js';
     }
 
     function parseFont(label) {
-        var div = document.createElement('div');
-        div.style.position = 'absolute';
-        div.style.opacity = 0;
-        div.style.font = label._font;
-        document.body.appendChild(div);
+        var fontInfo = fontInfoCache[label._font];
+        if (!defined(fontInfo)) {
+            var div = document.createElement('div');
+            div.style.position = 'absolute';
+            div.style.opacity = 0;
+            div.style.font = label._font;
+            document.body.appendChild(div);
 
-        label._fontFamily = getCSSValue(div,'font-family');
-        label._fontSize = getCSSValue(div,'font-size').replace('px', '');
-        label._fontStyle = getCSSValue(div,'font-style');
-        label._fontWeight = getCSSValue(div,'font-weight');
+            fontInfo = {
+                family : getCSSValue(div, 'font-family'),
+                size : getCSSValue(div, 'font-size').replace('px', ''),
+                style : getCSSValue(div, 'font-style'),
+                weight : getCSSValue(div, 'font-weight')
+            };
 
-        document.body.removeChild(div);
+            document.body.removeChild(div);
+            fontInfoCache[label._font] = fontInfo;
+        }
+        label._fontFamily = fontInfo.family;
+        label._fontSize = fontInfo.size;
+        label._fontStyle = fontInfo.style;
+        label._fontWeight = fontInfo.weight;
     }
 
     /**


### PR DESCRIPTION
This is a pull request to improve to label performances.

Instead of parsing the font for each label, a cache is used to store the information.
Adding an element to the dom and calling getComputedStyle forces a reflow and is bad for the performance.

The cache is just and object and is never cleared because I've assumed the it won't get very big.

Thoughts?
