### PR TITLE
Fix BIM tileset in clipping planes sandcastle

### DIFF
--- a/Apps/Sandcastle/gallery/3D Tiles Clipping Planes.html
+++ b/Apps/Sandcastle/gallery/3D Tiles Clipping Planes.html
@@ -130,7 +130,9 @@ function loadTileset(url) {
             // The clipping plane is initially positioned at the tileset's root transform.
             // Apply an additional matrix to center the clipping plane on the bounding sphere center.
             var transformCenter = Cesium.Matrix4.getTranslation(tileset.root.transform, new Cesium.Cartesian3());
-            var height = Cesium.Cartesian3.distance(transformCenter, tileset.boundingSphere.center);
+            var transformCartographic = Cesium.Cartographic.fromCartesian(transformCenter);
+            var boundingSphereCartographic = Cesium.Cartographic.fromCartesian(tileset.boundingSphere.center);
+            var height = boundingSphereCartographic.height - transformCartographic.height;
             clippingPlanes.modelMatrix = Cesium.Matrix4.fromTranslation(new Cesium.Cartesian3(0.0, 0.0, height));
         }
 


### PR DESCRIPTION
Fixes https://github.com/AnalyticalGraphicsInc/cesium/issues/8053

The previous code only works if the tileset transform and bounding sphere center are along the same surface normal, which was true of the point cloud but not the BIM tileset in the `3D Tiles Clipping Planes` sandcastle.

![Capture](https://user-images.githubusercontent.com/915398/72687941-daff6280-3ad0-11ea-8c66-ae505fcec61a.JPG)
