### PR TITLE
Change ReferenceProperty to return undefined instead of throw

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,6 +25,7 @@ Change Log
 * Reduced Cesium bundle size by avoiding unnecessarily importing `Cesium3DTileset` in `Picking.js` [#8532](https://github.com/AnalyticalGraphicsInc/cesium/pull/8532)
 * Fixed WebGL warning message about `EXT_float_blend` being implicitly enabled. [#8534](https://github.com/AnalyticalGraphicsInc/cesium/pull/8534)
 * Fixed a bug where toggling point cloud classification visibility would result in a grey screen on Linux / Nvidia [#8538](https://github.com/AnalyticalGraphicsInc/cesium/pull/8538)
+* Fixed a crash when deleting and re-creating polylines from CZML. `ReferenceProperty` now returns undefined when the target entity or property does not exist, instead of throwing. [#8544](https://github.com/AnalyticalGraphicsInc/cesium/pull/8544)
 
 ### 1.65.0 - 2020-01-06
 


### PR DESCRIPTION
Change `ReferenceProperty` to return undefined when asked for values and the target entity (or target property) does not exist.

This differs from the previous behavior, which was to throw. Throwing can lead to situations where it is effectively impossible to delete and re-create a property which is referenced.

In general, visualizers have always needed to be written to expect the values to properties to suddenly become undefined, which they generally deal with by hiding or removing the related primitives.

Fixes #8521