### PR TITLE
Added Color.lerp function

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,7 +7,7 @@ Change Log
 
 * Added `Entity.tileset` for loading a 3D Tiles tileset via the Entity API using the new `Cesium3DTilesetGraphics` class.
 * Added `tileset.uri`, `tileset.show`, and `tileset.maximumScreenSpaceError` properties to CZML processing for loading 3D Tiles.
-* Added `Color.lerp` for linearly interpolating between two RGB colors.
+* Added `Color.lerp` for linearly interpolating between two RGB colors. [#8607](https://github.com/AnalyticalGraphicsInc/cesium/pull/8607)
 
 ##### Fixes :wrench:
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@ Change Log
 
 * Added `Entity.tileset` for loading a 3D Tiles tileset via the Entity API using the new `Cesium3DTilesetGraphics` class.
 * Added `tileset.uri`, `tileset.show`, and `tileset.maximumScreenSpaceError` properties to CZML processing for loading 3D Tiles.
+* Added `Color.lerp` for linearly interpolating between two RGB colors.
 
 ##### Fixes :wrench:
 

--- a/Source/Core/Color.js
+++ b/Source/Core/Color.js
@@ -806,6 +806,30 @@ import CesiumMath from './Math.js';
     };
 
     /**
+     * Computes the linear interpolation or extrapolation at t between the provided colors.
+     *
+     * @param {Color} start The color corresponding to t at 0.0.
+     * @param {Color} end The color corresponding to t at 1.0.
+     * @param {Number} t The point along t at which to interpolate.
+     * @param {Color} result The object onto which to store the result.
+     * @returns {Color} The modified result parameter.
+     */
+    Color.lerp = function(start, end, t, result) {
+        //>>includeStart('debug', pragmas.debug);
+        Check.typeOf.object('start', start);
+        Check.typeOf.object('end', end);
+        Check.typeOf.number('t', t);
+        Check.typeOf.object('result', result);
+        //>>includeEnd('debug');
+
+        result.red = CesiumMath.lerp(start.red, end.red, t);
+        result.green = CesiumMath.lerp(start.green, end.green, t);
+        result.blue = CesiumMath.lerp(start.blue, end.blue, t);
+        result.alpha = CesiumMath.lerp(start.alpha, end.alpha, t);
+        return result;
+    };
+
+    /**
      * Multiplies the provided Color componentwise by the provided scalar.
      *
      * @param {Color} color The Color to be scaled.

--- a/Specs/Core/ColorSpec.js
+++ b/Specs/Core/ColorSpec.js
@@ -743,5 +743,34 @@ describe('Core/Color', function() {
         expect(result.alpha).toEqualEpsilon(0.2, CesiumMath.EPSILON15);
     });
 
+    it('lerp throws with undefined parameters', function() {
+        expect(function() {
+            Color.lerp(undefined, new Color(), 0.0, new Color());
+        }).toThrowDeveloperError();
+
+        expect(function() {
+            Color.lerp(new Color(), undefined, 0.0, new Color());
+        }).toThrowDeveloperError();
+
+        expect(function() {
+            Color.lerp(new Color(), new Color(), undefined, new Color());
+        }).toThrowDeveloperError();
+
+        expect(function() {
+            Color.lerp(new Color(), new Color(), 0.0, undefined);
+        }).toThrowDeveloperError();
+    });
+
+    it('can lerp between two colors', function() {
+        var colorA = new Color(0.0, 0.0, 0.0, 0.0);
+        var colorB = new Color(1.0, 1.0, 1.0, 1.0);
+        var result = Color.lerp(colorA, colorB, 0.5, new Color());
+
+        expect(result.red).toEqualEpsilon(0.5, CesiumMath.EPSILON15);
+        expect(result.green).toEqualEpsilon(0.5, CesiumMath.EPSILON15);
+        expect(result.blue).toEqualEpsilon(0.5, CesiumMath.EPSILON15);
+        expect(result.alpha).toEqualEpsilon(0.5, CesiumMath.EPSILON15);
+    });
+
     createPackableSpecs(Color, new Color(0.1, 0.2, 0.3, 0.4), [0.1, 0.2, 0.3, 0.4]);
 });


### PR DESCRIPTION
Fixes https://github.com/AnalyticalGraphicsInc/cesium/issues/8605

For now `Color` only supports RGB interpolation, though there may be a use for HSV or an even better color lerp in the future.