### PR TITLE
Fix terrain tile picking in Cesium Inspector

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -43,6 +43,7 @@ Change Log
 * Fixed a bug where a point in a `PointPrimitiveCollection` is rendered in the middle of the screen instead of being clipped. [#8542](https://github.com/AnalyticalGraphicsInc/cesium/pull/8542)
 * Fixed a crash when deleting and re-creating polylines from CZML. `ReferenceProperty` now returns undefined when the target entity or property does not exist, instead of throwing. [#8544](https://github.com/AnalyticalGraphicsInc/cesium/pull/8544)
 * Fixed a bug where rapidly updating a PolylineCollection could result in an instanceIndex is out of range error [#8546](https://github.com/AnalyticalGraphicsInc/cesium/pull/8546)
+* Fixed terrain tile picking in the Cesium Inspector. [#8567](https://github.com/AnalyticalGraphicsInc/cesium/pull/8567)
 
 ### 1.65.0 - 2020-01-06
 

--- a/Source/Widgets/CesiumInspector/CesiumInspectorViewModel.js
+++ b/Source/Widgets/CesiumInspector/CesiumInspectorViewModel.js
@@ -1,7 +1,9 @@
+import Cartesian3 from '../../Core/Cartesian3.js';
 import defined from '../../Core/defined.js';
 import defineProperties from '../../Core/defineProperties.js';
 import destroyObject from '../../Core/destroyObject.js';
 import DeveloperError from '../../Core/DeveloperError.js';
+import Ray from '../../Core/Ray.js';
 import Rectangle from '../../Core/Rectangle.js';
 import ScreenSpaceEventHandler from '../../Core/ScreenSpaceEventHandler.js';
 import ScreenSpaceEventType from '../../Core/ScreenSpaceEventType.js';
@@ -47,6 +49,9 @@ import createCommand from '../createCommand.js';
         bounded = Math.max(bounded, lower);
         return bounded;
     }
+
+    var scratchPickRay = new Ray();
+    var scratchPickCartesian = new Cartesian3();
 
     /**
      * The view model for {@link CesiumInspector}.
@@ -502,10 +507,9 @@ import createCommand from '../createCommand.js';
         function selectTile(e) {
             var selectedTile;
             var ellipsoid = globe.ellipsoid;
-            var cartesian = that._scene.camera.pickEllipsoid({
-                x : e.position.x,
-                y : e.position.y
-            }, ellipsoid);
+
+            var ray = that._scene.camera.getPickRay(e.position, scratchPickRay);
+            var cartesian = globe.pick(ray, that._scene, scratchPickCartesian);
 
             if (defined(cartesian)) {
                 var cartographic = ellipsoid.cartesianToCartographic(cartesian);


### PR DESCRIPTION
Replaced `camera.pickEllipsoid` with `globe.pick` so it actually picks terrain instead of the ellipsoid.

[Sandcastle](http://localhost:8080/Apps/Sandcastle/index.html#c=ZVFhb9MwEP0rVr4slYLjxHEcj6xCKkhUYjBBBULKFy+5MQvHrmw360D8d9ymRRu7T7539+6d303SoUnBAzh0hQw8oBV4tRvx1yOWXvTHdGVNkMqAu8jQ786gGAGci9CNs5MawF2eib0DGeCbdXrYzC3pojN/Fq8705lZCcM+gBnSE2MG52Rt/Bb6YN212ivzjOR7MIB7OYKT2EM4bJielhnAB2VkUNagy6ffWEkX4ksamlYVYZxhRoUoBG8EzRCrCy4IxTVhDWGsqTJUClHzhmNBmWCsYpQvslnDOgXRhZca70EOyvy4UaG//2y1TgkmBalKUhZFVcRBhFYsQ68IplVJeUVqHhHKS56h2BqjrHksiLIsG1IUtThLRpM2Thp/Z92I/jl8LYNT+wqv3777uFlvvp/cTbKk9eFRw3Imv1Hj1rqAdk6nGOcBxq2Ol/H57a7/CQH33h9obX4mtYOakBquuuS/o3cJ6rX0Plbudlp/Ub+gS5ZtHvuf0bQ9GvFpAqfl46Hlvlh+mEGMcZvH9CUrWKtvpXsy8S8) - click the top of the mountain in the center

**Before**
![2](https://user-images.githubusercontent.com/915398/73108564-a1fb2f80-3ece-11ea-80d1-7523031dceea.jpg)
**After**
![1](https://user-images.githubusercontent.com/915398/73108565-a1fb2f80-3ece-11ea-9290-4362b6c0b0ce.jpg)

