### PR TITLE
Fixed crash when creating plane with translation and normal on the Z axis 

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -48,6 +48,7 @@ Change Log
 * Fixed a crash when calling `camera.lookAt` with the origin as the target. This could happen when looking at a tileset with the origin as its center. [#8571](https://github.com/AnalyticalGraphicsInc/cesium/pull/8571)
 * Fixed a bug where `camera.viewBoundingSphere` was modifying the `offset` parameter [#8438](https://github.com/AnalyticalGraphicsInc/cesium/pull/8438)
 * Fixed a crash when creating a plane with both position and normal on the Z-axis. [#8576](https://github.com/AnalyticalGraphicsInc/cesium/pull/8576)
+
 ### 1.65.0 - 2020-01-06
 
 ##### Breaking Changes :mega:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -47,7 +47,7 @@ Change Log
 * Fixed a crash that could occur when an entity was deleted while the corresponding `Primitive` was being created asynchronously. [#8569](https://github.com/AnalyticalGraphicsInc/cesium/pull/8569)
 * Fixed a crash when calling `camera.lookAt` with the origin as the target. This could happen when looking at a tileset with the origin as its center. [#8571](https://github.com/AnalyticalGraphicsInc/cesium/pull/8571)
 * Fixed a bug where `camera.viewBoundingSphere` was modifying the `offset` parameter [#8438](https://github.com/AnalyticalGraphicsInc/cesium/pull/8438)
-
+* Fixed a crash when creating a plane with both position and normal on the Z-axis. [#8576](https://github.com/AnalyticalGraphicsInc/cesium/pull/8576)
 ### 1.65.0 - 2020-01-06
 
 ##### Breaking Changes :mega:

--- a/Source/DataSources/PlaneGeometryUpdater.js
+++ b/Source/DataSources/PlaneGeometryUpdater.js
@@ -240,6 +240,9 @@ import Property from './Property.js';
         var up = ellipsoid.geodeticSurfaceNormal(translation, scratchAxis2);
         if (CesiumMath.equalsEpsilon(Math.abs(Cartesian3.dot(up, transformedNormal)), 1.0, CesiumMath.EPSILON8)) {
             up = Cartesian3.clone(Cartesian3.UNIT_Z, up);
+            if (CesiumMath.equalsEpsilon(Math.abs(Cartesian3.dot(up, transformedNormal)), 1.0, CesiumMath.EPSILON8)) {
+                up = Cartesian3.clone(Cartesian3.UNIT_X, up);
+            }
         }
 
         var left = Cartesian3.cross(up, transformedNormal, scratchAxis);


### PR DESCRIPTION
[Sandcastle with crash](https://sandcastle.cesium.com/#c=dVJtS8MwEP4roV/WQbl2+m3rhjIFBzIFp4IUJGtPd5gmI0k7puy/m77MdTrvS5Ln7nlJSMk1Kwk3qNmYSdywKRoqcniqMb+X1sepkpaTRN3rjxKZyNKx1oJLvCJjuUzRkSOIRp3OXOmcC4e3glOurdtxeQ6P89ni9aU7fOx9X0F+RyU4Nmsz1AkBpSVLaIBnmf+VSOZqrYzDlGTDf92DdrJ2H7KWWFVGOUrj2MbhnVQ/Emf+IGoKooAd9v3gIJJzi5rc/Q8JlFAanm9mi2vYkF1divWK+xEMurR9nHrt4KqwguqO1cWJRi1+0qsZ3SVyV72aF3ixsVuBkwa/oHyttGWFFj5AaDF3zu6W4bJIP9BCakxFi8M9Kc6oZJSNE+/Xx0g8lgpujOu8FUI80Ccm3iQO3fwRTSiekXy/K1ELvq1GVoPJbQMCQBy641+WVUosue4ofgM)
[Sandcastle with fix](http://localhost:8080/Apps/Sandcastle/#c=dVJtS8MwEP4roV/WQbl2+m3rhjIFBzIFp4IUJGtPd5gmI0k7puy/m77MdTrvS5Ln7nlJSMk1Kwk3qNmYSdywKRoqcniqMb+X1sepkpaTRN3rjxKZyNKx1oJLvCJjuUzRkSOIRp3OXOmcC4e3glOurdtxeQ6P89ni9aU7fOx9X0F+RyU4Nmsz1AkBpSVLaIBnmf+VSOZqrYzDlGTDf92DdrJ2H7KWWFVGOUrj2MbhnVQ/Emf+IGoKooAd9v3gIJJzi5rc/Q8JlFAanm9mi2vYkF1divWK+xEMurR9nHrt4KqwguqO1cWJRi1+0qsZ3SVyV72aF3ixsVuBkwa/oHyttGWFFj5AaDF3zu6W4bJIP9BCakxFi8M9Kc6oZJSNE+/Xx0g8lgpujOu8FUI80Ccm3iQO3fwRTSiekXy/K1ELvq1GVoPJbQMCQBy641+WVUosue4ofgM)

When creating the model matrix the code tries to generate an up vector that is different than the normal, and does this by setting the up vector to `UNIT_Z`. But if the normal itself is `UNIT_Z`, the problem is still there. So I added another check that sets it to `UNIT_X` if setting to `UNIT_Z` failed.
