### PR TITLE
8321/polyline crash

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -41,6 +41,7 @@ Change Log
 * Fixed a bug where toggling point cloud classification visibility would result in a grey screen on Linux / Nvidia [#8538](https://github.com/AnalyticalGraphicsInc/cesium/pull/8538)
 * Fixed a bug where a point in a `PointPrimitiveCollection` is rendered in the middle of the screen instead of being clipped. [#8542](https://github.com/AnalyticalGraphicsInc/cesium/pull/8542)
 * Fixed a crash when deleting and re-creating polylines from CZML. `ReferenceProperty` now returns undefined when the target entity or property does not exist, instead of throwing. [#8544](https://github.com/AnalyticalGraphicsInc/cesium/pull/8544)
+* Fixed a bug where rapidly updating a PolylineCollection could result in an instanceIndex is out of range error [#8546](https://github.com/AnalyticalGraphicsInc/cesium/pull/8546)
 
 ### 1.65.0 - 2020-01-06
 

--- a/Source/Scene/Polyline.js
+++ b/Source/Scene/Polyline.js
@@ -286,7 +286,7 @@ import Material from './Material.js';
         },
 
         /**
-         * Gets the destruction status of Polyline
+         * Gets the destruction status of this polyline
          * @memberof Polyline.prototype
          * @type {Boolean}
          * @default undefined

--- a/Source/Scene/Polyline.js
+++ b/Source/Scene/Polyline.js
@@ -289,7 +289,7 @@ import Material from './Material.js';
          * Gets the destruction status of this polyline
          * @memberof Polyline.prototype
          * @type {Boolean}
-         * @default undefined
+         * @default false
          * @private
          */
         isDestroyed : {

--- a/Source/Scene/Polyline.js
+++ b/Source/Scene/Polyline.js
@@ -286,6 +286,19 @@ import Material from './Material.js';
         },
 
         /**
+         * Gets the destruction status of Polyline
+         * @memberof Polyline.prototype
+         * @type {Boolean}
+         * @default undefined
+         * @private
+         */
+        isDestroyed : {
+            get : function() {
+                return !defined(this._polylineCollection);
+            }
+        },
+
+        /**
          * Gets or sets the condition specifying at what distance from the camera that this polyline will be displayed.
          * @memberof Polyline.prototype
          * @type {DistanceDisplayCondition}

--- a/Source/Scene/PolylineCollection.js
+++ b/Source/Scene/PolylineCollection.js
@@ -258,12 +258,6 @@ import SceneMode from './SceneMode.js';
     PolylineCollection.prototype.remove = function(polyline) {
         if (this.contains(polyline)) {
             this._polylines[polyline._index] = undefined; // Removed later
-
-            var polylineUpdateIndex = this._polylinesToUpdate.indexOf(polyline);
-            if (polylineUpdateIndex !== -1) {
-                this._polylinesToUpdate.splice(polylineUpdateIndex, 1);
-            }
-
             this._polylinesRemoved = true;
             this._createVertexArray = true;
             this._createBatchTable = true;

--- a/Source/Scene/PolylineCollection.js
+++ b/Source/Scene/PolylineCollection.js
@@ -1050,17 +1050,18 @@ import SceneMode from './SceneMode.js';
         if (collection._polylinesRemoved) {
             collection._polylinesRemoved = false;
 
-            const definedPolylines = [];
-            let i=0;
-            for (let polyline of collection._polylines) {
+            var definedPolylines = [];
+            var i=0;
+            var polyline;
+            for (polyline of collection._polylines) {
                 if (defined(polyline)) {
                     polyline._index = i++;
                     definedPolylines.push(polyline);
                 }
             }
 
-            const definedPolylinesToUpdate = [];
-            for (let polyline of collection._polylinesToUpdate) {
+            var definedPolylinesToUpdate = [];
+            for (polyline of collection._polylinesToUpdate) {
                 if (defined(polyline._polylineCollection)) {
                     definedPolylinesToUpdate.push(polyline);
                 }

--- a/Source/Scene/PolylineCollection.js
+++ b/Source/Scene/PolylineCollection.js
@@ -257,6 +257,12 @@ import SceneMode from './SceneMode.js';
      */
     PolylineCollection.prototype.remove = function(polyline) {
         if (this.contains(polyline)) {
+
+            var index = this._polylinesToUpdate.indexOf(polyline);
+            if (index !== -1) {
+                this._polylinesToUpdate.splice(index, 1);
+            }
+
             this._polylinesRemoved = true;
             this._createVertexArray = true;
             this._createBatchTable = true;

--- a/Source/Scene/PolylineCollection.js
+++ b/Source/Scene/PolylineCollection.js
@@ -1049,10 +1049,13 @@ import SceneMode from './SceneMode.js';
     function removePolylines(collection) {
         if (collection._polylinesRemoved) {
             collection._polylinesRemoved = false;
+
             collection._polylines = collection._polylines
                                         .filter((polyline) => defined(polyline))
                                         .map((polyline, index) => {polyline._index = index; return polyline;});
 
+            collection._polylinesToUpdate = collection._polylinesToUpdate
+                                        .filter((polyline) => defined(polyline._polylineCollection));
         }
     }
 

--- a/Source/Scene/PolylineCollection.js
+++ b/Source/Scene/PolylineCollection.js
@@ -1049,20 +1049,23 @@ import SceneMode from './SceneMode.js';
     function removePolylines(collection) {
         if (collection._polylinesRemoved) {
             collection._polylinesRemoved = false;
-
             var definedPolylines = [];
-            var i=0;
+            var polyIndex=0;
             var polyline;
-            for (polyline of collection._polylines) {
+            var i;
+
+            for (i=0; i < collection._polylines.length; ++i) {
+                polyline = collection._polylines[i];
                 if (defined(polyline)) {
-                    polyline._index = i++;
+                    polyline._index = polyIndex++;
                     definedPolylines.push(polyline);
                 }
             }
 
             var definedPolylinesToUpdate = [];
-            for (polyline of collection._polylinesToUpdate) {
-                if (defined(polyline._polylineCollection)) {
+            for (i=0; i < collection._polylinesToUpdate.length; ++i) {
+                polyline = collection._polylines[i];
+                if (defined(polyline) && defined(polyline._polylineCollection)) {
                     definedPolylinesToUpdate.push(polyline);
                 }
             }

--- a/Source/Scene/PolylineCollection.js
+++ b/Source/Scene/PolylineCollection.js
@@ -1101,7 +1101,7 @@ import SceneMode from './SceneMode.js';
         var polylines = collection._polylines;
         var length = polylines.length;
         for ( var i = 0; i < length; ++i) {
-            if (polylines[i].isDestroyed) {
+            if (!polylines[i].isDestroyed) {
                 polylines[i]._destroy();
             }
         }

--- a/Source/Scene/PolylineCollection.js
+++ b/Source/Scene/PolylineCollection.js
@@ -1050,12 +1050,24 @@ import SceneMode from './SceneMode.js';
         if (collection._polylinesRemoved) {
             collection._polylinesRemoved = false;
 
-            collection._polylines = collection._polylines
-                                        .filter((polyline) => defined(polyline))
-                                        .map((polyline, index) => {polyline._index = index; return polyline;});
+            const definedPolylines = [];
+            let i=0;
+            for (let polyline of collection._polylines) {
+                if (defined(polyline)) {
+                    polyline._index = i++;
+                    definedPolylines.push(polyline);
+                }
+            }
 
-            collection._polylinesToUpdate = collection._polylinesToUpdate
-                                        .filter((polyline) => defined(polyline._polylineCollection));
+            const definedPolylinesToUpdate = [];
+            for (let polyline of collection._polylinesToUpdate) {
+                if (defined(polyline._polylineCollection)) {
+                    definedPolylinesToUpdate.push(polyline);
+                }
+            }
+
+            collection._polylines = definedPolylines;
+            collection._polylinesToUpdate = definedPolylinesToUpdate;
         }
     }
 

--- a/Source/Scene/PolylineCollection.js
+++ b/Source/Scene/PolylineCollection.js
@@ -257,12 +257,6 @@ import SceneMode from './SceneMode.js';
      */
     PolylineCollection.prototype.remove = function(polyline) {
         if (this.contains(polyline)) {
-
-            var index = this._polylinesToUpdate.indexOf(polyline);
-            if (index !== -1) {
-                this._polylinesToUpdate.splice(index, 1);
-            }
-
             this._polylinesRemoved = true;
             this._createVertexArray = true;
             this._createBatchTable = true;

--- a/Source/Scene/PolylineCollection.js
+++ b/Source/Scene/PolylineCollection.js
@@ -1043,11 +1043,11 @@ import SceneMode from './SceneMode.js';
         if (collection._polylinesRemoved) {
             collection._polylinesRemoved = false;
             var definedPolylines = [];
+            var definedPolylinesToUpdate = [];
             var polyIndex = 0;
             var polyline;
 
             var length = collection._polylines.length;
-            var definedPolylinesToUpdate = [];
             for (var i = 0; i < length; ++i) {
                 polyline = collection._polylines[i];
                 if (!polyline.isDestroyed) {

--- a/Source/Scene/PolylineCollection.js
+++ b/Source/Scene/PolylineCollection.js
@@ -257,7 +257,6 @@ import SceneMode from './SceneMode.js';
      */
     PolylineCollection.prototype.remove = function(polyline) {
         if (this.contains(polyline)) {
-            this._polylines[polyline._index] = undefined; // Removed later
             this._polylinesRemoved = true;
             this._createVertexArray = true;
             this._createBatchTable = true;
@@ -1046,13 +1045,12 @@ import SceneMode from './SceneMode.js';
             var definedPolylines = [];
             var polyIndex = 0;
             var polyline;
-            var i;
 
             var length = collection._polylines.length;
             var definedPolylinesToUpdate = [];
-            for (i = 0; i < length; ++i) {
+            for (var i = 0; i < length; ++i) {
                 polyline = collection._polylines[i];
-                if (defined(polyline) && defined(polyline._polylineCollection)) {
+                if (!polyline.isDestroyed) {
                     polyline._index = polyIndex++;
                     definedPolylinesToUpdate.push(polyline);
                     definedPolylines.push(polyline);
@@ -1068,7 +1066,7 @@ import SceneMode from './SceneMode.js';
         var polylines = collection._polylines;
         var length = polylines.length;
         for ( var i = 0; i < length; ++i) {
-            if (defined(polylines[i])) {
+            if (!polylines[i].isDestroyed) {
                 var bucket = polylines[i]._bucket;
                 if (defined(bucket)) {
                     bucket.shaderProgram = bucket.shaderProgram && bucket.shaderProgram.destroy();
@@ -1097,7 +1095,7 @@ import SceneMode from './SceneMode.js';
         var polylines = collection._polylines;
         var length = polylines.length;
         for ( var i = 0; i < length; ++i) {
-            if (defined(polylines[i])) {
+            if (polylines[i].isDestroyed) {
                 polylines[i]._destroy();
             }
         }

--- a/Source/Scene/PolylineCollection.js
+++ b/Source/Scene/PolylineCollection.js
@@ -1044,23 +1044,18 @@ import SceneMode from './SceneMode.js';
         if (collection._polylinesRemoved) {
             collection._polylinesRemoved = false;
             var definedPolylines = [];
-            var polyIndex=0;
+            var polyIndex = 0;
             var polyline;
             var i;
 
-            for (i=0; i < collection._polylines.length; ++i) {
-                polyline = collection._polylines[i];
-                if (defined(polyline)) {
-                    polyline._index = polyIndex++;
-                    definedPolylines.push(polyline);
-                }
-            }
-
+            var length = collection._polylines.length;
             var definedPolylinesToUpdate = [];
-            for (i=0; i < collection._polylinesToUpdate.length; ++i) {
+            for (i = 0; i < length; ++i) {
                 polyline = collection._polylines[i];
                 if (defined(polyline) && defined(polyline._polylineCollection)) {
+                    polyline._index = polyIndex++;
                     definedPolylinesToUpdate.push(polyline);
+                    definedPolylines.push(polyline);
                 }
             }
 

--- a/Source/Scene/PolylineCollection.js
+++ b/Source/Scene/PolylineCollection.js
@@ -1049,19 +1049,10 @@ import SceneMode from './SceneMode.js';
     function removePolylines(collection) {
         if (collection._polylinesRemoved) {
             collection._polylinesRemoved = false;
+            collection._polylines = collection._polylines
+                                        .filter((polyline) => defined(polyline))
+                                        .map((polyline, index) => {polyline._index = index; return polyline;});
 
-            var polylines = [];
-
-            var length = collection._polylines.length;
-            for ( var i = 0, j = 0; i < length; ++i) {
-                var polyline = collection._polylines[i];
-                if (defined(polyline)) {
-                    polyline._index = j++;
-                    polylines.push(polyline);
-                }
-            }
-
-            collection._polylines = polylines;
         }
     }
 

--- a/Specs/Scene/PolylineCollectionSpec.js
+++ b/Specs/Scene/PolylineCollectionSpec.js
@@ -325,7 +325,7 @@ describe('Scene/PolylineCollection', function() {
 
         expect(polylines._polylinesToUpdate.length).toEqual(2);
         polylines.remove(secondPolyline);
-        polylines.update(scene._frameState);
+        polylines.update(scene.frameState);
 
         expect(polylines._polylinesToUpdate.length).toEqual(1);
     });
@@ -341,7 +341,7 @@ describe('Scene/PolylineCollection', function() {
         expect(polylines._polylinesToUpdate.length).toEqual(2);
 
         polylines.remove(secondPolyline);
-        polylines.update(scene._frameState);
+        polylines.update(scene.frameState);
 
         expect(polylines._polylinesToUpdate.length).toEqual(1);
     });

--- a/Specs/Scene/PolylineCollectionSpec.js
+++ b/Specs/Scene/PolylineCollectionSpec.js
@@ -316,7 +316,7 @@ describe('Scene/PolylineCollection', function() {
         expect(polylines.length).toEqual(0);
     });
 
-    it('removes a polyline from the updated list when removed', function() {
+    it('removal of polyline from polyLinesToUpdate is deferred until scene is updated', function() {
         var firstPolyline = polylines.add();
         var secondPolyline = polylines.add();
 
@@ -324,23 +324,24 @@ describe('Scene/PolylineCollection', function() {
         secondPolyline.width = 5;
 
         expect(polylines._polylinesToUpdate.length).toEqual(2);
-
         polylines.remove(secondPolyline);
+        polylines.update(scene._frameState);
 
         expect(polylines._polylinesToUpdate.length).toEqual(1);
     });
 
-    it('only adds polyline to the update list once', function() {
+    it('removal of polyline from polylinesToUpdate after polyline is made dirty multiple times', function() {
         var firstPolyline = polylines.add();
         var secondPolyline = polylines.add();
 
         firstPolyline.width = 4;
         secondPolyline.width = 5;
-        secondPolyline.width = 7;
+        secondPolyline.width = 7; // Making the polyline dirty twice shouldn't affect the length of `_polylinesToUpdate`
 
         expect(polylines._polylinesToUpdate.length).toEqual(2);
 
         polylines.remove(secondPolyline);
+        polylines.update(scene._frameState);
 
         expect(polylines._polylinesToUpdate.length).toEqual(1);
     });


### PR DESCRIPTION
Fixes #8321 

This crash is caused by `polyLinesToUpdate` becoming out of sync with `polyLines`.  If the position of a polyLine is marked as dirty (i.e `.position = ....` is invoked) and the polyline is marked for removal, the polyLine will remain in the polyLinesToUpdate array, but not the main polyLines array. The arrays become out of sync and a failure occurs when we try to update a deleted polyLine

Tested on Linux / Nvidia

Test case here: http://localhost:8080/Apps/Sandcastle/index.html#c=lZJPb5wwEMW/yohLWGllkuyty64akUukSKnUP5eSgwOzWyvGRmPDilb73TtgWEKiHsrJ9rx583s2rSRoFZ6QYAcGT5ChU00lfgxn8VUxbDNrvFQG6Wq1zU1uWu4qrNZYeGXNsvOL1Z1mbXapx31TGCJcgQZFTapSXrXohCzLeLYK9kkCGaH0CPVo5oDw2GhJusuNQ/9gPFIrdVwMumnmGm6ug8WhMYFtKYhX8Cc3wF8fYXLnADPCQDSK+q+2TvXn7tOUMJPkeSXNRhzIVvd4JER3RyS7+Oc1M6zhdg2b51UwOQeifsnBvtdlCDa6gj14NDNTM9SnfEz2Nu0l1ZwjIIYcYnbd/TfsdqSd73AkvmNAAgleVXzBzts6QCpzBGlKfpnKthjkDPuNZbbx/2ItNEq6BFqmnRgG3fwgYUA8pVyQDqjn3ETrKHW+07gPxc+qqi15aEjHQiQeq1rzJJe8NMUrelE413emydSUlqoFVe7y6N0vn0fMLJ3jyqHR+qv6jXm0TxPWL9q0lSVfyVOLpGXXS37d7B/DoRAiTXj7sctbq18kvXH8Cw