### PR TITLE
Don't apply cullRequestsWhileMoving optimization when tileset is moving

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,7 +5,7 @@ Change Log
 
 ##### Fixes :wrench:
 
-* Fixed a bug where tiles would not load if the camera was tracking a moving tileset.
+* Fixed a bug where tiles would not load if the camera was tracking a moving tileset. [#8598](https://github.com/AnalyticalGraphicsInc/cesium/pull/8598)
 
 ### 1.66.0 - 2020-02-03
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,12 @@
 Change Log
 ==========
 
+### 1.67.0 - 2020-03-02
+
+##### Fixes :wrench:
+
+* Fixed a bug where tiles would not load if the camera was tracking a moving tileset.
+
 ### 1.66.0 - 2020-02-03
 
 ##### Deprecated :hourglass_flowing_sand:

--- a/Source/Scene/Cesium3DTilesetTraversal.js
+++ b/Source/Scene/Cesium3DTilesetTraversal.js
@@ -203,7 +203,7 @@ import Cesium3DTileRefine from './Cesium3DTileRefine.js';
 
     function isOnScreenLongEnough(tileset, tile, frameState) {
         // Prevent unnecessary loads while camera is moving by getting the ratio of travel distance to tile size.
-        if (!tileset.cullRequestsWhileMoving) {
+        if (!tileset._cullRequestsWhileMoving) {
             return true;
         }
 

--- a/Specs/Scene/Cesium3DTilesetSpec.js
+++ b/Specs/Scene/Cesium3DTilesetSpec.js
@@ -3668,6 +3668,17 @@ describe('Scene/Cesium3DTileset', function() {
         });
     });
 
+    it('does not apply cullRequestWhileMoving optimization if tileset is moving', function() {
+        viewNothing();
+        return Cesium3DTilesTester.loadTileset(scene, tilesetUniform).then(function(tileset) {
+            tileset.cullRequestsWhileMoving = true;
+            tileset.modelMatrix[12] += 1.0;
+            viewAllTiles();
+            scene.renderForSpecs();
+            expect(tileset._requestedTilesInFlight.length).toEqual(2);
+        });
+    });
+
     it('loads tiles when preloadWhenHidden is true', function() {
         var options = {
             show : false,


### PR DESCRIPTION
For https://github.com/AnalyticalGraphicsInc/cesium/pull/8580

Only applies the `cullRequestsWhileMoving` optimization if a tileset is stationary. This is to fix cases where the camera is tracking a moving tileset like https://github.com/AnalyticalGraphicsInc/cesium/pull/8580. You could do something more complicated like comparing the camera delta with the tileset delta https://github.com/AnalyticalGraphicsInc/cesium/pull/8580#issuecomment-582135660 but I wanted to keep it simple. It's not very common for tilesets to be moving so I think it's ok to just disable the optimization.

I put together a Sandcastle to simulate the fix. The NYC buildings are shifting slightly and the camera is moving. In local sandcastle you see tiles stream in during the flight path while in master you don't.

[Local sandcastle with the fix](http://localhost:8080/Apps/Sandcastle/index.html#c=pVZtbyI3EP4rVr6w6KjZ95e8qVFy1SFd2lOKeqpKP2x2B7DitantJeFy+e8dsywsCWnTFD5gj+eZl2fGg5e5IksG96DIGRFwTy5Bs7qiv61lTq9Yby+lMDkToHoD8jgRBD8GlELRFyWXrAR13AILBbmBr1LxctyoOP1BA1HwVw3a3IBAwLUsgRwTo2qYiKf+yUQ0YVB4MKjgbMw1wmYTXI0ZBz0SegGFkeqaPTBhkVusLkAAnXF5C7SEhZmP0d/FDIPQZhMNpml9NihM3liTYPaz3/MHxnkkteLbFEdS3ICWtSqATpWsLjTqjEonSkKvT7q5NPEsFKuYYUvQNC9LZ+PRqm2WtKg5v2nY0V/nKLxGVsXsuuaGLThbF8dz2w91O9CFAi7z8ifOZnNzhQaYyA2TQiNkmnO9yxQLU646UiuTis0QwG01+HVuFHvo2F4jsMIV00DNHIQzrUVhrTv9tg9aqxtSreiAUVTYkNfsQ1pwKaDlglY71cEhvCXr6UCpF7LtJ0vtxyUI85lpbCDs3W2sa9VtwGxKnHXQW8krMf/h+X9i3LiZU5WLUlZO/2SHOJjPATMDciDJrqFm9bRLEOtS5PhjS7jJttnjcbOgaO7CoKHb2oDTM/ktQw4e8Hb23F7/hAyH2M1QQkmMJIvakKksak2kIFjFjfGtLSkKzoo72xnPq7vRWKPXyT+tIyxxXyHVLznv3cGqlPcCI2mNEWfLvaUeKKqQs7Mz0it65Pt3shZc2mlghXHSLUtDRQUq71Jh9yd7OtrYG9Lba41GzzJlZ5nzOJmI3g5lER8QYtfl7tbgROqOgVwZXOUicHrkwyYS23PM6tIHlFnKDxytXj/6Zo9wJL4aDvYQUnognE/YtTgVvjBTzG8k592g5s3ZS7dW+YVUIfrfwsBbNca211OpKnL8vN1HVx9/Ho/Gvx/GYyd3pAVOI8mBcjlzUKO/XzuFszwXMw67Eu8VsJAVdjDYIt60qt2L2LW+C3JOjbyCmQLQztYDvcdK99+JxYFv5u8FQ/5+x0KqnePdmGi+/9zy4q3t7QVBkAYBDcPAz+Ig8qIB+SGMoyjzfOqGSRYlrpcOSOgFKYppmrp44vl++9/+9qZ1aeynfpL6oe/FYYam0ZVHo9D1YjfNojjK0sgbELc1/cZG3PGyNyjolK/G8j9yEWdJSrMkdKMk9YJwzUWYhGFEw8QNosx3E8tFGGdRSuM0iOLYj5L/wUUS+oEbh2665SLKwigK4igMk7hDRlmr1rCHD4FN1keDo1NtVhzOG60fWbXArrGvFofSoYFqwfFVpoe3dXFn3xtaW9jpsAWdlmxJWHk2OXr24JsckYLnWuPJFB8pv7JvMDk6Px2i/h7MvkEwtV+WoHi+sipz7/xzI6SUng5x+xJlpOS3uepY/Bs)
[cesium.com sandcastle without the fix](https://sandcastle.cesium.com/#c=pVZtbyI3EP4rVr6w6KjZ95e8qVFy1SFd2lOKeqpKP2x2B7DitantJeFy+e8dsywsCWnTFD5gj+eZl2fGg5e5IksG96DIGRFwTy5Bs7qiv61lTq9Yby+lMDkToHoD8jgRBD8GlELRFyWXrAR13AILBbmBr1LxctyoOP1BA1HwVw3a3IBAwLUsgRwTo2qYiKf+yUQ0YVB4MKjgbMw1wmYTXI0ZBz0SegGFkeqaPTBhkVusLkAAnXF5C7SEhZmP0d/FDIPQZhMNpml9NihM3liTYPaz3/MHxnkkteLbFEdS3ICWtSqATpWsLjTqjEonSkKvT7q5NPEsFKuYYUvQNC9LZ+PRqm2WtKg5v2nY0V/nKLxGVsXsuuaGLThbF8dz2w91O9CFAi7z8ifOZnNzhQaYyA2TQiNkmnO9yxQLU646UiuTis0QwG01+HVuFHvo2F4jsMIV00DNHIQzrUVhrTv9tg9aqxtSreiAUVTYkNfsQ1pwKaDlglY71cEhvCXr6UCpF7LtJ0vtxyUI85lpbCDs3W2sa9VtwGxKnHXQW8krMf/h+X9i3LiZU5WLUlZO/2SHOJjPATMDciDJrqFm9bRLEOtS5PhjS7jJttnjcbOgaO7CoKHb2oDTM/ktQw4e8Hb23F7/hAyH2M1QQkmMJIvakKksak2kIFjFjfGtLSkKzoo72xnPq7vRWKPXyT+tIyxxXyHVLznv3cGqlPcCI2mNEWfLvaUeKKqQs7Mz0it65Pt3shZc2mlghXHSLUtDRQUq71Jh9yd7OtrYG9Lba41GzzJlZ5nzOJmI3g5lER8QYtfl7tbgROqOgVwZXOUicHrkwyYS23PM6tIHlFnKDxytXj/6Zo9wJL4aDvYQUnognE/YtTgVvjBTzG8k592g5s3ZS7dW+YVUIfrfwsBbNca211OpKnL8vN1HVx9/Ho/Gvx/GYyd3pAVOI8mBcjlzUKO/XzuFszwXMw67Eu8VsJAVdjDYIt60qt2L2LW+C3JOjbyCmQLQztYDvcdK99+JxYFv5u8FQ/5+x0KqnePdmGi+/9zy4q3t7QVBkAYBDcPAz+Ig8qIB+SGMoyjzfOqGSRYlrpcOSOgFKYppmrp44vl++9/+9qZ1aeynfpL6oe/FYYam0ZVHo9D1YjfNojjK0sgbELc1/cZG3PGyNyjolK/G8j9yEWdJSrMkdKMk9YJwzUWYhGFEw8QNosx3E8tFGGdRSuM0iOLYj5L/wUUS+oEbh2665SLKwigK4igMk7hDRlmr1rCHD4FN1keDo1NtVhzOG60fWbXArrGvFofSoYFqwfFVpoe3dXFn3xtaW9jpsAWdlmxJWHk2OXr24JsckYLnWuPJFB8pv7JvMDk6Px2i/h7MvkEwtV+WoHi+sipz7/xzI6SUng5x+xJlpOS3uepY/Bs)