### PR TITLE
Use Authorization header for ion tokens

### DIFF
--- a/Source/Core/IonResource.js
+++ b/Source/Core/IonResource.js
@@ -175,21 +175,10 @@ import RuntimeError from './RuntimeError.js';
             return Resource.prototype._makeRequest.call(this, options);
         }
 
-        var acceptToken = '*/*;access_token=' + this._ionEndpoint.accessToken;
-        var existingAccept = acceptToken;
-
-        var oldHeaders = this.headers;
-        if (defined(oldHeaders) && defined(oldHeaders.Accept)) {
-            existingAccept = oldHeaders.Accept + ',' + acceptToken;
-        }
-
         if (!defined(options.headers)) {
-            options.headers = { Accept: existingAccept };
-        } else if (!defined(options.headers.Accept)) {
-            options.headers.Accept = existingAccept;
-        } else {
-            options.headers.Accept = options.headers.Accept + ',' + acceptToken;
+            options.headers = {};
         }
+        options.headers.Authorization = 'Bearer ' + this._ionEndpoint.accessToken;
 
         return Resource.prototype._makeRequest.call(this, options);
     };

--- a/Specs/Core/IonResourceSpec.js
+++ b/Specs/Core/IonResourceSpec.js
@@ -148,11 +148,11 @@ describe('Core/IonResource', function() {
         Ion.defaultAccessToken = defaultAccessToken;
     });
 
-    it('Calls base _makeRequest with expected options when resource no Accept header is already defined', function() {
+    it('Calls base _makeRequest with expected options when resource no Authorization header is defined', function() {
         var originalOptions = {};
         var expectedOptions = {
             headers: {
-                Accept: '*/*;access_token=' + endpoint.accessToken
+                Authorization: 'Bearer ' + endpoint.accessToken
             }
         };
 
@@ -163,37 +163,18 @@ describe('Core/IonResource', function() {
         expect(_makeRequest).toHaveBeenCalledWith(expectedOptions);
     });
 
-    it('Calls base _makeRequest with expected options when resource Accept header is already defined', function() {
+    it('Calls base _makeRequest with expected options when resource Authorization header is already defined', function() {
         var originalOptions = {};
         var expectedOptions = {
             headers: {
-                Accept: 'application/json,*/*;access_token=' + endpoint.accessToken
+                Authorization: 'Bearer ' + endpoint.accessToken
             }
         };
 
         var _makeRequest = spyOn(Resource.prototype, '_makeRequest');
         var endpointResource = IonResource._createEndpointResource(assetId);
         var resource = new IonResource(endpoint, endpointResource);
-        resource.headers.Accept = 'application/json';
-        resource._makeRequest(originalOptions);
-        expect(_makeRequest).toHaveBeenCalledWith(expectedOptions);
-    });
-
-    it('Calls base _makeRequest with expected options when options header.Accept is already defined', function() {
-        var originalOptions = {
-            headers: {
-                Accept: 'application/json'
-            }
-        };
-        var expectedOptions = {
-            headers: {
-                Accept: 'application/json,*/*;access_token=' + endpoint.accessToken
-            }
-        };
-
-        var _makeRequest = spyOn(Resource.prototype, '_makeRequest');
-        var endpointResource = IonResource._createEndpointResource(assetId);
-        var resource = new IonResource(endpoint, endpointResource);
+        resource.headers.Authorization = 'Not valid';
         resource._makeRequest(originalOptions);
         expect(_makeRequest).toHaveBeenCalledWith(expectedOptions);
     });


### PR DESCRIPTION
When it was first introduced, ion used the accept header to specify the token to trick the browser into avoiding a CORS preflight request on each tile. The spec has since changed to enforce a preflight request on long accept headers because it could otherwise serve as a vector for denial of service attacks. Since we are no longer avoiding the preflight, we should use the cleaner and correct Authorization header.

@kring mind reviewing this?

I didn't update CHANGES because this is a purely internal change.