### PR TITLE
Remove `access_token` from gist loading.

### DIFF
--- a/Apps/Sandcastle/CesiumSandcastle.js
+++ b/Apps/Sandcastle/CesiumSandcastle.js
@@ -711,7 +711,7 @@ require({
 
             var json, code, html;
             if (defined(queryObject.gist)) {
-                dojoscript.get('https://api.github.com/gists/' + queryObject.gist + '?access_token=dd8f755c2e5d9bbb26806bb93eaa2291f2047c60', {
+                dojoscript.get('https://api.github.com/gists/' + queryObject.gist, {
                     jsonp: 'callback'
                 }).then(function(data) {
                     var files = data.data.files;
@@ -720,7 +720,7 @@ require({
                     var html = defined(htmlFile) ? htmlFile.content : defaultHtml; // Use the default html for old gists
                     applyLoadedDemo(code, html);
                 }).otherwise(function(error) {
-                    appendConsole('consoleError', 'Unable to GET from GitHub API. This could be due to too many request, try again in an hour or copy and paste the code from the gist: https://gist.github.com/' + queryObject.gist, true);
+                    appendConsole('consoleError', 'Unable to GET gist from GitHub API. This could be due to too many requests from your IP. Try again in an hour or copy and paste the code from the gist: https://gist.github.com/' + queryObject.gist, true);
                     console.log(error);
                 });
             } else if (defined(queryObject.code)) {


### PR DESCRIPTION
GitHub has deprecated use of `access_token` in query parameters and is email spamming us nonstop about it.  (dozens of emails a day)

Gists can be read anonymously with a rate-limit of 60 requests per hour per client IP address.

Since we stopped using gists for Sandcastle example code two years ago, the gist codepath is only for extremely old examples, so the rate limit is unlikely to be an issue in practice.

Also someone with the credentials for @Cesium-Sandcastle needs to revoke the old access_token and stop the endless deluge of emails.  Also note that account is still using an agi.com email address.

Fixes #8593