### PR TITLE
Don't share geometry arrays between Batch and Primitive

### DIFF
--- a/Apps/Sandcastle/gallery/development/Circle Outline.html
+++ b/Apps/Sandcastle/gallery/development/Circle Outline.html
@@ -42,7 +42,7 @@ var circleOutlineInstance = new Cesium.GeometryInstance({
 });
 // Add the geometry instance to primitives.
 scene.primitives.add(new Cesium.Primitive({
-    geometryInstances : [circleOutlineInstance],
+    geometryInstances : circleOutlineInstance,
     appearance : new Cesium.PerInstanceColorAppearance({
         flat : true,
         renderState : {
@@ -72,7 +72,7 @@ circleOutlineInstance = new Cesium.GeometryInstance({
 });
 // Add the geometry instance to primitives.
 scene.primitives.add(new Cesium.Primitive({
-    geometryInstances : [circleOutlineInstance],
+    geometryInstances : circleOutlineInstance,
     appearance : new Cesium.PerInstanceColorAppearance({
         flat : true,
         renderState : {

--- a/Apps/Sandcastle/gallery/development/Circle.html
+++ b/Apps/Sandcastle/gallery/development/Circle.html
@@ -45,7 +45,7 @@ var redCircleInstance = new Cesium.GeometryInstance({
 });
 // Add the geometry instance to primitives.
 scene.primitives.add(new Cesium.Primitive({
-    geometryInstances: [redCircleInstance],
+    geometryInstances: redCircleInstance,
     appearance: new Cesium.PerInstanceColorAppearance({
         closed: true
     })
@@ -71,7 +71,7 @@ var greenCircleInstance = new Cesium.GeometryInstance({
 });
 // Add the geometry instance to primitives.
 scene.primitives.add(new Cesium.Primitive({
-    geometryInstances: [greenCircleInstance],
+    geometryInstances: greenCircleInstance,
     appearance: new Cesium.PerInstanceColorAppearance({
         closed: true
     })

--- a/Apps/Sandcastle/gallery/development/Corridor.html
+++ b/Apps/Sandcastle/gallery/development/Corridor.html
@@ -49,7 +49,7 @@ var redCorridorInstance = new Cesium.GeometryInstance({
 });
 // Add the geometry instance to primitives.
 scene.primitives.add(new Cesium.Primitive({
-    geometryInstances : [redCorridorInstance],
+    geometryInstances : redCorridorInstance,
     appearance : new Cesium.PerInstanceColorAppearance({
         closed : true
     })
@@ -118,7 +118,7 @@ var blueCorridorInstance = new Cesium.GeometryInstance({
 });
 // Add the geometry instance to primitives.
 scene.primitives.add(new Cesium.Primitive({
-    geometryInstances : [blueCorridorInstance],
+    geometryInstances : blueCorridorInstance,
     appearance : new Cesium.PerInstanceColorAppearance({
         closed : true
     })

--- a/Apps/Sandcastle/gallery/development/Cylinder Outline.html
+++ b/Apps/Sandcastle/gallery/development/Cylinder Outline.html
@@ -55,7 +55,7 @@ var cylinderOutline = new Cesium.GeometryInstance({
 });
 // Add the instance to primitives.
 scene.primitives.add(new Cesium.Primitive({
-    geometryInstances : [cylinderOutline],
+    geometryInstances : cylinderOutline,
     appearance : new Cesium.PerInstanceColorAppearance({
         flat : true,
         renderState : {

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -42,7 +42,8 @@ Change Log
 * Fixed a bug where toggling point cloud classification visibility would result in a grey screen on Linux / Nvidia [#8538](https://github.com/AnalyticalGraphicsInc/cesium/pull/8538)
 * Fixed a bug where a point in a `PointPrimitiveCollection` is rendered in the middle of the screen instead of being clipped. [#8542](https://github.com/AnalyticalGraphicsInc/cesium/pull/8542)
 * Fixed a crash when deleting and re-creating polylines from CZML. `ReferenceProperty` now returns undefined when the target entity or property does not exist, instead of throwing. [#8544](https://github.com/AnalyticalGraphicsInc/cesium/pull/8544)
-* Fixed a bug where rapidly updating a PolylineCollection could result in an instanceIndex is out of range error [#8546](https://github.com/AnalyticalGraphicsInc/cesium/pull/8546)
+* Fixed a bug where rapidly updating a `PolylineCollection` could result in an instanceIndex is out of range error. [#8546](https://github.com/AnalyticalGraphicsInc/cesium/pull/8546)
+* Fixed a crash that could occur when an entity was deleted while the corresponding `Primitive` was being created asynchronously. [#8569](https://github.com/AnalyticalGraphicsInc/cesium/pull/8569)
 
 ### 1.65.0 - 2020-01-06
 

--- a/Source/DataSources/StaticGeometryColorBatch.js
+++ b/Source/DataSources/StaticGeometryColorBatch.js
@@ -131,7 +131,7 @@ import Property from './Property.js';
                 primitive = new Primitive({
                     show : false,
                     asynchronous : true,
-                    geometryInstances : geometries,
+                    geometryInstances : geometries.slice(),
                     appearance : new this.appearanceType({
                         translucent : this.translucent,
                         closed : this.closed

--- a/Source/DataSources/StaticGeometryPerMaterialBatch.js
+++ b/Source/DataSources/StaticGeometryPerMaterialBatch.js
@@ -127,7 +127,7 @@ import Property from './Property.js';
                 primitive = new Primitive({
                     show : false,
                     asynchronous : true,
-                    geometryInstances : geometries,
+                    geometryInstances : geometries.slice(),
                     appearance : new this.appearanceType({
                         material : this.material,
                         translucent : this.material.isTranslucent(),

--- a/Source/DataSources/StaticGroundGeometryColorBatch.js
+++ b/Source/DataSources/StaticGroundGeometryColorBatch.js
@@ -89,7 +89,7 @@ import Property from './Property.js';
                 primitive = new GroundPrimitive({
                     show : false,
                     asynchronous : true,
-                    geometryInstances : geometries,
+                    geometryInstances : geometries.slice(),
                     classificationType : this.classificationType
                 });
                 primitives.add(primitive, this.zIndex);

--- a/Source/DataSources/StaticGroundGeometryPerMaterialBatch.js
+++ b/Source/DataSources/StaticGroundGeometryPerMaterialBatch.js
@@ -119,7 +119,7 @@ import Property from './Property.js';
                 primitive = new GroundPrimitive({
                     show : false,
                     asynchronous : true,
-                    geometryInstances : geometries,
+                    geometryInstances : geometries.slice(),
                     appearance : new this.appearanceType({
                         material : this.material
                         // translucent and closed properties overridden

--- a/Source/DataSources/StaticGroundPolylinePerMaterialBatch.js
+++ b/Source/DataSources/StaticGroundPolylinePerMaterialBatch.js
@@ -121,7 +121,7 @@ import Property from './Property.js';
                 primitive = new GroundPolylinePrimitive({
                     show : false,
                     asynchronous : this._asynchronous,
-                    geometryInstances : geometries,
+                    geometryInstances : geometries.slice(),
                     appearance : new this.appearanceType(),
                     classificationType : this.classificationType
                 });

--- a/Source/DataSources/StaticOutlineGeometryBatch.js
+++ b/Source/DataSources/StaticOutlineGeometryBatch.js
@@ -90,7 +90,7 @@ import Property from './Property.js';
                 primitive = new Primitive({
                     show : false,
                     asynchronous : true,
-                    geometryInstances : geometries,
+                    geometryInstances : geometries.slice(),
                     appearance : new PerInstanceColorAppearance({
                         flat : true,
                         translucent : this.translucent,


### PR DESCRIPTION
Make a copy of the array of geometry instances before passing to the Primitive constructor.

In the batches, `geometries` is a live reference to the array inside the AssociativeArray, which is owned by the batch. We need to make a copy of the array so that subsequent changes to the batch don't affect the Primitive's view of the instances, which could happen during async creation or combining.

Fixes #5947  

I marked this next release because the crash in #5947 is consistently affecting a customer application so I would like to get this looked at for 1.66.